### PR TITLE
fix(auth): keep loading indicator active until dashboard redirect completes

### DIFF
--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -16,6 +16,7 @@ function LoginForm() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(expired ? 'Your session has expired. Please log in again.' : null)
   const [loading, setLoading] = useState(false)
+  const [redirecting, setRedirecting] = useState(false)
 
   async function handleLogin(e: React.FormEvent) {
     e.preventDefault()
@@ -31,13 +32,15 @@ function LoginForm() {
       const { error } = await supabase.auth.signInWithPassword({ email, password })
       if (error) {
         setError('Email or password is incorrect.')
+        setLoading(false)
       } else {
+        setRedirecting(true)
         router.push('/dashboard')
         router.refresh()
+        // keep loading=true — page will unmount on redirect
       }
     } catch {
       setError('Unable to connect. Please check your internet and try again.')
-    } finally {
       setLoading(false)
     }
   }
@@ -87,7 +90,7 @@ function LoginForm() {
           disabled={loading}
           className="w-full py-2 px-4 bg-indigo-600 text-white rounded-md font-medium hover:bg-indigo-700 transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
         >
-          {loading ? 'Signing in...' : 'Log in'}
+          {redirecting ? 'Redirecting…' : loading ? 'Signing in…' : 'Log in'}
         </button>
       </form>
       <p className="mt-4 text-center text-sm text-gray-600 dark:text-gray-400">


### PR DESCRIPTION
## Summary

- The `finally` block was calling `setLoading(false)` on both success and failure paths, causing the button to flash back to "Log in" while the redirect was still in progress
- On success: button now shows `Redirecting…` and stays disabled until the page unmounts
- On failure: error message shown and button re-enables as before

## Test plan

- [ ] Enter valid credentials → button shows "Signing in…" then "Redirecting…" and stays disabled until the dashboard loads
- [ ] Enter invalid credentials → button re-enables and error message appears

Generated with Claude Code