### PR TITLE
feat(nav): Navigation System - Sidebar + Header (REQ-14)

### DIFF
--- a/app/assets/page.tsx
+++ b/app/assets/page.tsx
@@ -1,11 +1,16 @@
 import { redirect } from 'next/navigation'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import DashboardClient from './DashboardClient'
+import AuthenticatedLayout from '@/app/components/layouts/AuthenticatedLayout'
 
 export default async function AssetsPage() {
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) redirect('/auth/login')
 
-  return <DashboardClient />
+  return (
+    <AuthenticatedLayout>
+      <DashboardClient />
+    </AuthenticatedLayout>
+  )
 }

--- a/app/components/layouts/AuthenticatedLayout.tsx
+++ b/app/components/layouts/AuthenticatedLayout.tsx
@@ -1,0 +1,119 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { createBrowserClient } from '@supabase/ssr'
+import { toast } from 'sonner'
+import { NavigationProvider, useNavigation } from '../navigation/NavigationContext'
+import Sidebar from '../navigation/Sidebar'
+import Header from '../navigation/Header'
+import MobileDrawer from '../navigation/MobileDrawer'
+import { PageTitle } from '../navigation/Breadcrumb'
+
+function getInitials(email: string): string {
+  const parts = email.split('@')[0].split(/[._-]/)
+  return parts
+    .slice(0, 2)
+    .map((p) => p[0]?.toUpperCase() ?? '')
+    .join('')
+    .slice(0, 2) || email[0]?.toUpperCase() || 'U'
+}
+
+interface AuthenticatedLayoutInnerProps {
+  children: React.ReactNode
+  email: string
+  initials: string
+}
+
+function AuthenticatedLayoutInner({ children, email, initials }: AuthenticatedLayoutInnerProps) {
+  const { sidebarCollapsed } = useNavigation()
+  const [drawerOpen, setDrawerOpen] = useState(false)
+
+  return (
+    <div className="flex h-screen bg-gray-50 overflow-hidden">
+      {/* Desktop sidebar */}
+      <div className="hidden lg:flex shrink-0">
+        <Sidebar email={email} initials={initials} />
+      </div>
+
+      {/* Tablet sidebar */}
+      <div className="hidden md:flex lg:hidden shrink-0">
+        <Sidebar email={email} initials={initials} />
+      </div>
+
+      {/* Mobile drawer */}
+      <MobileDrawer
+        open={drawerOpen}
+        onClose={() => setDrawerOpen(false)}
+        email={email}
+        initials={initials}
+      />
+
+      {/* Main area */}
+      <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
+        <Header
+          email={email}
+          initials={initials}
+          onMobileMenuToggle={() => setDrawerOpen(true)}
+        />
+        {/* Mobile page title */}
+        <PageTitle />
+        <main className="flex-1 overflow-y-auto p-6">
+          {children}
+        </main>
+      </div>
+    </div>
+  )
+}
+
+export default function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [ready, setReady] = useState(false)
+
+  useEffect(() => {
+    const supabase = createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    )
+
+    supabase.auth.getSession().then(({ data: { session } }) => {
+      if (!session) {
+        router.push('/auth/login')
+        return
+      }
+      setEmail(session.user.email ?? 'User')
+      setReady(true)
+    })
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
+      if (event === 'SIGNED_OUT' || (!session && event !== 'INITIAL_SESSION')) {
+        toast.error('Session expired. Please log in again.', { duration: 5000 })
+        router.push('/auth/login')
+      }
+    })
+
+    return () => subscription.unsubscribe()
+  }, [router])
+
+  if (!ready) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+        <div className="flex flex-col items-center gap-3">
+          <div className="w-8 h-8 border-4 border-brand border-t-transparent rounded-full animate-spin" />
+          <span className="text-sm text-gray-500">Loading...</span>
+        </div>
+      </div>
+    )
+  }
+
+  const initials = getInitials(email)
+
+  return (
+    <NavigationProvider>
+      <AuthenticatedLayoutInner email={email} initials={initials}>
+        {children}
+      </AuthenticatedLayoutInner>
+    </NavigationProvider>
+  )
+}

