### PR TITLE
fix(gold-price): replace Doji scraper with SJC JSON API

### DIFF
--- a/app/api/v1/gold-price/refresh/route.ts
+++ b/app/api/v1/gold-price/refresh/route.ts
@@ -1,33 +1,38 @@
 import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 
-// Parse Vietnamese number format: "17,050" or "17.050,00"
-function parseVietnameseNumber(raw: string): number {
-  const cleaned = raw.replace(/[^\d.,]/g, '').trim()
-  if (/,\d{2}$/.test(cleaned)) {
-    return parseFloat(cleaned.replace(/\./g, '').replace(',', '.'))
-  }
-  return parseFloat(cleaned.replace(/,/g, ''))
+interface SJCPriceItem {
+  TypeName: string
+  BranchName: string
+  SellValue: number
 }
 
-async function scrapeDoji(): Promise<number> {
-  const html = await fetch('https://giavang.doji.vn', {
-    headers: {
-      'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
-      'Accept-Language': 'vi-VN,vi;q=0.9',
-    },
-  }).then((r) => r.text())
+// Fetches SJC ring gold (nhẫn 99.99%) sell price for HCM via SJC's own JSON API.
+// SellValue is in VND per lượng (1 lượng = 10 chỉ) → divide by 10 for price_per_chi.
+async function fetchSJCRingGoldPrice(): Promise<number> {
+  const res = await fetch('https://sjc.com.vn/GoldPrice/Services/PriceService.ashx', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: 'method=getCurrentGoldPrice',
+  })
+  if (!res.ok) throw new Error(`SJC API HTTP ${res.status}`)
 
-  // Page table: <td>NHẪN TRÒN 9999</td><td>BUY</td><td>SELL</td>
-  // Doji's own ring gold (NHẪN TRÒN 9999) — different from SJC pricing
-  // Price unit on page: nghìn VND/chỉ — multiply by 1000 to get VND/chỉ
-  const match = html.match(/NHẪN TRÒN[\s\S]{0,300}?<td[^>]*>([\d.,]+)<\/td>/)
-  if (!match) throw new Error('Doji: NHẪN TRÒN price row not found')
+  const json = await res.json()
+  if (!json.success || !Array.isArray(json.data)) throw new Error('SJC: unexpected response format')
 
-  const raw = parseVietnameseNumber(match[1])
-  if (isNaN(raw) || raw <= 0) throw new Error('Doji: invalid price value')
+  // "Vàng nhẫn SJC 99,99% 1 chỉ, 2 chỉ, 5 chỉ" — HCM branch
+  const item: SJCPriceItem | undefined = json.data.find(
+    (d: SJCPriceItem) =>
+      d.TypeName.includes('nhẫn') &&
+      d.TypeName.includes('99,99') &&
+      d.BranchName === 'Hồ Chí Minh'
+  )
+  if (!item) throw new Error('SJC: nhẫn 99.99% HCM price not found')
 
-  return raw * 1000
+  const pricePerLuong = item.SellValue
+  if (!pricePerLuong || pricePerLuong <= 0) throw new Error('SJC: invalid price value')
+
+  return pricePerLuong / 10
 }
 
 export async function POST() {
@@ -37,9 +42,9 @@ export async function POST() {
 
   let price: number
   try {
-    price = await scrapeDoji()
+    price = await fetchSJCRingGoldPrice()
   } catch (err) {
-    const msg = err instanceof Error ? err.message : 'Scraping failed'
+    const msg = err instanceof Error ? err.message : 'Failed to fetch gold price'
     return NextResponse.json({ error: msg }, { status: 502 })
   }
 


### PR DESCRIPTION
## Summary
- Doji (`giavang.doji.vn`) actively resets TLS connections from cloud/server IPs — causes 502 on every refresh
- Switch to SJC's own JSON endpoint (`PriceService.ashx`) which returns structured data with no scraping needed
- Uses "Vàng nhẫn SJC 99,99% 1 chỉ, 2 chỉ, 5 chỉ" sell price (HCM branch), divided by 10 to convert per-lượng → per-chỉ

## Test plan
- [ ] Click Refresh on Gold Price widget — should return a price without error
- [ ] Verify price is in the expected range (~17–18M VND/chỉ)
- [ ] Verify daily change % updates correctly on second refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)