### PR TITLE
fix(dashboard): force-refetch on app focus to fix stale data on PWA reopen

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -170,6 +170,12 @@ export default function DashboardClient({ userId }: { userId: string }) {
 
   useEffect(() => { fetchData() }, [fetchData])
 
+  useEffect(() => {
+    const onVisible = () => { if (document.visibilityState === 'visible') fetchData({ force: true }) }
+    document.addEventListener('visibilitychange', onVisible)
+    return () => document.removeEventListener('visibilitychange', onVisible)
+  }, [fetchData])
+
   async function handleFundClick(fundId: string) {
     setFundDetailId(fundId)
     // Fetch purchase history for this fund


### PR DESCRIPTION
## Summary
- Adds a `visibilitychange` listener on the Dashboard that calls `fetchData({ force: true })` whenever the app comes back to the foreground

## Root cause
`handleAssignToGoal` does an optimistic UI update immediately, then runs several async API calls, then calls `fetchData({ force: true })` to refresh and persist to localStorage. If the user sees the optimistic update and closes the PWA **before** that full sequence completes, localStorage still holds the pre-assignment state. On reopen (including force quit), the stale cache is served and the transaction appears unallocated again.

The `visibilitychange` approach is the standard PWA fix: every time the app comes back to the foreground, bypass the cache and fetch fresh server data. This ensures any mutation that didn't fully commit to localStorage is corrected on next open.

## Test plan
- [ ] Assign a transaction to a goal → immediately close PWA → reopen → should show assigned
- [ ] Assign a transaction → force quit → reopen → should show assigned
- [ ] Normal dashboard load should still be fast (localStorage cache used on initial mount; `visibilitychange` only triggers on tab/app focus)

🤖 Generated with [Claude Code](https://claude.com/claude-code)