--- a/app/components/navigation/Breadcrumb.tsx
+++ b/app/components/navigation/Breadcrumb.tsx
@@ -1,0 +1,68 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { ChevronRight } from 'lucide-react'
+
+const BREADCRUMB_MAP: Record<string, { label: string; parent?: string }> = {
+  '/': { label: 'Home' },
+  '/dashboard': { label: 'Assets Dashboard', parent: '/' },
+  '/planning': { label: 'Monthly Planning', parent: '/' },
+  '/funds': { label: 'Fund Library', parent: '/' },
+  '/settings': { label: 'Settings', parent: '/' },
+}
+
+interface Crumb {
+  label: string
+  href: string
+  current: boolean
+}
+
+function buildCrumbs(pathname: string): Crumb[] {
+  const entry = BREADCRUMB_MAP[pathname]
+  if (!entry) return [{ label: 'Home', href: '/', current: false }, { label: pathname.slice(1), href: pathname, current: true }]
+
+  const crumbs: Crumb[] = []
+  if (entry.parent) {
+    const parent = BREADCRUMB_MAP[entry.parent]
+    if (parent) crumbs.push({ label: parent.label, href: entry.parent, current: false })
+  }
+  crumbs.push({ label: entry.label, href: pathname, current: true })
+  return crumbs
+}
+
+export default function Breadcrumb() {
+  const pathname = usePathname()
+  const crumbs = buildCrumbs(pathname)
+
+  return (
+    <nav aria-label="Breadcrumb" className="hidden md:flex items-center gap-1">
+      {crumbs.map((crumb, i) => (
+        <span key={crumb.href} className="flex items-center gap-1">
+          {i > 0 && <ChevronRight size={12} className="text-gray-400" />}
+          {crumb.current ? (
+            <span aria-current="page" className="text-xs text-gray-400 font-medium">
+              {crumb.label}
+            </span>
+          ) : (
+            <Link href={crumb.href} className="text-xs text-gray-600 hover:text-gray-900 transition-colors">
+              {crumb.label}
+            </Link>
+          )}
+        </span>
+      ))}
+    </nav>
+  )
+}
+
+export function PageTitle() {
+  const pathname = usePathname()
+  const entry = BREADCRUMB_MAP[pathname]
+  const title = entry?.label ?? pathname.slice(1)
+
+  return (
+    <p className="text-sm font-medium text-gray-700 md:hidden px-4 py-2 border-b border-gray-100">
+      {title}
+    </p>
+  )
+}

