### PR TITLE
feat(insurance): add DELETE and GET savings API endpoints

### DIFF
--- a/app/api/v1/insurance-members/[id]/savings/route.ts
+++ b/app/api/v1/insurance-members/[id]/savings/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 
-export async function GET(_req: NextRequest, { params }: { params: Promise<{ memberId: string }> }) {
-  const { memberId } = await params
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -10,7 +10,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ mem
   const { data, error } = await supabase
     .from('insurance_savings')
     .select('id, amount_saved_vnd, created_at')
-    .eq('insurance_member_id', memberId)
+    .eq('insurance_member_id', id)
     .eq('user_id', user.id)
     .order('created_at', { ascending: false })
 

--- a/app/api/v1/insurance-members/[memberId]/savings/route.ts
+++ b/app/api/v1/insurance-members/[memberId]/savings/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ memberId: string }> }) {
+  const { memberId } = await params
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data, error } = await supabase
+    .from('insurance_savings')
+    .select('id, amount_saved_vnd, created_at')
+    .eq('insurance_member_id', memberId)
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false })
+
+  if (error) return NextResponse.json({ error: 'Failed to fetch savings' }, { status: 500 })
+  return NextResponse.json({ savings: data ?? [] })
+}

--- a/app/api/v1/insurance-savings/[id]/route.ts
+++ b/app/api/v1/insurance-savings/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data: record } = await supabase
+    .from('insurance_savings')
+    .select('id, user_id')
+    .eq('id', id)
+    .single()
+
+  if (!record) return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  if (record.user_id !== user.id) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+
+  const { error } = await supabase.from('insurance_savings').delete().eq('id', id)
+  if (error) return NextResponse.json({ error: 'Failed to delete' }, { status: 500 })
+  return NextResponse.json({ success: true })
+}


### PR DESCRIPTION
## Summary
- Add `DELETE /api/v1/insurance-savings/[id]` — deletes a savings record with 404/403 ownership checks
- Add `GET /api/v1/insurance-members/[memberId]/savings` — lists savings for a member ordered by `created_at DESC`
- Note: `POST /api/v1/insurance-savings` already existed and was not modified

## Test plan
- [ ] `DELETE /api/v1/insurance-savings/[id]` returns 401 when unauthenticated
- [ ] `DELETE /api/v1/insurance-savings/[id]` returns 404 for non-existent record
- [ ] `DELETE /api/v1/insurance-savings/[id]` returns 403 when record belongs to another user
- [ ] `DELETE /api/v1/insurance-savings/[id]` returns `{ success: true }` on success
- [ ] `GET /api/v1/insurance-members/[memberId]/savings` returns 401 when unauthenticated
- [ ] `GET /api/v1/insurance-members/[memberId]/savings` returns `{ savings: [] }` for member with no records
- [ ] `GET /api/v1/insurance-members/[memberId]/savings` returns records ordered by `created_at DESC`

🤖 Generated with [Claude Code](https://claude.com/claude-code)