### PR TITLE
fix(landing): prevent header button overflow on mobile

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -34,18 +34,18 @@ export default async function HomePage() {
               </div>
               <span className="text-xl font-bold text-gray-900 dark:text-gray-100">Allocate</span>
             </div>
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-2 sm:gap-3">
               <LanguageSwitcher />
               <ThemeToggleButton />
               <Link
                 href="/auth/login"
-                className="inline-flex items-center h-10 px-4 text-sm font-medium text-gray-900 dark:text-gray-100 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                className="hidden sm:inline-flex items-center h-10 px-4 text-sm font-medium text-gray-900 dark:text-gray-100 rounded-md hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors whitespace-nowrap"
               >
                 {t('loginLink')}
               </Link>
               <Link
                 href="/auth/signup"
-                className="inline-flex items-center h-10 px-4 text-sm font-medium bg-violet-600 text-white rounded-md hover:bg-violet-700 transition-colors"
+                className="inline-flex items-center h-10 px-3 sm:px-4 text-sm font-medium bg-violet-600 text-white rounded-md hover:bg-violet-700 transition-colors whitespace-nowrap"
               >
                 {t('signupLink')}
               </Link>


### PR DESCRIPTION
## Summary

On iPhone 15 (393px wide), the header tried to fit LanguageSwitcher + ThemeToggle + Login + Signup in one row. Vietnamese button text ("Đăng nhập", "Đăng ký") is longer than English equivalents, causing overflow/clipping.

**Changes:**
- Hide the Login link on mobile (`hidden sm:inline-flex`) — the hero section already has both buttons
- Reduce signup button horizontal padding on mobile (`px-3`, `sm:px-4`)
- Add `whitespace-nowrap` to prevent text wrapping inside buttons
- Tighten gap from `gap-3` to `gap-2` on mobile

## Test plan

- [ ] iPhone 15 / 390px viewport — header fits without overflow in both EN and VI
- [ ] Desktop — Login link reappears, layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)