--- a/app/components/navigation/Header.tsx
+++ b/app/components/navigation/Header.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { Menu, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
+import Breadcrumb from './Breadcrumb'
+import UserMenu from './UserMenu'
+import { useNavigation } from './NavigationContext'
+
+interface HeaderProps {
+  email: string
+  initials: string
+  onMobileMenuToggle: () => void
+}
+
+export default function Header({ email, initials, onMobileMenuToggle }: HeaderProps) {
+  const { sidebarCollapsed, setSidebarCollapsed } = useNavigation()
+
+  return (
+    <header className="h-16 border-b border-gray-200 bg-white flex items-center px-4 gap-4 shrink-0">
+      {/* Mobile hamburger */}
+      <button
+        onClick={onMobileMenuToggle}
+        aria-label="Toggle navigation menu"
+        className="lg:hidden p-1.5 rounded hover:bg-gray-100 transition-colors"
+      >
+        <Menu size={20} />
+      </button>
+
+      {/* Tablet sidebar toggle */}
+      <button
+        onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
+        aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        className="hidden md:flex lg:hidden p-1.5 rounded hover:bg-gray-100 transition-colors"
+      >
+        {sidebarCollapsed ? <PanelLeftOpen size={20} /> : <PanelLeftClose size={20} />}
+      </button>
+
+      {/* Mobile center logo */}
+      <span className="lg:hidden flex-1 text-center text-brand font-bold text-lg tracking-tight">
+        Allocate
+      </span>
+
+      {/* Breadcrumb (desktop/tablet only) */}
+      <div className="hidden md:block flex-1">
+        <Breadcrumb />
+      </div>
+
+      {/* User menu */}
+      <div className="ml-auto">
+        <UserMenu email={email} initials={initials} />
+      </div>
+    </header>
+  )
+}

--- a/app/components/navigation/MobileDrawer.tsx
+++ b/app/components/navigation/MobileDrawer.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+import { X } from 'lucide-react'
+import Sidebar from './Sidebar'
+
+interface MobileDrawerProps {
+  open: boolean
+  onClose: () => void
+  email: string
+  initials: string
+}
+
+export default function MobileDrawer({ open, onClose, email, initials }: MobileDrawerProps) {
+  const drawerRef = useRef<HTMLDivElement>(null)
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    if (open) document.addEventListener('keydown', handleKey)
+    return () => document.removeEventListener('keydown', handleKey)
+  }, [open, onClose])
+
+  // Focus trap
+  useEffect(() => {
+    if (open && drawerRef.current) {
+      const focusable = drawerRef.current.querySelectorAll<HTMLElement>(
+        'a, button, [tabindex]:not([tabindex="-1"])'
+      )
+      if (focusable.length) focusable[0].focus()
+
+      function handleTab(e: KeyboardEvent) {
+        if (e.key !== 'Tab') return
+        const els = Array.from(focusable)
+        const first = els[0]
+        const last = els[els.length - 1]
+        if (e.shiftKey) {
+          if (document.activeElement === first) { e.preventDefault(); last.focus() }
+        } else {
+          if (document.activeElement === last) { e.preventDefault(); first.focus() }
+        }
+      }
+      document.addEventListener('keydown', handleTab)
+      return () => document.removeEventListener('keydown', handleTab)
+    }
+  }, [open])
+
+  if (!open) return null
+
+  return (
+    <div className="fixed inset-0 z-50 lg:hidden">
+      {/* Overlay */}
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      {/* Drawer */}
+      <div
+        ref={drawerRef}
+        className="absolute left-0 top-0 h-full w-[280px] max-w-[90vw] bg-white shadow-xl flex flex-col"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Navigation menu"
+      >
+        <div className="flex items-center justify-between px-4 h-14 border-b border-gray-100">
+          <span className="text-brand font-bold text-xl tracking-tight">Allocate</span>
+          <button
+            onClick={onClose}
+            aria-label="Close navigation menu"
+            className="p-1 rounded hover:bg-gray-100 transition-colors"
+          >
+            <X size={20} />
+          </button>
+        </div>
+        <div className="flex-1 overflow-y-auto">
+          <Sidebar email={email} initials={initials} onNavClick={onClose} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/navigation/NavigationContext.tsx
+++ b/app/components/navigation/NavigationContext.tsx
@@ -1,0 +1,32 @@
+'use client'
+
+import { createContext, useContext, useState } from 'react'
+
+interface NavigationContextValue {
+  sidebarOpen: boolean
+  setSidebarOpen: (open: boolean) => void
+  sidebarCollapsed: boolean
+  setSidebarCollapsed: (collapsed: boolean) => void
+}
+
+const NavigationContext = createContext<NavigationContextValue>({
+  sidebarOpen: false,
+  setSidebarOpen: () => {},
+  sidebarCollapsed: false,
+  setSidebarCollapsed: () => {},
+})
+
+export function NavigationProvider({ children }: { children: React.ReactNode }) {
+  const [sidebarOpen, setSidebarOpen] = useState(false)
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
+
+  return (
+    <NavigationContext.Provider value={{ sidebarOpen, setSidebarOpen, sidebarCollapsed, setSidebarCollapsed }}>
+      {children}
+    </NavigationContext.Provider>
+  )
+}
+
+export function useNavigation() {
+  return useContext(NavigationContext)
+}

--- a/app/components/navigation/Sidebar.tsx
+++ b/app/components/navigation/Sidebar.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { Home, BarChart3, Calendar, BookOpen, Settings } from 'lucide-react'
+import { useNavigation } from './NavigationContext'
+
+const NAV_ITEMS = [
+  { label: 'Home', href: '/', icon: Home },
+  { label: 'Assets Dashboard', href: '/dashboard', icon: BarChart3 },
+  { label: 'Monthly Planning', href: '/planning', icon: Calendar },
+  { label: 'Fund Library', href: '/funds', icon: BookOpen },
+  { label: 'Settings', href: '/settings', icon: Settings },
+]
+
+interface SidebarProps {
+  email: string
+  initials: string
+  onNavClick?: () => void
+}
+
+export default function Sidebar({ email, initials, onNavClick }: SidebarProps) {
+  const pathname = usePathname()
+  const { sidebarCollapsed } = useNavigation()
+
+  return (
+    <nav
+      className={`flex flex-col h-full bg-white border-r border-gray-200 transition-all duration-200 ${
+        sidebarCollapsed ? 'w-16' : 'w-60'
+      }`}
+    >
+      {/* Logo */}
+      <div className={`flex items-center h-16 px-4 border-b border-gray-100 ${sidebarCollapsed ? 'justify-center' : ''}`}>
+        {sidebarCollapsed ? (
+          <span className="text-brand font-bold text-lg">A</span>
+        ) : (
+          <span className="text-brand font-bold text-xl tracking-tight">Allocate</span>
+        )}
+      </div>
+
+      {/* Nav items */}
+      <ul className="flex-1 py-3 space-y-0.5">
+        {NAV_ITEMS.map(({ label, href, icon: Icon }) => {
+          const active = pathname === href
+          return (
+            <li key={href}>
+              <Link
+                href={href}
+                onClick={onNavClick}
+                aria-current={active ? 'page' : undefined}
+                title={sidebarCollapsed ? label : undefined}
+                className={`flex items-center gap-3 h-11 px-3 mx-2 rounded-md border-l-4 transition-colors text-sm font-medium ${
+                  active
+                    ? 'border-brand bg-brand-light text-gray-900 font-semibold'
+                    : 'border-transparent text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                } ${sidebarCollapsed ? 'justify-center px-0 mx-2' : ''}`}
+              >
+                <Icon size={18} className="shrink-0" />
+                {!sidebarCollapsed && <span>{label}</span>}
+              </Link>
+            </li>
+          )
+        })}
+      </ul>
+
+      {/* Profile */}
+      {!sidebarCollapsed && (
+        <div className="flex items-center gap-3 px-4 py-3 border-t border-gray-100">
+          <div className="w-8 h-8 rounded-full bg-brand flex items-center justify-center text-white text-xs font-semibold shrink-0">
+            {initials}
+          </div>
+          <p className="text-xs text-gray-600 truncate">{email}</p>
+        </div>
+      )}
+    </nav>
+  )
+}

--- a/app/components/navigation/UserMenu.tsx
+++ b/app/components/navigation/UserMenu.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import Link from 'next/link'
+import { User, Settings, LogOut } from 'lucide-react'
+import { createBrowserClient } from '@supabase/ssr'
+import { useRouter } from 'next/navigation'
+import { toast } from 'sonner'
+
+interface UserMenuProps {
+  email: string
+  initials: string
+}
+
+export default function UserMenu({ email, initials }: UserMenuProps) {
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const router = useRouter()
+
+  useEffect(() => {
+    function handleClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClick)
+    return () => document.removeEventListener('mousedown', handleClick)
+  }, [])
+
+  async function handleLogout() {
+    setOpen(false)
+    const supabase = createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    )
+    const { error } = await supabase.auth.signOut()
+    if (error) {
+      toast.error('Failed to logout. Please try again.', {
+        action: { label: 'Retry', onClick: handleLogout },
+      })
+    } else {
+      toast.success('Logged out successfully')
+      router.push('/auth/login')
+      router.refresh()
+    }
+  }
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-label="User menu"
+        className="w-8 h-8 rounded-full bg-brand flex items-center justify-center text-white text-xs font-semibold hover:bg-brand-dark transition-colors"
+      >
+        {initials}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-10 w-52 bg-white border border-gray-200 rounded-lg shadow-lg z-50 py-1">
+          <div className="px-3 py-2 border-b border-gray-100">
+            <p className="text-xs text-gray-500 truncate">{email}</p>
+          </div>
+          <Link
+            href="/settings"
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+          >
+            <User size={14} /> Profile
+          </Link>
+          <Link
+            href="/settings"
+            onClick={() => setOpen(false)}
+            className="flex items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+          >
+            <Settings size={14} /> Settings
+          </Link>
+          <button
+            onClick={handleLogout}
+            className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors"
+          >
+            <LogOut size={14} /> Logout
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,71 +1,12 @@
-import { redirect } from 'next/navigation'
-import { createSupabaseServerClient } from '@/lib/supabase-server'
+import AuthenticatedLayout from '@/app/components/layouts/AuthenticatedLayout'
 
