### PR TITLE
fix(i18n): show localized page titles based on selected language

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -1,6 +1,13 @@
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { redirect } from 'next/navigation'
 import DashboardClient from '@/app/assets/DashboardClient'
+import { getTranslations } from 'next-intl/server'
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('nav')
+  return { title: t('dashboard') }
+}
 
 export default async function DashboardPage() {
   const supabase = await createSupabaseServerClient()

--- a/app/(app)/funds/page.tsx
+++ b/app/(app)/funds/page.tsx
@@ -1,4 +1,11 @@
 import FundLibraryClient from './FundLibraryClient'
+import { getTranslations } from 'next-intl/server'
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('nav')
+  return { title: t('funds') }
+}
 
 export default function FundsPage() {
   return <FundLibraryClient />

--- a/app/(app)/planning/page.tsx
+++ b/app/(app)/planning/page.tsx
@@ -1,4 +1,11 @@
 import PlanningClient from './PlanningClient'
+import { getTranslations } from 'next-intl/server'
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('nav')
+  return { title: t('planning') }
+}
 
 export default function PlanningPage() {
   return <PlanningClient />

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,4 +1,11 @@
 import SettingsClient from './SettingsClient'
+import { getTranslations } from 'next-intl/server'
+import type { Metadata } from 'next'
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslations('nav')
+  return { title: t('settings') }
+}
 
 export default async function SettingsPage({
   searchParams,

--- a/app/components/navigation/Breadcrumb.tsx
+++ b/app/components/navigation/Breadcrumb.tsx
@@ -3,54 +3,37 @@
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { ChevronRight } from 'lucide-react'
+import { useTranslations } from 'next-intl'
 
-const BREADCRUMB_MAP: Record<string, { label: string }> = {
-  '/dashboard': { label: 'Asset Overview' },
-  '/planning': { label: 'Monthly Plan' },
-  '/funds': { label: 'Fund Library' },
-  '/settings': { label: 'Settings' },
-}
-
-interface Crumb {
-  label: string
-  href: string
-  current: boolean
-}
-
-function buildCrumbs(pathname: string): Crumb[] {
-  const entry = BREADCRUMB_MAP[pathname]
-  if (!entry) return [{ label: pathname.slice(1), href: pathname, current: true }]
-  return [{ label: entry.label, href: pathname, current: true }]
+const PATH_TO_NAV_KEY: Record<string, 'dashboard' | 'planning' | 'funds' | 'settings'> = {
+  '/dashboard': 'dashboard',
+  '/planning': 'planning',
+  '/funds': 'funds',
+  '/settings': 'settings',
 }
 
 export default function Breadcrumb() {
   const pathname = usePathname()
-  const crumbs = buildCrumbs(pathname)
+  const t = useTranslations('nav')
+  const key = PATH_TO_NAV_KEY[pathname]
+  const label = key ? t(key) : pathname.slice(1)
 
   return (
     <nav aria-label="Breadcrumb" className="hidden md:flex items-center gap-1">
-      {crumbs.map((crumb, i) => (
-        <span key={crumb.href} className="flex items-center gap-1">
-          {i > 0 && <ChevronRight size={12} className="text-gray-400 dark:text-gray-500" />}
-          {crumb.current ? (
-            <span aria-current="page" className="text-lg font-semibold text-gray-900 dark:text-gray-100">
-              {crumb.label}
-            </span>
-          ) : (
-            <Link href={crumb.href} className="text-xs text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-100 transition-colors">
-              {crumb.label}
-            </Link>
-          )}
+      <span className="flex items-center gap-1">
+        <span aria-current="page" className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+          {label}
         </span>
-      ))}
+      </span>
     </nav>
   )
 }
 
 export function PageTitle() {
   const pathname = usePathname()
-  const entry = BREADCRUMB_MAP[pathname]
-  const title = entry?.label ?? pathname.slice(1)
+  const t = useTranslations('nav')
+  const key = PATH_TO_NAV_KEY[pathname]
+  const title = key ? t(key) : pathname.slice(1)
 
   return (
     <p className="text-sm font-medium text-gray-700 dark:text-gray-300 md:hidden px-4 py-2 border-b border-gray-100 dark:border-gray-700">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,7 +25,7 @@ export const viewport: Viewport = {
 }
 
 export const metadata: Metadata = {
-  title: 'Cairn',
+  title: { template: '%s | Cairn', default: 'Cairn' },
   description: 'Personal finance, one stone at a time. Plan, track, and grow toward every goal.',
   manifest: '/manifest.webmanifest',
   appleWebApp: { capable: true, statusBarStyle: 'default', title: 'Cairn' },


### PR DESCRIPTION
## Summary

- Root layout now uses `title: { template: '%s | Cairn', default: 'Cairn' }` so each page can set its own title
- Added `generateMetadata()` to all four app pages (Dashboard, Planning, Funds, Settings) using `getTranslations('nav')` from `next-intl/server`
- Titles now reflect the active locale automatically on page load

**EN:** `Asset Overview | Cairn`, `Monthly Plan | Cairn`, etc.
**VI:** `Tổng Quan Tài Sản | Cairn`, `Kế Hoạch Tháng | Cairn`, etc.

## Test plan

- [ ] Switch language to Vietnamese — navigate to each page and confirm browser tab shows the Vietnamese title
- [ ] Switch back to English — confirm English titles appear

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)