### PR TITLE
feat(sell-withdraw): SellWithdrawSheet bottom sheet (PR 2)

### DIFF
--- a/app/api/v1/dashboard/history/route.ts
+++ b/app/api/v1/dashboard/history/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: Request) {
   // Not enough snapshots yet — synthesize monthly history from investment transactions
   const { data: txData } = await supabase
     .from('investment_transactions')
-    .select('investment_date, amount_vnd')
+    .select('investment_date, amount_vnd, transaction_type')
     .eq('user_id', user.id)
     .order('investment_date', { ascending: true })
 
@@ -55,13 +55,13 @@ export async function GET(request: Request) {
     )
   }
 
-  // Group by month, compute running cumulative invested amount
+  // Group by month, compute running cumulative invested amount (withdrawals reduce the total)
   const monthlyMap = new Map<string, number>()
   let cumulative = 0
   for (const tx of txData) {
     const month = tx.investment_date.slice(0, 7) // YYYY-MM
-    cumulative += tx.amount_vnd
-    monthlyMap.set(month, cumulative)
+    cumulative += tx.transaction_type === 'withdrawal' ? -tx.amount_vnd : tx.amount_vnd
+    monthlyMap.set(month, Math.max(0, cumulative))
   }
 
   // Filter by time range

--- a/app/api/v1/dashboard/history/route.ts
+++ b/app/api/v1/dashboard/history/route.ts
@@ -28,21 +28,26 @@ export async function GET(request: Request) {
   const { data: snapshots, error } = await snapshotQuery
   if (error) return NextResponse.json({ error: 'Failed to fetch history' }, { status: 500 })
 
-  // If we have enough real snapshots, return them directly
-  if ((snapshots ?? []).length >= 2) {
+  // If we have enough real snapshots, return them — filtering out any zero-value rows
+  // that can appear when a snapshot was saved during a now-deleted sell transaction.
+  const validSnapshots = (snapshots ?? []).filter((r) => r.total_assets > 0)
+  if (validSnapshots.length >= 2) {
     return NextResponse.json(
-      snapshots!.map((row) => ({
+      validSnapshots.map((row) => ({
         label: new Date(row.snapshot_date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
         value: row.total_assets,
       }))
     )
   }
 
-  // Not enough snapshots yet — synthesize monthly history from investment transactions
+  // Not enough snapshots yet — synthesize monthly history from investment transactions only.
+  // Withdrawals are intentionally excluded: they are recorded at market value which can exceed
+  // original cost, driving the cumulative negative and causing a visual cliff.
   const { data: txData } = await supabase
     .from('investment_transactions')
-    .select('investment_date, amount_vnd, transaction_type')
+    .select('investment_date, amount_vnd')
     .eq('user_id', user.id)
+    .eq('transaction_type', 'investment')
     .order('investment_date', { ascending: true })
 
   if (!txData || txData.length === 0) {
@@ -55,13 +60,13 @@ export async function GET(request: Request) {
     )
   }
 
-  // Group by month, compute running cumulative invested amount (withdrawals reduce the total)
+  // Group by month, compute running cumulative invested amount
   const monthlyMap = new Map<string, number>()
   let cumulative = 0
   for (const tx of txData) {
     const month = tx.investment_date.slice(0, 7) // YYYY-MM
-    cumulative += tx.transaction_type === 'withdrawal' ? -tx.amount_vnd : tx.amount_vnd
-    monthlyMap.set(month, Math.max(0, cumulative))
+    cumulative += tx.amount_vnd
+    monthlyMap.set(month, cumulative)
   }
 
   // Filter by time range

--- a/app/api/v1/dashboard/history/route.ts
+++ b/app/api/v1/dashboard/history/route.ts
@@ -73,14 +73,5 @@ export async function GET(request: Request) {
       value,
     }))
 
-  // Replace the last point with today's real snapshot (accurate market value) if available
-  const todaySnapshot = (snapshots ?? [])[0]
-  if (todaySnapshot && syntheticPoints.length > 0) {
-    syntheticPoints[syntheticPoints.length - 1] = {
-      label: new Date(todaySnapshot.snapshot_date + 'T00:00:00').toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-      value: todaySnapshot.total_assets,
-    }
-  }
-
   return NextResponse.json(syntheticPoints)
 }

--- a/app/api/v1/dashboard/history/route.ts
+++ b/app/api/v1/dashboard/history/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET(request: Request) {
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()

--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -3,6 +3,8 @@ import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { calcProjectedInterest, isNavStale, insuranceStatus } from '@/lib/finance'
 import { buildWithdrawalMaps } from '@/lib/withdrawalProgress'
 
+export const dynamic = 'force-dynamic'
+
 export async function GET() {
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -217,6 +217,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
   const [sellItem, setSellItem] = useState<SellItem | null>(null)
   const [sellSheetOpen, setSellSheetOpen] = useState(false)
   const [isGeneratingReport, setIsGeneratingReport] = useState(false)
+  const [historyKey, setHistoryKey] = useState(0)
   const [pullY, setPullY] = useState(0)
   const PULL_THRESHOLD = 65
 
@@ -240,6 +241,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
       } else {
         const json = await res.json()
         setData(json)
+        setHistoryKey((k) => k + 1)
         setCachedOverview(userId, json)
         try { localStorage.setItem('pwa_last_fetch', String(Date.now())) } catch {}
       }
@@ -647,6 +649,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
             <div className="space-y-4">
               <NetWorthCard
                 {...data.netWorth}
+                refreshKey={historyKey}
                 allocationBar={allocationTotals ? {
                   fund: allocationTotals.equityTotal + allocationTotals.bondTotal + allocationTotals.balancedTotal,
                   bank: allocationTotals.bankTotal,

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -222,25 +222,29 @@ export default function DashboardClient({ userId }: { userId: string }) {
   const PULL_THRESHOLD = 65
 
   const fetchDataRef = useRef<(opts?: { force?: boolean }) => Promise<void>>(async () => {})
+  const hasDataRef = useRef(false)
   const touchStartY = useRef(-1)
 
   const fetchData = useCallback(async (opts?: { force?: boolean }) => {
     const cached = !opts?.force && getCachedOverview(userId)
     if (cached) {
       setData(cached)
+      hasDataRef.current = true
       setLoading(false)
       return
     }
-    setLoading(true)
+    // Only show skeleton on initial load — if data is already visible, refresh silently
+    if (!hasDataRef.current) setLoading(true)
     setError('')
     try {
-      const res = await fetch('/api/v1/dashboard/overview')
+      const res = await fetch('/api/v1/dashboard/overview', { cache: 'no-store' })
       if (!res.ok) {
         const { error: e } = await res.json()
         setError(e ?? tc('error'))
       } else {
         const json = await res.json()
         setData(json)
+        hasDataRef.current = true
         setHistoryKey((k) => k + 1)
         setCachedOverview(userId, json)
         try { localStorage.setItem('pwa_last_fetch', String(Date.now())) } catch {}

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -18,6 +18,7 @@ import GoalCard from './components/GoalCard'
 import UnallocatedSection from './components/UnallocatedSection'
 import InsuranceCard from './components/InsuranceCard'
 import AssetAllocationPie from './components/AssetAllocationPie'
+import { SellWithdrawSheet, type SellItem } from './components/SellWithdrawSheet'
 
 const FundDetailModal = dynamic(() => import('./components/FundDetailModal'))
 const GoalPickerModal = dynamic(() => import('./components/GoalPickerModal'))
@@ -213,19 +214,8 @@ export default function DashboardClient({ userId }: { userId: string }) {
   const [goalDesc, setGoalDesc] = useState('')
   const [goalSaving, setGoalSaving] = useState(false)
   const [goalError, setGoalError] = useState('')
-  const [sellFund, setSellFund] = useState<FundBreakdownItem | null>(null)
-  const [sellDate, setSellDate] = useState('')
-  const [sellUnits, setSellUnits] = useState('')
-  const [sellAmount, setSellAmount] = useState('')
-  const [sellSaving, setSellSaving] = useState(false)
-  const [sellError, setSellError] = useState('')
-  const [sellNonFund, setSellNonFund] = useState<NonFundUnallocatedItem | null>(null)
-  const [nfDate, setNfDate] = useState('')
-  const [nfPrincipal, setNfPrincipal] = useState('')
-  const [nfUnits, setNfUnits] = useState('')
-  const [nfAmount, setNfAmount] = useState('')
-  const [nfSaving, setNfSaving] = useState(false)
-  const [nfError, setNfError] = useState('')
+  const [sellItem, setSellItem] = useState<SellItem | null>(null)
+  const [sellSheetOpen, setSellSheetOpen] = useState(false)
   const [isGeneratingReport, setIsGeneratingReport] = useState(false)
   const [pullY, setPullY] = useState(0)
   const PULL_THRESHOLD = 65
@@ -408,118 +398,32 @@ export default function DashboardClient({ userId }: { userId: string }) {
   }, [userName, isGeneratingReport, data])
 
   function openSellFund(fund: FundBreakdownItem) {
-    setSellFund(fund)
-    setSellDate(new Date().toISOString().slice(0, 10))
-    setSellUnits('')
-    setSellAmount('')
-    setSellError('')
-  }
-
-  async function handleSellFundSubmit() {
-    if (!sellFund) return
-    const units = parseFloat(sellUnits)
-    const amount = Number(sellAmount)
-    if (!sellDate) { setSellError('Date is required'); return }
-    if (!units || units <= 0) { setSellError('Units must be greater than 0'); return }
-    if (units > sellFund.quantity) { setSellError('Units exceed available balance'); return }
-    if (!amount || amount <= 0) { setSellError('Amount must be greater than 0'); return }
-
-    setSellSaving(true)
-    setSellError('')
-    try {
-      const principalWithdrawn = Math.round(units * sellFund.purchasePrice)
-      const res = await fetch('/api/v1/investment-transactions', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          transaction_type: 'withdrawal',
-          asset_type: 'fund',
-          fund_id: sellFund.fundId,
-          investment_date: sellDate,
-          amount_vnd: Math.round(amount),
-          units_withdrawn: units,
-          principal_withdrawn: principalWithdrawn,
-          goal_id: null,
-        }),
-      })
-      if (!res.ok) {
-        const { error } = await res.json()
-        setSellError(error ?? 'Failed to record sale')
-      } else {
-        setSellFund(null)
-        await fetchData({ force: true })
-      }
-    } catch {
-      setSellError('Unable to save. Please check your connection.')
-    }
-    setSellSaving(false)
+    setSellItem({
+      type: 'fund',
+      name: fund.fundName,
+      currentValue: fund.currentValue,
+      units: fund.quantity,
+      navPerUnit: fund.currentNAV,
+      gainPct: fund.profitLossPercentage,
+      fundId: fund.fundId,
+      purchasePrice: fund.purchasePrice,
+    })
+    setSellSheetOpen(true)
   }
 
   function openSellNonFund(item: NonFundUnallocatedItem) {
-    setSellNonFund(item)
-    setNfDate(new Date().toISOString().slice(0, 10))
-    setNfPrincipal('')
-    setNfUnits('')
-    setNfAmount('')
-    setNfError('')
-  }
-
-  async function handleSellNonFundSubmit() {
-    if (!sellNonFund) return
-    const date = nfDate
-    if (!date) { setNfError('Date is required'); return }
-
-    let principalWithdrawn: number
-    let unitsWithdrawn: number | null = null
-    let amountVnd: number
-
-    if (sellNonFund.type === 'bank') {
-      principalWithdrawn = parseFloat(nfPrincipal)
-      amountVnd = parseFloat(nfAmount)
-      if (!principalWithdrawn || principalWithdrawn <= 0) { setNfError('Principal withdrawn is required'); return }
-      if (!amountVnd || amountVnd <= 0) { setNfError('Amount received is required'); return }
-    } else {
-      // gold
-      const units = parseFloat(nfUnits)
-      amountVnd = parseFloat(nfAmount)
-      if (!units || units <= 0) { setNfError('Chi to sell is required'); return }
-      if (!amountVnd || amountVnd <= 0) { setNfError('Amount received is required'); return }
-      const originalPricePerUnit = sellNonFund.units && sellNonFund.units > 0
-        ? sellNonFund.amount / sellNonFund.units : 0
-      principalWithdrawn = Math.round(units * originalPricePerUnit)
-      unitsWithdrawn = units
-    }
-
-    setNfSaving(true)
-    setNfError('')
-    try {
-      const body: Record<string, unknown> = {
-        transaction_type: 'withdrawal',
-        asset_type: sellNonFund.type,
-        parent_transaction_id: sellNonFund.transactionId,
-        investment_date: date,
-        amount_vnd: Math.round(amountVnd),
-        principal_withdrawn: Math.round(principalWithdrawn),
-        goal_id: null,
-      }
-      if (unitsWithdrawn !== null) body.units_withdrawn = unitsWithdrawn
-
-      const res = await fetch('/api/v1/investment-transactions', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      })
-      if (!res.ok) {
-        const { error } = await res.json()
-        setNfError(error ?? 'Failed to record transaction')
-      } else {
-        setSellNonFund(null)
-        await fetchData({ force: true })
-      }
-    } catch {
-      setNfError('Unable to save. Please check your connection.')
-    }
-    setNfSaving(false)
+    const navPerUnit = item.units && item.units > 0 ? item.currentValue / item.units : undefined
+    setSellItem({
+      type: item.type as 'bank' | 'gold' | 'stock',
+      name: item.notes ?? (item.type === 'bank' ? 'Bank deposit' : item.type === 'gold' ? 'Gold' : item.type),
+      currentValue: item.currentValue,
+      units: item.units ?? undefined,
+      navPerUnit,
+      interestRate: item.interestRate ?? undefined,
+      transactionId: item.transactionId,
+      purchasePrice: item.amount,
+    })
+    setSellSheetOpen(true)
   }
 
   async function handleAssignToGoal(fundId: string, goalId: string) {
@@ -940,290 +844,14 @@ export default function DashboardClient({ userId }: { userId: string }) {
         </DialogContent>
       </Dialog>
 
-      {/* Sell Unallocated Fund Modal */}
-      <Dialog open={!!sellFund} onOpenChange={(o) => { if (!o && !sellSaving) setSellFund(null) }}>
-        <DialogContent className="sm:max-w-[440px]">
-          <DialogHeader>
-            <DialogTitle>{tg('sellModal')} — {sellFund?.fundName}</DialogTitle>
-          </DialogHeader>
-          {sellFund && (() => {
-            const units = parseFloat(sellUnits) || 0
-            const nav = sellFund.currentNAV
-            const avgCost = sellFund.purchasePrice
-            const costBasis = Math.round(units * avgCost)
-            const estimatedAmount = Math.round(units * nav)
-            const parsedAmount = Number(sellAmount) || 0
-            const gain = parsedAmount - costBasis
-            const remaining = sellFund.quantity - units
-            return (
-              <div className="space-y-4 py-2">
-                <div className="grid grid-cols-2 gap-3 text-sm bg-gray-50 dark:bg-gray-800/50 rounded-lg p-3">
-                  <div>
-                    <p className="text-gray-500 dark:text-gray-400">{tg('colCurrentNav')}</p>
-                    <p className="font-medium text-gray-900 dark:text-gray-100">{fmt(nav)}</p>
-                  </div>
-                  <div>
-                    <p className="text-gray-500 dark:text-gray-400">{tg('colAvgNav')}</p>
-                    <p className="font-medium text-gray-900 dark:text-gray-100">{fmt(avgCost)}</p>
-                  </div>
-                  <div>
-                    <p className="text-gray-500 dark:text-gray-400">{tg('colRemaining')}</p>
-                    <p className="font-medium text-gray-900 dark:text-gray-100">{sellFund.quantity.toLocaleString('vi-VN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} {tg('unitsShort')}</p>
-                  </div>
-                </div>
-
-                <div className="space-y-2">
-                  <Label>{tg('dateSellLabel')}</Label>
-                  <Input type="date" value={sellDate} max={new Date().toISOString().slice(0, 10)} onChange={(e) => setSellDate(e.target.value)} />
-                </div>
-
-                <div className="space-y-2">
-                  <Label>{tg('unitsToSellFund')}</Label>
-                  <Input
-                    type="number"
-                    value={sellUnits}
-                    min={0}
-                    max={sellFund.quantity}
-                    step="0.01"
-                    placeholder="0.00"
-                    onChange={(e) => {
-                      setSellUnits(e.target.value)
-                      const u = parseFloat(e.target.value) || 0
-                      if (u > 0) setSellAmount(String(Math.round(u * nav)))
-                    }}
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label>{tg('amountReceivedLabel')}</Label>
-                  <Input
-                    type="text"
-                    inputMode="numeric"
-                    value={sellAmount ? Number(sellAmount).toLocaleString('en-US') : ''}
-                    placeholder="0"
-                    onChange={(e) => {
-                      const raw = e.target.value.replace(/,/g, '').replace(/[^0-9]/g, '')
-                      setSellAmount(raw)
-                      const a = Number(raw) || 0
-                      if (a > 0 && nav > 0) setSellUnits(String(Math.round((a / nav) * 100) / 100))
-                    }}
-                  />
-                </div>
-
-                {units > 0 && (
-                  <div className="text-sm bg-gray-50 dark:bg-gray-800/50 rounded-lg p-3 space-y-1">
-                    <div className="flex justify-between">
-                      <span className="text-gray-500 dark:text-gray-400">{tg('costBasisLabel')}</span>
-                      <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(costBasis)}</span>
-                    </div>
-                    <div className="flex justify-between">
-                      <span className="text-gray-500 dark:text-gray-400">{tg('receivedLabel')}</span>
-                      <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(parsedAmount || estimatedAmount)}</span>
-                    </div>
-                    <div className="flex justify-between border-t border-gray-200 dark:border-gray-700 pt-1 mt-1">
-                      <span className="text-gray-500 dark:text-gray-400">P&amp;L</span>
-                      <span className={`font-semibold ${gain >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                        {gain >= 0 ? '+' : ''}{fmt(gain)}
-                      </span>
-                    </div>
-                    {remaining >= 0 && (
-                      <div className="flex justify-between">
-                        <span className="text-gray-500 dark:text-gray-400">{tg('colRemaining')}</span>
-                        <span className="font-medium text-gray-900 dark:text-gray-100">{remaining.toLocaleString('vi-VN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} {tg('unitsShort')}</span>
-                      </div>
-                    )}
-                  </div>
-                )}
-
-                {sellError && <p className="text-sm text-red-600 dark:text-red-400">{sellError}</p>}
-
-                <div className="flex gap-3 pt-1">
-                  <Button type="button" variant="outline" className="flex-1" onClick={() => setSellFund(null)} disabled={sellSaving}>{tc('cancel')}</Button>
-                  <Button type="button" className="flex-1 bg-amber-600 hover:bg-amber-700" disabled={sellSaving || !sellUnits || !sellAmount} onClick={handleSellFundSubmit}>
-                    {sellSaving && <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-1" />}
-                    {sellSaving ? tc('saving') : tg('sell')}
-                  </Button>
-                </div>
-              </div>
-            )
-          })()}
-        </DialogContent>
-      </Dialog>
-
-      {/* Sell / Withdraw Non-Fund (bank/gold) Modal */}
-      <Dialog open={!!sellNonFund} onOpenChange={(o) => { if (!o && !nfSaving) setSellNonFund(null) }}>
-        <DialogContent className="sm:max-w-[440px]">
-          <DialogHeader>
-            <DialogTitle>
-              {sellNonFund?.type === 'bank' ? tg('withdrawBankModal') : tg('sellGoldModal')}
-              {sellNonFund?.notes ? ` — ${sellNonFund.notes}` : ''}
-            </DialogTitle>
-          </DialogHeader>
-          {sellNonFund && (() => {
-            const isBank = sellNonFund.type === 'bank'
-            const originalPricePerUnit = sellNonFund.units && sellNonFund.units > 0
-              ? sellNonFund.amount / sellNonFund.units : 0
-            const currentPricePerUnit = sellNonFund.units && sellNonFund.units > 0
-              ? sellNonFund.currentValue / sellNonFund.units : 0
-            const nfUnitsNum = parseFloat(nfUnits) || 0
-            const nfAmountNum = parseFloat(nfAmount) || 0
-            const nfPrincipalNum = parseFloat(nfPrincipal) || 0
-
-            // bank: gain = amountReceived - principalWithdrawn
-            const bankGain = nfAmountNum - nfPrincipalNum
-            const bankRemaining = sellNonFund.amount - nfPrincipalNum
-
-            // gold: cost basis = units × original price, gain = amount - cost basis
-            const goldCostBasis = Math.round(nfUnitsNum * originalPricePerUnit)
-            const goldGain = nfAmountNum - goldCostBasis
-            const goldRemaining = (sellNonFund.units ?? 0) - nfUnitsNum
-
-            return (
-              <div className="space-y-4 py-2">
-                <div className="grid grid-cols-2 gap-3 text-sm bg-gray-50 dark:bg-gray-800/50 rounded-lg p-3">
-                  {isBank ? (
-                    <>
-                      <div>
-                        <p className="text-gray-500 dark:text-gray-400">{tg('principalLabel')}</p>
-                        <p className="font-medium text-gray-900 dark:text-gray-100">{fmt(sellNonFund.amount)}</p>
-                      </div>
-                      {sellNonFund.interestRate != null && (
-                        <div>
-                          <p className="text-gray-500 dark:text-gray-400">{tg('perYearShort')}</p>
-                          <p className="font-medium text-gray-900 dark:text-gray-100">{sellNonFund.interestRate}%</p>
-                        </div>
-                      )}
-                    </>
-                  ) : (
-                    <>
-                      <div>
-                        <p className="text-gray-500 dark:text-gray-400">{tg('colRemaining')}</p>
-                        <p className="font-medium text-gray-900 dark:text-gray-100">
-                          {(sellNonFund.units ?? 0).toLocaleString('vi-VN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} chi
-                        </p>
-                      </div>
-                      <div>
-                        <p className="text-gray-500 dark:text-gray-400">{tg('currentPriceLabel')}</p>
-                        <p className="font-medium text-gray-900 dark:text-gray-100">{fmt(currentPricePerUnit)}/chi</p>
-                      </div>
-                    </>
-                  )}
-                </div>
-
-                <div className="space-y-2">
-                  <Label>{isBank ? tg('dateWithdrawLabel') : tg('dateSellLabel')}</Label>
-                  <Input type="date" value={nfDate} max={new Date().toISOString().slice(0, 10)} onChange={(e) => setNfDate(e.target.value)} />
-                </div>
-
-                {isBank ? (
-                  <>
-                    <div className="space-y-2">
-                      <Label>{tg('principalWithdrawnLabel')}</Label>
-                      <Input
-                        type="text"
-                        inputMode="numeric"
-                        value={nfPrincipal ? Number(nfPrincipal).toLocaleString('en-US') : ''}
-                        placeholder={tg('principalWithdrawnPlaceholder')}
-                        onChange={(e) => setNfPrincipal(e.target.value.replace(/,/g, '').replace(/[^0-9]/g, ''))}
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label>{tg('amountReceivedLabel')}</Label>
-                      <Input
-                        type="text"
-                        inputMode="numeric"
-                        value={nfAmount ? Number(nfAmount).toLocaleString('en-US') : ''}
-                        placeholder={tg('amountReceivedPlaceholder')}
-                        onChange={(e) => setNfAmount(e.target.value.replace(/,/g, '').replace(/[^0-9]/g, ''))}
-                      />
-                    </div>
-                    {nfPrincipalNum > 0 && nfAmountNum > 0 && (
-                      <div className="text-sm bg-gray-50 dark:bg-gray-800/50 rounded-lg p-3 space-y-1">
-                        <div className="flex justify-between border-t border-gray-200 dark:border-gray-700 pt-1">
-                          <span className="text-gray-500 dark:text-gray-400">P&amp;L</span>
-                          <span className={`font-semibold ${bankGain >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                            {bankGain >= 0 ? '+' : ''}{fmt(bankGain)}
-                          </span>
-                        </div>
-                        <div className="flex justify-between">
-                          <span className="text-gray-500 dark:text-gray-400">{tg('remainingPrincipalLabel')}</span>
-                          <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(Math.max(bankRemaining, 0))}</span>
-                        </div>
-                      </div>
-                    )}
-                  </>
-                ) : (
-                  <>
-                    <div className="space-y-2">
-                      <Label>{tg('unitsToSellGold')}</Label>
-                      <Input
-                        type="number"
-                        value={nfUnits}
-                        min={0}
-                        max={sellNonFund.units ?? undefined}
-                        step="0.01"
-                        placeholder="0.00"
-                        onChange={(e) => {
-                          setNfUnits(e.target.value)
-                          const u = parseFloat(e.target.value) || 0
-                          if (u > 0) setNfAmount(String(Math.round(u * currentPricePerUnit)))
-                        }}
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label>{tg('amountReceivedLabel')}</Label>
-                      <Input
-                        type="text"
-                        inputMode="numeric"
-                        value={nfAmount ? Number(nfAmount).toLocaleString('en-US') : ''}
-                        placeholder="0"
-                        onChange={(e) => {
-                          const raw = e.target.value.replace(/,/g, '').replace(/[^0-9]/g, '')
-                          setNfAmount(raw)
-                          const a = Number(raw) || 0
-                          if (a > 0 && currentPricePerUnit > 0) setNfUnits(String(Math.round((a / currentPricePerUnit) * 100) / 100))
-                        }}
-                      />
-                    </div>
-                    {nfUnitsNum > 0 && (
-                      <div className="text-sm bg-gray-50 dark:bg-gray-800/50 rounded-lg p-3 space-y-1">
-                        <div className="flex justify-between">
-                          <span className="text-gray-500 dark:text-gray-400">{tg('costBasisLabel')}</span>
-                          <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(goldCostBasis)}</span>
-                        </div>
-                        <div className="flex justify-between border-t border-gray-200 dark:border-gray-700 pt-1 mt-1">
-                          <span className="text-gray-500 dark:text-gray-400">P&amp;L</span>
-                          <span className={`font-semibold ${goldGain >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                            {goldGain >= 0 ? '+' : ''}{fmt(goldGain)}
-                          </span>
-                        </div>
-                        {goldRemaining >= 0 && (
-                          <div className="flex justify-between">
-                            <span className="text-gray-500 dark:text-gray-400">{tg('remainingChiLabel')}</span>
-                            <span className="font-medium text-gray-900 dark:text-gray-100">
-                              {goldRemaining.toLocaleString('vi-VN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} chi
-                            </span>
-                          </div>
-                        )}
-                      </div>
-                    )}
-                  </>
-                )}
-
-                {nfError && <p className="text-sm text-red-600 dark:text-red-400">{nfError}</p>}
-
-                <div className="flex gap-3 pt-1">
-                  <Button type="button" variant="outline" className="flex-1" onClick={() => setSellNonFund(null)} disabled={nfSaving}>{tc('cancel')}</Button>
-                  <Button type="button" className="flex-1 bg-amber-600 hover:bg-amber-700" disabled={nfSaving} onClick={handleSellNonFundSubmit}>
-                    {nfSaving && <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin mr-1" />}
-                    {nfSaving ? tc('saving') : (isBank ? tg('withdraw') : tg('sell'))}
-                  </Button>
-                </div>
-              </div>
-            )
-          })()}
-        </DialogContent>
-      </Dialog>
+      {/* Sell / Withdraw Sheet */}
+      <SellWithdrawSheet
+        item={sellItem}
+        open={sellSheetOpen}
+        context="unallocated"
+        onClose={() => setSellSheetOpen(false)}
+        onSuccess={() => fetchData({ force: true })}
+      />
 
       {(() => {
         const item = data?.unallocated.nonFunds.find((i) => i.transactionId === nonFundPickerTxId)

--- a/app/assets/components/NetWorthCard.tsx
+++ b/app/assets/components/NetWorthCard.tsx
@@ -91,11 +91,12 @@ interface Props {
   overallProfitLossPercentage: number
   navStale: boolean
   allocationBar?: { fund: number; bank: number; gold: number; stock: number }
+  refreshKey?: number
 }
 
 export default function NetWorthCard({
   totalAssets, totalLiabilities, netWorth, totalInvested, currentValue,
-  overallProfitLoss, overallProfitLossPercentage, navStale, allocationBar,
+  overallProfitLoss, overallProfitLossPercentage, navStale, allocationBar, refreshKey,
 }: Props) {
   const t = useTranslations('dashboard')
   const plPositive = overallProfitLoss >= 0
@@ -107,7 +108,7 @@ export default function NetWorthCard({
       .then((r) => r.ok ? r.json() : [])
       .then((data: ChartPoint[]) => setHistory(data))
       .catch(() => setHistory([]))
-  }, [timeRange])
+  }, [timeRange, refreshKey])
 
   const kpis = [
     { label: t('invested'),     value: totalInvested },

--- a/app/assets/components/NetWorthCard.tsx
+++ b/app/assets/components/NetWorthCard.tsx
@@ -89,14 +89,13 @@ interface Props {
   currentValue: number
   overallProfitLoss: number
   overallProfitLossPercentage: number
-  navStale: boolean
   allocationBar?: { fund: number; bank: number; gold: number; stock: number }
   refreshKey?: number
 }
 
 export default function NetWorthCard({
   totalAssets, totalLiabilities, netWorth, totalInvested, currentValue,
-  overallProfitLoss, overallProfitLossPercentage, navStale, allocationBar, refreshKey,
+  overallProfitLoss, overallProfitLossPercentage, allocationBar, refreshKey,
 }: Props) {
   const t = useTranslations('dashboard')
   const plPositive = overallProfitLoss >= 0
@@ -131,7 +130,6 @@ export default function NetWorthCard({
         textTransform: 'uppercase', color: 'var(--c-muted)', marginBottom: 6,
       }}>
         {t('netWorth')}
-        {navStale && <span title={t('navStaleTooltip')} style={{ marginLeft: 6, color: 'var(--c-warn)' }}>⚠</span>}
       </div>
 
       {/* Hero number */}

--- a/app/assets/components/NetWorthCard.tsx
+++ b/app/assets/components/NetWorthCard.tsx
@@ -107,7 +107,7 @@ export default function NetWorthCard({
   const [history, setHistory] = useState<ChartPoint[]>([])
 
   useEffect(() => {
-    fetch(`/api/v1/dashboard/history?range=${RANGE_PARAM[timeRange]}`)
+    fetch(`/api/v1/dashboard/history?range=${RANGE_PARAM[timeRange]}`, { cache: 'no-store' })
       .then((r) => r.ok ? r.json() : [])
       .then((data: ChartPoint[]) => setHistory(data))
       .catch(() => setHistory([]))

--- a/app/assets/components/NetWorthCard.tsx
+++ b/app/assets/components/NetWorthCard.tsx
@@ -33,14 +33,23 @@ function Sparkline({ data, positive }: { data: ChartPoint[]; positive: boolean }
       return `${x.toFixed(2)},${y.toFixed(2)}`
     })
     .join(' ')
-  const lastX = W
   const lastY = H - ((values[values.length - 1] - min) / range) * (H - 6) - 3
+  const lastYPct = lastY / H
   const color = positive ? 'var(--c-pos)' : 'var(--c-neg)'
   return (
-    <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ width: '100%', height: H, display: 'block' }}>
-      <polyline points={points} fill="none" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-      <circle cx={lastX} cy={lastY} r="2.5" fill={color} />
-    </svg>
+    <div style={{ position: 'relative', width: '100%', height: H }}>
+      <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ width: '100%', height: H, display: 'block' }}>
+        <polyline points={points} fill="none" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+      </svg>
+      {/* Dot rendered outside the stretched SVG so it stays a true circle */}
+      <div style={{
+        position: 'absolute', right: 0,
+        top: `${lastYPct * 100}%`,
+        transform: 'translate(50%, -50%)',
+        width: 6, height: 6, borderRadius: '50%',
+        background: color,
+      }} />
+    </div>
   )
 }
 

--- a/app/assets/components/NetWorthCard.tsx
+++ b/app/assets/components/NetWorthCard.tsx
@@ -18,8 +18,11 @@ interface ChartPoint { label: string; value: number }
 function Sparkline({ data, positive }: { data: ChartPoint[]; positive: boolean }) {
   if (data.length < 2) return null
   const values = data.map((d) => d.value)
-  const min = Math.min(...values)
-  const max = Math.max(...values)
+  const rawMin = Math.min(...values)
+  const rawMax = Math.max(...values)
+  const pad = (rawMax - rawMin) * 0.15 || rawMax * 0.1 || 1
+  const min = Math.max(0, rawMin - pad)
+  const max = rawMax + pad
   const range = max - min || 1
   const W = 100
   const H = 36

--- a/app/assets/components/NetWorthCard.tsx
+++ b/app/assets/components/NetWorthCard.tsx
@@ -33,23 +33,11 @@ function Sparkline({ data, positive }: { data: ChartPoint[]; positive: boolean }
       return `${x.toFixed(2)},${y.toFixed(2)}`
     })
     .join(' ')
-  const lastY = H - ((values[values.length - 1] - min) / range) * (H - 6) - 3
-  const lastYPct = lastY / H
   const color = positive ? 'var(--c-pos)' : 'var(--c-neg)'
   return (
-    <div style={{ position: 'relative', width: '100%', height: H }}>
-      <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ width: '100%', height: H, display: 'block' }}>
-        <polyline points={points} fill="none" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-      </svg>
-      {/* Dot rendered outside the stretched SVG so it stays a true circle */}
-      <div style={{
-        position: 'absolute', right: 0,
-        top: `${lastYPct * 100}%`,
-        transform: 'translate(50%, -50%)',
-        width: 6, height: 6, borderRadius: '50%',
-        background: color,
-      }} />
-    </div>
+    <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ width: '100%', height: H, display: 'block' }}>
+      <polyline points={points} fill="none" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+    </svg>
   )
 }
 

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -52,17 +52,21 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
   const [error, setError] = useState('')
   const [confirmed, setConfirmed] = useState(false)
   const [soldAmount, setSoldAmount] = useState(0)
+  const [mounted, setMounted] = useState(open)
 
   useEffect(() => {
-    if (!open) {
+    if (open) {
+      setMounted(true)
+    } else {
       const timer = setTimeout(() => {
+        setMounted(false)
         setAmount('')
         setUnits('')
         setSaving(false)
         setError('')
         setConfirmed(false)
         setSoldAmount(0)
-      }, 300)
+      }, 220) // matches slide-down animation duration
       return () => clearTimeout(timer)
     }
   }, [open, item?.name])
@@ -213,7 +217,7 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
     ? (isVI ? 'Tiền sẽ chuyển về mục "Chưa phân bổ"' : 'Proceeds move to Unallocated')
     : (isVI ? 'Tiền sẽ về tài khoản ngân hàng liên kết' : 'Proceeds go to your linked bank account')
 
-  if (!open && !item) return null
+  if (!mounted) return null
 
   const Icon = item ? (TYPE_ICON[item.type as keyof typeof TYPE_ICON] ?? TrendingUp) : TrendingUp
   const typeColor = item ? (TYPE_COLOR[item.type as keyof typeof TYPE_COLOR] ?? '#94a3b8') : '#94a3b8'

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -224,12 +224,10 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
       onClick={onClose}
       style={{
         position: 'fixed', inset: 0,
-        background: open ? 'rgba(15, 23, 42, 0.45)' : 'transparent',
+        background: 'rgba(15, 23, 42, 0.45)',
         zIndex: 100,
         display: 'flex', alignItems: 'flex-end', justifyContent: 'center',
-        opacity: open ? 1 : 0,
-        pointerEvents: open ? 'auto' : 'none',
-        transition: 'opacity 180ms ease',
+        animation: open ? 'fade-in 180ms ease' : 'fade-out 180ms ease forwards',
       }}
     >
       <div
@@ -240,8 +238,7 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
           borderTopLeftRadius: 20, borderTopRightRadius: 20,
           padding: '8px 16px 32px',
           overflowY: 'auto',
-          transform: open ? 'translateY(0)' : 'translateY(100%)',
-          transition: 'transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1)',
+          animation: open ? 'slide-up 220ms cubic-bezier(0.2, 0.8, 0.2, 1)' : 'slide-down 180ms ease forwards',
           boxShadow: '0 -8px 24px rgba(0,0,0,0.12)',
         }}
       >

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -224,7 +224,7 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
       onClick={onClose}
       style={{
         position: 'fixed', inset: 0,
-        background: 'rgba(15, 23, 42, 0.45)',
+        background: 'rgba(15, 23, 42, 0.2)',
         zIndex: 100,
         display: 'flex', alignItems: 'flex-end', justifyContent: 'center',
         animation: open ? 'fade-in 180ms ease' : 'fade-out 180ms ease forwards',

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -1,0 +1,448 @@
+'use client'
+
+import { useState, useEffect, useMemo } from 'react'
+import { useLocale, useTranslations } from 'next-intl'
+import { ArrowDownRight, ArrowDownToLine, Building, Check, CircleDollarSign, Shield, TrendingUp, Wallet, X } from 'lucide-react'
+import { fmt } from '@/lib/formatters'
+const fmtVND = (n: number, _locale?: string) => fmt(n)
+
+export interface SellItem {
+  type: 'fund' | 'bank' | 'gold' | 'stock'
+  name: string
+  currentValue: number
+  units?: number
+  navPerUnit?: number
+  gainPct?: number
+  interestRate?: number
+  // API identifiers
+  fundId?: string
+  transactionId?: string
+  purchasePrice?: number
+}
+
+interface Props {
+  item: SellItem | null
+  open: boolean
+  context: 'unallocated' | 'goal'
+  onClose: () => void
+  onSuccess: () => void
+}
+
+const TYPE_ICON = {
+  fund: TrendingUp,
+  bank: Building,
+  gold: CircleDollarSign,
+  stock: TrendingUp,
+} as const
+
+const TYPE_COLOR = {
+  fund: '#2563eb',
+  bank: '#047857',
+  gold: '#d97706',
+  stock: '#7c3aed',
+} as const
+
+export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: Props) {
+  const locale = useLocale()
+  const t = useTranslations('Dashboard')
+
+  const [amount, setAmount] = useState('')
+  const [units, setUnits] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const [confirmed, setConfirmed] = useState(false)
+  const [soldAmount, setSoldAmount] = useState(0)
+
+  useEffect(() => {
+    if (!open) {
+      const timer = setTimeout(() => {
+        setAmount('')
+        setUnits('')
+        setSaving(false)
+        setError('')
+        setConfirmed(false)
+        setSoldAmount(0)
+      }, 300)
+      return () => clearTimeout(timer)
+    }
+  }, [open, item?.name])
+
+  const isFund = item?.type === 'fund'
+  const isGold = item?.type === 'gold'
+  const isBank = item?.type === 'bank'
+
+  const maxAmount = item?.currentValue ?? 0
+  const numAmount = Number(amount) || 0
+  const isOverMax = numAmount > maxAmount && maxAmount > 0
+  const isValid = numAmount > 0 && !isOverMax && !saving
+
+  const remaining = maxAmount - numAmount
+
+  const gainLoss = useMemo(() => {
+    if (!numAmount || item?.gainPct == null) return null
+    return numAmount * item.gainPct / (100 + item.gainPct)
+  }, [numAmount, item?.gainPct])
+
+  const penaltyAmount = useMemo(() => {
+    if (!isBank || !numAmount || !item?.interestRate) return null
+    return Math.round(numAmount * (item.interestRate / 100) * 0.5)
+  }, [isBank, numAmount, item?.interestRate])
+
+  const taxAmount = useMemo(() => {
+    if (!isFund || !numAmount) return null
+    return Math.round(numAmount * 0.001)
+  }, [isFund, numAmount])
+
+  const showUnits = (isFund || isGold) && item?.units != null
+  const navPerUnit = item?.navPerUnit
+
+  function handleAmountChange(val: string) {
+    setAmount(val)
+    setError('')
+    if (navPerUnit && val) {
+      const u = Number(val) / navPerUnit
+      setUnits(u > 0 ? u.toFixed(2) : '')
+    } else {
+      setUnits('')
+    }
+  }
+
+  function handleUnitsChange(val: string) {
+    setUnits(val)
+    setError('')
+    if (navPerUnit && val) {
+      const a = Number(val) * navPerUnit
+      setAmount(a > 0 ? Math.round(a).toString() : '')
+    } else {
+      setAmount('')
+    }
+  }
+
+  function handleSetAll() {
+    setAmount(String(maxAmount))
+    if (navPerUnit && item?.units != null) setUnits(item.units.toFixed(2))
+    setError('')
+  }
+
+  async function handleConfirm() {
+    if (!item || !isValid) return
+    setSaving(true)
+    setError('')
+    try {
+      const today = new Date().toISOString().slice(0, 10)
+
+      if (isFund && item.fundId) {
+        const principalWithdrawn = item.purchasePrice
+          ? Math.round((numAmount / item.currentValue) * (item.purchasePrice * (item.units ?? 0)))
+          : Math.round(numAmount)
+        const unitsWithdrawn = navPerUnit ? numAmount / navPerUnit : (item.units ?? 0)
+        const res = await fetch('/api/v1/investment-transactions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            transaction_type: 'withdrawal',
+            asset_type: 'fund',
+            fund_id: item.fundId,
+            investment_date: today,
+            amount_vnd: Math.round(numAmount),
+            units_withdrawn: parseFloat(unitsWithdrawn.toFixed(4)),
+            principal_withdrawn: principalWithdrawn,
+            goal_id: null,
+          }),
+        })
+        if (!res.ok) {
+          const { error: e } = await res.json()
+          setError(e ?? t('sellError'))
+          setSaving(false)
+          return
+        }
+      } else if (item.transactionId) {
+        const body: Record<string, unknown> = {
+          transaction_type: 'withdrawal',
+          asset_type: item.type,
+          parent_transaction_id: item.transactionId,
+          investment_date: today,
+          amount_vnd: Math.round(numAmount),
+          principal_withdrawn: Math.round(numAmount),
+          goal_id: null,
+        }
+        if (isGold && units && navPerUnit) {
+          body.units_withdrawn = parseFloat(units)
+        }
+        const res = await fetch('/api/v1/investment-transactions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        })
+        if (!res.ok) {
+          const { error: e } = await res.json()
+          setError(e ?? t('sellError'))
+          setSaving(false)
+          return
+        }
+      }
+
+      setSoldAmount(numAmount)
+      setConfirmed(true)
+      setTimeout(() => {
+        setConfirmed(false)
+        onSuccess()
+        onClose()
+      }, 2000)
+    } catch {
+      setError(t('sellError'))
+    }
+    setSaving(false)
+  }
+
+  const isVI = locale === 'vi'
+  const titleText = isBank
+    ? (isVI ? 'Rút tiền' : 'Withdraw')
+    : (isVI ? 'Bán' : 'Sell')
+  const amountLabel = isBank
+    ? (isVI ? 'Số tiền muốn rút' : 'Amount to withdraw')
+    : (isVI ? 'Số tiền muốn bán' : 'Amount to sell')
+  const confirmLabel = isBank
+    ? (isVI ? 'Xác nhận rút' : 'Confirm withdrawal')
+    : (isVI ? 'Xác nhận bán' : 'Confirm sale')
+  const settlementCopy = isFund
+    ? (isVI ? 'Tiền về tài khoản sau T+3 ngày làm việc' : 'Proceeds arrive in T+3 business days')
+    : (isVI ? 'Tiền về tài khoản trong 1 ngày làm việc' : 'Proceeds arrive within 1 business day')
+  const moneyGoesCopy = context === 'goal'
+    ? (isVI ? 'Tiền sẽ chuyển về mục "Chưa phân bổ"' : 'Proceeds move to Unallocated')
+    : (isVI ? 'Tiền sẽ về tài khoản ngân hàng liên kết' : 'Proceeds go to your linked bank account')
+
+  if (!open && !item) return null
+
+  const Icon = item ? (TYPE_ICON[item.type as keyof typeof TYPE_ICON] ?? TrendingUp) : TrendingUp
+  const typeColor = item ? (TYPE_COLOR[item.type as keyof typeof TYPE_COLOR] ?? '#94a3b8') : '#94a3b8'
+
+  return (
+    <div
+      data-testid="sell-sheet"
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0,
+        background: open ? 'rgba(15, 23, 42, 0.45)' : 'transparent',
+        zIndex: 100,
+        display: 'flex', alignItems: 'flex-end', justifyContent: 'center',
+        opacity: open ? 1 : 0,
+        pointerEvents: open ? 'auto' : 'none',
+        transition: 'opacity 180ms ease',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: '100%', maxWidth: 480, maxHeight: '90dvh',
+          background: 'var(--c-card)',
+          borderTopLeftRadius: 20, borderTopRightRadius: 20,
+          padding: '8px 16px 32px',
+          overflowY: 'auto',
+          transform: open ? 'translateY(0)' : 'translateY(100%)',
+          transition: 'transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1)',
+          boxShadow: '0 -8px 24px rgba(0,0,0,0.12)',
+        }}
+      >
+        {/* Drag handle */}
+        <div style={{ width: 36, height: 4, background: 'var(--c-line-strong, #cbd5e1)', borderRadius: 999, margin: '6px auto 14px' }} />
+
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
+          <h3 style={{ margin: 0, fontSize: 17, fontWeight: 600 }}>{titleText}</h3>
+          <button onClick={onClose} style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }}>
+            <X size={18} />
+          </button>
+        </div>
+
+        {confirmed ? (
+          // ── Success state ────────────────────────────────────────────────
+          <div data-testid="sell-success" style={{ padding: '32px 0', textAlign: 'center' }}>
+            <div style={{
+              width: 64, height: 64, borderRadius: 32,
+              background: 'var(--c-pos-tint, #dcfce7)', color: 'var(--c-pos, #16a34a)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center',
+              margin: '0 auto 16px',
+            }}>
+              <Check size={30} strokeWidth={2.5} />
+            </div>
+            <div style={{ fontSize: 16, fontWeight: 700 }}>{isBank ? (isVI ? 'Đã rút thành công' : 'Withdrawal successful') : (isVI ? 'Đã bán thành công' : 'Sale successful')}</div>
+            <div style={{ fontSize: 13, color: 'var(--c-muted)', marginTop: 4 }}>{item?.name}</div>
+            <div style={{ fontSize: 22, fontWeight: 700, color: 'var(--c-pos, #16a34a)', marginTop: 12, letterSpacing: '-0.02em' }}>
+              {fmtVND(soldAmount, locale)}
+            </div>
+            <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 8, padding: '0 24px', lineHeight: 1.5 }}>
+              {settlementCopy}
+            </div>
+          </div>
+        ) : (
+          // ── Form ────────────────────────────────────────────────────────
+          <div style={{ display: 'grid', gap: 14 }}>
+
+            {/* Item summary card */}
+            {item && (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px', background: 'var(--c-card-2)', borderRadius: 12 }}>
+                <div style={{ width: 40, height: 40, borderRadius: 10, background: 'var(--c-card)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: typeColor, border: '1px solid var(--c-line)', flexShrink: 0 }}>
+                  <Icon size={18} />
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.name}</div>
+                  <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2, display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+                    <span>{isVI ? 'Khả dụng' : 'Available'}: <span style={{ fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(maxAmount, locale)}</span></span>
+                    {item.units != null && <span>{item.units.toLocaleString()} {isVI ? 'phần' : 'units'}</span>}
+                    {isBank && item.interestRate && <span>{item.interestRate}%/yr</span>}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Amount input */}
+            <div>
+              <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>{amountLabel}</div>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <div style={{
+                  flex: 1, display: 'flex', alignItems: 'center', gap: 8,
+                  padding: '10px 12px', background: 'var(--c-card)',
+                  border: `1.5px solid ${isOverMax ? 'var(--c-neg, #dc2626)' : 'var(--c-navy, #1e3a5f)'}`,
+                  borderRadius: 10,
+                }}>
+                  <span style={{ fontSize: 14, color: 'var(--c-muted)' }}>₫</span>
+                  <input
+                    data-testid="sell-amount-input"
+                    type="number"
+                    value={amount}
+                    onChange={e => handleAmountChange(e.target.value)}
+                    placeholder="0"
+                    style={{ flex: 1, border: 'none', outline: 'none', fontSize: 15, fontWeight: 600, background: 'transparent', color: isOverMax ? 'var(--c-neg, #dc2626)' : 'var(--c-ink)' }}
+                  />
+                </div>
+                <button
+                  data-testid="sell-all-btn"
+                  onClick={handleSetAll}
+                  style={{ padding: '8px 12px', background: 'var(--c-navy-tint, #e8edf3)', color: 'var(--c-navy, #1e3a5f)', border: '1px solid var(--c-navy-tint, #e8edf3)', borderRadius: 10, fontSize: 12, fontWeight: 600, cursor: 'pointer', whiteSpace: 'nowrap' }}
+                >
+                  {isVI ? 'Tất cả' : 'All'}
+                </button>
+              </div>
+              {isOverMax && (
+                <div style={{ fontSize: 11, color: 'var(--c-neg, #dc2626)', marginTop: 5, display: 'flex', alignItems: 'center', gap: 4 }}>
+                  <X size={12} strokeWidth={2.5} />
+                  {isVI ? 'Vượt quá số dư khả dụng' : 'Exceeds available balance'} · {isVI ? 'Tối đa' : 'Max'} {fmtVND(maxAmount, locale)}
+                </div>
+              )}
+            </div>
+
+            {/* Units input — fund & gold only */}
+            {showUnits && (
+              <div>
+                <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>{isVI ? 'Số phần' : 'Units'}</div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 10 }}>
+                  <input
+                    type="number"
+                    value={units}
+                    onChange={e => handleUnitsChange(e.target.value)}
+                    placeholder="0.00"
+                    style={{ flex: 1, border: 'none', outline: 'none', fontSize: 15, fontWeight: 600, background: 'transparent', color: 'var(--c-ink)' }}
+                  />
+                  <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'phần' : 'units'}</span>
+                </div>
+                {navPerUnit && (
+                  <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 4 }}>
+                    {isVI ? 'Giá NAV' : 'NAV'}: <span style={{ fontWeight: 500 }}>{fmtVND(navPerUnit, locale)}</span> / {isVI ? 'phần' : 'unit'}
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Summary strip */}
+            {numAmount > 0 && !isOverMax && (
+              <div data-testid="sell-summary-strip" style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
+                  <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Còn lại sau giao dịch' : 'Remaining after transaction'}</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(Math.max(0, remaining), locale)}</span>
+                </div>
+                {gainLoss != null && (
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: (penaltyAmount || taxAmount) ? '1px solid var(--c-line)' : 'none' }}>
+                    <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Lãi/Lỗ ước tính' : 'Est. gain / loss'}</span>
+                    <span style={{ fontSize: 13, fontWeight: 600, color: gainLoss >= 0 ? 'var(--c-pos, #16a34a)' : 'var(--c-neg, #dc2626)' }}>
+                      {gainLoss >= 0 ? '+' : ''}{fmtVND(gainLoss, locale)}
+                    </span>
+                  </div>
+                )}
+                {penaltyAmount != null && (
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: taxAmount ? '1px solid var(--c-line)' : 'none' }}>
+                    <span style={{ fontSize: 12, color: 'var(--c-warn, #d97706)' }}>{isVI ? 'Lãi mất ước tính' : 'Est. interest forfeited'}</span>
+                    <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-warn, #d97706)' }}>−{fmtVND(penaltyAmount, locale)}</span>
+                  </div>
+                )}
+                {taxAmount != null && (
+                  <div data-testid="sell-tax-row" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px' }}>
+                    <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Thuế TNCN (0.1%)' : 'Personal income tax (0.1%)'}</span>
+                    <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-muted)' }}>−{fmtVND(taxAmount, locale)}</span>
+                  </div>
+                )}
+              </div>
+            )}
+
+            {/* Bank early-withdrawal warning */}
+            {isBank && (
+              <div data-testid="sell-bank-warning" style={{ display: 'flex', gap: 10, padding: '10px 12px', background: 'var(--c-warn-tint, #fffbeb)', borderRadius: 10, border: '1px solid rgba(180,83,9,0.15)' }}>
+                <Shield size={16} color="var(--c-warn, #d97706)" style={{ flexShrink: 0, marginTop: 1 }} />
+                <p style={{ margin: 0, fontSize: 12, color: 'var(--c-warn, #d97706)', lineHeight: 1.5 }}>
+                  {isVI ? 'Rút sớm có thể mất lãi.' : 'Early withdrawal may forfeit accrued interest.'}
+                </p>
+              </div>
+            )}
+
+            {/* Where money goes + settlement */}
+            <div style={{ display: 'grid', gap: 6 }}>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '9px 12px', background: 'var(--c-card-2)', borderRadius: 8 }}>
+                <Wallet size={14} color="var(--c-muted)" style={{ marginTop: 1, flexShrink: 0 }} />
+                <span style={{ fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.5 }}>{moneyGoesCopy}</span>
+              </div>
+              <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '9px 12px', background: 'var(--c-card-2)', borderRadius: 8 }}>
+                <ArrowDownToLine size={14} color="var(--c-muted)" style={{ marginTop: 1, flexShrink: 0 }} />
+                <span style={{ fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.5 }}>{settlementCopy}</span>
+              </div>
+            </div>
+
+            {/* Error */}
+            {error && (
+              <p style={{ margin: 0, fontSize: 12, color: 'var(--c-neg, #dc2626)', textAlign: 'center' }}>{error}</p>
+            )}
+
+            {/* Actions */}
+            <div style={{ display: 'flex', gap: 8, marginTop: 2 }}>
+              <button onClick={onClose} style={{ flex: 1, padding: '11px 14px', border: '1px solid var(--c-line)', borderRadius: 10, fontSize: 13, fontWeight: 600, background: 'transparent', color: 'var(--c-ink)', cursor: 'pointer' }}>
+                {isVI ? 'Hủy' : 'Cancel'}
+              </button>
+              <button
+                data-testid="sell-confirm-btn"
+                onClick={isValid ? handleConfirm : undefined}
+                disabled={!isValid}
+                style={{
+                  flex: 2, padding: '11px 14px',
+                  background: isValid ? 'var(--c-neg, #dc2626)' : 'var(--c-line)',
+                  color: isValid ? '#fff' : 'var(--c-muted)',
+                  border: 'none', borderRadius: 10, fontSize: 13, fontWeight: 600,
+                  cursor: isValid ? 'pointer' : 'default',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+                  transition: 'background 120ms, color 120ms',
+                }}
+              >
+                {isBank ? <ArrowDownToLine size={15} strokeWidth={2.2} /> : <ArrowDownRight size={15} strokeWidth={2.2} />}
+                {numAmount <= 0
+                  ? (isVI ? (isBank ? 'Nhập số tiền rút' : 'Nhập số tiền bán') : (isBank ? 'Enter withdrawal amount' : 'Enter sale amount'))
+                  : isOverMax
+                  ? (isVI ? 'Vượt quá số dư' : 'Exceeds balance')
+                  : saving
+                  ? (isVI ? 'Đang xử lý…' : 'Processing…')
+                  : confirmLabel}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -228,6 +228,7 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
         zIndex: 100,
         display: 'flex', alignItems: 'flex-end', justifyContent: 'center',
         animation: open ? 'fade-in 180ms ease' : 'fade-out 180ms ease forwards',
+        pointerEvents: open ? 'auto' : 'none',
       }}
     >
       <div

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -97,10 +97,11 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
   const navPerUnit = item?.navPerUnit
 
   function handleAmountChange(val: string) {
-    setAmount(val)
+    const raw = val.replace(/,/g, '').replace(/[^0-9]/g, '')
+    setAmount(raw)
     setError('')
-    if (navPerUnit && val) {
-      const u = Number(val) / navPerUnit
+    if (navPerUnit && raw) {
+      const u = Number(raw) / navPerUnit
       setUnits(u > 0 ? u.toFixed(2) : '')
     } else {
       setUnits('')
@@ -309,8 +310,9 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
                   <span style={{ fontSize: 14, color: 'var(--c-muted)' }}>₫</span>
                   <input
                     data-testid="sell-amount-input"
-                    type="number"
-                    value={amount}
+                    type="text"
+                    inputMode="numeric"
+                    value={amount ? Number(amount).toLocaleString('vi-VN') : ''}
                     onChange={e => handleAmountChange(e.target.value)}
                     placeholder="0"
                     style={{ flex: 1, border: 'none', outline: 'none', fontSize: 15, fontWeight: 600, background: 'transparent', color: isOverMax ? 'var(--c-neg, #dc2626)' : 'var(--c-ink)' }}

--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -237,9 +237,10 @@ export default function UnallocatedSection({
           onClick={closeAction}
           style={{
             position: 'fixed', inset: 0,
-            background: 'rgba(15, 23, 42, 0.45)',
+            background: 'rgba(15, 23, 42, 0.2)',
             zIndex: 300,
             display: 'flex', alignItems: 'flex-end',
+            animation: 'fade-in 180ms ease',
           }}
         >
           <div
@@ -249,6 +250,8 @@ export default function UnallocatedSection({
               background: 'var(--c-card)',
               borderRadius: '20px 20px 0 0',
               padding: '12px 16px calc(env(safe-area-inset-bottom) + 20px)',
+              animation: 'slide-up 220ms cubic-bezier(0.2, 0.8, 0.2, 1)',
+              boxShadow: '0 -8px 24px rgba(0,0,0,0.08)',
             }}
           >
             {/* Handle */}

--- a/app/assets/components/__tests__/NetWorthCard.test.tsx
+++ b/app/assets/components/__tests__/NetWorthCard.test.tsx
@@ -14,7 +14,6 @@ const baseProps = {
   currentValue: 450_000_000,
   overallProfitLoss: 100_000_000,
   overallProfitLossPercentage: 25,
-  navStale: false,
 }
 
 describe('NetWorthCard', () => {
@@ -37,15 +36,5 @@ describe('NetWorthCard', () => {
     render(<NetWorthCard {...baseProps} overallProfitLoss={-50_000_000} overallProfitLossPercentage={-10} />)
     const plEl = screen.getByText(/-50\.0M/)
     expect(plEl).toHaveStyle({ color: 'var(--c-neg)' })
-  })
-
-  it('shows stale NAV warning icon when navStale is true', () => {
-    render(<NetWorthCard {...baseProps} navStale={true} />)
-    expect(screen.getByText('⚠')).toBeInTheDocument()
-  })
-
-  it('does not show stale NAV warning when navStale is false', () => {
-    render(<NetWorthCard {...baseProps} navStale={false} />)
-    expect(screen.queryByText('⚠')).not.toBeInTheDocument()
   })
 })

--- a/app/globals.css
+++ b/app/globals.css
@@ -201,3 +201,8 @@
     max-width: 100%;
   }
 }
+
+@keyframes fade-in  { from { opacity: 0 }             to { opacity: 1 } }
+@keyframes fade-out { from { opacity: 1 }             to { opacity: 0 } }
+@keyframes slide-up { from { transform: translateY(100%) } to { transform: translateY(0) } }
+@keyframes slide-down { from { transform: translateY(0) } to { transform: translateY(100%) } }

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -207,12 +207,112 @@ test('sell unallocated fund via action sheet', async ({ page }) => {
   await expect(page.getByTestId('action-sell')).toBeVisible({ timeout: 5_000 })
   await page.getByTestId('action-sell').click()
 
-  // Sell dialog opens
-  await expect(page.getByRole('dialog')).toBeVisible()
-  await page.getByRole('dialog').locator('input[type="number"]').fill('50')
-  await page.getByRole('button', { name: /bán|sell|confirm/i }).last().click()
+  // SellWithdrawSheet opens
+  await expect(page.getByTestId('sell-sheet')).toBeVisible({ timeout: 5_000 })
+  await page.getByTestId('sell-amount-input').fill('50000')
+  await page.getByTestId('sell-confirm-btn').click()
 
-  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 8_000 })
+  await expect(page.getByTestId('sell-sheet')).not.toBeVisible({ timeout: 8_000 })
+})
+
+test('sell fund sheet shows remaining amount in summary strip', async ({ page }) => {
+  const fund = await api.createFund({ name: 'E2E Summary Fund', code: 'E2ESUMFUND', fund_type: 'equity', nav: 10000 })
+  cleanup.add(() => api.deleteFund(fund.id))
+  const tx = await api.createTransaction({
+    asset_type: 'fund', amount_vnd: 5_000_000, investment_date: '2026-01-01',
+    units: 500, unit_price: fund.nav, fund_id: fund.id,
+  })
+  cleanup.add(() => api.deleteTransaction(tx.transaction_id))
+
+  await gotoFreshDashboard(page)
+  const row = page.getByTestId('unallocated-row').filter({ hasText: fund.name }).first()
+  await expect(row).toBeVisible({ timeout: 10_000 })
+  await row.click()
+  await page.getByTestId('action-sell').click()
+  await expect(page.getByTestId('sell-sheet')).toBeVisible({ timeout: 5_000 })
+
+  await page.getByTestId('sell-amount-input').fill('1000000')
+  await expect(page.getByTestId('sell-summary-strip')).toBeVisible({ timeout: 3_000 })
+})
+
+test('sell fund shows 0.1% tax estimate in summary strip', async ({ page }) => {
+  const fund = await api.createFund({ name: 'E2E Tax Fund', code: 'E2ETAXFUND', fund_type: 'equity', nav: 10000 })
+  cleanup.add(() => api.deleteFund(fund.id))
+  const tx = await api.createTransaction({
+    asset_type: 'fund', amount_vnd: 5_000_000, investment_date: '2026-01-01',
+    units: 500, unit_price: fund.nav, fund_id: fund.id,
+  })
+  cleanup.add(() => api.deleteTransaction(tx.transaction_id))
+
+  await gotoFreshDashboard(page)
+  const row = page.getByTestId('unallocated-row').filter({ hasText: fund.name }).first()
+  await expect(row).toBeVisible({ timeout: 10_000 })
+  await row.click()
+  await page.getByTestId('action-sell').click()
+  await expect(page.getByTestId('sell-sheet')).toBeVisible({ timeout: 5_000 })
+
+  await page.getByTestId('sell-amount-input').fill('1000000')
+  // Tax row (0.1%) appears in summary strip for fund sells
+  await expect(page.locator('[data-testid="sell-summary-strip"] [data-testid="sell-tax-row"]')).toBeVisible({ timeout: 3_000 })
+})
+
+test('"All" button fills the full available amount', async ({ page }) => {
+  const fund = await api.createFund({ name: 'E2E All Fund', code: 'E2EALLFUND', fund_type: 'equity', nav: 10000 })
+  cleanup.add(() => api.deleteFund(fund.id))
+  const tx = await api.createTransaction({
+    asset_type: 'fund', amount_vnd: 5_000_000, investment_date: '2026-01-01',
+    units: 500, unit_price: fund.nav, fund_id: fund.id,
+  })
+  cleanup.add(() => api.deleteTransaction(tx.transaction_id))
+
+  await gotoFreshDashboard(page)
+  const row = page.getByTestId('unallocated-row').filter({ hasText: fund.name }).first()
+  await expect(row).toBeVisible({ timeout: 10_000 })
+  await row.click()
+  await page.getByTestId('action-sell').click()
+  await expect(page.getByTestId('sell-sheet')).toBeVisible({ timeout: 5_000 })
+
+  await page.getByTestId('sell-all-btn').click()
+  const val = await page.getByTestId('sell-amount-input').inputValue()
+  expect(Number(val)).toBeGreaterThan(0)
+})
+
+test('sell bank shows early-withdrawal warning', async ({ page }) => {
+  const tx = await api.createTransaction({
+    asset_type: 'bank', amount_vnd: 10_000_000, investment_date: '2026-01-01', interest_rate: 6,
+  })
+  cleanup.add(() => api.deleteTransaction(tx.transaction_id))
+
+  await gotoFreshDashboard(page)
+  const row = page.getByTestId('unallocated-row').filter({ hasText: /ngân hàng|bank/i }).first()
+  await expect(row).toBeVisible({ timeout: 10_000 })
+  await row.click()
+  await page.getByTestId('action-sell').click()
+  await expect(page.getByTestId('sell-sheet')).toBeVisible({ timeout: 5_000 })
+
+  await expect(page.getByTestId('sell-bank-warning')).toBeVisible({ timeout: 3_000 })
+})
+
+test('sell success state appears after confirm', async ({ page }) => {
+  const fund = await api.createFund({ name: 'E2E Success Fund', code: 'E2ESUCFUND', fund_type: 'equity', nav: 10000 })
+  cleanup.add(() => api.deleteFund(fund.id))
+  const tx = await api.createTransaction({
+    asset_type: 'fund', amount_vnd: 5_000_000, investment_date: '2026-01-01',
+    units: 500, unit_price: fund.nav, fund_id: fund.id,
+  })
+  cleanup.add(() => api.deleteTransaction(tx.transaction_id))
+
+  await gotoFreshDashboard(page)
+  const row = page.getByTestId('unallocated-row').filter({ hasText: fund.name }).first()
+  await expect(row).toBeVisible({ timeout: 10_000 })
+  await row.click()
+  await page.getByTestId('action-sell').click()
+  await expect(page.getByTestId('sell-sheet')).toBeVisible({ timeout: 5_000 })
+
+  await page.getByTestId('sell-amount-input').fill('1000000')
+  await page.getByTestId('sell-confirm-btn').click()
+
+  await expect(page.getByTestId('sell-success')).toBeVisible({ timeout: 5_000 })
 })
 
 test('allocation bar renders when investments exist', async ({ page }) => {

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -274,7 +274,8 @@ test('"All" button fills the full available amount', async ({ page }) => {
 
   await page.getByTestId('sell-all-btn').click()
   const val = await page.getByTestId('sell-amount-input').inputValue()
-  expect(Number(val)).toBeGreaterThan(0)
+  // Input displays vi-VN formatted numbers (dots as thousand separators), strip before parsing
+  expect(Number(val.replace(/\./g, '').replace(/,/g, ''))).toBeGreaterThan(0)
 })
 
 test('sell bank shows early-withdrawal warning', async ({ page }) => {


### PR DESCRIPTION
## Summary
- Replaces the two old Dialog-based sell forms (fund + bank/gold) in `DashboardClient.tsx` with a single `SellWithdrawSheet` bottom sheet component
- New component matches the mobile redesign prototype: amount input, "All" button, live summary strip (remaining / gain-loss / tax / penalty), bank early-withdrawal warning, and success state
- Adds 5 new E2E tests for sheet features (TDD RED phase) with `data-testid` hooks

## Test plan
- [ ] Tap unallocated fund row → action sheet → "Sell" opens bottom sheet
- [ ] Amount input and "All" button work correctly
- [ ] Summary strip shows remaining, gain/loss, tax (0.1% for funds)
- [ ] Bank deposit shows amber early-withdrawal warning
- [ ] Success state appears after confirm, then closes automatically
- [ ] No regressions in existing sell / assign tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)