### PR TITLE
feat(chat): AI portfolio chatbox with multi-provider support

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,6 +1,9 @@
 import { redirect } from 'next/navigation'
+import dynamic from 'next/dynamic'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import AuthenticatedLayout from '@/app/components/layouts/AuthenticatedLayout'
+
+const ChatWidget = dynamic(() => import('@/components/ChatWidget'), { ssr: false })
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createSupabaseServerClient()
@@ -10,6 +13,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   return (
     <AuthenticatedLayout email={user.email ?? ''}>
       {children}
+      <ChatWidget />
     </AuthenticatedLayout>
   )
 }

--- a/app/api/v1/chat/route.ts
+++ b/app/api/v1/chat/route.ts
@@ -1,0 +1,225 @@
+import { streamText } from 'ai'
+import { NextRequest } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { CHAT_PROVIDERS, DEFAULT_PROVIDER } from '@/lib/chat-providers'
+
+export const maxDuration = 30
+
+const ALLOWED_MODELS = new Set(CHAT_PROVIDERS.map((p) => p.model))
+const DEFAULT_MODEL = CHAT_PROVIDERS.find((p) => p.id === DEFAULT_PROVIDER)!.model
+
+function fmt(n: number) {
+  return '₫ ' + Math.round(n).toLocaleString('vi-VN')
+}
+
+function calcProjectedInterest(amount: number, rate: number | null, investmentDate: string, expiryDate?: string | null): number {
+  if (!rate) return 0
+  const endMs = expiryDate ? Math.min(Date.now(), new Date(expiryDate).getTime()) : Date.now()
+  const days = Math.max(0, (endMs - new Date(investmentDate).getTime()) / 86400000)
+  return amount * Math.pow(1 + rate / 100, days / 365) - amount
+}
+
+function buildContext(
+  goals: Array<{ goal_id: string; goal_name: string; target_amount: number | null }> | null,
+  txs: Array<{
+    transaction_id: string; goal_id: string | null; asset_type: string | null
+    transaction_type: string | null; amount_vnd: number; units: number | null
+    unit_price: number | null; interest_rate: number | null; expiry_date: string | null
+    investment_date: string; units_withdrawn: number | null; principal_withdrawn: number | null
+    fund_id: string | null; notes: string | null
+    funds: { id: string; name: string; nav: number } | { id: string; name: string; nav: number }[] | null
+  }> | null,
+  goldPricePerChi: number | null
+): string {
+  if (!txs || !goals) return 'No financial data available.'
+
+  const investments = txs.filter((tx) => tx.transaction_type !== 'withdrawal' && !(tx.asset_type === 'fund' && tx.units == null))
+  const withdrawals = txs.filter((tx) => tx.transaction_type === 'withdrawal')
+
+  // Build withdrawal maps
+  const parentWdMap = new Map<string, { principal: number; units: number }>()
+  const fundWdMap = new Map<string, { units: number; cost: number }>()
+  for (const wd of withdrawals) {
+    if (wd.asset_type === 'fund' && wd.fund_id) {
+      const key = `${wd.goal_id ?? 'unallocated'}::${wd.fund_id}`
+      const e = fundWdMap.get(key) ?? { units: 0, cost: 0 }
+      e.units += wd.units_withdrawn ?? 0
+      e.cost += wd.principal_withdrawn ?? 0
+      fundWdMap.set(key, e)
+    } else if (wd.transaction_id) {
+      const parentId = (wd as { parent_transaction_id?: string }).parent_transaction_id
+      if (parentId) {
+        const e = parentWdMap.get(parentId) ?? { principal: 0, units: 0 }
+        e.principal += wd.principal_withdrawn ?? 0
+        e.units += wd.units_withdrawn ?? 0
+        parentWdMap.set(parentId, e)
+      }
+    }
+  }
+
+  // Aggregate funds by goal+fund_id
+  type FundAccum = { name: string; totalUnits: number; totalInvested: number; totalNavCost: number; nav: number; goalId: string | null }
+  const fundMap = new Map<string, FundAccum>()
+
+  let totalAssets = 0
+  let totalInvested = 0
+
+  // Non-fund assets
+  const goalNonFund = new Map<string, number>()
+  const goalNonFundInvested = new Map<string, number>()
+  const unallocatedNonFunds: string[] = []
+
+  for (const tx of investments) {
+    if (tx.asset_type === 'fund' && tx.units) {
+      const fund = Array.isArray(tx.funds) ? tx.funds[0] : tx.funds
+      if (!fund) continue
+      const key = `${tx.goal_id ?? 'unallocated'}::${fund.id}`
+      const e = fundMap.get(key)
+      if (e) {
+        e.totalUnits += tx.units
+        e.totalInvested += tx.amount_vnd
+        e.totalNavCost += tx.units * (tx.unit_price ?? 0)
+      } else {
+        fundMap.set(key, { name: fund.name, totalUnits: tx.units, totalInvested: tx.amount_vnd, totalNavCost: tx.units * (tx.unit_price ?? 0), nav: fund.nav, goalId: tx.goal_id ?? null })
+      }
+    } else {
+      const wd = parentWdMap.get(tx.transaction_id)
+      const withdrawnPrincipal = wd?.principal ?? 0
+      const withdrawnUnits = wd?.units ?? 0
+
+      let currentValue: number
+      let effectiveAmount: number
+      let effectiveUnits = tx.units ?? null
+
+      if (tx.asset_type === 'gold' && goldPricePerChi && tx.units) {
+        effectiveUnits = tx.units - withdrawnUnits
+        if (effectiveUnits <= 0) continue
+        currentValue = effectiveUnits * goldPricePerChi
+        effectiveAmount = tx.amount_vnd - withdrawnPrincipal
+      } else {
+        effectiveAmount = tx.amount_vnd - withdrawnPrincipal
+        if (effectiveAmount <= 0) continue
+        const interest = calcProjectedInterest(effectiveAmount, tx.interest_rate, tx.investment_date, tx.expiry_date)
+        currentValue = effectiveAmount + interest
+      }
+
+      totalAssets += currentValue
+      totalInvested += effectiveAmount
+
+      if (tx.goal_id) {
+        goalNonFund.set(tx.goal_id, (goalNonFund.get(tx.goal_id) ?? 0) + currentValue)
+        goalNonFundInvested.set(tx.goal_id, (goalNonFundInvested.get(tx.goal_id) ?? 0) + effectiveAmount)
+      } else {
+        if (tx.asset_type === 'gold') {
+          unallocatedNonFunds.push(`  - Gold: ${effectiveUnits?.toFixed(2)} chi @ ${fmt(goldPricePerChi!)} = ${fmt(currentValue)}`)
+        } else if (tx.asset_type === 'bank') {
+          const label = tx.notes ? `"${tx.notes}"` : new Date(tx.investment_date).toLocaleDateString('vi-VN')
+          const rateStr = tx.interest_rate ? ` ${tx.interest_rate}%/yr` : ''
+          const expiryStr = tx.expiry_date ? ` expires ${tx.expiry_date}` : ''
+          unallocatedNonFunds.push(`  - Bank deposit ${label}${rateStr}${expiryStr}: ${fmt(effectiveAmount)} principal, current value ${fmt(currentValue)}`)
+        } else {
+          unallocatedNonFunds.push(`  - ${tx.asset_type}: ${fmt(currentValue)}`)
+        }
+      }
+    }
+  }
+
+  // Apply fund withdrawals
+  for (const [key, wd] of fundWdMap) {
+    const acc = fundMap.get(key)
+    if (!acc || wd.units <= 0) continue
+    const before = acc.totalUnits
+    acc.totalNavCost -= before > 0 ? (wd.units / before) * acc.totalNavCost : 0
+    acc.totalUnits -= wd.units
+    acc.totalInvested -= wd.cost
+  }
+
+  // Build goal summaries
+  const goalMap = new Map(goals.map((g) => [g.goal_id, { name: g.goal_name, target: g.target_amount, fundValue: 0, fundInvested: 0, fundLines: [] as string[] }]))
+
+  for (const [key, acc] of fundMap) {
+    if (acc.totalUnits <= 0) continue
+    const currentValue = acc.nav * acc.totalUnits
+    totalAssets += currentValue
+    totalInvested += acc.totalInvested
+
+    if (acc.goalId && goalMap.has(acc.goalId)) {
+      const g = goalMap.get(acc.goalId)!
+      g.fundValue += currentValue
+      g.fundInvested += acc.totalInvested
+      g.fundLines.push(`    - ${acc.name}: ${acc.totalUnits.toFixed(2)} CCQ @ NAV ${fmt(acc.nav)} = ${fmt(currentValue)}`)
+    } else {
+      unallocatedNonFunds.unshift(`  - Fund ${acc.name}: ${acc.totalUnits.toFixed(2)} CCQ @ NAV ${fmt(acc.nav)} = ${fmt(currentValue)}`)
+    }
+  }
+
+  const pl = totalAssets - totalInvested
+  const plPct = totalInvested > 0 ? (pl / totalInvested) * 100 : 0
+
+  const lines: string[] = [
+    'NET WORTH',
+    `  Total Assets: ${fmt(totalAssets)}`,
+    `  Total Invested: ${fmt(totalInvested)}`,
+    `  Overall P&L: ${pl >= 0 ? '+' : ''}${fmt(pl)} (${plPct >= 0 ? '+' : ''}${plPct.toFixed(2)}%)`,
+    '',
+    'SAVINGS GOALS',
+  ]
+
+  for (const [goalId, g] of goalMap) {
+    const totalValue = g.fundValue + (goalNonFund.get(goalId) ?? 0)
+    const targetStr = g.target ? ` / Target: ${fmt(g.target)} (${Math.round(totalValue / g.target * 100)}%)` : ''
+    lines.push(`  [${g.name}] Current: ${fmt(totalValue)}${targetStr}`)
+    for (const fl of g.fundLines) lines.push(fl)
+  }
+
+  lines.push('', 'UNALLOCATED ASSETS')
+  if (unallocatedNonFunds.length > 0) {
+    lines.push(...unallocatedNonFunds)
+  } else {
+    lines.push('  (none)')
+  }
+
+  return lines.join('\n')
+}
+
+export async function POST(req: NextRequest) {
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return new Response('Unauthorized', { status: 401 })
+
+  const body = await req.json()
+  const { messages, model: requestedModel } = body
+
+  const model = ALLOWED_MODELS.has(requestedModel) ? requestedModel : DEFAULT_MODEL
+
+  const [goalsRes, txRes, goldRes] = await Promise.all([
+    supabase.from('savings_goals').select('goal_id, goal_name, target_amount').eq('user_id', user.id),
+    supabase
+      .from('investment_transactions')
+      .select('transaction_id, goal_id, asset_type, transaction_type, amount_vnd, units, unit_price, interest_rate, expiry_date, investment_date, units_withdrawn, principal_withdrawn, fund_id, parent_transaction_id, notes, funds(id, name, nav)')
+      .eq('user_id', user.id),
+    supabase.from('gold_price_settings').select('price_per_chi').eq('user_id', user.id).single(),
+  ])
+
+  const financialContext = buildContext(goalsRes.data, txRes.data as never, goldRes.data?.price_per_chi ?? null)
+
+  const result = streamText({
+    model,
+    system: `You are a personal finance assistant for this user's investment portfolio app (Allocate).
+Today: ${new Date().toLocaleDateString('vi-VN')}
+
+Here is the user's current portfolio data:
+${financialContext}
+
+Rules:
+- Respond in the same language the user writes in (Vietnamese or English)
+- Format Vietnamese dong as ₫ X,XXX,XXX
+- Be concise and helpful; do not make up data not provided above
+- CCQ = Chứng chỉ Quỹ = fund certificate units`,
+    messages,
+    maxOutputTokens: 1024,
+    providerOptions: { gateway: { tags: ['feature:chat'] } },
+  })
+
+  return result.toUIMessageStreamResponse()
+}

