### PR TITLE
fix(settings): mobile responsive layout

### DIFF
--- a/app/(app)/settings/SettingsClient.tsx
+++ b/app/(app)/settings/SettingsClient.tsx
@@ -47,12 +47,12 @@ export default function SettingsClient({ initialTab, initialGoalId }: Props) {
 
       {/* Tabs */}
       <div className="flex flex-col gap-2">
-        <div className="grid grid-cols-4 lg:w-auto w-full h-9 items-center rounded-xl bg-[#ececf0] dark:bg-gray-800 p-[3px]">
+        <div className="grid grid-cols-2 sm:grid-cols-4 w-full items-center rounded-xl bg-[#ececf0] dark:bg-gray-800 p-[3px] gap-[3px]">
           {TAB_IDS.map((tabId) => (
             <button
               key={tabId}
               onClick={() => handleTabChange(tabId)}
-              className={`inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center whitespace-nowrap rounded-xl border px-3 py-1 text-sm font-medium transition-[color,box-shadow] ${
+              className={`inline-flex items-center justify-center rounded-[10px] border px-3 py-2 text-xs sm:text-sm font-medium text-center leading-tight transition-[color,box-shadow] ${
                 activeTab === tabId
                   ? 'border-transparent bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
                   : 'border-transparent text-gray-900 dark:text-gray-400'

--- a/app/(app)/settings/tabs/FixedExpensesTab.tsx
+++ b/app/(app)/settings/tabs/FixedExpensesTab.tsx
@@ -176,41 +176,67 @@ export default function FixedExpensesTab() {
         ) : expenses.length === 0 ? (
           <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">{t('empty')}</div>
         ) : (
-          <div className="overflow-x-auto p-6">
-            <table className="w-full">
-              <thead>
-                <tr className="border-b border-black/10 dark:border-gray-700 text-left">
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colName')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colCategory')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colAmount')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colCreated')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-center">{tCommon('actions')}</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-black/5 dark:divide-gray-700">
-                {expenses.map((expense) => (
-                  <tr key={expense.expense_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
-                    <td className="px-4 py-4 font-medium text-gray-900 dark:text-gray-100">{expense.expense_name}</td>
-                    <td className="px-4 py-4">
-                      <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">{expense.category}</span>
-                    </td>
-                    <td className="px-4 py-4 text-right font-semibold text-gray-900 dark:text-gray-100">{fmt(expense.amount_vnd)}</td>
-                    <td className="px-4 py-4 text-sm text-gray-600 dark:text-gray-400">{new Date(expense.created_at).toLocaleDateString('vi-VN')}</td>
-                    <td className="px-4 py-4 text-center">
-                      <div className="flex items-center justify-center gap-1">
-                        <button onClick={() => openEdit(expense)} className="h-8 w-8 p-0 flex items-center justify-center border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
-                          <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
-                        </button>
-                        <button onClick={() => setConfirmExpense(expense)} className="h-8 w-8 p-0 flex items-center justify-center border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
-                          <Trash2 className="h-4 w-4 text-red-500 dark:text-red-400" />
-                        </button>
-                      </div>
-                    </td>
+          <>
+            {/* Mobile card layout */}
+            <div className="sm:hidden divide-y divide-black/5 dark:divide-gray-700 px-4 py-2">
+              {expenses.map((expense) => (
+                <div key={expense.expense_id} className="py-3 space-y-2">
+                  <div className="flex items-start justify-between gap-2">
+                    <span className="font-medium text-gray-900 dark:text-gray-100 text-sm">{expense.expense_name}</span>
+                    <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300 shrink-0">{expense.category}</span>
+                  </div>
+                  <div className="flex items-center justify-between text-xs">
+                    <span className="font-semibold text-gray-900 dark:text-gray-100">{fmt(expense.amount_vnd)}</span>
+                    <span className="text-gray-500 dark:text-gray-400">{new Date(expense.created_at).toLocaleDateString('vi-VN')}</span>
+                  </div>
+                  <div className="flex items-center gap-1 pt-0.5">
+                    <button onClick={() => openEdit(expense)} className="h-8 w-8 p-0 flex items-center justify-center border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+                      <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                    </button>
+                    <button onClick={() => setConfirmExpense(expense)} className="h-8 w-8 p-0 flex items-center justify-center border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+                      <Trash2 className="h-4 w-4 text-red-500 dark:text-red-400" />
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+            {/* Desktop table layout */}
+            <div className="hidden sm:block overflow-x-auto p-6">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-black/10 dark:border-gray-700 text-left">
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colName')}</th>
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colCategory')}</th>
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colAmount')}</th>
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colCreated')}</th>
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-center">{tCommon('actions')}</th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                </thead>
+                <tbody className="divide-y divide-black/5 dark:divide-gray-700">
+                  {expenses.map((expense) => (
+                    <tr key={expense.expense_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                      <td className="px-4 py-4 font-medium text-gray-900 dark:text-gray-100">{expense.expense_name}</td>
+                      <td className="px-4 py-4">
+                        <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">{expense.category}</span>
+                      </td>
+                      <td className="px-4 py-4 text-right font-semibold text-gray-900 dark:text-gray-100">{fmt(expense.amount_vnd)}</td>
+                      <td className="px-4 py-4 text-sm text-gray-600 dark:text-gray-400">{new Date(expense.created_at).toLocaleDateString('vi-VN')}</td>
+                      <td className="px-4 py-4 text-center">
+                        <div className="flex items-center justify-center gap-1">
+                          <button onClick={() => openEdit(expense)} className="h-8 w-8 p-0 flex items-center justify-center border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+                            <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                          </button>
+                          <button onClick={() => setConfirmExpense(expense)} className="h-8 w-8 p-0 flex items-center justify-center border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+                            <Trash2 className="h-4 w-4 text-red-500 dark:text-red-400" />
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
         )}
       </div>
 

--- a/app/(app)/settings/tabs/FixedExpensesTab.tsx
+++ b/app/(app)/settings/tabs/FixedExpensesTab.tsx
@@ -134,14 +134,14 @@ export default function FixedExpensesTab() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('title')}</h2>
           <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('total')}: {fmt(totalMonthly)} {t('perMonth')}</p>
         </div>
-        <button onClick={openCreate} className="flex items-center gap-2 h-9 px-4 bg-gray-950 hover:bg-gray-800 text-white text-sm font-bold rounded-md transition-colors">
-          <Plus className="h-4 w-4" />
-          {t('create')}
+        <button onClick={openCreate} className="flex items-center gap-2 h-9 px-3 sm:px-4 bg-gray-950 hover:bg-gray-800 text-white text-sm font-bold rounded-md transition-colors shrink-0 self-start sm:self-auto">
+          <Plus className="h-4 w-4 shrink-0" />
+          <span className="hidden sm:inline">{t('create')}</span>
         </button>
       </div>
 

--- a/app/(app)/settings/tabs/GoalDetailView.tsx
+++ b/app/(app)/settings/tabs/GoalDetailView.tsx
@@ -424,13 +424,13 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
       {/* Fund Investments Tab */}
       {activeDetailTab === 'fund' && (
         <div className="bg-white dark:bg-gray-900 rounded-xl border border-black/10 dark:border-gray-700 overflow-hidden">
-          <div className="flex items-center justify-between px-5 py-4 border-black/10 dark:border-gray-700">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-5 py-4 border-black/10 dark:border-gray-700">
             <div>
               <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('fundInvestments')}</h3>
               <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{t('fundInvestmentsSub')}</p>
             </div>
-            <button onClick={openFiAdd} className="flex items-center gap-2 h-9 px-4 bg-gray-950 hover:bg-gray-800 text-white text-sm font-bold rounded-md transition-colors">
-              <Plus className="h-4 w-4" />{t('addFundBtn')}
+            <button onClick={openFiAdd} className="flex items-center gap-2 h-9 px-3 sm:px-4 bg-gray-950 hover:bg-gray-800 text-white text-sm font-bold rounded-md transition-colors shrink-0 self-start sm:self-auto">
+              <Plus className="h-4 w-4 shrink-0" /><span className="hidden sm:inline">{t('addFundBtn')}</span>
             </button>
           </div>
 
@@ -443,9 +443,15 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
               <table className="w-full">
                 <thead>
                   <tr className="border-black/10 dark:border-gray-700 text-left">
-                    {[t('colDate'), t('colFund'), t('colAmount'), t('colUnits'), t('colNavBuy'), t('colNavCurrent'), t('colCurrentValue'), t('colGainLoss'), tc('actions')].map((h) => (
-                      <th key={h} className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{h}</th>
-                    ))}
+                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
+                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colFund')}</th>
+                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAmount')}</th>
+                    <th className="hidden sm:table-cell px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colUnits')}</th>
+                    <th className="hidden sm:table-cell px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colNavBuy')}</th>
+                    <th className="hidden sm:table-cell px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colNavCurrent')}</th>
+                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colCurrentValue')}</th>
+                    <th className="hidden sm:table-cell px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colGainLoss')}</th>
+                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-black/5 dark:divide-gray-700">
@@ -458,11 +464,11 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
                         <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{new Date(row.investment_date).toLocaleDateString('vi-VN')}</td>
                         <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{row.fund_display ?? row.fund_id ?? '—'}</td>
                         <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(row.amount_vnd)}</td>
-                        <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.units ?? '—'}</td>
-                        <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.unit_price != null ? fmt(row.unit_price) : '—'}</td>
-                        <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{fmt(currentNav)}</td>
+                        <td className="hidden sm:table-cell px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.units ?? '—'}</td>
+                        <td className="hidden sm:table-cell px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.unit_price != null ? fmt(row.unit_price) : '—'}</td>
+                        <td className="hidden sm:table-cell px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{fmt(currentNav)}</td>
                         <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(row.current_value)}</td>
-                        <td className={`px-4 py-3 font-medium ${pl >= 0 ? 'text-green-600' : 'text-red-600'}`}>{fmt(pl)}</td>
+                        <td className={`hidden sm:table-cell px-4 py-3 font-medium ${pl >= 0 ? 'text-green-600' : 'text-red-600'}`}>{fmt(pl)}</td>
                         <td className="px-4 py-3">
                           <div className="flex items-center gap-1">
                             <button onClick={() => openFiEdit(row)} className="p-1.5 rounded-md text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors">
@@ -489,13 +495,13 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
       {/* Other Transactions Tab (bank/stock/gold) */}
       {activeDetailTab === 'other' && (
         <div className="bg-white dark:bg-gray-900 rounded-xl border border-black/10 dark:border-gray-700 overflow-hidden">
-          <div className="flex items-center justify-between px-5 py-4 border-black/10 dark:border-gray-700">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 px-5 py-4 border-black/10 dark:border-gray-700">
             <div>
               <h3 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('otherInvestments')}</h3>
               <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{t('otherInvestmentsSub')}</p>
             </div>
-            <button onClick={openTxAdd} className="flex items-center gap-2 h-9 px-4 bg-gray-950 hover:bg-gray-800 text-white text-sm font-bold rounded-md transition-colors">
-              <Plus className="h-4 w-4" />{t('addTxBtn')}
+            <button onClick={openTxAdd} className="flex items-center gap-2 h-9 px-3 sm:px-4 bg-gray-950 hover:bg-gray-800 text-white text-sm font-bold rounded-md transition-colors shrink-0 self-start sm:self-auto">
+              <Plus className="h-4 w-4 shrink-0" /><span className="hidden sm:inline">{t('addTxBtn')}</span>
             </button>
           </div>
 
@@ -508,9 +514,14 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
               <table className="w-full">
                 <thead>
                   <tr className="border-black/10 dark:border-gray-700 text-left">
-                    {[t('colDate'), t('colType'), t('colAmount'), t('colUnits'), t('colInterestRate'), t('colGainLoss'), t('colNotes'), tc('actions')].map((h) => (
-                      <th key={h} className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{h}</th>
-                    ))}
+                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
+                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colType')}</th>
+                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAmount')}</th>
+                    <th className="hidden sm:table-cell px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colUnits')}</th>
+                    <th className="hidden sm:table-cell px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colInterestRate')}</th>
+                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colGainLoss')}</th>
+                    <th className="hidden sm:table-cell px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colNotes')}</th>
+                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-black/5 dark:divide-gray-700">
@@ -525,10 +536,10 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
                           </span>
                         </td>
                         <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(row.amount_vnd)}</td>
-                        <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.units ?? '—'}</td>
-                        <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.interest_rate != null ? `${row.interest_rate}%` : '—'}</td>
+                        <td className="hidden sm:table-cell px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.units ?? '—'}</td>
+                        <td className="hidden sm:table-cell px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.interest_rate != null ? `${row.interest_rate}%` : '—'}</td>
                         <td className={`px-4 py-3 font-medium ${gain >= 0 ? 'text-green-600' : 'text-red-600'}`}>{fmt(gain)}</td>
-                        <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-500 max-w-32 truncate">{row.notes ?? '—'}</td>
+                        <td className="hidden sm:table-cell px-4 py-3 text-sm text-gray-600 dark:text-gray-500 max-w-32 truncate">{row.notes ?? '—'}</td>
                         <td className="px-4 py-3">
                           <div className="flex items-center gap-1">
                             <button onClick={() => openTxEdit(row)} className="p-1.5 rounded-md text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors">

--- a/app/(app)/settings/tabs/GoalDetailView.tsx
+++ b/app/(app)/settings/tabs/GoalDetailView.tsx
@@ -566,55 +566,109 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
           ) : otherRows.length === 0 ? (
             <div className="text-center py-8 text-gray-400 dark:text-gray-500 text-sm">{t('noOtherInvestments')}</div>
           ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead>
-                  <tr className="border-black/10 dark:border-gray-700 text-left">
-                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
-                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colType')}</th>
-                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAmount')}</th>
-                    <th className="hidden sm:table-cell px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colUnits')}</th>
-                    <th className="hidden sm:table-cell px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colInterestRate')}</th>
-                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colGainLoss')}</th>
-                    <th className="hidden sm:table-cell px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colNotes')}</th>
-                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-black/5 dark:divide-gray-700">
-                  {otherRows.map((row) => {
-                    const gain = row.current_value - row.amount_vnd
-                    return (
-                      <tr key={row.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
-                        <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{new Date(row.investment_date).toLocaleDateString('vi-VN')}</td>
-                        <td className="px-4 py-3">
-                          <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${ASSET_COLORS[row.asset_type] ?? 'bg-gray-100 text-gray-700'}`}>
-                            {tt(`asset${row.asset_type.charAt(0).toUpperCase() + row.asset_type.slice(1)}` as 'assetFund' | 'assetBank' | 'assetStock' | 'assetGold') ?? row.asset_type}
-                          </span>
-                        </td>
-                        <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(row.amount_vnd)}</td>
-                        <td className="hidden sm:table-cell px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.units ?? '—'}</td>
-                        <td className="hidden sm:table-cell px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.interest_rate != null ? `${row.interest_rate}%` : '—'}</td>
-                        <td className={`px-4 py-3 font-medium ${gain >= 0 ? 'text-green-600' : 'text-red-600'}`}>{fmt(gain)}</td>
-                        <td className="hidden sm:table-cell px-4 py-3 text-sm text-gray-600 dark:text-gray-500 max-w-32 truncate">{row.notes ?? '—'}</td>
-                        <td className="px-4 py-3">
-                          <div className="flex items-center gap-1">
-                            <button onClick={() => openTxEdit(row)} className="p-1.5 rounded-md text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors">
-                              <Edit className="h-4 w-4" />
-                            </button>
-                            <button onClick={() => handleUnassign(row)} className="p-1.5 rounded-md text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors">
-                              <Unlink className="h-4 w-4" />
-                            </button>
-                            <button onClick={() => handleTxDelete(row)} disabled={deletingId === row.transaction_id} className="p-1.5 rounded-md text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-50">
-                              <Trash2 className="h-4 w-4" />
-                            </button>
+            <>
+              {/* Mobile card layout */}
+              <div className="sm:hidden divide-y divide-black/5 dark:divide-gray-700">
+                {otherRows.map((row) => {
+                  const gain = row.current_value - row.amount_vnd
+                  return (
+                    <div key={row.transaction_id} className="px-4 py-3 space-y-2">
+                      <div className="flex items-start justify-between gap-2">
+                        <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${ASSET_COLORS[row.asset_type] ?? 'bg-gray-100 text-gray-700'}`}>
+                          {tt(`asset${row.asset_type.charAt(0).toUpperCase() + row.asset_type.slice(1)}` as 'assetFund' | 'assetBank' | 'assetStock' | 'assetGold') ?? row.asset_type}
+                        </span>
+                        <span className="text-xs text-gray-500 dark:text-gray-400 shrink-0">{new Date(row.investment_date).toLocaleDateString('vi-VN')}</span>
+                      </div>
+                      <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                        <div>
+                          <span className="text-gray-500 dark:text-gray-400">{t('colAmount')}: </span>
+                          <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(row.amount_vnd)}</span>
+                        </div>
+                        <div>
+                          <span className="text-gray-500 dark:text-gray-400">{t('colGainLoss')}: </span>
+                          <span className={`font-medium ${gain >= 0 ? 'text-green-600' : 'text-red-600'}`}>{fmt(gain)}</span>
+                        </div>
+                        <div>
+                          <span className="text-gray-500 dark:text-gray-400">{t('colUnits')}: </span>
+                          <span className="text-gray-700 dark:text-gray-300">{row.units ?? '—'}</span>
+                        </div>
+                        <div>
+                          <span className="text-gray-500 dark:text-gray-400">{t('colInterestRate')}: </span>
+                          <span className="text-gray-700 dark:text-gray-300">{row.interest_rate != null ? `${row.interest_rate}%` : '—'}</span>
+                        </div>
+                        {row.notes && (
+                          <div className="col-span-2">
+                            <span className="text-gray-500 dark:text-gray-400">{t('colNotes')}: </span>
+                            <span className="text-gray-700 dark:text-gray-300">{row.notes}</span>
                           </div>
-                        </td>
-                      </tr>
-                    )
-                  })}
-                </tbody>
-              </table>
-            </div>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-1 pt-0.5">
+                        <button onClick={() => openTxEdit(row)} className="p-1.5 rounded-md text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors">
+                          <Edit className="h-4 w-4" />
+                        </button>
+                        <button onClick={() => handleUnassign(row)} className="p-1.5 rounded-md text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors">
+                          <Unlink className="h-4 w-4" />
+                        </button>
+                        <button onClick={() => handleTxDelete(row)} disabled={deletingId === row.transaction_id} className="p-1.5 rounded-md text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-50">
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+              {/* Desktop table layout */}
+              <div className="hidden sm:block overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-black/10 dark:border-gray-700 text-left">
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colType')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAmount')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colUnits')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colInterestRate')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colGainLoss')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colNotes')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-black/5 dark:divide-gray-700">
+                    {otherRows.map((row) => {
+                      const gain = row.current_value - row.amount_vnd
+                      return (
+                        <tr key={row.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                          <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{new Date(row.investment_date).toLocaleDateString('vi-VN')}</td>
+                          <td className="px-4 py-3">
+                            <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${ASSET_COLORS[row.asset_type] ?? 'bg-gray-100 text-gray-700'}`}>
+                              {tt(`asset${row.asset_type.charAt(0).toUpperCase() + row.asset_type.slice(1)}` as 'assetFund' | 'assetBank' | 'assetStock' | 'assetGold') ?? row.asset_type}
+                            </span>
+                          </td>
+                          <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(row.amount_vnd)}</td>
+                          <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.units ?? '—'}</td>
+                          <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.interest_rate != null ? `${row.interest_rate}%` : '—'}</td>
+                          <td className={`px-4 py-3 font-medium ${gain >= 0 ? 'text-green-600' : 'text-red-600'}`}>{fmt(gain)}</td>
+                          <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-500 max-w-32 truncate">{row.notes ?? '—'}</td>
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-1">
+                              <button onClick={() => openTxEdit(row)} className="p-1.5 rounded-md text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors">
+                                <Edit className="h-4 w-4" />
+                              </button>
+                              <button onClick={() => handleUnassign(row)} className="p-1.5 rounded-md text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors">
+                                <Unlink className="h-4 w-4" />
+                              </button>
+                              <button onClick={() => handleTxDelete(row)} disabled={deletingId === row.transaction_id} className="p-1.5 rounded-md text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-50">
+                                <Trash2 className="h-4 w-4" />
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </>
           )}
         </div>
       )}

--- a/app/(app)/settings/tabs/GoalDetailView.tsx
+++ b/app/(app)/settings/tabs/GoalDetailView.tsx
@@ -439,55 +439,111 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
           ) : fundRows.length === 0 ? (
             <div className="text-center py-8 text-gray-400 dark:text-gray-500 text-sm">{t('noFundInvestments')}</div>
           ) : (
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead>
-                  <tr className="border-black/10 dark:border-gray-700 text-left">
-                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
-                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colFund')}</th>
-                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAmount')}</th>
-                    <th className="hidden sm:table-cell px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colUnits')}</th>
-                    <th className="hidden sm:table-cell px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colNavBuy')}</th>
-                    <th className="hidden sm:table-cell px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colNavCurrent')}</th>
-                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colCurrentValue')}</th>
-                    <th className="hidden sm:table-cell px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colGainLoss')}</th>
-                    <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-black/5 dark:divide-gray-700">
-                  {fundRows.map((row) => {
-                    const pl = row.current_value - row.amount_vnd
-                    const fund = funds.find((f) => f.id === row.fund_id)
-                    const currentNav = fund?.nav ?? row.unit_price ?? 0
-                    return (
-                      <tr key={row.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
-                        <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{new Date(row.investment_date).toLocaleDateString('vi-VN')}</td>
-                        <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{row.fund_display ?? row.fund_id ?? '—'}</td>
-                        <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(row.amount_vnd)}</td>
-                        <td className="hidden sm:table-cell px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.units ?? '—'}</td>
-                        <td className="hidden sm:table-cell px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.unit_price != null ? fmt(row.unit_price) : '—'}</td>
-                        <td className="hidden sm:table-cell px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{fmt(currentNav)}</td>
-                        <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(row.current_value)}</td>
-                        <td className={`hidden sm:table-cell px-4 py-3 font-medium ${pl >= 0 ? 'text-green-600' : 'text-red-600'}`}>{fmt(pl)}</td>
-                        <td className="px-4 py-3">
-                          <div className="flex items-center gap-1">
-                            <button onClick={() => openFiEdit(row)} className="p-1.5 rounded-md text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors">
-                              <Edit className="h-4 w-4" />
-                            </button>
-                            <button onClick={() => handleUnassign(row)} className="p-1.5 rounded-md text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors">
-                              <Unlink className="h-4 w-4" />
-                            </button>
-                            <button onClick={() => handleFiDelete(row)} disabled={deletingId === row.transaction_id} className="p-1.5 rounded-md text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-50">
-                              <Trash2 className="h-4 w-4" />
-                            </button>
-                          </div>
-                        </td>
-                      </tr>
-                    )
-                  })}
-                </tbody>
-              </table>
-            </div>
+            <>
+              {/* Mobile card layout */}
+              <div className="sm:hidden divide-y divide-black/5 dark:divide-gray-700">
+                {fundRows.map((row) => {
+                  const pl = row.current_value - row.amount_vnd
+                  const fund = funds.find((f) => f.id === row.fund_id)
+                  const currentNav = fund?.nav ?? row.unit_price ?? 0
+                  return (
+                    <div key={row.transaction_id} className="px-4 py-3 space-y-2">
+                      <div className="flex items-start justify-between gap-2">
+                        <span className="font-medium text-gray-900 dark:text-gray-100 text-sm leading-tight">{row.fund_display ?? row.fund_id ?? '—'}</span>
+                        <span className="text-xs text-gray-500 dark:text-gray-400 shrink-0">{new Date(row.investment_date).toLocaleDateString('vi-VN')}</span>
+                      </div>
+                      <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                        <div>
+                          <span className="text-gray-500 dark:text-gray-400">{t('colAmount')}: </span>
+                          <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(row.amount_vnd)}</span>
+                        </div>
+                        <div>
+                          <span className="text-gray-500 dark:text-gray-400">{t('colCurrentValue')}: </span>
+                          <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(row.current_value)}</span>
+                        </div>
+                        <div>
+                          <span className="text-gray-500 dark:text-gray-400">{t('colUnits')}: </span>
+                          <span className="text-gray-700 dark:text-gray-300">{row.units ?? '—'}</span>
+                        </div>
+                        <div>
+                          <span className="text-gray-500 dark:text-gray-400">{t('colGainLoss')}: </span>
+                          <span className={`font-medium ${pl >= 0 ? 'text-green-600' : 'text-red-600'}`}>{fmt(pl)}</span>
+                        </div>
+                        <div>
+                          <span className="text-gray-500 dark:text-gray-400">{t('colNavBuy')}: </span>
+                          <span className="text-gray-700 dark:text-gray-300">{row.unit_price != null ? fmt(row.unit_price) : '—'}</span>
+                        </div>
+                        <div>
+                          <span className="text-gray-500 dark:text-gray-400">{t('colNavCurrent')}: </span>
+                          <span className="text-gray-700 dark:text-gray-300">{fmt(currentNav)}</span>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-1 pt-0.5">
+                        <button onClick={() => openFiEdit(row)} className="p-1.5 rounded-md text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors">
+                          <Edit className="h-4 w-4" />
+                        </button>
+                        <button onClick={() => handleUnassign(row)} className="p-1.5 rounded-md text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors">
+                          <Unlink className="h-4 w-4" />
+                        </button>
+                        <button onClick={() => handleFiDelete(row)} disabled={deletingId === row.transaction_id} className="p-1.5 rounded-md text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-50">
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+              {/* Desktop table layout */}
+              <div className="hidden sm:block overflow-x-auto">
+                <table className="w-full">
+                  <thead>
+                    <tr className="border-black/10 dark:border-gray-700 text-left">
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colFund')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAmount')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colUnits')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colNavBuy')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colNavCurrent')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colCurrentValue')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colGainLoss')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
+                    </tr>
+                  </thead>
+                  <tbody className="divide-y divide-black/5 dark:divide-gray-700">
+                    {fundRows.map((row) => {
+                      const pl = row.current_value - row.amount_vnd
+                      const fund = funds.find((f) => f.id === row.fund_id)
+                      const currentNav = fund?.nav ?? row.unit_price ?? 0
+                      return (
+                        <tr key={row.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                          <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{new Date(row.investment_date).toLocaleDateString('vi-VN')}</td>
+                          <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{row.fund_display ?? row.fund_id ?? '—'}</td>
+                          <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(row.amount_vnd)}</td>
+                          <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.units ?? '—'}</td>
+                          <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{row.unit_price != null ? fmt(row.unit_price) : '—'}</td>
+                          <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{fmt(currentNav)}</td>
+                          <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(row.current_value)}</td>
+                          <td className={`px-4 py-3 font-medium ${pl >= 0 ? 'text-green-600' : 'text-red-600'}`}>{fmt(pl)}</td>
+                          <td className="px-4 py-3">
+                            <div className="flex items-center gap-1">
+                              <button onClick={() => openFiEdit(row)} className="p-1.5 rounded-md text-blue-600 dark:text-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors">
+                                <Edit className="h-4 w-4" />
+                              </button>
+                              <button onClick={() => handleUnassign(row)} className="p-1.5 rounded-md text-amber-600 dark:text-amber-400 hover:bg-amber-50 dark:hover:bg-amber-900/20 transition-colors">
+                                <Unlink className="h-4 w-4" />
+                              </button>
+                              <button onClick={() => handleFiDelete(row)} disabled={deletingId === row.transaction_id} className="p-1.5 rounded-md text-red-500 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors disabled:opacity-50">
+                                <Trash2 className="h-4 w-4" />
+                              </button>
+                            </div>
+                          </td>
+                        </tr>
+                      )
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </>
           )}
         </div>
       )}

--- a/app/(app)/settings/tabs/InsuranceMembersTab.tsx
+++ b/app/(app)/settings/tabs/InsuranceMembersTab.tsx
@@ -142,14 +142,14 @@ export default function InsuranceMembersTab() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('title')}</h2>
           <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">
             {t('total')}: {fmt(totalAnnual)} {t('perYear')} · {fmt(totalMonthly)} {t('perMonth')}
           </p>
         </div>
-        <button onClick={openCreate} className="flex items-center gap-2 h-9 px-4 bg-gray-950 hover:bg-gray-800 text-white text-sm font-bold rounded-md transition-colors">
+        <button onClick={openCreate} className="flex items-center gap-2 h-9 px-4 bg-gray-950 hover:bg-gray-800 text-white text-sm font-bold rounded-md transition-colors shrink-0 self-start sm:self-auto">
           <Plus className="h-4 w-4" />
           {t('add')}
         </button>
@@ -171,10 +171,10 @@ export default function InsuranceMembersTab() {
               <thead>
                 <tr className="border-b border-black/10 dark:border-gray-700 text-left">
                   <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colName')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colRelationship')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colAnnual')}</th>
+                  <th className="hidden sm:table-cell px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colRelationship')}</th>
+                  <th className="hidden sm:table-cell px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colAnnual')}</th>
                   <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colMonthly')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colPaymentDate')}</th>
+                  <th className="hidden sm:table-cell px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colPaymentDate')}</th>
                   <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-center">{tCommon('actions')}</th>
                 </tr>
               </thead>
@@ -189,14 +189,14 @@ export default function InsuranceMembersTab() {
                         <span className="font-medium text-gray-900 dark:text-gray-100">{member.member_name}</span>
                       </div>
                     </td>
-                    <td className="px-4 py-4">
+                    <td className="hidden sm:table-cell px-4 py-4">
                       <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-semibold ${RELATIONSHIP_COLORS[member.relationship] ?? 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300'}`}>
                         {member.relationship}
                       </span>
                     </td>
-                    <td className="px-4 py-4 text-right font-medium text-gray-900 dark:text-gray-100">{fmt(member.annual_payment_vnd)}</td>
+                    <td className="hidden sm:table-cell px-4 py-4 text-right font-medium text-gray-900 dark:text-gray-100">{fmt(member.annual_payment_vnd)}</td>
                     <td className="px-4 py-4 text-right font-semibold text-violet-600 dark:text-violet-400">{fmt(member.monthly_premium_vnd)}</td>
-                    <td className="px-4 py-4 text-sm text-gray-600 dark:text-gray-400">
+                    <td className="hidden sm:table-cell px-4 py-4 text-sm text-gray-600 dark:text-gray-400">
                       {member.payment_date ? new Date(member.payment_date).toLocaleDateString('vi-VN') : '—'}
                     </td>
                     <td className="px-4 py-4">

--- a/app/(app)/settings/tabs/InsuranceMembersTab.tsx
+++ b/app/(app)/settings/tabs/InsuranceMembersTab.tsx
@@ -149,9 +149,9 @@ export default function InsuranceMembersTab() {
             {t('total')}: {fmt(totalAnnual)} {t('perYear')} · {fmt(totalMonthly)} {t('perMonth')}
           </p>
         </div>
-        <button onClick={openCreate} className="flex items-center gap-2 h-9 px-4 bg-gray-950 hover:bg-gray-800 text-white text-sm font-bold rounded-md transition-colors shrink-0 self-start sm:self-auto">
-          <Plus className="h-4 w-4" />
-          {t('add')}
+        <button onClick={openCreate} className="flex items-center gap-2 h-9 px-3 sm:px-4 bg-gray-950 hover:bg-gray-800 text-white text-sm font-bold rounded-md transition-colors shrink-0 self-start sm:self-auto">
+          <Plus className="h-4 w-4 shrink-0" />
+          <span className="hidden sm:inline">{t('add')}</span>
         </button>
       </div>
 

--- a/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
+++ b/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
@@ -406,12 +406,16 @@ export default function InvestmentTransactionsTab() {
                   ? (tx.unit_price != null ? fmtNav(tx.unit_price) : '—')
                   : (tx.interest_rate != null ? `${tx.interest_rate}%` : '—')
                 const rateOrNavLabel = tx.asset_type === 'fund' ? t('colTransaction') : t('colInterest')
+                const fundCode = tx.asset_type === 'fund' ? funds.find(f => f.id === tx.fund_id)?.code : null
                 return (
                   <div key={tx.transaction_id} className="py-3 space-y-2">
                     <div className="flex items-start justify-between gap-2">
-                      <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold ${ASSET_COLORS[tx.asset_type as AssetType] ?? 'bg-gray-100 text-gray-700'}`}>
-                        {t(`asset${tx.asset_type.charAt(0).toUpperCase() + tx.asset_type.slice(1)}` as 'assetFund' | 'assetBank' | 'assetStock' | 'assetGold') ?? tx.asset_type}
-                      </span>
+                      <div className="flex items-center gap-2">
+                        <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold ${ASSET_COLORS[tx.asset_type as AssetType] ?? 'bg-gray-100 text-gray-700'}`}>
+                          {t(`asset${tx.asset_type.charAt(0).toUpperCase() + tx.asset_type.slice(1)}` as 'assetFund' | 'assetBank' | 'assetStock' | 'assetGold') ?? tx.asset_type}
+                        </span>
+                        {fundCode && <span className="text-xs font-semibold text-gray-700 dark:text-gray-300">{fundCode}</span>}
+                      </div>
                       <span className="text-xs text-gray-500 dark:text-gray-400 shrink-0">{new Date(tx.investment_date).toLocaleDateString('vi-VN')}</span>
                     </div>
                     <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
@@ -479,13 +483,17 @@ export default function InvestmentTransactionsTab() {
                     const rateOrNav = tx.asset_type === 'fund'
                       ? (tx.unit_price != null ? fmtNav(tx.unit_price) : '—')
                       : (tx.interest_rate != null ? `${tx.interest_rate}%` : '—')
+                    const fundCode = tx.asset_type === 'fund' ? funds.find(f => f.id === tx.fund_id)?.code : null
                     return (
                       <tr key={tx.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
                         <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{new Date(tx.investment_date).toLocaleDateString('vi-VN')}</td>
                         <td className="px-4 py-3">
-                          <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold ${ASSET_COLORS[tx.asset_type as AssetType] ?? 'bg-gray-100 text-gray-700'}`}>
-                            {t(`asset${tx.asset_type.charAt(0).toUpperCase() + tx.asset_type.slice(1)}` as 'assetFund' | 'assetBank' | 'assetStock' | 'assetGold') ?? tx.asset_type}
-                          </span>
+                          <div className="flex items-center gap-2">
+                            <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold ${ASSET_COLORS[tx.asset_type as AssetType] ?? 'bg-gray-100 text-gray-700'}`}>
+                              {t(`asset${tx.asset_type.charAt(0).toUpperCase() + tx.asset_type.slice(1)}` as 'assetFund' | 'assetBank' | 'assetStock' | 'assetGold') ?? tx.asset_type}
+                            </span>
+                            {fundCode && <span className="text-xs font-semibold text-gray-700 dark:text-gray-300">{fundCode}</span>}
+                          </div>
                         </td>
                         <td className="px-4 py-3 text-right font-medium text-gray-900 dark:text-gray-100">{fmt(tx.amount_vnd)}</td>
                         <td className="px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">{tx.units ?? '—'}</td>

--- a/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
+++ b/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
@@ -523,7 +523,7 @@ export default function InvestmentTransactionsTab() {
               </table>
             </div>
             {/* Pagination */}
-            <div className="flex items-center justify-between px-4 sm:px-6 mt-4 pt-4 border-t border-black/10 dark:border-gray-700">
+            <div className="flex items-center justify-between px-4 py-4 border-t border-black/10 dark:border-gray-700">
               <p className="text-sm text-gray-600 dark:text-gray-400">{t('page')} {page} / {totalPages}</p>
               <div className="flex gap-2">
                 <button

--- a/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
+++ b/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslations } from 'next-intl'
-import { Plus, Download, Edit, Trash2, ChevronLeft, ChevronRight, ChevronDown } from 'lucide-react'
+import { Plus, FileSpreadsheet, Edit, Trash2, ChevronLeft, ChevronRight, ChevronDown } from 'lucide-react'
 import ConfirmModal from '@/app/components/ConfirmModal'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
@@ -329,7 +329,7 @@ export default function InvestmentTransactionsTab() {
             onClick={() => { setShowImport(true); setImportRaw(''); setImportRows([]); setImportFundId('') }}
             className="flex items-center gap-2 h-9 px-3 sm:px-4 text-sm font-medium text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
           >
-            <Download className="h-4 w-4 shrink-0" />
+            <FileSpreadsheet className="h-4 w-4 shrink-0" />
             <span className="hidden sm:inline">{t('importFromExcel')}</span>
           </button>
           <button

--- a/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
+++ b/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
@@ -319,25 +319,25 @@ export default function InvestmentTransactionsTab() {
   return (
     <div className="space-y-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <div>
           <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('title')}</h2>
           <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('totalCount', { count: total })}</p>
         </div>
-        <div className="flex gap-3">
+        <div className="flex gap-2 shrink-0 self-start sm:self-auto">
           <button
             onClick={() => { setShowImport(true); setImportRaw(''); setImportRows([]); setImportFundId('') }}
-            className="flex items-center gap-2 h-9 px-4 text-sm font-medium text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            className="flex items-center gap-2 h-9 px-3 sm:px-4 text-sm font-medium text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
           >
-            <Download className="h-4 w-4" />
-            {t('importFromExcel')}
+            <Download className="h-4 w-4 shrink-0" />
+            <span className="hidden sm:inline">{t('importFromExcel')}</span>
           </button>
           <button
             onClick={openAdd}
-            className="flex items-center gap-2 h-9 px-4 bg-gray-950 hover:bg-gray-800 text-white text-sm font-bold rounded-md transition-colors"
+            className="flex items-center gap-2 h-9 px-3 sm:px-4 bg-gray-950 hover:bg-gray-800 text-white text-sm font-bold rounded-md transition-colors"
           >
-            <Plus className="h-4 w-4" />
-            {t('create')}
+            <Plus className="h-4 w-4 shrink-0" />
+            <span className="hidden sm:inline">{t('create')}</span>
           </button>
         </div>
       </div>
@@ -404,11 +404,11 @@ export default function InvestmentTransactionsTab() {
                   <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
                   <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAsset')}</th>
                   <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colAmount')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colTransaction')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colInterest')}</th>
+                  <th className="hidden sm:table-cell px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colTransaction')}</th>
+                  <th className="hidden sm:table-cell px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colInterest')}</th>
                   <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colExpiry')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colGoal')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colNotes')}</th>
+                  <th className="hidden sm:table-cell px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colGoal')}</th>
+                  <th className="hidden sm:table-cell px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colNotes')}</th>
                   <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-center">{tc('actions')}</th>
                 </tr>
               </thead>
@@ -427,16 +427,16 @@ export default function InvestmentTransactionsTab() {
                         </span>
                       </td>
                       <td className="px-4 py-3 text-right font-medium text-gray-900 dark:text-gray-100">{fmt(tx.amount_vnd)}</td>
-                      <td className="px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">{tx.units ?? '—'}</td>
-                      <td className="px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">{rateOrNav}</td>
+                      <td className="hidden sm:table-cell px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">{tx.units ?? '—'}</td>
+                      <td className="hidden sm:table-cell px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">{rateOrNav}</td>
                       <td className="px-4 py-3 text-right font-medium text-gray-900 dark:text-gray-100">{fmt(currentValue)}</td>
-                      <td className="px-4 py-3">
+                      <td className="hidden sm:table-cell px-4 py-3">
                         {tx.savings_goals?.goal_name
                           ? <span className="inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900">{tx.savings_goals.goal_name}</span>
                           : <span className="inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400">{t('noGoal')}</span>
                         }
                       </td>
-                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 max-w-32 truncate">{tx.notes ?? '—'}</td>
+                      <td className="hidden sm:table-cell px-4 py-3 text-sm text-gray-600 dark:text-gray-400 max-w-32 truncate">{tx.notes ?? '—'}</td>
                       <td className="px-4 py-3 text-center">
                         <div className="flex items-center justify-center gap-1">
                           <button onClick={() => openEdit(tx)} className="h-8 w-8 p-0 flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">

--- a/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
+++ b/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
@@ -397,64 +397,125 @@ export default function InvestmentTransactionsTab() {
         ) : transactions.length === 0 ? (
           <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">{t('empty')}</div>
         ) : (
-          <div className="overflow-x-auto p-6">
-            <table className="w-full">
-              <thead>
-                <tr className="border-b border-black/10 dark:border-gray-700 text-left">
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAsset')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colAmount')}</th>
-                  <th className="hidden sm:table-cell px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colTransaction')}</th>
-                  <th className="hidden sm:table-cell px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colInterest')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colExpiry')}</th>
-                  <th className="hidden sm:table-cell px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colGoal')}</th>
-                  <th className="hidden sm:table-cell px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colNotes')}</th>
-                  <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-center">{tc('actions')}</th>
-                </tr>
-              </thead>
-              <tbody className="divide-y divide-black/5 dark:divide-gray-700">
-                {transactions.map((tx) => {
-                  const currentValue = calcCurrentValue(tx)
-                  const rateOrNav = tx.asset_type === 'fund'
-                    ? (tx.unit_price != null ? fmtNav(tx.unit_price) : '—')
-                    : (tx.interest_rate != null ? `${tx.interest_rate}%` : '—')
-                  return (
-                    <tr key={tx.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
-                      <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{new Date(tx.investment_date).toLocaleDateString('vi-VN')}</td>
-                      <td className="px-4 py-3">
-                        <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold ${ASSET_COLORS[tx.asset_type as AssetType] ?? 'bg-gray-100 text-gray-700'}`}>
-                          {t(`asset${tx.asset_type.charAt(0).toUpperCase() + tx.asset_type.slice(1)}` as 'assetFund' | 'assetBank' | 'assetStock' | 'assetGold') ?? tx.asset_type}
-                        </span>
-                      </td>
-                      <td className="px-4 py-3 text-right font-medium text-gray-900 dark:text-gray-100">{fmt(tx.amount_vnd)}</td>
-                      <td className="hidden sm:table-cell px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">{tx.units ?? '—'}</td>
-                      <td className="hidden sm:table-cell px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">{rateOrNav}</td>
-                      <td className="px-4 py-3 text-right font-medium text-gray-900 dark:text-gray-100">{fmt(currentValue)}</td>
-                      <td className="hidden sm:table-cell px-4 py-3">
+          <>
+            {/* Mobile card layout */}
+            <div className="sm:hidden divide-y divide-black/5 dark:divide-gray-700 px-4 py-2">
+              {transactions.map((tx) => {
+                const currentValue = calcCurrentValue(tx)
+                const rateOrNav = tx.asset_type === 'fund'
+                  ? (tx.unit_price != null ? fmtNav(tx.unit_price) : '—')
+                  : (tx.interest_rate != null ? `${tx.interest_rate}%` : '—')
+                const rateOrNavLabel = tx.asset_type === 'fund' ? t('colTransaction') : t('colInterest')
+                return (
+                  <div key={tx.transaction_id} className="py-3 space-y-2">
+                    <div className="flex items-start justify-between gap-2">
+                      <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold ${ASSET_COLORS[tx.asset_type as AssetType] ?? 'bg-gray-100 text-gray-700'}`}>
+                        {t(`asset${tx.asset_type.charAt(0).toUpperCase() + tx.asset_type.slice(1)}` as 'assetFund' | 'assetBank' | 'assetStock' | 'assetGold') ?? tx.asset_type}
+                      </span>
+                      <span className="text-xs text-gray-500 dark:text-gray-400 shrink-0">{new Date(tx.investment_date).toLocaleDateString('vi-VN')}</span>
+                    </div>
+                    <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
+                      <div>
+                        <span className="text-gray-500 dark:text-gray-400">{t('colAmount')}: </span>
+                        <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(tx.amount_vnd)}</span>
+                      </div>
+                      <div>
+                        <span className="text-gray-500 dark:text-gray-400">{t('colExpiry')}: </span>
+                        <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(currentValue)}</span>
+                      </div>
+                      <div>
+                        <span className="text-gray-500 dark:text-gray-400">{t('colTransaction')}: </span>
+                        <span className="text-gray-700 dark:text-gray-300">{tx.units ?? '—'}</span>
+                      </div>
+                      <div>
+                        <span className="text-gray-500 dark:text-gray-400">{rateOrNavLabel}: </span>
+                        <span className="text-gray-700 dark:text-gray-300">{rateOrNav}</span>
+                      </div>
+                      <div className="col-span-2">
+                        <span className="text-gray-500 dark:text-gray-400">{t('colGoal')}: </span>
                         {tx.savings_goals?.goal_name
-                          ? <span className="inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900">{tx.savings_goals.goal_name}</span>
-                          : <span className="inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400">{t('noGoal')}</span>
+                          ? <span className="inline-block px-2 py-0.5 rounded-full text-xs font-semibold bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900">{tx.savings_goals.goal_name}</span>
+                          : <span className="text-gray-400 dark:text-gray-500">{t('noGoal')}</span>
                         }
-                      </td>
-                      <td className="hidden sm:table-cell px-4 py-3 text-sm text-gray-600 dark:text-gray-400 max-w-32 truncate">{tx.notes ?? '—'}</td>
-                      <td className="px-4 py-3 text-center">
-                        <div className="flex items-center justify-center gap-1">
-                          <button onClick={() => openEdit(tx)} className="h-8 w-8 p-0 flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
-                            <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
-                          </button>
-                          <button onClick={() => setConfirmTx(tx)} className="h-8 w-8 p-0 flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
-                            <Trash2 className="h-4 w-4 text-red-500 dark:text-red-400" />
-                          </button>
+                      </div>
+                      {tx.notes && (
+                        <div className="col-span-2">
+                          <span className="text-gray-500 dark:text-gray-400">{t('colNotes')}: </span>
+                          <span className="text-gray-700 dark:text-gray-300">{tx.notes}</span>
                         </div>
-                      </td>
-                    </tr>
-                  )
-                })}
-              </tbody>
-            </table>
-
+                      )}
+                    </div>
+                    <div className="flex items-center gap-1 pt-0.5">
+                      <button onClick={() => openEdit(tx)} className="h-8 w-8 p-0 flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                        <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                      </button>
+                      <button onClick={() => setConfirmTx(tx)} className="h-8 w-8 p-0 flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                        <Trash2 className="h-4 w-4 text-red-500 dark:text-red-400" />
+                      </button>
+                    </div>
+                  </div>
+                )
+              })}
+            </div>
+            {/* Desktop table layout */}
+            <div className="hidden sm:block overflow-x-auto p-6">
+              <table className="w-full">
+                <thead>
+                  <tr className="border-b border-black/10 dark:border-gray-700 text-left">
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAsset')}</th>
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colAmount')}</th>
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colTransaction')}</th>
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colInterest')}</th>
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colExpiry')}</th>
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colGoal')}</th>
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colNotes')}</th>
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-center">{tc('actions')}</th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-black/5 dark:divide-gray-700">
+                  {transactions.map((tx) => {
+                    const currentValue = calcCurrentValue(tx)
+                    const rateOrNav = tx.asset_type === 'fund'
+                      ? (tx.unit_price != null ? fmtNav(tx.unit_price) : '—')
+                      : (tx.interest_rate != null ? `${tx.interest_rate}%` : '—')
+                    return (
+                      <tr key={tx.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+                        <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{new Date(tx.investment_date).toLocaleDateString('vi-VN')}</td>
+                        <td className="px-4 py-3">
+                          <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold ${ASSET_COLORS[tx.asset_type as AssetType] ?? 'bg-gray-100 text-gray-700'}`}>
+                            {t(`asset${tx.asset_type.charAt(0).toUpperCase() + tx.asset_type.slice(1)}` as 'assetFund' | 'assetBank' | 'assetStock' | 'assetGold') ?? tx.asset_type}
+                          </span>
+                        </td>
+                        <td className="px-4 py-3 text-right font-medium text-gray-900 dark:text-gray-100">{fmt(tx.amount_vnd)}</td>
+                        <td className="px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">{tx.units ?? '—'}</td>
+                        <td className="px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">{rateOrNav}</td>
+                        <td className="px-4 py-3 text-right font-medium text-gray-900 dark:text-gray-100">{fmt(currentValue)}</td>
+                        <td className="px-4 py-3">
+                          {tx.savings_goals?.goal_name
+                            ? <span className="inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900">{tx.savings_goals.goal_name}</span>
+                            : <span className="inline-block px-2.5 py-0.5 rounded-full text-xs font-semibold bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-400">{t('noGoal')}</span>
+                          }
+                        </td>
+                        <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 max-w-32 truncate">{tx.notes ?? '—'}</td>
+                        <td className="px-4 py-3 text-center">
+                          <div className="flex items-center justify-center gap-1">
+                            <button onClick={() => openEdit(tx)} className="h-8 w-8 p-0 flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                              <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                            </button>
+                            <button onClick={() => setConfirmTx(tx)} className="h-8 w-8 p-0 flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                              <Trash2 className="h-4 w-4 text-red-500 dark:text-red-400" />
+                            </button>
+                          </div>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
             {/* Pagination */}
-            <div className="flex items-center justify-between mt-6 pt-4 border-t border-black/10 dark:border-gray-700">
+            <div className="flex items-center justify-between px-4 sm:px-6 mt-4 pt-4 border-t border-black/10 dark:border-gray-700">
               <p className="text-sm text-gray-600 dark:text-gray-400">{t('page')} {page} / {totalPages}</p>
               <div className="flex gap-2">
                 <button
@@ -473,7 +534,7 @@ export default function InvestmentTransactionsTab() {
                 </button>
               </div>
             </div>
-          </div>
+          </>
         )}
       </div>
 

--- a/app/(app)/settings/tabs/SavingsGoalsTab.tsx
+++ b/app/(app)/settings/tabs/SavingsGoalsTab.tsx
@@ -251,25 +251,25 @@ export default function SavingsGoalsTab({ initialGoalId, onGoalChange }: Props) 
       {/* Summary Card */}
       {goals.length > 0 && (
         <div className="p-6 rounded-xl border border-violet-200 dark:border-violet-800 bg-gradient-to-br from-violet-50 to-purple-50 dark:from-violet-900/20 dark:to-purple-900/20">
-          <div className="flex items-center justify-between">
-            <div>
+          <div className="flex items-center justify-between gap-4">
+            <div className="min-w-0">
               <h3 className="text-sm font-medium text-violet-900 dark:text-violet-300 mb-2">{t('totalAcrossGoals')}</h3>
-              <div className="flex items-baseline gap-6">
+              <div className="flex flex-wrap items-baseline gap-x-6 gap-y-1">
                 <div>
                   <p className="text-xs text-violet-700 dark:text-violet-400">{t('currentValue')}</p>
-                  <p className="text-3xl font-bold text-violet-900 dark:text-violet-200 whitespace-nowrap">
+                  <p className="text-xl sm:text-3xl font-bold text-violet-900 dark:text-violet-200 whitespace-nowrap">
                     {fmt(goals.reduce((sum, g) => sum + g.totalInvested + g.projectedInterest, 0))}
                   </p>
                 </div>
                 <div>
                   <p className="text-xs text-violet-700 dark:text-violet-400">{t('interest')}</p>
-                  <p className="text-xl font-semibold text-green-600 dark:text-green-400 whitespace-nowrap">
+                  <p className="text-base sm:text-xl font-semibold text-green-600 dark:text-green-400 whitespace-nowrap">
                     +{fmt(goals.reduce((sum, g) => sum + g.projectedInterest, 0))}
                   </p>
                 </div>
               </div>
             </div>
-            <div className="flex h-16 w-16 items-center justify-center rounded-full bg-violet-500 text-white shrink-0">
+            <div className="hidden sm:flex h-16 w-16 items-center justify-center rounded-full bg-violet-500 text-white shrink-0">
               <TrendingUp className="h-8 w-8" />
             </div>
           </div>

--- a/app/(app)/settings/tabs/SavingsGoalsTab.tsx
+++ b/app/(app)/settings/tabs/SavingsGoalsTab.tsx
@@ -257,13 +257,13 @@ export default function SavingsGoalsTab({ initialGoalId, onGoalChange }: Props) 
               <div className="flex items-baseline gap-6">
                 <div>
                   <p className="text-xs text-violet-700 dark:text-violet-400">{t('currentValue')}</p>
-                  <p className="text-3xl font-bold text-violet-900 dark:text-violet-200">
+                  <p className="text-3xl font-bold text-violet-900 dark:text-violet-200 whitespace-nowrap">
                     {fmt(goals.reduce((sum, g) => sum + g.totalInvested + g.projectedInterest, 0))}
                   </p>
                 </div>
                 <div>
                   <p className="text-xs text-violet-700 dark:text-violet-400">{t('interest')}</p>
-                  <p className="text-xl font-semibold text-green-600 dark:text-green-400">
+                  <p className="text-xl font-semibold text-green-600 dark:text-green-400 whitespace-nowrap">
                     +{fmt(goals.reduce((sum, g) => sum + g.projectedInterest, 0))}
                   </p>
                 </div>

--- a/app/(app)/settings/tabs/SavingsGoalsTab.tsx
+++ b/app/(app)/settings/tabs/SavingsGoalsTab.tsx
@@ -162,14 +162,14 @@ export default function SavingsGoalsTab({ initialGoalId, onGoalChange }: Props) 
         <div className="mb-4 p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 text-green-800 dark:text-green-300 rounded-lg text-sm">{successMsg}</div>
       )}
 
-      <div className="flex items-start justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3">
         <div>
           <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('title')}</h2>
           <p className="text-sm text-gray-500 dark:text-gray-400 mt-1">{t('desc')}</p>
         </div>
-        <button onClick={openCreate} className="flex items-center gap-2 h-9 px-4 py-2 bg-gray-950 hover:bg-gray-800 text-white text-sm font-bold rounded-md transition-colors">
-          <Plus className="h-4 w-4" />
-          {t('create')}
+        <button onClick={openCreate} className="flex items-center gap-2 h-9 px-3 sm:px-4 py-2 bg-gray-950 hover:bg-gray-800 text-white text-sm font-bold rounded-md transition-colors shrink-0 self-start sm:self-auto">
+          <Plus className="h-4 w-4 shrink-0" />
+          <span className="hidden sm:inline">{t('create')}</span>
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- Tab bar changed to 2-column grid on mobile, 4-column on `sm+`, with `text-xs` on mobile and `text-sm` on wider screens — prevents overflow with long tab labels like "Investment Transactions"
- InsuranceMembersTab header now stacks vertically on mobile so the total text and Add button don't fight for space
- InsuranceMembersTab table hides Relationship, Annual Payment, and Payment Date columns on mobile — keeps Name, Monthly, and Actions visible

## Test plan
- [ ] Open Settings on a 375px viewport — tab bar should show 2×2 grid, all tabs readable
- [ ] Switch to sm+ viewport — tab bar should show 4 columns in a single row
- [ ] Open Insurance tab on mobile — header title and total should stack above the Add button
- [ ] Insurance table on mobile should show Name, Monthly, Actions only

🤖 Generated with [Claude Code](https://claude.com/claude-code)