### PR TITLE
fix(ui): prevent iOS Safari auto-zoom on input focus

### DIFF
--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -7,7 +7,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-10 w-full min-w-0 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 outline-none transition-colors placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:border-violet-500 focus:ring-2 focus:ring-violet-500/20 disabled:cursor-not-allowed disabled:opacity-50",
+        "h-10 w-full min-w-0 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-base text-gray-900 dark:text-gray-100 outline-none transition-colors placeholder:text-gray-400 dark:placeholder:text-gray-500 focus:border-violet-500 focus:ring-2 focus:ring-violet-500/20 disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

iOS Safari automatically zooms in when a focused `<input>` has `font-size` below 16px, and crucially **does not zoom back out** on blur. The shared `Input` component used `text-sm` (14px), triggering this on every form in the app.

**Fix:** change `text-sm` → `text-base` (16px) in `components/ui/input.tsx`. One change covers sign in, sign up, and all other forms.

## Test plan

- [ ] iPhone — tap email field on sign in → no zoom
- [ ] iPhone — tap email field on sign up → no zoom  
- [ ] Desktop — input text size looks correct (16px is standard body size, visually unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)