### PR TITLE
feat(db): add last_payment_date and version to insurance_members

### DIFF
--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -48,7 +48,7 @@ export async function GET() {
       .eq('user_id', user.id),
     supabase
       .from('insurance_members')
-      .select('member_id, member_name, coverage_type, annual_payment_vnd, payment_date')
+      .select('member_id, member_name, coverage_type, annual_payment_vnd, payment_date, last_payment_date')
       .eq('user_id', user.id),
     supabase
       .from('investment_transactions')
@@ -262,6 +262,7 @@ export async function GET() {
       savingsProgressPercentage,
       status,
       nextPaymentDate: m.payment_date ?? null,
+      lastPaymentDate: m.last_payment_date ?? null,
     }
   })
 

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -42,6 +42,7 @@ export interface InsuranceData {
   savingsProgressPercentage: number
   status: 'on_track' | 'upcoming' | 'overdue' | 'completed'
   nextPaymentDate: string | null
+  lastPaymentDate: string | null
 }
 
 export interface DashboardData {

--- a/app/assets/components/InsuranceCard.tsx
+++ b/app/assets/components/InsuranceCard.tsx
@@ -20,6 +20,7 @@ interface Props {
   savingsProgressPercentage: number
   status: 'on_track' | 'upcoming' | 'overdue' | 'completed'
   nextPaymentDate: string | null
+  lastPaymentDate: string | null
   onSavingsChange?: () => void
 }
 
@@ -32,7 +33,7 @@ const statusConfig = {
 
 export default function InsuranceCard({
   insuranceId, insuranceName, coverageType, annualPremium, amountSaved,
-  savingsProgressPercentage, status, nextPaymentDate, onSavingsChange,
+  savingsProgressPercentage, status, nextPaymentDate, lastPaymentDate, onSavingsChange,
 }: Props) {
   const cfg = statusConfig[status]
   const isCompleted = status === 'completed'
@@ -169,6 +170,11 @@ export default function InsuranceCard({
       {nextPaymentDate && !isCompleted && (
         <p className="text-xs text-gray-400 mt-2">
           Next payment: {new Date(nextPaymentDate).toLocaleDateString('vi-VN')}
+        </p>
+      )}
+      {lastPaymentDate && (
+        <p className="text-xs text-gray-400 mt-0.5">
+          Last paid: {new Date(lastPaymentDate).toLocaleDateString('vi-VN')}
         </p>
       )}
 

--- a/supabase/migrations/20260319000001_add_insurance_last_payment_date.sql
+++ b/supabase/migrations/20260319000001_add_insurance_last_payment_date.sql
@@ -1,0 +1,15 @@
+-- Add last_payment_date and version columns to insurance_members
+-- last_payment_date: records when a payment was last marked as paid (REQ-32)
+-- version: optimistic concurrency control for concurrent mark-paid requests
+
+ALTER TABLE insurance_members
+ADD COLUMN last_payment_date TIMESTAMP WITH TIME ZONE DEFAULT NULL,
+ADD COLUMN version INTEGER NOT NULL DEFAULT 0;
+
+-- Index for efficient sorting/filtering by most recent payment date
+CREATE INDEX idx_insurance_members_last_payment_date
+ON insurance_members (last_payment_date DESC NULLS LAST);
+
+-- Rollback:
+-- DROP INDEX idx_insurance_members_last_payment_date;
+-- ALTER TABLE insurance_members DROP COLUMN last_payment_date, DROP COLUMN version;


### PR DESCRIPTION
## Summary
- **Migration** `20260319000001`: adds `last_payment_date TIMESTAMPTZ NULL` and `version INT NOT NULL DEFAULT 0` to `insurance_members`, plus B-tree index `idx_insurance_members_last_payment_date (last_payment_date DESC NULLS LAST)`
- **Dashboard API**: SELECTs `last_payment_date` from `insurance_members`, includes `lastPaymentDate` in insurance output
- **InsuranceCard**: accepts `lastPaymentDate` prop, shows "Last paid: [date]" when not null, hidden when null
- **DashboardClient**: `InsuranceData` type updated with `lastPaymentDate: string | null`

**Enables REQ-32**: the mark-paid endpoint's `last_payment_date` update now works (column exists — graceful-skip branch no longer fires).

## Test plan
- [ ] Apply migration: verify `last_payment_date` and `version` columns exist on `insurance_members`
- [ ] Existing members have `last_payment_date = NULL` after migration
- [ ] Call mark-paid endpoint → `last_payment_date` updates to today in DB
- [ ] InsuranceCard shows "Last paid: [date]" after mark-paid
- [ ] InsuranceCard shows nothing for last payment date for new/unpaid members

🤖 Generated with [Claude Code](https://claude.com/claude-code)