### PR TITLE
feat(auth): User Authentication & Data Persistence (REQ-10)

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -28,9 +28,33 @@ export async function GET(request: NextRequest) {
     const { error } = await supabase.auth.exchangeCodeForSession(code)
 
     if (!error) {
-      return NextResponse.redirect(`${origin}/`)
+      return NextResponse.redirect(`${origin}/dashboard`)
     }
   }
 
-  return NextResponse.redirect(`${origin}/auth/login?error=true`)
+  // Show error page with 2-second redirect to login
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Authentication Failed</title>
+  <style>
+    body { margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center; background: #f9fafb; font-family: sans-serif; }
+    .card { background: white; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: 2rem; text-align: center; max-width: 400px; }
+    p { color: #dc2626; font-size: 0.875rem; }
+  </style>
+  <script>setTimeout(() => { window.location.href = '/auth/login'; }, 2000);</script>
+</head>
+<body>
+  <div class="card">
+    <p>Authentication failed. Redirecting to login...</p>
+  </div>
+</body>
+</html>`
+
+  return new NextResponse(html, {
+    status: 200,
+    headers: { 'Content-Type': 'text/html' },
+  })
 }

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,27 +1,43 @@
+'use client'
+
 import Link from 'next/link'
-import { redirect } from 'next/navigation'
-import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { useState } from 'react'
+import { createBrowserClient } from '@supabase/ssr'
 
-export default async function LoginPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ error?: string }>
-}) {
-  const { error } = await searchParams
+export default function LoginPage() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const expired = searchParams.get('expired') === 'true'
 
-  async function login(formData: FormData) {
-    'use server'
-    const email = formData.get('email') as string
-    const password = formData.get('password') as string
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState<string | null>(expired ? 'Your session has expired. Please log in again.' : null)
+  const [loading, setLoading] = useState(false)
 
-    const supabase = await createSupabaseServerClient()
-    const { error } = await supabase.auth.signInWithPassword({ email, password })
+  async function handleLogin(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
 
-    if (error) {
-      redirect('/auth/login?error=true')
+    const supabase = createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    )
+
+    try {
+      const { error } = await supabase.auth.signInWithPassword({ email, password })
+      if (error) {
+        setError('Email or password is incorrect.')
+      } else {
+        router.push('/dashboard')
+        router.refresh()
+      }
+    } catch {
+      setError('Unable to connect. Please check your internet and try again.')
+    } finally {
+      setLoading(false)
     }
-
-    redirect('/')
   }
 
   return (
@@ -29,11 +45,9 @@ export default async function LoginPage({
       <div className="w-full max-w-md bg-white rounded-lg shadow p-8">
         <h1 className="text-2xl font-bold text-center mb-6">Sign in to Allocate</h1>
         {error && (
-          <div className="mb-4 p-3 bg-red-50 text-red-700 text-sm rounded-md">
-            Invalid email or password. Please try again.
-          </div>
+          <div className="mb-4 p-3 bg-red-50 text-red-700 text-sm rounded-md">{error}</div>
         )}
-        <form action={login} className="space-y-4">
+        <form onSubmit={handleLogin} className="space-y-4">
           <div>
             <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
               Email
@@ -43,6 +57,8 @@ export default async function LoginPage({
               id="email"
               name="email"
               required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
               placeholder="you@example.com"
             />
@@ -56,15 +72,21 @@ export default async function LoginPage({
               id="password"
               name="password"
               required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
               placeholder="••••••••"
             />
           </div>
+          <div className="text-right">
+            <span className="text-sm text-gray-400 cursor-not-allowed">Forgot password?</span>
+          </div>
           <button
             type="submit"
-            className="w-full py-2 px-4 bg-indigo-600 text-white rounded-md font-medium hover:bg-indigo-700 transition-colors"
+            disabled={loading}
+            className="w-full py-2 px-4 bg-indigo-600 text-white rounded-md font-medium hover:bg-indigo-700 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
           >
-            Sign in
+            {loading ? 'Signing in...' : 'Log in'}
           </button>
         </form>
         <p className="mt-4 text-center text-sm text-gray-600">

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -1,49 +1,85 @@
+'use client'
+
 import Link from 'next/link'
-import { redirect } from 'next/navigation'
-import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { createBrowserClient } from '@supabase/ssr'
 
-export default async function SignupPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ error?: string }>
-}) {
-  const { error } = await searchParams
+export default function SignupPage() {
+  const router = useRouter()
 
-  async function signup(formData: FormData) {
-    'use server'
-    const email = formData.get('email') as string
-    const password = formData.get('password') as string
-    const confirmPassword = formData.get('confirmPassword') as string
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [passwordError, setPasswordError] = useState<string | null>(null)
+  const [confirmError, setConfirmError] = useState<string | null>(null)
+  const [formError, setFormError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [confirmSent, setConfirmSent] = useState(false)
 
-    if (password !== confirmPassword) {
-      redirect('/auth/signup?error=mismatch')
+  function handlePasswordBlur() {
+    if (password && password.length < 8) {
+      setPasswordError('Password must be at least 8 characters.')
+    } else {
+      setPasswordError(null)
     }
-
-    const supabase = await createSupabaseServerClient()
-    const { data, error } = await supabase.auth.signUp({ email, password })
-
-    if (error) {
-      redirect('/auth/signup?error=true')
-    }
-
-    // If session is null, Supabase requires email confirmation
-    if (!data.session) {
-      redirect('/auth/signup?error=confirm')
-    }
-
-    redirect('/')
   }
 
-  const errorMessage =
-    error === 'mismatch'
-      ? 'Passwords do not match.'
-      : error === 'confirm'
-        ? null // handled by the confirmation notice below
-        : error
-          ? 'Could not create account. Please try again.'
-          : null
+  function handleConfirmBlur() {
+    if (confirmPassword && password !== confirmPassword) {
+      setConfirmError('Passwords do not match.')
+    } else {
+      setConfirmError(null)
+    }
+  }
 
-  if (error === 'confirm') {
+  async function handleSignup(e: React.FormEvent) {
+    e.preventDefault()
+    setFormError(null)
+
+    if (password.length < 8) {
+      setPasswordError('Password must be at least 8 characters.')
+      return
+    }
+    if (password !== confirmPassword) {
+      setConfirmError('Passwords do not match.')
+      return
+    }
+
+    setLoading(true)
+
+    const supabase = createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    )
+
+    try {
+      const { data, error } = await supabase.auth.signUp({ email, password })
+
+      if (error) {
+        if (error.message.toLowerCase().includes('already') || error.status === 422) {
+          setFormError('Email already in use.')
+        } else {
+          setFormError('Could not create account. Please try again.')
+        }
+        return
+      }
+
+      if (!data.session) {
+        setConfirmSent(true)
+        return
+      }
+
+      router.push('/dashboard')
+      router.refresh()
+    } catch {
+      setFormError('Unable to connect. Please check your internet and try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (confirmSent) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-gray-50">
         <div className="w-full max-w-md bg-white rounded-lg shadow p-8 text-center">
@@ -68,10 +104,10 @@ export default async function SignupPage({
     <div className="min-h-screen flex items-center justify-center bg-gray-50">
       <div className="w-full max-w-md bg-white rounded-lg shadow p-8">
         <h1 className="text-2xl font-bold text-center mb-6">Create your account</h1>
-        {errorMessage && (
-          <div className="mb-4 p-3 bg-red-50 text-red-700 text-sm rounded-md">{errorMessage}</div>
+        {formError && (
+          <div className="mb-4 p-3 bg-red-50 text-red-700 text-sm rounded-md">{formError}</div>
         )}
-        <form action={signup} className="space-y-4">
+        <form onSubmit={handleSignup} className="space-y-4">
           <div>
             <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
               Email
@@ -81,6 +117,8 @@ export default async function SignupPage({
               id="email"
               name="email"
               required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
               placeholder="you@example.com"
             />
@@ -94,10 +132,16 @@ export default async function SignupPage({
               id="password"
               name="password"
               required
-              minLength={6}
+              minLength={8}
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              onBlur={handlePasswordBlur}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
               placeholder="••••••••"
             />
+            {passwordError && (
+              <p className="mt-1 text-xs text-red-600">{passwordError}</p>
+            )}
           </div>
           <div>
             <label
@@ -111,16 +155,23 @@ export default async function SignupPage({
               id="confirmPassword"
               name="confirmPassword"
               required
-              minLength={6}
+              minLength={8}
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              onBlur={handleConfirmBlur}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
               placeholder="••••••••"
             />
+            {confirmError && (
+              <p className="mt-1 text-xs text-red-600">{confirmError}</p>
+            )}
           </div>
           <button
             type="submit"
-            className="w-full py-2 px-4 bg-indigo-600 text-white rounded-md font-medium hover:bg-indigo-700 transition-colors"
+            disabled={loading}
+            className="w-full py-2 px-4 bg-indigo-600 text-white rounded-md font-medium hover:bg-indigo-700 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
           >
-            Sign up
+            {loading ? 'Creating account...' : 'Sign up'}
           </button>
         </form>
         <p className="mt-4 text-center text-sm text-gray-600">

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,71 @@
+import { redirect } from 'next/navigation'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+
+async function logout() {
+  'use server'
+  const supabase = await createSupabaseServerClient()
+  await supabase.auth.signOut()
+  redirect('/auth/login')
+}
+
+export default async function DashboardPage() {
+  const supabase = await createSupabaseServerClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+
+  if (!user) {
+    redirect('/auth/login')
+  }
+
+  return (
+    <main className="min-h-screen flex flex-col items-center justify-center px-20 py-20">
+      <div className="w-full max-w-2xl space-y-8">
+        <div className="flex items-center justify-between">
+          <h1 className="text-4xl font-bold tracking-tight text-gray-900">Dashboard</h1>
+          <div className="flex items-center gap-3">
+            <span className="text-sm text-gray-500">{user.email}</span>
+            <form action={logout}>
+              <button
+                type="submit"
+                className="text-sm px-3 py-1 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded transition-colors"
+              >
+                Log out
+              </button>
+            </form>
+          </div>
+        </div>
+
+        <div className="bg-white rounded-lg shadow p-6 space-y-3">
+          <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-4">
+            Navigation
+          </h2>
+          <a
+            href="/funds"
+            className="flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
+          >
+            📚 Fund Library
+          </a>
+          <a
+            href="/assets"
+            className="flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
+          >
+            📊 Assets Dashboard
+          </a>
+          <a
+            href="/planning"
+            className="flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
+          >
+            📅 Monthly Planning
+          </a>
+          <a
+            href="/settings"
+            className="flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
+          >
+            ⚙️ Settings
+          </a>
+        </div>
+      </div>
+    </main>
+  )
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
+import AuthProvider from '@/components/AuthProvider'
 
 const inter = Inter({
   subsets: ['latin'],
@@ -20,7 +21,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${inter.variable} font-sans antialiased bg-gray-50 text-gray-900`}>
-        {children}
+        <AuthProvider>{children}</AuthProvider>
       </body>
     </html>
   )

