### PR TITLE
feat(expenses): add effective date range (from/to month) to fixed expenses

### DIFF
--- a/app/(app)/settings/tabs/FixedExpensesTab.tsx
+++ b/app/(app)/settings/tabs/FixedExpensesTab.tsx
@@ -18,11 +18,26 @@ interface Expense {
   amount_vnd: number
   category: string
   created_at: string
+  effective_from: string | null
+  effective_to: string | null
 }
 
 const fmt = (n: number) => '₫ ' + Math.round(n).toLocaleString('vi-VN')
 
-const emptyForm = { expense_name: '', amount_vnd: '', category: '' }
+// "2026-04-01" → "2026-04" for <input type="month">
+function toMonthInput(date: string | null): string {
+  if (!date) return ''
+  return date.slice(0, 7)
+}
+
+// "Apr 2026" display label
+function fmtMonth(date: string | null): string {
+  if (!date) return ''
+  const d = new Date(date + 'T00:00:00')
+  return d.toLocaleDateString('en-US', { month: 'short', year: 'numeric' })
+}
+
+const emptyForm = { expense_name: '', amount_vnd: '', category: '', effective_from: '', effective_to: '' }
 
 const FIXED_CACHE_PREFIX = 'fixedExpensesCache'
 const CACHE_TTL = 2 * 60 * 1000