--- a/components/ChatWidget.tsx
+++ b/components/ChatWidget.tsx
@@ -1,0 +1,167 @@
+'use client'
+
+import { useRef, useEffect, useState, type FormEvent } from 'react'
+import { useChat } from '@ai-sdk/react'
+import { DefaultChatTransport } from 'ai'
+import { MessageCircle, X, ArrowUp } from 'lucide-react'
+import { useLocale } from 'next-intl'
+import { CHAT_PROVIDERS, DEFAULT_PROVIDER, type ProviderId } from '@/lib/chat-providers'
+
+const UI_TEXT = {
+  vi: { title: 'Trợ lý danh mục', placeholder: 'Hỏi về danh mục của bạn...', error: 'Đã xảy ra lỗi. Thử lại nhé.' },
+  en: { title: 'Portfolio Assistant', placeholder: 'Ask about your portfolio...', error: 'Something went wrong. Please try again.' },
+} as const
+
+// ChatInner is keyed by model so useChat resets when provider switches
+function ChatInner({ model, locale }: { model: string; locale: string }) {
+  const ui = UI_TEXT[locale as keyof typeof UI_TEXT] ?? UI_TEXT.en
+  const bottomRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [inputValue, setInputValue] = useState('')
+
+  const { messages, sendMessage, status, error, setMessages } = useChat({
+    transport: new DefaultChatTransport({ api: '/api/v1/chat', body: { model } }),
+  })
+
+  const isLoading = status === 'submitted' || status === 'streaming'
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages, status])
+
+  function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    const text = inputValue.trim()
+    if (!text || isLoading) return
+    setInputValue('')
+    sendMessage({ text })
+  }
+
+  return (
+    <>
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3">
+        {messages.length === 0 && (
+          <p className="text-xs text-gray-400 dark:text-gray-500 text-center mt-6">{ui.placeholder}</p>
+        )}
+        {messages.map((msg) => {
+          const text = msg.parts.filter((p) => p.type === 'text').map((p) => (p as { type: 'text'; text: string }).text).join('')
+          if (!text && msg.role !== 'user') return null
+          const isUser = msg.role === 'user'
+          return (
+            <div key={msg.id} className={`flex ${isUser ? 'justify-end' : 'justify-start'}`}>
+              <div
+                className={`max-w-[85%] rounded-2xl px-3 py-2 text-sm whitespace-pre-wrap break-words leading-relaxed ${
+                  isUser
+                    ? 'bg-violet-600 text-white rounded-br-sm'
+                    : 'bg-gray-100 dark:bg-gray-800 text-gray-900 dark:text-gray-100 rounded-bl-sm'
+                }`}
+              >
+                {text}
+              </div>
+            </div>
+          )
+        })}
+        {isLoading && messages[messages.length - 1]?.role === 'user' && (
+          <div className="flex justify-start">
+            <div className="bg-gray-100 dark:bg-gray-800 rounded-2xl rounded-bl-sm px-3 py-2">
+              <span className="flex gap-1 items-center h-4">
+                {[0, 1, 2].map((i) => (
+                  <span
+                    key={i}
+                    className="w-1.5 h-1.5 bg-gray-400 dark:bg-gray-500 rounded-full animate-bounce"
+                    style={{ animationDelay: `${i * 150}ms` }}
+                  />
+                ))}
+              </span>
+            </div>
+          </div>
+        )}
+        {error && (
+          <p className="text-xs text-red-500 text-center">{ui.error}</p>
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input */}
+      <form onSubmit={handleSubmit} className="p-3 border-t border-gray-100 dark:border-gray-700 flex gap-2 items-center">
+        <input
+          ref={inputRef}
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          placeholder={ui.placeholder}
+          disabled={isLoading}
+          className="flex-1 text-sm px-3 py-2 rounded-xl border border-gray-200 dark:border-gray-600 bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500 outline-none focus:border-violet-400 dark:focus:border-violet-500 disabled:opacity-50 transition-colors"
+        />
+        <button
+          type="submit"
+          disabled={!inputValue.trim() || isLoading}
+          className="w-8 h-8 flex items-center justify-center rounded-xl bg-violet-600 hover:bg-violet-700 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors shrink-0"
+        >
+          <ArrowUp className="h-4 w-4" />
+        </button>
+      </form>
+    </>
+  )
+}
+
+export default function ChatWidget() {
+  const locale = useLocale()
+  const ui = UI_TEXT[locale as keyof typeof UI_TEXT] ?? UI_TEXT.en
+  const [isOpen, setIsOpen] = useState(false)
+  const [providerId, setProviderId] = useState<ProviderId>(DEFAULT_PROVIDER)
+
+  const selectedModel = CHAT_PROVIDERS.find((p) => p.id === providerId)!.model
+
+  return (
+    <div className="fixed bottom-5 right-5 z-50 flex flex-col items-end gap-3">
+      {/* Chat panel */}
+      {isOpen && (
+        <div className="w-[min(380px,calc(100vw-2.5rem))] bg-white dark:bg-gray-900 rounded-2xl shadow-2xl border border-gray-200 dark:border-gray-700 flex flex-col overflow-hidden"
+          style={{ height: 'min(520px, calc(100dvh - 100px))' }}
+        >
+          {/* Header */}
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-gray-700 bg-gradient-to-r from-violet-600 to-indigo-600">
+            <div className="flex items-center gap-2">
+              <MessageCircle className="h-4 w-4 text-white" />
+              <span className="text-sm font-semibold text-white">{ui.title}</span>
+            </div>
+            <button onClick={() => setIsOpen(false)} className="text-white/70 hover:text-white transition-colors">
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+
+          {/* Provider selector */}
+          <div className="flex gap-1 px-3 py-2 border-b border-gray-100 dark:border-gray-700 flex-wrap">
+            {CHAT_PROVIDERS.map((p) => (
+              <button
+                key={p.id}
+                onClick={() => setProviderId(p.id)}
+                className={`text-xs px-2.5 py-1 rounded-full font-medium transition-colors ${
+                  providerId === p.id
+                    ? 'bg-violet-100 dark:bg-violet-900/40 text-violet-700 dark:text-violet-300'
+                    : 'text-gray-500 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800'
+                }`}
+              >
+                {p.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Chat content — keyed by model to reset conversation on switch */}
+          <ChatInner key={selectedModel} model={selectedModel} locale={locale} />
+        </div>
+      )}
+
+      {/* Toggle button */}
+      <button
+        onClick={() => setIsOpen((o) => !o)}
+        className="w-12 h-12 rounded-full bg-violet-600 hover:bg-violet-700 text-white shadow-lg hover:shadow-xl transition-all flex items-center justify-center"
+        aria-label={ui.title}
+      >
+        {isOpen ? <X className="h-5 w-5" /> : <MessageCircle className="h-5 w-5" />}
+      </button>
+    </div>
+  )
+}

--- a/lib/chat-providers.ts
+++ b/lib/chat-providers.ts
@@ -1,0 +1,10 @@
+export const CHAT_PROVIDERS = [
+  { id: 'anthropic', label: 'Claude',    model: 'anthropic/claude-haiku-4.5' },
+  { id: 'openai',    label: 'GPT',       model: 'openai/gpt-5.4'             },
+  { id: 'google',    label: 'Gemini',    model: 'google/gemini-2.5-flash'    },
+  { id: 'xai',       label: 'Grok',      model: 'xai/grok-3-mini'            },
+  { id: 'deepseek',  label: 'DeepSeek',  model: 'deepseek/deepseek-v3.2'    },
+] as const
+
+export type ProviderId = typeof CHAT_PROVIDERS[number]['id']
+export const DEFAULT_PROVIDER: ProviderId = 'anthropic'

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,11 @@
       "name": "allocate",
       "version": "0.1.0",
       "dependencies": {
+        "@ai-sdk/react": "^3.0.155",
         "@base-ui/react": "^1.3.0",
         "@supabase/ssr": "^0.9.0",
         "@supabase/supabase-js": "^2.99.2",
+        "ai": "^6.0.153",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
@@ -34,6 +36,70 @@
         "prettier": "^3.8.1",
         "tailwindcss": "^4",
         "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "3.0.93",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.93.tgz",
+      "integrity": "sha512-8D6C9eEvDq6IgrdlWzpbniahDkoLiieTCrpzH8p/Hw63/0iPnZJ1uZcqxHrDIVDW/+aaGhBXqmx5C7HSd2eMmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.8.tgz",
+      "integrity": "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.23.tgz",
+      "integrity": "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@standard-schema/spec": "^1.1.0",
+        "eventsource-parser": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/react": {
+      "version": "3.0.155",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/react/-/react-3.0.155.tgz",
+      "integrity": "sha512-cvDfJrfvpdTxacK8EHpeficVpxxmZV7mBVqP4oWAFU2QWSNdurmrtnd30OCCyynv11tfCFNfxsnyFtr60rJAQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider-utils": "4.0.23",
+        "ai": "6.0.153",
+        "swr": "^2.2.5",
+        "throttleit": "2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1980,6 +2046,15 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@parcel/watcher": {
       "version": "2.5.6",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
@@ -3741,6 +3816,15 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.1.0.tgz",
+      "integrity": "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3784,6 +3868,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/ai": {
+      "version": "6.0.153",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.153.tgz",
+      "integrity": "sha512-UlgBe4k0Ja1m1Eufn6FVSsHoF0sc7qwxX35ywJPDogIvBz0pHc+NOmCqiRY904DczNYIuwpZfKBLVz8HXgu3mg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "3.0.93",
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.23",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -4955,6 +5057,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -7361,6 +7472,12 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -10065,6 +10182,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swr": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.4.1.tgz",
+      "integrity": "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.3",
+        "use-sync-external-store": "^1.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -10112,6 +10242,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tiny-invariant": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@ai-sdk/react": "^3.0.155",
     "@base-ui/react": "^1.3.0",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.99.2",
+    "ai": "^6.0.153",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",


### PR DESCRIPTION
## Summary

- Adds a floating chat widget (bottom-right) on all authenticated pages
- Users can ask natural-language questions about their portfolio in Vietnamese or English
- Supports 5 AI providers: Claude (Anthropic), GPT (OpenAI), Gemini (Google), Grok (xAI), DeepSeek — switch via pill buttons in the widget header
- Routes all LLM calls through Vercel AI Gateway (OIDC auth, no per-provider API keys needed)
- Financial context is built server-side: net worth, P&L, goal progress, fund units (CCQ), gold holdings, bank deposits — all withdrawal-aware

## Files

| File | Description |
|------|-------------|
| lib/chat-providers.ts | Provider/model config |
| app/api/v1/chat/route.ts | Streaming chat endpoint with financial context |
| components/ChatWidget.tsx | Floating widget with provider selector |
| app/(app)/layout.tsx | Added ChatWidget to all authenticated pages |

## Setup required before testing

1. Enable AI Gateway in Vercel Dashboard -> Project Settings -> AI Gateway
2. Run `vercel env pull .env.local` to provision VERCEL_OIDC_TOKEN for local dev
3. The widget appears as a purple circle button in the bottom-right corner

## Test plan

- [ ] Open the app — purple chat button appears bottom-right on all pages
- [ ] Ask "Total net worth?" -> correct amount
- [ ] Ask in Vietnamese -> Vietnamese response
- [ ] Switch provider pill -> conversation resets, new provider answers
- [ ] Ask about a goal -> shows current value and % of target

Generated with Claude Code