### PR TITLE
fix(goals): rename fund table header from Remaining to Units

### DIFF
--- a/app/(app)/settings/tabs/GoalDetailView.tsx
+++ b/app/(app)/settings/tabs/GoalDetailView.tsx
@@ -548,7 +548,7 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
                   <thead>
                     <tr className="border-b border-black/10 dark:border-gray-700 text-left">
                       <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colFund')}</th>
-                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colRemaining')}</th>
+                      <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colUnits')}</th>
                       <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colAvgNav')}</th>
                       <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colCurrentNav')}</th>
                       <th className="px-4 pt-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colValue')}</th>


### PR DESCRIPTION
## Summary
- Fund investments table in Goal Detail view: column header "Remaining" → "Units" (uses existing `colUnits` translation key)
- Bank/gold/stock table header left as "Remaining" since it refers to remaining principal/chi, not a unit count

🤖 Generated with [Claude Code](https://claude.com/claude-code)