@@ -89,7 +104,13 @@ export default function FixedExpensesTab() {
 
   function openEdit(expense: Expense) {
     setEditExpense(expense)
-    setForm({ expense_name: expense.expense_name, amount_vnd: String(expense.amount_vnd), category: expense.category })
+    setForm({
+      expense_name: expense.expense_name,
+      amount_vnd: String(expense.amount_vnd),
+      category: expense.category,
+      effective_from: toMonthInput(expense.effective_from),
+      effective_to: toMonthInput(expense.effective_to),
+    })
     setFormError('')
     setShowForm(true)
   }
@@ -105,7 +126,13 @@ export default function FixedExpensesTab() {
     const res = await fetch(url, {
       method: editExpense ? 'PUT' : 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ expense_name: form.expense_name, amount_vnd: Number(form.amount_vnd), category: form.category }),
+      body: JSON.stringify({
+        expense_name: form.expense_name,
+        amount_vnd: Number(form.amount_vnd),
+        category: form.category,
+        effective_from: form.effective_from || null,
+        effective_to: form.effective_to || null,
+      }),
     })
     if (!res.ok) {
       const { error } = await res.json()
@@ -187,7 +214,11 @@ export default function FixedExpensesTab() {
                   </div>
                   <div className="flex items-center justify-between text-xs">
                     <span className="font-semibold text-gray-900 dark:text-gray-100">{fmt(expense.amount_vnd)}</span>
-                    <span className="text-gray-500 dark:text-gray-400">{new Date(expense.created_at).toLocaleDateString('vi-VN')}</span>
+                    {(expense.effective_from || expense.effective_to) && (
+                      <span className="text-gray-400 dark:text-gray-500">
+                        {fmtMonth(expense.effective_from) || '…'} → {fmtMonth(expense.effective_to) || '∞'}
+                      </span>
+                    )}
                   </div>
                   <div className="flex items-center gap-1 pt-0.5">
                     <button onClick={() => openEdit(expense)} className="h-8 w-8 p-0 flex items-center justify-center border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
@@ -208,7 +239,7 @@ export default function FixedExpensesTab() {
                     <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colName')}</th>
                     <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colCategory')}</th>
                     <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-right">{t('colAmount')}</th>
-                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colCreated')}</th>
+                    <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">Period</th>
                     <th className="px-4 pb-3 text-xs font-medium text-gray-500 dark:text-gray-400 uppercase text-center">{tCommon('actions')}</th>
                   </tr>
                 </thead>
@@ -220,7 +251,12 @@ export default function FixedExpensesTab() {
                         <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300">{expense.category}</span>
                       </td>
                       <td className="px-4 py-4 text-right font-semibold text-gray-900 dark:text-gray-100">{fmt(expense.amount_vnd)}</td>
-                      <td className="px-4 py-4 text-sm text-gray-600 dark:text-gray-400">{new Date(expense.created_at).toLocaleDateString('vi-VN')}</td>
+                      <td className="px-4 py-4 text-sm text-gray-500 dark:text-gray-400">
+                        {expense.effective_from || expense.effective_to
+                          ? <>{fmtMonth(expense.effective_from) || '…'} → {fmtMonth(expense.effective_to) || '∞'}</>
+                          : <span className="text-gray-300 dark:text-gray-600">Always</span>
+                        }
+                      </td>
                       <td className="px-4 py-4 text-center">
                         <div className="flex items-center justify-center gap-1">
                           <button onClick={() => openEdit(expense)} className="h-8 w-8 p-0 flex items-center justify-center border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
@@ -292,6 +328,27 @@ export default function FixedExpensesTab() {
                   onChange={(e) => setForm({ ...form, amount_vnd: e.target.value })}
                   placeholder={t('amountPlaceholder')}
                 />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="effective_from">{t('effectiveFromLabel')}</Label>
+                  <Input
+                    id="effective_from"
+                    type="month"
+                    value={form.effective_from}
+                    onChange={(e) => setForm({ ...form, effective_from: e.target.value })}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="effective_to">{t('effectiveToLabel')}</Label>
+                  <Input
+                    id="effective_to"
+                    type="month"
+                    value={form.effective_to}
+                    placeholder={t('effectiveToPlaceholder')}
+                    onChange={(e) => setForm({ ...form, effective_to: e.target.value })}
+                  />
+                </div>
               </div>
             </div>
             <div className="flex gap-3">

--- a/app/api/v1/fixed-expenses/[id]/route.ts
+++ b/app/api/v1/fixed-expenses/[id]/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 
+function toDateCol(ym: string | undefined | null): string | null {
+  if (!ym) return null
+  return `${ym}-01`
+}
+
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const supabase = await createSupabaseServerClient()
@@ -8,7 +13,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const body = await request.json()
-  const { expense_name, amount_vnd, category } = body
+  const { expense_name, amount_vnd, category, effective_from, effective_to } = body
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }
   if (expense_name !== undefined) {
@@ -29,6 +34,14 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       return NextResponse.json({ error: 'Amount must be greater than 0.' }, { status: 400 })
     }
     updates.amount_vnd = amountNum
+  }
+  if ('effective_from' in body) updates.effective_from = toDateCol(effective_from)
+  if ('effective_to' in body) updates.effective_to = toDateCol(effective_to)
+
+  const fromDate = (updates.effective_from ?? null) as string | null
+  const toDate = (updates.effective_to ?? null) as string | null
+  if (fromDate && toDate && fromDate > toDate) {
+    return NextResponse.json({ error: '"Active from" must be before "Active until".' }, { status: 400 })
   }
 
   const { data: expense, error } = await supabase

--- a/app/api/v1/fixed-expenses/route.ts
+++ b/app/api/v1/fixed-expenses/route.ts
@@ -1,6 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 
+function toDateCol(ym: string | undefined | null): string | null {
+  if (!ym) return null
+  return `${ym}-01`
+}
+
 export async function GET(request: NextRequest) {
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
@@ -8,6 +13,8 @@ export async function GET(request: NextRequest) {
 
   const { searchParams } = new URL(request.url)
   const category = searchParams.get('category')
+  const month = searchParams.get('month')
+  const year = searchParams.get('year')
 
   let query = supabase
     .from('fixed_expenses')
@@ -16,6 +23,13 @@ export async function GET(request: NextRequest) {
     .order('created_at', { ascending: false })
 
   if (category) query = query.eq('category', category)
+
+  if (month && year) {
+    const planDate = `${year}-${String(month).padStart(2, '0')}-01`
+    query = query
+      .or(`effective_from.is.null,effective_from.lte.${planDate}`)
+      .or(`effective_to.is.null,effective_to.gte.${planDate}`)
+  }
 
   const { data: expenses, error } = await query
   if (error) return NextResponse.json({ error: 'Failed to fetch expenses' }, { status: 500 })
@@ -28,7 +42,7 @@ export async function POST(request: NextRequest) {
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const body = await request.json()
-  const { expense_name, amount_vnd, category } = body
+  const { expense_name, amount_vnd, category, effective_from, effective_to } = body
 
   if (!expense_name || typeof expense_name !== 'string' || expense_name.trim().length === 0) {
     return NextResponse.json({ error: 'Expense name is required.' }, { status: 400 })
@@ -41,9 +55,22 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Amount must be greater than 0.' }, { status: 400 })
   }
 
+  const fromDate = toDateCol(effective_from)
+  const toDate = toDateCol(effective_to)
+  if (fromDate && toDate && fromDate > toDate) {
+    return NextResponse.json({ error: '"Active from" must be before "Active until".' }, { status: 400 })
+  }
+
   const { data: expense, error } = await supabase
     .from('fixed_expenses')
-    .insert({ user_id: user.id, expense_name: expense_name.trim(), amount_vnd: amountNum, category: category.trim() })
+    .insert({
+      user_id: user.id,
+      expense_name: expense_name.trim(),
+      amount_vnd: amountNum,
+      category: category.trim(),
+      effective_from: fromDate,
+      effective_to: toDate,
+    })
     .select()
     .single()
 

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -38,9 +38,15 @@ export async function GET(request: NextRequest) {
       supabase
         .from('fixed_expense_overrides')
         .select('fixed_expense_id, monthly_amount_override_vnd').eq('plan_id', plan.id),
-      supabase
-        .from('fixed_expenses')
-        .select('expense_id, expense_name, amount_vnd, category').eq('user_id', user.id),
+      (() => {
+        const planDate = `${plan.year}-${String(plan.month).padStart(2, '0')}-01`
+        return supabase
+          .from('fixed_expenses')
+          .select('expense_id, expense_name, amount_vnd, category, effective_from, effective_to')
+          .eq('user_id', user.id)
+          .or(`effective_from.is.null,effective_from.lte.${planDate}`)
+          .or(`effective_to.is.null,effective_to.gte.${planDate}`)
+      })(),
       supabase
         .from('insurance_members')
         .select('member_id, member_name, relationship, coverage_type, annual_payment_vnd, payment_date, last_payment_date')

--- a/messages/en.json
+++ b/messages/en.json
@@ -253,6 +253,9 @@
     "amountLabel": "Amount (VND)",
     "amountPlaceholder": "e.g., 5000000",
     "amountRequired": "Amount must be greater than 0.",
+    "effectiveFromLabel": "Active from (optional)",
+    "effectiveToLabel": "Active until (optional)",
+    "effectiveToPlaceholder": "No end date",
     "infoTitle": "About Fixed Expenses",
     "infoDesc": "Fixed expenses are automatically added to your Monthly Plan each month. You can override the amount for any specific month when planning."
   },

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -253,6 +253,9 @@
     "amountLabel": "Số tiền (VND)",
     "amountPlaceholder": "VD: 5000000",
     "amountRequired": "Số tiền phải lớn hơn 0.",
+    "effectiveFromLabel": "Hiệu lực từ (tùy chọn)",
+    "effectiveToLabel": "Hiệu lực đến (tùy chọn)",
+    "effectiveToPlaceholder": "Không có ngày kết thúc",
     "infoTitle": "Về Chi phí Cố định",
     "infoDesc": "Chi phí cố định được tự động thêm vào Kế hoạch Tháng mỗi tháng. Bạn có thể điều chỉnh số tiền cho từng tháng cụ thể khi lên kế hoạch."
   },

--- a/supabase/migrations/20260427000001_add_effective_dates_to_fixed_expenses.sql
+++ b/supabase/migrations/20260427000001_add_effective_dates_to_fixed_expenses.sql
@@ -1,0 +1,8 @@
+ALTER TABLE fixed_expenses
+  ADD COLUMN effective_from DATE,
+  ADD COLUMN effective_to DATE;
+
+ALTER TABLE fixed_expenses
+  ADD CONSTRAINT effective_dates_order CHECK (
+    effective_from IS NULL OR effective_to IS NULL OR effective_from <= effective_to
+  );


### PR DESCRIPTION
## Summary

Fixed expenses can now have an optional validity period:

- **Active from** — the first month the expense appears in Monthly Plans (optional; if empty, always shown from the beginning)
- **Active until** — the last month it appears (optional; if empty, never expires)

Existing expenses with no dates are unaffected — they continue to appear in all plans.

## Changes

- **DB migration**: adds nullable `effective_from DATE` and `effective_to DATE` columns to `fixed_expenses` with a check constraint ensuring `effective_from <= effective_to`
- **API `GET /api/v1/fixed-expenses`**: accepts optional `month`+`year` params to filter by date range (used in PlanningClient's no-plan fallback)
- **API `POST/PUT /api/v1/fixed-expenses`**: accepts `effective_from`/`effective_to` as `YYYY-MM` strings, stores as `YYYY-MM-01`
- **`GET /api/v1/monthly-plans?full=true`**: filters fixed expenses to only those whose date range covers the plan's month
- **Settings UI**: form has two `<input type="month">` pickers; list/table shows the period range

## ⚠️ Before merging: run migration in Supabase

```sql
ALTER TABLE fixed_expenses ADD COLUMN effective_from DATE, ADD COLUMN effective_to DATE;
ALTER TABLE fixed_expenses ADD CONSTRAINT effective_dates_order CHECK (effective_from IS NULL OR effective_to IS NULL OR effective_from <= effective_to);
```

## Test plan

- [ ] Create expense with no dates → appears in all Monthly Plans
- [ ] Create expense with `effective_from = current month` and `effective_to = next month`
  - Current month plan → expense appears
  - Past month plan → expense absent
  - Month after `effective_to` → expense absent
- [ ] Edit expense to clear dates → reverts to always-show

🤖 Generated with [Claude Code](https://claude.com/claude-code)