### PR TITLE
feat(design): Phase 1 — design tokens, DM Sans font, mobile bottom tabs

### DIFF
--- a/app/components/layouts/AuthenticatedLayout.tsx
+++ b/app/components/layouts/AuthenticatedLayout.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { createBrowserClient } from '@supabase/ssr'
 import { toast } from 'sonner'
 import { NavigationProvider } from '../navigation/NavigationContext'
 import Sidebar from '../navigation/Sidebar'
 import Header from '../navigation/Header'
-import MobileDrawer from '../navigation/MobileDrawer'
+import MobileBottomTabs from '../navigation/MobileBottomTabs'
 import { PageTitle } from '../navigation/Breadcrumb'
 import OfflineBanner from '@/app/components/OfflineBanner'
 
@@ -21,37 +21,25 @@ function getInitials(email: string): string {
 }
 
 function AuthenticatedLayoutInner({ children, email, initials }: { children: React.ReactNode; email: string; initials: string }) {
-  const [drawerOpen, setDrawerOpen] = useState(false)
-
   return (
-    <div className="flex h-screen bg-gray-50 dark:bg-gray-950 overflow-hidden">
-      {/* Desktop sidebar */}
-      <div className="hidden lg:flex shrink-0">
+    <div className="flex h-screen bg-canvas dark:bg-gray-950 overflow-hidden">
+      {/* Sidebar (tablet + desktop only) */}
+      <div className="hidden md:flex shrink-0">
         <Sidebar email={email} initials={initials} />
       </div>
-
-      {/* Tablet sidebar */}
-      <div className="hidden md:flex lg:hidden shrink-0">
-        <Sidebar email={email} initials={initials} />
-      </div>
-
-      {/* Mobile drawer */}
-      <MobileDrawer
-        open={drawerOpen}
-        onClose={() => setDrawerOpen(false)}
-        email={email}
-        initials={initials}
-      />
 
       {/* Main area */}
       <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
-        <Header onMobileMenuToggle={() => setDrawerOpen(true)} />
+        <Header />
         {/* Mobile page title */}
         <PageTitle />
-        <main className="flex-1 overflow-y-auto px-6 py-4">
+        <main className="flex-1 overflow-y-auto px-4 md:px-6 py-4 pb-20 md:pb-4">
           {children}
         </main>
       </div>
+
+      {/* Mobile bottom tab navigation */}
+      <MobileBottomTabs />
       <OfflineBanner />
     </div>
   )

--- a/app/components/navigation/Header.tsx
+++ b/app/components/navigation/Header.tsx
@@ -1,62 +1,51 @@
 'use client'
 
-import { Menu, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
+import { PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import Breadcrumb from './Breadcrumb'
 import UserMenu from './UserMenu'
 import { useNavigation } from './NavigationContext'
 import ThemeToggleButton from '../ThemeToggleButton'
 import { useTranslations } from 'next-intl'
 
-interface HeaderProps {
-  onMobileMenuToggle: () => void
-}
-
-export default function Header({ onMobileMenuToggle }: HeaderProps) {
+export default function Header() {
   const { sidebarCollapsed, setSidebarCollapsed } = useNavigation()
   const tc = useTranslations('common')
 
   return (
-    <header className="h-16 bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-700 flex items-center px-6 gap-4 shrink-0">
-      {/* Mobile hamburger */}
-      <button
-        onClick={onMobileMenuToggle}
-        aria-label="Toggle navigation menu"
-        className="lg:hidden p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-gray-600 dark:text-gray-400"
-      >
-        <Menu size={20} />
-      </button>
-
-      {/* Tablet sidebar toggle */}
+    <header className="h-14 bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-700 flex items-center px-4 md:px-6 gap-3 shrink-0">
+      {/* Tablet sidebar collapse toggle */}
       <button
         onClick={() => setSidebarCollapsed(!sidebarCollapsed)}
         aria-label={sidebarCollapsed ? tc('expandMenu') : tc('collapseMenu')}
-        className="hidden md:flex lg:hidden p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-gray-600 dark:text-gray-400"
+        className="hidden md:flex lg:hidden p-1.5 rounded hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors text-gray-500 dark:text-gray-400"
       >
-        {sidebarCollapsed ? <PanelLeftOpen size={20} /> : <PanelLeftClose size={20} />}
+        {sidebarCollapsed ? <PanelLeftOpen size={18} /> : <PanelLeftClose size={18} />}
       </button>
 
-      {/* Mobile center logo */}
-      <div className="lg:hidden flex-1 flex items-center justify-center gap-2">
+      {/* Mobile logo (no sidebar visible) */}
+      <div className="md:hidden flex items-center gap-2">
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img
           src="/cairn-icon.svg"
           alt="Cairn logo"
-          width={28}
-          height={28}
-          className="h-7 w-7 rounded-md"
+          width={26}
+          height={26}
+          className="h-6.5 w-6.5 rounded-md"
         />
-        <span className="text-brand font-bold text-lg tracking-tight">Cairn</span>
+        <span className="text-brand font-bold text-base tracking-tight">Cairn</span>
       </div>
 
-      {/* Breadcrumb (desktop/tablet only) */}
+      {/* Breadcrumb (tablet + desktop) */}
       <div className="hidden md:block flex-1">
         <Breadcrumb />
       </div>
 
+      <div className="flex-1 md:hidden" />
+
       {/* Theme toggle */}
       <ThemeToggleButton />
 
-      {/* Logout */}
+      {/* User menu */}
       <UserMenu />
     </header>
   )

--- a/app/components/navigation/MobileBottomTabs.tsx
+++ b/app/components/navigation/MobileBottomTabs.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { LayoutDashboard, Calendar, LineChart, Settings } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+
+const TABS = [
+  { href: '/dashboard', icon: LayoutDashboard, key: 'dashboard' },
+  { href: '/planning',  icon: Calendar,         key: 'planning'  },
+  { href: '/funds',     icon: LineChart,         key: 'funds'     },
+  { href: '/settings',  icon: Settings,          key: 'settings'  },
+] as const
+
+export default function MobileBottomTabs() {
+  const pathname = usePathname()
+  const t = useTranslations('nav')
+
+  return (
+    <nav
+      className="fixed bottom-0 left-0 right-0 z-40 md:hidden"
+      style={{
+        background: 'rgba(255, 255, 255, 0.92)',
+        backdropFilter: 'saturate(140%) blur(16px)',
+        WebkitBackdropFilter: 'saturate(140%) blur(16px)',
+        borderTop: '1px solid var(--c-line)',
+        paddingBottom: 'env(safe-area-inset-bottom, 0)',
+      }}
+    >
+      <div className="dark:bg-gray-900/90 dark:border-gray-700/80" style={{ borderTop: 'inherit', background: 'inherit' }}>
+        <div className="grid grid-cols-4 px-1 py-1.5">
+          {TABS.map(({ href, icon: Icon, key }) => {
+            const isActive = pathname.startsWith(href)
+            return (
+              <Link
+                key={href}
+                href={href}
+                className="flex flex-col items-center gap-0.5 py-2 rounded-xl transition-colors"
+                style={{
+                  color: isActive ? 'var(--c-navy)' : 'var(--c-muted)',
+                }}
+              >
+                <Icon size={22} strokeWidth={isActive ? 2.2 : 1.6} />
+                <span
+                  style={{
+                    fontSize: '10.5px',
+                    fontWeight: isActive ? 600 : 500,
+                    letterSpacing: '0.01em',
+                    lineHeight: 1,
+                  }}
+                >
+                  {t(key)}
+                </span>
+              </Link>
+            )
+          })}
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -14,6 +14,31 @@
   --brand: #0F2A4A;            /* navy — wordmark, primary brand text */
   --brand-light: #ecfdf5;      /* emerald-50 — soft accent bg / hover surface */
   --brand-dark: #10B981;       /* emerald — active state / strong accent */
+
+  /* Cairn design system tokens (mobile redesign) */
+  --c-canvas: #faf8f4;
+  --c-card: #ffffff;
+  --c-card-2: #f5f2ec;
+  --c-line: #e9e5dc;
+  --c-line-strong: #d8d3c5;
+  --c-ink: #18181b;
+  --c-ink-2: #3f3f46;
+  --c-muted: #78716c;
+  --c-muted-2: #a8a29e;
+  --c-navy: #0F2A4A;
+  --c-navy-2: #1e3a63;
+  --c-navy-tint: #eef2f8;
+  --c-pos: #047857;
+  --c-pos-tint: #ecfdf5;
+  --c-neg: #b91c1c;
+  --c-neg-tint: #fef2f2;
+  --c-warn: #b45309;
+  --c-warn-tint: #fef7e6;
+  --c-accent-fund: #2563eb;
+  --c-accent-savings: #047857;
+  --c-accent-fixed: #b45309;
+  --c-accent-insurance: #7c3aed;
+  --c-accent-other: #475569;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
   --card: oklch(1 0 0);
@@ -54,7 +79,8 @@
   --color-brand: var(--brand);
   --color-brand-light: var(--brand-light);
   --color-brand-dark: var(--brand-dark);
-  --font-sans: "Geist", "Geist Fallback", ui-sans-serif, system-ui, sans-serif;
+  --color-canvas: var(--c-canvas);
+  --font-sans: "DM Sans", var(--font-dm-sans), "Geist", var(--font-geist), ui-sans-serif, system-ui, sans-serif;
   --font-mono: ui-monospace, monospace;
   --font-heading: var(--font-sans);
   --color-sidebar-ring: var(--sidebar-ring);
@@ -104,6 +130,22 @@
   --brand: #F8FAFC;            /* cream — wordmark on dark */
   --brand-light: #0F2A4A;      /* navy — brand-tinted surface in dark mode */
   --brand-dark: #34D399;       /* mint — active state / strong accent */
+
+  /* Cairn design system tokens — dark overrides */
+  --c-canvas: #0a0a0a;
+  --c-card: #161616;
+  --c-card-2: #222222;
+  --c-line: #2a2a2a;
+  --c-line-strong: #3a3a3a;
+  --c-ink: #f5f5f5;
+  --c-ink-2: #d4d4d4;
+  --c-muted: #a3a3a3;
+  --c-muted-2: #737373;
+  --c-navy: #f8fafc;
+  --c-navy-tint: #1a2540;
+  --c-pos-tint: rgba(4, 120, 87, 0.15);
+  --c-neg-tint: rgba(185, 28, 28, 0.15);
+  --c-warn-tint: rgba(180, 83, 9, 0.15);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next'
-import { Inter, Geist } from 'next/font/google'
+import { DM_Sans, Geist } from 'next/font/google'
 import { Toaster } from 'sonner'
 import ThemeProvider from './components/ThemeProvider'
 import ServiceWorkerRegistration from './components/ServiceWorkerRegistration'
@@ -8,12 +8,13 @@ import { getMessages, getLocale } from 'next-intl/server'
 import './globals.css'
 import { cn } from "@/lib/utils";
 
-const geist = Geist({subsets:['latin'],variable:'--font-sans'});
-
-const inter = Inter({
-  subsets: ['latin'],
-  variable: '--font-inter',
+const dmSans = DM_Sans({
+  subsets: ['latin', 'latin-ext'],
+  variable: '--font-dm-sans',
+  weight: ['400', '500', '600', '700'],
 })
+
+const geist = Geist({subsets:['latin'],variable:'--font-geist'});
 
 export const viewport: Viewport = {
   width: 'device-width',
@@ -47,11 +48,11 @@ export default async function RootLayout({
   const locale = await getLocale()
 
   return (
-    <html lang={locale} suppressHydrationWarning className={cn("font-sans", geist.variable)}>
+    <html lang={locale} suppressHydrationWarning className={cn("font-sans", dmSans.variable, geist.variable)}>
       <head>
         <script dangerouslySetInnerHTML={{ __html: `try{var t=localStorage.getItem('theme');if(t==='dark'||(!t&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}` }} />
       </head>
-      <body className={`${inter.variable} font-sans antialiased bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100`}>
+      <body className={`${dmSans.variable} font-sans antialiased bg-canvas dark:bg-gray-950 text-gray-900 dark:text-gray-100`}>
         <NextIntlClientProvider messages={messages} locale={locale}>
           <ThemeProvider>
             {children}

--- a/e2e/investments.spec.ts
+++ b/e2e/investments.spec.ts
@@ -10,7 +10,11 @@ async function openTransactionsTab(page: import('@playwright/test').Page) {
   await page.evaluate(() => {
     Object.keys(localStorage).filter(k => k.includes('transaction') || k.includes('Transaction')).forEach(k => localStorage.removeItem(k))
   })
-  await page.goto('/settings?tab=transactions')
+  // Wait for the API response to ensure the table is populated before any assertion
+  await Promise.all([
+    page.waitForResponse(r => r.url().includes('/api/v1/investment-transactions') && r.status() === 200, { timeout: 20_000 }),
+    page.goto('/settings?tab=transactions'),
+  ])
   await page.waitForSelector('[data-testid="create-btn"]', { timeout: 15_000 })
 }
 
@@ -30,7 +34,10 @@ test('can add a bank transaction', async ({ page }) => {
   await page.getByLabel(/date|ngày/i).first().fill('2026-01-15')
   await page.getByLabel(/amount|số tiền/i).first().fill('10000000')
 
-  await page.getByRole('button', { name: /save|create|lưu/i }).click()
+  await Promise.all([
+    page.waitForResponse(r => r.url().includes('/api/v1/investment-transactions') && r.status() === 200, { timeout: 15_000 }),
+    page.getByRole('button', { name: /save|create|lưu/i }).click(),
+  ])
   await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5_000 })
 
   // Scope to table row to avoid matching hidden sm:hidden mobile cards or <option> elements
@@ -54,7 +61,10 @@ test('can add a gold transaction', async ({ page }) => {
   await page.getByLabel(/chi|chỉ/i).first().fill('1')
   await page.getByLabel(/unit price|giá/i).first().fill('8500000')
 
-  await page.getByRole('button', { name: /save|create|lưu/i }).click()
+  await Promise.all([
+    page.waitForResponse(r => r.url().includes('/api/v1/investment-transactions') && r.status() === 200, { timeout: 15_000 }),
+    page.getByRole('button', { name: /save|create|lưu/i }).click(),
+  ])
   await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5_000 })
 
   await expect(page.locator('tr').filter({ hasText: /gold|vàng/i }).first()).toBeVisible({ timeout: 15_000 })

--- a/e2e/investments.spec.ts
+++ b/e2e/investments.spec.ts
@@ -2,6 +2,9 @@ import { test, expect } from '@playwright/test'
 import * as api from './helpers/api'
 import { makeCleanupStack } from './helpers/cleanup'
 
+// API rejects future dates — use today so the row sorts to top of page 1
+const TODAY = new Date().toISOString().slice(0, 10)
+
 const cleanup = makeCleanupStack()
 test.afterEach(() => cleanup.run())
 
@@ -31,7 +34,7 @@ test('can add a bank transaction', async ({ page }) => {
   await expect(page.getByRole('dialog')).toBeVisible()
 
   // Bank is the default asset type — no selection needed
-  await page.getByLabel(/date|ngày/i).first().fill('2099-12-31')
+  await page.getByLabel(/date|ngày/i).first().fill(TODAY)
   await page.getByLabel(/amount|số tiền/i).first().fill('10000000')
 
   await Promise.all([
@@ -56,7 +59,7 @@ test('can add a gold transaction', async ({ page }) => {
   await page.locator('#asset_type').click()
   await page.locator('[data-open] [role="option"]:not(option)').filter({ hasText: /gold|vàng/i }).click({ force: true })
 
-  await page.getByLabel(/date|ngày/i).first().fill('2099-12-31')
+  await page.getByLabel(/date|ngày/i).first().fill(TODAY)
   await page.getByLabel(/amount|số tiền/i).first().fill('8500000')
   await page.getByLabel(/chi|chỉ/i).first().fill('1')
   await page.getByLabel(/unit price|giá/i).first().fill('8500000')
@@ -92,12 +95,15 @@ test('can add a fund transaction', async ({ page }) => {
   await openFundOption.waitFor({ state: 'visible', timeout: 5_000 })
   await openFundOption.click({ force: true })
 
-  await page.getByLabel(/date|ngày/i).first().fill('2099-12-31')
+  await page.getByLabel(/date|ngày/i).first().fill(TODAY)
   await page.getByLabel(/amount|số tiền/i).first().fill('5000000')
   await page.getByLabel(/units|ccq/i).first().fill('200')
   await page.getByLabel(/\bnav\b|purchase/i).first().fill(String(fund!.nav))
 
-  await page.getByRole('button', { name: /save|create|lưu/i }).click()
+  await Promise.all([
+    page.waitForResponse(r => r.url().includes('/api/v1/investment-transactions') && r.status() === 200, { timeout: 15_000 }),
+    page.getByRole('button', { name: /save|create|lưu/i }).click(),
+  ])
   await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5_000 })
 
   await expect(page.locator('tr').filter({ hasText: fund!.code }).first()).toBeVisible({ timeout: 15_000 })

--- a/e2e/investments.spec.ts
+++ b/e2e/investments.spec.ts
@@ -107,8 +107,8 @@ test('can add a fund transaction', async ({ page }) => {
 })
 
 test('filter by asset type shows only matching rows', async ({ page }) => {
-  const bankTx = await api.createTransaction({ asset_type: 'bank', amount_vnd: 5_000_000, investment_date: '2026-01-01' })
-  const goldTx = await api.createTransaction({ asset_type: 'gold', amount_vnd: 8_500_000, investment_date: '2026-01-01', units: 1, unit_price: 8_500_000 })
+  const bankTx = await api.createTransaction({ asset_type: 'bank', amount_vnd: 5_000_000, investment_date: '2099-12-31' })
+  const goldTx = await api.createTransaction({ asset_type: 'gold', amount_vnd: 8_500_000, investment_date: '2099-12-31', units: 1, unit_price: 8_500_000 })
   cleanup.add(() => api.deleteTransaction(bankTx.transaction_id))
   cleanup.add(() => api.deleteTransaction(goldTx.transaction_id))
 
@@ -127,7 +127,7 @@ test('filter by asset type shows only matching rows', async ({ page }) => {
 test('can delete a transaction', async ({ page }) => {
   await api.deleteAllTransactionsByNotes('E2E Delete TX')
 
-  const tx = await api.createTransaction({ asset_type: 'bank', amount_vnd: 9_999_000, investment_date: '2026-01-01', notes: 'E2E Delete TX' })
+  const tx = await api.createTransaction({ asset_type: 'bank', amount_vnd: 9_999_000, investment_date: '2099-12-31', notes: 'E2E Delete TX' })
   cleanup.add(() => api.deleteTransaction(tx.transaction_id))
 
   await openTransactionsTab(page)

--- a/e2e/investments.spec.ts
+++ b/e2e/investments.spec.ts
@@ -31,7 +31,7 @@ test('can add a bank transaction', async ({ page }) => {
   await expect(page.getByRole('dialog')).toBeVisible()
 
   // Bank is the default asset type — no selection needed
-  await page.getByLabel(/date|ngày/i).first().fill('2026-01-15')
+  await page.getByLabel(/date|ngày/i).first().fill('2099-12-31')
   await page.getByLabel(/amount|số tiền/i).first().fill('10000000')
 
   await Promise.all([
@@ -56,7 +56,7 @@ test('can add a gold transaction', async ({ page }) => {
   await page.locator('#asset_type').click()
   await page.locator('[data-open] [role="option"]:not(option)').filter({ hasText: /gold|vàng/i }).click({ force: true })
 
-  await page.getByLabel(/date|ngày/i).first().fill('2026-01-15')
+  await page.getByLabel(/date|ngày/i).first().fill('2099-12-31')
   await page.getByLabel(/amount|số tiền/i).first().fill('8500000')
   await page.getByLabel(/chi|chỉ/i).first().fill('1')
   await page.getByLabel(/unit price|giá/i).first().fill('8500000')
@@ -92,7 +92,7 @@ test('can add a fund transaction', async ({ page }) => {
   await openFundOption.waitFor({ state: 'visible', timeout: 5_000 })
   await openFundOption.click({ force: true })
 
-  await page.getByLabel(/date|ngày/i).first().fill('2026-01-15')
+  await page.getByLabel(/date|ngày/i).first().fill('2099-12-31')
   await page.getByLabel(/amount|số tiền/i).first().fill('5000000')
   await page.getByLabel(/units|ccq/i).first().fill('200')
   await page.getByLabel(/\bnav\b|purchase/i).first().fill(String(fund!.nav))


### PR DESCRIPTION
## Summary

- **Design tokens**: Adds `--c-canvas`, `--c-navy`, `--c-pos`, `--c-neg`, `--c-warn`, section accent color variables to `globals.css` with dark-mode overrides — matching the Cairn mobile redesign spec
- **DM Sans font**: Replaces Geist as primary font; `latin-ext` subset for Vietnamese coverage
- **Mobile bottom tabs**: New `MobileBottomTabs` (frosted-glass, fixed bottom, hidden on `md+`) replaces mobile drawer — Dashboard / Plan / Funds / Settings, active state from `usePathname`
- **Sidebar on md+**: Tablet now always shows the sidebar (was hidden behind a drawer)
- **Cleanup**: Removes `MobileDrawer` and hamburger button; `Header` simplified

## Test plan

- [ ] Mobile: bottom tabs visible, no hamburger, content clears the tab bar
- [ ] Tablet: sidebar + collapse toggle, no bottom tabs
- [ ] Desktop: sidebar, no bottom tabs
- [ ] Dark mode: tab bar and canvas adapt correctly
- [ ] Tab active state changes on navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)