### PR TITLE
fix(assets): fund detail modal purchase history shows wrong date

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -140,8 +140,8 @@ export default function DashboardClient() {
       if (res.ok) {
         const items = await res.json()
         setPurchaseHistory(
-          (items as Array<{ nav_at_purchase: number; units_purchased: number; created_at: string }>)
-            .map((i) => ({ purchase_date: i.created_at, units: i.units_purchased, nav_at_purchase: i.nav_at_purchase }))
+          (items as Array<{ nav_at_purchase: number; units_purchased: number; investment_date: string | null; created_at: string }>)
+            .map((i) => ({ purchase_date: i.investment_date ?? i.created_at, units: i.units_purchased, nav_at_purchase: i.nav_at_purchase }))
             .sort((a, b) => new Date(b.purchase_date).getTime() - new Date(a.purchase_date).getTime())
         )
       }


### PR DESCRIPTION
## Summary
- Fund detail modal (Unallocated Investments) was displaying `created_at` (DB insertion timestamp) as the purchase date instead of `investment_date` (user-set date)
- This caused a mismatch between the date shown in the Purchase History modal and the date in Settings > Investment Transactions

## Test plan
- [ ] Go to Assets Dashboard → Unallocated Investments → click a fund
- [ ] Verify Purchase History dates match the dates in Settings > Investment Transactions for the same transactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)