### PR TITLE
fix(investments): bust dashboard cache on transaction changes

### DIFF
--- a/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
+++ b/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
@@ -236,6 +236,10 @@ export default function InvestmentTransactionsTab() {
     setFormMode('edit')
   }
 
+  function bustDashboardCache() {
+    try { localStorage.removeItem('dashboardOverviewCache') } catch {}
+  }
+
   async function handleSave() {
     setFormError('')
     if (!txForm.amount_vnd || Number(txForm.amount_vnd) <= 0) { setFormError(t('amountRequired')); return }
@@ -267,6 +271,7 @@ export default function InvestmentTransactionsTab() {
       const { error } = await res.json()
       setFormError(error ?? tc('error'))
     } else {
+      bustDashboardCache()
       setFormMode(null)
       await fetchTransactions()
     }
@@ -298,6 +303,7 @@ export default function InvestmentTransactionsTab() {
     setImporting(false)
     if (res.ok) {
       const { inserted } = await res.json()
+      bustDashboardCache()
       setShowImport(false)
       setImportRaw('')
       setImportRows([])
@@ -312,6 +318,7 @@ export default function InvestmentTransactionsTab() {
     setDeletingId(tx.transaction_id)
     const res = await fetch(`/api/v1/investment-transactions/${tx.transaction_id}`, { method: 'DELETE' })
     if (res.ok) {
+      bustDashboardCache()
       setConfirmTx(null)
       await fetchTransactions()
     }


### PR DESCRIPTION
## Summary
- Adds `bustDashboardCache()` in `InvestmentTransactionsTab` that clears `dashboardOverviewCache` from localStorage
- Called after create/edit, import, and delete — same pattern already used in `SavingsGoalsTab`

## Root cause
The Dashboard uses a 2-minute localStorage cache. `InvestmentTransactionsTab` never cleared it, so new/edited/deleted transactions wouldn't appear on the Dashboard until the TTL expired naturally.

## Test plan
- [ ] Create an unassigned investment transaction from Settings → navigate to Dashboard immediately → new total should reflect the change
- [ ] Same for edit, delete, and batch import

🤖 Generated with [Claude Code](https://claude.com/claude-code)