### PR TITLE
fix(auth): scope dashboard cache key by user ID to prevent cross-account data leak

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,5 +1,10 @@
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { redirect } from 'next/navigation'
 import DashboardClient from '@/app/assets/DashboardClient'
 
-export default function DashboardPage() {
-  return <DashboardClient />
+export default async function DashboardPage() {
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) redirect('/auth/login')
+  return <DashboardClient userId={user.id} />
 }

--- a/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
+++ b/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
@@ -236,6 +236,14 @@ export default function InvestmentTransactionsTab() {
     setFormMode('edit')
   }
 
+  function bustDashboardCache() {
+    try {
+      Object.keys(localStorage)
+        .filter(k => k.startsWith('dashboardOverviewCache'))
+        .forEach(k => localStorage.removeItem(k))
+    } catch {}
+  }
+
   async function handleSave() {
     setFormError('')
     if (!txForm.amount_vnd || Number(txForm.amount_vnd) <= 0) { setFormError(t('amountRequired')); return }
@@ -267,6 +275,7 @@ export default function InvestmentTransactionsTab() {
       const { error } = await res.json()
       setFormError(error ?? tc('error'))
     } else {
+      bustDashboardCache()
       setFormMode(null)
       await fetchTransactions()
     }
@@ -298,6 +307,7 @@ export default function InvestmentTransactionsTab() {
     setImporting(false)
     if (res.ok) {
       const { inserted } = await res.json()
+      bustDashboardCache()
       setShowImport(false)
       setImportRaw('')
       setImportRows([])
@@ -312,6 +322,7 @@ export default function InvestmentTransactionsTab() {
     setDeletingId(tx.transaction_id)
     const res = await fetch(`/api/v1/investment-transactions/${tx.transaction_id}`, { method: 'DELETE' })
     if (res.ok) {
+      bustDashboardCache()
       setConfirmTx(null)
       await fetchTransactions()
     }

--- a/app/(app)/settings/tabs/SavingsGoalsTab.tsx
+++ b/app/(app)/settings/tabs/SavingsGoalsTab.tsx
@@ -46,7 +46,11 @@ function setGoalsCache(data: GoalWithStats[]) {
 }
 function bustGoalsCache() {
   try { localStorage.removeItem(GOALS_CACHE_KEY) } catch {}
-  try { localStorage.removeItem('dashboardOverviewCache') } catch {}
+  try {
+    Object.keys(localStorage)
+      .filter(k => k.startsWith('dashboardOverviewCache'))
+      .forEach(k => localStorage.removeItem(k))
+  } catch {}
 }
 
 export default function SavingsGoalsTab({ initialGoalId, onGoalChange }: Props) {

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -86,12 +86,13 @@ export interface DashboardData {
   insurance: InsuranceData[]
 }
 
-const OVERVIEW_CACHE_KEY = 'dashboardOverviewCache'
 const OVERVIEW_CACHE_TTL = 2 * 60 * 1000 // 2 minutes
 
-function getCachedOverview(): DashboardData | null {
+function overviewCacheKey(userId: string) { return `dashboardOverviewCache_${userId}` }
+
+function getCachedOverview(userId: string): DashboardData | null {
   try {
-    const raw = localStorage.getItem(OVERVIEW_CACHE_KEY)
+    const raw = localStorage.getItem(overviewCacheKey(userId))
     if (!raw) return null
     const { data, ts } = JSON.parse(raw)
     if (Date.now() - ts > OVERVIEW_CACHE_TTL) return null
@@ -99,14 +100,14 @@ function getCachedOverview(): DashboardData | null {
   } catch { return null }
 }
 
-function setCachedOverview(data: DashboardData) {
-  try { localStorage.setItem(OVERVIEW_CACHE_KEY, JSON.stringify({ data, ts: Date.now() })) } catch { /* ignore */ }
+function setCachedOverview(userId: string, data: DashboardData) {
+  try { localStorage.setItem(overviewCacheKey(userId), JSON.stringify({ data, ts: Date.now() })) } catch { /* ignore */ }
 }
 
 // Fetch fund detail (purchase history) from investment_transactions
 interface PurchaseHistory { purchase_date: string; units: number; nav_at_purchase: number }
 
-export default function DashboardClient() {
+export default function DashboardClient({ userId }: { userId: string }) {
   const t = useTranslations('dashboard')
   const tc = useTranslations('common')
   const tt = useTranslations('transactions')
@@ -143,7 +144,7 @@ export default function DashboardClient() {
   const [nfError, setNfError] = useState('')
 
   const fetchData = useCallback(async (opts?: { force?: boolean }) => {
-    const cached = !opts?.force && getCachedOverview()
+    const cached = !opts?.force && getCachedOverview(userId)
     if (cached) {
       setData(cached)
       setLoading(false)
@@ -159,7 +160,7 @@ export default function DashboardClient() {
       } else {
         const json = await res.json()
         setData(json)
-        setCachedOverview(json)
+        setCachedOverview(userId, json)
       }
     } catch {
       setError(tc('error'))


### PR DESCRIPTION
## Summary
- Cache key changed from `dashboardOverviewCache` → `dashboardOverviewCache_${userId}` so account B can never read account A's cached data
- `DashboardPage` (server component) reads the authenticated user ID and passes it to `DashboardClient` as a prop
- `bustDashboardCache()` in `InvestmentTransactionsTab` and `SavingsGoalsTab` updated to clear all `dashboardOverviewCache_*` keys (covers any user)
- Also includes the PR #143 fix (bust cache on transaction create/edit/delete/import) since this branch supersedes it

## Root cause
The dashboard uses a 2-minute localStorage cache with a flat key. After logout → login with a different account, if the cache wasn't fully cleared (timing race or stale entry), account B would be served account A's financial data.

## Test plan
- [ ] Login as account A → visit dashboard (cache populated with A's data)
- [ ] Logout → login as account B → dashboard should show B's data immediately, never A's

🤖 Generated with [Claude Code](https://claude.com/claude-code)