### PR TITLE
fix(favicon): bust browser favicon cache

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -31,10 +31,10 @@ export const metadata: Metadata = {
   appleWebApp: { capable: true, statusBarStyle: 'default', title: 'Cairn' },
   icons: {
     icon: [
-      { url: '/favicon-32.png', sizes: '32x32', type: 'image/png' },
-      { url: '/icon-192.png',   sizes: '192x192', type: 'image/png' },
+      { url: '/favicon-32.png?v=2', sizes: '32x32', type: 'image/png' },
+      { url: '/icon-192.png?v=2',   sizes: '192x192', type: 'image/png' },
     ],
-    apple: [{ url: '/apple-touch-icon.png', sizes: '180x180', type: 'image/png' }],
+    apple: [{ url: '/apple-touch-icon.png?v=2', sizes: '180x180', type: 'image/png' }],
   },
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,18 @@ const nextConfig: NextConfig = {
   turbopack: {
     root: __dirname,
   },
+  async headers() {
+    return [
+      {
+        source: '/favicon.ico',
+        headers: [{ key: 'Cache-Control', value: 'no-store' }],
+      },
+      {
+        source: '/favicon-32.png',
+        headers: [{ key: 'Cache-Control', value: 'no-store' }],
+      },
+    ]
+  },
 }
 
 export default withNextIntl(nextConfig)


### PR DESCRIPTION
## Summary
- Adds `?v=2` to all favicon/icon URLs in `metadata.icons` (layout.tsx) — browsers cache favicons by URL, so changing the URL forces a fresh fetch
- Adds `Cache-Control: no-store` headers for `/favicon.ico` and `/favicon-32.png` in `next.config.ts` so future updates aren't cached at the browser level

## Why
Browsers maintain a separate favicon cache independent of SW/HTTP cache. Even after the file on the server was updated, the browser kept serving the old cached version because the URL hadn't changed.

## Test plan
- [ ] Deploy and open the app in a fresh tab — new Cairn favicon should appear immediately
- [ ] Subsequent refreshes should consistently show the new icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)