### PR TITLE
feat(withdraw): affects-progress checkbox on withdraw modal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,15 @@
+## Development Methodology
+
+**Always use Test-Driven Development (TDD).** For every feature or bug fix, write tests first — then implement.
+
+Rules:
+1. Write unit tests and/or E2E tests that define the expected behavior **before** writing any implementation code
+2. Run the tests to confirm they fail (red phase)
+3. Implement the minimum code needed to make the tests pass (green phase)
+4. Refactor if needed, keeping tests green
+
+This applies to both new features and bug fixes. Never write implementation code without a failing test first.
+
 ## Git & PR Workflow
 
 **Never push code directly to `main`.** Every change — no matter how small — must go through a branch and PR.

--- a/app/(app)/settings/tabs/GoalDetailView.tsx
+++ b/app/(app)/settings/tabs/GoalDetailView.tsx
@@ -51,6 +51,7 @@ interface WithdrawalRow {
   parent_transaction_id: string | null
   fund_id: string | null
   notes: string | null
+  affects_progress: boolean | null
 }
 
 interface FundGroup {
@@ -140,7 +141,7 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
 
     const withdrawals: WithdrawalRow[] = all
       .filter((tx: { transaction_type: string }) => tx.transaction_type === 'withdrawal')
-      .map((tx: { transaction_id: string; investment_date: string; amount_vnd: number; principal_withdrawn: number | null; units_withdrawn: number | null; parent_transaction_id: string | null; fund_id: string | null; notes: string | null }) => ({
+      .map((tx: { transaction_id: string; investment_date: string; amount_vnd: number; principal_withdrawn: number | null; units_withdrawn: number | null; parent_transaction_id: string | null; fund_id: string | null; notes: string | null; affects_progress: boolean | null }) => ({
         transaction_id: tx.transaction_id,
         investment_date: tx.investment_date,
         amount_vnd: tx.amount_vnd,
@@ -149,6 +150,7 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
         parent_transaction_id: tx.parent_transaction_id,
         fund_id: tx.fund_id,
         notes: tx.notes,
+        affects_progress: tx.affects_progress,
       }))
 
     // Build withdrawal lookup by parent transaction
@@ -176,8 +178,8 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
           notes: tx.notes,
           fund_id: tx.fund_id,
           fund_code: tx.fund_id && fundMap[tx.fund_id] ? fundMap[tx.fund_id].code : null,
-          total_principal_withdrawn: ws.reduce((s: number, w: WithdrawalRow) => s + (w.principal_withdrawn ?? 0), 0),
-          total_units_withdrawn: ws.reduce((s: number, w: WithdrawalRow) => s + (w.units_withdrawn ?? 0), 0),
+          total_principal_withdrawn: ws.filter((w: WithdrawalRow) => w.affects_progress !== false).reduce((s: number, w: WithdrawalRow) => s + (w.principal_withdrawn ?? 0), 0),
+          total_units_withdrawn: ws.filter((w: WithdrawalRow) => w.affects_progress !== false).reduce((s: number, w: WithdrawalRow) => s + (w.units_withdrawn ?? 0), 0),
           total_received: ws.reduce((s: number, w: WithdrawalRow) => s + w.amount_vnd, 0),
         }
       })
@@ -216,7 +218,9 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
   // Add fund sell withdrawals (no parent_transaction_id = fund-level sell)
   for (const w of withdrawalRows) {
     if (w.fund_id && !w.parent_transaction_id && fundGroupMap[w.fund_id]) {
-      fundGroupMap[w.fund_id].units_sold += w.units_withdrawn ?? 0
+      if (w.affects_progress !== false) {
+        fundGroupMap[w.fund_id].units_sold += w.units_withdrawn ?? 0
+      }
       fundGroupMap[w.fund_id].total_received_from_sells += w.amount_vnd
     }
   }
@@ -372,7 +376,11 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
     setSaving(true)
     const res = await fetch('/api/v1/investment-transactions', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
     if (!res.ok) { const { error } = await res.json(); setFormError(error ?? tc('error')) }
-    else { setFormMode(null); setWithdrawSource(null); await fetchData() }
+    else {
+      // Bust dashboard cache so progress bar reflects the new withdrawal immediately
+      Object.keys(localStorage).filter(k => k.startsWith('dashboardOverviewCache')).forEach(k => localStorage.removeItem(k))
+      setFormMode(null); setWithdrawSource(null); await fetchData()
+    }
     setSaving(false)
   }
 

--- a/app/(app)/settings/tabs/GoalDetailView.tsx
+++ b/app/(app)/settings/tabs/GoalDetailView.tsx
@@ -84,7 +84,7 @@ const ASSET_COLORS: Record<string, string> = {
 
 const emptyTxForm = { asset_type: 'bank', investment_date: '', amount_vnd: '', unit_price: '', units: '', interest_rate: '', expiry_date: '', notes: '', fund_id: '' }
 const emptyFiForm = { fund_id: '', investment_date: '', amount_vnd: '', units: '', unit_price: '' }
-const emptyWithdrawForm = { investment_date: '', amount_vnd: '', principal_withdrawn: '', units_withdrawn: '', notes: '' }
+const emptyWithdrawForm = { investment_date: '', amount_vnd: '', principal_withdrawn: '', units_withdrawn: '', notes: '', affects_progress: true }
 
 export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: () => void }) {
   const t = useTranslations('goals')
@@ -366,6 +366,7 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
       // For fund: store fund_id and asset_type for grouping
       asset_type: type === 'fund' ? 'fund' : null,
       fund_id: type === 'fund' ? withdrawSource.fund_group?.fund_id : null,
+      affects_progress: withdrawForm.affects_progress,
     }
 
     setSaving(true)