--- a/components/AuthProvider.tsx
+++ b/components/AuthProvider.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { createBrowserClient } from '@supabase/ssr'
+import { useRouter, usePathname } from 'next/navigation'
+import { useEffect, useState } from 'react'
+
+export default function AuthProvider({ children }: { children: React.ReactNode }) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const [checking, setChecking] = useState(true)
+
+  useEffect(() => {
+    const supabase = createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    )
+
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      setChecking(false)
+
+      const isAuthPage = pathname.startsWith('/auth/')
+      if (!session && !isAuthPage) {
+        router.push('/auth/login')
+      } else if (session && isAuthPage && pathname !== '/auth/callback') {
+        router.push('/dashboard')
+      }
+    })
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'TOKEN_REFRESHED') return
+
+      if (!session && !pathname.startsWith('/auth/')) {
+        router.push('/auth/login?expired=true')
+      }
+    })
+
+    return () => subscription.unsubscribe()
+  }, [pathname, router])
+
+  if (checking) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="flex flex-col items-center gap-3">
+          <div className="w-8 h-8 border-4 border-indigo-600 border-t-transparent rounded-full animate-spin" />
+          <span className="text-sm text-gray-500">Loading...</span>
+        </div>
+      </div>
+    )
+  }
+
+  return <>{children}</>
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,8 +1,14 @@
 import { createServerClient } from '@supabase/ssr'
