### PR TITLE
feat(goals): add unassign button to remove transactions from a goal

### DIFF
--- a/app/settings/tabs/GoalDetailView.tsx
+++ b/app/settings/tabs/GoalDetailView.tsx
@@ -239,6 +239,20 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
     }
   }
 
+  async function handleUnassign(row: TxRow) {
+    if (!confirm('Bỏ gán giao dịch này khỏi mục tiêu?')) return
+    const res = await fetch(`/api/v1/investment-transactions/${row.transaction_id}/assign`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ goal_id: null }),
+    })
+    if (res.ok) {
+      setSuccessMsg('Đã bỏ gán khỏi mục tiêu.')
+      setTimeout(() => setSuccessMsg(''), 4000)
+      await fetchData()
+    }
+  }
+
   const fundRows = rows.filter((r) => r._source === 'fund')
   const otherRows = rows.filter((r) => r._source === 'other')
 
@@ -353,6 +367,7 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
                       <td className="px-4 py-3">
                         <div className="flex gap-2">
                           <button onClick={() => openFiEdit(row)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Sửa</button>
+                          <button onClick={() => handleUnassign(row)} className="text-xs text-amber-600 dark:text-amber-400 hover:underline">Bỏ gán</button>
                           <button onClick={() => handleFiDelete(row)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Xóa</button>
                         </div>
                       </td>
@@ -410,6 +425,7 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
                       <td className="px-4 py-3">
                         <div className="flex gap-2">
                           <button onClick={() => openTxEdit(row)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Sửa</button>
+                          <button onClick={() => handleUnassign(row)} className="text-xs text-amber-600 dark:text-amber-400 hover:underline">Bỏ gán</button>
                           <button onClick={() => handleTxDelete(row)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Xóa</button>
                         </div>
                       </td>


### PR DESCRIPTION
## Summary
- Both **Fund investments** and **Other transactions** (gold, bank, stock) in Settings → Savings Goals now have a **"Bỏ gán"** button between Sửa and Xóa
- Clicking it unassigns the transaction from the goal (sets `goal_id = null`) via the existing `PUT /api/v1/investment-transactions/[id]/assign` endpoint
- Transaction moves back to the Unallocated section on the Assets page
- No new API needed — reuses the assign endpoint with `goal_id: null`

## Test plan
- [ ] Settings → Savings Goals → open a goal
- [ ] Fund investments table: click "Bỏ gán" → confirm → transaction disappears from goal, appears in Unallocated
- [ ] Other transactions table: same flow for gold/bank/stock
- [ ] Success message "Đã bỏ gán khỏi mục tiêu." appears after unassign

🤖 Generated with [Claude Code](https://claude.com/claude-code)