### PR TITLE
fix(goals): improve number formatting in goal detail table

### DIFF
--- a/app/(app)/settings/tabs/GoalDetailView.tsx
+++ b/app/(app)/settings/tabs/GoalDetailView.tsx
@@ -87,7 +87,8 @@ function calcProjectedInterest(amount: number, rate: number | null, investmentDa
 }
 
 const fmt = (n: number) => '₫ ' + Math.round(n).toLocaleString('vi-VN')
-const fmtUnits = (n: number) => (n % 1 === 0 ? n.toString() : n.toFixed(4))
+const fmtNav = (n: number) => '₫ ' + n.toLocaleString('vi-VN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+const fmtUnits = (n: number) => n.toLocaleString('vi-VN', { maximumFractionDigits: 2 })
 
 const emptyTxForm = { asset_type: 'bank', investment_date: '', amount_vnd: '', unit_price: '', units: '', interest_rate: '', expiry_date: '', notes: '', fund_id: '' }
 const emptyFiForm = { fund_id: '', investment_date: '', amount_vnd: '', units: '', unit_price: '' }
@@ -579,8 +580,8 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
                     <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
                       <div><span className="text-gray-500 dark:text-gray-400">{t('colRemaining')}: </span><span className="font-medium text-gray-900 dark:text-gray-100">{fmtUnits(g.remaining_units)} {t('unitsShort')}</span></div>
                       <div><span className="text-gray-500 dark:text-gray-400">{t('colValue')}: </span><span className="font-medium text-gray-900 dark:text-gray-100">{fmt(g.current_value)}</span></div>
-                      <div><span className="text-gray-500 dark:text-gray-400">{t('colAvgNav')}: </span><span className="text-gray-700 dark:text-gray-300">{fmt(g.avg_cost_per_unit)}</span></div>
-                      <div><span className="text-gray-500 dark:text-gray-400">{t('colCurrentNav')}: </span><span className="text-gray-700 dark:text-gray-300">{fmt(g.current_nav)}</span></div>
+                      <div><span className="text-gray-500 dark:text-gray-400">{t('colAvgNav')}: </span><span className="text-gray-700 dark:text-gray-300">{fmtNav(g.avg_cost_per_unit)}</span></div>
+                      <div><span className="text-gray-500 dark:text-gray-400">{t('colCurrentNav')}: </span><span className="text-gray-700 dark:text-gray-300">{fmtNav(g.current_nav)}</span></div>
                       <div className="col-span-2"><span className="text-gray-500 dark:text-gray-400">{t('colGainLoss')}: </span><span className={`font-medium ${g.total_pl >= 0 ? 'text-green-600' : 'text-red-600'}`}>{fmt(g.total_pl)}</span></div>
                     </div>
                     {g.remaining_units > 0 && (
@@ -618,8 +619,8 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
                             : <span className="font-medium text-gray-900 dark:text-gray-100">{fmtUnits(g.remaining_units)}</span>
                           }
                         </td>
-                        <td className="px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">{fmt(g.avg_cost_per_unit)}</td>
-                        <td className="px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">{fmt(g.current_nav)}</td>
+                        <td className="px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">{fmtNav(g.avg_cost_per_unit)}</td>
+                        <td className="px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">{fmtNav(g.current_nav)}</td>
                         <td className="px-4 py-3 text-right font-medium text-gray-900 dark:text-gray-100">{fmt(g.current_value)}</td>
                         <td className={`px-4 py-3 text-right font-medium ${g.total_pl >= 0 ? 'text-green-600' : 'text-red-600'}`}>{fmt(g.total_pl)}</td>
                         <td className="px-4 py-3">
@@ -938,7 +939,7 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
           {/* Context info */}
           <div className="text-sm text-gray-500 dark:text-gray-400 -mt-2">
             {wType === 'fund' && wGroup && (
-              <span>{wGroup.fund_code} · {t('colCurrentNav')}: <strong className="text-gray-800 dark:text-gray-200">{fmt(wGroup.current_nav)}</strong> · {t('colRemaining')}: <strong className="text-gray-800 dark:text-gray-200">{fmtUnits(wGroup.remaining_units)} {t('unitsShort')}</strong></span>
+              <span>{wGroup.fund_code} · {t('colCurrentNav')}: <strong className="text-gray-800 dark:text-gray-200">{fmtNav(wGroup.current_nav)}</strong> · {t('colRemaining')}: <strong className="text-gray-800 dark:text-gray-200">{fmtUnits(wGroup.remaining_units)} {t('unitsShort')}</strong></span>
             )}
             {wType === 'gold' && wRow && goldPrice && (
               <span>{t('assetGold')} · {t('currentPriceLabel')}: <strong className="text-gray-800 dark:text-gray-200">{fmt(goldPrice)}/chi</strong> · {t('colRemaining')}: <strong className="text-gray-800 dark:text-gray-200">{fmtUnits((wRow.units ?? 0) - wRow.total_units_withdrawn)} chi</strong></span>

--- a/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
+++ b/app/(app)/settings/tabs/InvestmentTransactionsTab.tsx
@@ -71,6 +71,7 @@ function calcCurrentValue(tx: Transaction): number {
 
 const fmt = (n: number) => '₫ ' + Math.round(n).toLocaleString('vi-VN')
 const fmtNav = (n: number) => '₫ ' + n.toLocaleString('vi-VN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+const fmtUnits = (n: number) => n.toLocaleString('vi-VN', { maximumFractionDigits: 2 })
 
 interface ParsedRow {
   investment_date: string
@@ -471,7 +472,7 @@ export default function InvestmentTransactionsTab() {
                         <>
                           <div>
                             <span className="text-gray-500 dark:text-gray-400">{t('colTransaction')}: </span>
-                            <span className="text-gray-700 dark:text-gray-300">{tx.units ?? '—'}</span>
+                            <span className="text-gray-700 dark:text-gray-300">{tx.units != null ? fmtUnits(tx.units) : '—'}</span>
                           </div>
                           <div>
                             <span className="text-gray-500 dark:text-gray-400">{rateOrNavLabel}: </span>
@@ -551,7 +552,9 @@ export default function InvestmentTransactionsTab() {
                         </td>
                         <td className="px-4 py-3 text-right font-medium text-gray-900 dark:text-gray-100">{fmt(tx.amount_vnd)}</td>
                         <td className="px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">
-                          {isWithdrawal ? (tx.units_withdrawn ?? '—') : (tx.units ?? '—')}
+                          {isWithdrawal
+                            ? (tx.units_withdrawn != null ? fmtUnits(tx.units_withdrawn) : '—')
+                            : (tx.units != null ? fmtUnits(tx.units) : '—')}
                         </td>
                         <td className="px-4 py-3 text-right text-sm text-gray-600 dark:text-gray-400">{isWithdrawal ? '—' : rateOrNav}</td>
                         <td className="px-4 py-3 text-right font-medium">
@@ -679,8 +682,8 @@ export default function InvestmentTransactionsTab() {
                         <tr key={i} className={row.error ? 'bg-red-50 dark:bg-red-900/10' : ''}>
                           <td className="px-3 py-2 text-gray-700 dark:text-gray-300">{row.investment_date || '—'}</td>
                           <td className="px-3 py-2 text-gray-700 dark:text-gray-300">{isNaN(row.amount_vnd) ? '—' : Math.round(row.amount_vnd).toLocaleString('vi-VN')}</td>
-                          <td className="px-3 py-2 text-gray-700 dark:text-gray-300">{isNaN(row.unit_price) ? '—' : row.unit_price.toLocaleString('vi-VN')}</td>
-                          <td className="px-3 py-2 text-gray-700 dark:text-gray-300">{isNaN(row.units) ? '—' : row.units}</td>
+                          <td className="px-3 py-2 text-gray-700 dark:text-gray-300">{isNaN(row.unit_price) ? '—' : fmtNav(row.unit_price)}</td>
+                          <td className="px-3 py-2 text-gray-700 dark:text-gray-300">{isNaN(row.units) ? '—' : fmtUnits(row.units)}</td>
                           <td className="px-3 py-2">
                             {row.error
                               ? <span className="text-red-500 dark:text-red-400">{row.error}</span>

--- a/app/assets/components/FundDetailModal.tsx
+++ b/app/assets/components/FundDetailModal.tsx
@@ -5,6 +5,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 
 const fmt = (n: number) => '₫ ' + Math.round(n).toLocaleString('vi-VN')
 const fmtNav = (n: number) => '₫ ' + n.toLocaleString('vi-VN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+const fmtUnits = (n: number) => n.toLocaleString('vi-VN', { maximumFractionDigits: 2 })
 const fmtPct = (n: number) => `${n >= 0 ? '+' : ''}${n.toFixed(2)}%`
 
 interface PurchaseHistory {
@@ -52,7 +53,7 @@ export default function FundDetailModal({
             </div>
             <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3">
               <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">{t('unitsHeld')}</p>
-              <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{quantity.toLocaleString('vi-VN')}</p>
+              <p className="text-sm font-semibold text-gray-900 dark:text-gray-100">{fmtUnits(quantity)}</p>
             </div>
             <div className="bg-gray-50 dark:bg-gray-800 rounded-lg p-3">
               <p className="text-xs text-gray-400 dark:text-gray-500 mb-1">{t('currentValue')}</p>
@@ -91,7 +92,7 @@ export default function FundDetailModal({
                   {purchaseHistory.map((row, i) => (
                     <tr key={i}>
                       <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{new Date(row.purchase_date).toLocaleDateString()}</td>
-                      <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{row.units}</td>
+                      <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{fmtUnits(row.units)}</td>
                       <td className="px-3 py-2 text-gray-600 dark:text-gray-400">{fmtNav(row.nav_at_purchase)}</td>
                     </tr>
                   ))}


### PR DESCRIPTION
## Summary
- NAV price columns (avg cost per unit, current NAV) now use `fmtNav` which shows 2 decimal places — so `₫25.219` becomes `₫25.219,00`, making it unambiguous vs a decimal fraction
- CCQ unit column now uses vi-VN locale with thousands separator and max 2 decimal places — so `2878.8300` becomes `2.878,83`

## Test plan
- [ ] Open Goal Details for a fund goal
- [ ] Verify CCQ column shows values like `2.878,83` (with dot separator, comma decimal)
- [ ] Verify NAV TB MUA and NAV HIỆN TẠI show values like `₫25.219,00` (2 decimal places, unambiguous)
- [ ] Verify GIÁ TRỊ and Lãi/Lỗ columns still use whole-number VND formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)