@@ -997,6 +998,17 @@ export default function GoalDetailView({ goal, onBack }: { goal: Goal; onBack: (
               <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{tc('notes')}</label>
               <input type="text" value={withdrawForm.notes} onChange={(e) => setWithdrawForm({ ...withdrawForm, notes: e.target.value })} className="w-full border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-base bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500" />
             </div>
+
+            <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                data-testid="affects-progress-checkbox"
+                checked={withdrawForm.affects_progress}
+                onChange={(e) => setWithdrawForm({ ...withdrawForm, affects_progress: e.target.checked })}
+                className="rounded border-gray-300 dark:border-gray-600 text-indigo-600 focus:ring-indigo-500"
+              />
+              {t('affectsProgressLabel')}
+            </label>
           </div>
 
           {/* Live preview */}

--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { calcProjectedInterest, isNavStale, insuranceStatus } from '@/lib/finance'
+import { buildWithdrawalMaps } from '@/lib/withdrawalProgress'
 
 export async function GET() {
   const supabase = await createSupabaseServerClient()
@@ -15,7 +16,7 @@ export async function GET() {
       .eq('user_id', user.id),
     supabase
       .from('investment_transactions')
-      .select('transaction_id, goal_id, amount_vnd, interest_rate, investment_date, asset_type, transaction_type, units, unit_price, units_withdrawn, principal_withdrawn, fund_id, parent_transaction_id, expiry_date, notes, funds(id, name, nav, updated_at, fund_type)')
+      .select('transaction_id, goal_id, amount_vnd, interest_rate, investment_date, asset_type, transaction_type, units, unit_price, units_withdrawn, principal_withdrawn, fund_id, parent_transaction_id, expiry_date, notes, affects_progress, funds(id, name, nav, updated_at, fund_type)')
       .eq('user_id', user.id),
     supabase
       .from('insurance_members')
@@ -57,24 +58,7 @@ export async function GET() {
   )
   const withdrawals = allTxsRaw.filter((tx) => tx.transaction_type === 'withdrawal')
 
-  // Build withdrawal lookup: parent_transaction_id → { principal, units } (bank/gold)
-  const parentWdMap = new Map<string, { principal: number; units: number }>()
-  // Build fund withdrawal lookup: "goal_key::fund_id" → { units, cost }
-  const fundWdMap = new Map<string, { units: number; cost: number }>()
-  for (const wd of withdrawals) {
-    if (wd.asset_type === 'fund' && wd.fund_id) {
-      const key = `${wd.goal_id ?? 'unallocated'}::${wd.fund_id}`
-      const e = fundWdMap.get(key) ?? { units: 0, cost: 0 }
-      e.units += wd.units_withdrawn ?? 0
-      e.cost += wd.principal_withdrawn ?? 0
-      fundWdMap.set(key, e)
-    } else if (wd.parent_transaction_id) {
-      const e = parentWdMap.get(wd.parent_transaction_id) ?? { principal: 0, units: 0 }
-      e.principal += wd.principal_withdrawn ?? 0
-      e.units += wd.units_withdrawn ?? 0
-      parentWdMap.set(wd.parent_transaction_id, e)
-    }
-  }
+  const { parentWdMap, fundWdMap } = buildWithdrawalMaps(withdrawals)
 
   const insuranceMembers = insuranceRes.data ?? []
   const goldPricePerChi: number | null = goldPriceRes.data?.price_per_chi ?? null

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -48,7 +48,7 @@ export async function POST(request: NextRequest) {
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const body = await request.json()
-  const { goal_id, asset_type, transaction_type = 'investment', investment_date, amount_vnd, unit_price, units, interest_rate, notes, fund_id, plan_id, expiry_date, parent_transaction_id, principal_withdrawn, units_withdrawn } = body
+  const { goal_id, asset_type, transaction_type = 'investment', investment_date, amount_vnd, unit_price, units, interest_rate, notes, fund_id, plan_id, expiry_date, parent_transaction_id, principal_withdrawn, units_withdrawn, affects_progress } = body
 
   const isWithdrawal = transaction_type === 'withdrawal'
 
@@ -114,6 +114,7 @@ export async function POST(request: NextRequest) {
       parent_transaction_id: parent_transaction_id || null,
       principal_withdrawn: principal_withdrawn ? Number(principal_withdrawn) : null,
       units_withdrawn: units_withdrawn ? Number(units_withdrawn) : null,
+      affects_progress: isWithdrawal ? (affects_progress !== false) : true,
     })
     .select()
     .single()

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -22,7 +22,7 @@ export async function GET(request: NextRequest) {
 
   let query = supabase
     .from('investment_transactions')
-    .select('transaction_id, goal_id, asset_type, transaction_type, parent_transaction_id, investment_date, amount_vnd, unit_price, units, interest_rate, expiry_date, notes, fund_id, principal_withdrawn, units_withdrawn, savings_goals(goal_name), funds(id, name, nav)', { count: 'exact' })
+    .select('transaction_id, goal_id, asset_type, transaction_type, parent_transaction_id, investment_date, amount_vnd, unit_price, units, interest_rate, expiry_date, notes, fund_id, principal_withdrawn, units_withdrawn, affects_progress, savings_goals(goal_name), funds(id, name, nav)', { count: 'exact' })
     .eq('user_id', user.id)
     .order('investment_date', { ascending: false })
     .range(offset, offset + limit - 1)

--- a/e2e/goals.spec.ts
+++ b/e2e/goals.spec.ts
@@ -155,3 +155,85 @@ test('un-assign investment from goal in Goal Detail', async ({ page }) => {
 
   await expect(page.getByTestId('unassign-btn')).toHaveCount(0, { timeout: 10_000 })
 })
+
+test('withdraw modal has affects-progress checkbox checked by default', async ({ page }) => {
+  const goal = await api.createGoal({ goal_name: 'E2E Withdraw Progress Goal', target_amount: 50_000_000 })
+  cleanup.add(() => api.deleteGoal(goal.goal_id))
+
+  const tx = await api.createTransaction({
+    asset_type: 'bank',
+    amount_vnd: 5_000_000,
+    investment_date: '2026-01-01',
+    goal_id: goal.goal_id,
+  })
+  cleanup.add(() => api.deleteTransaction(tx.transaction_id))
+
+  await page.goto(`/settings?tab=goals&goal=${goal.goal_id}`)
+  await page.waitForLoadState('networkidle')
+  await expect(page.getByTestId('goal-back-btn').first()).toBeVisible({ timeout: 15_000 })
+
+  // Switch to "Other" tab to reveal bank investment
+  await page.getByRole('button', { name: /tiết kiệm & khác|other investments/i }).first().click()
+
+  // Open withdraw modal
+  const withdrawBtn = page.getByRole('button', { name: /rút|withdraw/i }).first()
+  await expect(withdrawBtn).toBeVisible({ timeout: 10_000 })
+  await withdrawBtn.click()
+
+  await expect(page.getByRole('dialog')).toBeVisible()
+
+  // Checkbox must be present and checked by default
+  const checkbox = page.getByTestId('affects-progress-checkbox')
+  await expect(checkbox).toBeVisible({ timeout: 5_000 })
+  await expect(checkbox).toBeChecked()
+})
+
+test('withdraw with affects-progress unchecked stores affects_progress=false', async ({ page }) => {
+  const goal = await api.createGoal({ goal_name: 'E2E Withdraw No Progress Goal', target_amount: 50_000_000 })
+  cleanup.add(() => api.deleteGoal(goal.goal_id))
+
+  const tx = await api.createTransaction({
+    asset_type: 'bank',
+    amount_vnd: 10_000_000,
+    investment_date: '2026-01-01',
+    goal_id: goal.goal_id,
+  })
+  cleanup.add(() => api.deleteTransaction(tx.transaction_id))
+
+  await page.goto(`/settings?tab=goals&goal=${goal.goal_id}`)
+  await page.waitForLoadState('networkidle')
+  await expect(page.getByTestId('goal-back-btn').first()).toBeVisible({ timeout: 15_000 })
+
+  await page.getByRole('button', { name: /tiết kiệm & khác|other investments/i }).first().click()
+
+  const withdrawBtn = page.getByRole('button', { name: /rút|withdraw/i }).first()
+  await expect(withdrawBtn).toBeVisible({ timeout: 10_000 })
+  await withdrawBtn.click()
+
+  await expect(page.getByRole('dialog')).toBeVisible()
+
+  // Uncheck the affects-progress checkbox
+  const checkbox = page.getByTestId('affects-progress-checkbox')
+  await expect(checkbox).toBeChecked()
+  await checkbox.uncheck()
+  await expect(checkbox).not.toBeChecked()
+
+  // Fill required fields and submit
+  const principalInput = page.locator('[role="dialog"] input[type="text"], [role="dialog"] input[inputmode="numeric"]').first()
+  await principalInput.fill('5000000')
+  await page.getByRole('button', { name: /rút|withdraw/i }).last().click()
+
+  // Modal should close
+  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 10_000 })
+
+  // Verify via API that the withdrawal stored affects_progress=false
+  const { createClient } = await import('@supabase/supabase-js')
+  const supabase = createClient(process.env.E2E_SUPABASE_URL!, process.env.E2E_SUPABASE_SERVICE_ROLE_KEY!)
+  const { data: withdrawals } = await supabase
+    .from('investment_transactions')
+    .select('affects_progress')
+    .eq('parent_transaction_id', tx.transaction_id)
+    .eq('transaction_type', 'withdrawal')
+  expect(withdrawals).toHaveLength(1)
+  expect(withdrawals![0].affects_progress).toBe(false)
+})

--- a/lib/__tests__/withdrawalProgress.test.ts
+++ b/lib/__tests__/withdrawalProgress.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest'
+import { buildWithdrawalMaps, type WithdrawalRow } from '../withdrawalProgress'
+
+function makeWithdrawal(overrides: Partial<WithdrawalRow> = {}): WithdrawalRow {
+  return {
+    transaction_id: 'tx-1',
+    goal_id: 'goal-1',
+    asset_type: null,
+    fund_id: null,
+    parent_transaction_id: 'parent-1',
+    units_withdrawn: null,
+    principal_withdrawn: 1_000_000,
+    affects_progress: null,
+    ...overrides,
+  }
+}
+
+describe('buildWithdrawalMaps', () => {
+  describe('bank/gold withdrawals (parent_transaction_id)', () => {
+    it('includes withdrawal when affects_progress is null (default truthy)', () => {
+      const wd = makeWithdrawal({ affects_progress: null })
+      const { parentWdMap } = buildWithdrawalMaps([wd])
+      expect(parentWdMap.get('parent-1')).toEqual({ principal: 1_000_000, units: 0 })
+    })
+
+    it('includes withdrawal when affects_progress is true', () => {
+      const wd = makeWithdrawal({ affects_progress: true })
+      const { parentWdMap } = buildWithdrawalMaps([wd])
+      expect(parentWdMap.get('parent-1')).toEqual({ principal: 1_000_000, units: 0 })
+    })
+
+    it('excludes withdrawal when affects_progress is false', () => {
+      const wd = makeWithdrawal({ affects_progress: false })
+      const { parentWdMap } = buildWithdrawalMaps([wd])
+      expect(parentWdMap.has('parent-1')).toBe(false)
+    })
+
+    it('accumulates only affects_progress=true withdrawals in mixed array', () => {
+      const wds = [
+        makeWithdrawal({ transaction_id: 'tx-1', affects_progress: true, principal_withdrawn: 500_000 }),
+        makeWithdrawal({ transaction_id: 'tx-2', affects_progress: false, principal_withdrawn: 300_000 }),
+        makeWithdrawal({ transaction_id: 'tx-3', affects_progress: null, principal_withdrawn: 200_000 }),
+      ]
+      const { parentWdMap } = buildWithdrawalMaps(wds)
+      expect(parentWdMap.get('parent-1')).toEqual({ principal: 700_000, units: 0 })
+    })
+  })
+
+  describe('fund withdrawals (asset_type=fund + fund_id)', () => {
+    it('includes fund withdrawal when affects_progress is true', () => {
+      const wd = makeWithdrawal({
+        asset_type: 'fund',
+        fund_id: 'fund-1',
+        parent_transaction_id: null,
+        units_withdrawn: 100,
+        principal_withdrawn: 2_000_000,
+        affects_progress: true,
+      })
+      const { fundWdMap } = buildWithdrawalMaps([wd])
+      expect(fundWdMap.get('goal-1::fund-1')).toEqual({ units: 100, cost: 2_000_000 })
+    })
+
+    it('excludes fund withdrawal when affects_progress is false', () => {
+      const wd = makeWithdrawal({
+        asset_type: 'fund',
+        fund_id: 'fund-1',
+        parent_transaction_id: null,
+        units_withdrawn: 100,
+        principal_withdrawn: 2_000_000,
+        affects_progress: false,
+      })
+      const { fundWdMap } = buildWithdrawalMaps([wd])
+      expect(fundWdMap.has('goal-1::fund-1')).toBe(false)
+    })
+
+    it('uses "unallocated" key when goal_id is null', () => {
+      const wd = makeWithdrawal({
+        goal_id: null,
+        asset_type: 'fund',
+        fund_id: 'fund-1',
+        parent_transaction_id: null,
+        units_withdrawn: 50,
+        principal_withdrawn: 1_000_000,
+        affects_progress: true,
+      })
+      const { fundWdMap } = buildWithdrawalMaps([wd])
+      expect(fundWdMap.get('unallocated::fund-1')).toEqual({ units: 50, cost: 1_000_000 })
+    })
+  })
+
+  it('returns empty maps for empty input', () => {
+    const { parentWdMap, fundWdMap } = buildWithdrawalMaps([])
+    expect(parentWdMap.size).toBe(0)
+    expect(fundWdMap.size).toBe(0)
+  })
+})

--- a/lib/withdrawalProgress.ts
+++ b/lib/withdrawalProgress.ts
@@ -1,0 +1,40 @@
+export type WithdrawalRow = {
+  transaction_id: string
+  goal_id: string | null
+  asset_type: string | null
+  fund_id: string | null
+  parent_transaction_id: string | null
+  units_withdrawn: number | null
+  principal_withdrawn: number | null
+  affects_progress: boolean | null
+}
+
+export type ParentWdMap = Map<string, { principal: number; units: number }>
+export type FundWdMap = Map<string, { units: number; cost: number }>
+
+export function buildWithdrawalMaps(withdrawals: WithdrawalRow[]): {
+  parentWdMap: ParentWdMap
+  fundWdMap: FundWdMap
+} {
+  const parentWdMap: ParentWdMap = new Map()
+  const fundWdMap: FundWdMap = new Map()
+
+  for (const wd of withdrawals) {
+    if (wd.affects_progress === false) continue
+
+    if (wd.asset_type === 'fund' && wd.fund_id) {
+      const key = `${wd.goal_id ?? 'unallocated'}::${wd.fund_id}`
+      const e = fundWdMap.get(key) ?? { units: 0, cost: 0 }
+      e.units += wd.units_withdrawn ?? 0
+      e.cost += wd.principal_withdrawn ?? 0
+      fundWdMap.set(key, e)
+    } else if (wd.parent_transaction_id) {
+      const e = parentWdMap.get(wd.parent_transaction_id) ?? { principal: 0, units: 0 }
+      e.principal += wd.principal_withdrawn ?? 0
+      e.units += wd.units_withdrawn ?? 0
+      parentWdMap.set(wd.parent_transaction_id, e)
+    }
+  }
+
+  return { parentWdMap, fundWdMap }
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -154,6 +154,7 @@
     "amountReceivedPlaceholder": "Total amount received from bank",
     "unitsToSellGold": "Chi to sell",
     "unitsToSellFund": "Units to sell",
+    "affectsProgressLabel": "Count toward goal progress",
     "costBasisLabel": "Cost basis",
     "receivedLabel": "Received",
     "currentPriceLabel": "Current price",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -154,6 +154,7 @@
     "amountReceivedPlaceholder": "Tổng tiền ngân hàng trả",
     "unitsToSellGold": "Chi bán",
     "unitsToSellFund": "Đơn vị bán",
+    "affectsProgressLabel": "Tính vào tiến độ mục tiêu",
     "costBasisLabel": "Giá vốn",
     "receivedLabel": "Nhận được",
     "currentPriceLabel": "Giá hiện tại",

--- a/supabase/migrations/20260505000001_add_affects_progress_to_withdrawals.sql
+++ b/supabase/migrations/20260505000001_add_affects_progress_to_withdrawals.sql
@@ -1,0 +1,2 @@
+ALTER TABLE investment_transactions
+  ADD COLUMN IF NOT EXISTS affects_progress BOOLEAN NOT NULL DEFAULT true;


### PR DESCRIPTION
## Summary

- Adds a **\"Count toward goal progress\"** checkbox to the withdraw modal (checked by default)
- When unchecked, the withdrawal is saved with `affects_progress = false` and excluded from progress bar calculations — the bar stays unchanged
- When checked (default), behaviour is identical to before: the withdrawal reduces `currentValue` and lowers the progress bar

## Changes

- **DB migration**: `affects_progress BOOLEAN NOT NULL DEFAULT true` on `investment_transactions`
- **`lib/withdrawalProgress.ts`**: Pure helper `buildWithdrawalMaps()` extracted from the dashboard route, filters out `affects_progress = false` withdrawals
- **`app/api/v1/dashboard/overview/route.ts`**: Uses the helper; adds `affects_progress` to the Supabase select
- **`app/api/v1/investment-transactions/route.ts`**: Accepts and stores `affects_progress` from request body
- **`app/(app)/settings/tabs/GoalDetailView.tsx`**: Checkbox added after the Notes field in the withdraw modal
- **i18n**: Added `affectsProgressLabel` key to both `en.json` and `vi.json`

## Test plan

- [x] Unit tests: 8 passing — `buildWithdrawalMaps` correctly filters `affects_progress = false` rows
- [x] E2E: 2 new tests — checkbox presence + `affects_progress=false` stored on submit
- [x] Manual: Open withdraw modal → checkbox visible and checked by default
- [x] Manual: Uncheck → submit → progress bar unchanged on dashboard
- [x] Manual: Leave checked → submit → progress bar decreases as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)