### PR TITLE
fix(cache): eliminate page navigation flicker

### DIFF
--- a/app/funds/FundLibraryClient.tsx
+++ b/app/funds/FundLibraryClient.tsx
@@ -54,8 +54,8 @@ function bustFundsCache() {
 }
 
 export default function FundLibraryClient() {
-  const [funds, setFunds] = useState<Fund[]>([])
-  const [loading, setLoading] = useState(true)
+  const [funds, setFunds] = useState<Fund[]>(() => getFundsCache() ?? [])
+  const [loading, setLoading] = useState(() => !getFundsCache())
   const [error, setError] = useState<string | null>(null)
   const [sortBy, setSortBy] = useState<SortKey>('name')
 
@@ -85,13 +85,7 @@ export default function FundLibraryClient() {
   }, [])
 
   const loadFunds = useCallback(async (opts?: { force?: boolean }) => {
-    const cached = !opts?.force && getFundsCache()
-    if (cached) {
-      setFunds(cached)
-      setLoading(false)
-    } else {
-      setLoading(true)
-    }
+    if (opts?.force) bustFundsCache()
     setError(null)
     try {
       const res = await fetch('/api/funds')

--- a/app/planning/PlanningClient.tsx
+++ b/app/planning/PlanningClient.tsx
@@ -92,17 +92,21 @@ function nextMonth(m: number, y: number) { return m === 12 ? { m: 1, y: y + 1 } 
 
 export default function PlanningClient() {
   const now = new Date()
-  const [month, setMonth] = useState(now.getMonth() + 1)
-  const [year, setYear] = useState(now.getFullYear())
-  const [plan, setPlan] = useState<MonthlyPlan | null>(null)
-  const [investments, setInvestments] = useState<FundInvestment[]>([])
-  const [savings, setSavings] = useState<DirectSaving[]>([])
-  const [fixedExpenses, setFixedExpenses] = useState<FixedExpense[]>([])
-  const [insuranceMembers, setInsuranceMembers] = useState<InsuranceMember[]>([])
-  const [otherExpenses, setOtherExpenses] = useState<OtherExpense[]>([])
-  const [funds, setFunds] = useState<Fund[]>([])
-  const [goals, setGoals] = useState<Goal[]>([])
-  const [loading, setLoading] = useState(true)
+  const initialMonth = now.getMonth() + 1
+  const initialYear = now.getFullYear()
+  const [initialCache] = useState(() => getPlanCache(initialMonth, initialYear))
+
+  const [month, setMonth] = useState(initialMonth)
+  const [year, setYear] = useState(initialYear)
+  const [plan, setPlan] = useState<MonthlyPlan | null>(initialCache?.plan ?? null)
+  const [investments, setInvestments] = useState<FundInvestment[]>(initialCache?.investments ?? [])
+  const [savings, setSavings] = useState<DirectSaving[]>(initialCache?.savings ?? [])
+  const [fixedExpenses, setFixedExpenses] = useState<FixedExpense[]>(initialCache?.fixedExpenses ?? [])
+  const [insuranceMembers, setInsuranceMembers] = useState<InsuranceMember[]>(initialCache?.insuranceMembers ?? [])
+  const [otherExpenses, setOtherExpenses] = useState<OtherExpense[]>(initialCache?.otherExpenses ?? [])
+  const [funds, setFunds] = useState<Fund[]>(initialCache?.funds ?? [])
+  const [goals, setGoals] = useState<Goal[]>(initialCache?.goals ?? [])
+  const [loading, setLoading] = useState(!initialCache)
   const [toast, setToast] = useState('')
 
   const showToast = useCallback((msg: string) => {
@@ -110,26 +114,8 @@ export default function PlanningClient() {
     setTimeout(() => setToast(''), 3000)
   }, [])
 
-  function applyPlanData(p: ReturnType<typeof getPlanCache>) {
-    if (!p) return
-    setPlan(p.plan)
-    setInvestments(p.investments)
-    setSavings(p.savings)
-    setFixedExpenses(p.fixedExpenses)
-    setInsuranceMembers(p.insuranceMembers)
-    setOtherExpenses(p.otherExpenses)
-    setGoals(p.goals)
-    setFunds(p.funds)
-  }
-
   const fetchPlan = useCallback(async (opts?: { force?: boolean }) => {
-    const cached = !opts?.force && getPlanCache(month, year)
-    if (cached) {
-      applyPlanData(cached)
-      setLoading(false)
-    } else {
-      setLoading(true)
-    }
+    if (opts?.force) bustPlanCache(month, year)
 
     const res = await fetch(`/api/v1/monthly-plans?month=${month}&year=${year}&full=true`)
     if (res.ok) {
@@ -169,7 +155,14 @@ export default function PlanningClient() {
         funds: p.funds ?? [],
       }
       setPlanCache(month, year, fresh)
-      applyPlanData(fresh)
+      setPlan(fresh.plan)
+      setInvestments(fresh.investments)
+      setSavings(fresh.savings)
+      setFixedExpenses(fresh.fixedExpenses)
+      setInsuranceMembers(fresh.insuranceMembers)
+      setOtherExpenses(fresh.otherExpenses)
+      setGoals(fresh.goals)
+      setFunds(fresh.funds)
     } else {
       bustPlanCache(month, year)
       setPlan(null)

--- a/app/settings/tabs/FixedExpensesTab.tsx
+++ b/app/settings/tabs/FixedExpensesTab.tsx
@@ -36,10 +36,13 @@ function bustFixedCache() {
 }
 
 export default function FixedExpensesTab() {
-  const [expenses, setExpenses] = useState<Expense[]>([])
-  const [loading, setLoading] = useState(true)
+  const [expenses, setExpenses] = useState<Expense[]>(() => getFixedCache('') ?? [])
+  const [loading, setLoading] = useState(() => !getFixedCache(''))
   const [filterCategory, setFilterCategory] = useState('')
-  const [categories, setCategories] = useState<string[]>([])
+  const [categories, setCategories] = useState<string[]>(() => {
+    const cached = getFixedCache('')
+    return cached ? [...new Set<string>(cached.map(e => e.category))] : []
+  })
   const [showForm, setShowForm] = useState(false)
   const [editExpense, setEditExpense] = useState<Expense | null>(null)
   const [form, setForm] = useState(emptyForm)
@@ -50,17 +53,7 @@ export default function FixedExpensesTab() {
   const [successMsg, setSuccessMsg] = useState('')
 
   const fetchExpenses = useCallback(async (opts?: { force?: boolean }) => {
-    const cached = !opts?.force && getFixedCache(filterCategory)
-    if (cached) {
-      setExpenses(cached)
-      setLoading(false)
-      if (!filterCategory && cached.length) {
-        setCategories([...new Set<string>(cached.map((e: Expense) => e.category))])
-      }
-    } else {
-      setLoading(true)
-    }
-
+    if (opts?.force) bustFixedCache()
     const params = new URLSearchParams()
     if (filterCategory) params.set('category', filterCategory)
     const res = await fetch(`/api/v1/fixed-expenses?${params}`)
@@ -108,7 +101,6 @@ export default function FixedExpensesTab() {
       setFormError(error ?? 'Đã xảy ra lỗi.')
     } else {
       setShowForm(false)
-      bustFixedCache()
       await fetchExpenses({ force: true })
     }
     setSaving(false)
@@ -121,7 +113,6 @@ export default function FixedExpensesTab() {
       setConfirmExpense(null)
       setSuccessMsg('Đã xóa chi phí.')
       setTimeout(() => setSuccessMsg(''), 4000)
-      bustFixedCache()
       await fetchExpenses({ force: true })
     }
     setDeletingId(null)

--- a/app/settings/tabs/InsuranceMembersTab.tsx
+++ b/app/settings/tabs/InsuranceMembersTab.tsx
@@ -36,8 +36,8 @@ function bustInsCache() {
 }
 
 export default function InsuranceMembersTab() {
-  const [members, setMembers] = useState<InsuranceMember[]>([])
-  const [loading, setLoading] = useState(true)
+  const [members, setMembers] = useState<InsuranceMember[]>(() => getInsCache() ?? [])
+  const [loading, setLoading] = useState(() => !getInsCache())
   const [showForm, setShowForm] = useState(false)
   const [editMember, setEditMember] = useState<InsuranceMember | null>(null)
   const [form, setForm] = useState(emptyForm)
@@ -48,13 +48,7 @@ export default function InsuranceMembersTab() {
   const [successMsg, setSuccessMsg] = useState('')
 
   const fetchMembers = useCallback(async (opts?: { force?: boolean }) => {
-    const cached = !opts?.force && getInsCache()
-    if (cached) {
-      setMembers(cached)
-      setLoading(false)
-    } else {
-      setLoading(true)
-    }
+    if (opts?.force) bustInsCache()
     const res = await fetch('/api/v1/insurance-members')
     const { members } = await res.json()
     const list: InsuranceMember[] = members ?? []
@@ -107,7 +101,6 @@ export default function InsuranceMembersTab() {
       setFormError(error ?? 'Đã xảy ra lỗi.')
     } else {
       setShowForm(false)
-      bustInsCache()
       await fetchMembers({ force: true })
     }
     setSaving(false)
@@ -120,7 +113,6 @@ export default function InsuranceMembersTab() {
       setConfirmMember(null)
       setSuccessMsg('Đã xóa thành viên.')
       setTimeout(() => setSuccessMsg(''), 4000)
-      bustInsCache()
       await fetchMembers({ force: true })
     }
     setDeletingId(null)

--- a/app/settings/tabs/SavingsGoalsTab.tsx
+++ b/app/settings/tabs/SavingsGoalsTab.tsx
@@ -42,8 +42,8 @@ function bustGoalsCache() {
 }
 
 export default function SavingsGoalsTab({ initialGoalId, onGoalChange }: Props) {
-  const [goals, setGoals] = useState<GoalWithStats[]>([])
-  const [loading, setLoading] = useState(true)
+  const [goals, setGoals] = useState<GoalWithStats[]>(() => getGoalsCache() ?? [])
+  const [loading, setLoading] = useState(() => !getGoalsCache())
   const [selectedGoal, setSelectedGoal] = useState<SavingsGoal | null>(null)
   const [showForm, setShowForm] = useState(false)
   const [editGoal, setEditGoal] = useState<SavingsGoal | null>(null)
@@ -58,29 +58,16 @@ export default function SavingsGoalsTab({ initialGoalId, onGoalChange }: Props) 
   const hasAutoSelected = useRef(false)
 
   const fetchGoals = useCallback(async (opts?: { force?: boolean }) => {
-    const cached = !opts?.force && getGoalsCache()
-    if (cached) {
-      setGoals(cached)
-      setLoading(false)
-      if (initialGoalId && !hasAutoSelected.current) {
-        const match = cached.find((g: GoalWithStats) => g.goal_id === initialGoalId)
-        if (match) { setSelectedGoal(match); hasAutoSelected.current = true }
-      }
-    } else {
-      setLoading(true)
-    }
-
+    if (opts?.force) bustGoalsCache()
     const res = await fetch('/api/v1/savings-goals?stats=true')
     const { goals: fetched } = await res.json()
     const list: GoalWithStats[] = fetched ?? []
     setGoalsCache(list)
     setGoals(list)
-
     if (initialGoalId && !hasAutoSelected.current) {
       const match = list.find((g: GoalWithStats) => g.goal_id === initialGoalId)
       if (match) { setSelectedGoal(match); hasAutoSelected.current = true }
     }
-
     setLoading(false)
   }, [initialGoalId]) // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -131,7 +118,6 @@ export default function SavingsGoalsTab({ initialGoalId, onGoalChange }: Props) 
       setFormError(error ?? 'Đã xảy ra lỗi.')
     } else {
       setShowForm(false)
-      bustGoalsCache()
       await fetchGoals({ force: true })
     }
     setSaving(false)
@@ -145,7 +131,6 @@ export default function SavingsGoalsTab({ initialGoalId, onGoalChange }: Props) 
       const { message } = await res.json()
       setSuccessMsg(message)
       setTimeout(() => setSuccessMsg(''), 5000)
-      bustGoalsCache()
       await fetchGoals({ force: true })
     }
     setDeletingGoal(false)


### PR DESCRIPTION
## Summary
- Replace `useEffect`-based cache reads with lazy `useState` initializers across all cached pages
- Data now populates synchronously on first render, eliminating the blank-frame flash that occurred because `useEffect` runs after the initial paint
- Affects: Planning page, Savings Goals tab, Fixed Expenses tab, Insurance tab, Fund Library

## Root cause
The previous pattern checked the cache inside `useEffect`, which runs *after* the first render. Even with a cache hit, the component would paint one frame with empty/loading state before the cache data appeared. The fix is to use `useState(() => getCache() ?? [])` so the initial state is populated synchronously.

## Test plan
- [ ] Navigate between sidebar pages multiple times — no white flash or spinner on cached pages
- [ ] First visit (no cache) still shows loading state correctly
- [ ] After mutations (add/edit/delete), data refreshes correctly after cache bust

🤖 Generated with [Claude Code](https://claude.com/claude-code)