### PR TITLE
fix(sw): bump cache version to bust stale favicon

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v3'
+const CACHE_VERSION = 'v4'
 const API_CACHE = `api-v1-${CACHE_VERSION}`
 const STATIC_CACHE = `static-assets-${CACHE_VERSION}`
 const PAGE_CACHE = `pages-${CACHE_VERSION}`


### PR DESCRIPTION
## Summary
- Bumps `CACHE_VERSION` from `v3` → `v4` in `public/sw.js`
- The service worker uses `cacheFirst` for all image requests (including `/favicon.ico`), so the old favicon was served from cache even after the file was updated on the server
- Bumping the version triggers the SW activate handler to delete all old caches, forcing fresh fetches

## Test plan
- [ ] Deploy and hard-refresh once — SW activates, old caches deleted
- [ ] Subsequent refreshes should consistently show the new Cairn favicon

🤖 Generated with [Claude Code](https://claude.com/claude-code)