-import { NextResponse, type NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 
-export async function proxy(request: NextRequest) {
-  let supabaseResponse = NextResponse.next({ request })
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  if (pathname.startsWith('/auth/')) {
+    return NextResponse.next()
+  }
+
+  let response = NextResponse.next()
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -13,12 +19,10 @@ export async function proxy(request: NextRequest) {
           return request.cookies.getAll()
         },
         setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value }) =>
-            request.cookies.set(name, value)
-          )
-          supabaseResponse = NextResponse.next({ request })
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
+          response = NextResponse.next({ request })
           cookiesToSet.forEach(({ name, value, options }) =>
-            supabaseResponse.cookies.set(name, value, options)
+            response.cookies.set(name, value, options)
           )
         },
       },
@@ -29,24 +33,15 @@ export async function proxy(request: NextRequest) {
     data: { user },
   } = await supabase.auth.getUser()
 
-  const { pathname } = request.nextUrl
-
-  const protectedRoutes = ['/dashboard', '/settings']
-  const isProtected = protectedRoutes.some((route) =>
-    pathname.startsWith(route)
-  )
-
-  if (isProtected && !user) {
+  if (!user) {
     const loginUrl = request.nextUrl.clone()
     loginUrl.pathname = '/auth/login'
     return NextResponse.redirect(loginUrl)
   }
 
-  return supabaseResponse
+  return response
 }
 
 export const config = {
-  matcher: [
-    '/((?!_next/static|_next/image|favicon.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)',
-  ],
+  matcher: ['/((?!_next/static|_next/image|favicon\\.ico|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'],
 }


