### PR TITLE
feat(home): Landing Page for unauthenticated visitors (REQ-13)

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,131 +1,176 @@
-import { redirect } from 'next/navigation'
-import { createSupabaseServerClient } from '@/lib/supabase-server'
+'use client'
 
-async function logout() {
-  'use server'
-  const supabase = await createSupabaseServerClient()
-  await supabase.auth.signOut()
-  redirect('/auth/login')
-}
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
+import { createBrowserClient } from '@supabase/ssr'
 
-export default async function HomePage() {
-  const supabase = await createSupabaseServerClient()
+const BENEFITS = [
+  {
+    icon: '📊',
+    title: 'Auto-Calculate Allocations',
+    description:
+      'Intelligently distribute your monthly salary across invoices, insurance, and investments with smart recommendations.',
+  },
+  {
+    icon: '💰',
+    title: 'Track Net Worth',
+    description:
+      'Monitor your total assets, liabilities, and net worth in real-time. See your financial health at a glance.',
+  },
+  {
+    icon: '📈',
+    title: 'Plan Investments',
+    description:
+      'Organize and track your investment funds. Know exactly how much you're allocating to each fund every month.',
+  },
+  {
+    icon: '🛡️',
+    title: 'Manage Insurance',
+    description:
+      'Keep all your insurance policies in one place. Track coverage amounts and monthly premiums effortlessly.',
+  },
+]
 
-  const { data: healthData, error: healthError } = await supabase
-    .from('health_check')
-    .select('*')
-    .limit(1)
+export default function HomePage() {
+  const router = useRouter()
+  const [loading, setLoading] = useState(true)
+  const [authError, setAuthError] = useState(false)
 
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  useEffect(() => {
+    const supabase = createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    )
 
-  const dbStatus =
-    healthError || !healthData
-      ? `✗ Database error: ${healthError?.message ?? 'No data'}`
-      : '✓ Database connected'
+    supabase.auth
+      .getSession()
+      .then(({ data: { session }, error }) => {
+        if (error) {
+          setAuthError(true)
+          setLoading(false)
+          return
+        }
+        if (session) {
+          router.replace('/assets')
+        } else {
+          setLoading(false)
+        }
+      })
+      .catch(() => {
+        setAuthError(true)
+        setLoading(false)
+      })
+  }, [router])
 
-  return (
-    <main className="min-h-screen flex flex-col items-center justify-center px-20 py-20">
-      <div className="w-full max-w-2xl space-y-8">
-        <h1 className="text-4xl font-bold tracking-tight text-gray-900">
-          Welcome to Allocate
-        </h1>
-
-        {user && (
-          <div className="bg-white rounded-lg shadow p-4">
-            <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-3">Navigation</h2>
-            <a
-              href="/funds"
-              className="flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
-            >
-              📚 Fund Library
-            </a>
-            <a
-              href="/assets"
-              className="flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors mt-2"
-            >
-              📊 Assets Dashboard
-            </a>
-            <a
-              href="/planning"
-              className="flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors mt-2"
-            >
-              📅 Monthly Planning
-            </a>
-            <a
-              href="/settings"
-              className="flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors mt-2"
-            >
-              ⚙️ Settings
-            </a>
-          </div>
-        )}
-
-        <div className="bg-white rounded-lg shadow p-6 space-y-4">
-          <h2 className="text-lg font-semibold text-gray-700">System Status</h2>
-
-          <div className="space-y-3">
-            <StatusRow label="Framework" value="Next.js 16 running" ok />
-
-            <StatusRow
-              label="Database"
-              value={dbStatus}
-              ok={!healthError && !!healthData}
-            />
-
-            <div className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0">
-              <span className="text-sm font-medium text-gray-600">Authentication</span>
-              <div className="flex items-center gap-3">
-                {user ? (
-                  <>
-                    <span className="text-sm text-gray-800">
-                      Logged in as: <strong>{user.email}</strong>
-                    </span>
-                    <form action={logout}>
-                      <button
-                        type="submit"
-                        className="text-sm px-3 py-1 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded transition-colors"
-                      >
-                        Logout
-                      </button>
-                    </form>
-                  </>
-                ) : (
-                  <>
-                    <span className="text-sm text-gray-500">Not logged in</span>
-                    <a
-                      href="/auth/login"
-                      className="text-sm px-3 py-1 bg-indigo-600 hover:bg-indigo-700 text-white rounded transition-colors"
-                    >
-                      Login
-                    </a>
-                  </>
-                )}
-              </div>
-            </div>
-          </div>
+  if (loading && !authError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-white">
+        <div className="flex flex-col items-center gap-3">
+          <div className="w-8 h-8 border-4 border-indigo-600 border-t-transparent rounded-full animate-spin" />
+          <span className="text-sm text-gray-500">Loading...</span>
         </div>
       </div>
-    </main>
-  )
-}
+    )
+  }
 