-async function logout() {
-  'use server'
-  const supabase = await createSupabaseServerClient()
-  await supabase.auth.signOut()
-  redirect('/auth/login')
-}
-
-export default async function DashboardPage() {
-  const supabase = await createSupabaseServerClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
-
-  if (!user) {
-    redirect('/auth/login')
-  }
-
+export default function DashboardPage() {
   return (
-    <main className="min-h-screen flex flex-col items-center justify-center px-20 py-20">
-      <div className="w-full max-w-2xl space-y-8">
-        <div className="flex items-center justify-between">
-          <h1 className="text-4xl font-bold tracking-tight text-gray-900">Dashboard</h1>
-          <div className="flex items-center gap-3">
-            <span className="text-sm text-gray-500">{user.email}</span>
-            <form action={logout}>
-              <button
-                type="submit"
-                className="text-sm px-3 py-1 bg-gray-100 hover:bg-gray-200 text-gray-700 rounded transition-colors"
-              >
-                Log out
-              </button>
-            </form>
-          </div>
-        </div>
-
-        <div className="bg-white rounded-lg shadow p-6 space-y-3">
-          <h2 className="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-4">
-            Navigation
-          </h2>
-          <a
-            href="/funds"
-            className="flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
-          >
-            📚 Fund Library
-          </a>
-          <a
-            href="/assets"
-            className="flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
-          >
-            📊 Assets Dashboard
-          </a>
-          <a
-            href="/planning"
-            className="flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
-          >
-            📅 Monthly Planning
-          </a>
-          <a
-            href="/settings"
-            className="flex items-center gap-2 text-sm font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
-          >
-            ⚙️ Settings
-          </a>
-        </div>
+    <AuthenticatedLayout>
+      <div className="space-y-6">
+        <h1 className="text-2xl font-bold text-gray-900">Assets Dashboard</h1>
+        <p className="text-gray-500">Your financial overview will appear here.</p>
       </div>
-    </main>
+    </AuthenticatedLayout>
   )
 }

--- a/app/funds/page.tsx
+++ b/app/funds/page.tsx
@@ -1,16 +1,16 @@
 import { redirect } from 'next/navigation'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import FundLibraryClient from './FundLibraryClient'
+import AuthenticatedLayout from '@/app/components/layouts/AuthenticatedLayout'
 
 export default async function FundsPage() {
   const supabase = await createSupabaseServerClient()
-  const {
-    data: { user },
-  } = await supabase.auth.getUser()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/auth/login')
 
-  if (!user) {
-    redirect('/auth/login')
-  }
-
-  return <FundLibraryClient />
+  return (
+    <AuthenticatedLayout>
+      <FundLibraryClient />
+    </AuthenticatedLayout>
+  )
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,11 +3,17 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --brand: #7c3aed;
+  --brand-light: #f3f0ff;
+  --brand-dark: #6d28d9;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-brand: var(--brand);
+  --color-brand-light: var(--brand-light);
+  --color-brand-dark: var(--brand-dark);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
@@ -16,6 +22,9 @@
   :root {
     --background: #0a0a0a;
     --foreground: #ededed;
+    --brand: #a78bfa;
+    --brand-light: #3730a3;
+    --brand-dark: #c4b5fd;
   }
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
+import { Toaster } from 'sonner'
 import './globals.css'
 import AuthProvider from '@/components/AuthProvider'
 
@@ -22,6 +23,7 @@ export default function RootLayout({
     <html lang="en">
       <body className={`${inter.variable} font-sans antialiased bg-gray-50 text-gray-900`}>
         <AuthProvider>{children}</AuthProvider>
+        <Toaster position="top-right" richColors />
       </body>
     </html>
   )

--- a/app/planning/page.tsx
+++ b/app/planning/page.tsx
@@ -1,11 +1,16 @@
 import { redirect } from 'next/navigation'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import PlanningClient from './PlanningClient'
+import AuthenticatedLayout from '@/app/components/layouts/AuthenticatedLayout'
 
 export default async function PlanningPage() {
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) redirect('/auth/login')
 
-  return <PlanningClient />
+  return (
+    <AuthenticatedLayout>
+      <PlanningClient />
+    </AuthenticatedLayout>
+  )
 }

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,11 +1,16 @@
 import { redirect } from 'next/navigation'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import SettingsClient from './SettingsClient'
+import AuthenticatedLayout from '@/app/components/layouts/AuthenticatedLayout'
 
 export default async function SettingsPage() {
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) redirect('/auth/login')
 
-  return <SettingsClient />
+  return (
+    <AuthenticatedLayout>
+      <SettingsClient />
+    </AuthenticatedLayout>
+  )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.99.2",
+        "lucide-react": "^0.577.0",
         "next": "16.1.7",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "sonner": "^2.0.7"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
@@ -5000,6 +5002,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lucide-react": {
+      "version": "0.577.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
+      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -6003,6 +6014,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   "dependencies": {
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.2",
+    "lucide-react": "^0.577.0",
     "next": "16.1.7",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "sonner": "^2.0.7"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",


### PR DESCRIPTION
## Summary
- Persistent 240px sidebar on desktop (lg+) with 5 nav items, active state highlighting, and `aria-current="page"`
- Collapsible sidebar on tablet (md-lg) with 64px icon-only collapsed state and toggle button in header
- Full-screen mobile drawer with hamburger menu, focus trap, Escape key, and overlay close
- Header with breadcrumbs (desktop/tablet), page title (mobile), and UserMenu dropdown (Profile/Settings/Logout)
- `AuthenticatedLayout` wrapping all protected pages with session expiry detection and sonner toasts
- Brand color tokens (`--color-brand`, `--color-brand-light`, `--color-brand-dark`) in globals.css

## Test plan
- [ ] Desktop (≥1024px): sidebar is always visible at 240px, active item highlighted with left border
- [ ] Tablet (768-1023px): sidebar collapses to 64px icons, toggle button in header expands/collapses
- [ ] Mobile (<768px): hamburger opens full-screen drawer, overlay/Escape/nav-click closes it
- [ ] Breadcrumbs visible on tablet+, page title shown below header on mobile
- [ ] User menu dropdown: Profile, Settings, Logout — logout redirects to /auth/login with toast
- [ ] Session expiry: `onAuthStateChange` triggers toast + redirect to /login

🤖 Generated with [Claude Code](https://claude.com/claude-code)