### PR DESCRIPTION
## Summary
- Adds `proxy.ts` (Next.js 16 route protection) redirecting unauthenticated users to `/auth/login`
- Rewrites login and signup pages as client components with spec-compliant error messages, on-blur validation, and `/dashboard` redirects
- Adds `AuthProvider` with loading spinner and session expiry handling (`?expired=true`)
- Creates `/dashboard` route as the post-login landing page with logout button
- Fixes PKCE callback to redirect to `/dashboard` on success and show "Authentication failed. Redirecting to login..." with 2s auto-redirect on failure

## Test plan
- [ ] Visit `/funds` while logged out → should redirect to `/auth/login`
- [ ] Sign up with mismatched passwords → error on blur of confirm field
- [ ] Sign up with password < 8 chars → error on blur of password field
- [ ] Sign up with existing email → "Email already in use" error
- [ ] Successful signup → redirected to `/dashboard`
- [ ] Login with wrong credentials → "Email or password is incorrect"
- [ ] Successful login → redirected to `/dashboard`
- [ ] Click "Log out" → redirected to `/auth/login`
- [ ] Session expiry (simulate by clearing cookies) → redirected to `/auth/login` with "Your session has expired" message
- [ ] Visit `/auth/callback` with invalid code → "Authentication failed. Redirecting to login..." → auto-redirect after 2s
- [ ] Page refresh while logged in → session persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)