### PR TITLE
feat(insurance): add Mark as Paid button to InsuranceCard

### DIFF
--- a/app/api/v1/insurance-members/[id]/mark-paid/route.ts
+++ b/app/api/v1/insurance-members/[id]/mark-paid/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+
+export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Authentication required' }, { status: 401 })
+
+  const { data: member } = await supabase
+    .from('insurance_members')
+    .select('member_id, user_id, payment_date')
+    .eq('member_id', id)
+    .single()
+
+  if (!member) return NextResponse.json({ error: 'Unable to find insurance record. Please refresh and try again.' }, { status: 404 })
+  if (member.user_id !== user.id) return NextResponse.json({ error: "You don't have permission to mark this payment" }, { status: 403 })
+
+  if (member.payment_date) {
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    const paymentDate = new Date(member.payment_date)
+    if (paymentDate > today) {
+      return NextResponse.json({ error: 'Payment date has not arrived yet' }, { status: 422 })
+    }
+  }
+
+  // Delete all savings records to reset balance to 0
+  const { error: deleteError } = await supabase
+    .from('insurance_savings')
+    .delete()
+    .eq('insurance_member_id', id)
+    .eq('user_id', user.id)
+
+  if (deleteError) return NextResponse.json({ error: 'An unexpected error occurred. Please try again.' }, { status: 500 })
+
+  return NextResponse.json({
+    data: {
+      member_id: id,
+      amount_saved: 0,
+      payment_date: member.payment_date,
+      last_payment_date: new Date().toISOString().split('T')[0],
+    },
+  })
+}

--- a/app/assets/components/InsuranceCard.tsx
+++ b/app/assets/components/InsuranceCard.tsx
@@ -37,11 +37,14 @@ export default function InsuranceCard({
   const cfg = statusConfig[status]
   const isCompleted = status === 'completed'
   const progress = Math.min(savingsProgressPercentage, 100)
+  const showMarkAsPaid = status === 'upcoming' || status === 'overdue'
 
   const [inputAmount, setInputAmount] = useState('')
   const [savingsList, setSavingsList] = useState<SavingsRecord[]>([])
   const [isLoading, setIsLoading] = useState(false)
   const [toast, setToast] = useState<{ msg: string; type: 'success' | 'error' } | null>(null)
+  const [showConfirm, setShowConfirm] = useState(false)
+  const [markPaidLoading, setMarkPaidLoading] = useState(false)
 
   const showToast = (msg: string, type: 'success' | 'error' = 'success') => {
     setToast({ msg, type })
@@ -57,6 +60,16 @@ export default function InsuranceCard({
   }, [insuranceId])
 
   useEffect(() => { fetchSavings() }, [fetchSavings])
+
+  // Close confirm dialog on Escape
+  useEffect(() => {
+    if (!showConfirm) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setShowConfirm(false)
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [showConfirm])
 
   async function handleAdd() {
     const amount = Number(inputAmount)
@@ -92,6 +105,29 @@ export default function InsuranceCard({
       showToast('Failed to delete', 'error')
     }
     setIsLoading(false)
+  }
+
+  async function handleMarkAsPaid() {
+    setMarkPaidLoading(true)
+    try {
+      const res = await fetch(`/api/v1/insurance-members/${insuranceId}/mark-paid`, { method: 'POST' })
+      if (res.ok) {
+        setShowConfirm(false)
+        showToast('Payment marked! Savings reset to ₫0.')
+        onSavingsChange?.()
+      } else {
+        const body = await res.json().catch(() => ({}))
+        const msg = res.status === 401 ? "You don't have permission to mark this payment. Contact support."
+          : res.status === 422 ? body.error ?? 'Payment is not yet due.'
+          : body.error ?? 'Something went wrong. Please try again.'
+        showToast(msg, 'error')
+        setShowConfirm(false)
+      }
+    } catch {
+      showToast('Connection lost. Please check your internet and try again.', 'error')
+      setShowConfirm(false)
+    }
+    setMarkPaidLoading(false)
   }
 
   return (
@@ -184,6 +220,62 @@ export default function InsuranceCard({
               </li>
             ))}
           </ul>
+        </div>
+      )}
+
+      {/* Mark as Paid */}
+      {showMarkAsPaid && (
+        <div className="border-t border-gray-100 mt-3 pt-3">
+          <button
+            onClick={() => setShowConfirm(true)}
+            className="w-full py-2 bg-indigo-600 text-white text-xs font-medium rounded-lg hover:bg-indigo-700 transition-colors"
+          >
+            Mark as Paid
+          </button>
+        </div>
+      )}
+
+      {/* Confirmation Dialog */}
+      {showConfirm && (
+        <div
+          className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4"
+          onClick={(e) => { if (e.target === e.currentTarget) setShowConfirm(false) }}
+        >
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6">
+            <h3 className="text-base font-semibold text-gray-900 mb-1">Confirm Payment</h3>
+            <p className="text-sm text-gray-600 mb-4">
+              Mark payment as completed for <strong>{insuranceName}</strong>?
+            </p>
+            <div className="bg-gray-50 rounded-lg p-3 mb-4 border-l-4 border-indigo-500">
+              <p className="text-xs text-gray-700 font-medium">{insuranceName}</p>
+              <p className="text-xs text-gray-500 mt-0.5">Annual Payment: {fmt(annualPremium)}</p>
+            </div>
+            <p className="text-xs text-gray-400 mb-5">Your savings balance will be reset to ₫0.</p>
+            <div className="flex gap-3">
+              <button
+                onClick={() => setShowConfirm(false)}
+                disabled={markPaidLoading}
+                className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleMarkAsPaid}
+                disabled={markPaidLoading}
+                className="flex-1 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 disabled:opacity-50 flex items-center justify-center gap-2"
+              >
+                {markPaidLoading ? (
+                  <>
+                    <svg className="animate-spin h-3.5 w-3.5 text-white" fill="none" viewBox="0 0 24 24">
+                      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                    </svg>
+                    Processing...
+                  </>
+                ) : 'Confirm'}
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/insurance-members/[id]/mark-paid` endpoint — validates auth/ownership/date, deletes all savings records to reset balance to ₫0
- Add "Mark as Paid" button to `InsuranceCard` (visible only when status is `upcoming` or `overdue`)
- Confirmation dialog with member info, consequence message, loading state (spinner + "Processing..."), success/error toasts
- Dialog dismissal via Cancel button, Escape key, or clicking outside backdrop

## Test plan
- [ ] Insurance card with upcoming/overdue payment shows "Mark as Paid" button
- [ ] Clicking button opens "Confirm Payment" dialog with member name and annual premium
- [ ] Cancel / Escape / outside-click closes dialog without API call
- [ ] Confirm triggers loading state ("Processing..." + spinner)
- [ ] On success: toast "Payment marked! Savings reset to ₫0." and dashboard refreshes
- [ ] On API error: appropriate error toast shown, button returns to default
- [ ] Card with `on_track` or `completed` status does NOT show the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)