### PR TITLE
feat(brand): use Cairn icon in sidebar and mobile nav

### DIFF
--- a/app/components/navigation/Header.tsx
+++ b/app/components/navigation/Header.tsx
@@ -36,9 +36,17 @@ export default function Header({ onMobileMenuToggle }: HeaderProps) {
       </button>
 
       {/* Mobile center logo */}
-      <span className="lg:hidden flex-1 text-center text-brand font-bold text-lg tracking-tight">
-        Cairn
-      </span>
+      <div className="lg:hidden flex-1 flex items-center justify-center gap-2">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src="/cairn-icon.svg"
+          alt="Cairn logo"
+          width={28}
+          height={28}
+          className="h-7 w-7 rounded-md"
+        />
+        <span className="text-brand font-bold text-lg tracking-tight">Cairn</span>
+      </div>
 
       {/* Breadcrumb (desktop/tablet only) */}
       <div className="hidden md:block flex-1">

--- a/app/components/navigation/MobileDrawer.tsx
+++ b/app/components/navigation/MobileDrawer.tsx
@@ -66,7 +66,17 @@ export default function MobileDrawer({ open, onClose, email, initials }: MobileD
         aria-label="Navigation menu"
       >
         <div className="flex items-center justify-between px-4 h-14 border-b border-gray-100 dark:border-gray-700">
-          <span className="text-brand font-bold text-xl tracking-tight">Cairn</span>
+          <div className="flex items-center gap-2">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src="/cairn-icon.svg"
+              alt="Cairn logo"
+              width={28}
+              height={28}
+              className="h-7 w-7 rounded-md"
+            />
+            <span className="text-brand font-bold text-xl tracking-tight">Cairn</span>
+          </div>
           <button
             onClick={onClose}
             aria-label="Close navigation menu"

--- a/app/components/navigation/Sidebar.tsx
+++ b/app/components/navigation/Sidebar.tsx
@@ -34,10 +34,16 @@ export default function Sidebar({ email, initials, onNavClick, hideLogo = false 
     >
       {/* Logo */}
       {!hideLogo && (
-        <div className={`flex items-center h-16 px-6 border-b border-gray-100 dark:border-gray-700 ${sidebarCollapsed ? 'justify-center px-0' : ''}`}>
-          {sidebarCollapsed ? (
-            <span className="text-brand font-semibold text-lg">C</span>
-          ) : (
+        <div className={`flex items-center gap-2 h-16 px-6 border-b border-gray-100 dark:border-gray-700 ${sidebarCollapsed ? 'justify-center px-0' : ''}`}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src="/cairn-icon.svg"
+            alt="Cairn logo"
+            width={32}
+            height={32}
+            className="h-8 w-8 rounded-lg shrink-0"
+          />
+          {!sidebarCollapsed && (
             <span className="text-brand font-semibold text-xl">Cairn</span>
           )}
         </div>


### PR DESCRIPTION
## Summary

Wire the Cairn icon into the in-app navigation. Landing, auth, offline, and favicon already show the mark — only the sidebar, mobile header, and mobile drawer were still rendering text-only wordmarks ("Cairn", plus a bare "C" in the collapsed sidebar). This closes that gap so the brand reads consistently once signed in.

### Changes

- **Sidebar** — icon + "Cairn" wordmark when expanded; icon only when collapsed (the placeholder "C" letter is gone)
- **Mobile Header** — icon + wordmark lockup in the center position (was text-only)
- **MobileDrawer** — icon + wordmark at the top of the drawer (was text-only)

No new assets or script changes — the icon is served from the existing `/cairn-icon.svg`. Sized at 28–32px so it sits at the same visual weight as the adjacent wordmark text.

### Test plan

- [ ] **Desktop sidebar**: expanded shows the stones icon next to "Cairn"; collapsed shows just the icon (no letter)
- [ ] **Mobile header**: center shows icon + "Cairn" side by side instead of text only
- [ ] **Mobile drawer**: top of the drawer shows icon + "Cairn"; close (X) button stays on the right
- [ ] **Dark mode**: icon tile retains its navy background; wordmark switches to cream via `text-brand`
- [ ] **Keyboard nav** in the drawer: focus trap still works (icon image isn't focusable, so nothing regressed)