-function StatusRow({
-  label,
-  value,
-  ok,
-}: {
-  label: string
-  value: string
-  ok: boolean
-}) {
+  if (authError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-white">
+        <div className="text-center space-y-4">
+          <p className="text-red-600 text-sm">Something went wrong. Please try again.</p>
+          <button
+            onClick={() => {
+              setAuthError(false)
+              setLoading(true)
+              window.location.reload()
+            }}
+            className="px-4 py-2 bg-indigo-600 text-white rounded-md text-sm font-medium hover:bg-indigo-700 transition-colors"
+          >
+            Retry
+          </button>
+        </div>
+      </div>
+    )
+  }
+
   return (
-    <div className="flex items-center justify-between py-2 border-b border-gray-100 last:border-0">
-      <span className="text-sm font-medium text-gray-600">{label}</span>
-      <span className={`text-sm ${ok ? 'text-green-600' : 'text-red-600'}`}>
-        {value}
-      </span>
+    <div className="min-h-screen flex flex-col bg-white text-gray-900">
+      {/* Header */}
+      <header className="border-b border-gray-200 px-6 py-4">
+        <div className="max-w-6xl mx-auto flex items-center justify-between">
+          <span className="text-2xl font-bold text-indigo-700 tracking-tight">Allocate</span>
+          <nav className="flex items-center gap-6">
+            <Link
+              href="/auth/login"
+              className="text-sm font-medium text-gray-600 hover:text-indigo-700 transition-colors"
+            >
+              Log In
+            </Link>
+            <Link
+              href="/auth/signup"
+              className="text-sm font-medium px-4 py-2 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors"
+            >
+              Sign Up
+            </Link>
+          </nav>
+        </div>
+      </header>
+
+      <main className="flex-1">
+        {/* Hero */}
+        <section className="py-24 px-6 text-center">
+          <div className="max-w-3xl mx-auto">
+            <h1 className="text-4xl sm:text-5xl font-extrabold tracking-tight leading-tight mb-6">
+              Automate Your Monthly Allocation
+            </h1>
+            <p className="text-lg text-gray-600 mb-10 max-w-xl mx-auto leading-relaxed">
+              Take control of your finances with intelligent allocation planning. Track investments,
+              manage insurance, and optimize your monthly budget in minutes.
+            </p>
+            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+              <Link
+                href="/auth/signup"
+                className="px-6 py-3 bg-indigo-600 text-white font-semibold rounded-lg hover:bg-indigo-700 transition-colors shadow-sm"
+              >
+                Sign Up
+              </Link>
+              <Link
+                href="/auth/login"
+                className="px-6 py-3 border-2 border-indigo-600 text-indigo-700 font-semibold rounded-lg hover:bg-indigo-50 transition-colors"
+              >
+                Log In
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* Benefits */}
+        <section className="py-20 px-6 bg-gray-50">
+          <div className="max-w-6xl mx-auto">
+            <h2 className="text-3xl font-bold text-center mb-14">Why Choose Allocate?</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+              {BENEFITS.map((b) => (
+                <div
+                  key={b.title}
+                  className="bg-white rounded-xl p-6 shadow-sm hover:shadow-md transition-shadow"
+                >
+                  <div className="w-12 h-12 bg-indigo-50 rounded-lg flex items-center justify-center text-2xl mb-4">
+                    {b.icon}
+                  </div>
+                  <h3 className="font-semibold text-gray-900 mb-2">{b.title}</h3>
+                  <p className="text-sm text-gray-600 leading-relaxed">{b.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+      </main>
+
+      {/* Footer */}
+      <footer className="border-t border-gray-200 py-8 px-6 text-center">
+        <p className="text-sm text-gray-400">© 2026 Allocate. All rights reserved.</p>
+      </footer>
     </div>
   )
 }

--- a/proxy.ts
+++ b/proxy.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from 'next/server'
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
-  if (pathname.startsWith('/auth/')) {
+  if (pathname === '/' || pathname.startsWith('/auth/')) {
     return NextResponse.next()
   }
 


### PR DESCRIPTION
## Summary
- Replaces the old system-status home page with a proper landing page for unauthenticated visitors
- Updates `proxy.ts` to allow public access to `/` (was previously redirecting all non-auth routes to login)
- Hero section: "Automate Your Monthly Allocation" headline + subheadline + Sign Up / Log In CTAs
- 4 benefit cards: Auto-Calculate Allocations, Track Net Worth, Plan Investments, Manage Insurance
- Authenticated users visiting `/` are redirected to `/assets`
- Loading spinner while auth state is checked; error state with retry button on failure
- Responsive: single-column mobile, 2-column tablet, 4-column desktop

## Test plan
- [ ] Visit `/` while logged out → see landing page with hero + benefit cards
- [ ] Click "Sign Up" CTA → navigates to `/auth/signup`
- [ ] Click "Log In" CTA → navigates to `/auth/login`
- [ ] Visit `/` while logged in → immediately redirected to `/assets`
- [ ] Briefly see spinner on first load while auth state resolves
- [ ] Verify responsive layout at mobile, tablet, and desktop widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)