### PR TITLE
fix: bust dashboard cache on goal create/delete

### DIFF
--- a/app/(app)/settings/tabs/SavingsGoalsTab.tsx
+++ b/app/(app)/settings/tabs/SavingsGoalsTab.tsx
@@ -46,6 +46,7 @@ function setGoalsCache(data: GoalWithStats[]) {
 }
 function bustGoalsCache() {
   try { localStorage.removeItem(GOALS_CACHE_KEY) } catch {}
+  try { localStorage.removeItem('dashboardOverviewCache') } catch {}
 }
 
 export default function SavingsGoalsTab({ initialGoalId, onGoalChange }: Props) {


### PR DESCRIPTION
## Summary

- `SavingsGoalsTab.bustGoalsCache()` only cleared `savingsGoalsCache` (the settings page's own cache)
- The dashboard (`DashboardClient`) has a separate `dashboardOverviewCache` with a 2-minute TTL that was never invalidated
- Result: creating or deleting a goal in Settings → Asset Overview still shows stale data until the cache expires naturally

## Fix

One line added to `bustGoalsCache()` to also remove `dashboardOverviewCache`, so the dashboard fetches fresh data the next time the user visits it.

## Test plan

- [ ] Create a new goal in Settings → Savings Goals → navigate to Asset Overview — new goal appears immediately
- [ ] Delete a goal in Settings → navigate to Asset Overview — goal is gone immediately
- [ ] No regression on dashboard load performance (cache still works for subsequent visits within 2 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)