### PR TITLE
fix(dashboard): expand insurance upcoming window from 7 to 30 days

### DIFF
--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -23,11 +23,11 @@ function insuranceStatus(paymentDate: string | null): 'on_track' | 'upcoming' | 
   const payment = new Date(paymentDate)
   const today = new Date()
   today.setHours(0, 0, 0, 0)
-  const sevenDaysLater = new Date(today)
-  sevenDaysLater.setDate(today.getDate() + 7)
+  const thirtyDaysLater = new Date(today)
+  thirtyDaysLater.setDate(today.getDate() + 30)
 
   if (payment < today) return 'overdue'
-  if (payment <= sevenDaysLater) return 'upcoming'
+  if (payment <= thirtyDaysLater) return 'upcoming'
   return 'on_track'
 }
 


### PR DESCRIPTION
## Summary
- Change `insuranceStatus()` threshold from 7 days to 30 days so the `upcoming` status (and "Mark as Paid" button) appears one month before the payment due date

## Test plan
- [ ] Insurance card with payment due within 30 days shows `upcoming` status and "Mark as Paid" button
- [ ] Insurance card with payment due in 31+ days shows `on_track` status, no button

🤖 Generated with [Claude Code](https://claude.com/claude-code)