### PR TITLE
feat(mobile): add slide-in/out animation to hamburger drawer

### DIFF
--- a/app/components/navigation/MobileDrawer.tsx
+++ b/app/components/navigation/MobileDrawer.tsx
@@ -47,20 +47,21 @@ export default function MobileDrawer({ open, onClose, email, initials }: MobileD
     }
   }, [open])
 
-  if (!open) return null
-
   return (
-    <div className="fixed inset-0 z-50 lg:hidden">
+    <div
+      className={`fixed inset-0 z-50 lg:hidden transition-all duration-300 ${open ? 'pointer-events-auto' : 'pointer-events-none'}`}
+      aria-hidden={!open}
+    >
       {/* Overlay */}
       <div
-        className="absolute inset-0 bg-black/40"
+        className={`absolute inset-0 bg-black/40 transition-opacity duration-300 ${open ? 'opacity-100' : 'opacity-0'}`}
         onClick={onClose}
         aria-hidden="true"
       />
       {/* Drawer */}
       <div
         ref={drawerRef}
-        className="absolute left-0 top-0 h-full w-[280px] max-w-[90vw] bg-white dark:bg-gray-900 shadow-xl flex flex-col"
+        className={`absolute left-0 top-0 h-full w-[280px] max-w-[90vw] bg-white dark:bg-gray-900 shadow-xl flex flex-col transition-transform duration-300 ease-in-out ${open ? 'translate-x-0' : '-translate-x-full'}`}
         role="dialog"
         aria-modal="true"
         aria-label="Navigation menu"


### PR DESCRIPTION
## Summary

- Drawer now stays mounted and uses CSS `translate-x` transition instead of being unmounted instantly
- Opens with a 300ms ease-in-out slide from the left
- Closes with a reverse slide-out animation
- Overlay fades in/out in sync with the drawer
- `pointer-events-none` when closed so it doesn't block taps on the page

## Test plan

- [ ] Open hamburger menu on mobile — drawer slides in from left
- [ ] Close via X button or overlay tap — drawer slides back out
- [ ] Close via Escape key still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)