### PR TITLE
feat(planning): mobile planning view — TDD implementation

### DIFF
--- a/app/(app)/funds/FundLibraryClient.tsx
+++ b/app/(app)/funds/FundLibraryClient.tsx
@@ -12,6 +12,8 @@ type Fund = {
   fund_type: FundType
   nav: number
   nav_source_url: string | null
+  is_dca: boolean
+  dca_monthly_amount_vnd: number | null
   created_at: string
   updated_at: string
 }
@@ -73,6 +75,8 @@ export default function FundLibraryClient() {
   const [formType, setFormType] = useState<FundType | ''>('')
   const [formNav, setFormNav] = useState('')
   const [formNavUrl, setFormNavUrl] = useState('')
+  const [formIsDca, setFormIsDca] = useState(false)
+  const [formDcaAmount, setFormDcaAmount] = useState('')
   const [formError, setFormError] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [deleting, setDeleting] = useState(false)
@@ -117,6 +121,8 @@ export default function FundLibraryClient() {
     setFormType('')
     setFormNav('')
     setFormNavUrl('')
+    setFormIsDca(false)
+    setFormDcaAmount('')
     setFormError(null)
     setSelectedFund(null)
     setModalMode('add')
@@ -128,6 +134,8 @@ export default function FundLibraryClient() {
     setFormType(fund.fund_type)
     setFormNav(String(fund.nav))
     setFormNavUrl(fund.nav_source_url ?? '')
+    setFormIsDca(fund.is_dca)
+    setFormDcaAmount(fund.dca_monthly_amount_vnd ? String(fund.dca_monthly_amount_vnd) : '')
     setFormError(null)
     setSelectedFund(fund)
     setModalMode('edit')
@@ -157,7 +165,15 @@ export default function FundLibraryClient() {
       const res = await fetch(url, {
         method,
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: formName.trim(), code: formCode.trim(), fund_type: formType, nav: navNum, nav_source_url: formNavUrl.trim() || null }),
+        body: JSON.stringify({
+          name: formName.trim(),
+          code: formCode.trim(),
+          fund_type: formType,
+          nav: navNum,
+          nav_source_url: formNavUrl.trim() || null,
+          is_dca: formIsDca,
+          dca_monthly_amount_vnd: formIsDca && formDcaAmount ? Number(formDcaAmount) : null,
+        }),
       })
       const data = await res.json()
       if (!res.ok) {
@@ -330,7 +346,12 @@ export default function FundLibraryClient() {
                 <tbody>
                   {sortedFunds.map((fund) => (
                     <tr key={fund.id} className="border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800">
-                      <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">{fund.name}</td>
+                      <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">
+                        <span>{fund.name}</span>
+                        {fund.is_dca && (
+                          <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300 font-medium">DCA</span>
+                        )}
+                      </td>
                       <td className="px-4 py-3 text-sm font-mono text-gray-500 dark:text-gray-400">{fund.code}</td>
                       <td className="px-4 py-3">
                         <span className={`text-xs px-2 py-1 rounded font-medium ${FUND_TYPE_COLORS[fund.fund_type]}`}>
@@ -371,7 +392,12 @@ export default function FundLibraryClient() {
                 <div key={fund.id} className="bg-white dark:bg-gray-900 rounded-lg shadow p-4 border border-gray-100 dark:border-gray-700">
                   <div className="flex items-start justify-between mb-2">
                     <div>
-                      <p className="font-semibold text-gray-900 dark:text-gray-100 text-sm">{fund.name}</p>
+                      <div className="flex items-center gap-1.5">
+                        <p className="font-semibold text-gray-900 dark:text-gray-100 text-sm">{fund.name}</p>
+                        {fund.is_dca && (
+                          <span className="text-xs px-1.5 py-0.5 rounded bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300 font-medium">DCA</span>
+                        )}
+                      </div>
                       <p className="text-xs font-mono text-gray-500 dark:text-gray-400">{fund.code}</p>
                     </div>
                     <span className={`text-xs px-2 py-1 rounded font-medium ${FUND_TYPE_COLORS[fund.fund_type]}`}>
@@ -475,6 +501,33 @@ export default function FundLibraryClient() {
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
                 />
               </div>
+              <div className="flex items-center justify-between py-1">
+                <div>
+                  <p className="text-sm font-medium text-gray-700 dark:text-gray-300">DCA</p>
+                  <p className="text-xs text-gray-400 dark:text-gray-500">Auto-add fixed amount each month</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => setFormIsDca((v) => !v)}
+                  className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-indigo-500 ${formIsDca ? 'bg-indigo-600' : 'bg-gray-300 dark:bg-gray-600'}`}
+                >
+                  <span className={`inline-block h-4 w-4 rounded-full bg-white shadow transform transition-transform ${formIsDca ? 'translate-x-6' : 'translate-x-1'}`} />
+                </button>
+              </div>
+              {formIsDca && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Monthly DCA Amount (₫)</label>
+                  <input
+                    type="number"
+                    value={formDcaAmount}
+                    onChange={(e) => setFormDcaAmount(e.target.value)}
+                    min="1"
+                    step="1"
+                    placeholder="e.g., 5000000"
+                    className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 text-sm"
+                  />
+                </div>
+              )}
             </div>
             <div className="flex gap-3 mt-6">
               <button

--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import SalaryInput from './components/SalaryInput'
 import FundInvestmentsSection from './components/FundInvestmentsSection'
@@ -196,107 +197,112 @@ export default function PlanningClient() {
   const refetch = useCallback(() => fetchPlan({ force: true }), [fetchPlan])
 
   return (
-    <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
-      <div className="max-w-6xl mx-auto px-4 py-8">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-8">
-          <h1 className="text-2xl font-bold text-gray-900 dark:text-gray-100">{t('title')}</h1>
-          <div className="flex items-center gap-3">
-            <button onClick={() => navigate('prev')} className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400">‹</button>
-            <span className="text-lg font-semibold text-gray-800 dark:text-gray-200 min-w-[120px] text-center">
-              {MONTHS[month - 1]} {year}
-            </span>
-            <button onClick={() => navigate('next')} className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400">›</button>
+    <div className="space-y-6">
+      {/* Month navigation */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={() => navigate('prev')}
+          className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400 transition-colors"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </button>
+        <span className="text-2xl font-semibold text-gray-900 dark:text-gray-100 min-w-[160px] text-center">
+          {MONTHS[month - 1]} {year}
+        </span>
+        <button
+          onClick={() => navigate('next')}
+          className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400 transition-colors"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </button>
+      </div>
+
+      {/* Toast */}
+      {toast && (
+        <div className="fixed top-4 right-4 z-50 px-4 py-3 bg-green-600 text-white text-sm font-medium rounded-lg shadow-lg">
+          {toast}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="text-center py-20 text-gray-400 dark:text-gray-500">{t('loading')}</div>
+      ) : (
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+          {/* Left col: salary + sections */}
+          <div className="lg:col-span-2 space-y-6">
+            <SalaryInput
+              plan={plan}
+              month={month}
+              year={year}
+              onPlanCreated={(p) => { setPlan(p); refetch() }}
+              onPlanDeleted={() => {
+                const deletedMonth = MONTHS[month - 1]
+                const deletedYear = year
+                bustPlanCache(month, year)
+                setPlan(null)
+                setInvestments([])
+                setSavings([])
+                setFixedExpenses([])
+                showToast(t('deletedToast', { month: deletedMonth, year: deletedYear }))
+              }}
+            />
+
+            {plan ? (
+              <>
+                <FundInvestmentsSection
+                  plan={plan}
+                  investments={investments}
+                  funds={funds}
+                  goals={goals}
+                  onRefresh={refetch}
+                  onToast={showToast}
+                />
+                <DirectSavingsSection
+                  plan={plan}
+                  savings={savings}
+                  goals={goals}
+                  onRefresh={refetch}
+                  onToast={showToast}
+                />
+                <FixedExpensesSection
+                  plan={plan}
+                  fixedExpenses={fixedExpenses}
+                  onRefresh={refetch}
+                  onToast={showToast}
+                />
+                <InsuranceSection
+                  plan={plan}
+                  insuranceMembers={insuranceMembers}
+                  onRefresh={refetch}
+                  onToast={showToast}
+                />
+                <OtherExpensesSection
+                  plan={plan}
+                  otherExpenses={otherExpenses}
+                  onRefresh={refetch}
+                  onToast={showToast}
+                />
+              </>
+            ) : (
+              <div className="text-center py-8 text-gray-400 dark:text-gray-500 text-sm">
+                {t('enterPlanPrompt')}
+              </div>
+            )}
+          </div>
+
+          {/* Right col: allocation summary */}
+          <div>
+            <AllocationSummary
+              plan={plan}
+              investments={investments}
+              savings={savings}
+              fixedExpenses={fixedExpenses}
+              insuranceMembers={insuranceMembers}
+              otherExpenses={otherExpenses}
+            />
           </div>
         </div>
-
-        {/* Toast */}
-        {toast && (
-          <div className="fixed top-4 right-4 z-50 px-4 py-3 bg-green-600 text-white text-sm font-medium rounded-lg shadow-lg">
-            {toast}
-          </div>
-        )}
-
-        {loading ? (
-          <div className="text-center py-20 text-gray-400 dark:text-gray-500">{t('loading')}</div>
-        ) : (
-          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-            {/* Left col: salary + sections */}
-            <div className="lg:col-span-2 space-y-6">
-              <SalaryInput
-                plan={plan}
-                month={month}
-                year={year}
-                onPlanCreated={(p) => { setPlan(p); refetch() }}
-                onPlanDeleted={() => {
-                  const deletedMonth = MONTHS[month - 1]
-                  const deletedYear = year
-                  bustPlanCache(month, year)
-                  setPlan(null)
-                  setInvestments([])
-                  setSavings([])
-                  setFixedExpenses([])
-                  showToast(t('deletedToast', { month: deletedMonth, year: deletedYear }))
-                }}
-              />
-
-              {plan ? (
-                <>
-                  <FundInvestmentsSection
-                    plan={plan}
-                    investments={investments}
-                    funds={funds}
-                    goals={goals}
-                    onRefresh={refetch}
-                    onToast={showToast}
-                  />
-                  <DirectSavingsSection
-                    plan={plan}
-                    savings={savings}
-                    goals={goals}
-                    onRefresh={refetch}
-                    onToast={showToast}
-                  />
-                  <FixedExpensesSection
-                    plan={plan}
-                    fixedExpenses={fixedExpenses}
-                    onRefresh={refetch}
-                    onToast={showToast}
-                  />
-                  <InsuranceSection
-                    plan={plan}
-                    insuranceMembers={insuranceMembers}
-                    onRefresh={refetch}
-                    onToast={showToast}
-                  />
-                  <OtherExpensesSection
-                    plan={plan}
-                    otherExpenses={otherExpenses}
-                    onRefresh={refetch}
-                    onToast={showToast}
-                  />
-                </>
-              ) : (
-                <div className="text-center py-8 text-gray-400 dark:text-gray-500 text-sm">
-                  {t('enterPlanPrompt')}
-                </div>
-              )}
-            </div>
-
-            {/* Right col: allocation summary */}
-            <div>
-              <AllocationSummary
-                plan={plan}
-                investments={investments}
-                savings={savings}
-                fixedExpenses={fixedExpenses}
-                insuranceMembers={insuranceMembers}
-                otherExpenses={otherExpenses}
-              />
-            </div>
-          </div>
-        )}
-      </div>
+      )}
     </div>
   )
 }

--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -24,9 +24,10 @@ export interface FundInvestment {
   fund_id: string
   goal_id: string | null
   amount_vnd: number
-  units: number
-  unit_price: number
+  units: number | null
+  unit_price: number | null
   investment_date: string | null
+  is_dca_seeded: boolean
   funds: { name: string; nav: number } | null
   savings_goals: { goal_name: string } | null
 }

--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -10,6 +10,7 @@ import FixedExpensesSection from './components/FixedExpensesSection'
 import InsuranceSection from './components/InsuranceSection'
 import OtherExpensesSection from './components/OtherExpensesSection'
 import AllocationSummary from './components/AllocationSummary'
+import MobilePlanningView from './components/MobilePlanningView'
 
 export interface MonthlyPlan {
   id: string
@@ -198,7 +199,36 @@ export default function PlanningClient() {
   const refetch = useCallback(() => fetchPlan({ force: true }), [fetchPlan])
 
   return (
-    <div className="space-y-6">
+    <>
+      {/* Mobile view (hidden on md+) */}
+      <MobilePlanningView
+        month={month}
+        year={year}
+        plan={plan}
+        investments={investments}
+        savings={savings}
+        fixedExpenses={fixedExpenses}
+        insuranceMembers={insuranceMembers}
+        otherExpenses={otherExpenses}
+        funds={funds}
+        goals={goals}
+        onNavigatePrev={() => navigate('prev')}
+        onNavigateNext={() => navigate('next')}
+        onPlanCreated={(p) => { setPlan(p); refetch() }}
+        onPlanDeleted={() => {
+          bustPlanCache(month, year)
+          setPlan(null)
+          setInvestments([])
+          setSavings([])
+          setFixedExpenses([])
+          showToast(t('deletedToast', { month: MONTHS[month - 1], year }))
+        }}
+        onRefresh={refetch}
+        onToast={showToast}
+      />
+
+      {/* Desktop view (hidden on mobile) */}
+      <div className="hidden md:block space-y-6">
       {/* Month navigation */}
       <div className="flex items-center gap-3">
         <button
@@ -304,6 +334,7 @@ export default function PlanningClient() {
           </div>
         </div>
       )}
-    </div>
+      </div>
+    </>
   )
 }

--- a/app/(app)/planning/components/AllocationSummary.tsx
+++ b/app/(app)/planning/components/AllocationSummary.tsx
@@ -24,7 +24,7 @@ export default function AllocationSummary({ plan, investments, savings, fixedExp
   if (!plan) {
     return (
       <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-5">
-        <h2 className="font-semibold text-gray-900 dark:text-gray-100 mb-3">{t('summaryTitle')}</h2>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">{t('summaryTitle')}</h2>
         <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-6">{t('enterSalary')}</p>
       </div>
     )
@@ -32,9 +32,7 @@ export default function AllocationSummary({ plan, investments, savings, fixedExp
 
   const salary = plan.salary_vnd
 
-  // Build goal map: goal_name → total invested/saved
   const goalMap = new Map<string, number>()
-
   const addToGoal = (label: string, amount: number) => {
     goalMap.set(label, (goalMap.get(label) ?? 0) + amount)
   }
@@ -49,7 +47,7 @@ export default function AllocationSummary({ plan, investments, savings, fixedExp
   }
 
   const totalFixed = fixedExpenses.reduce((sum, e) => {
-    if (e.override === 0) return sum // skipped this month
+    if (e.override === 0) return sum
     const monthly = e.override != null ? e.override : e.amount_vnd
     return sum + monthly
   }, 0)
@@ -65,7 +63,6 @@ export default function AllocationSummary({ plan, investments, savings, fixedExp
   const totalAllocated = totalInvested + totalSaved + totalFixed + totalInsurance + totalOther
   const remaining = salary - totalAllocated
 
-  // Build rows sorted: named goals alphabetically, then Unassigned
   const goalRows: GoalRow[] = []
   const unassignedLabel = t('unassigned')
   const unassigned = goalMap.get(unassignedLabel)
@@ -80,90 +77,90 @@ export default function AllocationSummary({ plan, investments, savings, fixedExp
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden sticky top-6">
       <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
-        <h2 className="font-semibold text-gray-900 dark:text-gray-100">{t('summaryTitle')}</h2>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('summaryTitle')}</h2>
         <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{t('salaryRow', { amount: fmt(salary) })}</p>
       </div>
 
-      <div className="p-5">
-        <table className="w-full text-sm">
-          <thead>
-            <tr>
-              <th className="pb-2 text-left text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide">{t('colGoal')}</th>
-              <th className="pb-2 text-right text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide px-3">{t('colAllocation')}</th>
-              <th className="pb-2 text-right text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wide whitespace-nowrap">{t('colPercent')}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {/* Goal rows */}
+      <div className="p-5 space-y-4">
+        {/* Goal rows */}
+        <div>
+          <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2 uppercase tracking-wide">{t('colGoal')}</p>
+          <div className="space-y-2">
             {goalRows.length === 0 ? (
-              <tr>
-                <td colSpan={3} className="py-2 text-sm text-gray-400 dark:text-gray-500 text-center">{t('noAllocations')}</td>
-              </tr>
+              <p className="text-sm text-gray-400 dark:text-gray-500">{t('noAllocations')}</p>
             ) : (
               goalRows.map((row) => (
-                <tr key={row.label} className="border-t border-gray-100 dark:border-gray-700">
-                  <td className="py-2 text-gray-700 dark:text-gray-300 font-medium">{row.label}</td>
-                  <td className="py-2 text-right text-gray-600 dark:text-gray-400 px-3">{fmt(row.total)}</td>
-                  <td className="py-2 text-right text-gray-400 dark:text-gray-500">{pct(row.total)}</td>
-                </tr>
+                <div key={row.label} className="flex items-center justify-between text-sm">
+                  <span className="text-gray-600 dark:text-gray-400">{row.label}</span>
+                  <div className="text-right">
+                    <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(row.total)}</span>
+                    <span className="text-gray-500 dark:text-gray-400 ml-2">{pct(row.total)}</span>
+                  </div>
+                </div>
               ))
             )}
+          </div>
+        </div>
 
-            {/* Fixed Expenses */}
-            {fixedExpenses.length > 0 && (
-              <tr className="border-t border-gray-200 dark:border-gray-600">
-                <td className="pt-3 pb-1 text-gray-600 dark:text-gray-400">{t('rowFixedExpenses')}</td>
-                <td className="pt-3 pb-1 text-right text-gray-700 dark:text-gray-300 font-medium px-3">{fmt(totalFixed)}</td>
-                <td className="pt-3 pb-1 text-right text-gray-400 dark:text-gray-500">{pct(totalFixed)}</td>
-              </tr>
-            )}
+        {/* Expenses */}
+        <div className="space-y-2 pt-3 border-t border-gray-100 dark:border-gray-700">
+          {fixedExpenses.length > 0 && (
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-gray-600 dark:text-gray-400">{t('rowFixedExpenses')}</span>
+              <div className="text-right">
+                <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(totalFixed)}</span>
+                <span className="text-gray-500 dark:text-gray-400 ml-2">{pct(totalFixed)}</span>
+              </div>
+            </div>
+          )}
+          {insuranceMembers.length > 0 && (
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-gray-600 dark:text-gray-400">{t('rowInsurance')}</span>
+              <div className="text-right">
+                <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(totalInsurance)}</span>
+                <span className="text-gray-500 dark:text-gray-400 ml-2">{pct(totalInsurance)}</span>
+              </div>
+            </div>
+          )}
+          {otherExpenses.length > 0 && (
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-gray-600 dark:text-gray-400">{t('rowOtherExpenses')}</span>
+              <div className="text-right">
+                <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(totalOther)}</span>
+                <span className="text-gray-500 dark:text-gray-400 ml-2">{pct(totalOther)}</span>
+              </div>
+            </div>
+          )}
+        </div>
 
-            {/* Insurance */}
-            {insuranceMembers.length > 0 && (
-              <tr className={fixedExpenses.length > 0 ? '' : 'border-t border-gray-200 dark:border-gray-600'}>
-                <td className="py-1 text-gray-600 dark:text-gray-400">{t('rowInsurance')}</td>
-                <td className="py-1 text-right text-gray-700 dark:text-gray-300 font-medium px-3">{fmt(totalInsurance)}</td>
-                <td className="py-1 text-right text-gray-400 dark:text-gray-500">{pct(totalInsurance)}</td>
-              </tr>
-            )}
+        {/* Total + Remaining */}
+        <div className="pt-3 border-t border-gray-100 dark:border-gray-700">
+          <div className="flex items-center justify-between mb-3">
+            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{t('rowTotal')}</span>
+            <div className="text-right">
+              <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">{fmt(totalAllocated)}</span>
+              <span className="text-sm text-gray-500 dark:text-gray-400 ml-2">{pct(totalAllocated)}</span>
+            </div>
+          </div>
 
-            {/* Other Expenses */}
-            {otherExpenses.length > 0 && (
-              <tr className={(fixedExpenses.length > 0 || insuranceMembers.length > 0) ? '' : 'border-t border-gray-200 dark:border-gray-600'}>
-                <td className="py-1 text-gray-600 dark:text-gray-400">{t('rowOtherExpenses')}</td>
-                <td className="py-1 text-right text-gray-700 dark:text-gray-300 font-medium px-3">{fmt(totalOther)}</td>
-                <td className="py-1 text-right text-gray-400 dark:text-gray-500">{pct(totalOther)}</td>
-              </tr>
-            )}
-
-            {/* Total Allocated */}
-            <tr className="border-t border-gray-200 dark:border-gray-600">
-              <td className="pt-2 pb-1 font-semibold text-gray-700 dark:text-gray-300">{t('rowTotal')}</td>
-              <td className="pt-2 pb-1 text-right font-semibold text-gray-900 dark:text-gray-100 px-3">{fmt(totalAllocated)}</td>
-              <td className="pt-2 pb-1 text-right font-semibold text-gray-400 dark:text-gray-500">{pct(totalAllocated)}</td>
-            </tr>
-
-            {/* Spacer */}
-            <tr><td colSpan={3} className="pt-2" /></tr>
-
-            {/* Remaining Salary — inside the table so columns stay aligned */}
-            <tr>
-              <td className={`py-2 pl-3 rounded-l-lg font-semibold ${remaining >= 0 ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400' : 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400'}`}>
-                {t('rowRemaining')}
-              </td>
-              <td className={`py-2 text-right font-semibold px-3 ${remaining >= 0 ? 'bg-green-50 dark:bg-green-900/20 text-green-700 dark:text-green-400' : 'bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-400'}`}>
+          <div className={`flex items-center justify-between p-3 rounded-lg ${remaining >= 0 ? 'bg-green-50 dark:bg-green-900/20' : 'bg-red-50 dark:bg-red-900/20'}`}>
+            <span className={`text-sm font-semibold ${remaining >= 0 ? 'text-green-900 dark:text-green-400' : 'text-red-900 dark:text-red-400'}`}>
+              {t('rowRemaining')}
+            </span>
+            <div className="text-right">
+              <span className={`text-sm font-bold ${remaining >= 0 ? 'text-green-900 dark:text-green-400' : 'text-red-900 dark:text-red-400'}`}>
                 {fmt(remaining)}
-              </td>
-              <td className={`py-2 pr-3 text-right text-xs font-semibold rounded-r-lg whitespace-nowrap ${remaining >= 0 ? 'bg-green-50 dark:bg-green-900/20 text-green-500 dark:text-green-400' : 'bg-red-50 dark:bg-red-900/20 text-red-400 dark:text-red-300'}`}>
+              </span>
+              <span className={`text-sm ml-2 ${remaining >= 0 ? 'text-green-700 dark:text-green-500' : 'text-red-700 dark:text-red-400'}`}>
                 {pct(Math.abs(remaining))}
-              </td>
-            </tr>
-          </tbody>
-        </table>
+              </span>
+            </div>
+          </div>
 
-        {remaining < 0 && (
-          <p className="text-xs text-red-500 dark:text-red-400 text-center mt-2">{t('overAllocated', { amount: fmt(Math.abs(remaining)) })}</p>
-        )}
+          {remaining < 0 && (
+            <p className="text-xs text-red-500 dark:text-red-400 text-center mt-2">{t('overAllocated', { amount: fmt(Math.abs(remaining)) })}</p>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/app/(app)/planning/components/AllocationSummary.tsx
+++ b/app/(app)/planning/components/AllocationSummary.tsx
@@ -23,8 +23,8 @@ export default function AllocationSummary({ plan, investments, savings, fixedExp
   const t = useTranslations('planning')
   if (!plan) {
     return (
-      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-5">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-3">{t('summaryTitle')}</h2>
+      <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">{t('summaryTitle')}</h2>
         <p className="text-sm text-gray-400 dark:text-gray-500 text-center py-6">{t('enterSalary')}</p>
       </div>
     )
@@ -75,91 +75,96 @@ export default function AllocationSummary({ plan, investments, savings, fixedExp
   const pct = (n: number) => salary > 0 ? `${Math.round((n / salary) * 100)}%` : '—'
 
   return (
-    <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden sticky top-6">
-      <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('summaryTitle')}</h2>
-        <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{t('salaryRow', { amount: fmt(salary) })}</p>
-      </div>
+    <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-6 sticky top-6">
+      <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100 mb-4">{t('summaryTitle')}</h2>
 
-      <div className="p-5 space-y-4">
-        {/* Goal rows */}
-        <div>
-          <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2 uppercase tracking-wide">{t('colGoal')}</p>
-          <div className="space-y-2">
-            {goalRows.length === 0 ? (
-              <p className="text-sm text-gray-400 dark:text-gray-500">{t('noAllocations')}</p>
-            ) : (
-              goalRows.map((row) => (
-                <div key={row.label} className="flex items-center justify-between text-sm">
-                  <span className="text-gray-600 dark:text-gray-400">{row.label}</span>
-                  <div className="text-right">
-                    <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(row.total)}</span>
-                    <span className="text-gray-500 dark:text-gray-400 ml-2">{pct(row.total)}</span>
+      <div className="space-y-4">
+        {/* Salary */}
+        <div className="pb-4 border-b border-gray-200 dark:border-gray-700">
+          <p className="text-sm text-gray-500 dark:text-gray-400 mb-1">{t('salaryLabel')}</p>
+          <p className="text-2xl font-bold text-gray-900 dark:text-gray-100">{fmt(salary)}</p>
+        </div>
+
+        <div className="space-y-3">
+          {/* Goal rows */}
+          <div>
+            <p className="text-sm font-medium text-gray-900 dark:text-gray-100 mb-2">{t('colGoal')}</p>
+            <div className="space-y-2">
+              {goalRows.length === 0 ? (
+                <p className="text-sm text-gray-400 dark:text-gray-500">{t('noAllocations')}</p>
+              ) : (
+                goalRows.map((row) => (
+                  <div key={row.label} className="flex items-center justify-between text-sm">
+                    <span className="text-gray-600 dark:text-gray-400">{row.label}</span>
+                    <div className="text-right">
+                      <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(row.total)}</span>
+                      <span className="text-gray-500 dark:text-gray-400 ml-2">{pct(row.total)}</span>
+                    </div>
                   </div>
+                ))
+              )}
+            </div>
+          </div>
+
+          {/* Expenses */}
+          <div className="space-y-2 pt-3 border-t border-gray-200 dark:border-gray-700">
+            {fixedExpenses.length > 0 && (
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-gray-600 dark:text-gray-400">{t('rowFixedExpenses')}</span>
+                <div className="text-right">
+                  <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(totalFixed)}</span>
+                  <span className="text-gray-500 dark:text-gray-400 ml-2">{pct(totalFixed)}</span>
                 </div>
-              ))
+              </div>
+            )}
+            {insuranceMembers.length > 0 && (
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-gray-600 dark:text-gray-400">{t('rowInsurance')}</span>
+                <div className="text-right">
+                  <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(totalInsurance)}</span>
+                  <span className="text-gray-500 dark:text-gray-400 ml-2">{pct(totalInsurance)}</span>
+                </div>
+              </div>
+            )}
+            {otherExpenses.length > 0 && (
+              <div className="flex items-center justify-between text-sm">
+                <span className="text-gray-600 dark:text-gray-400">{t('rowOtherExpenses')}</span>
+                <div className="text-right">
+                  <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(totalOther)}</span>
+                  <span className="text-gray-500 dark:text-gray-400 ml-2">{pct(totalOther)}</span>
+                </div>
+              </div>
             )}
           </div>
-        </div>
 
-        {/* Expenses */}
-        <div className="space-y-2 pt-3 border-t border-gray-100 dark:border-gray-700">
-          {fixedExpenses.length > 0 && (
-            <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600 dark:text-gray-400">{t('rowFixedExpenses')}</span>
+          {/* Total + Remaining */}
+          <div className="pt-3 border-t border-gray-200 dark:border-gray-700">
+            <div className="flex items-center justify-between mb-2">
+              <span className="font-medium text-gray-900 dark:text-gray-100">{t('rowTotal')}</span>
               <div className="text-right">
-                <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(totalFixed)}</span>
-                <span className="text-gray-500 dark:text-gray-400 ml-2">{pct(totalFixed)}</span>
+                <span className="font-semibold text-gray-900 dark:text-gray-100">{fmt(totalAllocated)}</span>
+                <span className="text-gray-500 dark:text-gray-400 ml-2">{pct(totalAllocated)}</span>
               </div>
             </div>
-          )}
-          {insuranceMembers.length > 0 && (
-            <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600 dark:text-gray-400">{t('rowInsurance')}</span>
-              <div className="text-right">
-                <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(totalInsurance)}</span>
-                <span className="text-gray-500 dark:text-gray-400 ml-2">{pct(totalInsurance)}</span>
-              </div>
-            </div>
-          )}
-          {otherExpenses.length > 0 && (
-            <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600 dark:text-gray-400">{t('rowOtherExpenses')}</span>
-              <div className="text-right">
-                <span className="font-medium text-gray-900 dark:text-gray-100">{fmt(totalOther)}</span>
-                <span className="text-gray-500 dark:text-gray-400 ml-2">{pct(totalOther)}</span>
-              </div>
-            </div>
-          )}
-        </div>
 
-        {/* Total + Remaining */}
-        <div className="pt-3 border-t border-gray-100 dark:border-gray-700">
-          <div className="flex items-center justify-between mb-3">
-            <span className="text-sm font-medium text-gray-700 dark:text-gray-300">{t('rowTotal')}</span>
-            <div className="text-right">
-              <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">{fmt(totalAllocated)}</span>
-              <span className="text-sm text-gray-500 dark:text-gray-400 ml-2">{pct(totalAllocated)}</span>
-            </div>
-          </div>
-
-          <div className={`flex items-center justify-between p-3 rounded-lg ${remaining >= 0 ? 'bg-green-50 dark:bg-green-900/20' : 'bg-red-50 dark:bg-red-900/20'}`}>
-            <span className={`text-sm font-semibold ${remaining >= 0 ? 'text-green-900 dark:text-green-400' : 'text-red-900 dark:text-red-400'}`}>
-              {t('rowRemaining')}
-            </span>
-            <div className="text-right">
-              <span className={`text-sm font-bold ${remaining >= 0 ? 'text-green-900 dark:text-green-400' : 'text-red-900 dark:text-red-400'}`}>
-                {fmt(remaining)}
+            <div className={`flex items-center justify-between p-3 rounded-lg ${remaining >= 0 ? 'bg-green-50 dark:bg-green-900/20' : 'bg-red-50 dark:bg-red-900/20'}`}>
+              <span className={`font-semibold ${remaining >= 0 ? 'text-green-900 dark:text-green-400' : 'text-red-900 dark:text-red-400'}`}>
+                {t('rowRemaining')}
               </span>
-              <span className={`text-sm ml-2 ${remaining >= 0 ? 'text-green-700 dark:text-green-500' : 'text-red-700 dark:text-red-400'}`}>
-                {pct(Math.abs(remaining))}
-              </span>
+              <div className="text-right">
+                <span className={`font-bold ${remaining >= 0 ? 'text-green-900 dark:text-green-400' : 'text-red-900 dark:text-red-400'}`}>
+                  {fmt(remaining)}
+                </span>
+                <span className={`ml-2 ${remaining >= 0 ? 'text-green-700 dark:text-green-500' : 'text-red-700 dark:text-red-400'}`}>
+                  {pct(Math.abs(remaining))}
+                </span>
+              </div>
             </div>
-          </div>
 
-          {remaining < 0 && (
-            <p className="text-xs text-red-500 dark:text-red-400 text-center mt-2">{t('overAllocated', { amount: fmt(Math.abs(remaining)) })}</p>
-          )}
+            {remaining < 0 && (
+              <p className="text-xs text-red-500 dark:text-red-400 text-center mt-2">{t('overAllocated', { amount: fmt(Math.abs(remaining)) })}</p>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/app/(app)/planning/components/DirectSavingsSection.tsx
+++ b/app/(app)/planning/components/DirectSavingsSection.tsx
@@ -109,7 +109,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-      <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between px-5 py-4 border-t border-b border-gray-200 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('directSavingsTitle')}</h2>
         <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-700 dark:hover:bg-gray-200 transition-colors">
           <Plus className="h-3.5 w-3.5" />
@@ -122,7 +122,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
       ) : (
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-gray-200 dark:border-gray-700">
+            <tr className="border-t border-b border-gray-200 dark:border-gray-700">
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
               <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAmount')}</th>
               <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colInterest')}</th>

--- a/app/(app)/planning/components/DirectSavingsSection.tsx
+++ b/app/(app)/planning/components/DirectSavingsSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { Plus, Pencil, Trash2 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import type { MonthlyPlan, DirectSaving, Goal } from '../PlanningClient'
 
@@ -109,8 +110,9 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
       <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-700">
-        <h2 className="font-semibold text-gray-900 dark:text-gray-100">{t('directSavingsTitle')}</h2>
-        <button onClick={openAdd} className="px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('directSavingsTitle')}</h2>
+        <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+          <Plus className="h-3.5 w-3.5" />
           {t('addSavings')}
         </button>
       </div>
@@ -119,25 +121,33 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
         <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">{t('addSavingsDesc')}</div>
       ) : (
         <table className="w-full text-sm">
-          <thead className="bg-gray-50 dark:bg-gray-800">
-            <tr>
+          <thead>
+            <tr className="border-b border-gray-100 dark:border-gray-700">
               {[t('colDate'), t('colAmount'), t('colInterest'), t('colExpiry'), t('colGoalCol'), tc('actions')].map((h) => (
-                <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
+                <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{h}</th>
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+          <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
             {savings.map((item) => (
-              <tr key={item.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+              <tr key={item.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.investment_date ? new Date(item.investment_date).toLocaleDateString('vi-VN') : '—'}</td>
                 <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(item.amount_vnd)}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.interest_rate != null ? `${item.interest_rate}%` : '—'}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.expiry_date ? new Date(item.expiry_date).toLocaleDateString('vi-VN') : '—'}</td>
-                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.savings_goals?.goal_name ?? t('unassigned')}</td>
                 <td className="px-4 py-3">
-                  <div className="flex gap-3">
-                    <button onClick={() => openEdit(item)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">{tc('edit')}</button>
-                    <button onClick={() => setConfirmDelete(item)} className="text-xs text-red-500 dark:text-red-400 hover:underline">{tc('delete')}</button>
+                  <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${item.savings_goals ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300' : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'}`}>
+                    {item.savings_goals?.goal_name ?? t('unassigned')}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex gap-1">
+                    <button onClick={() => openEdit(item)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                      <Pencil className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                    </button>
+                    <button onClick={() => setConfirmDelete(item)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                      <Trash2 className="h-4 w-4 text-red-500 dark:text-red-400" />
+                    </button>
                   </div>
                 </td>
               </tr>

--- a/app/(app)/planning/components/DirectSavingsSection.tsx
+++ b/app/(app)/planning/components/DirectSavingsSection.tsx
@@ -109,7 +109,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-      <div className="flex items-center justify-between px-5 py-4 border-t border-b border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between px-5 py-4">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('directSavingsTitle')}</h2>
         <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-700 dark:hover:bg-gray-200 transition-colors">
           <Plus className="h-3.5 w-3.5" />
@@ -122,7 +122,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
       ) : (
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-t border-b border-gray-200 dark:border-gray-700">
+            <tr className="border-b border-gray-200 dark:border-gray-700">
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
               <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAmount')}</th>
               <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colInterest')}</th>

--- a/app/(app)/planning/components/DirectSavingsSection.tsx
+++ b/app/(app)/planning/components/DirectSavingsSection.tsx
@@ -111,7 +111,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
       <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('directSavingsTitle')}</h2>
-        <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+        <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-700 dark:hover:bg-gray-200 transition-colors">
           <Plus className="h-3.5 w-3.5" />
           {t('addSavings')}
         </button>
@@ -132,11 +132,11 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
             {savings.map((item) => (
               <tr key={item.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.investment_date ? new Date(item.investment_date).toLocaleDateString('vi-VN') : '—'}</td>
-                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(item.amount_vnd)}</td>
+                <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{fmt(item.amount_vnd)}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.interest_rate != null ? `${item.interest_rate}%` : '—'}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.expiry_date ? new Date(item.expiry_date).toLocaleDateString('vi-VN') : '—'}</td>
                 <td className="px-4 py-3">
-                  <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${item.savings_goals ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300' : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'}`}>
+                  <span className={`inline-block px-2.5 py-0.5 rounded-md text-xs font-medium ${item.savings_goals ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'}`}>
                     {item.savings_goals?.goal_name ?? t('unassigned')}
                   </span>
                 </td>

--- a/app/(app)/planning/components/DirectSavingsSection.tsx
+++ b/app/(app)/planning/components/DirectSavingsSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Plus, Pencil, Trash2 } from 'lucide-react'
+import { Plus, Edit, Trash2 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import type { MonthlyPlan, DirectSaving, Goal } from '../PlanningClient'
 
@@ -123,30 +123,33 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-gray-100 dark:border-gray-700">
-              {[t('colDate'), t('colAmount'), t('colInterest'), t('colExpiry'), t('colGoalCol'), tc('actions')].map((h) => (
-                <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{h}</th>
-              ))}
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
+              <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAmount')}</th>
+              <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colInterest')}</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colExpiry')}</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colGoalCol')}</th>
+              <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
             {savings.map((item) => (
               <tr key={item.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.investment_date ? new Date(item.investment_date).toLocaleDateString('vi-VN') : '—'}</td>
-                <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{fmt(item.amount_vnd)}</td>
-                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.interest_rate != null ? `${item.interest_rate}%` : '—'}</td>
-                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.expiry_date ? new Date(item.expiry_date).toLocaleDateString('vi-VN') : '—'}</td>
+                <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{item.investment_date ? new Date(item.investment_date).toLocaleDateString('vi-VN') : '—'}</td>
+                <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100 text-right">{fmt(item.amount_vnd)}</td>
+                <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 text-right">{item.interest_rate != null ? `${item.interest_rate}%` : '—'}</td>
+                <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{item.expiry_date ? new Date(item.expiry_date).toLocaleDateString('vi-VN') : '—'}</td>
                 <td className="px-4 py-3">
-                  <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${item.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-normal bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'}`}>
+                  <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${item.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-normal bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'}`}>
                     {item.savings_goals?.goal_name ?? t('unassigned')}
                   </span>
                 </td>
-                <td className="px-4 py-3">
-                  <div className="flex gap-1">
+                <td className="px-4 py-3 text-center">
+                  <div className="flex gap-1 justify-center">
                     <button onClick={() => openEdit(item)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
-                      <Pencil className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                      <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
                     </button>
                     <button onClick={() => setConfirmDelete(item)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
-                      <Trash2 className="h-4 w-4 text-red-500 dark:text-red-400" />
+                      <Trash2 className="h-4 w-4 text-red-600 dark:text-red-400" />
                     </button>
                   </div>
                 </td>

--- a/app/(app)/planning/components/DirectSavingsSection.tsx
+++ b/app/(app)/planning/components/DirectSavingsSection.tsx
@@ -109,7 +109,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-      <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+      <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('directSavingsTitle')}</h2>
         <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-700 dark:hover:bg-gray-200 transition-colors">
           <Plus className="h-3.5 w-3.5" />
@@ -122,7 +122,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
       ) : (
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-gray-100 dark:border-gray-700">
+            <tr className="border-b border-gray-200 dark:border-gray-700">
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
               <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAmount')}</th>
               <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colInterest')}</th>
@@ -131,7 +131,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
               <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
             {savings.map((item) => (
               <tr key={item.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
                 <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{item.investment_date ? new Date(item.investment_date).toLocaleDateString('vi-VN') : '—'}</td>

--- a/app/(app)/planning/components/DirectSavingsSection.tsx
+++ b/app/(app)/planning/components/DirectSavingsSection.tsx
@@ -139,7 +139,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
                 <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 text-right">{item.interest_rate != null ? `${item.interest_rate}%` : '—'}</td>
                 <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{item.expiry_date ? new Date(item.expiry_date).toLocaleDateString('vi-VN') : '—'}</td>
                 <td className="px-4 py-3">
-                  <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${item.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'}`}>
+                  <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${item.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-medium bg-gray-100 text-gray-900 dark:bg-gray-700 dark:text-gray-100'}`}>
                     {item.savings_goals?.goal_name ?? t('unassigned')}
                   </span>
                 </td>

--- a/app/(app)/planning/components/DirectSavingsSection.tsx
+++ b/app/(app)/planning/components/DirectSavingsSection.tsx
@@ -136,7 +136,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.interest_rate != null ? `${item.interest_rate}%` : '—'}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.expiry_date ? new Date(item.expiry_date).toLocaleDateString('vi-VN') : '—'}</td>
                 <td className="px-4 py-3">
-                  <span className={`inline-block px-2.5 py-0.5 rounded-md text-xs font-medium ${item.savings_goals ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400'}`}>
+                  <span className={`inline-block px-2.5 py-0.5 rounded-md text-xs ${item.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-normal border border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500'}`}>
                     {item.savings_goals?.goal_name ?? t('unassigned')}
                   </span>
                 </td>

--- a/app/(app)/planning/components/DirectSavingsSection.tsx
+++ b/app/(app)/planning/components/DirectSavingsSection.tsx
@@ -139,7 +139,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
                 <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 text-right">{item.interest_rate != null ? `${item.interest_rate}%` : '—'}</td>
                 <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{item.expiry_date ? new Date(item.expiry_date).toLocaleDateString('vi-VN') : '—'}</td>
                 <td className="px-4 py-3">
-                  <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${item.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-normal bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'}`}>
+                  <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${item.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'}`}>
                     {item.savings_goals?.goal_name ?? t('unassigned')}
                   </span>
                 </td>

--- a/app/(app)/planning/components/DirectSavingsSection.tsx
+++ b/app/(app)/planning/components/DirectSavingsSection.tsx
@@ -136,7 +136,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.interest_rate != null ? `${item.interest_rate}%` : '—'}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.expiry_date ? new Date(item.expiry_date).toLocaleDateString('vi-VN') : '—'}</td>
                 <td className="px-4 py-3">
-                  <span className={`inline-block px-2.5 py-0.5 rounded-md text-xs font-medium ${item.savings_goals ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'}`}>
+                  <span className={`inline-block px-2.5 py-0.5 rounded-md text-xs font-medium ${item.savings_goals ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400'}`}>
                     {item.savings_goals?.goal_name ?? t('unassigned')}
                   </span>
                 </td>

--- a/app/(app)/planning/components/DirectSavingsSection.tsx
+++ b/app/(app)/planning/components/DirectSavingsSection.tsx
@@ -136,7 +136,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.interest_rate != null ? `${item.interest_rate}%` : '—'}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{item.expiry_date ? new Date(item.expiry_date).toLocaleDateString('vi-VN') : '—'}</td>
                 <td className="px-4 py-3">
-                  <span className={`inline-block px-2.5 py-0.5 rounded-md text-xs ${item.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-normal border border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500'}`}>
+                  <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${item.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-normal bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'}`}>
                     {item.savings_goals?.goal_name ?? t('unassigned')}
                   </span>
                 </td>

--- a/app/(app)/planning/components/FixedExpensesSection.tsx
+++ b/app/(app)/planning/components/FixedExpensesSection.tsx
@@ -132,12 +132,10 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
                       {t('skipped')}
                     </span>
                   ) : (
-                    <>
-                      <span className={`text-sm font-medium ${hasOverride ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'}`}>
-                        {fmt(thisMonth)}
-                      </span>
-                      {hasOverride && <div className="text-xs text-amber-500 dark:text-amber-400">({t('overridden')})</div>}
-                    </>
+                    <div className={`text-sm font-medium ${hasOverride ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'}`}>
+                      <div>{fmt(thisMonth)}</div>
+                      {hasOverride && <div className="text-xs">{t('overridden')}</div>}
+                    </div>
                   )}
                 </td>
                 <td className="px-4 py-3 text-center">

--- a/app/(app)/planning/components/FixedExpensesSection.tsx
+++ b/app/(app)/planning/components/FixedExpensesSection.tsx
@@ -143,13 +143,13 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
                 <td className="px-4 py-3 text-center">
                   <div className="flex gap-1 justify-center">
                     {isSkipped ? (
-                      <button onClick={() => handleRestore(expense)} className="h-8 px-2 text-xs font-medium text-gray-600 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">{t('restore')}</button>
+                      <button onClick={() => handleRestore(expense)} className="h-8 px-2 text-xs font-medium text-gray-900 dark:text-gray-100 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">{t('restore')}</button>
                     ) : (
                       <>
                         <button onClick={() => openEdit(expense)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                           <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
                         </button>
-                        <button onClick={() => setConfirmSkip(expense)} className="h-8 px-2 text-xs font-medium text-gray-600 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">{t('skip')}</button>
+                        <button onClick={() => setConfirmSkip(expense)} className="h-8 px-2 text-xs font-medium text-gray-900 dark:text-gray-100 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">{t('skip')}</button>
                       </>
                     )}
                   </div>

--- a/app/(app)/planning/components/FixedExpensesSection.tsx
+++ b/app/(app)/planning/components/FixedExpensesSection.tsx
@@ -93,7 +93,7 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
   if (fixedExpenses.length === 0) {
     return (
       <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-        <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+        <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
           <h2 className="font-semibold text-gray-900 dark:text-gray-100">{t('fixedExpensesTitle')}</h2>
         </div>
         <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">{t('fixedExpensesDesc')}</div>
@@ -103,21 +103,21 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-      <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+      <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('fixedExpensesTitle')}</h2>
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{t('fixedExpensesDesc')}</p>
       </div>
 
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-gray-100 dark:border-gray-700">
+          <tr className="border-b border-gray-200 dark:border-gray-700">
             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colExpense')}</th>
             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDefault')}</th>
             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colThisMonth')}</th>
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
+        <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
           {fixedExpenses.map((expense) => {
             const isSkipped = expense.override === 0
             const hasOverride = expense.override != null && expense.override > 0 && expense.override !== expense.amount_vnd

--- a/app/(app)/planning/components/FixedExpensesSection.tsx
+++ b/app/(app)/planning/components/FixedExpensesSection.tsx
@@ -124,7 +124,7 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
             const thisMonth = expense.override ?? expense.amount_vnd
             return (
               <tr key={expense.expense_id} className={`hover:bg-gray-50 dark:hover:bg-gray-800/50 ${isSkipped ? 'opacity-60' : ''}`}>
-                <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">{expense.expense_name}</td>
+                <td className="px-4 py-3 text-base font-medium text-gray-900 dark:text-gray-100">{expense.expense_name}</td>
                 <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 text-right">{fmt(expense.amount_vnd)}</td>
                 <td className="px-4 py-3 text-right">
                   {isSkipped ? (

--- a/app/(app)/planning/components/FixedExpensesSection.tsx
+++ b/app/(app)/planning/components/FixedExpensesSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Pencil } from 'lucide-react'
+import { Edit } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import type { MonthlyPlan, FixedExpense } from '../PlanningClient'
 
@@ -111,9 +111,10 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-gray-100 dark:border-gray-700">
-            {[t('colExpense'), t('colDefault'), t('colThisMonth'), tc('actions')].map((h) => (
-              <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{h}</th>
-            ))}
+            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colExpense')}</th>
+            <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDefault')}</th>
+            <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colThisMonth')}</th>
+            <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
@@ -123,30 +124,30 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
             const thisMonth = expense.override ?? expense.amount_vnd
             return (
               <tr key={expense.expense_id} className={`hover:bg-gray-50 dark:hover:bg-gray-800/50 ${isSkipped ? 'opacity-60' : ''}`}>
-                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{expense.expense_name}</td>
-                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{fmt(expense.amount_vnd)}</td>
-                <td className="px-4 py-3">
+                <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">{expense.expense_name}</td>
+                <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 text-right">{fmt(expense.amount_vnd)}</td>
+                <td className="px-4 py-3 text-right">
                   {isSkipped ? (
                     <span className="inline-block px-2 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">
                       {t('skipped')}
                     </span>
                   ) : (
                     <>
-                      <span className={hasOverride ? 'text-amber-600 dark:text-amber-400 font-medium' : 'text-gray-900 dark:text-gray-100 font-medium'}>
+                      <span className={`text-sm font-medium ${hasOverride ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'}`}>
                         {fmt(thisMonth)}
                       </span>
-                      {hasOverride && <span className="ml-1.5 text-xs text-amber-500 dark:text-amber-400">({t('overridden')})</span>}
+                      {hasOverride && <div className="text-xs text-amber-500 dark:text-amber-400">({t('overridden')})</div>}
                     </>
                   )}
                 </td>
-                <td className="px-4 py-3">
-                  <div className="flex gap-1">
+                <td className="px-4 py-3 text-center">
+                  <div className="flex gap-1 justify-center">
                     {isSkipped ? (
                       <button onClick={() => handleRestore(expense)} className="px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">{t('restore')}</button>
                     ) : (
                       <>
                         <button onClick={() => openEdit(expense)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
-                          <Pencil className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                          <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
                         </button>
                         <button onClick={() => setConfirmSkip(expense)} className="px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">{t('skip')}</button>
                       </>

--- a/app/(app)/planning/components/FixedExpensesSection.tsx
+++ b/app/(app)/planning/components/FixedExpensesSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { Pencil } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import type { MonthlyPlan, FixedExpense } from '../PlanningClient'
 
@@ -103,25 +104,25 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
       <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
-        <h2 className="font-semibold text-gray-900 dark:text-gray-100">{t('fixedExpensesTitle')}</h2>
-        <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{t('fixedExpensesDesc')}</p>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('fixedExpensesTitle')}</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{t('fixedExpensesDesc')}</p>
       </div>
 
       <table className="w-full text-sm">
-        <thead className="bg-gray-50 dark:bg-gray-800">
-          <tr>
+        <thead>
+          <tr className="border-b border-gray-100 dark:border-gray-700">
             {[t('colExpense'), t('colDefault'), t('colThisMonth'), tc('actions')].map((h) => (
-              <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
+              <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{h}</th>
             ))}
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+        <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
           {fixedExpenses.map((expense) => {
             const isSkipped = expense.override === 0
             const hasOverride = expense.override != null && expense.override > 0 && expense.override !== expense.amount_vnd
             const thisMonth = expense.override ?? expense.amount_vnd
             return (
-              <tr key={expense.expense_id} className={`hover:bg-gray-50 dark:hover:bg-gray-800 ${isSkipped ? 'opacity-60' : ''}`}>
+              <tr key={expense.expense_id} className={`hover:bg-gray-50 dark:hover:bg-gray-800/50 ${isSkipped ? 'opacity-60' : ''}`}>
                 <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{expense.expense_name}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{fmt(expense.amount_vnd)}</td>
                 <td className="px-4 py-3">
@@ -131,21 +132,23 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
                     </span>
                   ) : (
                     <>
-                      <span className={hasOverride ? 'text-indigo-600 dark:text-indigo-400 font-medium' : 'text-gray-500 dark:text-gray-400'}>
+                      <span className={hasOverride ? 'text-amber-600 dark:text-amber-400 font-medium' : 'text-gray-900 dark:text-gray-100 font-medium'}>
                         {fmt(thisMonth)}
                       </span>
-                      {hasOverride && <span className="ml-1.5 text-xs text-indigo-400 dark:text-indigo-500">{t('overridden')}</span>}
+                      {hasOverride && <span className="ml-1.5 text-xs text-amber-500 dark:text-amber-400">({t('overridden')})</span>}
                     </>
                   )}
                 </td>
                 <td className="px-4 py-3">
-                  <div className="flex gap-3">
+                  <div className="flex gap-1">
                     {isSkipped ? (
-                      <button onClick={() => handleRestore(expense)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">{t('restore')}</button>
+                      <button onClick={() => handleRestore(expense)} className="px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">{t('restore')}</button>
                     ) : (
                       <>
-                        <button onClick={() => openEdit(expense)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">{tc('edit')}</button>
-                        <button onClick={() => setConfirmSkip(expense)} className="text-xs text-red-500 dark:text-red-400 hover:underline">{t('skip')}</button>
+                        <button onClick={() => openEdit(expense)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                          <Pencil className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                        </button>
+                        <button onClick={() => setConfirmSkip(expense)} className="px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">{t('skip')}</button>
                       </>
                     )}
                   </div>

--- a/app/(app)/planning/components/FixedExpensesSection.tsx
+++ b/app/(app)/planning/components/FixedExpensesSection.tsx
@@ -93,7 +93,7 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
   if (fixedExpenses.length === 0) {
     return (
       <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-        <div className="px-5 py-4 border-t border-b border-gray-200 dark:border-gray-700">
+        <div className="px-5 py-4">
           <h2 className="font-semibold text-gray-900 dark:text-gray-100">{t('fixedExpensesTitle')}</h2>
         </div>
         <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">{t('fixedExpensesDesc')}</div>
@@ -103,14 +103,14 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-      <div className="px-5 py-4 border-t border-b border-gray-200 dark:border-gray-700">
+      <div className="px-5 py-4">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('fixedExpensesTitle')}</h2>
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{t('fixedExpensesDesc')}</p>
       </div>
 
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-t border-b border-gray-200 dark:border-gray-700">
+          <tr className="border-b border-gray-200 dark:border-gray-700">
             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colExpense')}</th>
             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDefault')}</th>
             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colThisMonth')}</th>

--- a/app/(app)/planning/components/FixedExpensesSection.tsx
+++ b/app/(app)/planning/components/FixedExpensesSection.tsx
@@ -93,7 +93,7 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
   if (fixedExpenses.length === 0) {
     return (
       <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-        <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="px-5 py-4 border-t border-b border-gray-200 dark:border-gray-700">
           <h2 className="font-semibold text-gray-900 dark:text-gray-100">{t('fixedExpensesTitle')}</h2>
         </div>
         <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">{t('fixedExpensesDesc')}</div>
@@ -103,14 +103,14 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-      <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+      <div className="px-5 py-4 border-t border-b border-gray-200 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('fixedExpensesTitle')}</h2>
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{t('fixedExpensesDesc')}</p>
       </div>
 
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-gray-200 dark:border-gray-700">
+          <tr className="border-t border-b border-gray-200 dark:border-gray-700">
             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colExpense')}</th>
             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDefault')}</th>
             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colThisMonth')}</th>

--- a/app/(app)/planning/components/FixedExpensesSection.tsx
+++ b/app/(app)/planning/components/FixedExpensesSection.tsx
@@ -143,13 +143,13 @@ export default function FixedExpensesSection({ plan, fixedExpenses, onRefresh, o
                 <td className="px-4 py-3 text-center">
                   <div className="flex gap-1 justify-center">
                     {isSkipped ? (
-                      <button onClick={() => handleRestore(expense)} className="px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">{t('restore')}</button>
+                      <button onClick={() => handleRestore(expense)} className="h-8 px-2 text-xs font-medium text-gray-600 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">{t('restore')}</button>
                     ) : (
                       <>
                         <button onClick={() => openEdit(expense)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                           <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
                         </button>
-                        <button onClick={() => setConfirmSkip(expense)} className="px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">{t('skip')}</button>
+                        <button onClick={() => setConfirmSkip(expense)} className="h-8 px-2 text-xs font-medium text-gray-600 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">{t('skip')}</button>
                       </>
                     )}
                   </div>

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Plus, Pencil, Trash2 } from 'lucide-react'
+import { Plus, Edit, Trash2 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import type { MonthlyPlan, FundInvestment, Fund, Goal } from '../PlanningClient'
 
@@ -132,30 +132,33 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-gray-100 dark:border-gray-700">
-              {[t('colFund'), t('colDate'), t('colAmount'), t('colUnits'), t('colGoalCol'), tc('actions')].map((h) => (
-                <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{h}</th>
-              ))}
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colFund')}</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
+              <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAmount')}</th>
+              <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colUnits')}</th>
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colGoalCol')}</th>
+              <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
             {investments.map((inv) => (
               <tr key={inv.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                <td className="px-4 py-3 font-semibold text-gray-900 dark:text-gray-100 text-base">{inv.funds?.name ?? '—'}</td>
-                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{inv.investment_date ?? '—'}</td>
-                <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{fmt(inv.amount_vnd)}</td>
-                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{inv.units}</td>
+                <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">{inv.funds?.name ?? '—'}</td>
+                <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{inv.investment_date ?? '—'}</td>
+                <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100 text-right">{fmt(inv.amount_vnd)}</td>
+                <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 text-right">{inv.units}</td>
                 <td className="px-4 py-3">
-                  <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${inv.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-normal bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'}`}>
+                  <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${inv.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-normal bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'}`}>
                     {inv.savings_goals?.goal_name ?? t('unassigned')}
                   </span>
                 </td>
-                <td className="px-4 py-3">
-                  <div className="flex gap-1">
+                <td className="px-4 py-3 text-center">
+                  <div className="flex gap-1 justify-center">
                     <button onClick={() => openEdit(inv)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
-                      <Pencil className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                      <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
                     </button>
                     <button onClick={() => setConfirmDelete(inv)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
-                      <Trash2 className="h-4 w-4 text-red-500 dark:text-red-400" />
+                      <Trash2 className="h-4 w-4 text-red-600 dark:text-red-400" />
                     </button>
                   </div>
                 </td>

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -143,7 +143,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
           <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
             {investments.map((inv) => (
               <tr key={inv.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">{inv.funds?.name ?? '—'}</td>
+                <td className="px-4 py-3 text-base font-medium text-gray-900 dark:text-gray-100">{inv.funds?.name ?? '—'}</td>
                 <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{inv.investment_date ?? '—'}</td>
                 <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100 text-right">{fmt(inv.amount_vnd)}</td>
                 <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 text-right">{inv.units}</td>

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -46,8 +46,8 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
       fund_id: inv.fund_id,
       goal_id: inv.goal_id ?? '',
       amount_vnd: String(inv.amount_vnd),
-      units: String(inv.units),
-      unit_price: String(inv.unit_price),
+      units: inv.units != null ? String(inv.units) : '',
+      unit_price: inv.unit_price != null ? String(inv.unit_price) : '',
       investment_date: inv.investment_date ?? minDate,
     })
     setFormError('')
@@ -143,10 +143,20 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
           <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
             {investments.map((inv) => (
               <tr key={inv.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                <td className="px-4 py-3 text-base font-medium text-gray-900 dark:text-gray-100">{inv.funds?.name ?? '—'}</td>
+                <td className="px-4 py-3 text-base font-medium text-gray-900 dark:text-gray-100">
+                  <span>{inv.funds?.name ?? '—'}</span>
+                  {inv.is_dca_seeded && (
+                    <span className="ml-2 text-xs px-1.5 py-0.5 rounded bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300 font-medium">DCA</span>
+                  )}
+                </td>
                 <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{inv.investment_date ?? '—'}</td>
                 <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100 text-right">{fmt(inv.amount_vnd)}</td>
-                <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 text-right">{inv.units}</td>
+                <td className="px-4 py-3 text-sm text-right">
+                  {inv.units != null
+                    ? <span className="text-gray-600 dark:text-gray-400">{inv.units}</span>
+                    : <span className="text-amber-500 dark:text-amber-400 italic">Pending</span>
+                  }
+                </td>
                 <td className="px-4 py-3">
                   <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${inv.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-medium bg-gray-100 text-gray-900 dark:bg-gray-700 dark:text-gray-100'}`}>
                     {inv.savings_goals?.goal_name ?? t('unassigned')}

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -145,7 +145,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
                 <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{fmt(inv.amount_vnd)}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{inv.units}</td>
                 <td className="px-4 py-3">
-                  <span className={`inline-block px-2.5 py-0.5 rounded-md text-xs font-medium ${inv.savings_goals ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'}`}>
+                  <span className={`inline-block px-2.5 py-0.5 rounded-md text-xs font-medium ${inv.savings_goals ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400'}`}>
                     {inv.savings_goals?.goal_name ?? t('unassigned')}
                   </span>
                 </td>

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -148,7 +148,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
                 <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100 text-right">{fmt(inv.amount_vnd)}</td>
                 <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 text-right">{inv.units}</td>
                 <td className="px-4 py-3">
-                  <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${inv.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'}`}>
+                  <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${inv.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-medium bg-gray-100 text-gray-900 dark:bg-gray-700 dark:text-gray-100'}`}>
                     {inv.savings_goals?.goal_name ?? t('unassigned')}
                   </span>
                 </td>

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -148,7 +148,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
                 <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100 text-right">{fmt(inv.amount_vnd)}</td>
                 <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 text-right">{inv.units}</td>
                 <td className="px-4 py-3">
-                  <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${inv.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-normal bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'}`}>
+                  <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${inv.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-medium bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'}`}>
                     {inv.savings_goals?.goal_name ?? t('unassigned')}
                   </span>
                 </td>

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -118,7 +118,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-      <div className="flex items-center justify-between px-5 py-4 border-t border-b border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between px-5 py-4">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('fundInvestmentsTitle')}</h2>
         <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-700 dark:hover:bg-gray-200 transition-colors">
           <Plus className="h-3.5 w-3.5" />
@@ -131,7 +131,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
       ) : (
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-t border-b border-gray-200 dark:border-gray-700">
+            <tr className="border-b border-gray-200 dark:border-gray-700">
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colFund')}</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
               <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAmount')}</th>

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -118,7 +118,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-      <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between px-5 py-4 border-t border-b border-gray-200 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('fundInvestmentsTitle')}</h2>
         <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-700 dark:hover:bg-gray-200 transition-colors">
           <Plus className="h-3.5 w-3.5" />
@@ -131,7 +131,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
       ) : (
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-gray-200 dark:border-gray-700">
+            <tr className="border-t border-b border-gray-200 dark:border-gray-700">
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colFund')}</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
               <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAmount')}</th>

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -145,7 +145,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
                 <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{fmt(inv.amount_vnd)}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{inv.units}</td>
                 <td className="px-4 py-3">
-                  <span className={`inline-block px-2.5 py-0.5 rounded-md text-xs ${inv.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-normal border border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500'}`}>
+                  <span className={`inline-block px-2.5 py-0.5 rounded-full text-xs ${inv.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-normal bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'}`}>
                     {inv.savings_goals?.goal_name ?? t('unassigned')}
                   </span>
                 </td>

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -120,7 +120,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
       <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('fundInvestmentsTitle')}</h2>
-        <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+        <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-700 dark:hover:bg-gray-200 transition-colors">
           <Plus className="h-3.5 w-3.5" />
           {t('addFundInvestment')}
         </button>
@@ -140,12 +140,12 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
           <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
             {investments.map((inv) => (
               <tr key={inv.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{inv.funds?.name ?? '—'}</td>
+                <td className="px-4 py-3 font-semibold text-gray-900 dark:text-gray-100 text-base">{inv.funds?.name ?? '—'}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{inv.investment_date ?? '—'}</td>
-                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(inv.amount_vnd)}</td>
+                <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{fmt(inv.amount_vnd)}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{inv.units}</td>
                 <td className="px-4 py-3">
-                  <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${inv.savings_goals ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300' : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'}`}>
+                  <span className={`inline-block px-2.5 py-0.5 rounded-md text-xs font-medium ${inv.savings_goals ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'bg-gray-100 text-gray-500 dark:bg-gray-700 dark:text-gray-400'}`}>
                     {inv.savings_goals?.goal_name ?? t('unassigned')}
                   </span>
                 </td>

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -145,7 +145,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
                 <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{fmt(inv.amount_vnd)}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{inv.units}</td>
                 <td className="px-4 py-3">
-                  <span className={`inline-block px-2.5 py-0.5 rounded-md text-xs font-medium ${inv.savings_goals ? 'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'border border-gray-300 dark:border-gray-600 text-gray-500 dark:text-gray-400'}`}>
+                  <span className={`inline-block px-2.5 py-0.5 rounded-md text-xs ${inv.savings_goals ? 'font-medium bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' : 'font-normal border border-gray-300 dark:border-gray-600 text-gray-400 dark:text-gray-500'}`}>
                     {inv.savings_goals?.goal_name ?? t('unassigned')}
                   </span>
                 </td>

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -118,7 +118,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-      <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+      <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('fundInvestmentsTitle')}</h2>
         <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-700 dark:hover:bg-gray-200 transition-colors">
           <Plus className="h-3.5 w-3.5" />
@@ -131,7 +131,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
       ) : (
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-gray-100 dark:border-gray-700">
+            <tr className="border-b border-gray-200 dark:border-gray-700">
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colFund')}</th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDate')}</th>
               <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colAmount')}</th>
@@ -140,7 +140,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
               <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
             {investments.map((inv) => (
               <tr key={inv.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
                 <td className="px-4 py-3 text-base font-medium text-gray-900 dark:text-gray-100">{inv.funds?.name ?? '—'}</td>

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { Plus, Pencil, Trash2 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import type { MonthlyPlan, FundInvestment, Fund, Goal } from '../PlanningClient'
 
@@ -118,8 +119,9 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
       <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-700">
-        <h2 className="font-semibold text-gray-900 dark:text-gray-100">{t('fundInvestmentsTitle')}</h2>
-        <button onClick={openAdd} className="px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('fundInvestmentsTitle')}</h2>
+        <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+          <Plus className="h-3.5 w-3.5" />
           {t('addFundInvestment')}
         </button>
       </div>
@@ -128,25 +130,33 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
         <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">{t('addFundInvestmentDesc')}</div>
       ) : (
         <table className="w-full text-sm">
-          <thead className="bg-gray-50 dark:bg-gray-800">
-            <tr>
+          <thead>
+            <tr className="border-b border-gray-100 dark:border-gray-700">
               {[t('colFund'), t('colDate'), t('colAmount'), t('colUnits'), t('colGoalCol'), tc('actions')].map((h) => (
-                <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
+                <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{h}</th>
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+          <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
             {investments.map((inv) => (
-              <tr key={inv.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
+              <tr key={inv.transaction_id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
                 <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{inv.funds?.name ?? '—'}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{inv.investment_date ?? '—'}</td>
-                <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{fmt(inv.amount_vnd)}</td>
+                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(inv.amount_vnd)}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{inv.units}</td>
-                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{inv.savings_goals?.goal_name ?? t('unassigned')}</td>
                 <td className="px-4 py-3">
-                  <div className="flex gap-3">
-                    <button onClick={() => openEdit(inv)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">{tc('edit')}</button>
-                    <button onClick={() => setConfirmDelete(inv)} className="text-xs text-red-500 dark:text-red-400 hover:underline">{tc('delete')}</button>
+                  <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${inv.savings_goals ? 'bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300' : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'}`}>
+                    {inv.savings_goals?.goal_name ?? t('unassigned')}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  <div className="flex gap-1">
+                    <button onClick={() => openEdit(inv)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                      <Pencil className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                    </button>
+                    <button onClick={() => setConfirmDelete(inv)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                      <Trash2 className="h-4 w-4 text-red-500 dark:text-red-400" />
+                    </button>
                   </div>
                 </td>
               </tr>

--- a/app/(app)/planning/components/InsuranceSection.tsx
+++ b/app/(app)/planning/components/InsuranceSection.tsx
@@ -82,7 +82,7 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
   if (insuranceMembers.length === 0) {
     return (
       <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-        <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+        <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
           <h2 className="font-semibold text-gray-900 dark:text-gray-100">{t('insuranceTitle')}</h2>
         </div>
         <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">{t('insuranceDesc')}</div>
@@ -97,14 +97,14 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-      <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+      <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('insuranceTitle')}</h2>
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{t('insuranceDesc')}</p>
       </div>
 
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-gray-100 dark:border-gray-700">
+          <tr className="border-b border-gray-200 dark:border-gray-700">
             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colMember')}</th>
             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colRelationship')}</th>
             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDefault')}</th>
@@ -112,7 +112,7 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
             <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
+        <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
           {insuranceMembers.map((m) => {
             const defaultMonthly = Math.round(m.annual_payment_vnd / 12)
             const hasOverride = m.monthlyOverride != null && m.monthlyOverride !== defaultMonthly

--- a/app/(app)/planning/components/InsuranceSection.tsx
+++ b/app/(app)/planning/components/InsuranceSection.tsx
@@ -118,7 +118,7 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
             const hasOverride = m.monthlyOverride != null && m.monthlyOverride !== defaultMonthly
             return (
               <tr key={m.member_id} className={`hover:bg-gray-50 dark:hover:bg-gray-800/50 ${m.excluded ? 'opacity-60' : ''}`}>
-                <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">{m.member_name}</td>
+                <td className="px-4 py-3 text-base font-medium text-gray-900 dark:text-gray-100">{m.member_name}</td>
                 <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{m.relationship}</td>
                 <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 text-right">{fmt(defaultMonthly)}</td>
                 <td className="px-4 py-3 text-right">

--- a/app/(app)/planning/components/InsuranceSection.tsx
+++ b/app/(app)/planning/components/InsuranceSection.tsx
@@ -104,7 +104,7 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
 
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-b border-gray-200 dark:border-gray-700">
+          <tr className="border-t border-b border-gray-200 dark:border-gray-700">
             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colMember')}</th>
             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colRelationship')}</th>
             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDefault')}</th>
@@ -151,13 +151,11 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
             )
           })}
         </tbody>
-        <tfoot>
-          <tr className="border-t border-gray-200 dark:border-gray-700">
-            <td colSpan={3} className="px-4 py-3 text-base font-medium text-gray-900 dark:text-gray-100">{t('colTotalMonth')}</td>
-            <td colSpan={2} className="px-4 py-3 text-lg font-semibold text-gray-900 dark:text-gray-100 text-right">{fmt(totalMonthly)}</td>
-          </tr>
-        </tfoot>
       </table>
+      <div className="px-4 mt-4 flex items-center justify-between border-t border-gray-200 dark:border-gray-700 pt-4 pb-4">
+        <span className="text-base font-medium text-gray-900 dark:text-gray-100">{t('colTotalMonth')}</span>
+        <span className="text-lg font-semibold text-gray-900 dark:text-gray-100">{fmt(totalMonthly)}</span>
+      </div>
 
       {/* Edit Override Modal */}
       {editItem && (

--- a/app/(app)/planning/components/InsuranceSection.tsx
+++ b/app/(app)/planning/components/InsuranceSection.tsx
@@ -138,13 +138,13 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
                 <td className="px-4 py-3 text-center">
                   <div className="flex gap-1 justify-center">
                     {m.excluded ? (
-                      <button onClick={() => handleRestore(m)} className="px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">{t('restore')}</button>
+                      <button onClick={() => handleRestore(m)} className="h-8 px-2 text-xs font-medium text-gray-600 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">{t('restore')}</button>
                     ) : (
                       <>
                         <button onClick={() => openEdit(m)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                           <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
                         </button>
-                        <button onClick={() => setConfirmSkip(m)} className="px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">{t('skip')}</button>
+                        <button onClick={() => setConfirmSkip(m)} className="h-8 px-2 text-xs font-medium text-gray-600 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">{t('skip')}</button>
                       </>
                     )}
                   </div>

--- a/app/(app)/planning/components/InsuranceSection.tsx
+++ b/app/(app)/planning/components/InsuranceSection.tsx
@@ -82,7 +82,7 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
   if (insuranceMembers.length === 0) {
     return (
       <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-        <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+        <div className="px-5 py-4">
           <h2 className="font-semibold text-gray-900 dark:text-gray-100">{t('insuranceTitle')}</h2>
         </div>
         <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">{t('insuranceDesc')}</div>
@@ -97,14 +97,14 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-      <div className="px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+      <div className="px-5 py-4">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('insuranceTitle')}</h2>
         <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{t('insuranceDesc')}</p>
       </div>
 
       <table className="w-full text-sm">
         <thead>
-          <tr className="border-t border-b border-gray-200 dark:border-gray-700">
+          <tr className="border-b border-gray-200 dark:border-gray-700">
             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colMember')}</th>
             <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colRelationship')}</th>
             <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDefault')}</th>

--- a/app/(app)/planning/components/InsuranceSection.tsx
+++ b/app/(app)/planning/components/InsuranceSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { Pencil } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import type { MonthlyPlan, InsuranceMember } from '../PlanningClient'
 
@@ -97,24 +98,24 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
       <div className="px-5 py-4 border-b border-gray-100 dark:border-gray-700">
-        <h2 className="font-semibold text-gray-900 dark:text-gray-100">{t('insuranceTitle')}</h2>
-        <p className="text-xs text-gray-400 dark:text-gray-500 mt-0.5">{t('insuranceDesc')}</p>
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('insuranceTitle')}</h2>
+        <p className="text-sm text-gray-500 dark:text-gray-400 mt-0.5">{t('insuranceDesc')}</p>
       </div>
 
       <table className="w-full text-sm">
-        <thead className="bg-gray-50 dark:bg-gray-800">
-          <tr>
+        <thead>
+          <tr className="border-b border-gray-100 dark:border-gray-700">
             {[t('colMember'), t('colRelationship'), t('colDefault'), t('colThisMonth'), tc('actions')].map((h) => (
-              <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
+              <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{h}</th>
             ))}
           </tr>
         </thead>
-        <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+        <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
           {insuranceMembers.map((m) => {
             const defaultMonthly = Math.round(m.annual_payment_vnd / 12)
             const hasOverride = m.monthlyOverride != null && m.monthlyOverride !== defaultMonthly
             return (
-              <tr key={m.member_id} className={`hover:bg-gray-50 dark:hover:bg-gray-800 ${m.excluded ? 'opacity-60' : ''}`}>
+              <tr key={m.member_id} className={`hover:bg-gray-50 dark:hover:bg-gray-800/50 ${m.excluded ? 'opacity-60' : ''}`}>
                 <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{m.member_name}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{m.relationship}</td>
                 <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{fmt(defaultMonthly)}</td>
@@ -125,21 +126,23 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
                     </span>
                   ) : (
                     <>
-                      <span className={hasOverride ? 'text-indigo-600 dark:text-indigo-400 font-medium' : 'text-gray-700 dark:text-gray-300'}>
+                      <span className={`font-medium ${hasOverride ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'}`}>
                         {fmt(m.monthlyOverride ?? defaultMonthly)}
                       </span>
-                      {hasOverride && <span className="ml-1.5 text-xs text-indigo-400 dark:text-indigo-500">{t('overridden')}</span>}
+                      {hasOverride && <span className="ml-1.5 text-xs text-amber-500 dark:text-amber-400">({t('overridden')})</span>}
                     </>
                   )}
                 </td>
                 <td className="px-4 py-3">
-                  <div className="flex gap-3">
+                  <div className="flex gap-1">
                     {m.excluded ? (
-                      <button onClick={() => handleRestore(m)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">{t('restore')}</button>
+                      <button onClick={() => handleRestore(m)} className="px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">{t('restore')}</button>
                     ) : (
                       <>
-                        <button onClick={() => openEdit(m)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">{tc('edit')}</button>
-                        <button onClick={() => setConfirmSkip(m)} className="text-xs text-red-500 dark:text-red-400 hover:underline">{t('skip')}</button>
+                        <button onClick={() => openEdit(m)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                          <Pencil className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                        </button>
+                        <button onClick={() => setConfirmSkip(m)} className="px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">{t('skip')}</button>
                       </>
                     )}
                   </div>
@@ -149,7 +152,7 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
           })}
         </tbody>
         <tfoot>
-          <tr className="border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800">
+          <tr className="border-t border-gray-200 dark:border-gray-700">
             <td colSpan={3} className="px-4 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300">{t('colTotalMonth')}</td>
             <td colSpan={2} className="px-4 py-3 text-sm font-semibold text-gray-900 dark:text-gray-100">{fmt(totalMonthly)}</td>
           </tr>

--- a/app/(app)/planning/components/InsuranceSection.tsx
+++ b/app/(app)/planning/components/InsuranceSection.tsx
@@ -138,13 +138,13 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
                 <td className="px-4 py-3 text-center">
                   <div className="flex gap-1 justify-center">
                     {m.excluded ? (
-                      <button onClick={() => handleRestore(m)} className="h-8 px-2 text-xs font-medium text-gray-600 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">{t('restore')}</button>
+                      <button onClick={() => handleRestore(m)} className="h-8 px-2 text-xs font-medium text-gray-900 dark:text-gray-100 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">{t('restore')}</button>
                     ) : (
                       <>
                         <button onClick={() => openEdit(m)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                           <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
                         </button>
-                        <button onClick={() => setConfirmSkip(m)} className="h-8 px-2 text-xs font-medium text-gray-600 dark:text-gray-300 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">{t('skip')}</button>
+                        <button onClick={() => setConfirmSkip(m)} className="h-8 px-2 text-xs font-medium text-gray-900 dark:text-gray-100 rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">{t('skip')}</button>
                       </>
                     )}
                   </div>

--- a/app/(app)/planning/components/InsuranceSection.tsx
+++ b/app/(app)/planning/components/InsuranceSection.tsx
@@ -155,8 +155,8 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
         </tbody>
         <tfoot>
           <tr className="border-t border-gray-200 dark:border-gray-700">
-            <td colSpan={3} className="px-4 py-3 text-sm font-semibold text-gray-700 dark:text-gray-300">{t('colTotalMonth')}</td>
-            <td colSpan={2} className="px-4 py-3 text-sm font-semibold text-gray-900 dark:text-gray-100">{fmt(totalMonthly)}</td>
+            <td colSpan={3} className="px-4 py-3 text-base font-medium text-gray-900 dark:text-gray-100">{t('colTotalMonth')}</td>
+            <td colSpan={2} className="px-4 py-3 text-lg font-semibold text-gray-900 dark:text-gray-100 text-right">{fmt(totalMonthly)}</td>
           </tr>
         </tfoot>
       </table>

--- a/app/(app)/planning/components/InsuranceSection.tsx
+++ b/app/(app)/planning/components/InsuranceSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Pencil } from 'lucide-react'
+import { Edit } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import type { MonthlyPlan, InsuranceMember } from '../PlanningClient'
 
@@ -105,9 +105,11 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
       <table className="w-full text-sm">
         <thead>
           <tr className="border-b border-gray-100 dark:border-gray-700">
-            {[t('colMember'), t('colRelationship'), t('colDefault'), t('colThisMonth'), tc('actions')].map((h) => (
-              <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{h}</th>
-            ))}
+            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colMember')}</th>
+            <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colRelationship')}</th>
+            <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDefault')}</th>
+            <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colThisMonth')}</th>
+            <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
           </tr>
         </thead>
         <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
@@ -116,31 +118,31 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
             const hasOverride = m.monthlyOverride != null && m.monthlyOverride !== defaultMonthly
             return (
               <tr key={m.member_id} className={`hover:bg-gray-50 dark:hover:bg-gray-800/50 ${m.excluded ? 'opacity-60' : ''}`}>
-                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{m.member_name}</td>
-                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{m.relationship}</td>
-                <td className="px-4 py-3 text-gray-500 dark:text-gray-400">{fmt(defaultMonthly)}</td>
-                <td className="px-4 py-3">
+                <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">{m.member_name}</td>
+                <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400">{m.relationship}</td>
+                <td className="px-4 py-3 text-sm text-gray-600 dark:text-gray-400 text-right">{fmt(defaultMonthly)}</td>
+                <td className="px-4 py-3 text-right">
                   {m.excluded ? (
                     <span className="inline-block px-2 py-0.5 rounded text-xs font-medium bg-gray-100 dark:bg-gray-700 text-gray-500 dark:text-gray-400">
                       {t('skipped')}
                     </span>
                   ) : (
                     <>
-                      <span className={`font-medium ${hasOverride ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'}`}>
+                      <span className={`text-sm font-medium ${hasOverride ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'}`}>
                         {fmt(m.monthlyOverride ?? defaultMonthly)}
                       </span>
-                      {hasOverride && <span className="ml-1.5 text-xs text-amber-500 dark:text-amber-400">({t('overridden')})</span>}
+                      {hasOverride && <div className="text-xs text-amber-500 dark:text-amber-400">({t('overridden')})</div>}
                     </>
                   )}
                 </td>
-                <td className="px-4 py-3">
-                  <div className="flex gap-1">
+                <td className="px-4 py-3 text-center">
+                  <div className="flex gap-1 justify-center">
                     {m.excluded ? (
                       <button onClick={() => handleRestore(m)} className="px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">{t('restore')}</button>
                     ) : (
                       <>
                         <button onClick={() => openEdit(m)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
-                          <Pencil className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                          <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
                         </button>
                         <button onClick={() => setConfirmSkip(m)} className="px-2 py-1 text-xs font-medium text-gray-600 dark:text-gray-300 border border-gray-200 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">{t('skip')}</button>
                       </>

--- a/app/(app)/planning/components/InsuranceSection.tsx
+++ b/app/(app)/planning/components/InsuranceSection.tsx
@@ -127,12 +127,10 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
                       {t('skipped')}
                     </span>
                   ) : (
-                    <>
-                      <span className={`text-sm font-medium ${hasOverride ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'}`}>
-                        {fmt(m.monthlyOverride ?? defaultMonthly)}
-                      </span>
-                      {hasOverride && <div className="text-xs text-amber-500 dark:text-amber-400">({t('overridden')})</div>}
-                    </>
+                    <div className={`text-sm font-medium ${hasOverride ? 'text-amber-600 dark:text-amber-400' : 'text-gray-900 dark:text-gray-100'}`}>
+                      <div>{fmt(m.monthlyOverride ?? defaultMonthly)}</div>
+                      {hasOverride && <div className="text-xs">{t('overridden')}</div>}
+                    </div>
                   )}
                 </td>
                 <td className="px-4 py-3 text-center">

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -1,0 +1,1361 @@
+'use client'
+
+import { useState, useMemo, useEffect } from 'react'
+import { useLocale } from 'next-intl'
+import {
+  Wallet, Target, Building, Shield, ShoppingCart,
+  ChevronDown, ChevronUp, ChevronLeft, ChevronRight,
+  MoreHorizontal, Plus, Edit2, Trash2, Check, RefreshCw, X, Calendar,
+} from 'lucide-react'
+import MobileTopBar from '@/app/components/navigation/MobileTopBar'
+import { fmtCompact, fmt } from '@/lib/formatters'
+import type {
+  MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
+  InsuranceMember, OtherExpense, Fund, Goal,
+} from '../PlanningClient'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Props {
+  month: number
+  year: number
+  plan: MonthlyPlan | null
+  investments: FundInvestment[]
+  savings: DirectSaving[]
+  fixedExpenses: FixedExpense[]
+  insuranceMembers: InsuranceMember[]
+  otherExpenses: OtherExpense[]
+  funds: Fund[]
+  goals: Goal[]
+  onNavigatePrev: () => void
+  onNavigateNext: () => void
+  onPlanCreated: (plan: MonthlyPlan) => void
+  onPlanDeleted: () => void
+  onRefresh: () => void
+  onToast: (msg: string) => void
+}
+
+interface GoalRow {
+  goalId: string
+  goalName: string
+  totalAllocated: number
+  items: Array<{ name: string; type: string; amount: number; isDCA?: boolean }>
+}
+
+type SheetState =
+  | null
+  | { type: 'salary' }
+  | { type: 'delete-plan' }
+  | { type: 'override-fe'; expense: FixedExpense }
+  | { type: 'override-ins'; member: InsuranceMember }
+  | { type: 'other-expense'; existing: OtherExpense | null }
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const SHORT_MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
+const LONG_MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December']
+
+function getMonthLabel(month: number, year: number, short = false) {
+  const names = short ? SHORT_MONTHS : LONG_MONTHS
+  return `${names[month - 1]} ${year}`
+}
+
+function getFixedTotal(fixedExpenses: FixedExpense[]) {
+  return fixedExpenses.reduce((s, e) => {
+    if (e.override === 0) return s
+    return s + (e.override ?? e.amount_vnd)
+  }, 0)
+}
+
+function getInsTotal(insuranceMembers: InsuranceMember[]) {
+  return insuranceMembers.reduce((s, m) => {
+    if (m.excluded) return s
+    return s + (m.monthlyOverride ?? Math.round(m.annual_payment_vnd / 12))
+  }, 0)
+}
+
+function buildByGoal(investments: FundInvestment[], savings: DirectSaving[]): GoalRow[] {
+  const map = new Map<string, GoalRow>()
+
+  for (const inv of investments) {
+    const goalId = inv.goal_id ?? '__unassigned__'
+    const goalName = inv.savings_goals?.goal_name ?? 'Unassigned'
+    if (!map.has(goalId)) {
+      map.set(goalId, { goalId, goalName, totalAllocated: 0, items: [] })
+    }
+    const row = map.get(goalId)!
+    row.totalAllocated += inv.amount_vnd
+    row.items.push({ name: inv.funds?.name ?? 'Unknown fund', type: 'fund', amount: inv.amount_vnd, isDCA: inv.is_dca_seeded })
+  }
+
+  for (const sav of savings) {
+    const goalId = sav.goal_id ?? '__unassigned__'
+    const goalName = sav.savings_goals?.goal_name ?? 'Unassigned'
+    if (!map.has(goalId)) {
+      map.set(goalId, { goalId, goalName, totalAllocated: 0, items: [] })
+    }
+    const row = map.get(goalId)!
+    row.totalAllocated += sav.amount_vnd
+    row.items.push({ name: 'Direct savings', type: 'bank', amount: sav.amount_vnd })
+  }
+
+  return [...map.values()].sort((a, b) => a.goalName.localeCompare(b.goalName))
+}
+
+// ─── Shared sheet overlay wrapper ─────────────────────────────────────────────
+
+function Sheet({ open, onClose, title, children }: { open: boolean; onClose: () => void; title: string; children: React.ReactNode }) {
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    if (open) setMounted(true)
+    else { const t = setTimeout(() => setMounted(false), 220); return () => clearTimeout(t) }
+  }, [open])
+  if (!mounted) return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.3)',
+        zIndex: 200, pointerEvents: open ? 'auto' : 'none',
+        display: 'flex', alignItems: 'flex-end',
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          width: '100%', background: 'var(--c-card)', borderRadius: '16px 16px 0 0',
+          paddingBottom: 'env(safe-area-inset-bottom,0)',
+          animation: open ? 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' : 'slide-down 180ms ease forwards',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '8px auto 0' }} />
+        <div style={{ padding: '14px 16px 0' }}>
+          <p style={{ fontWeight: 700, fontSize: 16, color: 'var(--c-ink)', marginBottom: 16 }}>{title}</p>
+        </div>
+        <div style={{ padding: '0 16px 24px' }}>{children}</div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Salary sheet ─────────────────────────────────────────────────────────────
+
+function SalarySheet({
+  open, onClose, plan, month, year, onPlanCreated, onToast,
+}: {
+  open: boolean
+  onClose: () => void
+  plan: MonthlyPlan | null
+  month: number
+  year: number
+  onPlanCreated: (p: MonthlyPlan) => void
+  onToast: (msg: string) => void
+}) {
+  const isVI = useLocale() === 'vi'
+  const [value, setValue] = useState(plan ? String(plan.salary_vnd) : '')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => { if (open) setValue(plan ? String(plan.salary_vnd) : '') }, [open, plan])
+
+  async function handleSave() {
+    const num = Number(value)
+    if (!value || isNaN(num) || num <= 0) { setError(isVI ? 'Vui lòng nhập thu nhập hợp lệ' : 'Please enter a valid income'); return }
+    setError('')
+    setSaving(true)
+    try {
+      if (plan) {
+        const res = await fetch(`/api/v1/monthly-plans/${plan.id}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ salary_vnd: num }),
+        })
+        if (!res.ok) { const { error: e } = await res.json(); setError(e ?? 'Error'); setSaving(false); return }
+        onToast(isVI ? 'Đã lưu thu nhập' : 'Income saved')
+      } else {
+        const res = await fetch('/api/v1/monthly-plans', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ month, year, salary_vnd: num }),
+        })
+        if (!res.ok) { const { error: e } = await res.json(); setError(e ?? 'Error'); setSaving(false); return }
+        const newPlan = await res.json()
+        onPlanCreated(newPlan)
+        onToast(isVI ? 'Đã thêm thu nhập' : 'Income set')
+      }
+      onClose()
+    } catch { setError(isVI ? 'Lỗi kết nối' : 'Connection error') }
+    setSaving(false)
+  }
+
+  const label = isVI ? (plan ? 'Sửa thu nhập' : 'Thêm thu nhập') : (plan ? 'Edit income' : 'Set income')
+
+  return (
+    <Sheet open={open} onClose={onClose} title={label}>
+      <div style={{ display: 'grid', gap: 14 }}>
+        <label style={{ fontSize: 13, color: 'var(--c-muted)', display: 'block' }}>
+          {isVI ? 'Thu nhập tháng (₫)' : 'Monthly income (₫)'}
+        </label>
+        {error && <p style={{ color: 'var(--c-neg)', fontSize: 13 }}>{error}</p>}
+        <input
+          type="text"
+          inputMode="numeric"
+          value={value ? Number(value).toLocaleString('en-US') : ''}
+          onChange={(e) => setValue(e.target.value.replace(/,/g, '').replace(/[^0-9]/g, ''))}
+          placeholder="e.g. 45,000,000"
+          style={{
+            width: '100%', padding: '10px 12px', fontSize: 16, fontVariantNumeric: 'tabular-nums',
+            border: '1px solid var(--c-line)', borderRadius: 10,
+            background: 'var(--c-card-2)', color: 'var(--c-ink)', boxSizing: 'border-box',
+          }}
+          data-testid="mobile-salary-input"
+          autoFocus
+        />
+        <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+          <button
+            onClick={onClose}
+            style={{
+              flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)',
+              background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500,
+              cursor: 'pointer', fontFamily: 'inherit',
+            }}
+          >
+            {isVI ? 'Hủy' : 'Cancel'}
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            style={{
+              flex: 2, padding: '10px 0', borderRadius: 10, border: 'none',
+              background: 'var(--c-navy)', color: '#fff', fontSize: 14, fontWeight: 600,
+              cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit', opacity: saving ? 0.7 : 1,
+            }}
+          >
+            {saving ? (isVI ? 'Đang lưu...' : 'Saving...') : (isVI ? 'Lưu' : 'Save')}
+          </button>
+        </div>
+      </div>
+    </Sheet>
+  )
+}
+
+// ─── Delete plan sheet ────────────────────────────────────────────────────────
+
+function DeletePlanSheet({
+  open, onClose, monthLabel, onPlanDeleted, planId, onToast,
+}: {
+  open: boolean
+  onClose: () => void
+  monthLabel: string
+  onPlanDeleted: () => void
+  planId: string
+  onToast: (msg: string) => void
+}) {
+  const isVI = useLocale() === 'vi'
+  const [deleting, setDeleting] = useState(false)
+
+  async function handleDelete() {
+    setDeleting(true)
+    try {
+      const res = await fetch(`/api/v1/monthly-plans/${planId}`, { method: 'DELETE' })
+      if (res.ok) { onPlanDeleted(); onClose(); onToast(isVI ? 'Đã xoá kế hoạch' : 'Plan deleted') }
+    } catch {}
+    setDeleting(false)
+  }
+
+  return (
+    <Sheet open={open} onClose={onClose} title={isVI ? 'Xoá kế hoạch tháng?' : 'Delete monthly plan?'}>
+      <div style={{ display: 'grid', gap: 16 }}>
+        <div style={{ padding: '12px 14px', background: 'var(--c-neg-tint)', borderRadius: 10 }}>
+          <p style={{ margin: 0, fontSize: 13, color: 'var(--c-neg)', lineHeight: 1.5 }}>
+            {isVI
+              ? `Toàn bộ dữ liệu kế hoạch cho ${monthLabel} sẽ bị xoá vĩnh viễn.`
+              : `All plan data for ${monthLabel} will be permanently deleted.`}
+          </p>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            onClick={onClose}
+            style={{
+              flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)',
+              background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500,
+              cursor: 'pointer', fontFamily: 'inherit',
+            }}
+          >
+            {isVI ? 'Huỷ' : 'Cancel'}
+          </button>
+          <button
+            onClick={handleDelete}
+            disabled={deleting}
+            style={{
+              flex: 2, padding: '10px 0', borderRadius: 10, border: 'none',
+              background: 'var(--c-neg)', color: '#fff', fontSize: 14, fontWeight: 600,
+              cursor: deleting ? 'default' : 'pointer', fontFamily: 'inherit',
+              display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+            }}
+          >
+            <Trash2 size={14} />
+            {deleting ? (isVI ? 'Đang xoá...' : 'Deleting...') : (isVI ? 'Xoá kế hoạch' : 'Delete plan')}
+          </button>
+        </div>
+      </div>
+    </Sheet>
+  )
+}
+
+// ─── Override sheet (fixed expense or insurance) ──────────────────────────────
+
+function OverrideSheet({
+  open, onClose, name, defaultAmount, planId, apiPath, onRefresh, onToast,
+}: {
+  open: boolean
+  onClose: () => void
+  name: string
+  defaultAmount: number
+  planId: string
+  apiPath: string
+  onRefresh: () => void
+  onToast: (msg: string) => void
+}) {
+  const isVI = useLocale() === 'vi'
+  const [value, setValue] = useState(String(defaultAmount))
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => { if (open) { setValue(String(defaultAmount)); setError('') } }, [open, defaultAmount])
+
+  async function handleSave() {
+    const num = Number(value)
+    if (!value || isNaN(num) || num <= 0) { setError(isVI ? 'Vui lòng nhập số tiền hợp lệ' : 'Please enter a valid amount'); return }
+    setError('')
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/v1/monthly-plans/${planId}/${apiPath}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(apiPath.includes('fixed') ? { fixed_expense_id: apiPath.split('/')[0], monthly_amount_override_vnd: num } : { member_id: apiPath.split('/')[0], monthly_amount_override_vnd: num }),
+      })
+      if (!res.ok) { const { error: e } = await res.json(); setError(e ?? 'Error'); setSaving(false); return }
+      onRefresh()
+      onToast(isVI ? 'Đã lưu' : 'Saved')
+      onClose()
+    } catch { setError(isVI ? 'Lỗi kết nối' : 'Connection error') }
+    setSaving(false)
+  }
+
+  return (
+    <Sheet open={open} onClose={onClose} title={isVI ? 'Ghi đè số tiền' : 'Override amount'}>
+      <div style={{ display: 'grid', gap: 14 }}>
+        <div style={{ fontSize: 13, color: 'var(--c-muted)' }}>{name}</div>
+        {error && <p style={{ color: 'var(--c-neg)', fontSize: 13 }}>{error}</p>}
+        <input
+          type="text"
+          inputMode="numeric"
+          value={value ? Number(value).toLocaleString('en-US') : ''}
+          onChange={(e) => setValue(e.target.value.replace(/,/g, '').replace(/[^0-9]/g, ''))}
+          style={{
+            width: '100%', padding: '10px 12px', fontSize: 15,
+            border: '1px solid var(--c-line)', borderRadius: 10,
+            background: 'var(--c-card-2)', color: 'var(--c-ink)', boxSizing: 'border-box',
+          }}
+          autoFocus
+        />
+        <button
+          onClick={() => setValue(String(defaultAmount))}
+          style={{
+            alignSelf: 'flex-start', padding: '4px 8px', fontSize: 11,
+            background: 'transparent', border: '1px solid var(--c-line)',
+            borderRadius: 6, color: 'var(--c-navy)', cursor: 'pointer', fontFamily: 'inherit', fontWeight: 500,
+          }}
+        >
+          {isVI ? 'Mặc định' : 'Default'}: {fmtCompact(defaultAmount)}
+        </button>
+        <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+          <button
+            onClick={onClose}
+            style={{
+              flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)',
+              background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500,
+              cursor: 'pointer', fontFamily: 'inherit',
+            }}
+          >
+            {isVI ? 'Hủy' : 'Cancel'}
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving || !value || Number(value) <= 0}
+            style={{
+              flex: 2, padding: '10px 0', borderRadius: 10, border: 'none',
+              background: 'var(--c-navy)', color: '#fff', fontSize: 14, fontWeight: 600,
+              cursor: 'pointer', fontFamily: 'inherit',
+            }}
+          >
+            {isVI ? 'Lưu' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </Sheet>
+  )
+}
+
+// ─── Other expense sheet ──────────────────────────────────────────────────────
+
+function OtherExpenseSheet({
+  open, onClose, existing, planId, onRefresh, onToast,
+}: {
+  open: boolean
+  onClose: () => void
+  existing: OtherExpense | null
+  planId: string
+  onRefresh: () => void
+  onToast: (msg: string) => void
+}) {
+  const isVI = useLocale() === 'vi'
+  const [desc, setDesc] = useState(existing?.description ?? '')
+  const [amount, setAmount] = useState(existing?.amount_vnd ? String(existing.amount_vnd) : '')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (open) { setDesc(existing?.description ?? ''); setAmount(existing?.amount_vnd ? String(existing.amount_vnd) : ''); setError('') }
+  }, [open, existing])
+
+  async function handleSave() {
+    if (!desc.trim()) { setError(isVI ? 'Vui lòng nhập mô tả' : 'Description is required'); return }
+    const num = Number(amount)
+    if (!amount || isNaN(num) || num <= 0) { setError(isVI ? 'Vui lòng nhập số tiền hợp lệ' : 'Please enter a valid amount'); return }
+    setError('')
+    setSaving(true)
+    const url = existing
+      ? `/api/v1/monthly-plans/${planId}/other-expenses/${existing.id}`
+      : `/api/v1/monthly-plans/${planId}/other-expenses`
+    try {
+      const res = await fetch(url, {
+        method: existing ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description: desc.trim(), amount_vnd: num }),
+      })
+      if (!res.ok) { const { error: e } = await res.json(); setError(e ?? 'Error'); setSaving(false); return }
+      onRefresh()
+      onToast(existing ? (isVI ? 'Đã cập nhật' : 'Updated') : (isVI ? 'Đã thêm' : 'Added'))
+      onClose()
+    } catch { setError(isVI ? 'Lỗi kết nối' : 'Connection error') }
+    setSaving(false)
+  }
+
+  const title = isVI ? (existing ? 'Sửa khoản chi' : 'Thêm khoản chi') : (existing ? 'Edit expense' : 'Add expense')
+
+  return (
+    <Sheet open={open} onClose={onClose} title={title}>
+      <div style={{ display: 'grid', gap: 14 }}>
+        {error && <p style={{ color: 'var(--c-neg)', fontSize: 13 }}>{error}</p>}
+        <div>
+          <label style={{ fontSize: 13, color: 'var(--c-muted)', display: 'block', marginBottom: 4 }}>
+            {isVI ? 'Mô tả' : 'Description'}
+          </label>
+          <input
+            value={desc}
+            onChange={(e) => setDesc(e.target.value)}
+            placeholder={isVI ? 'VD. Mua laptop...' : 'e.g. Buy laptop...'}
+            style={{
+              width: '100%', padding: '10px 12px', fontSize: 14,
+              border: '1px solid var(--c-line)', borderRadius: 10,
+              background: 'var(--c-card-2)', color: 'var(--c-ink)', boxSizing: 'border-box',
+            }}
+            autoFocus
+          />
+        </div>
+        <div>
+          <label style={{ fontSize: 13, color: 'var(--c-muted)', display: 'block', marginBottom: 4 }}>
+            {isVI ? 'Số tiền (₫)' : 'Amount (₫)'}
+          </label>
+          <input
+            type="text"
+            inputMode="numeric"
+            value={amount ? Number(amount).toLocaleString('en-US') : ''}
+            onChange={(e) => setAmount(e.target.value.replace(/,/g, '').replace(/[^0-9]/g, ''))}
+            placeholder="0"
+            style={{
+              width: '100%', padding: '10px 12px', fontSize: 14, fontVariantNumeric: 'tabular-nums',
+              border: '1px solid var(--c-line)', borderRadius: 10,
+              background: 'var(--c-card-2)', color: 'var(--c-ink)', boxSizing: 'border-box',
+            }}
+          />
+        </div>
+        <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+          <button
+            onClick={onClose}
+            style={{
+              flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)',
+              background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500,
+              cursor: 'pointer', fontFamily: 'inherit',
+            }}
+          >
+            {isVI ? 'Hủy' : 'Cancel'}
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            style={{
+              flex: 2, padding: '10px 0', borderRadius: 10, border: 'none',
+              background: 'var(--c-navy)', color: '#fff', fontSize: 14, fontWeight: 600,
+              cursor: 'pointer', fontFamily: 'inherit',
+            }}
+          >
+            {isVI ? 'Lưu' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </Sheet>
+  )
+}
+
+// ─── Stacked bar ─────────────────────────────────────────────────────────────
+
+function StackedBar({ segments, total, height = 8 }: {
+  segments: Array<{ value: number; color: string }>
+  total: number
+  height?: number
+}) {
+  if (total <= 0) return <div style={{ height, borderRadius: 999, background: 'rgba(255,255,255,0.15)' }} />
+  return (
+    <div style={{ height, borderRadius: 999, overflow: 'hidden', display: 'flex' }}>
+      {segments.map((seg, i) => {
+        const pct = Math.min(100, (seg.value / total) * 100)
+        if (pct <= 0) return null
+        return (
+          <div key={i} style={{ width: `${pct}%`, background: seg.color, flexShrink: 0 }} />
+        )
+      })}
+    </div>
+  )
+}
+
+// ─── NoPlanState ─────────────────────────────────────────────────────────────
+
+function NoPlanState({ monthLabel, onSetSalary, isVI }: { monthLabel: string; onSetSalary: () => void; isVI: boolean }) {
+  return (
+    <div style={{
+      padding: '44px 20px', textAlign: 'center',
+      background: 'var(--c-card)', border: '1px dashed var(--c-line-strong)',
+      borderRadius: 16,
+    }}>
+      <div style={{ width: 48, height: 48, borderRadius: 24, background: 'var(--c-card-2)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', marginBottom: 12, color: 'var(--c-muted)' }}>
+        <Calendar size={22} />
+      </div>
+      <h3 style={{ margin: 0, fontSize: 15, fontWeight: 600, color: 'var(--c-ink)' }}>
+        {isVI ? `Chưa có kế hoạch cho ${monthLabel}` : `No plan for ${monthLabel}`}
+      </h3>
+      <p style={{ margin: '4px 0 16px', fontSize: 12, color: 'var(--c-muted)' }}>
+        {isVI ? 'Nhập thu nhập để bắt đầu phân bổ.' : 'Enter your income to start allocating.'}
+      </p>
+      <button
+        onClick={onSetSalary}
+        style={{
+          display: 'inline-flex', alignItems: 'center', gap: 6,
+          padding: '9px 16px', borderRadius: 10, border: 'none',
+          background: 'var(--c-navy)', color: '#fff', fontSize: 13, fontWeight: 600,
+          cursor: 'pointer', fontFamily: 'inherit',
+        }}
+      >
+        <Plus size={14} strokeWidth={2.4} />
+        {isVI ? 'Thêm thu nhập' : 'Set income'}
+      </button>
+    </div>
+  )
+}
+
+// ─── SalaryCard ───────────────────────────────────────────────────────────────
+
+function SalaryCard({ amount, isVI, onEdit, onDelete }: { amount: number; isVI: boolean; onEdit: () => void; onDelete: () => void }) {
+  return (
+    <div style={{
+      background: 'var(--c-card)', border: '1px solid var(--c-line)',
+      borderRadius: 16, boxShadow: 'var(--shadow-card)',
+      padding: '14px 16px', display: 'flex', alignItems: 'center', gap: 12,
+    }}>
+      <div style={{
+        width: 36, height: 36, borderRadius: 8,
+        background: 'var(--c-pos-tint)', color: 'var(--c-pos)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+      }}>
+        <Wallet size={16} />
+      </div>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 11, color: 'var(--c-muted)', letterSpacing: '0.06em', textTransform: 'uppercase', fontWeight: 600 }}>
+          {isVI ? 'Thu nhập tháng' : 'Monthly income'}
+        </div>
+        <div style={{ fontSize: 20, fontWeight: 600, fontVariantNumeric: 'tabular-nums', marginTop: 2 }}>
+          {fmtCompact(amount)}
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap: 4 }}>
+        <button
+          onClick={onEdit}
+          aria-label="Edit income"
+          style={{ padding: 6, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--c-card-2)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+        >
+          <Edit2 size={16} color="var(--c-muted)" />
+        </button>
+        <button
+          onClick={onDelete}
+          aria-label="Delete plan"
+          style={{ padding: 6, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--c-card-2)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+        >
+          <Trash2 size={16} color="var(--c-neg)" />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ─── AllocationSummaryCard ────────────────────────────────────────────────────
+
+function AllocationSummaryCard({
+  salary, totalGoals, totalFixed, totalInsurance, totalOther, isVI,
+}: {
+  salary: number
+  totalGoals: number
+  totalFixed: number
+  totalInsurance: number
+  totalOther: number
+  isVI: boolean
+}) {
+  const totalAllocated = totalGoals + totalFixed + totalInsurance + totalOther
+  const remaining = salary - totalAllocated
+  const pct = (v: number) => salary > 0 ? `${Math.round((v / salary) * 100)}%` : '—'
+
+  const rows = [
+    ...(totalGoals > 0 ? [{ l: isVI ? 'Đầu tư & tiết kiệm' : 'Invest & save', v: totalGoals, color: 'var(--c-accent-fund)' }] : []),
+    ...(totalFixed > 0 ? [{ l: isVI ? 'Chi phí cố định' : 'Fixed expenses', v: totalFixed, color: 'var(--c-accent-fixed)' }] : []),
+    ...(totalInsurance > 0 ? [{ l: isVI ? 'Bảo hiểm' : 'Insurance', v: totalInsurance, color: 'var(--c-accent-insurance)' }] : []),
+    ...(totalOther > 0 ? [{ l: isVI ? 'Khoản khác' : 'Other', v: totalOther, color: 'var(--c-accent-other)' }] : []),
+  ]
+
+  const segments = rows.map((r) => ({ value: r.v, color: r.color }))
+
+  return (
+    <div style={{
+      background: 'var(--c-navy)', color: '#fff',
+      borderRadius: 16, padding: 16,
+      border: '1px solid var(--c-line)', boxShadow: 'var(--shadow-card)',
+    }}>
+      <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.7)', letterSpacing: '0.06em', textTransform: 'uppercase', fontWeight: 600 }}>
+        {isVI ? 'Phân bổ tháng này' : "This month's allocation"}
+      </div>
+      <div style={{ fontSize: 26, fontWeight: 600, fontVariantNumeric: 'tabular-nums', letterSpacing: '-0.025em', marginTop: 4 }}>
+        {fmtCompact(totalAllocated)}
+      </div>
+      <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.6)', marginTop: 2 }}>
+        {pct(totalAllocated)} {isVI ? 'thu nhập' : 'of income'}
+        {remaining < 0 && (
+          <span style={{ color: '#fca5a5', marginLeft: 8 }}>
+            ⚠ {isVI ? 'Vượt ngân sách' : 'Over budget'}
+          </span>
+        )}
+      </div>
+
+      {/* Stacked bar */}
+      <div style={{ marginTop: 12, padding: 2, background: 'rgba(255,255,255,0.08)', borderRadius: 999 }}>
+        <StackedBar segments={segments} total={salary} height={8} />
+      </div>
+
+      {/* Category rows */}
+      <div style={{ marginTop: 12, display: 'grid', gap: 7 }}>
+        {rows.map((r, i) => (
+          <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: r.color, flexShrink: 0 }} />
+            <span style={{ flex: 1, fontSize: 12, color: 'rgba(255,255,255,0.75)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.l}</span>
+            <span style={{ fontSize: 12, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(r.v)}</span>
+            <span style={{ fontSize: 10, color: 'rgba(255,255,255,0.45)', minWidth: 30, textAlign: 'right' }}>{pct(r.v)}</span>
+          </div>
+        ))}
+        {/* Remaining row */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingTop: 7, borderTop: '1px solid rgba(255,255,255,0.12)', marginTop: 2 }}>
+          <span style={{ width: 8, height: 8, borderRadius: 2, background: remaining >= 0 ? 'rgba(255,255,255,0.25)' : '#fca5a5', flexShrink: 0 }} />
+          <span style={{ flex: 1, fontSize: 12, color: remaining >= 0 ? 'rgba(255,255,255,0.75)' : '#fca5a5', fontWeight: 600 }}>
+            {isVI ? 'Còn lại' : 'Remaining'}
+          </span>
+          <span style={{ fontSize: 13, fontWeight: 700, fontVariantNumeric: 'tabular-nums', color: remaining >= 0 ? '#86efac' : '#fca5a5' }}>
+            {remaining >= 0 ? '+' : ''}{fmtCompact(remaining)}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── BudgetSection ────────────────────────────────────────────────────────────
+
+function BudgetSection({
+  icon: Icon, iconColor, title, total, count, defaultOpen = true, children, testId,
+}: {
+  icon: React.ElementType
+  iconColor: string
+  title: string
+  total: number
+  count?: string
+  defaultOpen?: boolean
+  children: React.ReactNode
+  testId?: string
+}) {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <div data-testid="budget-section" style={{
+      background: 'var(--c-card)', border: '1px solid var(--c-line)',
+      borderRadius: 16, boxShadow: 'var(--shadow-card)', overflow: 'hidden',
+    }}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        data-testid={testId}
+        style={{
+          width: '100%', textAlign: 'left',
+          background: 'transparent', border: 'none', cursor: 'pointer',
+          padding: '14px', display: 'flex', alignItems: 'center', gap: 12,
+          fontFamily: 'inherit',
+        }}
+      >
+        <div style={{
+          width: 36, height: 36, borderRadius: 8,
+          background: 'var(--c-card-2)', color: iconColor,
+          display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+        }}>
+          <Icon size={16} />
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--c-ink)' }}>{title}</div>
+          {count && <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2 }}>{count}</div>}
+        </div>
+        <span style={{ fontSize: 14, fontWeight: 600, fontVariantNumeric: 'tabular-nums', color: 'var(--c-ink)' }}>
+          {fmtCompact(total)}
+        </span>
+        {open ? <ChevronUp size={16} color="var(--c-muted)" /> : <ChevronDown size={16} color="var(--c-muted)" />}
+      </button>
+      {open && (
+        <div style={{ borderTop: '1px solid var(--c-line)', background: 'var(--c-card-2)' }}>
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── GoalAllocationRow ────────────────────────────────────────────────────────
+
+function GoalAllocationRow({ entry, isVI }: { entry: GoalRow; isVI: boolean }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        style={{
+          width: '100%', textAlign: 'left', background: 'transparent', border: 'none', cursor: 'pointer',
+          padding: '12px 14px', display: 'flex', alignItems: 'center', gap: 10,
+          borderTop: '1px solid var(--c-line)', fontFamily: 'inherit',
+        }}
+      >
+        <div style={{ width: 28, height: 28, borderRadius: 6, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+          <Target size={14} />
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 13, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--c-ink)' }}>
+            {entry.goalName}
+          </div>
+          <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1 }}>
+            {entry.items.length} {isVI ? 'khoản' : 'allocations'}
+          </div>
+        </div>
+        <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums', color: 'var(--c-ink)' }}>
+          {fmtCompact(entry.totalAllocated)}
+        </span>
+        {open ? <ChevronUp size={14} color="var(--c-muted)" /> : <ChevronDown size={14} color="var(--c-muted)" />}
+      </button>
+      {open && entry.items.map((item, i) => (
+        <div key={i} style={{
+          padding: '8px 14px 8px 56px', display: 'flex', alignItems: 'center',
+          borderTop: '1px solid var(--c-line)', background: 'var(--c-card)',
+        }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 12, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--c-ink)' }}>
+              {item.name}
+            </div>
+            <div style={{ fontSize: 10, color: 'var(--c-muted)', textTransform: 'capitalize', marginTop: 1, display: 'flex', alignItems: 'center', gap: 4 }}>
+              {item.type}
+              {item.isDCA && (
+                <span style={{ fontSize: 10, padding: '1px 5px', borderRadius: 4, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', fontWeight: 600 }}>DCA</span>
+              )}
+            </div>
+          </div>
+          <span style={{ fontSize: 12, fontWeight: 500, fontVariantNumeric: 'tabular-nums', color: 'var(--c-muted)' }}>
+            {fmtCompact(item.amount)}
+          </span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ─── PlanLineItem (with kebab menu) ───────────────────────────────────────────
+
+function PlanLineItem({
+  primary, secondary, amount, muted, last, isVI,
+  onSkip, onRestore, onOverride,
+}: {
+  primary: string
+  secondary?: string | null
+  amount: number
+  muted?: boolean
+  last?: boolean
+  isVI: boolean
+  onSkip?: () => void
+  onRestore?: () => void
+  onOverride?: () => void
+}) {
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  return (
+    <div style={{
+      padding: '10px 14px 10px 60px', display: 'flex', alignItems: 'center', gap: 8,
+      borderBottom: last ? 'none' : '1px solid var(--c-line)',
+      opacity: muted ? 0.55 : 1, position: 'relative',
+    }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          fontSize: 13, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+          textDecoration: muted ? 'line-through' : 'none', color: 'var(--c-ink)',
+        }}>
+          {primary}
+        </div>
+        {secondary && (
+          <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1 }}>{secondary}</div>
+        )}
+      </div>
+      <span style={{
+        fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums',
+        color: muted ? 'var(--c-muted)' : 'var(--c-ink)',
+        textDecoration: muted ? 'line-through' : 'none',
+      }}>
+        {fmtCompact(muted ? 0 : amount)}
+      </span>
+      {/* Kebab menu */}
+      <button
+        onClick={() => setMenuOpen((o) => !o)}
+        aria-label="More options"
+        style={{ padding: 4, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 4, display: 'flex', alignItems: 'center' }}
+      >
+        <MoreHorizontal size={14} color="var(--c-muted)" />
+      </button>
+      {menuOpen && (
+        <>
+          <div onClick={() => setMenuOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 5 }} />
+          <div style={{
+            position: 'absolute', top: '100%', right: 8, marginTop: 2, zIndex: 6,
+            background: 'var(--c-card)', border: '1px solid var(--c-line)',
+            borderRadius: 8, boxShadow: 'var(--shadow-pop)',
+            minWidth: 170, overflow: 'hidden',
+          }}>
+            {muted ? (
+              <button
+                onClick={() => { onRestore?.(); setMenuOpen(false) }}
+                style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', color: 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8 }}
+              >
+                <Check size={14} color="var(--c-muted)" />
+                {isVI ? 'Bao gồm tháng này' : 'Include this month'}
+              </button>
+            ) : (
+              <>
+                <button
+                  onClick={() => { onOverride?.(); setMenuOpen(false) }}
+                  style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', color: 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8, borderBottom: '1px solid var(--c-line)' }}
+                >
+                  <Edit2 size={14} color="var(--c-muted)" />
+                  {isVI ? 'Ghi đè số tiền' : 'Override amount'}
+                </button>
+                <button
+                  onClick={() => { onSkip?.(); setMenuOpen(false) }}
+                  style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', color: 'var(--c-neg)', display: 'flex', alignItems: 'center', gap: 8 }}
+                >
+                  <X size={14} color="var(--c-neg)" />
+                  {isVI ? 'Bỏ qua tháng này' : 'Skip this month'}
+                </button>
+              </>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+// ─── MonthPicker ──────────────────────────────────────────────────────────────
+
+function MonthPicker({ month, year, onPrev, onNext }: {
+  month: number
+  year: number
+  onPrev: () => void
+  onNext: () => void
+}) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: 3, background: 'var(--c-card-2)', border: '1px solid var(--c-line)', borderRadius: 10 }}>
+      <button
+        onClick={onPrev}
+        data-testid="mobile-prev-month"
+        aria-label="Previous month"
+        style={{ padding: 6, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, display: 'flex', alignItems: 'center' }}
+      >
+        <ChevronLeft size={16} color="var(--c-ink)" />
+      </button>
+      <span style={{ padding: '4px 10px', minWidth: 78, textAlign: 'center', fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>
+        {getMonthLabel(month, year, true)}
+      </span>
+      <button
+        onClick={onNext}
+        data-testid="mobile-next-month"
+        aria-label="Next month"
+        style={{ padding: 6, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, display: 'flex', alignItems: 'center' }}
+      >
+        <ChevronRight size={16} color="var(--c-ink)" />
+      </button>
+    </div>
+  )
+}
+
+// ─── Main MobilePlanningView ──────────────────────────────────────────────────
+
+export default function MobilePlanningView({
+  month, year, plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,
+  funds, goals, onNavigatePrev, onNavigateNext, onPlanCreated, onPlanDeleted, onRefresh, onToast,
+}: Props) {
+  const locale = useLocale()
+  const isVI = locale === 'vi'
+  const [sheet, setSheet] = useState<SheetState>(null)
+  const [overrideTarget, setOverrideTarget] = useState<{ type: 'fe' | 'ins'; id: string; name: string; defaultAmount: number } | null>(null)
+  const [otherSheetTarget, setOtherSheetTarget] = useState<OtherExpense | null | 'new'>('new')
+
+  const monthLabel = getMonthLabel(month, year)
+  const shortLabel = getMonthLabel(month, year, true)
+
+  // ─── Computed totals ────────────────────────────────────────────────────────
+
+  const byGoal = useMemo(() => buildByGoal(investments, savings), [investments, savings])
+  const totalGoals = useMemo(() => byGoal.reduce((s, g) => s + g.totalAllocated, 0), [byGoal])
+  const totalFixed = useMemo(() => getFixedTotal(fixedExpenses), [fixedExpenses])
+  const totalInsurance = useMemo(() => getInsTotal(insuranceMembers), [insuranceMembers])
+  const totalOther = useMemo(() => otherExpenses.reduce((s, e) => s + e.amount_vnd, 0), [otherExpenses])
+  const totalOutflow = totalGoals + totalFixed + totalInsurance + totalOther
+  const remaining = plan ? plan.salary_vnd - totalOutflow : 0
+
+  // ─── Skip/restore handlers ─────────────────────────────────────────────────
+
+  async function handleSkipFE(expense: FixedExpense) {
+    if (!plan) return
+    await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fixed_expense_id: expense.expense_id, monthly_amount_override_vnd: 0 }),
+    })
+    onToast(isVI ? `Đã bỏ qua ${expense.expense_name}` : `Skipped ${expense.expense_name}`)
+    onRefresh()
+  }
+
+  async function handleRestoreFE(expense: FixedExpense) {
+    if (!plan) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`)
+    if (!res.ok) return
+    const overrides: Array<{ id: string; fixed_expense_id: string }> = await res.json()
+    const match = overrides.find((o) => o.fixed_expense_id === expense.expense_id)
+    if (!match) return
+    await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides/${match.id}`, { method: 'DELETE' })
+    onToast(isVI ? `Đã khôi phục ${expense.expense_name}` : `Restored ${expense.expense_name}`)
+    onRefresh()
+  }
+
+  async function handleSkipIns(member: InsuranceMember) {
+    if (!plan) return
+    await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ member_id: member.member_id }),
+    })
+    onToast(isVI ? `Đã bỏ qua ${member.member_name}` : `Skipped ${member.member_name}`)
+    onRefresh()
+  }
+
+  async function handleRestoreIns(member: InsuranceMember) {
+    if (!plan) return
+    await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance/${member.member_id}`, { method: 'DELETE' })
+    onToast(isVI ? `Đã khôi phục ${member.member_name}` : `Restored ${member.member_name}`)
+    onRefresh()
+  }
+
+  // ─── Override sheet helpers ────────────────────────────────────────────────
+
+  function openOverrideFE(expense: FixedExpense) {
+    const defaultAmt = (expense.override != null && expense.override > 0) ? expense.override : expense.amount_vnd
+    setOverrideTarget({ type: 'fe', id: expense.expense_id, name: expense.expense_name, defaultAmount: defaultAmt })
+    setSheet({ type: 'override-fe', expense })
+  }
+
+  function openOverrideIns(member: InsuranceMember) {
+    const defaultAmt = member.monthlyOverride ?? Math.round(member.annual_payment_vnd / 12)
+    setOverrideTarget({ type: 'ins', id: member.member_id, name: member.member_name, defaultAmount: defaultAmt })
+    setSheet({ type: 'override-ins', member })
+  }
+
+  async function handleOverrideSave(amount: number) {
+    if (!plan || !overrideTarget) return
+    if (overrideTarget.type === 'fe') {
+      await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fixed_expense_id: overrideTarget.id, monthly_amount_override_vnd: amount }),
+      })
+    } else {
+      await fetch(`/api/v1/monthly-plans/${plan.id}/insurance-overrides`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ member_id: overrideTarget.id, monthly_amount_override_vnd: amount }),
+      })
+    }
+    setSheet(null)
+    setOverrideTarget(null)
+    onToast(isVI ? 'Đã ghi đè' : 'Override saved')
+    onRefresh()
+  }
+
+  // ─── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="md:hidden" style={{ background: 'var(--c-canvas)', minHeight: '100%' }}>
+      <MobileTopBar
+        subtitle={isVI ? 'Kế hoạch tháng' : 'Monthly plan'}
+        title={isVI ? 'Ngân sách' : 'Budget'}
+        trailing={<MonthPicker month={month} year={year} onPrev={onNavigatePrev} onNext={onNavigateNext} />}
+      />
+
+      <div style={{ padding: '4px 16px 100px', display: 'grid', gap: 10 }}>
+        {!plan ? (
+          <NoPlanState monthLabel={monthLabel} isVI={isVI} onSetSalary={() => setSheet({ type: 'salary' })} />
+        ) : (
+          <>
+            {/* Salary card */}
+            <SalaryCard
+              amount={plan.salary_vnd}
+              isVI={isVI}
+              onEdit={() => setSheet({ type: 'salary' })}
+              onDelete={() => setSheet({ type: 'delete-plan' })}
+            />
+
+            {/* Summary strip */}
+            <div style={{
+              border: '1px solid var(--c-line)',
+              borderRadius: 16, boxShadow: 'var(--shadow-card)',
+              display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)',
+              gap: 1, overflow: 'hidden', background: 'var(--c-line)',
+            } as React.CSSProperties}>
+              {[
+                { l: isVI ? 'Tổng chi' : 'Outflow', v: fmtCompact(totalOutflow), c: 'var(--c-ink)' },
+                { l: isVI ? 'Còn lại' : 'Remaining', v: fmtCompact(remaining), c: remaining >= 0 ? 'var(--c-pos)' : 'var(--c-neg)' },
+                { l: isVI ? '% Tiết kiệm' : 'Saved %', v: plan.salary_vnd > 0 ? `${Math.round((totalGoals / plan.salary_vnd) * 100)}%` : '—', c: 'var(--c-navy)' },
+              ].map((k, i) => (
+                <div key={i} style={{ background: 'var(--c-card)', padding: '10px 12px' }}>
+                  <div style={{ fontSize: 10, color: 'var(--c-muted)' }}>{k.l}</div>
+                  <div style={{ fontSize: 13, fontWeight: 600, color: k.c, marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>
+                    {k.v}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Allocation summary card */}
+            <AllocationSummaryCard
+              salary={plan.salary_vnd}
+              totalGoals={totalGoals}
+              totalFixed={totalFixed}
+              totalInsurance={totalInsurance}
+              totalOther={totalOther}
+              isVI={isVI}
+            />
+
+            {/* By goal section */}
+            <BudgetSection
+              icon={Target}
+              iconColor="var(--c-navy)"
+              title={isVI ? 'Theo mục tiêu' : 'By goal'}
+              count={`${byGoal.length} ${isVI ? 'mục tiêu' : 'goals'}`}
+              total={totalGoals}
+              testId="section-by-goal"
+            >
+              {byGoal.length === 0 ? (
+                <div style={{ padding: '12px 14px', fontSize: 13, color: 'var(--c-muted)' }}>
+                  {isVI ? 'Chưa có phân bổ' : 'No allocations yet'}
+                </div>
+              ) : (
+                byGoal.map((entry) => <GoalAllocationRow key={entry.goalId} entry={entry} isVI={isVI} />)
+              )}
+            </BudgetSection>
+
+            {/* Fixed expenses section */}
+            {fixedExpenses.length > 0 && (
+              <BudgetSection
+                icon={Building}
+                iconColor="var(--c-accent-fixed)"
+                title={isVI ? 'Chi phí cố định' : 'Fixed expenses'}
+                count={`${fixedExpenses.length} ${isVI ? 'khoản' : 'items'}`}
+                total={totalFixed}
+                testId="section-fixed-expenses"
+              >
+                {fixedExpenses.map((fe, i) => {
+                  const isSkipped = fe.override === 0
+                  const hasOverride = fe.override != null && fe.override > 0 && fe.override !== fe.amount_vnd
+                  const thisMonth = isSkipped ? 0 : (fe.override ?? fe.amount_vnd)
+                  const secondary = isSkipped
+                    ? (isVI ? 'Bỏ qua tháng này' : 'Skipped')
+                    : hasOverride ? (isVI ? '(đã ghi đè)' : '(overridden)') : null
+                  return (
+                    <PlanLineItem
+                      key={fe.expense_id}
+                      primary={fe.expense_name}
+                      secondary={secondary}
+                      amount={thisMonth}
+                      muted={isSkipped}
+                      last={i === fixedExpenses.length - 1}
+                      isVI={isVI}
+                      onSkip={() => handleSkipFE(fe)}
+                      onRestore={() => handleRestoreFE(fe)}
+                      onOverride={() => openOverrideFE(fe)}
+                    />
+                  )
+                })}
+              </BudgetSection>
+            )}
+
+            {/* Insurance section */}
+            {insuranceMembers.length > 0 && (
+              <BudgetSection
+                icon={Shield}
+                iconColor="var(--c-accent-insurance)"
+                title={isVI ? 'Bảo hiểm' : 'Insurance'}
+                count={`${insuranceMembers.length} ${isVI ? 'thành viên' : 'members'}`}
+                total={totalInsurance}
+                testId="section-insurance"
+              >
+                {insuranceMembers.map((m, i) => {
+                  const defaultMonthly = Math.round(m.annual_payment_vnd / 12)
+                  const hasOverride = m.monthlyOverride != null && m.monthlyOverride !== defaultMonthly
+                  const thisMonth = m.excluded ? 0 : (m.monthlyOverride ?? defaultMonthly)
+                  const secondary = m.excluded
+                    ? (isVI ? 'Bỏ qua tháng này' : 'Skipped')
+                    : hasOverride ? (isVI ? '(đã ghi đè)' : '(overridden)') : (isVI ? 'Đóng góp tháng' : 'Monthly contribution')
+                  return (
+                    <PlanLineItem
+                      key={m.member_id}
+                      primary={m.member_name}
+                      secondary={secondary}
+                      amount={thisMonth}
+                      muted={m.excluded}
+                      last={i === insuranceMembers.length - 1}
+                      isVI={isVI}
+                      onSkip={() => handleSkipIns(m)}
+                      onRestore={() => handleRestoreIns(m)}
+                      onOverride={() => openOverrideIns(m)}
+                    />
+                  )
+                })}
+              </BudgetSection>
+            )}
+
+            {/* Other expenses section */}
+            <BudgetSection
+              icon={ShoppingCart}
+              iconColor="var(--c-accent-other)"
+              title={isVI ? 'Khoản khác' : 'Other'}
+              count={`${otherExpenses.length} ${isVI ? 'khoản' : 'one-offs'}`}
+              total={totalOther}
+              testId="section-other"
+            >
+              {otherExpenses.map((o, i) => (
+                <div
+                  key={o.id}
+                  style={{
+                    padding: '10px 14px 10px 60px', display: 'flex', alignItems: 'center', gap: 8,
+                    borderBottom: i === otherExpenses.length - 1 ? 'none' : '1px solid var(--c-line)',
+                  }}
+                >
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 13, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--c-ink)' }}>
+                      {o.description}
+                    </div>
+                  </div>
+                  <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums', color: 'var(--c-ink)' }}>
+                    {fmtCompact(o.amount_vnd)}
+                  </span>
+                  <button
+                    onClick={() => { setOtherSheetTarget(o); setSheet({ type: 'other-expense', existing: o }) }}
+                    aria-label="Edit expense"
+                    style={{ padding: 4, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 4, display: 'flex', alignItems: 'center' }}
+                  >
+                    <Edit2 size={14} color="var(--c-muted)" />
+                  </button>
+                </div>
+              ))}
+              <div style={{ padding: '10px 14px 12px 60px' }}>
+                <button
+                  onClick={() => { setOtherSheetTarget('new'); setSheet({ type: 'other-expense', existing: null }) }}
+                  style={{
+                    padding: '4px 0', fontSize: 12, color: 'var(--c-navy)',
+                    border: 'none', background: 'transparent', cursor: 'pointer',
+                    fontFamily: 'inherit', display: 'flex', alignItems: 'center', gap: 4,
+                  }}
+                >
+                  <Plus size={12} strokeWidth={2.4} />
+                  {isVI ? 'Thêm khoản' : 'Add item'}
+                </button>
+              </div>
+            </BudgetSection>
+          </>
+        )}
+      </div>
+
+      {/* ─── Salary sheet ──────────────────────────────────────────────────── */}
+      <SalarySheet
+        open={sheet?.type === 'salary'}
+        onClose={() => setSheet(null)}
+        plan={plan}
+        month={month}
+        year={year}
+        onPlanCreated={onPlanCreated}
+        onToast={onToast}
+      />
+
+      {/* ─── Delete plan sheet ─────────────────────────────────────────────── */}
+      {plan && (
+        <DeletePlanSheet
+          open={sheet?.type === 'delete-plan'}
+          onClose={() => setSheet(null)}
+          monthLabel={monthLabel}
+          onPlanDeleted={onPlanDeleted}
+          planId={plan.id}
+          onToast={onToast}
+        />
+      )}
+
+      {/* ─── Override sheet ────────────────────────────────────────────────── */}
+      {overrideTarget && plan && (
+        <SimpleOverrideSheet
+          open={sheet?.type === 'override-fe' || sheet?.type === 'override-ins'}
+          onClose={() => { setSheet(null); setOverrideTarget(null) }}
+          name={overrideTarget.name}
+          defaultAmount={overrideTarget.defaultAmount}
+          planId={plan.id}
+          targetId={overrideTarget.id}
+          targetType={overrideTarget.type}
+          isVI={isVI}
+          onSaved={handleOverrideSave}
+        />
+      )}
+
+      {/* ─── Other expense sheet ───────────────────────────────────────────── */}
+      {plan && (
+        <OtherExpenseSheet
+          open={sheet?.type === 'other-expense'}
+          onClose={() => setSheet(null)}
+          existing={sheet?.type === 'other-expense' ? sheet.existing : null}
+          planId={plan.id}
+          onRefresh={onRefresh}
+          onToast={onToast}
+        />
+      )}
+    </div>
+  )
+}
+
+// ─── SimpleOverrideSheet (used inline — keeps handleOverrideSave in parent) ───
+
+function SimpleOverrideSheet({
+  open, onClose, name, defaultAmount, planId, targetId, targetType, isVI, onSaved,
+}: {
+  open: boolean
+  onClose: () => void
+  name: string
+  defaultAmount: number
+  planId: string
+  targetId: string
+  targetType: 'fe' | 'ins'
+  isVI: boolean
+  onSaved: (amount: number) => void
+}) {
+  const [value, setValue] = useState(String(defaultAmount))
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  useEffect(() => { if (open) { setValue(String(defaultAmount)); setError('') } }, [open, defaultAmount])
+
+  async function handleSave() {
+    const num = Number(value)
+    if (!value || isNaN(num) || num <= 0) { setError(isVI ? 'Vui lòng nhập số tiền hợp lệ' : 'Please enter a valid amount'); return }
+    setError('')
+    setSaving(true)
+    try {
+      const endpoint = targetType === 'fe' ? 'fixed-expense-overrides' : 'insurance-overrides'
+      const body = targetType === 'fe'
+        ? { fixed_expense_id: targetId, monthly_amount_override_vnd: num }
+        : { member_id: targetId, monthly_amount_override_vnd: num }
+      await fetch(`/api/v1/monthly-plans/${planId}/${endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+      onSaved(num)
+    } catch { setError(isVI ? 'Lỗi kết nối' : 'Connection error') }
+    setSaving(false)
+  }
+
+  return (
+    <Sheet open={open} onClose={onClose} title={isVI ? 'Ghi đè số tiền' : 'Override amount'}>
+      <div style={{ display: 'grid', gap: 14 }}>
+        <div style={{ fontSize: 13, color: 'var(--c-muted)' }}>{name}</div>
+        {error && <p style={{ color: 'var(--c-neg)', fontSize: 13 }}>{error}</p>}
+        <input
+          type="text"
+          inputMode="numeric"
+          value={value ? Number(value).toLocaleString('en-US') : ''}
+          onChange={(e) => setValue(e.target.value.replace(/,/g, '').replace(/[^0-9]/g, ''))}
+          style={{
+            width: '100%', padding: '10px 12px', fontSize: 15,
+            border: '1px solid var(--c-line)', borderRadius: 10,
+            background: 'var(--c-card-2)', color: 'var(--c-ink)', boxSizing: 'border-box',
+          }}
+          autoFocus
+        />
+        <button
+          onClick={() => setValue(String(defaultAmount))}
+          style={{
+            alignSelf: 'flex-start', padding: '4px 8px', fontSize: 11,
+            background: 'transparent', border: '1px solid var(--c-line)',
+            borderRadius: 6, color: 'var(--c-navy)', cursor: 'pointer', fontFamily: 'inherit', fontWeight: 500,
+          }}
+        >
+          {isVI ? 'Mặc định' : 'Default'}: {fmtCompact(defaultAmount)}
+        </button>
+        <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+          <button onClick={onClose} style={{ flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)', background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit' }}>
+            {isVI ? 'Hủy' : 'Cancel'}
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-navy)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit' }}
+          >
+            {isVI ? 'Lưu' : 'Save'}
+          </button>
+        </div>
+      </div>
+    </Sheet>
+  )
+}

--- a/app/(app)/planning/components/OtherExpensesSection.tsx
+++ b/app/(app)/planning/components/OtherExpensesSection.tsx
@@ -89,7 +89,7 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-      <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-700">
+      <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('otherExpensesTitle')}</h2>
         <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-700 dark:hover:bg-gray-200 transition-colors">
           <Plus className="h-3.5 w-3.5" />
@@ -102,13 +102,13 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
       ) : (
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-gray-100 dark:border-gray-700">
+            <tr className="border-b border-gray-200 dark:border-gray-700">
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDescription')}</th>
               <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('amount')}</th>
               <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
+          <tbody className="divide-y divide-gray-200 dark:divide-gray-700">
             {otherExpenses.map((item) => (
               <tr key={item.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
                 <td className="px-4 py-3 text-base font-medium text-gray-900 dark:text-gray-100">{item.description}</td>

--- a/app/(app)/planning/components/OtherExpensesSection.tsx
+++ b/app/(app)/planning/components/OtherExpensesSection.tsx
@@ -91,7 +91,7 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
       <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('otherExpensesTitle')}</h2>
-        <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+        <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-700 dark:hover:bg-gray-200 transition-colors">
           <Plus className="h-3.5 w-3.5" />
           {t('addOtherExpense')}
         </button>

--- a/app/(app)/planning/components/OtherExpensesSection.tsx
+++ b/app/(app)/planning/components/OtherExpensesSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Plus, Pencil, Trash2 } from 'lucide-react'
+import { Plus, Edit, Trash2 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import type { MonthlyPlan, OtherExpense } from '../PlanningClient'
 
@@ -103,23 +103,23 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
         <table className="w-full text-sm">
           <thead>
             <tr className="border-b border-gray-100 dark:border-gray-700">
-              {[t('colDescription'), tc('amount'), tc('actions')].map((h) => (
-                <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{h}</th>
-              ))}
+              <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDescription')}</th>
+              <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('amount')}</th>
+              <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>
             </tr>
           </thead>
           <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
             {otherExpenses.map((item) => (
               <tr key={item.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{item.description}</td>
-                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(item.amount_vnd)}</td>
-                <td className="px-4 py-3">
-                  <div className="flex gap-1">
+                <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">{item.description}</td>
+                <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100 text-right">{fmt(item.amount_vnd)}</td>
+                <td className="px-4 py-3 text-center">
+                  <div className="flex gap-1 justify-center">
                     <button onClick={() => openEdit(item)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
-                      <Pencil className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                      <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
                     </button>
                     <button onClick={() => setConfirmDelete(item)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
-                      <Trash2 className="h-4 w-4 text-red-500 dark:text-red-400" />
+                      <Trash2 className="h-4 w-4 text-red-600 dark:text-red-400" />
                     </button>
                   </div>
                 </td>

--- a/app/(app)/planning/components/OtherExpensesSection.tsx
+++ b/app/(app)/planning/components/OtherExpensesSection.tsx
@@ -89,7 +89,7 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-      <div className="flex items-center justify-between px-5 py-4 border-b border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between px-5 py-4 border-t border-b border-gray-200 dark:border-gray-700">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('otherExpensesTitle')}</h2>
         <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-700 dark:hover:bg-gray-200 transition-colors">
           <Plus className="h-3.5 w-3.5" />
@@ -102,7 +102,7 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
       ) : (
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-b border-gray-200 dark:border-gray-700">
+            <tr className="border-t border-b border-gray-200 dark:border-gray-700">
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDescription')}</th>
               <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('amount')}</th>
               <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>

--- a/app/(app)/planning/components/OtherExpensesSection.tsx
+++ b/app/(app)/planning/components/OtherExpensesSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { Plus, Pencil, Trash2 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import type { MonthlyPlan, OtherExpense } from '../PlanningClient'
 
@@ -89,8 +90,9 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
       <div className="flex items-center justify-between px-5 py-4 border-b border-gray-100 dark:border-gray-700">
-        <h2 className="font-semibold text-gray-900 dark:text-gray-100">{t('otherExpensesTitle')}</h2>
-        <button onClick={openAdd} className="px-3 py-1.5 text-sm bg-indigo-600 text-white rounded-lg hover:bg-indigo-700">
+        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('otherExpensesTitle')}</h2>
+        <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium border border-gray-200 dark:border-gray-600 text-gray-900 dark:text-gray-100 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors">
+          <Plus className="h-3.5 w-3.5" />
           {t('addOtherExpense')}
         </button>
       </div>
@@ -99,22 +101,26 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
         <div className="text-center py-10 text-gray-400 dark:text-gray-500 text-sm">{t('addOtherExpenseDesc')}</div>
       ) : (
         <table className="w-full text-sm">
-          <thead className="bg-gray-50 dark:bg-gray-800">
-            <tr>
+          <thead>
+            <tr className="border-b border-gray-100 dark:border-gray-700">
               {[t('colDescription'), tc('amount'), tc('actions')].map((h) => (
-                <th key={h} className="px-4 py-3 text-left text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">{h}</th>
+                <th key={h} className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{h}</th>
               ))}
             </tr>
           </thead>
-          <tbody className="divide-y divide-gray-100 dark:divide-gray-700">
+          <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
             {otherExpenses.map((item) => (
-              <tr key={item.id} className="hover:bg-gray-50 dark:hover:bg-gray-800">
-                <td className="px-4 py-3 text-gray-700 dark:text-gray-300">{item.description}</td>
+              <tr key={item.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
+                <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{item.description}</td>
                 <td className="px-4 py-3 font-medium text-gray-900 dark:text-gray-100">{fmt(item.amount_vnd)}</td>
                 <td className="px-4 py-3">
-                  <div className="flex gap-3">
-                    <button onClick={() => openEdit(item)} className="text-xs text-indigo-600 dark:text-indigo-400 hover:underline">{tc('edit')}</button>
-                    <button onClick={() => setConfirmDelete(item)} className="text-xs text-red-500 dark:text-red-400 hover:underline">{tc('delete')}</button>
+                  <div className="flex gap-1">
+                    <button onClick={() => openEdit(item)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                      <Pencil className="h-4 w-4 text-blue-600 dark:text-blue-400" />
+                    </button>
+                    <button onClick={() => setConfirmDelete(item)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                      <Trash2 className="h-4 w-4 text-red-500 dark:text-red-400" />
+                    </button>
                   </div>
                 </td>
               </tr>

--- a/app/(app)/planning/components/OtherExpensesSection.tsx
+++ b/app/(app)/planning/components/OtherExpensesSection.tsx
@@ -89,7 +89,7 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
 
   return (
     <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 overflow-hidden">
-      <div className="flex items-center justify-between px-5 py-4 border-t border-b border-gray-200 dark:border-gray-700">
+      <div className="flex items-center justify-between px-5 py-4">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">{t('otherExpensesTitle')}</h2>
         <button onClick={openAdd} className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium bg-gray-900 dark:bg-gray-100 text-white dark:text-gray-900 rounded-lg hover:bg-gray-700 dark:hover:bg-gray-200 transition-colors">
           <Plus className="h-3.5 w-3.5" />
@@ -102,7 +102,7 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
       ) : (
         <table className="w-full text-sm">
           <thead>
-            <tr className="border-t border-b border-gray-200 dark:border-gray-700">
+            <tr className="border-b border-gray-200 dark:border-gray-700">
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{t('colDescription')}</th>
               <th className="px-4 py-3 text-right text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('amount')}</th>
               <th className="px-4 py-3 text-center text-xs font-medium text-gray-500 dark:text-gray-400 uppercase">{tc('actions')}</th>

--- a/app/(app)/planning/components/OtherExpensesSection.tsx
+++ b/app/(app)/planning/components/OtherExpensesSection.tsx
@@ -111,7 +111,7 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
           <tbody className="divide-y divide-gray-50 dark:divide-gray-700/50">
             {otherExpenses.map((item) => (
               <tr key={item.id} className="hover:bg-gray-50 dark:hover:bg-gray-800/50">
-                <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100">{item.description}</td>
+                <td className="px-4 py-3 text-base font-medium text-gray-900 dark:text-gray-100">{item.description}</td>
                 <td className="px-4 py-3 text-sm font-medium text-gray-900 dark:text-gray-100 text-right">{fmt(item.amount_vnd)}</td>
                 <td className="px-4 py-3 text-center">
                   <div className="flex gap-1 justify-center">

--- a/app/(app)/planning/components/SalaryInput.tsx
+++ b/app/(app)/planning/components/SalaryInput.tsx
@@ -101,7 +101,7 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
             <button
               onClick={() => setShowConfirm(true)}
               disabled={deleting || saving}
-              className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+              className="flex items-center gap-1.5 px-3 h-9 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
             >
               {deleting ? (
                 <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
@@ -123,7 +123,7 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
               onKeyDown={handleKeyDown}
               disabled={saving}
               placeholder={t('salaryPlaceholder')}
-              className="w-full pl-7 pr-4 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500 disabled:opacity-60"
+              className="w-full pl-7 pr-4 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg text-lg font-medium bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500 disabled:opacity-60"
             />
           </div>
           {saving && (

--- a/app/(app)/planning/components/SalaryInput.tsx
+++ b/app/(app)/planning/components/SalaryInput.tsx
@@ -101,7 +101,7 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
             <button
               onClick={() => setShowConfirm(true)}
               disabled={deleting || saving}
-              className="flex items-center gap-1.5 px-3 h-9 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+              className="px-4 h-10 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
             >
               {deleting ? (
                 <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />

--- a/app/(app)/planning/components/SalaryInput.tsx
+++ b/app/(app)/planning/components/SalaryInput.tsx
@@ -101,7 +101,7 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
             <button
               onClick={() => setShowConfirm(true)}
               disabled={deleting || saving}
-              className="px-4 h-10 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+              className="px-3 h-9 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
             >
               {deleting ? (
                 <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />

--- a/app/(app)/planning/components/SalaryInput.tsx
+++ b/app/(app)/planning/components/SalaryInput.tsx
@@ -95,7 +95,7 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
   return (
     <>
       <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-5">
-        <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center justify-between mb-4">
           <label className="text-sm font-medium text-gray-900 dark:text-gray-100">{t('salaryLabel')}</label>
           {plan && (
             <button
@@ -113,19 +113,16 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
         </div>
         {error && <p className="text-red-600 dark:text-red-400 text-sm mb-2">{error}</p>}
         <div className="flex items-center gap-3">
-          <div className="relative flex-1">
-            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 dark:text-gray-500 text-sm font-medium">₫</span>
-            <input
-              type="number"
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              onBlur={saveSalary}
-              onKeyDown={handleKeyDown}
-              disabled={saving}
-              placeholder={t('salaryPlaceholder')}
-              className="w-full pl-7 pr-4 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg text-lg font-medium bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500 disabled:opacity-60"
-            />
-          </div>
+          <input
+            type="number"
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            onBlur={saveSalary}
+            onKeyDown={handleKeyDown}
+            disabled={saving}
+            placeholder={t('salaryPlaceholder')}
+            className="flex-1 px-3 py-2 border border-gray-200 dark:border-gray-600 rounded-md text-lg font-medium bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500 disabled:opacity-60"
+          />
           {saving && (
             <div className="w-5 h-5 border-2 border-violet-600 border-t-transparent rounded-full animate-spin" />
           )}

--- a/app/(app)/planning/components/SalaryInput.tsx
+++ b/app/(app)/planning/components/SalaryInput.tsx
@@ -95,7 +95,22 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
   return (
     <>
       <div className="bg-white dark:bg-gray-900 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-5">
-        <label className="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-2">{t('salaryLabel')}</label>
+        <div className="flex items-center justify-between mb-3">
+          <label className="text-sm font-medium text-gray-900 dark:text-gray-100">{t('salaryLabel')}</label>
+          {plan && (
+            <button
+              onClick={() => setShowConfirm(true)}
+              disabled={deleting || saving}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+            >
+              {deleting ? (
+                <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+              ) : (
+                tc('delete')
+              )}
+            </button>
+          )}
+        </div>
         {error && <p className="text-red-600 dark:text-red-400 text-sm mb-2">{error}</p>}
         <div className="flex items-center gap-3">
           <div className="relative flex-1">
@@ -108,24 +123,11 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
               onKeyDown={handleKeyDown}
               disabled={saving}
               placeholder={t('salaryPlaceholder')}
-              className="w-full pl-7 pr-4 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-60"
+              className="w-full pl-7 pr-4 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg text-sm bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-violet-500 disabled:opacity-60"
             />
           </div>
           {saving && (
-            <div className="w-5 h-5 border-2 border-indigo-600 border-t-transparent rounded-full animate-spin" />
-          )}
-          {plan && (
-            <button
-              onClick={() => setShowConfirm(true)}
-              disabled={deleting || saving}
-              className="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-white bg-red-600 rounded-lg hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed"
-            >
-              {deleting ? (
-                <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
-              ) : (
-                tc('delete')
-              )}
-            </button>
+            <div className="w-5 h-5 border-2 border-violet-600 border-t-transparent rounded-full animate-spin" />
           )}
         </div>
       </div>

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -1,0 +1,338 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MobilePlanningView from '../MobilePlanningView'
+import type { MonthlyPlan, FixedExpense, InsuranceMember, OtherExpense, FundInvestment, DirectSaving } from '../../PlanningClient'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+
+vi.mock('@/lib/formatters', () => ({
+  fmt: (n: number) => `₫ ${n}`,
+  fmtCompact: (n: number) => {
+    const abs = Math.abs(n)
+    const sign = n < 0 ? '-' : ''
+    if (abs >= 1_000_000_000) return sign + (abs / 1_000_000_000).toFixed(1) + 'B ₫'
+    if (abs >= 1_000_000) return sign + (abs / 1_000_000).toFixed(1) + 'M ₫'
+    return `₫ ${n}`
+  },
+}))
+
+vi.mock('@/app/components/navigation/MobileTopBar', () => ({
+  default: ({ title, trailing }: { title: string; trailing?: React.ReactNode }) => (
+    <header>
+      <h1>{title}</h1>
+      {trailing}
+    </header>
+  ),
+}))
+
+const basePlan: MonthlyPlan = {
+  id: 'plan-1',
+  month: 5,
+  year: 2026,
+  salary_vnd: 45_000_000,
+}
+
+const baseFixedExpenses: FixedExpense[] = [
+  { expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000 },
+  { expense_id: 'fe2', expense_name: 'Utilities', amount_vnd: 1_200_000 },
+]
+
+const baseInsuranceMembers: InsuranceMember[] = [
+  {
+    member_id: 'i1',
+    member_name: 'John',
+    relationship: 'Self',
+    annual_payment_vnd: 18_000_000,
+    payment_date: null,
+  },
+]
+
+const baseOtherExpenses: OtherExpense[] = [
+  { id: 'o1', plan_id: 'plan-1', description: 'Family trip', amount_vnd: 6_000_000, created_at: '2026-05-01' },
+]
+
+const baseInvestments: FundInvestment[] = [
+  {
+    transaction_id: 'tx1',
+    plan_id: 'plan-1',
+    fund_id: 'f1',
+    goal_id: 'g1',
+    amount_vnd: 5_000_000,
+    units: null,
+    unit_price: null,
+    investment_date: '2026-05-01',
+    is_dca_seeded: false,
+    funds: { name: 'VFMVF1', nav: 36120 },
+    savings_goals: { goal_name: 'Retirement' },
+  },
+]
+
+const baseSavings: DirectSaving[] = [
+  {
+    transaction_id: 'sv1',
+    plan_id: 'plan-1',
+    goal_id: 'g2',
+    amount_vnd: 3_000_000,
+    interest_rate: null,
+    expiry_date: null,
+    investment_date: '2026-05-01',
+    savings_goals: { goal_name: 'Emergency fund' },
+  },
+]
+
+const defaultProps = {
+  month: 5,
+  year: 2026,
+  plan: null as MonthlyPlan | null,
+  investments: [] as FundInvestment[],
+  savings: [] as DirectSaving[],
+  fixedExpenses: [] as FixedExpense[],
+  insuranceMembers: [] as InsuranceMember[],
+  otherExpenses: [] as OtherExpense[],
+  funds: [],
+  goals: [],
+  onNavigatePrev: vi.fn(),
+  onNavigateNext: vi.fn(),
+  onPlanCreated: vi.fn(),
+  onPlanDeleted: vi.fn(),
+  onRefresh: vi.fn(),
+  onToast: vi.fn(),
+}
+
+describe('MobilePlanningView — no plan', () => {
+  it('shows month label in no-plan state', () => {
+    render(<MobilePlanningView {...defaultProps} />)
+    expect(screen.getAllByText(/May 2026/).length).toBeGreaterThan(0)
+  })
+
+  it('shows "Set income" CTA when plan is null', () => {
+    render(<MobilePlanningView {...defaultProps} />)
+    expect(screen.getByRole('button', { name: /set income/i })).toBeInTheDocument()
+  })
+
+  it('does not show salary card when plan is null', () => {
+    render(<MobilePlanningView {...defaultProps} />)
+    expect(screen.queryByText(/Monthly income/i)).not.toBeInTheDocument()
+  })
+
+  it('opens salary sheet when "Set income" is clicked', async () => {
+    render(<MobilePlanningView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /set income/i }))
+    // Sheet opens with a "Set income" or similar title
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+})
+
+describe('MobilePlanningView — with plan', () => {
+  it('shows salary card with "Monthly income" label', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getByText(/Monthly income/i)).toBeInTheDocument()
+  })
+
+  it('shows formatted salary in salary card', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    // 45_000_000 → "45.0M ₫" from fmtCompact mock (appears in salary card and remaining strip)
+    expect(screen.getAllByText('45.0M ₫').length).toBeGreaterThan(0)
+  })
+
+  it('shows Outflow label in summary strip', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getByText(/Outflow/i)).toBeInTheDocument()
+  })
+
+  it('shows Remaining label in summary strip', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getAllByText(/Remaining/i).length).toBeGreaterThan(0)
+  })
+
+  it('shows Saved % label in summary strip', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getByText(/Saved %/i)).toBeInTheDocument()
+  })
+
+  it("shows allocation summary card with \"This month's allocation\" label", () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getByText(/This month's allocation/i)).toBeInTheDocument()
+  })
+
+  it('shows edit (pencil) and delete (trash) buttons on salary card', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getByLabelText(/edit/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/delete/i)).toBeInTheDocument()
+  })
+
+  it('opens salary edit sheet when edit button is clicked', async () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    await userEvent.click(screen.getByLabelText(/edit/i))
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  it('opens delete confirmation when delete button is clicked', async () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    await userEvent.click(screen.getByLabelText(/delete/i))
+    expect(screen.getByText(/Delete monthly plan/i)).toBeInTheDocument()
+  })
+})
+
+describe('MobilePlanningView — fixed expenses section', () => {
+  it('shows fixed expenses section when expenses exist', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={baseFixedExpenses} />)
+    expect(screen.getAllByText(/Fixed expenses/i).length).toBeGreaterThan(0)
+  })
+
+  it('shows expense names in fixed expenses section', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={baseFixedExpenses} />)
+    expect(screen.getByText('Rent')).toBeInTheDocument()
+    expect(screen.getByText('Utilities')).toBeInTheDocument()
+  })
+
+  it('shows "Skipped" for a skipped expense (override === 0)', () => {
+    const skippedExpenses: FixedExpense[] = [
+      { expense_id: 'fe1', expense_name: 'Gym', amount_vnd: 600_000, override: 0 },
+    ]
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={skippedExpenses} />)
+    expect(screen.getByText(/Skipped/i)).toBeInTheDocument()
+  })
+
+  it('shows "(overridden)" for an overridden expense', () => {
+    const overriddenExpenses: FixedExpense[] = [
+      { expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000, override: 5_000_000 },
+    ]
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={overriddenExpenses} />)
+    expect(screen.getByText(/overridden/i)).toBeInTheDocument()
+  })
+
+  it('excludes skipped expenses from section total', () => {
+    const expenses: FixedExpense[] = [
+      { expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000 },
+      { expense_id: 'fe2', expense_name: 'Gym', amount_vnd: 600_000, override: 0 },
+    ]
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={expenses} />)
+    // Section total should be 8.5M only (gym is skipped)
+    const section = screen.getByTestId('section-fixed-expenses').closest('[data-testid="budget-section"]')
+    if (section) {
+      expect(section).toHaveTextContent('8.5M ₫')
+      expect(section).not.toHaveTextContent('9.1M ₫') // 8.5 + 0.6
+    }
+  })
+})
+
+describe('MobilePlanningView — insurance section', () => {
+  it('shows insurance section when members exist', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} insuranceMembers={baseInsuranceMembers} />)
+    expect(screen.getAllByText('Insurance').length).toBeGreaterThan(0)
+  })
+
+  it('shows member name in insurance section', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} insuranceMembers={baseInsuranceMembers} />)
+    expect(screen.getByText('John')).toBeInTheDocument()
+  })
+
+  it('shows "Skipped" for an excluded insurance member', () => {
+    const excludedMembers: InsuranceMember[] = [
+      {
+        member_id: 'i1',
+        member_name: 'John',
+        relationship: 'Self',
+        annual_payment_vnd: 18_000_000,
+        payment_date: null,
+        excluded: true,
+      },
+    ]
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} insuranceMembers={excludedMembers} />)
+    expect(screen.getByText(/Skipped/i)).toBeInTheDocument()
+  })
+})
+
+describe('MobilePlanningView — other expenses section', () => {
+  it('shows other expenses section', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} otherExpenses={baseOtherExpenses} />)
+    expect(screen.getAllByText(/Other/i).length).toBeGreaterThan(0)
+    expect(screen.getByText('Family trip')).toBeInTheDocument()
+  })
+
+  it('shows "Add item" button in other expenses section', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getByRole('button', { name: /Add item/i })).toBeInTheDocument()
+  })
+})
+
+describe('MobilePlanningView — by goal section', () => {
+  it('shows investments grouped by goal', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} investments={baseInvestments} savings={baseSavings} />)
+    expect(screen.getByText('Retirement')).toBeInTheDocument()
+    expect(screen.getByText('Emergency fund')).toBeInTheDocument()
+  })
+
+  it('shows "By goal" section header', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} investments={baseInvestments} />)
+    expect(screen.getByText(/By goal/i)).toBeInTheDocument()
+  })
+})
+
+describe('MobilePlanningView — allocation summary with all categories', () => {
+  it('shows fixed expenses row in allocation summary when expenses exist', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={baseFixedExpenses} />)
+    expect(screen.getAllByText(/Fixed expenses/i).length).toBeGreaterThan(0)
+  })
+
+  it('shows insurance row in allocation summary when members exist', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} insuranceMembers={baseInsuranceMembers} />)
+    expect(screen.getAllByText(/Insurance/i).length).toBeGreaterThan(0)
+  })
+
+  it('shows over-budget warning when remaining is negative', () => {
+    // salary 1M, fixed expenses 2M → remaining -1M → over budget
+    const bigExpenses: FixedExpense[] = [
+      { expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 2_000_000 },
+    ]
+    const smallPlan: MonthlyPlan = { id: 'p2', month: 5, year: 2026, salary_vnd: 1_000_000 }
+    render(<MobilePlanningView {...defaultProps} plan={smallPlan} fixedExpenses={bigExpenses} />)
+    expect(screen.getByText(/Over budget/i)).toBeInTheDocument()
+  })
+})
+
+describe('MobilePlanningView — month navigation', () => {
+  it('calls onNavigatePrev when prev button is clicked', async () => {
+    const onNavigatePrev = vi.fn()
+    render(<MobilePlanningView {...defaultProps} onNavigatePrev={onNavigatePrev} />)
+    await userEvent.click(screen.getByTestId('mobile-prev-month'))
+    expect(onNavigatePrev).toHaveBeenCalledOnce()
+  })
+
+  it('calls onNavigateNext when next button is clicked', async () => {
+    const onNavigateNext = vi.fn()
+    render(<MobilePlanningView {...defaultProps} onNavigateNext={onNavigateNext} />)
+    await userEvent.click(screen.getByTestId('mobile-next-month'))
+    expect(onNavigateNext).toHaveBeenCalledOnce()
+  })
+
+  it('shows current month in month picker', () => {
+    render(<MobilePlanningView {...defaultProps} />)
+    expect(screen.getByText('May 2026')).toBeInTheDocument()
+  })
+})
+
+describe('MobilePlanningView — collapsible sections', () => {
+  it('fixed expenses section is open by default', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={baseFixedExpenses} />)
+    // When open, the expense items are visible
+    expect(screen.getByText('Rent')).toBeInTheDocument()
+  })
+
+  it('toggles fixed expenses section on header click', async () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={baseFixedExpenses} />)
+    // Items are visible initially (section is open)
+    expect(screen.getByText('Rent')).toBeInTheDocument()
+    // Click the header to collapse
+    const sectionBtn = screen.getByTestId('section-fixed-expenses')
+    await userEvent.click(sectionBtn)
+    // Items should be hidden now
+    expect(screen.queryByText('Rent')).not.toBeInTheDocument()
+  })
+})

--- a/app/api/funds/[id]/route.ts
+++ b/app/api/funds/[id]/route.ts
@@ -40,7 +40,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   }
 
   const body = await request.json()
-  const { name, code, fund_type, nav, nav_source_url } = body
+  const { name, code, fund_type, nav, nav_source_url, is_dca, dca_monthly_amount_vnd } = body
 
   if (!name || typeof name !== 'string' || name.trim().length === 0) {
     return NextResponse.json({ error: 'Name is required' }, { status: 400 })
@@ -70,6 +70,8 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       fund_type,
       nav: navNum,
       nav_source_url: typeof nav_source_url === 'string' && nav_source_url.trim() ? nav_source_url.trim() : null,
+      is_dca: is_dca === true,
+      dca_monthly_amount_vnd: is_dca === true && dca_monthly_amount_vnd ? Number(dca_monthly_amount_vnd) : null,
     })
     .eq('id', id)
     .eq('user_id', user.id)

--- a/app/api/funds/route.ts
+++ b/app/api/funds/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await request.json()
-  const { name, code, fund_type, nav, nav_source_url } = body
+  const { name, code, fund_type, nav, nav_source_url, is_dca, dca_monthly_amount_vnd } = body
 
   // Validate required fields
   if (!name || typeof name !== 'string' || name.trim().length === 0) {
@@ -69,6 +69,8 @@ export async function POST(request: NextRequest) {
       fund_type,
       nav: navNum,
       nav_source_url: typeof nav_source_url === 'string' && nav_source_url.trim() ? nav_source_url.trim() : null,
+      is_dca: is_dca === true,
+      dca_monthly_amount_vnd: is_dca === true && dca_monthly_amount_vnd ? Number(dca_monthly_amount_vnd) : null,
     })
     .select()
     .single()

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -29,7 +29,7 @@ export async function GET(request: NextRequest) {
     const [invRes, savRes, overridesRes, expRes, insRes, exclRes, insOverridesRes, goalsRes, fundsRes, otherExpRes] = await Promise.all([
       supabase
         .from('investment_transactions')
-        .select('transaction_id, plan_id, fund_id, goal_id, amount_vnd, units, unit_price, investment_date, funds(name, nav), savings_goals(goal_name)')
+        .select('transaction_id, plan_id, fund_id, goal_id, amount_vnd, units, unit_price, investment_date, is_dca_seeded, funds(name, nav), savings_goals(goal_name)')
         .eq('plan_id', plan.id).eq('asset_type', 'fund'),
       supabase
         .from('investment_transactions')
@@ -56,11 +56,38 @@ export async function GET(request: NextRequest) {
         .select('goal_id, goal_name').eq('user_id', user.id).order('created_at', { ascending: false }),
       supabase
         .from('funds')
-        .select('id, name, nav').eq('user_id', user.id).order('name', { ascending: true }),
+        .select('id, name, nav, is_dca, dca_monthly_amount_vnd').eq('user_id', user.id).order('name', { ascending: true }),
       supabase
         .from('plan_other_expenses')
         .select('id, description, amount_vnd, created_at').eq('plan_id', plan.id).order('created_at', { ascending: true }),
     ])
+    // Auto-seed DCA fund entries that don't have a row for this plan yet
+    const allFunds = fundsRes.data ?? []
+    const dcaFunds = allFunds.filter((f) => f.is_dca && f.dca_monthly_amount_vnd)
+    const existingFundIds = new Set((invRes.data ?? []).map((i) => i.fund_id))
+    const missingDca = dcaFunds.filter((f) => !existingFundIds.has(f.id))
+    if (missingDca.length > 0) {
+      const firstOfMonth = `${plan.year}-${String(plan.month).padStart(2, '0')}-01`
+      await supabase.from('investment_transactions').insert(
+        missingDca.map((f) => ({
+          user_id: user.id,
+          plan_id: plan.id,
+          fund_id: f.id,
+          asset_type: 'fund',
+          amount_vnd: f.dca_monthly_amount_vnd,
+          units: null,
+          unit_price: null,
+          investment_date: firstOfMonth,
+          is_dca_seeded: true,
+        }))
+      )
+      const { data: refreshed } = await supabase
+        .from('investment_transactions')
+        .select('transaction_id, plan_id, fund_id, goal_id, amount_vnd, units, unit_price, investment_date, is_dca_seeded, funds(name, nav), savings_goals(goal_name)')
+        .eq('plan_id', plan.id).eq('asset_type', 'fund')
+      invRes.data = refreshed
+    }
+
     return NextResponse.json({
       ...plan,
       fund_investments:        invRes.data ?? [],

--- a/app/components/navigation/MobileTopBar.tsx
+++ b/app/components/navigation/MobileTopBar.tsx
@@ -1,0 +1,25 @@
+'use client'
+
+import React from 'react'
+
+interface Props {
+  title: string
+  subtitle?: string
+  trailing?: React.ReactNode
+  dense?: boolean
+}
+
+export default function MobileTopBar({ title, subtitle, trailing, dense }: Props) {
+  return (
+    <header
+      className="md:hidden sticky top-0 z-30 flex items-center justify-between bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800"
+      style={{ padding: dense ? '8px 16px' : '12px 16px' }}
+    >
+      <div>
+        {subtitle && <p className="text-xs text-gray-500 dark:text-gray-400 leading-none mb-0.5">{subtitle}</p>}
+        <h1 className="text-base font-semibold text-gray-900 dark:text-gray-100 leading-tight">{title}</h1>
+      </div>
+      {trailing && <div className="flex items-center">{trailing}</div>}
+    </header>
+  )
+}

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -1,0 +1,9 @@
+export const fmt = (n: number) => '₫ ' + Math.round(n).toLocaleString('vi-VN')
+
+export const fmtCompact = (n: number) => {
+  const abs = Math.abs(n)
+  const sign = n < 0 ? '-' : ''
+  if (abs >= 1_000_000_000) return sign + (abs / 1_000_000_000).toFixed(1) + 'B ₫'
+  if (abs >= 1_000_000) return sign + (abs / 1_000_000).toFixed(1) + 'M ₫'
+  return fmt(n)
+}

--- a/supabase/migrations/20260402000001_add_dca_to_funds.sql
+++ b/supabase/migrations/20260402000001_add_dca_to_funds.sql
@@ -1,0 +1,8 @@
+-- Add DCA configuration to funds table
+ALTER TABLE funds
+  ADD COLUMN is_dca BOOLEAN NOT NULL DEFAULT false,
+  ADD COLUMN dca_monthly_amount_vnd BIGINT NULL CHECK (dca_monthly_amount_vnd IS NULL OR dca_monthly_amount_vnd > 0);
+
+-- Track which investment_transactions were auto-seeded by DCA
+ALTER TABLE investment_transactions
+  ADD COLUMN is_dca_seeded BOOLEAN NOT NULL DEFAULT false;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./vitest.setup.ts'],
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+})

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'


### PR DESCRIPTION
## Summary

- Implements \`MobilePlanningView\` component for the monthly plan screen following the Cairn design prototype
- Full bottom-sheet interactions: set/edit income, delete plan, skip/restore/override fixed expenses and insurance, add/edit other expenses
- Collapsible budget sections (By goal, Fixed expenses, Insurance, Other) with kebab menus
- AllocationSummaryCard in navy with stacked bar + category breakdown + over-budget warning
- Integrated into \`PlanningClient\` — mobile view shown on \`< md\`, desktop layout hidden on mobile
- Also adds \`MobileTopBar\` shared nav component and \`lib/formatters.ts\` shared currency formatter

## Test plan

- [x] 33 unit tests written first (TDD red → green) covering all UI states: no-plan, with-plan, sections, navigation, collapsible toggle
- [x] \`npx vitest run\` → 33/33 pass
- [x] TypeScript: \`npx tsc --noEmit\` → no new errors
- [ ] Verify on Vercel preview at mobile viewport (375px): salary card, section collapsing, bottom sheets, month navigation
- [ ] Verify desktop layout unchanged at 1280px

🤖 Generated with [Claude Code](https://claude.com/claude-code)