### PR TITLE
feat: dark mode across all pages + Edit/Delete for planning sections

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -203,18 +203,18 @@ export default function DashboardClient() {
   const detailFund = fundDetailId ? allFunds.find((f) => f.fundId === fundDetailId) : null
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       <div className="max-w-6xl mx-auto px-4 py-8">
         {/* Header */}
         <div className="flex items-center justify-between mb-8 flex-wrap gap-3">
-          <h1 className="text-2xl font-bold text-gray-900">Assets Dashboard</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Assets Dashboard</h1>
           <div className="flex items-center gap-3 flex-wrap">
             {/* Sort dropdown */}
             {!loading && data && (
               <select
                 value={sortOrder}
                 onChange={(e) => handleSortChange(e.target.value as SortOrder)}
-                className="text-sm border border-gray-200 rounded-lg px-3 py-1.5 bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                className="text-sm border border-gray-200 dark:border-gray-600 rounded-lg px-3 py-1.5 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
               >
                 <option value="manual">Manual Order</option>
                 <option value="progress-desc">Progress: High to Low</option>
@@ -234,9 +234,9 @@ export default function DashboardClient() {
 
         {/* Error state */}
         {error && (
-          <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-xl flex items-center justify-between">
-            <p className="text-sm text-red-700">{error}</p>
-            <button onClick={fetchData} className="text-sm text-red-600 font-medium hover:underline ml-4">Retry</button>
+          <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl flex items-center justify-between">
+            <p className="text-sm text-red-700 dark:text-red-400">{error}</p>
+            <button onClick={fetchData} className="text-sm text-red-600 dark:text-red-400 font-medium hover:underline ml-4">Retry</button>
           </div>
         )}
 
@@ -259,13 +259,13 @@ export default function DashboardClient() {
         {!loading && !error && isEmpty && (
           <div className="flex flex-col items-center py-16 px-4">
             {/* Icon */}
-            <div className="w-20 h-20 rounded-2xl bg-indigo-50 flex items-center justify-center mb-6">
+            <div className="w-20 h-20 rounded-2xl bg-indigo-50 dark:bg-indigo-900/20 flex items-center justify-center mb-6">
               <span className="text-4xl">📊</span>
             </div>
 
             {/* Title & description */}
-            <h2 className="text-2xl font-bold text-gray-900 mb-2">No Assets Yet</h2>
-            <p className="text-gray-500 text-center max-w-sm mb-10">
+            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">No Assets Yet</h2>
+            <p className="text-gray-500 dark:text-gray-400 text-center max-w-sm mb-10">
               Start by adding financial goals, investment funds, or insurance to track your wealth.
             </p>
 
@@ -279,25 +279,25 @@ export default function DashboardClient() {
                 <a
                   key={title}
                   href="/settings"
-                  className="flex items-center gap-4 bg-white border border-gray-100 rounded-xl px-5 py-4 shadow-sm hover:shadow-md hover:border-indigo-100 transition-all group"
+                  className="flex items-center gap-4 bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-700 rounded-xl px-5 py-4 shadow-sm hover:shadow-md hover:border-indigo-100 dark:hover:border-indigo-700 transition-all group"
                 >
-                  <div className="w-10 h-10 rounded-lg bg-indigo-50 flex items-center justify-center flex-shrink-0 text-xl">
+                  <div className="w-10 h-10 rounded-lg bg-indigo-50 dark:bg-indigo-900/20 flex items-center justify-center flex-shrink-0 text-xl">
                     {icon}
                   </div>
                   <div className="flex-1 min-w-0">
-                    <p className="font-semibold text-gray-900 text-sm">{title}</p>
-                    <p className="text-xs text-gray-500 mt-0.5">{desc}</p>
+                    <p className="font-semibold text-gray-900 dark:text-gray-100 text-sm">{title}</p>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{desc}</p>
                   </div>
-                  <span className="text-gray-300 group-hover:text-indigo-500 transition-colors text-lg">→</span>
+                  <span className="text-gray-300 dark:text-gray-600 group-hover:text-indigo-500 transition-colors text-lg">→</span>
                 </a>
               ))}
             </div>
 
             {/* Divider + Settings button */}
             <div className="flex items-center gap-3 w-full max-w-md mb-5">
-              <div className="flex-1 h-px bg-gray-200" />
-              <span className="text-xs text-gray-400 whitespace-nowrap">Or manage everything in</span>
-              <div className="flex-1 h-px bg-gray-200" />
+              <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
+              <span className="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">Or manage everything in</span>
+              <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
             </div>
             <a
               href="/settings"
@@ -317,7 +317,7 @@ export default function DashboardClient() {
             {/* Goals */}
             {sortedGoals.length > 0 && (
               <section>
-                <h2 className="text-lg font-semibold text-gray-900 mb-4">Goals</h2>
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Goals</h2>
                 <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                   {sortedGoals.map((goal) => (
                     <GoalCard
@@ -342,7 +342,7 @@ export default function DashboardClient() {
             {/* Insurance */}
             {data.insurance.length > 0 && (
               <section>
-                <h2 className="text-lg font-semibold text-gray-900 mb-4">Insurance</h2>
+                <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Insurance</h2>
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                   {data.insurance.map((ins) => (
                     <InsuranceCard key={ins.insuranceId} {...ins} onSavingsChange={fetchData} />

--- a/app/assets/components/FundDetailModal.tsx
+++ b/app/assets/components/FundDetailModal.tsx
@@ -43,13 +43,13 @@ export default function FundDetailModal({
       className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4"
       onClick={(e) => { if (e.target === overlayRef.current) onClose() }}
     >
-      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg max-h-[90vh] flex flex-col">
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-lg max-h-[90vh] flex flex-col">
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 flex-shrink-0">
-          <h2 className="text-lg font-semibold text-gray-900">{fundName}</h2>
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-gray-700 flex-shrink-0">
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{fundName}</h2>
           <button
             onClick={onClose}
-            className="text-gray-400 hover:text-gray-600 text-xl leading-none w-8 h-8 flex items-center justify-center rounded-lg hover:bg-gray-100"
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-xl leading-none w-8 h-8 flex items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800"
             aria-label="Close"
           >
             ×
@@ -60,27 +60,27 @@ export default function FundDetailModal({
         <div className="overflow-y-auto flex-1 px-6 py-5 space-y-5">
           {/* Summary stats */}
           <div className="grid grid-cols-2 gap-4">
-            <div className="bg-gray-50 rounded-lg p-3">
-              <p className="text-xs text-gray-400 mb-1">Current NAV</p>
-              <p className="text-sm font-semibold text-gray-900">{fmt(currentNAV)}</p>
+            <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3">
+              <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">Current NAV</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{fmt(currentNAV)}</p>
             </div>
-            <div className="bg-gray-50 rounded-lg p-3">
-              <p className="text-xs text-gray-400 mb-1">Units Held</p>
-              <p className="text-sm font-semibold text-gray-900">{quantity.toLocaleString('vi-VN')}</p>
+            <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3">
+              <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">Units Held</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{quantity.toLocaleString('vi-VN')}</p>
             </div>
-            <div className="bg-gray-50 rounded-lg p-3">
-              <p className="text-xs text-gray-400 mb-1">Current Value</p>
-              <p className="text-sm font-semibold text-gray-900">{fmt(currentValue)}</p>
+            <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3">
+              <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">Current Value</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{fmt(currentValue)}</p>
             </div>
-            <div className="bg-gray-50 rounded-lg p-3">
-              <p className="text-xs text-gray-400 mb-1">Avg Entry Price</p>
-              <p className="text-sm font-semibold text-gray-900">{fmt(purchasePrice)}</p>
+            <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3">
+              <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">Avg Entry Price</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{fmt(purchasePrice)}</p>
             </div>
           </div>
 
           {/* P&L */}
-          <div className={`rounded-lg p-4 ${plPositive ? 'bg-green-50' : 'bg-red-50'}`}>
-            <p className="text-xs text-gray-500 mb-1">Total Gain / Loss</p>
+          <div className={`rounded-lg p-4 ${plPositive ? 'bg-green-50 dark:bg-green-900/20' : 'bg-red-50 dark:bg-red-900/20'}`}>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-1">Total Gain / Loss</p>
             <p className={`text-xl font-bold ${plPositive ? 'text-green-700' : 'text-red-700'}`}>
               {fmt(profitLoss)}
             </p>
@@ -92,21 +92,21 @@ export default function FundDetailModal({
           {/* Purchase history */}
           {purchaseHistory.length > 0 && (
             <div>
-              <h3 className="text-sm font-semibold text-gray-700 mb-3">Purchase History</h3>
+              <h3 className="text-sm font-semibold text-gray-700 dark:text-gray-300 mb-3">Purchase History</h3>
               <table className="w-full text-sm">
-                <thead className="bg-gray-50">
+                <thead className="bg-gray-50 dark:bg-gray-800">
                   <tr>
                     {['Date', 'Units', 'NAV at Purchase'].map((h) => (
-                      <th key={h} className="px-3 py-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">{h}</th>
+                      <th key={h} className="px-3 py-2 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">{h}</th>
                     ))}
                   </tr>
                 </thead>
-                <tbody className="divide-y divide-gray-50">
+                <tbody className="divide-y divide-gray-50 dark:divide-gray-700">
                   {purchaseHistory.map((row, i) => (
                     <tr key={i}>
-                      <td className="px-3 py-2 text-gray-600">{new Date(row.purchase_date).toLocaleDateString('vi-VN')}</td>
-                      <td className="px-3 py-2 text-gray-600">{row.units}</td>
-                      <td className="px-3 py-2 text-gray-600">{fmt(row.nav_at_purchase)}</td>
+                      <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{new Date(row.purchase_date).toLocaleDateString('vi-VN')}</td>
+                      <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{row.units}</td>
+                      <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{fmt(row.nav_at_purchase)}</td>
                     </tr>
                   ))}
                 </tbody>

--- a/app/assets/components/GoalCard.tsx
+++ b/app/assets/components/GoalCard.tsx
@@ -26,19 +26,19 @@ export default function GoalCard({
 
   return (
     <div
-      className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden cursor-pointer hover:border-indigo-200 hover:shadow-md transition-all"
+      className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden cursor-pointer hover:border-indigo-200 dark:hover:border-indigo-700 hover:shadow-md transition-all"
       onClick={() => router.push(`/savings-goals/${goalId}`)}
     >
       <div className="p-5">
         <div className="flex items-start justify-between mb-2">
-          <h3 className="font-semibold text-gray-900 text-sm">{goalName}</h3>
-          <span className="text-gray-300 text-sm ml-2">→</span>
+          <h3 className="font-semibold text-gray-900 dark:text-gray-100 text-sm">{goalName}</h3>
+          <span className="text-gray-300 dark:text-gray-600 text-sm ml-2">→</span>
         </div>
 
-        <p className="text-2xl font-bold text-gray-900 mb-1">{fmt(currentValue)}</p>
+        <p className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-1">{fmt(currentValue)}</p>
 
         <div className="flex items-center gap-2 mb-3">
-          <span className="text-xs text-gray-400">P&amp;L</span>
+          <span className="text-xs text-gray-400 dark:text-gray-500">P&amp;L</span>
           <span className={`text-xs font-medium ${plPositive ? 'text-green-600' : 'text-red-600'}`}>
             {fmt(profitLoss)} ({fmtPct(profitLossPercentage)})
           </span>
@@ -46,14 +46,14 @@ export default function GoalCard({
 
         {targetAmount != null && (
           <div>
-            <div className="flex items-center justify-between text-xs text-gray-400 mb-1">
+            <div className="flex items-center justify-between text-xs text-gray-400 dark:text-gray-500 mb-1">
               <span>Target: {fmt(targetAmount)}</span>
               {exceededTarget
                 ? <span className="text-green-600 font-medium">Target exceeded</span>
                 : <span>{Math.round(progressPercentage ?? 0)}%</span>
               }
             </div>
-            <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
+            <div className="h-1.5 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
               <div
                 className={`h-full rounded-full transition-all ${exceededTarget ? 'bg-green-500' : 'bg-indigo-500'}`}
                 style={{ width: `${Math.min(progressPercentage ?? 0, 100)}%` }}
@@ -63,7 +63,7 @@ export default function GoalCard({
         )}
 
         {targetAmount == null && currentValue === 0 && (
-          <p className="text-xs text-gray-400">No transactions yet</p>
+          <p className="text-xs text-gray-400 dark:text-gray-500">No transactions yet</p>
         )}
       </div>
     </div>

--- a/app/assets/components/GoalPickerModal.tsx
+++ b/app/assets/components/GoalPickerModal.tsx
@@ -38,16 +38,16 @@ export default function GoalPickerModal({ fundName, goals, onConfirm, onCancel, 
       className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4"
       onClick={(e) => { if (e.target === overlayRef.current && !isLoading) onCancel() }}
     >
-      <div className="bg-white rounded-xl shadow-xl w-full max-w-sm max-h-[90vh] flex flex-col">
-        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 flex-shrink-0">
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm max-h-[90vh] flex flex-col">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-100 dark:border-gray-700 flex-shrink-0">
           <div>
-            <h2 className="text-base font-semibold text-gray-900">Assign to Goal</h2>
-            <p className="text-xs text-gray-400 mt-0.5">{fundName}</p>
+            <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">Assign to Goal</h2>
+            <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{fundName}</p>
           </div>
           <button
             onClick={onCancel}
             disabled={isLoading}
-            className="text-gray-400 hover:text-gray-600 text-xl leading-none w-8 h-8 flex items-center justify-center rounded-lg hover:bg-gray-100 disabled:opacity-50"
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 text-xl leading-none w-8 h-8 flex items-center justify-center rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-50"
             aria-label="Close"
           >
             ×
@@ -56,27 +56,27 @@ export default function GoalPickerModal({ fundName, goals, onConfirm, onCancel, 
 
         {error && (
           <div className="px-6 pt-4">
-            <p className="text-xs text-red-600 bg-red-50 rounded-lg px-3 py-2">{error}</p>
+            <p className="text-xs text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 rounded-lg px-3 py-2">{error}</p>
           </div>
         )}
 
         <div className="overflow-y-auto flex-1 px-2 py-2">
           {goals.length === 0 ? (
-            <p className="text-sm text-gray-400 text-center py-6">No goals available</p>
+            <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-6">No goals available</p>
           ) : (
             goals.map((goal) => (
               <button
                 key={goal.id}
                 onClick={() => setSelected(goal.id)}
                 className={`w-full text-left px-4 py-3 rounded-lg mb-1 transition-colors min-h-[44px] ${
-                  selected === goal.id ? 'bg-indigo-50 border border-indigo-300' : 'hover:bg-gray-50 border border-transparent'
+                  selected === goal.id ? 'bg-indigo-50 dark:bg-indigo-900/20 border border-indigo-300 dark:border-indigo-700' : 'hover:bg-gray-50 dark:hover:bg-gray-800 border border-transparent'
                 }`}
               >
-                <p className="text-sm font-medium text-gray-900">{goal.name}</p>
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{goal.name}</p>
                 <div className="flex items-center gap-3 mt-0.5">
-                  <span className="text-xs text-gray-400">Target: {fmt(goal.targetAmount)}</span>
+                  <span className="text-xs text-gray-400 dark:text-gray-500">Target: {fmt(goal.targetAmount)}</span>
                   {goal.progressPercent != null && (
-                    <span className="text-xs text-gray-400">{Math.round(goal.progressPercent)}% complete</span>
+                    <span className="text-xs text-gray-400 dark:text-gray-500">{Math.round(goal.progressPercent)}% complete</span>
                   )}
                 </div>
               </button>
@@ -84,11 +84,11 @@ export default function GoalPickerModal({ fundName, goals, onConfirm, onCancel, 
           )}
         </div>
 
-        <div className="flex gap-3 px-6 py-4 border-t border-gray-100 flex-shrink-0">
+        <div className="flex gap-3 px-6 py-4 border-t border-gray-100 dark:border-gray-700 flex-shrink-0">
           <button
             onClick={onCancel}
             disabled={isLoading}
-            className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50 min-h-[44px]"
+            className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50 min-h-[44px]"
           >
             Cancel
           </button>

--- a/app/assets/components/InsuranceCard.tsx
+++ b/app/assets/components/InsuranceCard.tsx
@@ -15,7 +15,6 @@ const fmtDate = (dateStr: string): string => {
   }
 }
 
-// Compute display status from raw payment date using user's local timezone
 type DisplayStatus = 'overdue' | 'due' | 'not_due_yet'
 
 function computeDisplayStatus(nextPaymentDate: string | null): DisplayStatus {
@@ -24,7 +23,6 @@ function computeDisplayStatus(nextPaymentDate: string | null): DisplayStatus {
     const payment = new Date(nextPaymentDate)
     if (isNaN(payment.getTime())) return 'not_due_yet'
     const now = new Date()
-    // Normalise both to local midnight so hour-of-day doesn't affect the result
     const todayMs = new Date(now.getFullYear(), now.getMonth(), now.getDate()).getTime()
     const paymentMs = new Date(payment.getFullYear(), payment.getMonth(), payment.getDate()).getTime()
     if (paymentMs < todayMs) return 'overdue'
@@ -55,10 +53,10 @@ interface Props {
 }
 
 const statusConfig: Record<DisplayStatus | 'completed', { label: string; className: string; icon?: boolean }> = {
-  not_due_yet: { label: 'Not Due Yet', className: 'bg-green-100 text-green-700' },
-  due: { label: 'Due', className: 'bg-yellow-100 text-yellow-700' },
-  overdue: { label: 'Overdue', className: 'bg-red-100 text-red-700', icon: true },
-  completed: { label: 'Completed', className: 'bg-gray-100 text-gray-500' },
+  not_due_yet: { label: 'Not Due Yet', className: 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400' },
+  due: { label: 'Due', className: 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400' },
+  overdue: { label: 'Overdue', className: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400', icon: true },
+  completed: { label: 'Completed', className: 'bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400' },
 }
 
 export default function InsuranceCard({
@@ -69,7 +67,6 @@ export default function InsuranceCard({
   const displayStatus: DisplayStatus | 'completed' = isCompleted ? 'completed' : computeDisplayStatus(nextPaymentDate)
   const cfg = statusConfig[displayStatus]
   const progress = Math.min(savingsProgressPercentage, 100)
-  // Use server-side status for button — preserves the 30-day upcoming window from PR #17
   const showMarkAsPaid = status === 'upcoming' || status === 'overdue'
 
   const [inputAmount, setInputAmount] = useState('')
@@ -94,7 +91,6 @@ export default function InsuranceCard({
 
   useEffect(() => { fetchSavings() }, [fetchSavings])
 
-  // Close confirm dialog on Escape
   useEffect(() => {
     if (!showConfirm) return
     function onKey(e: KeyboardEvent) {
@@ -164,10 +160,10 @@ export default function InsuranceCard({
   }
 
   return (
-    <div className={`bg-white rounded-xl shadow-sm border border-gray-100 p-5 ${isCompleted ? 'opacity-60' : ''}`}>
+    <div className={`bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-5 ${isCompleted ? 'opacity-60' : ''}`}>
       {/* Header */}
       <div className="flex items-start justify-between mb-1">
-        <h3 className="font-semibold text-gray-900 text-sm">{insuranceName}</h3>
+        <h3 className="font-semibold text-gray-900 dark:text-gray-100 text-sm">{insuranceName}</h3>
         <span className={`inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full ${cfg.className}`}>
           {cfg.icon && <TriangleAlert size={11} />}
           {cfg.label}
@@ -175,54 +171,54 @@ export default function InsuranceCard({
       </div>
 
       {coverageType && (
-        <p className="text-xs text-gray-400 mb-3">{coverageType}</p>
+        <p className="text-xs text-gray-400 dark:text-gray-500 mb-3">{coverageType}</p>
       )}
 
       <div className="grid grid-cols-2 gap-3 mb-3 text-xs">
         <div>
-          <p className="text-gray-400 mb-0.5">Annual Premium</p>
-          <p className="font-medium text-gray-800">{fmt(annualPremium)}</p>
+          <p className="text-gray-400 dark:text-gray-500 mb-0.5">Annual Premium</p>
+          <p className="font-medium text-gray-800 dark:text-gray-200">{fmt(annualPremium)}</p>
         </div>
         <div>
-          <p className="text-gray-400 mb-0.5">Amount Saved</p>
-          <p className="font-medium text-gray-800">{fmt(amountSaved)}</p>
+          <p className="text-gray-400 dark:text-gray-500 mb-0.5">Amount Saved</p>
+          <p className="font-medium text-gray-800 dark:text-gray-200">{fmt(amountSaved)}</p>
         </div>
       </div>
 
       <div>
-        <div className="flex items-center justify-between text-xs text-gray-400 mb-1">
+        <div className="flex items-center justify-between text-xs text-gray-400 dark:text-gray-500 mb-1">
           <span>Savings Progress</span>
           <span>{Math.round(progress)}%</span>
         </div>
-        <div className="h-1.5 bg-gray-100 rounded-full overflow-hidden">
+        <div className="h-1.5 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
           <div
-            className={`h-full rounded-full ${isCompleted ? 'bg-gray-400' : 'bg-indigo-500'}`}
+            className={`h-full rounded-full ${isCompleted ? 'bg-gray-400 dark:bg-gray-500' : 'bg-indigo-500'}`}
             style={{ width: `${progress}%` }}
           />
         </div>
       </div>
 
       {nextPaymentDate && !isCompleted && (
-        <p className="text-xs text-gray-400 mt-2">
+        <p className="text-xs text-gray-400 dark:text-gray-500 mt-2">
           Next Due: {fmtDate(nextPaymentDate)}
         </p>
       )}
       {lastPaymentDate && (
-        <p className="text-xs text-gray-400 mt-0.5">
+        <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">
           Last Paid: {fmtDate(lastPaymentDate)}
         </p>
       )}
 
       {/* Toast */}
       {toast && (
-        <p className={`text-xs mt-2 ${toast.type === 'error' ? 'text-red-600' : 'text-green-600'}`}>
+        <p className={`text-xs mt-2 ${toast.type === 'error' ? 'text-red-600 dark:text-red-400' : 'text-green-600 dark:text-green-400'}`}>
           {toast.msg}
         </p>
       )}
 
       {/* Add Savings */}
-      <div className="border-t border-gray-100 mt-3 pt-3">
-        <p className="text-xs font-medium text-gray-600 mb-2">Add Savings</p>
+      <div className="border-t border-gray-100 dark:border-gray-700 mt-3 pt-3">
+        <p className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">Add Savings</p>
         <div className="flex gap-2">
           <input
             type="number"
@@ -230,7 +226,7 @@ export default function InsuranceCard({
             onChange={(e) => setInputAmount(e.target.value)}
             onKeyDown={(e) => e.key === 'Enter' && handleAdd()}
             placeholder="Enter amount (VND)"
-            className="flex-1 min-w-0 border border-gray-300 rounded-lg px-3 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="flex-1 min-w-0 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-xs bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
           <button
             onClick={handleAdd}
@@ -244,16 +240,16 @@ export default function InsuranceCard({
 
       {/* Savings Records */}
       {savingsList.length > 0 && (
-        <div className="border-t border-gray-100 mt-3 pt-3">
-          <p className="text-xs font-medium text-gray-600 mb-2">Savings Records</p>
+        <div className="border-t border-gray-100 dark:border-gray-700 mt-3 pt-3">
+          <p className="text-xs font-medium text-gray-600 dark:text-gray-400 mb-2">Savings Records</p>
           <ul className="space-y-1.5">
             {savingsList.map((s) => (
               <li key={s.id} className="flex items-center justify-between">
-                <span className="text-xs text-gray-700">{fmt(s.amount_saved_vnd)}</span>
+                <span className="text-xs text-gray-700 dark:text-gray-300">{fmt(s.amount_saved_vnd)}</span>
                 <button
                   onClick={() => handleDelete(s.id)}
                   disabled={isLoading}
-                  className="text-gray-300 hover:text-red-500 disabled:opacity-40 transition-colors"
+                  className="text-gray-300 dark:text-gray-600 hover:text-red-500 dark:hover:text-red-400 disabled:opacity-40 transition-colors"
                   aria-label="Delete"
                 >
                   <Trash2 size={13} />
@@ -266,7 +262,7 @@ export default function InsuranceCard({
 
       {/* Mark as Paid */}
       {showMarkAsPaid && (
-        <div className="border-t border-gray-100 mt-3 pt-3">
+        <div className="border-t border-gray-100 dark:border-gray-700 mt-3 pt-3">
           <button
             onClick={() => setShowConfirm(true)}
             className="w-full py-2 bg-indigo-600 text-white text-xs font-medium rounded-lg hover:bg-indigo-700 transition-colors"
@@ -282,21 +278,21 @@ export default function InsuranceCard({
           className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4"
           onClick={(e) => { if (e.target === e.currentTarget) setShowConfirm(false) }}
         >
-          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6">
-            <h3 className="text-base font-semibold text-gray-900 mb-1">Confirm Payment</h3>
-            <p className="text-sm text-gray-600 mb-4">
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm p-6 border border-gray-100 dark:border-gray-700">
+            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">Confirm Payment</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
               Mark payment as completed for <strong>{insuranceName}</strong>?
             </p>
-            <div className="bg-gray-50 rounded-lg p-3 mb-4 border-l-4 border-indigo-500">
-              <p className="text-xs text-gray-700 font-medium">{insuranceName}</p>
-              <p className="text-xs text-gray-500 mt-0.5">Annual Payment: {fmt(annualPremium)}</p>
+            <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3 mb-4 border-l-4 border-indigo-500">
+              <p className="text-xs text-gray-700 dark:text-gray-300 font-medium">{insuranceName}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Annual Payment: {fmt(annualPremium)}</p>
             </div>
-            <p className="text-xs text-gray-400 mb-5">Your savings balance will be reset to ₫0.</p>
+            <p className="text-xs text-gray-400 dark:text-gray-500 mb-5">Your savings balance will be reset to ₫0.</p>
             <div className="flex gap-3">
               <button
                 onClick={() => setShowConfirm(false)}
                 disabled={markPaidLoading}
-                className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50 disabled:opacity-50"
+                className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50"
               >
                 Cancel
               </button>

--- a/app/assets/components/NetWorthCard.tsx
+++ b/app/assets/components/NetWorthCard.tsx
@@ -19,34 +19,34 @@ export default function NetWorthCard({
   const plPositive = overallProfitLoss >= 0
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
-      <p className="text-sm font-medium text-gray-500 mb-1">Net Worth</p>
-      <p className="text-4xl font-bold text-gray-900 mb-6">{fmt(netWorth)}</p>
+    <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6">
+      <p className="text-sm font-medium text-gray-500 dark:text-gray-400 mb-1">Net Worth</p>
+      <p className="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-6">{fmt(netWorth)}</p>
 
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 border-t border-gray-100 pt-5">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 border-t border-gray-100 dark:border-gray-700 pt-5">
         <div>
-          <p className="text-xs text-gray-400 mb-1">Total Assets</p>
-          <p className="text-sm font-semibold text-gray-800">{fmt(totalAssets)}</p>
+          <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">Total Assets</p>
+          <p className="text-sm font-semibold text-gray-800 dark:text-gray-200">{fmt(totalAssets)}</p>
         </div>
         <div>
-          <p className="text-xs text-gray-400 mb-1">Total Liabilities</p>
-          <p className="text-sm font-semibold text-gray-800">{fmt(totalLiabilities)}</p>
+          <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">Total Liabilities</p>
+          <p className="text-sm font-semibold text-gray-800 dark:text-gray-200">{fmt(totalLiabilities)}</p>
         </div>
         <div>
-          <p className="text-xs text-gray-400 mb-1">
+          <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">
             Portfolio Value
             {navStale && <span title="NAV data may be stale" className="ml-1 text-amber-500">⚠️</span>}
           </p>
-          <p className="text-sm font-semibold text-gray-800">{fmt(currentValue)}</p>
+          <p className="text-sm font-semibold text-gray-800 dark:text-gray-200">{fmt(currentValue)}</p>
         </div>
         <div>
-          <p className="text-xs text-gray-400 mb-1">Total Invested</p>
-          <p className="text-sm font-semibold text-gray-800">{fmt(totalInvested)}</p>
+          <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">Total Invested</p>
+          <p className="text-sm font-semibold text-gray-800 dark:text-gray-200">{fmt(totalInvested)}</p>
         </div>
       </div>
 
       <div className="mt-4 flex items-center gap-2">
-        <span className="text-xs text-gray-400">Overall P&amp;L</span>
+        <span className="text-xs text-gray-400 dark:text-gray-500">Overall P&amp;L</span>
         <span className={`text-sm font-semibold ${plPositive ? 'text-green-600' : 'text-red-600'}`}>
           {fmt(overallProfitLoss)} ({fmtPct(overallProfitLossPercentage)})
         </span>

--- a/app/assets/components/Skeletons.tsx
+++ b/app/assets/components/Skeletons.tsx
@@ -1,13 +1,13 @@
 export function NetWorthSkeleton() {
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 animate-pulse">
-      <div className="h-4 bg-gray-200 rounded w-24 mb-4" />
-      <div className="h-10 bg-gray-200 rounded w-48 mb-6" />
+    <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6 animate-pulse">
+      <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-24 mb-4" />
+      <div className="h-10 bg-gray-200 dark:bg-gray-700 rounded w-48 mb-6" />
       <div className="grid grid-cols-3 gap-4">
         {[0, 1, 2].map((i) => (
           <div key={i}>
-            <div className="h-3 bg-gray-200 rounded w-20 mb-2" />
-            <div className="h-5 bg-gray-200 rounded w-28" />
+            <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-20 mb-2" />
+            <div className="h-5 bg-gray-200 dark:bg-gray-700 rounded w-28" />
           </div>
         ))}
       </div>
@@ -17,30 +17,30 @@ export function NetWorthSkeleton() {
 
 export function GoalSkeleton() {
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5 animate-pulse">
+    <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-5 animate-pulse">
       <div className="flex items-center justify-between mb-3">
-        <div className="h-4 bg-gray-200 rounded w-32" />
-        <div className="h-4 bg-gray-200 rounded w-16" />
+        <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-32" />
+        <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-16" />
       </div>
-      <div className="h-6 bg-gray-200 rounded w-40 mb-3" />
-      <div className="h-2 bg-gray-200 rounded-full w-full" />
+      <div className="h-6 bg-gray-200 dark:bg-gray-700 rounded w-40 mb-3" />
+      <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full w-full" />
     </div>
   )
 }
 
 export function InsuranceSkeleton() {
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5 animate-pulse">
+    <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-5 animate-pulse">
       <div className="flex items-center justify-between mb-3">
-        <div className="h-4 bg-gray-200 rounded w-28" />
-        <div className="h-5 bg-gray-200 rounded w-16" />
+        <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-28" />
+        <div className="h-5 bg-gray-200 dark:bg-gray-700 rounded w-16" />
       </div>
-      <div className="h-3 bg-gray-200 rounded w-24 mb-4" />
+      <div className="h-3 bg-gray-200 dark:bg-gray-700 rounded w-24 mb-4" />
       <div className="grid grid-cols-2 gap-3">
-        <div className="h-4 bg-gray-200 rounded" />
-        <div className="h-4 bg-gray-200 rounded" />
+        <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded" />
+        <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded" />
       </div>
-      <div className="h-2 bg-gray-200 rounded-full w-full mt-3" />
+      <div className="h-2 bg-gray-200 dark:bg-gray-700 rounded-full w-full mt-3" />
     </div>
   )
 }

--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -14,34 +14,34 @@ export default function UnallocatedSection({ unallocatedAmount, funds, onFundCli
   return (
     <section>
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-semibold text-gray-900">Unallocated Investments</h2>
-        <span className="text-sm text-gray-500">Total: {fmt(unallocatedAmount)}</span>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Unallocated Investments</h2>
+        <span className="text-sm text-gray-500 dark:text-gray-400">Total: {fmt(unallocatedAmount)}</span>
       </div>
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
         {funds.map((fund) => (
           <div
             key={fund.fundId}
-            className="flex items-center justify-between px-5 py-4 border-b border-gray-50 last:border-0 hover:bg-gray-50"
+            className="flex items-center justify-between px-5 py-4 border-b border-gray-50 dark:border-gray-700 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-800"
           >
             <button
               onClick={() => onFundClick(fund.fundId)}
               className="flex-1 text-left"
             >
-              <p className="font-medium text-gray-900 text-sm">{fund.fundName}</p>
-              <p className="text-xs text-gray-500 mt-0.5">
+              <p className="font-medium text-gray-900 dark:text-gray-100 text-sm">{fund.fundName}</p>
+              <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">
                 {fund.quantity} units · NAV {fmt(fund.currentNAV)}
               </p>
             </button>
             <div className="flex items-center gap-4 ml-4">
               <div className="text-right">
-                <p className="text-sm font-medium text-gray-900">{fmt(fund.currentValue)}</p>
+                <p className="text-sm font-medium text-gray-900 dark:text-gray-100">{fmt(fund.currentValue)}</p>
                 <p className={`text-xs ${fund.profitLoss >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                   {fmtPct(fund.profitLossPercentage)}
                 </p>
               </div>
               <button
                 onClick={() => onAssignToGoal(fund.fundId)}
-                className="text-xs px-2 py-1 border border-indigo-300 text-indigo-600 rounded-md hover:bg-indigo-50 whitespace-nowrap"
+                className="text-xs px-2 py-1 border border-indigo-300 dark:border-indigo-700 text-indigo-600 dark:text-indigo-400 rounded-md hover:bg-indigo-50 dark:hover:bg-indigo-900/20 whitespace-nowrap"
               >
                 Assign to Goal
               </button>

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -5,6 +5,8 @@ import { useRouter, useSearchParams } from 'next/navigation'
 import { useState, Suspense } from 'react'
 import { createBrowserClient } from '@supabase/ssr'
 
+const inputCls = 'w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500'
+
 function LoginForm() {
   const router = useRouter()
   const searchParams = useSearchParams()
@@ -41,14 +43,14 @@ function LoginForm() {
   }
 
   return (
-    <div className="w-full max-w-md bg-white rounded-lg shadow p-8">
-      <h1 className="text-2xl font-bold text-center mb-6">Sign in to Allocate</h1>
+    <div className="w-full max-w-md bg-white dark:bg-gray-900 rounded-lg shadow p-8 border border-transparent dark:border-gray-700">
+      <h1 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100 mb-6">Sign in to Allocate</h1>
       {error && (
-        <div className="mb-4 p-3 bg-red-50 text-red-700 text-sm rounded-md">{error}</div>
+        <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400 text-sm rounded-md">{error}</div>
       )}
       <form onSubmit={handleLogin} className="space-y-4">
         <div>
-          <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+          <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             Email
           </label>
           <input
@@ -58,12 +60,12 @@ function LoginForm() {
             required
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className={inputCls}
             placeholder="you@example.com"
           />
         </div>
         <div>
-          <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+          <label htmlFor="password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
             Password
           </label>
           <input
@@ -73,12 +75,12 @@ function LoginForm() {
             required
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className={inputCls}
             placeholder="••••••••"
           />
         </div>
         <div className="text-right">
-          <span className="text-sm text-gray-400 cursor-not-allowed">Forgot password?</span>
+          <span className="text-sm text-gray-400 dark:text-gray-500 cursor-not-allowed">Forgot password?</span>
         </div>
         <button
           type="submit"
@@ -88,9 +90,9 @@ function LoginForm() {
           {loading ? 'Signing in...' : 'Log in'}
         </button>
       </form>
-      <p className="mt-4 text-center text-sm text-gray-600">
+      <p className="mt-4 text-center text-sm text-gray-600 dark:text-gray-400">
         Don&apos;t have an account?{' '}
-        <Link href="/auth/signup" className="text-indigo-600 hover:underline font-medium">
+        <Link href="/auth/signup" className="text-indigo-600 dark:text-indigo-400 hover:underline font-medium">
           Sign up
         </Link>
       </p>
@@ -100,8 +102,8 @@ function LoginForm() {
 
 export default function LoginPage() {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <Suspense fallback={<div className="w-full max-w-md bg-white rounded-lg shadow p-8 animate-pulse h-80" />}>
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-950">
+      <Suspense fallback={<div className="w-full max-w-md bg-white dark:bg-gray-900 rounded-lg shadow p-8 animate-pulse h-80" />}>
         <LoginForm />
       </Suspense>
     </div>

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -5,6 +5,8 @@ import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 import { createBrowserClient } from '@supabase/ssr'
 
+const inputCls = 'w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500'
+
 export default function SignupPage() {
   const router = useRouter()
 
@@ -81,11 +83,11 @@ export default function SignupPage() {
 
   if (confirmSent) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
-        <div className="w-full max-w-md bg-white rounded-lg shadow p-8 text-center">
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-950">
+        <div className="w-full max-w-md bg-white dark:bg-gray-900 rounded-lg shadow p-8 text-center border border-transparent dark:border-gray-700">
           <div className="text-4xl mb-4">📧</div>
-          <h1 className="text-2xl font-bold mb-3">Check your email</h1>
-          <p className="text-gray-600 text-sm mb-6">
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-3">Check your email</h1>
+          <p className="text-gray-600 dark:text-gray-400 text-sm mb-6">
             We sent a confirmation link to your email address. Click it to activate your account,
             then come back to sign in.
           </p>
@@ -101,15 +103,15 @@ export default function SignupPage() {
   }
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-50">
-      <div className="w-full max-w-md bg-white rounded-lg shadow p-8">
-        <h1 className="text-2xl font-bold text-center mb-6">Create your account</h1>
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-950">
+      <div className="w-full max-w-md bg-white dark:bg-gray-900 rounded-lg shadow p-8 border border-transparent dark:border-gray-700">
+        <h1 className="text-2xl font-bold text-center text-gray-900 dark:text-gray-100 mb-6">Create your account</h1>
         {formError && (
-          <div className="mb-4 p-3 bg-red-50 text-red-700 text-sm rounded-md">{formError}</div>
+          <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400 text-sm rounded-md">{formError}</div>
         )}
         <form onSubmit={handleSignup} className="space-y-4">
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Email
             </label>
             <input
@@ -119,12 +121,12 @@ export default function SignupPage() {
               required
               value={email}
               onChange={(e) => setEmail(e.target.value)}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className={inputCls}
               placeholder="you@example.com"
             />
           </div>
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Password
             </label>
             <input
@@ -136,18 +138,15 @@ export default function SignupPage() {
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               onBlur={handlePasswordBlur}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className={inputCls}
               placeholder="••••••••"
             />
             {passwordError && (
-              <p className="mt-1 text-xs text-red-600">{passwordError}</p>
+              <p className="mt-1 text-xs text-red-600 dark:text-red-400">{passwordError}</p>
             )}
           </div>
           <div>
-            <label
-              htmlFor="confirmPassword"
-              className="block text-sm font-medium text-gray-700 mb-1"
-            >
+            <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
               Confirm Password
             </label>
             <input
@@ -159,11 +158,11 @@ export default function SignupPage() {
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
               onBlur={handleConfirmBlur}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className={inputCls}
               placeholder="••••••••"
             />
             {confirmError && (
-              <p className="mt-1 text-xs text-red-600">{confirmError}</p>
+              <p className="mt-1 text-xs text-red-600 dark:text-red-400">{confirmError}</p>
             )}
           </div>
           <button
@@ -174,9 +173,9 @@ export default function SignupPage() {
             {loading ? 'Creating account...' : 'Sign up'}
           </button>
         </form>
-        <p className="mt-4 text-center text-sm text-gray-600">
+        <p className="mt-4 text-center text-sm text-gray-600 dark:text-gray-400">
           Already have an account?{' '}
-          <Link href="/auth/login" className="text-indigo-600 hover:underline font-medium">
+          <Link href="/auth/login" className="text-indigo-600 dark:text-indigo-400 hover:underline font-medium">
             Sign in
           </Link>
         </p>

--- a/app/components/layouts/AuthenticatedLayout.tsx
+++ b/app/components/layouts/AuthenticatedLayout.tsx
@@ -30,7 +30,7 @@ function AuthenticatedLayoutInner({ children, email, initials }: AuthenticatedLa
   const [drawerOpen, setDrawerOpen] = useState(false)
 
   return (
-    <div className="flex h-screen bg-gray-50 overflow-hidden">
+    <div className="flex h-screen bg-gray-50 dark:bg-gray-950 overflow-hidden">
       {/* Desktop sidebar */}
       <div className="hidden lg:flex shrink-0">
         <Sidebar email={email} initials={initials} />
@@ -98,10 +98,10 @@ export default function AuthenticatedLayout({ children }: { children: React.Reac
 
   if (!ready) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50">
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-950">
         <div className="flex flex-col items-center gap-3">
           <div className="w-8 h-8 border-4 border-brand border-t-transparent rounded-full animate-spin" />
-          <span className="text-sm text-gray-500">Loading...</span>
+          <span className="text-sm text-gray-500 dark:text-gray-400">Loading...</span>
         </div>
       </div>
     )

--- a/app/components/navigation/Breadcrumb.tsx
+++ b/app/components/navigation/Breadcrumb.tsx
@@ -31,13 +31,13 @@ export default function Breadcrumb() {
     <nav aria-label="Breadcrumb" className="hidden md:flex items-center gap-1">
       {crumbs.map((crumb, i) => (
         <span key={crumb.href} className="flex items-center gap-1">
-          {i > 0 && <ChevronRight size={12} className="text-gray-400" />}
+          {i > 0 && <ChevronRight size={12} className="text-gray-400 dark:text-gray-500" />}
           {crumb.current ? (
-            <span aria-current="page" className="text-xs text-gray-400 font-medium">
+            <span aria-current="page" className="text-xs text-gray-400 dark:text-gray-500 font-medium">
               {crumb.label}
             </span>
           ) : (
-            <Link href={crumb.href} className="text-xs text-gray-600 hover:text-gray-900 transition-colors">
+            <Link href={crumb.href} className="text-xs text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors">
               {crumb.label}
             </Link>
           )}
@@ -53,7 +53,7 @@ export function PageTitle() {
   const title = entry?.label ?? pathname.slice(1)
 
   return (
-    <p className="text-sm font-medium text-gray-700 md:hidden px-4 py-2 border-b border-gray-100">
+    <p className="text-sm font-medium text-gray-700 dark:text-gray-300 md:hidden px-4 py-2 border-b border-gray-100 dark:border-gray-700">
       {title}
     </p>
   )

--- a/app/components/navigation/Header.tsx
+++ b/app/components/navigation/Header.tsx
@@ -15,12 +15,12 @@ export default function Header({ email, initials, onMobileMenuToggle }: HeaderPr
   const { sidebarCollapsed, setSidebarCollapsed } = useNavigation()
 
   return (
-    <header className="h-16 border-b border-gray-200 bg-white flex items-center px-4 gap-4 shrink-0">
+    <header className="h-16 border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 flex items-center px-4 gap-4 shrink-0">
       {/* Mobile hamburger */}
       <button
         onClick={onMobileMenuToggle}
         aria-label="Toggle navigation menu"
-        className="lg:hidden p-1.5 rounded hover:bg-gray-100 transition-colors"
+        className="lg:hidden p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-gray-600 dark:text-gray-400"
       >
         <Menu size={20} />
       </button>
@@ -29,7 +29,7 @@ export default function Header({ email, initials, onMobileMenuToggle }: HeaderPr
       <button
         onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
         aria-label={sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
-        className="hidden md:flex lg:hidden p-1.5 rounded hover:bg-gray-100 transition-colors"
+        className="hidden md:flex lg:hidden p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-gray-600 dark:text-gray-400"
       >
         {sidebarCollapsed ? <PanelLeftOpen size={20} /> : <PanelLeftClose size={20} />}
       </button>

--- a/app/components/navigation/MobileDrawer.tsx
+++ b/app/components/navigation/MobileDrawer.tsx
@@ -60,17 +60,17 @@ export default function MobileDrawer({ open, onClose, email, initials }: MobileD
       {/* Drawer */}
       <div
         ref={drawerRef}
-        className="absolute left-0 top-0 h-full w-[280px] max-w-[90vw] bg-white shadow-xl flex flex-col"
+        className="absolute left-0 top-0 h-full w-[280px] max-w-[90vw] bg-white dark:bg-gray-900 shadow-xl flex flex-col"
         role="dialog"
         aria-modal="true"
         aria-label="Navigation menu"
       >
-        <div className="flex items-center justify-between px-4 h-14 border-b border-gray-100">
+        <div className="flex items-center justify-between px-4 h-14 border-b border-gray-100 dark:border-gray-700">
           <span className="text-brand font-bold text-xl tracking-tight">Allocate</span>
           <button
             onClick={onClose}
             aria-label="Close navigation menu"
-            className="p-1 rounded hover:bg-gray-100 transition-colors"
+            className="p-1 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-gray-600 dark:text-gray-400"
           >
             <X size={20} />
           </button>

--- a/app/components/navigation/Sidebar.tsx
+++ b/app/components/navigation/Sidebar.tsx
@@ -24,12 +24,12 @@ export default function Sidebar({ email, initials, onNavClick }: SidebarProps) {
 
   return (
     <nav
-      className={`flex flex-col h-full bg-white border-r border-gray-200 transition-all duration-200 ${
+      className={`flex flex-col h-full bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700 transition-all duration-200 ${
         sidebarCollapsed ? 'w-16' : 'w-60'
       }`}
     >
       {/* Logo */}
-      <div className={`flex items-center h-16 px-4 border-b border-gray-100 ${sidebarCollapsed ? 'justify-center' : ''}`}>
+      <div className={`flex items-center h-16 px-4 border-b border-gray-100 dark:border-gray-700 ${sidebarCollapsed ? 'justify-center' : ''}`}>
         {sidebarCollapsed ? (
           <span className="text-brand font-bold text-lg">A</span>
         ) : (
@@ -50,8 +50,8 @@ export default function Sidebar({ email, initials, onNavClick }: SidebarProps) {
                 title={sidebarCollapsed ? label : undefined}
                 className={`flex items-center gap-3 h-11 px-3 mx-2 rounded-md border-l-4 transition-colors text-sm font-medium ${
                   active
-                    ? 'border-brand bg-brand-light text-gray-900 font-semibold'
-                    : 'border-transparent text-gray-600 hover:bg-gray-50 hover:text-gray-900'
+                    ? 'border-brand bg-brand-light dark:bg-brand/20 text-gray-900 dark:text-gray-100 font-semibold'
+                    : 'border-transparent text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 hover:text-gray-900 dark:hover:text-gray-100'
                 } ${sidebarCollapsed ? 'justify-center px-0 mx-2' : ''}`}
               >
                 <Icon size={18} className="shrink-0" />
@@ -64,11 +64,11 @@ export default function Sidebar({ email, initials, onNavClick }: SidebarProps) {
 
       {/* Profile */}
       {!sidebarCollapsed && (
-        <div className="flex items-center gap-3 px-4 py-3 border-t border-gray-100">
+        <div className="flex items-center gap-3 px-4 py-3 border-t border-gray-100 dark:border-gray-700">
           <div className="w-8 h-8 rounded-full bg-brand flex items-center justify-center text-white text-xs font-semibold shrink-0">
             {initials}
           </div>
-          <p className="text-xs text-gray-600 truncate">{email}</p>
+          <p className="text-xs text-gray-600 dark:text-gray-400 truncate">{email}</p>
         </div>
       )}
     </nav>

--- a/app/components/navigation/UserMenu.tsx
+++ b/app/components/navigation/UserMenu.tsx
@@ -57,27 +57,27 @@ export default function UserMenu({ email, initials }: UserMenuProps) {
       </button>
 
       {open && (
-        <div className="absolute right-0 top-10 w-52 bg-white border border-gray-200 rounded-lg shadow-lg z-50 py-1">
-          <div className="px-3 py-2 border-b border-gray-100">
-            <p className="text-xs text-gray-500 truncate">{email}</p>
+        <div className="absolute right-0 top-10 w-52 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg z-50 py-1">
+          <div className="px-3 py-2 border-b border-gray-100 dark:border-gray-700">
+            <p className="text-xs text-gray-500 dark:text-gray-400 truncate">{email}</p>
           </div>
           <Link
             href="/settings"
             onClick={() => setOpen(false)}
-            className="flex items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+            className="flex items-center gap-2 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
           >
             <User size={14} /> Profile
           </Link>
           <Link
             href="/settings"
             onClick={() => setOpen(false)}
-            className="flex items-center gap-2 px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+            className="flex items-center gap-2 px-3 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
           >
             <Settings size={14} /> Settings
           </Link>
           <button
             onClick={handleLogout}
-            className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors"
+            className="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
           >
             <LogOut size={14} /> Logout
           </button>

--- a/app/funds/FundLibraryClient.tsx
+++ b/app/funds/FundLibraryClient.tsx
@@ -171,14 +171,14 @@ export default function FundLibraryClient() {
   const SortButton = ({ col, label }: { col: SortKey; label: string }) => (
     <button
       onClick={() => setSortBy(col)}
-      className={`text-left font-semibold text-sm ${sortBy === col ? 'text-indigo-600' : 'text-gray-600'}`}
+      className={`text-left font-semibold text-sm ${sortBy === col ? 'text-indigo-600 dark:text-indigo-400' : 'text-gray-600 dark:text-gray-400'}`}
     >
       {label} {sortBy === col && '↑'}
     </button>
   )
 
   return (
-    <main className="min-h-screen bg-gray-50 px-4 py-8 sm:px-8">
+    <main className="min-h-screen bg-gray-50 dark:bg-gray-950 px-4 py-8 sm:px-8">
       {/* Toasts */}
       <div className="fixed top-4 right-4 z-50 flex flex-col gap-2">
         {toasts.map((t) => (
@@ -195,8 +195,8 @@ export default function FundLibraryClient() {
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
           <div>
-            <h1 className="text-2xl font-bold text-gray-900">Fund Library</h1>
-            <p className="text-sm text-gray-500 mt-1">Manage your investment funds</p>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Fund Library</h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">Manage your investment funds</p>
           </div>
           <button
             onClick={openAddModal}
@@ -208,19 +208,19 @@ export default function FundLibraryClient() {
 
         {/* Content */}
         {loading ? (
-          <div className="bg-white rounded-lg shadow overflow-hidden">
+          <div className="bg-white dark:bg-gray-900 rounded-lg shadow overflow-hidden">
             {[...Array(3)].map((_, i) => (
-              <div key={i} className="flex gap-4 p-4 border-b border-gray-100 animate-pulse">
-                <div className="h-4 bg-gray-200 rounded flex-1" />
-                <div className="h-4 bg-gray-200 rounded w-20" />
-                <div className="h-4 bg-gray-200 rounded w-16" />
-                <div className="h-4 bg-gray-200 rounded w-16" />
+              <div key={i} className="flex gap-4 p-4 border-b border-gray-100 dark:border-gray-700 animate-pulse">
+                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded flex-1" />
+                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-20" />
+                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-16" />
+                <div className="h-4 bg-gray-200 dark:bg-gray-700 rounded w-16" />
               </div>
             ))}
           </div>
         ) : error ? (
-          <div className="bg-white rounded-lg shadow p-8 text-center">
-            <p className="text-red-600 mb-4">{error}</p>
+          <div className="bg-white dark:bg-gray-900 rounded-lg shadow p-8 text-center border border-gray-100 dark:border-gray-700">
+            <p className="text-red-600 dark:text-red-400 mb-4">{error}</p>
             <button
               onClick={loadFunds}
               className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded hover:bg-indigo-700 transition-colors"
@@ -229,10 +229,10 @@ export default function FundLibraryClient() {
             </button>
           </div>
         ) : funds.length === 0 ? (
-          <div className="bg-white rounded-lg shadow p-16 text-center">
+          <div className="bg-white dark:bg-gray-900 rounded-lg shadow p-16 text-center border border-gray-100 dark:border-gray-700">
             <div className="text-5xl mb-4">📚</div>
-            <h2 className="text-lg font-semibold text-gray-900 mb-2">No funds yet</h2>
-            <p className="text-gray-500 text-sm mb-6">
+            <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-2">No funds yet</h2>
+            <p className="text-gray-500 dark:text-gray-400 text-sm mb-6">
               Add your first fund to get started. You&apos;ll be able to select these funds when setting up your allocation.
             </p>
             <button
@@ -245,39 +245,39 @@ export default function FundLibraryClient() {
         ) : (
           <>
             {/* Desktop table */}
-            <div className="hidden md:block bg-white rounded-lg shadow overflow-x-auto">
+            <div className="hidden md:block bg-white dark:bg-gray-900 rounded-lg shadow overflow-x-auto border border-gray-100 dark:border-gray-700">
               <table className="w-full">
-                <thead className="bg-gray-50 border-b border-gray-200">
+                <thead className="bg-gray-50 dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">
                   <tr>
                     <th className="px-4 py-3 text-left"><SortButton col="name" label="Name" /></th>
                     <th className="px-4 py-3 text-left"><SortButton col="code" label="Code" /></th>
                     <th className="px-4 py-3 text-left"><SortButton col="fund_type" label="Type" /></th>
-                    <th className="px-4 py-3 text-left text-sm font-semibold text-gray-600">NAV</th>
-                    <th className="px-4 py-3 text-right text-sm font-semibold text-gray-600">Actions</th>
+                    <th className="px-4 py-3 text-left text-sm font-semibold text-gray-600 dark:text-gray-400">NAV</th>
+                    <th className="px-4 py-3 text-right text-sm font-semibold text-gray-600 dark:text-gray-400">Actions</th>
                   </tr>
                 </thead>
                 <tbody>
                   {sortedFunds.map((fund) => (
-                    <tr key={fund.id} className="border-b border-gray-100 hover:bg-gray-50">
-                      <td className="px-4 py-3 text-sm font-medium text-gray-900">{fund.name}</td>
-                      <td className="px-4 py-3 text-sm font-mono text-gray-500">{fund.code}</td>
+                    <tr key={fund.id} className="border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800">
+                      <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">{fund.name}</td>
+                      <td className="px-4 py-3 text-sm font-mono text-gray-500 dark:text-gray-400">{fund.code}</td>
                       <td className="px-4 py-3">
                         <span className={`text-xs px-2 py-1 rounded font-medium ${FUND_TYPE_COLORS[fund.fund_type]}`}>
                           {FUND_TYPE_LABELS[fund.fund_type]}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-sm font-medium text-gray-900">{fund.nav.toLocaleString()}</td>
+                      <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">{fund.nav.toLocaleString()}</td>
                       <td className="px-4 py-3 text-right">
                         <div className="flex gap-2 justify-end">
                           <button
                             onClick={() => openEditModal(fund)}
-                            className="text-xs px-3 py-1 border border-gray-300 rounded hover:bg-gray-100 text-gray-700 transition-colors"
+                            className="text-xs px-3 py-1 border border-gray-300 dark:border-gray-600 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 transition-colors"
                           >
                             Edit
                           </button>
                           <button
                             onClick={() => setDeleteTarget(fund)}
-                            className="text-xs px-3 py-1 border border-red-200 rounded hover:bg-red-50 text-red-600 transition-colors"
+                            className="text-xs px-3 py-1 border border-red-200 dark:border-red-800 rounded hover:bg-red-50 dark:hover:bg-red-900/20 text-red-600 dark:text-red-400 transition-colors"
                           >
                             Delete
                           </button>
@@ -292,27 +292,27 @@ export default function FundLibraryClient() {
             {/* Mobile card list */}
             <div className="md:hidden flex flex-col gap-3">
               {sortedFunds.map((fund) => (
-                <div key={fund.id} className="bg-white rounded-lg shadow p-4">
+                <div key={fund.id} className="bg-white dark:bg-gray-900 rounded-lg shadow p-4 border border-gray-100 dark:border-gray-700">
                   <div className="flex items-start justify-between mb-2">
                     <div>
-                      <p className="font-semibold text-gray-900 text-sm">{fund.name}</p>
-                      <p className="text-xs font-mono text-gray-500">{fund.code}</p>
+                      <p className="font-semibold text-gray-900 dark:text-gray-100 text-sm">{fund.name}</p>
+                      <p className="text-xs font-mono text-gray-500 dark:text-gray-400">{fund.code}</p>
                     </div>
                     <span className={`text-xs px-2 py-1 rounded font-medium ${FUND_TYPE_COLORS[fund.fund_type]}`}>
                       {FUND_TYPE_LABELS[fund.fund_type]}
                     </span>
                   </div>
-                  <p className="text-sm text-gray-700 mb-3">NAV: <span className="font-medium">{fund.nav.toLocaleString()}</span></p>
+                  <p className="text-sm text-gray-700 dark:text-gray-300 mb-3">NAV: <span className="font-medium">{fund.nav.toLocaleString()}</span></p>
                   <div className="flex gap-2">
                     <button
                       onClick={() => openEditModal(fund)}
-                      className="flex-1 text-xs px-3 py-2 border border-gray-300 rounded hover:bg-gray-100 text-gray-700 transition-colors"
+                      className="flex-1 text-xs px-3 py-2 border border-gray-300 dark:border-gray-600 rounded hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-300 transition-colors"
                     >
                       Edit
                     </button>
                     <button
                       onClick={() => setDeleteTarget(fund)}
-                      className="flex-1 text-xs px-3 py-2 border border-red-200 rounded hover:bg-red-50 text-red-600 transition-colors"
+                      className="flex-1 text-xs px-3 py-2 border border-red-200 dark:border-red-800 rounded hover:bg-red-50 dark:hover:bg-red-900/20 text-red-600 dark:text-red-400 transition-colors"
                     >
                       Delete
                     </button>
@@ -327,43 +327,43 @@ export default function FundLibraryClient() {
       {/* Add/Edit Modal */}
       {modalMode && (
         <div className="fixed inset-0 bg-black/50 z-40 flex items-center justify-center p-4">
-          <div className="bg-white rounded-lg shadow-xl w-full max-w-md p-6">
-            <h2 className="text-lg font-bold text-gray-900 mb-4">
+          <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full max-w-md p-6 border border-gray-100 dark:border-gray-700">
+            <h2 className="text-lg font-bold text-gray-900 dark:text-gray-100 mb-4">
               {modalMode === 'add' ? 'Add Fund' : 'Edit Fund'}
             </h2>
             {formError && (
-              <div className="mb-4 p-3 bg-red-50 text-red-700 text-sm rounded">{formError}</div>
+              <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400 text-sm rounded border border-red-200 dark:border-red-800">{formError}</div>
             )}
             <div className="space-y-4">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Fund Name *</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Fund Name *</label>
                 <input
                   type="text"
                   value={formName}
                   onChange={(e) => setFormName(e.target.value)}
                   maxLength={255}
                   placeholder="e.g., Vanguard S&P 500 ETF"
-                  className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
                 />
               </div>
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Code *</label>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Code *</label>
                   <input
                     type="text"
                     value={formCode}
                     onChange={(e) => setFormCode(e.target.value.toUpperCase())}
                     maxLength={50}
                     placeholder="e.g., VOO"
-                    className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm font-mono"
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm font-mono"
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Type *</label>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Type *</label>
                   <select
                     value={formType}
                     onChange={(e) => setFormType(e.target.value as FundType)}
-                    className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
                   >
                     <option value="">Select type</option>
                     {(Object.keys(FUND_TYPE_LABELS) as FundType[]).map((t) => (
@@ -373,7 +373,7 @@ export default function FundLibraryClient() {
                 </div>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">NAV *</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">NAV *</label>
                 <input
                   type="number"
                   value={formNav}
@@ -381,7 +381,7 @@ export default function FundLibraryClient() {
                   min="0.01"
                   step="0.01"
                   placeholder="e.g., 450.25"
-                  className="w-full px-3 py-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                  className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
                 />
               </div>
             </div>
@@ -389,7 +389,7 @@ export default function FundLibraryClient() {
               <button
                 onClick={closeModal}
                 disabled={saving}
-                className="flex-1 px-4 py-2 border border-gray-300 rounded text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-50"
+                className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors disabled:opacity-50"
               >
                 Cancel
               </button>
@@ -408,14 +408,14 @@ export default function FundLibraryClient() {
       {/* Delete Confirmation Modal */}
       {deleteTarget && (
         <div className="fixed inset-0 bg-black/50 z-40 flex items-center justify-center p-4">
-          <div className="bg-white rounded-lg shadow-xl w-full max-w-sm p-6">
-            <h2 className="text-lg font-bold text-gray-900 mb-2">Delete {deleteTarget.name}?</h2>
-            <p className="text-sm text-gray-500 mb-6">This action cannot be undone.</p>
+          <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl w-full max-w-sm p-6 border border-gray-100 dark:border-gray-700">
+            <h2 className="text-lg font-bold text-gray-900 dark:text-gray-100 mb-2">Delete {deleteTarget.name}?</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">This action cannot be undone.</p>
             <div className="flex gap-3">
               <button
                 onClick={() => setDeleteTarget(null)}
                 disabled={deleting}
-                className="flex-1 px-4 py-2 border border-gray-300 rounded text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors disabled:opacity-50"
+                className="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 rounded text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors disabled:opacity-50"
               >
                 Cancel
               </button>

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,7 @@
 @import "tailwindcss";
 
+@variant dark (@media (prefers-color-scheme: dark));
+
 :root {
   --background: #ffffff;
   --foreground: #171717;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -20,7 +20,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${inter.variable} font-sans antialiased bg-gray-50 text-gray-900`}>
+      <body className={`${inter.variable} font-sans antialiased bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100`}>
         {children}
         <Toaster position="top-right" richColors />
       </body>

--- a/app/planning/PlanningClient.tsx
+++ b/app/planning/PlanningClient.tsx
@@ -130,17 +130,17 @@ export default function PlanningClient() {
   const refetch = useCallback(() => fetchPlan(), [fetchPlan])
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       <div className="max-w-6xl mx-auto px-4 py-8">
         {/* Header */}
         <div className="flex items-center justify-between mb-8">
-          <h1 className="text-2xl font-bold text-gray-900">Monthly Planning</h1>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Monthly Planning</h1>
           <div className="flex items-center gap-3">
-            <button onClick={() => navigate('prev')} className="p-2 rounded-lg border border-gray-200 hover:bg-gray-100 text-gray-600">‹</button>
-            <span className="text-lg font-semibold text-gray-800 min-w-[120px] text-center">
+            <button onClick={() => navigate('prev')} className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400">‹</button>
+            <span className="text-lg font-semibold text-gray-800 dark:text-gray-200 min-w-[120px] text-center">
               {MONTHS[month - 1]} {year}
             </span>
-            <button onClick={() => navigate('next')} className="p-2 rounded-lg border border-gray-200 hover:bg-gray-100 text-gray-600">›</button>
+            <button onClick={() => navigate('next')} className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400">›</button>
           </div>
         </div>
 
@@ -152,7 +152,7 @@ export default function PlanningClient() {
         )}
 
         {loading ? (
-          <div className="text-center py-20 text-gray-400">Loading...</div>
+          <div className="text-center py-20 text-gray-400 dark:text-gray-500">Loading...</div>
         ) : (
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             {/* Left col: salary + sections */}
@@ -199,7 +199,7 @@ export default function PlanningClient() {
                   />
                 </>
               ) : (
-                <div className="text-center py-8 text-gray-400 text-sm">
+                <div className="text-center py-8 text-gray-400 dark:text-gray-500 text-sm">
                   Enter your monthly salary to begin planning.
                 </div>
               )}

--- a/app/planning/PlanningClient.tsx
+++ b/app/planning/PlanningClient.tsx
@@ -196,6 +196,8 @@ export default function PlanningClient() {
                   <InsuranceSection
                     plan={plan}
                     insuranceMembers={insuranceMembers}
+                    onRefresh={refetch}
+                    onToast={showToast}
                   />
                 </>
               ) : (

--- a/app/planning/components/AllocationSummary.tsx
+++ b/app/planning/components/AllocationSummary.tsx
@@ -20,9 +20,9 @@ interface GoalRow {
 export default function AllocationSummary({ plan, investments, savings, fixedExpenses, insuranceMembers }: Props) {
   if (!plan) {
     return (
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
-        <h2 className="font-semibold text-gray-900 mb-3">Allocation Summary</h2>
-        <p className="text-sm text-gray-400 text-center py-6">Enter your salary to see the summary.</p>
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-5">
+        <h2 className="font-semibold text-gray-900 dark:text-gray-100 mb-3">Allocation Summary</h2>
+        <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-6">Enter your salary to see the summary.</p>
       </div>
     )
   }
@@ -46,7 +46,6 @@ export default function AllocationSummary({ plan, investments, savings, fixedExp
   }
 
   const totalFixed = fixedExpenses.reduce((sum, e) => {
-    // amount_vnd in fixed_expenses is already a monthly amount (entered directly by the user)
     const monthly = e.override != null ? e.override : e.amount_vnd
     return sum + monthly
   }, 0)
@@ -70,10 +69,10 @@ export default function AllocationSummary({ plan, investments, savings, fixedExp
   const pct = (n: number) => salary > 0 ? `${Math.round((n / salary) * 100)}%` : '—'
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden sticky top-6">
-      <div className="px-5 py-4 border-b border-gray-100">
-        <h2 className="font-semibold text-gray-900">Allocation Summary</h2>
-        <p className="text-xs text-gray-400 mt-0.5">Salary: {fmt(salary)}</p>
+    <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden sticky top-6">
+      <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+        <h2 className="font-semibold text-gray-900 dark:text-gray-100">Allocation Summary</h2>
+        <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">Salary: {fmt(salary)}</p>
       </div>
 
       <div className="p-5 space-y-4">
@@ -83,16 +82,16 @@ export default function AllocationSummary({ plan, investments, savings, fixedExp
             <thead>
               <tr>
                 {['Goal', 'Allocated', '% Salary'].map((h) => (
-                  <th key={h} className="pb-2 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">{h}</th>
+                  <th key={h} className="pb-2 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">{h}</th>
                 ))}
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-50">
+            <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
               {goalRows.map((row) => (
                 <tr key={row.label}>
-                  <td className="py-2 text-gray-700 font-medium pr-2">{row.label}</td>
-                  <td className="py-2 text-gray-600 pr-2">{fmt(row.total)}</td>
-                  <td className="py-2 text-gray-400">{pct(row.total)}</td>
+                  <td className="py-2 text-gray-700 dark:text-gray-300 font-medium pr-2">{row.label}</td>
+                  <td className="py-2 text-gray-600 dark:text-gray-400 pr-2">{fmt(row.total)}</td>
+                  <td className="py-2 text-gray-400 dark:text-gray-500">{pct(row.total)}</td>
                 </tr>
               ))}
             </tbody>
@@ -100,18 +99,18 @@ export default function AllocationSummary({ plan, investments, savings, fixedExp
         )}
 
         {goalRows.length === 0 && (
-          <p className="text-sm text-gray-400 text-center py-2">No allocations yet</p>
+          <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-2">No allocations yet</p>
         )}
 
         {/* Divider */}
-        <div className="border-t border-gray-100 pt-4 space-y-2">
+        <div className="border-t border-gray-100 dark:border-gray-700 pt-4 space-y-2">
           {/* Fixed expenses row */}
           {fixedExpenses.length > 0 && (
             <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600">Fixed Expenses</span>
+              <span className="text-gray-600 dark:text-gray-400">Fixed Expenses</span>
               <div className="text-right">
-                <span className="text-gray-700 font-medium">{fmt(totalFixed)}</span>
-                <span className="ml-2 text-gray-400 text-xs">{pct(totalFixed)}</span>
+                <span className="text-gray-700 dark:text-gray-300 font-medium">{fmt(totalFixed)}</span>
+                <span className="ml-2 text-gray-400 dark:text-gray-500 text-xs">{pct(totalFixed)}</span>
               </div>
             </div>
           )}
@@ -119,40 +118,40 @@ export default function AllocationSummary({ plan, investments, savings, fixedExp
           {/* Insurance row */}
           {insuranceMembers.length > 0 && (
             <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600">Insurance</span>
+              <span className="text-gray-600 dark:text-gray-400">Insurance</span>
               <div className="text-right">
-                <span className="text-gray-700 font-medium">{fmt(totalInsurance)}</span>
-                <span className="ml-2 text-gray-400 text-xs">{pct(totalInsurance)}</span>
+                <span className="text-gray-700 dark:text-gray-300 font-medium">{fmt(totalInsurance)}</span>
+                <span className="ml-2 text-gray-400 dark:text-gray-500 text-xs">{pct(totalInsurance)}</span>
               </div>
             </div>
           )}
 
           {/* Total row */}
-          <div className="flex items-center justify-between text-sm border-t border-gray-100 pt-2 mt-2">
-            <span className="font-semibold text-gray-700">Total Allocated</span>
+          <div className="flex items-center justify-between text-sm border-t border-gray-100 dark:border-gray-700 pt-2 mt-2">
+            <span className="font-semibold text-gray-700 dark:text-gray-300">Total Allocated</span>
             <div className="text-right">
-              <span className="font-semibold text-gray-900">{fmt(totalAllocated)}</span>
-              <span className="ml-2 text-gray-400 text-xs">{pct(totalAllocated)}</span>
+              <span className="font-semibold text-gray-900 dark:text-gray-100">{fmt(totalAllocated)}</span>
+              <span className="ml-2 text-gray-400 dark:text-gray-500 text-xs">{pct(totalAllocated)}</span>
             </div>
           </div>
 
           {/* Remaining row */}
-          <div className={`flex items-center justify-between text-sm rounded-lg px-3 py-2 ${remaining >= 0 ? 'bg-green-50' : 'bg-red-50'}`}>
-            <span className={`font-semibold ${remaining >= 0 ? 'text-green-700' : 'text-red-700'}`}>
+          <div className={`flex items-center justify-between text-sm rounded-lg px-3 py-2 ${remaining >= 0 ? 'bg-green-50 dark:bg-green-900/20' : 'bg-red-50 dark:bg-red-900/20'}`}>
+            <span className={`font-semibold ${remaining >= 0 ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'}`}>
               Remaining Salary
             </span>
             <div className="text-right">
-              <span className={`font-semibold ${remaining >= 0 ? 'text-green-700' : 'text-red-700'}`}>
+              <span className={`font-semibold ${remaining >= 0 ? 'text-green-700 dark:text-green-400' : 'text-red-700 dark:text-red-400'}`}>
                 {fmt(remaining)}
               </span>
-              <span className={`ml-2 text-xs ${remaining >= 0 ? 'text-green-500' : 'text-red-400'}`}>
+              <span className={`ml-2 text-xs ${remaining >= 0 ? 'text-green-500 dark:text-green-400' : 'text-red-400 dark:text-red-300'}`}>
                 {pct(Math.abs(remaining))}
               </span>
             </div>
           </div>
 
           {remaining < 0 && (
-            <p className="text-xs text-red-500 text-center">Over-allocated by {fmt(Math.abs(remaining))}</p>
+            <p className="text-xs text-red-500 dark:text-red-400 text-center">Over-allocated by {fmt(Math.abs(remaining))}</p>
           )}
         </div>
       </div>

--- a/app/planning/components/DirectSavingsSection.tsx
+++ b/app/planning/components/DirectSavingsSection.tsx
@@ -15,6 +15,8 @@ interface Props {
 const fmt = (n: number) => '₫ ' + Math.round(n).toLocaleString('vi-VN')
 const emptyForm = { goal_id: '', amount_vnd: '', profit_percent: '', expiry_date: '' }
 
+const inputCls = 'w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500'
+
 export default function DirectSavingsSection({ plan, savings, onRefresh, onToast }: Props) {
   const [goals, setGoals] = useState<Goal[]>([])
   const [showForm, setShowForm] = useState(false)
@@ -100,36 +102,36 @@ export default function DirectSavingsSection({ plan, savings, onRefresh, onToast
   }
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
-      <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
-        <h2 className="font-semibold text-gray-900">Direct Savings</h2>
+    <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
+      <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+        <h2 className="font-semibold text-gray-900 dark:text-gray-100">Direct Savings</h2>
         <button onClick={openAdd} className="px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700">
           Add Direct Saving
         </button>
       </div>
 
       {savings.length === 0 ? (
-        <div className="text-center py-10 text-gray-400 text-sm">Add direct savings to allocate additional funds</div>
+        <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">Add direct savings to allocate additional funds</div>
       ) : (
         <table className="w-full text-sm">
-          <thead className="bg-gray-50">
+          <thead className="bg-gray-50 dark:bg-gray-800">
             <tr>
               {['Amount', 'Profit %', 'Expiry Date', 'Goal', 'Actions'].map((h) => (
-                <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">{h}</th>
+                <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-50">
+          <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
             {savings.map((item) => (
-              <tr key={item.id} className="hover:bg-gray-50">
-                <td className="px-4 py-3 font-medium text-gray-900">{fmt(item.amount_vnd)}</td>
-                <td className="px-4 py-3 text-gray-500">{item.profit_percent != null ? `${item.profit_percent}%` : '—'}</td>
-                <td className="px-4 py-3 text-gray-500">{item.expiry_date ? new Date(item.expiry_date).toLocaleDateString('vi-VN') : '—'}</td>
-                <td className="px-4 py-3 text-gray-500">{item.savings_goals?.goal_name ?? 'Unassigned'}</td>
+              <tr key={item.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(item.amount_vnd)}</td>
+                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.profit_percent != null ? `${item.profit_percent}%` : '—'}</td>
+                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.expiry_date ? new Date(item.expiry_date).toLocaleDateString('vi-VN') : '—'}</td>
+                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.savings_goals?.goal_name ?? 'Unassigned'}</td>
                 <td className="px-4 py-3">
                   <div className="flex gap-3">
-                    <button onClick={() => openEdit(item)} className="text-xs text-indigo-600 hover:underline">Edit</button>
-                    <button onClick={() => setConfirmDelete(item)} className="text-xs text-red-500 hover:underline">Delete</button>
+                    <button onClick={() => openEdit(item)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Edit</button>
+                    <button onClick={() => setConfirmDelete(item)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Delete</button>
                   </div>
                 </td>
               </tr>
@@ -138,43 +140,37 @@ export default function DirectSavingsSection({ plan, savings, onRefresh, onToast
         </table>
       )}
 
-      {/* Add/Edit Modal — fields in spec order: Goal, Amount, Profit%, Expiry */}
+      {/* Add/Edit Modal */}
       {showForm && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">{editItem ? 'Edit Direct Saving' : 'Add Direct Saving'}</h3>
-            {formError && <p className="text-red-600 text-sm mb-3">{formError}</p>}
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm p-6 border border-gray-100 dark:border-gray-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">{editItem ? 'Edit Direct Saving' : 'Add Direct Saving'}</h3>
+            {formError && <p className="text-red-600 dark:text-red-400 text-sm mb-3">{formError}</p>}
             <div className="space-y-3">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Goal (optional)</label>
-                <select
-                  value={form.goal_id}
-                  onChange={(e) => setForm({ ...form, goal_id: e.target.value })}
-                  disabled={goals.length === 0}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
-                >
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Goal (optional)</label>
+                <select value={form.goal_id} onChange={(e) => setForm({ ...form, goal_id: e.target.value })}
+                  disabled={goals.length === 0} className={`${inputCls} disabled:opacity-50`}>
                   <option value="">{goals.length === 0 ? 'No goals available' : 'Unassigned'}</option>
                   {goals.map((g) => <option key={g.goal_id} value={g.goal_id}>{g.goal_name}</option>)}
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Amount (VND) *</label>
-                <input type="number" value={form.amount_vnd} onChange={(e) => setForm({ ...form, amount_vnd: e.target.value })}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Amount (VND) *</label>
+                <input type="number" value={form.amount_vnd} onChange={(e) => setForm({ ...form, amount_vnd: e.target.value })} className={inputCls} />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Profit % (optional)</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Profit % (optional)</label>
                 <input type="number" step="0.01" value={form.profit_percent} onChange={(e) => setForm({ ...form, profit_percent: e.target.value })}
-                  placeholder="e.g. 5.5" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                  placeholder="e.g. 5.5" className={inputCls} />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Expiry Date (optional)</label>
-                <input type="date" value={form.expiry_date} onChange={(e) => setForm({ ...form, expiry_date: e.target.value })}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Expiry Date (optional)</label>
+                <input type="date" value={form.expiry_date} onChange={(e) => setForm({ ...form, expiry_date: e.target.value })} className={inputCls} />
               </div>
             </div>
             <div className="flex gap-3 mt-5">
-              <button onClick={() => setShowForm(false)} className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50">Cancel</button>
+              <button onClick={() => setShowForm(false)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
               <button onClick={handleSave} disabled={saving} className="flex-1 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 disabled:opacity-50 flex items-center justify-center gap-2">
                 {saving && <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />}
                 {saving ? 'Saving...' : 'Save'}
@@ -187,11 +183,11 @@ export default function DirectSavingsSection({ plan, savings, onRefresh, onToast
       {/* Delete Confirmation */}
       {confirmDelete && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6">
-            <h3 className="text-base font-semibold text-gray-900 mb-2">Delete Saving</h3>
-            <p className="text-sm text-gray-600 mb-5">Are you sure you want to delete this saving?</p>
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm p-6 border border-gray-100 dark:border-gray-700">
+            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-2">Delete Saving</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-5">Are you sure you want to delete this saving?</p>
             <div className="flex gap-3">
-              <button onClick={() => setConfirmDelete(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50">Cancel</button>
+              <button onClick={() => setConfirmDelete(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
               <button onClick={() => handleDelete(confirmDelete)} className="flex-1 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700">Confirm</button>
             </div>
           </div>

--- a/app/planning/components/FixedExpensesSection.tsx
+++ b/app/planning/components/FixedExpensesSection.tsx
@@ -12,6 +12,8 @@ interface Props {
 
 const fmt = (n: number) => '₫ ' + Math.round(n).toLocaleString('vi-VN')
 
+const inputCls = 'w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500'
+
 export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, onToast }: Props) {
   const [editItem, setEditItem] = useState<FixedExpense | null>(null)
   const [overrideValue, setOverrideValue] = useState('')
@@ -62,7 +64,6 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
       setConfirmRemove(null)
       return
     }
-    // Find override ID — we need to fetch it
     const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`)
     if (!res.ok) { setConfirmRemove(null); return }
     const overrides: Array<{ id: string; fixed_expense_id: string }> = await res.json()
@@ -79,50 +80,50 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
 
   if (fixedExpenses.length === 0) {
     return (
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
-        <div className="px-5 py-4 border-b border-gray-100">
-          <h2 className="font-semibold text-gray-900">Fixed Expenses</h2>
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
+        <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+          <h2 className="font-semibold text-gray-900 dark:text-gray-100">Fixed Expenses</h2>
         </div>
-        <div className="text-center py-10 text-gray-400 text-sm">No fixed expenses configured</div>
+        <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">No fixed expenses configured</div>
       </div>
     )
   }
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
-      <div className="px-5 py-4 border-b border-gray-100">
-        <h2 className="font-semibold text-gray-900">Fixed Expenses</h2>
-        <p className="text-xs text-gray-400 mt-0.5">Monthly amounts as entered in Settings. Override for this month only.</p>
+    <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
+      <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+        <h2 className="font-semibold text-gray-900 dark:text-gray-100">Fixed Expenses</h2>
+        <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">Monthly amounts as entered in Settings. Override for this month only.</p>
       </div>
 
       <table className="w-full text-sm">
-        <thead className="bg-gray-50">
+        <thead className="bg-gray-50 dark:bg-gray-800">
           <tr>
             {['Expense', 'Default Monthly', 'This Month', 'Actions'].map((h) => (
-              <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">{h}</th>
+              <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
             ))}
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-50">
+        <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
           {fixedExpenses.map((expense) => {
             const defaultMonthly = expense.amount_vnd
             const thisMonth = expense.override ?? defaultMonthly
             const hasOverride = expense.override != null
             return (
-              <tr key={expense.expense_id} className="hover:bg-gray-50">
-                <td className="px-4 py-3 font-medium text-gray-900">{expense.expense_name}</td>
-                <td className="px-4 py-3 text-gray-500">{fmt(defaultMonthly)}</td>
+              <tr key={expense.expense_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{expense.expense_name}</td>
+                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{fmt(defaultMonthly)}</td>
                 <td className="px-4 py-3">
-                  <span className={hasOverride ? 'text-indigo-600 font-medium' : 'text-gray-500'}>
+                  <span className={hasOverride ? 'text-indigo-600 dark:text-indigo-400 font-medium' : 'text-gray-500 dark:text-gray-400'}>
                     {fmt(thisMonth)}
                   </span>
-                  {hasOverride && <span className="ml-1.5 text-xs text-indigo-400">(overridden)</span>}
+                  {hasOverride && <span className="ml-1.5 text-xs text-indigo-400 dark:text-indigo-500">(overridden)</span>}
                 </td>
                 <td className="px-4 py-3">
                   <div className="flex gap-3">
-                    <button onClick={() => openEdit(expense)} className="text-xs text-indigo-600 hover:underline">Edit</button>
+                    <button onClick={() => openEdit(expense)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Edit</button>
                     {hasOverride && (
-                      <button onClick={() => setConfirmRemove(expense)} className="text-xs text-red-500 hover:underline">Reset</button>
+                      <button onClick={() => setConfirmRemove(expense)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Reset</button>
                     )}
                   </div>
                 </td>
@@ -135,22 +136,17 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
       {/* Edit Override Modal */}
       {editItem && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-1">Override Monthly Amount</h3>
-            <p className="text-sm text-gray-500 mb-4">{editItem.expense_name}</p>
-            {formError && <p className="text-red-600 text-sm mb-3">{formError}</p>}
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm p-6 border border-gray-100 dark:border-gray-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-1">Override Monthly Amount</h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-4">{editItem.expense_name}</p>
+            {formError && <p className="text-red-600 dark:text-red-400 text-sm mb-3">{formError}</p>}
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">This Month Amount (VND) *</label>
-              <input
-                type="number"
-                value={overrideValue}
-                onChange={(e) => setOverrideValue(e.target.value)}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-              />
-              <p className="text-xs text-gray-400 mt-1">Default: {fmt(editItem.amount_vnd)}/month</p>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">This Month Amount (VND) *</label>
+              <input type="number" value={overrideValue} onChange={(e) => setOverrideValue(e.target.value)} className={inputCls} />
+              <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">Default: {fmt(editItem.amount_vnd)}/month</p>
             </div>
             <div className="flex gap-3 mt-5">
-              <button onClick={() => setEditItem(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50">Cancel</button>
+              <button onClick={() => setEditItem(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
               <button onClick={handleSaveOverride} disabled={saving} className="flex-1 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 disabled:opacity-50 flex items-center justify-center gap-2">
                 {saving && <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />}
                 {saving ? 'Saving...' : 'Save'}
@@ -163,11 +159,11 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
       {/* Reset Confirmation */}
       {confirmRemove && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6">
-            <h3 className="text-base font-semibold text-gray-900 mb-2">Reset Override</h3>
-            <p className="text-sm text-gray-600 mb-5">Reset <strong>{confirmRemove.expense_name}</strong> to the default monthly amount?</p>
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm p-6 border border-gray-100 dark:border-gray-700">
+            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-2">Reset Override</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-5">Reset <strong>{confirmRemove.expense_name}</strong> to the default monthly amount?</p>
             <div className="flex gap-3">
-              <button onClick={() => setConfirmRemove(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50">Cancel</button>
+              <button onClick={() => setConfirmRemove(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
               <button onClick={() => handleRemoveOverride(confirmRemove)} className="flex-1 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700">Confirm</button>
             </div>
           </div>

--- a/app/planning/components/FixedExpensesSection.tsx
+++ b/app/planning/components/FixedExpensesSection.tsx
@@ -20,6 +20,7 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
   const [formError, setFormError] = useState('')
   const [saving, setSaving] = useState(false)
   const [confirmRemove, setConfirmRemove] = useState<FixedExpense | null>(null)
+  const [confirmDelete, setConfirmDelete] = useState<FixedExpense | null>(null)
 
   function openEdit(expense: FixedExpense) {
     setEditItem(expense)
@@ -78,6 +79,15 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
     }
   }
 
+  async function handleDelete(expense: FixedExpense) {
+    const res = await fetch(`/api/v1/fixed-expenses/${expense.expense_id}`, { method: 'DELETE' })
+    if (res.ok) {
+      setConfirmDelete(null)
+      onToast('Fixed expense deleted')
+      onRefresh()
+    }
+  }
+
   if (fixedExpenses.length === 0) {
     return (
       <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
@@ -123,8 +133,9 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
                   <div className="flex gap-3">
                     <button onClick={() => openEdit(expense)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Edit</button>
                     {hasOverride && (
-                      <button onClick={() => setConfirmRemove(expense)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Reset</button>
+                      <button onClick={() => setConfirmRemove(expense)} className="text-xs text-gray-500 dark:text-gray-400 hover:underline">Reset</button>
                     )}
+                    <button onClick={() => setConfirmDelete(expense)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Delete</button>
                   </div>
                 </td>
               </tr>
@@ -151,6 +162,20 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
                 {saving && <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />}
                 {saving ? 'Saving...' : 'Save'}
               </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation */}
+      {confirmDelete && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm p-6 border border-gray-100 dark:border-gray-700">
+            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-2">Delete Expense</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-5">Are you sure you want to delete <strong>{confirmDelete.expense_name}</strong>? This will remove it from all plans.</p>
+            <div className="flex gap-3">
+              <button onClick={() => setConfirmDelete(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
+              <button onClick={() => handleDelete(confirmDelete)} className="flex-1 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700">Delete</button>
             </div>
           </div>
         </div>

--- a/app/planning/components/FundInvestmentsSection.tsx
+++ b/app/planning/components/FundInvestmentsSection.tsx
@@ -17,6 +17,8 @@ const fmt = (n: number) => '₫ ' + Math.round(n).toLocaleString('vi-VN')
 
 const emptyForm = { fund_id: '', goal_id: '', amount_vnd: '', units_purchased: '', nav_at_purchase: '', investment_date: '' }
 
+const inputCls = 'w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500'
+
 export default function FundInvestmentsSection({ plan, investments, onRefresh, onToast }: Props) {
   const [funds, setFunds] = useState<Fund[]>([])
   const [goals, setGoals] = useState<Goal[]>([])
@@ -124,37 +126,37 @@ export default function FundInvestmentsSection({ plan, investments, onRefresh, o
   }
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
-      <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
-        <h2 className="font-semibold text-gray-900">Fund Investments</h2>
+    <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
+      <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+        <h2 className="font-semibold text-gray-900 dark:text-gray-100">Fund Investments</h2>
         <button onClick={openAdd} className="px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700">
           Add Fund Investment
         </button>
       </div>
 
       {investments.length === 0 ? (
-        <div className="text-center py-10 text-gray-400 text-sm">Add your first fund investment to get started</div>
+        <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">Add your first fund investment to get started</div>
       ) : (
         <table className="w-full text-sm">
-          <thead className="bg-gray-50">
+          <thead className="bg-gray-50 dark:bg-gray-800">
             <tr>
               {['Fund', 'Date', 'Amount', 'Units', 'Goal', 'Actions'].map((h) => (
-                <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">{h}</th>
+                <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-50">
+          <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
             {investments.map((inv) => (
-              <tr key={inv.id} className="hover:bg-gray-50">
-                <td className="px-4 py-3 font-medium text-gray-900">{inv.funds?.name ?? '—'}</td>
-                <td className="px-4 py-3 text-gray-500">{inv.investment_date ?? '—'}</td>
-                <td className="px-4 py-3">{fmt(inv.amount_vnd)}</td>
-                <td className="px-4 py-3 text-gray-500">{inv.units_purchased}</td>
-                <td className="px-4 py-3 text-gray-500">{inv.savings_goals?.goal_name ?? 'Unassigned'}</td>
+              <tr key={inv.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{inv.funds?.name ?? '—'}</td>
+                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{inv.investment_date ?? '—'}</td>
+                <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{fmt(inv.amount_vnd)}</td>
+                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{inv.units_purchased}</td>
+                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{inv.savings_goals?.goal_name ?? 'Unassigned'}</td>
                 <td className="px-4 py-3">
                   <div className="flex gap-3">
-                    <button onClick={() => openEdit(inv)} className="text-xs text-indigo-600 hover:underline">Edit</button>
-                    <button onClick={() => setConfirmDelete(inv)} className="text-xs text-red-500 hover:underline">Delete</button>
+                    <button onClick={() => openEdit(inv)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Edit</button>
+                    <button onClick={() => setConfirmDelete(inv)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Delete</button>
                   </div>
                 </td>
               </tr>
@@ -166,17 +168,13 @@ export default function FundInvestmentsSection({ plan, investments, onRefresh, o
       {/* Add/Edit Modal */}
       {showForm && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl w-full max-w-md p-6 max-h-[90vh] overflow-y-auto">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">{editItem ? 'Edit Fund Investment' : 'Add Fund Investment'}</h3>
-            {formError && <p className="text-red-600 text-sm mb-3">{formError}</p>}
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-md p-6 max-h-[90vh] overflow-y-auto border border-gray-100 dark:border-gray-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">{editItem ? 'Edit Fund Investment' : 'Add Fund Investment'}</h3>
+            {formError && <p className="text-red-600 dark:text-red-400 text-sm mb-3">{formError}</p>}
             <div className="space-y-3">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Fund *</label>
-                <select
-                  value={form.fund_id}
-                  onChange={(e) => handleFundSelect(e.target.value)}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                >
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Fund *</label>
+                <select value={form.fund_id} onChange={(e) => handleFundSelect(e.target.value)} className={inputCls}>
                   <option value="">Select fund...</option>
                   {funds.map((f) => (
                     <option key={f.id} value={f.id}>{f.name} (NAV: {f.nav})</option>
@@ -184,48 +182,36 @@ export default function FundInvestmentsSection({ plan, investments, onRefresh, o
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Investment Date *</label>
-                <input
-                  type="date"
-                  value={form.investment_date}
-                  min={minDate}
-                  max={maxDate}
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Investment Date *</label>
+                <input type="date" value={form.investment_date} min={minDate} max={maxDate}
                   onChange={(e) => setForm((prev) => ({ ...prev, investment_date: e.target.value }))}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
-                />
+                  className={inputCls} />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Goal (optional)</label>
-                <select
-                  value={form.goal_id}
-                  onChange={(e) => setForm({ ...form, goal_id: e.target.value })}
-                  disabled={goals.length === 0}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50"
-                >
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Goal (optional)</label>
+                <select value={form.goal_id} onChange={(e) => setForm({ ...form, goal_id: e.target.value })}
+                  disabled={goals.length === 0} className={`${inputCls} disabled:opacity-50`}>
                   <option value="">{goals.length === 0 ? 'No goals available' : 'Unassigned'}</option>
                   {goals.map((g) => <option key={g.goal_id} value={g.goal_id}>{g.goal_name}</option>)}
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Amount (VND) *</label>
-                <input type="number" value={form.amount_vnd} onChange={(e) => setForm({ ...form, amount_vnd: e.target.value })}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Amount (VND) *</label>
+                <input type="number" value={form.amount_vnd} onChange={(e) => setForm({ ...form, amount_vnd: e.target.value })} className={inputCls} />
               </div>
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Units Purchased *</label>
-                  <input type="number" step="0.0001" value={form.units_purchased} onChange={(e) => setForm({ ...form, units_purchased: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Units Purchased *</label>
+                  <input type="number" step="0.0001" value={form.units_purchased} onChange={(e) => setForm({ ...form, units_purchased: e.target.value })} className={inputCls} />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">NAV at Purchase *</label>
-                  <input type="number" step="0.0001" value={form.nav_at_purchase} onChange={(e) => setForm({ ...form, nav_at_purchase: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">NAV at Purchase *</label>
+                  <input type="number" step="0.0001" value={form.nav_at_purchase} onChange={(e) => setForm({ ...form, nav_at_purchase: e.target.value })} className={inputCls} />
                 </div>
               </div>
             </div>
             <div className="flex gap-3 mt-5">
-              <button onClick={() => setShowForm(false)} className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50">Cancel</button>
+              <button onClick={() => setShowForm(false)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
               <button onClick={handleSave} disabled={saving} className="flex-1 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 disabled:opacity-50 flex items-center justify-center gap-2">
                 {saving && <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />}
                 {saving ? 'Saving...' : 'Save'}
@@ -238,11 +224,11 @@ export default function FundInvestmentsSection({ plan, investments, onRefresh, o
       {/* Delete Confirmation */}
       {confirmDelete && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6">
-            <h3 className="text-base font-semibold text-gray-900 mb-2">Delete Investment</h3>
-            <p className="text-sm text-gray-600 mb-5">Are you sure you want to delete this investment?</p>
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm p-6 border border-gray-100 dark:border-gray-700">
+            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-2">Delete Investment</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-5">Are you sure you want to delete this investment?</p>
             <div className="flex gap-3">
-              <button onClick={() => setConfirmDelete(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50">Cancel</button>
+              <button onClick={() => setConfirmDelete(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
               <button onClick={() => handleDelete(confirmDelete)} className="flex-1 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700">Confirm</button>
             </div>
           </div>

--- a/app/planning/components/InsuranceSection.tsx
+++ b/app/planning/components/InsuranceSection.tsx
@@ -10,11 +10,11 @@ const fmt = (n: number) => '₫ ' + Math.round(n).toLocaleString('vi-VN')
 export default function InsuranceSection({ insuranceMembers }: Props) {
   if (insuranceMembers.length === 0) {
     return (
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
-        <div className="px-5 py-4 border-b border-gray-100">
-          <h2 className="font-semibold text-gray-900">Insurance</h2>
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
+        <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+          <h2 className="font-semibold text-gray-900 dark:text-gray-100">Insurance</h2>
         </div>
-        <div className="text-center py-10 text-gray-400 text-sm">No insurance members configured</div>
+        <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">No insurance members configured</div>
       </div>
     )
   }
@@ -22,33 +22,33 @@ export default function InsuranceSection({ insuranceMembers }: Props) {
   const totalMonthly = insuranceMembers.reduce((sum, m) => sum + Math.round(m.annual_payment_vnd / 12), 0)
 
   return (
-    <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
-      <div className="px-5 py-4 border-b border-gray-100">
-        <h2 className="font-semibold text-gray-900">Insurance</h2>
-        <p className="text-xs text-gray-400 mt-0.5">Monthly premiums (annual ÷ 12) across all members.</p>
+    <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
+      <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+        <h2 className="font-semibold text-gray-900 dark:text-gray-100">Insurance</h2>
+        <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">Monthly premiums (annual ÷ 12) across all members.</p>
       </div>
 
       <table className="w-full text-sm">
-        <thead className="bg-gray-50">
+        <thead className="bg-gray-50 dark:bg-gray-800">
           <tr>
             {['Member', 'Relationship', 'Monthly Premium'].map((h) => (
-              <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">{h}</th>
+              <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
             ))}
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-50">
+        <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
           {insuranceMembers.map((m) => (
-            <tr key={m.member_id} className="hover:bg-gray-50">
-              <td className="px-4 py-3 font-medium text-gray-900">{m.member_name}</td>
-              <td className="px-4 py-3 text-gray-500">{m.relationship}</td>
-              <td className="px-4 py-3 text-gray-700">{fmt(Math.round(m.annual_payment_vnd / 12))}</td>
+            <tr key={m.member_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+              <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{m.member_name}</td>
+              <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{m.relationship}</td>
+              <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{fmt(Math.round(m.annual_payment_vnd / 12))}</td>
             </tr>
           ))}
         </tbody>
         <tfoot>
-          <tr className="border-t border-gray-200 bg-gray-50">
-            <td colSpan={2} className="px-4 py-3 text-sm font-semibold text-gray-700">Total Monthly</td>
-            <td className="px-4 py-3 text-sm font-semibold text-gray-900">{fmt(totalMonthly)}</td>
+          <tr className="border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
+            <td colSpan={2} className="px-4 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300">Total Monthly</td>
+            <td className="px-4 py-3 text-sm font-semibold text-gray-900 dark:text-gray-100">{fmt(totalMonthly)}</td>
           </tr>
         </tfoot>
       </table>

--- a/app/planning/components/InsuranceSection.tsx
+++ b/app/planning/components/InsuranceSection.tsx
@@ -1,13 +1,79 @@
+'use client'
+
+import { useState } from 'react'
 import type { MonthlyPlan, InsuranceMember } from '../PlanningClient'
 
 interface Props {
   plan: MonthlyPlan
   insuranceMembers: InsuranceMember[]
+  onRefresh: () => void
+  onToast: (msg: string) => void
 }
 
 const fmt = (n: number) => '₫ ' + Math.round(n).toLocaleString('vi-VN')
 
-export default function InsuranceSection({ insuranceMembers }: Props) {
+const inputCls = 'w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500'
+
+export default function InsuranceSection({ insuranceMembers, onRefresh, onToast }: Props) {
+  const [editItem, setEditItem] = useState<InsuranceMember | null>(null)
+  const [form, setForm] = useState({ member_name: '', relationship: '', annual_payment_vnd: '', payment_date: '' })
+  const [formError, setFormError] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState<InsuranceMember | null>(null)
+
+  function openEdit(member: InsuranceMember) {
+    setEditItem(member)
+    setForm({
+      member_name: member.member_name,
+      relationship: member.relationship,
+      annual_payment_vnd: String(member.annual_payment_vnd),
+      payment_date: member.payment_date ?? '',
+    })
+    setFormError('')
+  }
+
+  async function handleSave() {
+    if (!editItem) return
+    setFormError('')
+    if (!form.member_name.trim()) { setFormError('Member name is required'); return }
+    if (!form.relationship.trim()) { setFormError('Relationship is required'); return }
+    if (!form.annual_payment_vnd || Number(form.annual_payment_vnd) <= 0) { setFormError('Annual payment must be positive'); return }
+
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/v1/insurance-members/${editItem.member_id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          member_name: form.member_name.trim(),
+          relationship: form.relationship.trim(),
+          annual_payment_vnd: Number(form.annual_payment_vnd),
+          payment_date: form.payment_date || null,
+        }),
+      })
+      if (!res.ok) {
+        const { error } = await res.json()
+        setFormError(error ?? 'Something went wrong. Please try again later.')
+      } else {
+        setEditItem(null)
+        onToast('Insurance member updated')
+        onRefresh()
+      }
+    } catch {
+      setFormError('Unable to save. Please check your connection and try again.')
+    }
+    setSaving(false)
+  }
+
+  async function handleDelete(member: InsuranceMember) {
+    const res = await fetch(`/api/v1/insurance-members/${member.member_id}`, { method: 'DELETE' })
+    if (res.ok) {
+      setConfirmDelete(null)
+      onToast('Insurance member deleted')
+      onRefresh()
+    }
+  }
+
   if (insuranceMembers.length === 0) {
     return (
       <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
@@ -31,7 +97,7 @@ export default function InsuranceSection({ insuranceMembers }: Props) {
       <table className="w-full text-sm">
         <thead className="bg-gray-50 dark:bg-gray-800">
           <tr>
-            {['Member', 'Relationship', 'Monthly Premium'].map((h) => (
+            {['Member', 'Relationship', 'Monthly Premium', 'Actions'].map((h) => (
               <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
             ))}
           </tr>
@@ -42,16 +108,71 @@ export default function InsuranceSection({ insuranceMembers }: Props) {
               <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{m.member_name}</td>
               <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{m.relationship}</td>
               <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{fmt(Math.round(m.annual_payment_vnd / 12))}</td>
+              <td className="px-4 py-3">
+                <div className="flex gap-3">
+                  <button onClick={() => openEdit(m)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Edit</button>
+                  <button onClick={() => setConfirmDelete(m)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Delete</button>
+                </div>
+              </td>
             </tr>
           ))}
         </tbody>
         <tfoot>
           <tr className="border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
-            <td colSpan={2} className="px-4 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300">Total Monthly</td>
+            <td colSpan={3} className="px-4 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300">Total Monthly</td>
             <td className="px-4 py-3 text-sm font-semibold text-gray-900 dark:text-gray-100">{fmt(totalMonthly)}</td>
           </tr>
         </tfoot>
       </table>
+
+      {/* Edit Modal */}
+      {editItem && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm p-6 border border-gray-100 dark:border-gray-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Edit Insurance Member</h3>
+            {formError && <p className="text-red-600 dark:text-red-400 text-sm mb-3">{formError}</p>}
+            <div className="space-y-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Member Name *</label>
+                <input type="text" value={form.member_name} onChange={(e) => setForm({ ...form, member_name: e.target.value })} className={inputCls} />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Relationship *</label>
+                <input type="text" value={form.relationship} onChange={(e) => setForm({ ...form, relationship: e.target.value })} className={inputCls} />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Annual Payment (VND) *</label>
+                <input type="number" value={form.annual_payment_vnd} onChange={(e) => setForm({ ...form, annual_payment_vnd: e.target.value })} className={inputCls} />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Payment Date</label>
+                <input type="date" value={form.payment_date} onChange={(e) => setForm({ ...form, payment_date: e.target.value })} className={inputCls} />
+              </div>
+            </div>
+            <div className="flex gap-3 mt-5">
+              <button onClick={() => setEditItem(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
+              <button onClick={handleSave} disabled={saving} className="flex-1 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 disabled:opacity-50 flex items-center justify-center gap-2">
+                {saving && <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />}
+                {saving ? 'Saving...' : 'Save'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Delete Confirmation */}
+      {confirmDelete && (
+        <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm p-6 border border-gray-100 dark:border-gray-700">
+            <h3 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-2">Delete Insurance Member</h3>
+            <p className="text-sm text-gray-600 dark:text-gray-400 mb-5">Are you sure you want to delete <strong>{confirmDelete.member_name}</strong>? This cannot be undone.</p>
+            <div className="flex gap-3">
+              <button onClick={() => setConfirmDelete(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
+              <button onClick={() => handleDelete(confirmDelete)} className="flex-1 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700">Delete</button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/app/planning/components/SalaryInput.tsx
+++ b/app/planning/components/SalaryInput.tsx
@@ -91,12 +91,12 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
 
   return (
     <>
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-5">
-        <label className="block text-sm font-semibold text-gray-700 mb-2">Monthly Salary (VND)</label>
-        {error && <p className="text-red-600 text-sm mb-2">{error}</p>}
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-5">
+        <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">Monthly Salary (VND)</label>
+        {error && <p className="text-red-600 dark:text-red-400 text-sm mb-2">{error}</p>}
         <div className="flex items-center gap-3">
           <div className="relative flex-1">
-            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm font-medium">₫</span>
+            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 text-sm font-medium">₫</span>
             <input
               type="number"
               value={value}
@@ -105,7 +105,7 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
               onKeyDown={handleKeyDown}
               disabled={saving}
               placeholder="Enter your monthly salary to begin planning"
-              className="w-full pl-7 pr-4 py-2.5 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-60"
+              className="w-full pl-7 pr-4 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-60"
             />
           </div>
           {saving && (
@@ -131,17 +131,17 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
       {showConfirm && (
         <div className="fixed inset-0 z-50 flex items-center justify-center">
           <div className="absolute inset-0 bg-black/40" onClick={() => setShowConfirm(false)} />
-          <div className="relative bg-white rounded-xl shadow-xl p-6 w-full max-w-sm mx-4">
-            <h2 className="text-base font-semibold text-gray-900 mb-1">Delete salary record?</h2>
-            <p className="text-sm text-gray-500 mb-5">
+          <div className="relative bg-white dark:bg-gray-900 rounded-xl shadow-xl p-6 w-full max-w-sm mx-4 border border-gray-100 dark:border-gray-700">
+            <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100 mb-1">Delete salary record?</h2>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-5">
               This will permanently delete the salary record for{' '}
-              <span className="font-medium text-gray-700">{MONTHS[month - 1]} {year}</span>{' '}
+              <span className="font-medium text-gray-700 dark:text-gray-300">{MONTHS[month - 1]} {year}</span>{' '}
               and all associated allocations. This action cannot be undone.
             </p>
             <div className="flex justify-end gap-3">
               <button
                 onClick={() => setShowConfirm(false)}
-                className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200"
+                className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-800 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700"
               >
                 Cancel
               </button>

--- a/app/savings-goals/[goalId]/GoalDetailClient.tsx
+++ b/app/savings-goals/[goalId]/GoalDetailClient.tsx
@@ -77,28 +77,28 @@ export default function GoalDetailClient({ goalId }: { goalId: string }) {
   const exceededTarget = goal?.progressPercentage !== null && (goal?.progressPercentage ?? 0) >= 100
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       <div className="max-w-4xl mx-auto px-4 py-8">
         {/* Back */}
         <button
           onClick={() => router.push('/dashboard')}
-          className="flex items-center gap-1.5 text-sm text-indigo-600 hover:text-indigo-800 font-medium mb-6"
+          className="flex items-center gap-1.5 text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 font-medium mb-6"
         >
           ← Back to Dashboard
         </button>
 
         {error && (
-          <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-xl text-sm text-red-700 flex items-center justify-between">
+          <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl text-sm text-red-700 dark:text-red-400 flex items-center justify-between">
             {error}
-            <button onClick={fetchData} className="text-red-600 font-medium hover:underline ml-4">Retry</button>
+            <button onClick={fetchData} className="text-red-600 dark:text-red-400 font-medium hover:underline ml-4">Retry</button>
           </div>
         )}
 
         {loading && (
           <div className="space-y-4">
-            <div className="h-8 w-48 bg-gray-200 rounded-lg animate-pulse" />
-            <div className="h-32 bg-gray-200 rounded-xl animate-pulse" />
-            <div className="h-64 bg-gray-200 rounded-xl animate-pulse" />
+            <div className="h-8 w-48 bg-gray-200 dark:bg-gray-700 rounded-lg animate-pulse" />
+            <div className="h-32 bg-gray-200 dark:bg-gray-700 rounded-xl animate-pulse" />
+            <div className="h-64 bg-gray-200 dark:bg-gray-700 rounded-xl animate-pulse" />
           </div>
         )}
 
@@ -106,27 +106,27 @@ export default function GoalDetailClient({ goalId }: { goalId: string }) {
           <>
             {/* Goal header */}
             <div className="mb-6">
-              <h1 className="text-2xl font-bold text-gray-900 mb-1">
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-1">
                 {goal?.goalName ?? 'Goal'}
               </h1>
               {!goal && (
-                <p className="text-sm text-gray-400">Goal not found or has no data yet.</p>
+                <p className="text-sm text-gray-400 dark:text-gray-500">Goal not found or has no data yet.</p>
               )}
             </div>
 
             {/* Summary cards */}
             {goal && (
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8">
-                <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-4">
-                  <p className="text-xs text-gray-400 font-medium uppercase tracking-wide mb-1">Current Value</p>
-                  <p className="text-lg font-bold text-gray-900">{fmt(goal.currentValue)}</p>
+                <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-100 dark:border-gray-700 shadow-sm p-4">
+                  <p className="text-xs text-gray-400 dark:text-gray-500 font-medium uppercase tracking-wide mb-1">Current Value</p>
+                  <p className="text-lg font-bold text-gray-900 dark:text-gray-100">{fmt(goal.currentValue)}</p>
                 </div>
-                <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-4">
-                  <p className="text-xs text-gray-400 font-medium uppercase tracking-wide mb-1">Invested</p>
-                  <p className="text-lg font-bold text-gray-900">{fmt(goal.totalInvested)}</p>
+                <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-100 dark:border-gray-700 shadow-sm p-4">
+                  <p className="text-xs text-gray-400 dark:text-gray-500 font-medium uppercase tracking-wide mb-1">Invested</p>
+                  <p className="text-lg font-bold text-gray-900 dark:text-gray-100">{fmt(goal.totalInvested)}</p>
                 </div>
-                <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-4">
-                  <p className="text-xs text-gray-400 font-medium uppercase tracking-wide mb-1">P&amp;L</p>
+                <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-100 dark:border-gray-700 shadow-sm p-4">
+                  <p className="text-xs text-gray-400 dark:text-gray-500 font-medium uppercase tracking-wide mb-1">P&amp;L</p>
                   <p className={`text-lg font-bold ${plPositive ? 'text-green-600' : 'text-red-600'}`}>
                     {fmt(goal.profitLoss)}
                   </p>
@@ -135,12 +135,12 @@ export default function GoalDetailClient({ goalId }: { goalId: string }) {
                   </p>
                 </div>
                 {goal.targetAmount != null && (
-                  <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-4">
-                    <p className="text-xs text-gray-400 font-medium uppercase tracking-wide mb-1">Progress</p>
-                    <p className={`text-lg font-bold ${exceededTarget ? 'text-green-600' : 'text-gray-900'}`}>
+                  <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-100 dark:border-gray-700 shadow-sm p-4">
+                    <p className="text-xs text-gray-400 dark:text-gray-500 font-medium uppercase tracking-wide mb-1">Progress</p>
+                    <p className={`text-lg font-bold ${exceededTarget ? 'text-green-600' : 'text-gray-900 dark:text-gray-100'}`}>
                       {exceededTarget ? '🎉 Done' : `${Math.round(goal.progressPercentage ?? 0)}%`}
                     </p>
-                    <p className="text-xs text-gray-400">of {fmt(goal.targetAmount)}</p>
+                    <p className="text-xs text-gray-400 dark:text-gray-500">of {fmt(goal.targetAmount)}</p>
                   </div>
                 )}
               </div>
@@ -148,14 +148,14 @@ export default function GoalDetailClient({ goalId }: { goalId: string }) {
 
             {/* Progress bar */}
             {goal?.targetAmount != null && (
-              <div className="mb-8 bg-white rounded-xl border border-gray-100 shadow-sm p-5">
-                <div className="flex items-center justify-between text-sm text-gray-600 mb-2">
+              <div className="mb-8 bg-white dark:bg-gray-900 rounded-xl border border-gray-100 dark:border-gray-700 shadow-sm p-5">
+                <div className="flex items-center justify-between text-sm text-gray-600 dark:text-gray-400 mb-2">
                   <span>Target: {fmt(goal.targetAmount)}</span>
                   <span className={exceededTarget ? 'text-green-600 font-medium' : ''}>
                     {exceededTarget ? 'Target exceeded!' : `${Math.round(goal.progressPercentage ?? 0)}% complete`}
                   </span>
                 </div>
-                <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
+                <div className="h-2 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
                   <div
                     className={`h-full rounded-full transition-all ${exceededTarget ? 'bg-green-500' : 'bg-indigo-500'}`}
                     style={{ width: `${Math.min(goal.progressPercentage ?? 0, 100)}%` }}
@@ -165,29 +165,29 @@ export default function GoalDetailClient({ goalId }: { goalId: string }) {
             )}
 
             {/* Transactions table */}
-            <div className="bg-white rounded-xl border border-gray-100 shadow-sm overflow-hidden">
-              <div className="px-5 py-4 border-b border-gray-100">
-                <h2 className="font-semibold text-gray-900">Transactions</h2>
+            <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-100 dark:border-gray-700 shadow-sm overflow-hidden">
+              <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+                <h2 className="font-semibold text-gray-900 dark:text-gray-100">Transactions</h2>
               </div>
 
               {transactions.length === 0 ? (
-                <div className="text-center py-12 text-gray-400 text-sm">No transactions yet.</div>
+                <div className="text-center py-12 text-gray-400 dark:text-gray-500 text-sm">No transactions yet.</div>
               ) : (
                 <div className="overflow-x-auto">
                   <table className="w-full text-sm">
-                    <thead className="bg-gray-50">
+                    <thead className="bg-gray-50 dark:bg-gray-800">
                       <tr>
                         {['Date', 'Type', 'Fund', 'Amount', 'Units', 'Unit Price', 'Interest Rate', 'Notes'].map((h) => (
-                          <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-500 uppercase tracking-wide">
+                          <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">
                             {h}
                           </th>
                         ))}
                       </tr>
                     </thead>
-                    <tbody className="divide-y divide-gray-50">
+                    <tbody className="divide-y divide-gray-50 dark:divide-gray-700">
                       {transactions.map((tx) => (
-                        <tr key={tx.transaction_id} className="hover:bg-gray-50">
-                          <td className="px-4 py-3 text-gray-700 whitespace-nowrap">
+                        <tr key={tx.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                          <td className="px-4 py-3 text-gray-700 dark:text-gray-300 whitespace-nowrap">
                             {new Date(tx.investment_date).toLocaleDateString('vi-VN')}
                           </td>
                           <td className="px-4 py-3">
@@ -195,16 +195,16 @@ export default function GoalDetailClient({ goalId }: { goalId: string }) {
                               {tx.asset_type}
                             </span>
                           </td>
-                          <td className="px-4 py-3 text-gray-500 text-xs">{tx.fund_name ?? '—'}</td>
-                          <td className="px-4 py-3 font-medium text-gray-900 whitespace-nowrap">{fmt(tx.amount_vnd)}</td>
-                          <td className="px-4 py-3 text-gray-500">{tx.units ?? '—'}</td>
-                          <td className="px-4 py-3 text-gray-500 whitespace-nowrap">
+                          <td className="px-4 py-3 text-gray-500 dark:text-gray-400 text-xs">{tx.fund_name ?? '—'}</td>
+                          <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100 whitespace-nowrap">{fmt(tx.amount_vnd)}</td>
+                          <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{tx.units ?? '—'}</td>
+                          <td className="px-4 py-3 text-gray-500 dark:text-gray-400 whitespace-nowrap">
                             {tx.unit_price != null ? fmt(tx.unit_price) : '—'}
                           </td>
-                          <td className="px-4 py-3 text-gray-500">
+                          <td className="px-4 py-3 text-gray-500 dark:text-gray-400">
                             {tx.interest_rate != null ? `${tx.interest_rate}%` : '—'}
                           </td>
-                          <td className="px-4 py-3 text-gray-400 max-w-32 truncate">{tx.notes ?? '—'}</td>
+                          <td className="px-4 py-3 text-gray-400 dark:text-gray-500 max-w-32 truncate">{tx.notes ?? '—'}</td>
                         </tr>
                       ))}
                     </tbody>

--- a/app/settings/SettingsClient.tsx
+++ b/app/settings/SettingsClient.tsx
@@ -21,15 +21,15 @@ export default function SettingsClient() {
   const [activeTab, setActiveTab] = useState<TabId>('goals')
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
       <div className="max-w-6xl mx-auto px-4 py-8">
         <div className="mb-8">
-          <h1 className="text-2xl font-bold text-gray-900">Settings</h1>
-          <p className="text-sm text-gray-500 mt-1">Manage your savings goals, investments, expenses, and insurance.</p>
+          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">Settings</h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">Manage your savings goals, investments, expenses, and insurance.</p>
         </div>
 
         {/* Tabs */}
-        <div className="border-b border-gray-200 mb-6">
+        <div className="border-b border-gray-200 dark:border-gray-700 mb-6">
           <nav className="-mb-px flex gap-1 overflow-x-auto">
             {TABS.map((tab) => (
               <button
@@ -37,8 +37,8 @@ export default function SettingsClient() {
                 onClick={() => setActiveTab(tab.id)}
                 className={`whitespace-nowrap py-3 px-4 text-sm font-medium border-b-2 transition-colors ${
                   activeTab === tab.id
-                    ? 'border-indigo-600 text-indigo-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                    ? 'border-indigo-600 text-indigo-600 dark:text-indigo-400 dark:border-indigo-400'
+                    : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-500'
                 }`}
               >
                 {tab.label}

--- a/app/settings/tabs/FixedExpensesTab.tsx
+++ b/app/settings/tabs/FixedExpensesTab.tsx
@@ -95,8 +95,8 @@ export default function FixedExpensesTab() {
     <div>
       <div className="flex items-center justify-between mb-4">
         <div>
-          <h2 className="text-lg font-semibold text-gray-900">Fixed Expenses</h2>
-          {expenses.length > 0 && <p className="text-sm text-gray-500 mt-0.5">Total: {fmt(totalMonthly)} / month</p>}
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Fixed Expenses</h2>
+          {expenses.length > 0 && <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">Total: {fmt(totalMonthly)} / month</p>}
         </div>
         <button onClick={openCreate} className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700">
           Create Expense
@@ -104,17 +104,17 @@ export default function FixedExpensesTab() {
       </div>
 
       {successMsg && (
-        <div className="mb-4 p-3 bg-green-50 border border-green-200 text-green-800 rounded-lg text-sm">{successMsg}</div>
+        <div className="mb-4 p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 text-green-800 dark:text-green-300 rounded-lg text-sm">{successMsg}</div>
       )}
 
       {/* Filter */}
       {categories.length > 0 && (
         <div className="mb-4 flex items-center gap-3">
-          <label className="text-sm text-gray-600 font-medium">Category:</label>
+          <label className="text-sm text-gray-600 dark:text-gray-400 font-medium">Category:</label>
           <select
             value={filterCategory}
             onChange={(e) => setFilterCategory(e.target.value)}
-            className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
           >
             <option value="">All</option>
             {categories.map((c) => <option key={c} value={c}>{c}</option>)}
@@ -122,33 +122,33 @@ export default function FixedExpensesTab() {
         </div>
       )}
 
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
         {loading ? (
-          <div className="text-center py-10 text-gray-400 text-sm">Loading...</div>
+          <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">Loading...</div>
         ) : expenses.length === 0 ? (
-          <div className="text-center py-10 text-gray-400 text-sm">No expenses yet.</div>
+          <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">No expenses yet.</div>
         ) : (
           <table className="w-full text-sm">
-            <thead className="bg-gray-50">
+            <thead className="bg-gray-50 dark:bg-gray-800">
               <tr>
                 {['Name', 'Category', 'Amount / Month', 'Created', 'Actions'].map((h) => (
-                  <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">{h}</th>
+                  <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
                 ))}
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-50">
+            <tbody className="divide-y divide-gray-50 dark:divide-gray-700">
               {expenses.map((expense) => (
-                <tr key={expense.expense_id} className="hover:bg-gray-50">
-                  <td className="px-4 py-3 font-medium text-gray-900">{expense.expense_name}</td>
+                <tr key={expense.expense_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                  <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{expense.expense_name}</td>
                   <td className="px-4 py-3">
-                    <span className="inline-block px-2 py-0.5 rounded bg-gray-100 text-gray-700 text-xs font-medium">{expense.category}</span>
+                    <span className="inline-block px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs font-medium">{expense.category}</span>
                   </td>
-                  <td className="px-4 py-3 font-medium text-gray-900">{fmt(expense.amount_vnd)}</td>
-                  <td className="px-4 py-3 text-gray-400 text-xs">{new Date(expense.created_at).toLocaleDateString('vi-VN')}</td>
+                  <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(expense.amount_vnd)}</td>
+                  <td className="px-4 py-3 text-gray-400 dark:text-gray-500 text-xs">{new Date(expense.created_at).toLocaleDateString('vi-VN')}</td>
                   <td className="px-4 py-3">
                     <div className="flex gap-3">
-                      <button onClick={() => openEdit(expense)} className="text-xs text-indigo-600 hover:underline">Edit</button>
-                      <button onClick={() => handleDelete(expense)} className="text-xs text-red-500 hover:underline">Delete</button>
+                      <button onClick={() => openEdit(expense)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Edit</button>
+                      <button onClick={() => handleDelete(expense)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Delete</button>
                     </div>
                   </td>
                 </tr>
@@ -161,28 +161,28 @@ export default function FixedExpensesTab() {
       {/* Create/Edit Modal */}
       {showForm && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">{editExpense ? 'Edit Expense' : 'Create Expense'}</h3>
-            {formError && <p className="text-red-600 text-sm mb-3">{formError}</p>}
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm p-6 border border-gray-100 dark:border-gray-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">{editExpense ? 'Edit Expense' : 'Create Expense'}</h3>
+            {formError && <p className="text-red-600 dark:text-red-400 text-sm mb-3">{formError}</p>}
             <div className="space-y-3">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Expense Name *</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Expense Name *</label>
                 <input type="text" value={form.expense_name} onChange={(e) => setForm({ ...form, expense_name: e.target.value })}
-                  placeholder="e.g. Rent" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                  placeholder="e.g. Rent" className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Category *</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Category *</label>
                 <input type="text" value={form.category} onChange={(e) => setForm({ ...form, category: e.target.value })}
-                  placeholder="e.g. Housing" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                  placeholder="e.g. Housing" className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Amount (VND) *</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Amount (VND) *</label>
                 <input type="number" value={form.amount_vnd} onChange={(e) => setForm({ ...form, amount_vnd: e.target.value })}
-                  placeholder="e.g. 5000000" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                  placeholder="e.g. 5000000" className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
               </div>
             </div>
             <div className="flex gap-3 mt-5">
-              <button onClick={() => setShowForm(false)} className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50">Cancel</button>
+              <button onClick={() => setShowForm(false)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
               <button onClick={handleSave} disabled={saving} className="flex-1 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 disabled:opacity-50">
                 {saving ? 'Saving...' : 'Save'}
               </button>

--- a/app/settings/tabs/GoalDetailView.tsx
+++ b/app/settings/tabs/GoalDetailView.tsx
@@ -253,15 +253,15 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
   return (
     <div>
       <div className="flex items-center gap-3 mb-6">
-        <button onClick={onBack} className="text-sm text-indigo-600 hover:text-indigo-800 font-medium">← Back</button>
+        <button onClick={onBack} className="text-sm text-indigo-600 dark:text-indigo-400 hover:text-indigo-800 dark:hover:text-indigo-300 font-medium">← Back</button>
         <div>
-          <h2 className="text-xl font-bold text-gray-900">{goal.goal_name}</h2>
-          {goal.description && <p className="text-sm text-gray-500">{goal.description}</p>}
+          <h2 className="text-xl font-bold text-gray-900 dark:text-gray-100">{goal.goal_name}</h2>
+          {goal.description && <p className="text-sm text-gray-500 dark:text-gray-400">{goal.description}</p>}
         </div>
       </div>
 
       {successMsg && (
-        <div className="mb-4 p-3 bg-green-50 border border-green-200 text-green-800 rounded-lg text-sm">{successMsg}</div>
+        <div className="mb-4 p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 text-green-800 dark:text-green-300 rounded-lg text-sm">{successMsg}</div>
       )}
 
       {/* Summary */}
@@ -271,9 +271,9 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
           { label: 'Total Invested', value: fmt(totalInvested) },
           { label: 'Total Gain / Loss', value: fmt(totalGain) },
         ].map((item) => (
-          <div key={item.label} className="bg-white rounded-xl shadow-sm border border-gray-100 p-4 text-center">
-            <p className="text-xs text-gray-500 font-medium uppercase tracking-wide mb-1">{item.label}</p>
-            <p className={`text-xl font-bold ${item.label === 'Total Gain / Loss' ? (totalGain >= 0 ? 'text-green-600' : 'text-red-600') : 'text-indigo-700'}`}>
+          <div key={item.label} className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-4 text-center">
+            <p className="text-xs text-gray-500 dark:text-gray-400 font-medium uppercase tracking-wide mb-1">{item.label}</p>
+            <p className={`text-xl font-bold ${item.label === 'Total Gain / Loss' ? (totalGain >= 0 ? 'text-green-600' : 'text-red-600') : 'text-indigo-700 dark:text-indigo-300'}`}>
               {item.value}
             </p>
           </div>
@@ -281,11 +281,11 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
       </div>
 
       {/* Fund Investments (synced with Monthly Planning) */}
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden mb-4">
-        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden mb-4">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-700">
           <div>
-            <h3 className="font-semibold text-gray-900">Fund Investments</h3>
-            <p className="text-xs text-gray-400 mt-0.5">Synced with Monthly Planning</p>
+            <h3 className="font-semibold text-gray-900 dark:text-gray-100">Fund Investments</h3>
+            <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">Synced with Monthly Planning</p>
           </div>
           <button onClick={openFiAdd} className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700">
             Add Fund Investment
@@ -293,36 +293,36 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
         </div>
 
         {loading ? (
-          <div className="text-center py-8 text-gray-400 text-sm">Loading...</div>
+          <div className="text-center py-8 text-gray-400 dark:text-gray-500 text-sm">Loading...</div>
         ) : rows.filter(r => r._source === 'fi').length === 0 ? (
-          <div className="text-center py-8 text-gray-400 text-sm">No fund investments yet.</div>
+          <div className="text-center py-8 text-gray-400 dark:text-gray-500 text-sm">No fund investments yet.</div>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
-              <thead className="bg-gray-50">
+              <thead className="bg-gray-50 dark:bg-gray-800">
                 <tr>
                   {['Date', 'Fund', 'Amount', 'Units', 'NAV at Purchase', 'Current NAV', 'Current Value', 'P&L', 'Actions'].map((h) => (
-                    <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">{h}</th>
+                    <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
                   ))}
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-50">
+              <tbody className="divide-y divide-gray-50 dark:divide-gray-700">
                 {rows.filter((r): r is FiRow => r._source === 'fi').map((row) => {
                   const pl = row.current_value - row.amount_vnd
                   return (
-                    <tr key={row._id} className="hover:bg-gray-50">
-                      <td className="px-4 py-3 text-gray-700">{new Date(row.created_at).toLocaleDateString('vi-VN')}</td>
-                      <td className="px-4 py-3 font-medium text-gray-900">{row.fund_name}</td>
-                      <td className="px-4 py-3 text-gray-700">{fmt(row.amount_vnd)}</td>
-                      <td className="px-4 py-3 text-gray-500">{row.units_purchased}</td>
-                      <td className="px-4 py-3 text-gray-500">{fmt(row.nav_at_purchase)}</td>
-                      <td className="px-4 py-3 text-gray-500">{fmt(row.current_nav)}</td>
-                      <td className="px-4 py-3 font-medium text-gray-900">{fmt(row.current_value)}</td>
+                    <tr key={row._id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                      <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{new Date(row.created_at).toLocaleDateString('vi-VN')}</td>
+                      <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{row.fund_name}</td>
+                      <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{fmt(row.amount_vnd)}</td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{row.units_purchased}</td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{fmt(row.nav_at_purchase)}</td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{fmt(row.current_nav)}</td>
+                      <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(row.current_value)}</td>
                       <td className={`px-4 py-3 font-medium ${pl >= 0 ? 'text-green-600' : 'text-red-600'}`}>{fmt(pl)}</td>
                       <td className="px-4 py-3">
                         <div className="flex gap-2">
-                          <button onClick={() => openFiEdit(row)} className="text-xs text-indigo-600 hover:underline">Edit</button>
-                          <button onClick={() => handleFiDelete(row)} className="text-xs text-red-500 hover:underline">Delete</button>
+                          <button onClick={() => openFiEdit(row)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Edit</button>
+                          <button onClick={() => handleFiDelete(row)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Delete</button>
                         </div>
                       </td>
                     </tr>
@@ -335,11 +335,11 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
       </div>
 
       {/* Other Transactions (bank/stock/gold) */}
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
-        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-700">
           <div>
-            <h3 className="font-semibold text-gray-900">Other Transactions</h3>
-            <p className="text-xs text-gray-400 mt-0.5">Bank deposits, stocks, gold</p>
+            <h3 className="font-semibold text-gray-900 dark:text-gray-100">Other Transactions</h3>
+            <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">Bank deposits, stocks, gold</p>
           </div>
           <button onClick={openTxAdd} className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700">
             Add Transaction
@@ -347,40 +347,40 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
         </div>
 
         {loading ? (
-          <div className="text-center py-8 text-gray-400 text-sm">Loading...</div>
+          <div className="text-center py-8 text-gray-400 dark:text-gray-500 text-sm">Loading...</div>
         ) : rows.filter(r => r._source === 'tx').length === 0 ? (
-          <div className="text-center py-8 text-gray-400 text-sm">No transactions yet.</div>
+          <div className="text-center py-8 text-gray-400 dark:text-gray-500 text-sm">No transactions yet.</div>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
-              <thead className="bg-gray-50">
+              <thead className="bg-gray-50 dark:bg-gray-800">
                 <tr>
                   {['Date', 'Type', 'Fund', 'Amount', 'Units', 'Interest Rate', 'Gain/Loss', 'Notes', 'Actions'].map((h) => (
-                    <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">{h}</th>
+                    <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
                   ))}
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-50">
+              <tbody className="divide-y divide-gray-50 dark:divide-gray-700">
                 {rows.filter((r): r is TxRow => r._source === 'tx').map((row) => {
                   const gain = row.current_value - row.amount_vnd
                   return (
-                    <tr key={row._id} className="hover:bg-gray-50">
-                      <td className="px-4 py-3 text-gray-700">{new Date(row.investment_date).toLocaleDateString('vi-VN')}</td>
+                    <tr key={row._id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                      <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{new Date(row.investment_date).toLocaleDateString('vi-VN')}</td>
                       <td className="px-4 py-3">
                         <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${ASSET_COLORS[row.asset_type] ?? 'bg-gray-100 text-gray-700'}`}>
                           {row.asset_type}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-gray-500 text-xs">{row.fund_display ?? '—'}</td>
-                      <td className="px-4 py-3 font-medium text-gray-900">{fmt(row.amount_vnd)}</td>
-                      <td className="px-4 py-3 text-gray-500">{row.units ?? '—'}</td>
-                      <td className="px-4 py-3 text-gray-500">{row.interest_rate != null ? `${row.interest_rate}%` : '—'}</td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400 text-xs">{row.fund_display ?? '—'}</td>
+                      <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(row.amount_vnd)}</td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{row.units ?? '—'}</td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{row.interest_rate != null ? `${row.interest_rate}%` : '—'}</td>
                       <td className={`px-4 py-3 font-medium ${gain >= 0 ? 'text-green-600' : 'text-red-600'}`}>{fmt(gain)}</td>
-                      <td className="px-4 py-3 text-gray-400 max-w-32 truncate">{row.notes ?? '—'}</td>
+                      <td className="px-4 py-3 text-gray-400 dark:text-gray-500 max-w-32 truncate">{row.notes ?? '—'}</td>
                       <td className="px-4 py-3">
                         <div className="flex gap-2">
-                          <button onClick={() => openTxEdit(row)} className="text-xs text-indigo-600 hover:underline">Edit</button>
-                          <button onClick={() => handleTxDelete(row)} className="text-xs text-red-500 hover:underline">Delete</button>
+                          <button onClick={() => openTxEdit(row)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Edit</button>
+                          <button onClick={() => handleTxDelete(row)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Delete</button>
                         </div>
                       </td>
                     </tr>
@@ -395,41 +395,41 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
       {/* Fund Investment Add/Edit Modal */}
       {(formMode === 'fi-add' || formMode === 'fi-edit') && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl w-full max-w-md p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">{formMode === 'fi-edit' ? 'Edit Fund Investment' : 'Add Fund Investment'}</h3>
-            {formError && <p className="text-red-600 text-sm mb-3">{formError}</p>}
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-md p-6 border border-gray-100 dark:border-gray-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">{formMode === 'fi-edit' ? 'Edit Fund Investment' : 'Add Fund Investment'}</h3>
+            {formError && <p className="text-red-600 dark:text-red-400 text-sm mb-3">{formError}</p>}
             <div className="space-y-3">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Fund *</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Fund *</label>
                 <select
                   value={fiForm.fund_id}
                   onChange={(e) => setFiForm({ ...fiForm, fund_id: e.target.value })}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 >
                   <option value="">Select a fund...</option>
                   {funds.map((f) => <option key={f.id} value={f.id}>{f.code} - {f.name}</option>)}
                 </select>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Amount (VND) *</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Amount (VND) *</label>
                 <input type="number" value={fiForm.amount_vnd} onChange={(e) => setFiForm({ ...fiForm, amount_vnd: e.target.value })}
-                  placeholder="e.g. 10000000" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                  placeholder="e.g. 10000000" className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
               </div>
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Units *</label>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Units *</label>
                   <input type="number" value={fiForm.units_purchased} onChange={(e) => setFiForm({ ...fiForm, units_purchased: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                    className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">NAV at Purchase *</label>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">NAV at Purchase *</label>
                   <input type="number" value={fiForm.nav_at_purchase} onChange={(e) => setFiForm({ ...fiForm, nav_at_purchase: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                    className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
                 </div>
               </div>
             </div>
             <div className="flex gap-3 mt-5">
-              <button onClick={() => setFormMode(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50">Cancel</button>
+              <button onClick={() => setFormMode(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
               <button onClick={handleFiSave} disabled={saving} className="flex-1 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 disabled:opacity-50">
                 {saving ? 'Saving...' : 'Save'}
               </button>
@@ -441,55 +441,55 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
       {/* Other Transaction Add/Edit Modal */}
       {(formMode === 'tx-add' || formMode === 'tx-edit') && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl w-full max-w-lg p-6 max-h-[90vh] overflow-y-auto">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">{formMode === 'tx-edit' ? 'Edit Transaction' : 'Add Transaction'}</h3>
-            {formError && <p className="text-red-600 text-sm mb-3">{formError}</p>}
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-lg p-6 max-h-[90vh] overflow-y-auto border border-gray-100 dark:border-gray-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">{formMode === 'tx-edit' ? 'Edit Transaction' : 'Add Transaction'}</h3>
+            {formError && <p className="text-red-600 dark:text-red-400 text-sm mb-3">{formError}</p>}
             <div className="space-y-3">
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Asset Type *</label>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Asset Type *</label>
                   <select value={txForm.asset_type} onChange={(e) => setTxForm({ ...txForm, asset_type: e.target.value, fund_id: '' })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500">
+                    className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500">
                     {['bank', 'stock', 'gold'].map((t) => <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>)}
                   </select>
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Investment Date *</label>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Investment Date *</label>
                   <input type="date" value={txForm.investment_date} max={new Date().toISOString().slice(0, 10)}
                     onChange={(e) => setTxForm({ ...txForm, investment_date: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                    className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
                 </div>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Amount (VND) *</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Amount (VND) *</label>
                 <input type="number" value={txForm.amount_vnd} onChange={(e) => setTxForm({ ...txForm, amount_vnd: e.target.value })}
-                  placeholder="e.g. 10000000" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                  placeholder="e.g. 10000000" className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
               </div>
               <div className="grid grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Unit Price</label>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Unit Price</label>
                   <input type="number" value={txForm.unit_price} onChange={(e) => setTxForm({ ...txForm, unit_price: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                    className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Units</label>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Units</label>
                   <input type="number" value={txForm.units} onChange={(e) => setTxForm({ ...txForm, units: e.target.value })}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                    className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
                 </div>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Interest Rate (%/year)</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Interest Rate (%/year)</label>
                 <input type="number" step="0.1" value={txForm.interest_rate} onChange={(e) => setTxForm({ ...txForm, interest_rate: e.target.value })}
-                  placeholder="e.g. 5.5" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                  placeholder="e.g. 5.5" className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Notes</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Notes</label>
                 <textarea value={txForm.notes} onChange={(e) => setTxForm({ ...txForm, notes: e.target.value })} rows={2}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none" />
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none" />
               </div>
             </div>
             <div className="flex gap-3 mt-5">
-              <button onClick={() => setFormMode(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50">Cancel</button>
+              <button onClick={() => setFormMode(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
               <button onClick={handleTxSave} disabled={saving} className="flex-1 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 disabled:opacity-50">
                 {saving ? 'Saving...' : 'Save'}
               </button>

--- a/app/settings/tabs/InsuranceMembersTab.tsx
+++ b/app/settings/tabs/InsuranceMembersTab.tsx
@@ -100,9 +100,9 @@ export default function InsuranceMembersTab() {
     <div>
       <div className="flex items-center justify-between mb-4">
         <div>
-          <h2 className="text-lg font-semibold text-gray-900">Insurance Members</h2>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Insurance Members</h2>
           {members.length > 0 && (
-            <p className="text-sm text-gray-500 mt-0.5">
+            <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">
               Total: {fmt(totalAnnual)} / year · {fmt(totalMonthly)} / month
             </p>
           )}
@@ -113,39 +113,39 @@ export default function InsuranceMembersTab() {
       </div>
 
       {successMsg && (
-        <div className="mb-4 p-3 bg-green-50 border border-green-200 text-green-800 rounded-lg text-sm">{successMsg}</div>
+        <div className="mb-4 p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 text-green-800 dark:text-green-300 rounded-lg text-sm">{successMsg}</div>
       )}
 
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
         {loading ? (
-          <div className="text-center py-10 text-gray-400 text-sm">Loading...</div>
+          <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">Loading...</div>
         ) : members.length === 0 ? (
-          <div className="text-center py-10 text-gray-400 text-sm">No insurance members yet.</div>
+          <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">No insurance members yet.</div>
         ) : (
           <table className="w-full text-sm">
-            <thead className="bg-gray-50">
+            <thead className="bg-gray-50 dark:bg-gray-800">
               <tr>
                 {['Member', 'Relationship', 'Annual Payment', 'Monthly Premium', 'Payment Date', 'Actions'].map((h) => (
-                  <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">{h}</th>
+                  <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
                 ))}
               </tr>
             </thead>
-            <tbody className="divide-y divide-gray-50">
+            <tbody className="divide-y divide-gray-50 dark:divide-gray-700">
               {members.map((member) => (
-                <tr key={member.member_id} className="hover:bg-gray-50">
-                  <td className="px-4 py-3 font-medium text-gray-900">{member.member_name}</td>
+                <tr key={member.member_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                  <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{member.member_name}</td>
                   <td className="px-4 py-3">
-                    <span className="inline-block px-2 py-0.5 rounded bg-gray-100 text-gray-700 text-xs font-medium">{member.relationship}</span>
+                    <span className="inline-block px-2 py-0.5 rounded bg-gray-100 dark:bg-gray-700 text-gray-700 dark:text-gray-300 text-xs font-medium">{member.relationship}</span>
                   </td>
-                  <td className="px-4 py-3 text-gray-700">{fmt(member.annual_payment_vnd)}</td>
-                  <td className="px-4 py-3 font-medium text-indigo-600">{fmt(member.monthly_premium_vnd)}</td>
-                  <td className="px-4 py-3 text-gray-500">
+                  <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{fmt(member.annual_payment_vnd)}</td>
+                  <td className="px-4 py-3 font-medium text-indigo-600 dark:text-indigo-400">{fmt(member.monthly_premium_vnd)}</td>
+                  <td className="px-4 py-3 text-gray-500 dark:text-gray-400">
                     {member.payment_date ? new Date(member.payment_date).toLocaleDateString('vi-VN') : '—'}
                   </td>
                   <td className="px-4 py-3">
                     <div className="flex gap-3">
-                      <button onClick={() => openEdit(member)} className="text-xs text-indigo-600 hover:underline">Edit</button>
-                      <button onClick={() => handleDelete(member)} className="text-xs text-red-500 hover:underline">Delete</button>
+                      <button onClick={() => openEdit(member)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Edit</button>
+                      <button onClick={() => handleDelete(member)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Delete</button>
                     </div>
                   </td>
                 </tr>
@@ -158,36 +158,36 @@ export default function InsuranceMembersTab() {
       {/* Create/Edit Modal */}
       {showForm && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">{editMember ? 'Edit Member' : 'Add Member'}</h3>
-            {formError && <p className="text-red-600 text-sm mb-3">{formError}</p>}
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm p-6 border border-gray-100 dark:border-gray-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">{editMember ? 'Edit Member' : 'Add Member'}</h3>
+            {formError && <p className="text-red-600 dark:text-red-400 text-sm mb-3">{formError}</p>}
             <div className="space-y-3">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Member Name *</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Member Name *</label>
                 <input type="text" value={form.member_name} onChange={(e) => setForm({ ...form, member_name: e.target.value })}
-                  placeholder="e.g. John" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                  placeholder="e.g. John" className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Relationship *</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Relationship *</label>
                 <input type="text" value={form.relationship} onChange={(e) => setForm({ ...form, relationship: e.target.value })}
-                  placeholder="e.g. Spouse, Child, Self" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                  placeholder="e.g. Spouse, Child, Self" className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Annual Payment (VND) *</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Annual Payment (VND) *</label>
                 <input type="number" value={form.annual_payment_vnd} onChange={(e) => setForm({ ...form, annual_payment_vnd: e.target.value })}
-                  placeholder="e.g. 12000000" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                  placeholder="e.g. 12000000" className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
                 {form.annual_payment_vnd && Number(form.annual_payment_vnd) > 0 && (
-                  <p className="text-xs text-gray-400 mt-1">Monthly: {fmt(Math.round(Number(form.annual_payment_vnd) / 12))}</p>
+                  <p className="text-xs text-gray-400 dark:text-gray-500 mt-1">Monthly: {fmt(Math.round(Number(form.annual_payment_vnd) / 12))}</p>
                 )}
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Payment Date</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Payment Date</label>
                 <input type="date" value={form.payment_date} onChange={(e) => setForm({ ...form, payment_date: e.target.value })}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
               </div>
             </div>
             <div className="flex gap-3 mt-5">
-              <button onClick={() => setShowForm(false)} className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50">Cancel</button>
+              <button onClick={() => setShowForm(false)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
               <button onClick={handleSave} disabled={saving} className="flex-1 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 disabled:opacity-50">
                 {saving ? 'Saving...' : 'Save'}
               </button>

--- a/app/settings/tabs/InvestmentTransactionsTab.tsx
+++ b/app/settings/tabs/InvestmentTransactionsTab.tsx
@@ -67,71 +67,71 @@ export default function InvestmentTransactionsTab() {
   return (
     <div>
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-semibold text-gray-900">Investment Transactions</h2>
-        <span className="text-sm text-gray-500">{total} total</span>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Investment Transactions</h2>
+        <span className="text-sm text-gray-500 dark:text-gray-400">{total} total</span>
       </div>
 
       {/* Filters */}
-      <div className="bg-white rounded-xl border border-gray-100 shadow-sm p-4 mb-4 flex flex-wrap gap-3 items-end">
+      <div className="bg-white dark:bg-gray-900 rounded-xl border border-gray-100 dark:border-gray-700 shadow-sm p-4 mb-4 flex flex-wrap gap-3 items-end">
         <div>
-          <label className="block text-xs font-medium text-gray-600 mb-1">Asset Type</label>
+          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">Asset Type</label>
           <select
             value={filterAsset}
             onChange={(e) => setFilterAsset(e.target.value)}
-            className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
           >
             <option value="">All</option>
             {ASSET_TYPES.map((t) => <option key={t} value={t}>{t.charAt(0).toUpperCase() + t.slice(1)}</option>)}
           </select>
         </div>
         <div>
-          <label className="block text-xs font-medium text-gray-600 mb-1">From Date</label>
+          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">From Date</label>
           <input type="date" value={filterFrom} onChange={(e) => setFilterFrom(e.target.value)}
-            className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+            className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
         </div>
         <div>
-          <label className="block text-xs font-medium text-gray-600 mb-1">To Date</label>
+          <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">To Date</label>
           <input type="date" value={filterTo} onChange={(e) => setFilterTo(e.target.value)}
-            className="border border-gray-300 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+            className="border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-1.5 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
         </div>
         <div className="flex gap-2">
           <button onClick={applyFilters} className="px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700">Apply</button>
-          <button onClick={resetFilters} className="px-3 py-1.5 text-sm text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50">Reset</button>
+          <button onClick={resetFilters} className="px-3 py-1.5 text-sm text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Reset</button>
         </div>
       </div>
 
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
         {loading ? (
-          <div className="text-center py-10 text-gray-400 text-sm">Loading...</div>
+          <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">Loading...</div>
         ) : transactions.length === 0 ? (
-          <div className="text-center py-10 text-gray-400 text-sm">No transactions found.</div>
+          <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">No transactions found.</div>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
-              <thead className="bg-gray-50">
+              <thead className="bg-gray-50 dark:bg-gray-800">
                 <tr>
                   {['Date', 'Asset', 'Amount', 'Units', 'Rate', 'Projected Interest', 'Goal', 'Notes'].map((h) => (
-                    <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">{h}</th>
+                    <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
                   ))}
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-50">
+              <tbody className="divide-y divide-gray-50 dark:divide-gray-700">
                 {transactions.map((tx) => {
                   const interest = calcProjectedInterest(tx.amount_vnd, tx.interest_rate, tx.investment_date)
                   return (
-                    <tr key={tx.transaction_id} className="hover:bg-gray-50">
-                      <td className="px-4 py-3 text-gray-700">{new Date(tx.investment_date).toLocaleDateString('vi-VN')}</td>
+                    <tr key={tx.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                      <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{new Date(tx.investment_date).toLocaleDateString('vi-VN')}</td>
                       <td className="px-4 py-3">
                         <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${ASSET_COLORS[tx.asset_type as AssetType] ?? 'bg-gray-100 text-gray-700'}`}>
                           {tx.asset_type}
                         </span>
                       </td>
-                      <td className="px-4 py-3 font-medium">{fmt(tx.amount_vnd)}</td>
-                      <td className="px-4 py-3 text-gray-500">{tx.units ?? '—'}</td>
-                      <td className="px-4 py-3 text-gray-500">{tx.interest_rate != null ? `${tx.interest_rate}%` : '—'}</td>
-                      <td className="px-4 py-3 text-indigo-600 font-medium">{fmt(interest)}</td>
-                      <td className="px-4 py-3 text-gray-500">{tx.savings_goals?.goal_name ?? <span className="text-gray-300">Unassigned</span>}</td>
-                      <td className="px-4 py-3 text-gray-400 max-w-32 truncate">{tx.notes ?? '—'}</td>
+                      <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(tx.amount_vnd)}</td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{tx.units ?? '—'}</td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{tx.interest_rate != null ? `${tx.interest_rate}%` : '—'}</td>
+                      <td className="px-4 py-3 text-indigo-600 dark:text-indigo-400 font-medium">{fmt(interest)}</td>
+                      <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{tx.savings_goals?.goal_name ?? <span className="text-gray-300 dark:text-gray-600">Unassigned</span>}</td>
+                      <td className="px-4 py-3 text-gray-400 dark:text-gray-500 max-w-32 truncate">{tx.notes ?? '—'}</td>
                     </tr>
                   )
                 })}
@@ -142,19 +142,19 @@ export default function InvestmentTransactionsTab() {
 
         {/* Pagination */}
         {totalPages > 1 && (
-          <div className="flex items-center justify-between px-5 py-3 border-t border-gray-100">
+          <div className="flex items-center justify-between px-5 py-3 border-t border-gray-100 dark:border-gray-700">
             <button
               onClick={() => setPage((p) => Math.max(1, p - 1))}
               disabled={page === 1}
-              className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg disabled:opacity-40 hover:bg-gray-50"
+              className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg disabled:opacity-40 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300"
             >
               Previous
             </button>
-            <span className="text-sm text-gray-500">Page {page} of {totalPages}</span>
+            <span className="text-sm text-gray-500 dark:text-gray-400">Page {page} of {totalPages}</span>
             <button
               onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
               disabled={page === totalPages}
-              className="px-3 py-1.5 text-sm border border-gray-300 rounded-lg disabled:opacity-40 hover:bg-gray-50"
+              className="px-3 py-1.5 text-sm border border-gray-300 dark:border-gray-600 rounded-lg disabled:opacity-40 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-700 dark:text-gray-300"
             >
               Next
             </button>

--- a/app/settings/tabs/SavingsGoalsTab.tsx
+++ b/app/settings/tabs/SavingsGoalsTab.tsx
@@ -163,61 +163,61 @@ export default function SavingsGoalsTab() {
   return (
     <div>
       {successMsg && (
-        <div className="mb-4 p-3 bg-green-50 border border-green-200 text-green-800 rounded-lg text-sm">{successMsg}</div>
+        <div className="mb-4 p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 text-green-800 dark:text-green-300 rounded-lg text-sm">{successMsg}</div>
       )}
 
       <div className="flex items-center justify-between mb-6">
-        <h2 className="text-lg font-semibold text-gray-900">Savings Goals</h2>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Savings Goals</h2>
         <button onClick={openCreate} className="px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors">
           Create Goal
         </button>
       </div>
 
       {loading ? (
-        <div className="text-center py-12 text-gray-400 text-sm">Loading...</div>
+        <div className="text-center py-12 text-gray-400 dark:text-gray-500 text-sm">Loading...</div>
       ) : goals.length === 0 ? (
-        <div className="text-center py-12 text-gray-400">
+        <div className="text-center py-12 text-gray-400 dark:text-gray-500">
           <p className="text-lg mb-2">No savings goals yet</p>
           <p className="text-sm">Create a goal to start tracking your investments.</p>
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {goals.map((goal) => (
-            <div key={goal.goal_id} className="bg-white rounded-xl shadow-sm border border-gray-100 p-5 hover:shadow-md transition-shadow">
+            <div key={goal.goal_id} className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-5 hover:shadow-md transition-shadow">
               <div className="mb-3">
-                <h3 className="font-semibold text-gray-900 text-base">{goal.goal_name}</h3>
-                {goal.description && <p className="text-sm text-gray-500 mt-1">{goal.description}</p>}
+                <h3 className="font-semibold text-gray-900 dark:text-gray-100 text-base">{goal.goal_name}</h3>
+                {goal.description && <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{goal.description}</p>}
               </div>
 
-              <div className="bg-indigo-50 rounded-lg p-3 mb-3">
-                <p className="text-xs text-indigo-600 font-medium mb-1">Current Total Value</p>
-                <p className="text-xl font-bold text-indigo-700">{fmt(goal.totalInvested + goal.projectedInterest)}</p>
-                <div className="flex gap-4 mt-2 text-xs text-gray-500">
+              <div className="bg-indigo-50 dark:bg-indigo-900/20 rounded-lg p-3 mb-3">
+                <p className="text-xs text-indigo-600 dark:text-indigo-400 font-medium mb-1">Current Total Value</p>
+                <p className="text-xl font-bold text-indigo-700 dark:text-indigo-300">{fmt(goal.totalInvested + goal.projectedInterest)}</p>
+                <div className="flex gap-4 mt-2 text-xs text-gray-500 dark:text-gray-400">
                   <span>Invested: {fmt(goal.totalInvested)}</span>
                   <span>Interest: {fmt(goal.projectedInterest)}</span>
                 </div>
               </div>
 
-              <p className="text-xs text-gray-400 mb-4">
+              <p className="text-xs text-gray-400 dark:text-gray-500 mb-4">
                 {new Date(goal.created_at).toLocaleDateString('vi-VN')} · {goal.transactionCount} transaction{goal.transactionCount !== 1 ? 's' : ''}
               </p>
 
               <div className="flex gap-2">
                 <button
                   onClick={() => setSelectedGoal(goal)}
-                  className="flex-1 py-2 text-sm font-medium text-indigo-600 border border-indigo-200 rounded-lg hover:bg-indigo-50 transition-colors"
+                  className="flex-1 py-2 text-sm font-medium text-indigo-600 dark:text-indigo-400 border border-indigo-200 dark:border-indigo-700 rounded-lg hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition-colors"
                 >
                   View Details
                 </button>
                 <button
                   onClick={() => openEdit(goal)}
-                  className="px-3 py-2 text-sm font-medium text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors"
+                  className="px-3 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
                 >
                   Edit
                 </button>
                 <button
                   onClick={() => handleDelete(goal)}
-                  className="px-3 py-2 text-sm font-medium text-red-600 border border-red-200 rounded-lg hover:bg-red-50 transition-colors"
+                  className="px-3 py-2 text-sm font-medium text-red-600 dark:text-red-400 border border-red-200 dark:border-red-800 rounded-lg hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors"
                 >
                   Delete
                 </button>
@@ -230,33 +230,33 @@ export default function SavingsGoalsTab() {
       {/* Create/Edit Modal */}
       {showForm && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl w-full max-w-md p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">{editGoal ? 'Edit Goal' : 'Create Goal'}</h3>
-            {formError && <p className="text-red-600 text-sm mb-3">{formError}</p>}
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-md p-6 border border-gray-100 dark:border-gray-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">{editGoal ? 'Edit Goal' : 'Create Goal'}</h3>
+            {formError && <p className="text-red-600 dark:text-red-400 text-sm mb-3">{formError}</p>}
             <div className="space-y-3">
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Goal Name *</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Goal Name *</label>
                 <input
                   type="text"
                   value={formName}
                   onChange={(e) => setFormName(e.target.value)}
                   placeholder="e.g. Retirement"
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 />
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Description</label>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Description</label>
                 <textarea
                   value={formDesc}
                   onChange={(e) => setFormDesc(e.target.value)}
                   rows={3}
                   placeholder="Optional description"
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
+                  className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-none"
                 />
               </div>
             </div>
             <div className="flex gap-3 mt-5">
-              <button onClick={() => setShowForm(false)} className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50">Cancel</button>
+              <button onClick={() => setShowForm(false)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
               <button onClick={handleSave} disabled={saving} className="flex-1 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 disabled:opacity-50">
                 {saving ? 'Saving...' : 'Save'}
               </button>

--- a/app/settings/tabs/UnassignedInvestmentsTab.tsx
+++ b/app/settings/tabs/UnassignedInvestmentsTab.tsx
@@ -98,7 +98,7 @@ export default function UnassignedInvestmentsTab() {
   return (
     <div>
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-semibold text-gray-900">Unassigned Investments</h2>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">Unassigned Investments</h2>
         {selected.size > 0 && (
           <button
             onClick={() => { setAssignGoalId(''); setShowAssign(true) }}
@@ -110,18 +110,18 @@ export default function UnassignedInvestmentsTab() {
       </div>
 
       {successMsg && (
-        <div className="mb-4 p-3 bg-green-50 border border-green-200 text-green-800 rounded-lg text-sm">{successMsg}</div>
+        <div className="mb-4 p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 text-green-800 dark:text-green-300 rounded-lg text-sm">{successMsg}</div>
       )}
 
-      <div className="bg-white rounded-xl shadow-sm border border-gray-100 overflow-hidden">
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
         {loading ? (
-          <div className="text-center py-10 text-gray-400 text-sm">Loading...</div>
+          <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">Loading...</div>
         ) : transactions.length === 0 ? (
-          <div className="text-center py-10 text-gray-400 text-sm">No unassigned investments.</div>
+          <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">No unassigned investments.</div>
         ) : (
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
-              <thead className="bg-gray-50">
+              <thead className="bg-gray-50 dark:bg-gray-800">
                 <tr>
                   <th className="px-4 py-3 w-10">
                     <input
@@ -132,13 +132,13 @@ export default function UnassignedInvestmentsTab() {
                     />
                   </th>
                   {['Date', 'Asset', 'Amount', 'Rate', 'Notes', 'Actions'].map((h) => (
-                    <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 uppercase tracking-wide">{h}</th>
+                    <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
                   ))}
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-50">
+              <tbody className="divide-y divide-gray-50 dark:divide-gray-700">
                 {transactions.map((tx) => (
-                  <tr key={tx.transaction_id} className="hover:bg-gray-50">
+                  <tr key={tx.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
                     <td className="px-4 py-3">
                       <input
                         type="checkbox"
@@ -147,19 +147,19 @@ export default function UnassignedInvestmentsTab() {
                         className="rounded"
                       />
                     </td>
-                    <td className="px-4 py-3 text-gray-700">{new Date(tx.investment_date).toLocaleDateString('vi-VN')}</td>
+                    <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{new Date(tx.investment_date).toLocaleDateString('vi-VN')}</td>
                     <td className="px-4 py-3">
                       <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${ASSET_COLORS[tx.asset_type] ?? 'bg-gray-100 text-gray-700'}`}>
                         {tx.asset_type}
                       </span>
                     </td>
-                    <td className="px-4 py-3 font-medium">{fmt(tx.amount_vnd)}</td>
-                    <td className="px-4 py-3 text-gray-500">{tx.interest_rate != null ? `${tx.interest_rate}%` : '—'}</td>
-                    <td className="px-4 py-3 text-gray-400 max-w-32 truncate">{tx.notes ?? '—'}</td>
+                    <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(tx.amount_vnd)}</td>
+                    <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{tx.interest_rate != null ? `${tx.interest_rate}%` : '—'}</td>
+                    <td className="px-4 py-3 text-gray-400 dark:text-gray-500 max-w-32 truncate">{tx.notes ?? '—'}</td>
                     <td className="px-4 py-3">
                       <button
                         onClick={() => handleDelete(tx.transaction_id)}
-                        className="text-xs text-red-500 hover:underline"
+                        className="text-xs text-red-500 dark:text-red-400 hover:underline"
                       >
                         Delete
                       </button>
@@ -175,19 +175,19 @@ export default function UnassignedInvestmentsTab() {
       {/* Assign modal */}
       {showAssign && (
         <div className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">Assign to Goal</h3>
-            <p className="text-sm text-gray-500 mb-3">Assigning {selected.size} transaction(s).</p>
+          <div className="bg-white dark:bg-gray-900 rounded-xl shadow-xl w-full max-w-sm p-6 border border-gray-100 dark:border-gray-700">
+            <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">Assign to Goal</h3>
+            <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">Assigning {selected.size} transaction(s).</p>
             <select
               value={assignGoalId}
               onChange={(e) => setAssignGoalId(e.target.value)}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm mb-4 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-sm mb-4 bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
             >
               <option value="">Select a goal...</option>
               {goals.map((g) => <option key={g.goal_id} value={g.goal_id}>{g.goal_name}</option>)}
             </select>
             <div className="flex gap-3">
-              <button onClick={() => setShowAssign(false)} className="flex-1 py-2 text-sm font-medium text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50">Cancel</button>
+              <button onClick={() => setShowAssign(false)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Cancel</button>
               <button onClick={handleAssign} disabled={!assignGoalId || assigning} className="flex-1 py-2 text-sm font-medium text-white bg-indigo-600 rounded-lg hover:bg-indigo-700 disabled:opacity-50">
                 {assigning ? 'Assigning...' : 'Assign'}
               </button>


### PR DESCRIPTION
## Summary

- Apply dark mode to all pages, navigation, settings tabs, fund library, savings goals, and assets dashboard (including all sub-components: GoalCard, UnallocatedSection, FundDetailModal, GoalPickerModal, Skeletons)
- Fix Tailwind v4 dark mode by declaring `@variant dark` with media strategy in `globals.css`
- Add Edit and Delete buttons to Fixed Expenses and Insurance sections on the Monthly Planning page, matching the Fund Investments section pattern

## Test plan

- [ ] Toggle system dark mode — all pages should switch correctly (login, signup, dashboard, planning, settings, fund library, savings goals)
- [ ] Assets dashboard: NetWorthCard, GoalCard, UnallocatedSection, InsuranceCard, modals all render correctly in dark mode
- [ ] Loading skeletons render with dark background in dark mode
- [ ] Fixed Expenses: Delete button opens confirm modal and removes the expense; Reset button still works when override exists
- [ ] Insurance: Edit button opens modal with pre-filled fields and saves via PUT; Delete button opens confirm and removes the member
- [ ] Total Monthly row in Insurance table spans all 4 columns correctly after Actions column was added

🤖 Generated with [Claude Code](https://claude.com/claude-code)