### PR TITLE
fix(ux): add loading state to all delete operations

### DIFF
--- a/app/planning/components/OtherExpensesSection.tsx
+++ b/app/planning/components/OtherExpensesSection.tsx
@@ -20,6 +20,7 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
   const [formError, setFormError] = useState('')
   const [saving, setSaving] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState<OtherExpense | null>(null)
+  const [deleting, setDeleting] = useState(false)
 
   function openAdd() {
     setEditItem(null)
@@ -72,12 +73,14 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
   }
 
   async function handleDelete(item: OtherExpense) {
+    setDeleting(true)
     const res = await fetch(`/api/v1/monthly-plans/${plan.id}/other-expenses/${item.id}`, { method: 'DELETE' })
     if (res.ok) {
       setConfirmDelete(null)
       onToast('Đã xóa chi phí khác')
       onRefresh()
     }
+    setDeleting(false)
   }
 
   return (
@@ -163,8 +166,10 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
             <p className="text-sm text-gray-600 dark:text-gray-400 mb-1">Bạn có chắc muốn xóa khoản chi phí này?</p>
             <p className="text-sm font-medium text-gray-800 dark:text-gray-200 mb-5">{confirmDelete.description} — {fmt(confirmDelete.amount_vnd)}</p>
             <div className="flex gap-3">
-              <button onClick={() => setConfirmDelete(null)} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800">Hủy</button>
-              <button onClick={() => handleDelete(confirmDelete)} className="flex-1 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700">Xác nhận</button>
+              <button onClick={() => setConfirmDelete(null)} disabled={deleting} className="flex-1 py-2 text-sm font-medium text-gray-600 dark:text-gray-300 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 disabled:opacity-50">Hủy</button>
+              <button onClick={() => handleDelete(confirmDelete)} disabled={deleting} className="flex-1 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-50">
+                {deleting ? 'Đang xóa...' : 'Xác nhận'}
+              </button>
             </div>
           </div>
         </div>

--- a/app/settings/tabs/FixedExpensesTab.tsx
+++ b/app/settings/tabs/FixedExpensesTab.tsx
@@ -24,6 +24,7 @@ export default function FixedExpensesTab() {
   const [form, setForm] = useState(emptyForm)
   const [formError, setFormError] = useState('')
   const [saving, setSaving] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
   const [successMsg, setSuccessMsg] = useState('')
 
   const fetchExpenses = useCallback(async () => {
@@ -81,12 +82,14 @@ export default function FixedExpensesTab() {
 
   async function handleDelete(expense: Expense) {
     if (!confirm(`Xóa "${expense.expense_name}"?`)) return
+    setDeletingId(expense.expense_id)
     const res = await fetch(`/api/v1/fixed-expenses/${expense.expense_id}`, { method: 'DELETE' })
     if (res.ok) {
       setSuccessMsg('Đã xóa chi phí.')
       setTimeout(() => setSuccessMsg(''), 4000)
       await fetchExpenses()
     }
+    setDeletingId(null)
   }
 
   const totalMonthly = expenses.reduce((s, e) => s + e.amount_vnd, 0)
@@ -148,7 +151,9 @@ export default function FixedExpensesTab() {
                   <td className="px-4 py-3">
                     <div className="flex gap-3">
                       <button onClick={() => openEdit(expense)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Sửa</button>
-                      <button onClick={() => handleDelete(expense)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Xóa</button>
+                      <button onClick={() => handleDelete(expense)} disabled={deletingId === expense.expense_id} className="text-xs text-red-500 dark:text-red-400 hover:underline disabled:opacity-50">
+                        {deletingId === expense.expense_id ? 'Đang xóa...' : 'Xóa'}
+                      </button>
                     </div>
                   </td>
                 </tr>

--- a/app/settings/tabs/GoalDetailView.tsx
+++ b/app/settings/tabs/GoalDetailView.tsx
@@ -66,6 +66,7 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
   const [successMsg, setSuccessMsg] = useState('')
   const [formError, setFormError] = useState('')
   const [saving, setSaving] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
 
   // Form mode: null = closed, 'tx-add', 'tx-edit', 'fi-add', 'fi-edit'
   const [formMode, setFormMode] = useState<'tx-add' | 'tx-edit' | 'fi-add' | 'fi-edit' | null>(null)
@@ -180,8 +181,10 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
 
   async function handleTxDelete(row: TxRow) {
     if (!confirm('Xóa giao dịch này?')) return
+    setDeletingId(row.transaction_id)
     const res = await fetch(`/api/v1/investment-transactions/${row.transaction_id}`, { method: 'DELETE' })
     if (res.ok) { setSuccessMsg('Đã xóa giao dịch.'); setTimeout(() => setSuccessMsg(''), 4000); await fetchData() }
+    setDeletingId(null)
   }
 
   // --- Fund investment handlers ---
@@ -231,12 +234,14 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
 
   async function handleFiDelete(row: TxRow) {
     if (!confirm('Xóa khoản đầu tư quỹ này?')) return
+    setDeletingId(row.transaction_id)
     const res = await fetch(`/api/v1/investment-transactions/${row.transaction_id}`, { method: 'DELETE' })
     if (res.ok) {
       setSuccessMsg('Đã xóa khoản đầu tư.')
       setTimeout(() => setSuccessMsg(''), 4000)
       await fetchData()
     }
+    setDeletingId(null)
   }
 
   async function handleUnassign(row: TxRow) {
@@ -368,7 +373,9 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
                         <div className="flex gap-2">
                           <button onClick={() => openFiEdit(row)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Sửa</button>
                           <button onClick={() => handleUnassign(row)} className="text-xs text-amber-600 dark:text-amber-400 hover:underline">Bỏ gán</button>
-                          <button onClick={() => handleFiDelete(row)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Xóa</button>
+                          <button onClick={() => handleFiDelete(row)} disabled={deletingId === row.transaction_id} className="text-xs text-red-500 dark:text-red-400 hover:underline disabled:opacity-50">
+                            {deletingId === row.transaction_id ? 'Đang xóa...' : 'Xóa'}
+                          </button>
                         </div>
                       </td>
                     </tr>
@@ -426,7 +433,9 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
                         <div className="flex gap-2">
                           <button onClick={() => openTxEdit(row)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Sửa</button>
                           <button onClick={() => handleUnassign(row)} className="text-xs text-amber-600 dark:text-amber-400 hover:underline">Bỏ gán</button>
-                          <button onClick={() => handleTxDelete(row)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Xóa</button>
+                          <button onClick={() => handleTxDelete(row)} disabled={deletingId === row.transaction_id} className="text-xs text-red-500 dark:text-red-400 hover:underline disabled:opacity-50">
+                            {deletingId === row.transaction_id ? 'Đang xóa...' : 'Xóa'}
+                          </button>
                         </div>
                       </td>
                     </tr>

--- a/app/settings/tabs/InsuranceMembersTab.tsx
+++ b/app/settings/tabs/InsuranceMembersTab.tsx
@@ -24,6 +24,7 @@ export default function InsuranceMembersTab() {
   const [form, setForm] = useState(emptyForm)
   const [formError, setFormError] = useState('')
   const [saving, setSaving] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
   const [successMsg, setSuccessMsg] = useState('')
 
   const fetchMembers = useCallback(async () => {
@@ -85,12 +86,14 @@ export default function InsuranceMembersTab() {
 
   async function handleDelete(member: InsuranceMember) {
     if (!confirm(`Xóa "${member.member_name}"?`)) return
+    setDeletingId(member.member_id)
     const res = await fetch(`/api/v1/insurance-members/${member.member_id}`, { method: 'DELETE' })
     if (res.ok) {
       setSuccessMsg('Đã xóa thành viên.')
       setTimeout(() => setSuccessMsg(''), 4000)
       await fetchMembers()
     }
+    setDeletingId(null)
   }
 
   const totalAnnual = members.reduce((s, m) => s + m.annual_payment_vnd, 0)
@@ -145,7 +148,9 @@ export default function InsuranceMembersTab() {
                   <td className="px-4 py-3">
                     <div className="flex gap-3">
                       <button onClick={() => openEdit(member)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">Sửa</button>
-                      <button onClick={() => handleDelete(member)} className="text-xs text-red-500 dark:text-red-400 hover:underline">Xóa</button>
+                      <button onClick={() => handleDelete(member)} disabled={deletingId === member.member_id} className="text-xs text-red-500 dark:text-red-400 hover:underline disabled:opacity-50">
+                        {deletingId === member.member_id ? 'Đang xóa...' : 'Xóa'}
+                      </button>
                     </div>
                   </td>
                 </tr>

--- a/app/settings/tabs/InvestmentTransactionsTab.tsx
+++ b/app/settings/tabs/InvestmentTransactionsTab.tsx
@@ -138,6 +138,7 @@ export default function InvestmentTransactionsTab() {
   const [formMode, setFormMode] = useState<'add' | 'edit' | null>(null)
   const [formError, setFormError] = useState('')
   const [saving, setSaving] = useState(false)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
 
   const [showImport, setShowImport] = useState(false)
   const [importFundId, setImportFundId] = useState('')
@@ -299,8 +300,10 @@ export default function InvestmentTransactionsTab() {
 
   async function handleDelete(tx: Transaction) {
     if (!confirm('Xóa giao dịch này?')) return
+    setDeletingId(tx.transaction_id)
     const res = await fetch(`/api/v1/investment-transactions/${tx.transaction_id}`, { method: 'DELETE' })
     if (res.ok) await fetchTransactions()
+    setDeletingId(null)
   }
 
   const totalPages = Math.max(1, Math.ceil(total / 20))
@@ -412,9 +415,10 @@ export default function InvestmentTransactionsTab() {
                         </button>
                         <button
                           onClick={() => handleDelete(tx)}
-                          className="text-xs text-red-500 dark:text-red-400 hover:underline"
+                          disabled={deletingId === tx.transaction_id}
+                          className="text-xs text-red-500 dark:text-red-400 hover:underline disabled:opacity-50"
                         >
-                          Xóa
+                          {deletingId === tx.transaction_id ? 'Đang xóa...' : 'Xóa'}
                         </button>
                       </td>
                     </tr>


### PR DESCRIPTION
## Summary

- Delete buttons now show **"Đang xóa..."** and become disabled immediately after the user confirms, preventing double-clicks
- The button stays disabled until the API call completes and the list refreshes
- OtherExpensesSection's confirm modal: both Hủy and Xác nhận buttons disabled during delete

## Files changed

| File | Change |
|---|---|
| `InsuranceMembersTab` | `deletingId` state, button disabled + label change |
| `FixedExpensesTab` | `deletingId` state, button disabled + label change |
| `InvestmentTransactionsTab` | `deletingId` state, button disabled + label change |
| `GoalDetailView` | `deletingId` state for both fund and tx delete buttons |
| `OtherExpensesSection` | `deleting` boolean, both modal buttons disabled |
| `FundLibraryClient` | Already had proper loading state — no change |

## Test plan

- [ ] Click Xóa on any item → confirm → button shows "Đang xóa..." and is disabled
- [ ] Item disappears after deletion completes
- [ ] Clicking multiple times before confirming is not possible (confirm dialog is blocking)
- [ ] Planning other expenses: confirm modal buttons both disable during delete

🤖 Generated with [Claude Code](https://claude.com/claude-code)