### PR TITLE
feat(nav): remove Home nav item from sidebar, redirect / to /dashboard (REQ-24)

### DIFF
--- a/app/components/navigation/Breadcrumb.tsx
+++ b/app/components/navigation/Breadcrumb.tsx
@@ -4,12 +4,11 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { ChevronRight } from 'lucide-react'
 
-const BREADCRUMB_MAP: Record<string, { label: string; parent?: string }> = {
-  '/': { label: 'Home' },
-  '/dashboard': { label: 'Assets Dashboard', parent: '/' },
-  '/planning': { label: 'Monthly Planning', parent: '/' },
-  '/funds': { label: 'Fund Library', parent: '/' },
-  '/settings': { label: 'Settings', parent: '/' },
+const BREADCRUMB_MAP: Record<string, { label: string }> = {
+  '/dashboard': { label: 'Assets Dashboard' },
+  '/planning': { label: 'Monthly Planning' },
+  '/funds': { label: 'Fund Library' },
+  '/settings': { label: 'Settings' },
 }
 
 interface Crumb {
@@ -20,15 +19,8 @@ interface Crumb {
 
 function buildCrumbs(pathname: string): Crumb[] {
   const entry = BREADCRUMB_MAP[pathname]
-  if (!entry) return [{ label: 'Home', href: '/', current: false }, { label: pathname.slice(1), href: pathname, current: true }]
-
-  const crumbs: Crumb[] = []
-  if (entry.parent) {
-    const parent = BREADCRUMB_MAP[entry.parent]
-    if (parent) crumbs.push({ label: parent.label, href: entry.parent, current: false })
-  }
-  crumbs.push({ label: entry.label, href: pathname, current: true })
-  return crumbs
+  if (!entry) return [{ label: pathname.slice(1), href: pathname, current: true }]
+  return [{ label: entry.label, href: pathname, current: true }]
 }
 
 export default function Breadcrumb() {

--- a/app/components/navigation/Sidebar.tsx
+++ b/app/components/navigation/Sidebar.tsx
@@ -2,11 +2,10 @@
 
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
-import { Home, BarChart3, Calendar, BookOpen, Settings } from 'lucide-react'
+import { BarChart3, Calendar, BookOpen, Settings } from 'lucide-react'
 import { useNavigation } from './NavigationContext'
 
 const NAV_ITEMS = [
-  { label: 'Home', href: '/', icon: Home },
   { label: 'Assets Dashboard', href: '/dashboard', icon: BarChart3 },
   { label: 'Monthly Planning', href: '/planning', icon: Calendar },
   { label: 'Fund Library', href: '/funds', icon: BookOpen },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,7 +32,7 @@ const BENEFITS = [
 export default async function HomePage() {
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
-  if (user) redirect('/assets')
+  if (user) redirect('/dashboard')
 
   return (
     <div className="min-h-screen flex flex-col bg-white text-gray-900">


### PR DESCRIPTION
## Summary
- Remove Home item from sidebar — 4 nav items: Assets Dashboard, Monthly Planning, Fund Library, Settings
- Remove Home as breadcrumb root — each route shows its own label only
- Redirect authenticated users from `/` to `/dashboard` (server-side, no flash)

## Test plan
- [ ] Authenticated: sidebar shows exactly 4 items, no Home
- [ ] Authenticated: visiting `/` redirects immediately to `/dashboard`
- [ ] Unauthenticated: visiting `/` shows landing page
- [ ] Breadcrumbs on each route show only that route's label (no "Home" prefix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)