### PR TITLE
docs(claude): enforce PR isolation rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,11 @@ braingrid task update TASK-456 --status COMPLETED
 
 Rules:
 1. Create a feature/fix branch (e.g. `fix/some-bug`, `feat/some-feature`)
-2. Push to that branch and open a PR
-3. Wait for explicit user approval ("merge it", "looks good") before merging
-4. Only merge after the user has reviewed and tested on the Vercel preview deployment
+2. **Always branch off `main` and set `main` as the PR target.** Never base a branch on another feature branch or open PR.
+3. Push to that branch and open a PR
+4. Wait for explicit user approval ("merge it", "looks good") before merging
+5. Only merge after the user has reviewed and tested on the Vercel preview deployment
 
-**Why:** The user reviews and tests every change on the preview deployment before it reaches main. Direct pushes skip this process.
+**PR isolation rule:** Each PR must be independent. If you are working on a new feature while another PR is open, start fresh from the latest `main` — do not stack branches or include commits that belong to an open PR. If a conflict arises because another PR hasn't merged yet, resolve it after that PR merges rather than combining them.
+
+**Why:** The user reviews and tests every change on the preview deployment before it reaches main. Stacked or combined PRs make it impossible to review and deploy changes independently.


### PR DESCRIPTION
## Summary
- Each PR must branch off `main` and target `main`
- Never stack branches on top of open PRs
- Adds the rule to CLAUDE.md so it's enforced in every future session

🤖 Generated with [Claude Code](https://claude.com/claude-code)