### PR TITLE
fix: server-side exception and missing insurance_savings migration

### DIFF
--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -12,9 +12,14 @@ export async function createSupabaseServerClient() {
           return cookieStore.getAll()
         },
         setAll(cookiesToSet) {
-          cookiesToSet.forEach(({ name, value, options }) => {
-            cookieStore.set(name, value, options)
-          })
+          try {
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookieStore.set(name, value, options)
+            })
+          } catch {
+            // Called from a Server Component — session refresh cookies are
+            // set by middleware instead, so this error can be safely ignored.
+          }
         },
       },
     }

--- a/supabase/migrations/20260319000001_create_insurance_savings_table.sql
+++ b/supabase/migrations/20260319000001_create_insurance_savings_table.sql
@@ -1,0 +1,18 @@
+-- insurance_savings
+-- Records lump-sum savings contributions towards an insurance member's annual premium.
+CREATE TABLE IF NOT EXISTS insurance_savings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  insurance_member_id UUID NOT NULL REFERENCES insurance_members(member_id) ON DELETE CASCADE,
+  amount_saved_vnd BIGINT NOT NULL CHECK (amount_saved_vnd > 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+ALTER TABLE insurance_savings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "insurance_savings_select" ON insurance_savings
+  FOR SELECT TO authenticated USING (user_id = auth.uid());
+CREATE POLICY "insurance_savings_insert" ON insurance_savings
+  FOR INSERT TO authenticated WITH CHECK (user_id = auth.uid());
+CREATE POLICY "insurance_savings_delete" ON insurance_savings
+  FOR DELETE TO authenticated USING (user_id = auth.uid());


### PR DESCRIPTION
## Summary
- **Fix server-side crash (digest 872718933)**: `supabase-server.ts` was missing a `try-catch` in `setAll()`. When Supabase attempts to refresh an expired session token inside a Server Component, it calls `cookieStore.set()` which Next.js forbids (only allowed in Server Actions/Route Handlers). The crash was silent on login but triggered on session expiry. Added try-catch per the [official Supabase SSR pattern](https://supabase.com/docs/guides/auth/server-side/nextjs).
- **Add missing `insurance_savings` migration**: The table was created manually in Supabase but never committed as a migration file, causing failures in preview deployments and any fresh environment.

## Test plan
- [ ] Merge and verify `allocate-kohl.vercel.app` no longer shows the digest error
- [ ] Verify preview deployments load the dashboard without 400/500 errors
- [ ] Run the migration against Supabase if not already applied: `supabase db push`

🤖 Generated with [Claude Code](https://claude.com/claude-code)