### PR TITLE
feat(settings): mobile redesign — Settings screen

### DIFF
--- a/app/(app)/settings/SettingsClient.tsx
+++ b/app/(app)/settings/SettingsClient.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback } from 'react'
 import { useRouter } from 'next/navigation'
 import { useTranslations } from 'next-intl'
-import MobileTopBar from '@/app/components/navigation/MobileTopBar'
+import MobileSettingsView from './components/MobileSettingsView'
 import SavingsGoalsTab from './tabs/SavingsGoalsTab'
 import InvestmentTransactionsTab from './tabs/InvestmentTransactionsTab'
 import FixedExpensesTab from './tabs/FixedExpensesTab'
@@ -18,9 +18,12 @@ const VALID_TABS = TAB_IDS as unknown as string[]
 interface Props {
   initialTab?: string
   initialGoalId?: string
+  email: string
+  initials: string
+  displayName: string
 }
 
-export default function SettingsClient({ initialTab, initialGoalId }: Props) {
+export default function SettingsClient({ initialTab, initialGoalId, email, initials, displayName }: Props) {
   const router = useRouter()
   const t = useTranslations('settings')
   const [activeTab, setActiveTab] = useState<TabId>(
@@ -41,43 +44,48 @@ export default function SettingsClient({ initialTab, initialGoalId }: Props) {
   }, [router])
 
   return (
-    <div className="space-y-6">
-      <MobileTopBar subtitle={t('pageSubtitle')} title={t('pageTitle')} />
-      <div>
-        <p className="text-sm text-gray-500 dark:text-gray-400">{t('description')}</p>
-      </div>
+    <>
+      {/* Mobile redesign view */}
+      <MobileSettingsView email={email} initials={initials} displayName={displayName} />
 
-      {/* Tabs */}
-      <div className="flex flex-col gap-2">
-        <div className="grid grid-cols-2 sm:grid-cols-4 w-full items-center rounded-xl bg-[#ececf0] dark:bg-gray-800 p-[3px] gap-[3px]">
-          {TAB_IDS.map((tabId) => (
-            <button
-              key={tabId}
-              onClick={() => handleTabChange(tabId)}
-              className={`inline-flex items-center justify-center rounded-[10px] border px-3 py-2 text-xs sm:text-sm font-medium text-center leading-tight transition-[color,box-shadow] ${
-                activeTab === tabId
-                  ? 'border-transparent bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
-                  : 'border-transparent text-gray-900 dark:text-gray-400'
-              }`}
-            >
-              {t(`tabs.${tabId}`)}
-            </button>
-          ))}
+      {/* Desktop view */}
+      <div className="hidden md:block space-y-6">
+        <div>
+          <p className="text-sm text-gray-500 dark:text-gray-400">{t('description')}</p>
         </div>
 
-        {/* Tab content */}
-        <div className="mt-4">
-          {activeTab === 'goals' && (
-            <SavingsGoalsTab
-              initialGoalId={initialGoalId}
-              onGoalChange={handleGoalChange}
-            />
-          )}
-          {activeTab === 'transactions' && <InvestmentTransactionsTab />}
-          {activeTab === 'expenses' && <FixedExpensesTab />}
-          {activeTab === 'insurance' && <InsuranceMembersTab />}
+        {/* Tabs */}
+        <div className="flex flex-col gap-2">
+          <div className="grid grid-cols-2 sm:grid-cols-4 w-full items-center rounded-xl bg-[#ececf0] dark:bg-gray-800 p-[3px] gap-[3px]">
+            {TAB_IDS.map((tabId) => (
+              <button
+                key={tabId}
+                onClick={() => handleTabChange(tabId)}
+                className={`inline-flex items-center justify-center rounded-[10px] border px-3 py-2 text-xs sm:text-sm font-medium text-center leading-tight transition-[color,box-shadow] ${
+                  activeTab === tabId
+                    ? 'border-transparent bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 shadow-sm'
+                    : 'border-transparent text-gray-900 dark:text-gray-400'
+                }`}
+              >
+                {t(`tabs.${tabId}`)}
+              </button>
+            ))}
+          </div>
+
+          {/* Tab content */}
+          <div className="mt-4">
+            {activeTab === 'goals' && (
+              <SavingsGoalsTab
+                initialGoalId={initialGoalId}
+                onGoalChange={handleGoalChange}
+              />
+            )}
+            {activeTab === 'transactions' && <InvestmentTransactionsTab />}
+            {activeTab === 'expenses' && <FixedExpensesTab />}
+            {activeTab === 'insurance' && <InsuranceMembersTab />}
+          </div>
         </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -76,9 +76,10 @@ function BottomSheet({ open, onClose, title, children }: {
 
 // ─── Profile sheet ─────────────────────────────────────────────────────────────
 
-function ProfileSheet({ open, onClose, displayName, email }: {
+function ProfileSheet({ open, onClose, onSave, displayName, email }: {
   open: boolean
   onClose: () => void
+  onSave: (name: string) => void
   displayName: string
   email: string
 }) {
@@ -91,6 +92,7 @@ function ProfileSheet({ open, onClose, displayName, email }: {
 
   function handleSave() {
     setSaved(true)
+    onSave(name)
     setTimeout(() => { setSaved(false); onClose() }, 1200)
   }
 
@@ -340,6 +342,8 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
   const router = useRouter()
   const [, startTransition] = useTransition()
 
+  const [localDisplayName, setLocalDisplayName] = useState(displayName)
+
   const [showProfile, setShowProfile] = useState(false)
   const [showAppearance, setShowAppearance] = useState(false)
   const [showCurrency, setShowCurrency] = useState(false)
@@ -425,7 +429,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
             {initials}
           </div>
           <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--c-ink)' }}>{displayName}</div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--c-ink)' }}>{localDisplayName}</div>
             <div style={{ fontSize: 12, color: 'var(--c-muted)', marginTop: 2 }}>{email}</div>
           </div>
           <ChevronRight size={16} color="var(--c-muted)" />
@@ -577,7 +581,8 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
       <ProfileSheet
         open={showProfile}
         onClose={() => setShowProfile(false)}
-        displayName={displayName}
+        onSave={name => setLocalDisplayName(name)}
+        displayName={localDisplayName}
         email={email}
       />
       <AppearanceSheet

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -12,6 +12,7 @@ import {
 import { toast } from 'sonner'
 import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import DownloadReportSheet from '@/app/assets/components/DownloadReportSheet'
+import type { DashboardData } from '@/app/assets/DashboardClient'
 
 interface Props {
   email: string
@@ -373,6 +374,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
   const [showAppearance, setShowAppearance] = useState(false)
   const [showCurrency, setShowCurrency] = useState(false)
   const [showReport, setShowReport] = useState(false)
+  const [overviewCache, setOverviewCache] = useState<DashboardData | null>(null)
 
   const [syncing, setSyncing] = useState(false)
   const [syncDone, setSyncDone] = useState(false)
@@ -409,12 +411,23 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
     setTimeout(() => setSyncDone(false), 3000)
   }
 
+  function handleOpenReport() {
+    setShowReport(true)
+    fetch('/api/v1/dashboard/overview', { cache: 'no-store' })
+      .then(r => r.ok ? r.json() : null)
+      .then((json: DashboardData | null) => { if (json) setOverviewCache(json) })
+      .catch(() => {})
+  }
+
   async function handleExportReport() {
-    const res = await fetch('/api/v1/dashboard/overview', { cache: 'no-store' })
-    if (!res.ok) throw new Error('Failed to load portfolio data')
-    const data = await res.json()
+    let data = overviewCache
+    if (!data) {
+      const res = await fetch('/api/v1/dashboard/overview', { cache: 'no-store' })
+      if (!res.ok) throw new Error('Failed to load portfolio data')
+      data = await res.json()
+    }
     const { downloadPortfolioPDF } = await import('@/lib/generateReport')
-    await downloadPortfolioPDF(data, locale)
+    await downloadPortfolioPDF(data!, locale)
   }
 
   async function handleSignOut() {
@@ -507,7 +520,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
             <SettingsRow
               icon={<Download size={16} />}
               label={isVI ? 'Xuất dữ liệu' : 'Export data'}
-              onClick={() => setShowReport(true)}
+              onClick={handleOpenReport}
               last
             />
           </div>
@@ -634,7 +647,12 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
       <DownloadReportSheet
         open={showReport}
         onClose={() => setShowReport(false)}
-        data={null}
+        data={overviewCache ? {
+          netWorth: overviewCache.netWorth.netWorth,
+          currentValue: overviewCache.netWorth.currentValue,
+          totalPL: overviewCache.netWorth.overallProfitLoss,
+          goalCount: overviewCache.goals.length,
+        } : null}
         onExport={handleExportReport}
       />
     </>

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -363,6 +363,12 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
 
   const [localDisplayName, setLocalDisplayName] = useState(displayName)
 
+  const localInitials = localDisplayName
+    .split(/\s+/)
+    .slice(0, 2)
+    .map(w => w[0]?.toUpperCase() ?? '')
+    .join('') || initials
+
   const [showProfile, setShowProfile] = useState(false)
   const [showAppearance, setShowAppearance] = useState(false)
   const [showCurrency, setShowCurrency] = useState(false)
@@ -451,11 +457,11 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
           {/* Avatar */}
           <div style={{
             width: 48, height: 48, borderRadius: 24,
-            background: 'var(--c-navy)', color: '#fff',
+            background: 'var(--c-btn-primary)', color: '#fff',
             display: 'flex', alignItems: 'center', justifyContent: 'center',
             fontSize: 16, fontWeight: 700, flexShrink: 0,
           }}>
-            {initials}
+            {localInitials}
           </div>
           <div style={{ flex: 1, minWidth: 0 }}>
             <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--c-ink)' }}>{localDisplayName}</div>

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -454,6 +454,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
 
   return (
     <>
+      <div className="md:hidden -mx-4 -mt-4" style={{ background: 'var(--c-canvas)', minHeight: '100%' }}>
       <div style={{ padding: '4px 16px 80px' }}>
 
         {/* Profile card */}
@@ -623,6 +624,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
         <p style={{ textAlign: 'center', fontSize: 11, color: 'var(--c-muted)', marginTop: 16 }}>
           Cairn v0.4 · {isVI ? 'Bản nội bộ' : 'Internal preview'}
         </p>
+      </div>
       </div>
 
       {/* Sheets */}

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useTransition } from 'react'
 import { useLocale } from 'next-intl'
 import { useRouter } from 'next/navigation'
 import { createBrowserClient } from '@supabase/ssr'
+import { useTheme, type ThemeChoice } from '@/app/components/ThemeProvider'
 import {
   Globe, Sun, Wallet, Download, RefreshCw,
   TrendingUp, CircleDollarSign, LogOut, ChevronRight, Check,
@@ -160,7 +161,7 @@ function ProfileSheet({ open, onClose, onSave, displayName, email }: {
               onClick={handleSave}
               style={{
                 flex: 2, padding: '10px 0', fontSize: 13, fontWeight: 600,
-                background: 'var(--c-navy)', border: 'none',
+                background: 'var(--c-btn-primary)', border: 'none',
                 borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
                 color: '#fff',
               }}
@@ -177,18 +178,29 @@ function ProfileSheet({ open, onClose, onSave, displayName, email }: {
 // ─── Appearance sheet ──────────────────────────────────────────────────────────
 
 function AppearanceSheet({ open, onClose }: { open: boolean; onClose: () => void }) {
-  const [theme, setTheme] = useState('light')
+  const { theme: currentTheme, setTheme } = useTheme()
 
-  const options = [
-    { v: 'light',  icon: <Sun size={18} />,         label: 'Light'  },
-    { v: 'dark',   icon: <span style={{ fontSize: 16 }}>🌙</span>, label: 'Dark'   },
-    { v: 'system', icon: <span style={{ fontSize: 16 }}>⚙️</span>,  label: 'System' },
+  const storedChoice = (): ThemeChoice => {
+    if (typeof localStorage === 'undefined') return currentTheme
+    const v = localStorage.getItem('theme')
+    return (v === 'light' || v === 'dark') ? v : 'system'
+  }
+
+  const [selected, setSelected] = useState<ThemeChoice>(currentTheme)
+
+  useEffect(() => {
+    if (open) setSelected(storedChoice())
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  const options: { v: ThemeChoice; icon: React.ReactNode; label: string }[] = [
+    { v: 'light',  icon: <Sun size={18} />,                               label: 'Light'  },
+    { v: 'dark',   icon: <span style={{ fontSize: 16 }}>🌙</span>,        label: 'Dark'   },
+    { v: 'system', icon: <span style={{ fontSize: 16 }}>⚙️</span>,         label: 'System' },
   ]
 
   function handleApply() {
-    if (typeof document !== 'undefined') {
-      document.documentElement.classList.toggle('dark', theme === 'dark')
-    }
+    setTheme(selected)
     onClose()
   }
 
@@ -198,21 +210,21 @@ function AppearanceSheet({ open, onClose }: { open: boolean; onClose: () => void
         {options.map(opt => (
           <button
             key={opt.v}
-            onClick={() => setTheme(opt.v)}
+            onClick={() => setSelected(opt.v)}
             style={{
               width: '100%', textAlign: 'left', padding: '14px 16px',
-              background: theme === opt.v ? 'var(--c-navy-tint)' : 'var(--c-card)',
-              border: `1.5px solid ${theme === opt.v ? 'var(--c-navy)' : 'var(--c-line)'}`,
+              background: selected === opt.v ? 'var(--c-navy-tint)' : 'var(--c-card)',
+              border: `1.5px solid ${selected === opt.v ? 'var(--c-navy)' : 'var(--c-line)'}`,
               borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit',
               display: 'flex', alignItems: 'center', gap: 12, transition: 'all 120ms',
             }}
           >
-            <span style={{ color: theme === opt.v ? 'var(--c-navy)' : 'var(--c-muted)' }}>{opt.icon}</span>
-            <span style={{ fontSize: 13, fontWeight: 600, color: theme === opt.v ? 'var(--c-navy)' : 'var(--c-ink)', flex: 1 }}>
+            <span style={{ color: selected === opt.v ? 'var(--c-navy)' : 'var(--c-muted)' }}>{opt.icon}</span>
+            <span style={{ fontSize: 13, fontWeight: 600, color: selected === opt.v ? 'var(--c-navy)' : 'var(--c-ink)', flex: 1 }}>
               {opt.label}
             </span>
-            {theme === opt.v && (
-              <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            {selected === opt.v && (
+              <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-btn-primary)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                 <Check size={12} strokeWidth={2.5} color="#fff" />
               </div>
             )}
@@ -224,7 +236,7 @@ function AppearanceSheet({ open, onClose }: { open: boolean; onClose: () => void
         aria-label="apply"
         style={{
           width: '100%', padding: '11px 0', fontSize: 13, fontWeight: 600,
-          background: 'var(--c-navy)', border: 'none',
+          background: 'var(--c-btn-primary)', border: 'none',
           borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
           color: '#fff',
         }}
@@ -263,7 +275,7 @@ function CurrencySheet({ open, onClose }: { open: boolean; onClose: () => void }
           >
             <div style={{
               width: 36, height: 36, borderRadius: 8,
-              background: currency === c.v ? 'var(--c-navy)' : 'var(--c-card-2)',
+              background: currency === c.v ? 'var(--c-btn-primary)' : 'var(--c-card-2)',
               display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
             }}>
               <span style={{ fontSize: 14, fontWeight: 700, color: currency === c.v ? '#fff' : 'var(--c-muted)' }}>
@@ -277,7 +289,7 @@ function CurrencySheet({ open, onClose }: { open: boolean; onClose: () => void }
               <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1 }}>{c.label}</div>
             </div>
             {currency === c.v && (
-              <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-btn-primary)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                 <Check size={12} strokeWidth={2.5} color="#fff" />
               </div>
             )}
@@ -289,7 +301,7 @@ function CurrencySheet({ open, onClose }: { open: boolean; onClose: () => void }
         aria-label="apply"
         style={{
           width: '100%', padding: '11px 0', fontSize: 13, fontWeight: 600,
-          background: 'var(--c-navy)', border: 'none',
+          background: 'var(--c-btn-primary)', border: 'none',
           borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
           color: '#fff',
         }}
@@ -344,6 +356,11 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
   const [, startTransition] = useTransition()
   const { setMobileTopBar } = useNavigation()
 
+  const supabase = createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  )
+
   const [localDisplayName, setLocalDisplayName] = useState(displayName)
 
   const [showProfile, setShowProfile] = useState(false)
@@ -395,10 +412,6 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
   }
 
   async function handleSignOut() {
-    const supabase = createBrowserClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-    )
     const { error } = await supabase.auth.signOut()
     if (error) {
       toast.error(isVI ? 'Đăng xuất thất bại' : 'Sign out failed')
@@ -526,7 +539,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
                 aria-label="sync now"
                 style={{
                   padding: '7px 14px', fontSize: 12, fontWeight: 600,
-                  background: 'var(--c-navy)', border: 'none', borderRadius: 8,
+                  background: 'var(--c-btn-primary)', border: 'none', borderRadius: 8,
                   color: '#fff', cursor: syncing ? 'not-allowed' : 'pointer',
                   fontFamily: 'inherit', opacity: syncing ? 0.6 : 1,
                   transition: 'opacity 150ms',
@@ -597,7 +610,10 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
       <ProfileSheet
         open={showProfile}
         onClose={() => setShowProfile(false)}
-        onSave={name => setLocalDisplayName(name)}
+        onSave={async (name) => {
+          setLocalDisplayName(name)
+          await supabase.auth.updateUser({ data: { display_name: name } })
+        }}
         displayName={localDisplayName}
         email={email}
       />

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -1,0 +1,593 @@
+'use client'
+
+import { useState, useEffect, useTransition } from 'react'
+import { useLocale } from 'next-intl'
+import { useRouter } from 'next/navigation'
+import { createBrowserClient } from '@supabase/ssr'
+import {
+  Globe, Sun, Wallet, Download, RefreshCw,
+  TrendingUp, CircleDollarSign, LogOut, ChevronRight, Check,
+} from 'lucide-react'
+import { toast } from 'sonner'
+import MobileTopBar from '@/app/components/navigation/MobileTopBar'
+
+interface Props {
+  email: string
+  initials: string
+  displayName: string
+}
+
+// ─── Bottom sheet wrapper ──────────────────────────────────────────────────────
+
+function BottomSheet({ open, onClose, title, children }: {
+  open: boolean
+  onClose: () => void
+  title: string
+  children: React.ReactNode
+}) {
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    if (open) {
+      setMounted(true)
+    } else {
+      const t = setTimeout(() => setMounted(false), 220)
+      return () => clearTimeout(t)
+    }
+  }, [open])
+
+  if (!mounted) return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0,
+        background: 'rgba(15,23,42,0.2)',
+        zIndex: 150,
+        pointerEvents: open ? 'auto' : 'none',
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          position: 'absolute', bottom: 0, left: 0, right: 0,
+          background: 'var(--c-card)',
+          borderRadius: '16px 16px 0 0',
+          padding: '0 0 env(safe-area-inset-bottom,0)',
+          animation: open
+            ? 'slide-up 220ms cubic-bezier(0.2, 0.8, 0.2, 1)'
+            : 'slide-down 180ms ease forwards',
+          maxHeight: '85dvh',
+          overflowY: 'auto',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '10px auto 0' }} />
+        <div style={{ padding: '14px 16px 0', borderBottom: '1px solid var(--c-line)', marginBottom: 16 }}>
+          <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--c-ink)', paddingBottom: 14 }}>{title}</div>
+        </div>
+        <div style={{ padding: '0 16px 28px' }}>
+          {children}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Profile sheet ─────────────────────────────────────────────────────────────
+
+function ProfileSheet({ open, onClose, displayName, email }: {
+  open: boolean
+  onClose: () => void
+  displayName: string
+  email: string
+}) {
+  const [name, setName] = useState(displayName)
+  const [saved, setSaved] = useState(false)
+
+  useEffect(() => {
+    if (open) { setName(displayName); setSaved(false) }
+  }, [open, displayName])
+
+  function handleSave() {
+    setSaved(true)
+    setTimeout(() => { setSaved(false); onClose() }, 1200)
+  }
+
+  return (
+    <BottomSheet open={open} onClose={onClose} title="Profile">
+      {saved ? (
+        <div style={{ padding: '28px 0', textAlign: 'center' }}>
+          <div style={{
+            width: 52, height: 52, borderRadius: 26,
+            background: 'var(--c-pos-tint)', color: 'var(--c-pos)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 12px',
+          }}>
+            <Check size={26} strokeWidth={2.5} />
+          </div>
+          <div style={{ fontSize: 15, fontWeight: 600 }}>Saved</div>
+        </div>
+      ) : (
+        <div style={{ display: 'grid', gap: 14 }}>
+          <div>
+            <div style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--c-muted)', marginBottom: 6 }}>
+              Full name
+            </div>
+            <input
+              value={name}
+              onChange={e => setName(e.target.value)}
+              style={{
+                width: '100%', padding: '10px 12px', fontSize: 13,
+                background: 'var(--c-card-2)', border: '1px solid var(--c-line)',
+                borderRadius: 10, color: 'var(--c-ink)', fontFamily: 'inherit',
+                outline: 'none',
+              }}
+            />
+          </div>
+          <div>
+            <div style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--c-muted)', marginBottom: 6 }}>
+              Email
+            </div>
+            <input
+              type="email"
+              defaultValue={email}
+              readOnly
+              style={{
+                width: '100%', padding: '10px 12px', fontSize: 13,
+                background: 'var(--c-card-2)', border: '1px solid var(--c-line)',
+                borderRadius: 10, color: 'var(--c-muted)', fontFamily: 'inherit',
+                outline: 'none',
+              }}
+            />
+          </div>
+          <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+            <button
+              onClick={onClose}
+              aria-label="cancel"
+              style={{
+                flex: 1, padding: '10px 0', fontSize: 13, fontWeight: 500,
+                background: 'var(--c-card)', border: '1px solid var(--c-line)',
+                borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
+                color: 'var(--c-ink)',
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={handleSave}
+              style={{
+                flex: 2, padding: '10px 0', fontSize: 13, fontWeight: 600,
+                background: 'var(--c-navy)', border: 'none',
+                borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
+                color: '#fff',
+              }}
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      )}
+    </BottomSheet>
+  )
+}
+
+// ─── Appearance sheet ──────────────────────────────────────────────────────────
+
+function AppearanceSheet({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [theme, setTheme] = useState('light')
+
+  const options = [
+    { v: 'light',  icon: <Sun size={18} />,         label: 'Light'  },
+    { v: 'dark',   icon: <span style={{ fontSize: 16 }}>🌙</span>, label: 'Dark'   },
+    { v: 'system', icon: <span style={{ fontSize: 16 }}>⚙️</span>,  label: 'System' },
+  ]
+
+  function handleApply() {
+    if (typeof document !== 'undefined') {
+      document.documentElement.classList.toggle('dark', theme === 'dark')
+    }
+    onClose()
+  }
+
+  return (
+    <BottomSheet open={open} onClose={onClose} title="Appearance">
+      <div style={{ display: 'grid', gap: 8, marginBottom: 14 }}>
+        {options.map(opt => (
+          <button
+            key={opt.v}
+            onClick={() => setTheme(opt.v)}
+            style={{
+              width: '100%', textAlign: 'left', padding: '14px 16px',
+              background: theme === opt.v ? 'var(--c-navy-tint)' : 'var(--c-card)',
+              border: `1.5px solid ${theme === opt.v ? 'var(--c-navy)' : 'var(--c-line)'}`,
+              borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit',
+              display: 'flex', alignItems: 'center', gap: 12, transition: 'all 120ms',
+            }}
+          >
+            <span style={{ color: theme === opt.v ? 'var(--c-navy)' : 'var(--c-muted)' }}>{opt.icon}</span>
+            <span style={{ fontSize: 13, fontWeight: 600, color: theme === opt.v ? 'var(--c-navy)' : 'var(--c-ink)', flex: 1 }}>
+              {opt.label}
+            </span>
+            {theme === opt.v && (
+              <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Check size={12} strokeWidth={2.5} color="#fff" />
+              </div>
+            )}
+          </button>
+        ))}
+      </div>
+      <button
+        onClick={handleApply}
+        aria-label="apply"
+        style={{
+          width: '100%', padding: '11px 0', fontSize: 13, fontWeight: 600,
+          background: 'var(--c-navy)', border: 'none',
+          borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
+          color: '#fff',
+        }}
+      >
+        Apply
+      </button>
+    </BottomSheet>
+  )
+}
+
+// ─── Currency sheet ────────────────────────────────────────────────────────────
+
+function CurrencySheet({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [currency, setCurrency] = useState('VND')
+
+  const currencies = [
+    { v: 'VND', label: 'Vietnamese Dong', symbol: '₫' },
+    { v: 'USD', label: 'US Dollar',       symbol: '$' },
+    { v: 'EUR', label: 'Euro',            symbol: '€' },
+  ]
+
+  return (
+    <BottomSheet open={open} onClose={onClose} title="Currency">
+      <div style={{ display: 'grid', gap: 8, marginBottom: 14 }}>
+        {currencies.map(c => (
+          <button
+            key={c.v}
+            onClick={() => setCurrency(c.v)}
+            style={{
+              width: '100%', textAlign: 'left', padding: '14px 16px',
+              background: currency === c.v ? 'var(--c-navy-tint)' : 'var(--c-card)',
+              border: `1.5px solid ${currency === c.v ? 'var(--c-navy)' : 'var(--c-line)'}`,
+              borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit',
+              display: 'flex', alignItems: 'center', gap: 12, transition: 'all 120ms',
+            }}
+          >
+            <div style={{
+              width: 36, height: 36, borderRadius: 8,
+              background: currency === c.v ? 'var(--c-navy)' : 'var(--c-card-2)',
+              display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+            }}>
+              <span style={{ fontSize: 14, fontWeight: 700, color: currency === c.v ? '#fff' : 'var(--c-muted)' }}>
+                {c.symbol}
+              </span>
+            </div>
+            <div style={{ flex: 1 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: currency === c.v ? 'var(--c-navy)' : 'var(--c-ink)' }}>
+                {c.v}
+              </div>
+              <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1 }}>{c.label}</div>
+            </div>
+            {currency === c.v && (
+              <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Check size={12} strokeWidth={2.5} color="#fff" />
+              </div>
+            )}
+          </button>
+        ))}
+      </div>
+      <button
+        onClick={onClose}
+        aria-label="apply"
+        style={{
+          width: '100%', padding: '11px 0', fontSize: 13, fontWeight: 600,
+          background: 'var(--c-navy)', border: 'none',
+          borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
+          color: '#fff',
+        }}
+      >
+        Apply
+      </button>
+    </BottomSheet>
+  )
+}
+
+// ─── Settings row ──────────────────────────────────────────────────────────────
+
+function SettingsRow({ icon, label, value, onClick, last = false }: {
+  icon: React.ReactNode
+  label: string
+  value?: string
+  onClick: () => void
+  last?: boolean
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label={label}
+      style={{
+        width: '100%', textAlign: 'left', padding: '12px 14px',
+        background: 'transparent', border: 'none',
+        borderBottom: last ? 'none' : '1px solid var(--c-line)',
+        display: 'flex', alignItems: 'center', gap: 12,
+        cursor: 'pointer', fontFamily: 'inherit', transition: 'background 120ms',
+      }}
+      onMouseEnter={e => (e.currentTarget.style.background = 'var(--c-card-2)')}
+      onMouseLeave={e => (e.currentTarget.style.background = 'transparent')}
+    >
+      <div style={{
+        width: 32, height: 32, borderRadius: 8, background: 'var(--c-card-2)',
+        color: 'var(--c-muted)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+      }}>
+        {icon}
+      </div>
+      <span style={{ flex: 1, fontSize: 13, color: 'var(--c-ink)', fontWeight: 500 }}>{label}</span>
+      {value && <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{value}</span>}
+      <ChevronRight size={14} color="var(--c-muted)" />
+    </button>
+  )
+}
+
+// ─── Main component ────────────────────────────────────────────────────────────
+
+export default function MobileSettingsView({ email, initials, displayName }: Props) {
+  const locale = useLocale()
+  const router = useRouter()
+  const [, startTransition] = useTransition()
+
+  const [showProfile, setShowProfile] = useState(false)
+  const [showAppearance, setShowAppearance] = useState(false)
+  const [showCurrency, setShowCurrency] = useState(false)
+
+  const [syncing, setSyncing] = useState(false)
+  const [syncDone, setSyncDone] = useState(false)
+  const [lastSync, setLastSync] = useState('2h')
+
+  const isVI = locale === 'vi'
+
+  function switchLocale(next: string) {
+    document.cookie = `locale=${next};path=/;max-age=31536000;SameSite=Lax`
+    startTransition(() => router.refresh())
+  }
+
+  async function handleSync() {
+    setSyncing(true)
+    setSyncDone(false)
+    try {
+      await Promise.all([
+        fetch('/api/cron/refresh-navs'),
+        fetch('/api/cron/refresh-gold'),
+      ])
+    } catch {
+      // ignore
+    }
+    setSyncing(false)
+    setSyncDone(true)
+    setLastSync(isVI ? 'Vừa xong' : 'Just now')
+    setTimeout(() => setSyncDone(false), 3000)
+  }
+
+  async function handleSignOut() {
+    const supabase = createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    )
+    const { error } = await supabase.auth.signOut()
+    if (error) {
+      toast.error(isVI ? 'Đăng xuất thất bại' : 'Sign out failed')
+    } else {
+      Object.keys(localStorage)
+        .filter(k =>
+          k.startsWith('dashboardOverviewCache') ||
+          k.startsWith('planningCache_') ||
+          k.startsWith('savingsGoalsCache') ||
+          k.startsWith('fixedExpensesCache') ||
+          k.startsWith('insuranceMembersCache') ||
+          k.startsWith('fundLibraryCache')
+        )
+        .forEach(k => localStorage.removeItem(k))
+      router.push('/auth/login')
+    }
+  }
+
+  const localeLabel = isVI ? 'Tiếng Việt' : 'English'
+  const appearanceLabel = isVI ? 'Sáng' : 'Light'
+
+  return (
+    <>
+      <MobileTopBar subtitle={isVI ? 'Cài đặt' : 'Settings'} title={isVI ? 'Tùy chọn' : 'Preferences'} />
+
+      <div style={{ padding: '4px 16px 80px' }}>
+
+        {/* Profile card */}
+        <button
+          onClick={() => setShowProfile(true)}
+          aria-label="profile"
+          style={{
+            width: '100%', padding: 18, display: 'flex', alignItems: 'center', gap: 14,
+            textAlign: 'left', background: 'var(--c-card)', border: '1px solid var(--c-line)',
+            borderRadius: 16, cursor: 'pointer', fontFamily: 'inherit',
+            boxShadow: 'var(--shadow-card)',
+          }}
+        >
+          {/* Avatar */}
+          <div style={{
+            width: 48, height: 48, borderRadius: 24,
+            background: 'var(--c-navy)', color: '#fff',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: 16, fontWeight: 700, flexShrink: 0,
+          }}>
+            {initials}
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--c-ink)' }}>{displayName}</div>
+            <div style={{ fontSize: 12, color: 'var(--c-muted)', marginTop: 2 }}>{email}</div>
+          </div>
+          <ChevronRight size={16} color="var(--c-muted)" />
+        </button>
+
+        {/* Preferences section */}
+        <section style={{ marginTop: 22 }}>
+          <div style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--c-muted)', marginBottom: 8, paddingLeft: 4 }}>
+            {isVI ? 'Tùy chỉnh' : 'Preferences'}
+          </div>
+          <div style={{ background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 16, overflow: 'hidden', boxShadow: 'var(--shadow-card)' }}>
+            <SettingsRow
+              icon={<Globe size={16} />}
+              label={isVI ? 'Ngôn ngữ' : 'Language'}
+              value={localeLabel}
+              onClick={() => switchLocale(isVI ? 'en' : 'vi')}
+            />
+            <SettingsRow
+              icon={<Sun size={16} />}
+              label={isVI ? 'Giao diện' : 'Appearance'}
+              value={appearanceLabel}
+              onClick={() => setShowAppearance(true)}
+            />
+            <SettingsRow
+              icon={<Wallet size={16} />}
+              label={isVI ? 'Tiền tệ' : 'Currency'}
+              value="VND"
+              onClick={() => setShowCurrency(true)}
+              last
+            />
+          </div>
+        </section>
+
+        {/* Data section */}
+        <section style={{ marginTop: 22 }}>
+          <div style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--c-muted)', marginBottom: 8, paddingLeft: 4 }}>
+            {isVI ? 'Dữ liệu' : 'Data'}
+          </div>
+          <div style={{ background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 16, overflow: 'hidden', boxShadow: 'var(--shadow-card)' }}>
+            <SettingsRow
+              icon={<Download size={16} />}
+              label={isVI ? 'Xuất dữ liệu' : 'Export data'}
+              onClick={() => { /* TODO: open download report sheet */ }}
+              last
+            />
+          </div>
+        </section>
+
+        {/* Price sync section */}
+        <section style={{ marginTop: 22 }}>
+          <div style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--c-muted)', marginBottom: 8, paddingLeft: 4 }}>
+            {isVI ? 'Đồng bộ giá' : 'Price sync'}
+          </div>
+          <div style={{ background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 16, padding: 16, boxShadow: 'var(--shadow-card)' }}>
+            {/* Sync header row */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 12 }}>
+              <div style={{
+                width: 32, height: 32, borderRadius: 8, background: 'var(--c-navy-tint)', color: 'var(--c-navy)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+              }}>
+                <RefreshCw size={16} style={{ animation: syncing ? 'spin 1s linear infinite' : 'none' }} />
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>
+                  {isVI ? 'Đồng bộ tất cả giá' : 'Sync all prices'}
+                </div>
+                <div style={{ fontSize: 11, color: syncDone ? 'var(--c-pos)' : 'var(--c-muted)', marginTop: 2, transition: 'color 200ms' }}>
+                  {syncing
+                    ? (isVI ? 'Đang tải...' : 'Updating…')
+                    : syncDone
+                    ? (isVI ? '✓ Đã cập nhật' : '✓ Updated')
+                    : (isVI ? `Lần cuối: ${lastSync} trước` : `Last synced: ${lastSync} ago`)}
+                </div>
+              </div>
+              <button
+                onClick={handleSync}
+                disabled={syncing}
+                aria-label="sync now"
+                style={{
+                  padding: '7px 14px', fontSize: 12, fontWeight: 600,
+                  background: 'var(--c-navy)', border: 'none', borderRadius: 8,
+                  color: '#fff', cursor: syncing ? 'not-allowed' : 'pointer',
+                  fontFamily: 'inherit', opacity: syncing ? 0.6 : 1,
+                  transition: 'opacity 150ms',
+                }}
+              >
+                {syncing
+                  ? (isVI ? 'Đang...' : 'Syncing…')
+                  : (isVI ? 'Đồng bộ' : 'Sync now')}
+              </button>
+            </div>
+
+            {/* Source rows */}
+            <div style={{ display: 'grid', gap: 8, padding: '12px 0 0', borderTop: '1px solid var(--c-line)' }}>
+              {[
+                {
+                  icon: <TrendingUp size={14} />,
+                  color: '#2563eb',
+                  label: isVI ? 'NAV quỹ đầu tư' : 'Fund NAV',
+                  note: isVI ? 'Tự động đồng bộ lúc 18:00 mỗi ngày' : 'Auto-syncs daily at 6:00 PM',
+                },
+                {
+                  icon: <CircleDollarSign size={14} />,
+                  color: '#d97706',
+                  label: isVI ? 'Giá vàng DOJI' : 'Gold price (DOJI)',
+                  note: isVI ? 'Tự động đồng bộ lúc 09:00 mỗi ngày' : 'Auto-syncs daily at 9:00 AM',
+                },
+              ].map((row, i) => (
+                <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <div style={{
+                    width: 28, height: 28, borderRadius: 7, background: 'var(--c-card-2)',
+                    color: row.color, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                  }}>
+                    {row.icon}
+                  </div>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-ink)' }}>{row.label}</div>
+                    <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1 }}>{row.note}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Sign out */}
+        <button
+          onClick={handleSignOut}
+          aria-label="sign out"
+          style={{
+            width: '100%', marginTop: 22, padding: '13px 14px',
+            background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 10,
+            color: 'var(--c-neg)', fontSize: 13, fontWeight: 600,
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+            cursor: 'pointer', fontFamily: 'inherit', boxShadow: 'var(--shadow-card)',
+          }}
+        >
+          <LogOut size={16} />
+          {isVI ? 'Đăng xuất' : 'Sign out'}
+        </button>
+
+        {/* Version */}
+        <p style={{ textAlign: 'center', fontSize: 11, color: 'var(--c-muted)', marginTop: 16 }}>
+          Cairn v0.4 · {isVI ? 'Bản nội bộ' : 'Internal preview'}
+        </p>
+      </div>
+
+      {/* Sheets */}
+      <ProfileSheet
+        open={showProfile}
+        onClose={() => setShowProfile(false)}
+        displayName={displayName}
+        email={email}
+      />
+      <AppearanceSheet
+        open={showAppearance}
+        onClose={() => setShowAppearance(false)}
+      />
+      <CurrencySheet
+        open={showCurrency}
+        onClose={() => setShowCurrency(false)}
+      />
+    </>
+  )
+}

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -9,7 +9,7 @@ import {
   TrendingUp, CircleDollarSign, LogOut, ChevronRight, Check,
 } from 'lucide-react'
 import { toast } from 'sonner'
-import MobileTopBar from '@/app/components/navigation/MobileTopBar'
+import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import DownloadReportSheet from '@/app/assets/components/DownloadReportSheet'
 
 interface Props {
@@ -342,6 +342,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
   const locale = useLocale()
   const router = useRouter()
   const [, startTransition] = useTransition()
+  const { setMobileTopBar } = useNavigation()
 
   const [localDisplayName, setLocalDisplayName] = useState(displayName)
 
@@ -355,6 +356,13 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
   const [lastSync, setLastSync] = useState('2h')
 
   const isVI = locale === 'vi'
+
+  useEffect(() => {
+    setMobileTopBar({
+      title: isVI ? 'Tùy chọn' : 'Preferences',
+      subtitle: isVI ? 'Cài đặt' : 'Settings',
+    })
+  }, [isVI, setMobileTopBar])
 
   function switchLocale(next: string) {
     document.cookie = `locale=${next};path=/;max-age=31536000;SameSite=Lax`
@@ -414,8 +422,6 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
 
   return (
     <>
-      <MobileTopBar subtitle={isVI ? 'Cài đặt' : 'Settings'} title={isVI ? 'Tùy chọn' : 'Preferences'} />
-
       <div style={{ padding: '4px 16px 80px' }}>
 
         {/* Profile card */}

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -10,6 +10,7 @@ import {
 } from 'lucide-react'
 import { toast } from 'sonner'
 import MobileTopBar from '@/app/components/navigation/MobileTopBar'
+import DownloadReportSheet from '@/app/assets/components/DownloadReportSheet'
 
 interface Props {
   email: string
@@ -347,6 +348,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
   const [showProfile, setShowProfile] = useState(false)
   const [showAppearance, setShowAppearance] = useState(false)
   const [showCurrency, setShowCurrency] = useState(false)
+  const [showReport, setShowReport] = useState(false)
 
   const [syncing, setSyncing] = useState(false)
   const [syncDone, setSyncDone] = useState(false)
@@ -374,6 +376,14 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
     setSyncDone(true)
     setLastSync(isVI ? 'Vừa xong' : 'Just now')
     setTimeout(() => setSyncDone(false), 3000)
+  }
+
+  async function handleExportReport() {
+    const res = await fetch('/api/v1/dashboard/overview', { cache: 'no-store' })
+    if (!res.ok) throw new Error('Failed to load portfolio data')
+    const data = await res.json()
+    const { downloadPortfolioPDF } = await import('@/lib/generateReport')
+    await downloadPortfolioPDF(data, locale)
   }
 
   async function handleSignOut() {
@@ -472,7 +482,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
             <SettingsRow
               icon={<Download size={16} />}
               label={isVI ? 'Xuất dữ liệu' : 'Export data'}
-              onClick={() => { /* TODO: open download report sheet */ }}
+              onClick={() => setShowReport(true)}
               last
             />
           </div>
@@ -592,6 +602,12 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
       <CurrencySheet
         open={showCurrency}
         onClose={() => setShowCurrency(false)}
+      />
+      <DownloadReportSheet
+        open={showReport}
+        onClose={() => setShowReport(false)}
+        data={null}
+        onExport={handleExportReport}
       />
     </>
   )

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MobileSettingsView from '../MobileSettingsView'
 
@@ -179,6 +179,24 @@ describe('MobileSettingsView — data section', () => {
   it('renders Export data row', () => {
     render(<MobileSettingsView {...defaultProps} />)
     expect(screen.getByText(/export data/i)).toBeInTheDocument()
+  })
+
+  it('opens download report sheet when Export data is clicked', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /export data/i }))
+    expect(screen.getByText(/portfolio report/i)).toBeInTheDocument()
+  })
+
+  it('closes download report sheet when backdrop is clicked', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /export data/i }))
+    expect(screen.getByText(/portfolio report/i)).toBeInTheDocument()
+    // Click the backdrop (the fixed overlay div) to close
+    const backdrop = document.querySelector('[style*="position: fixed"][style*="inset: 0"]') as HTMLElement
+    if (backdrop) fireEvent.click(backdrop)
+    await waitFor(() =>
+      expect(screen.queryByText(/portfolio report/i)).not.toBeInTheDocument()
+    )
   })
 })
 

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -17,6 +17,10 @@ vi.mock('next/navigation', () => ({
   useTransition: () => [false, (fn: () => void) => fn()],
 }))
 
+vi.mock('@/app/components/navigation/NavigationContext', () => ({
+  useNavigation: () => ({ setMobileTopBar: vi.fn() }),
+}))
+
 vi.mock('@supabase/ssr', () => ({
   createBrowserClient: () => ({
     auth: { signOut: signOutMock },

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -51,9 +51,20 @@ describe('MobileSettingsView — profile card', () => {
     expect(screen.getByText('phuong.tran@example.com')).toBeInTheDocument()
   })
 
-  it('renders user initials in avatar', () => {
+  it('renders user initials derived from display name', () => {
     render(<MobileSettingsView {...defaultProps} />)
-    expect(screen.getByText('PT')).toBeInTheDocument()
+    // 'Phuong' → single word → 'P'
+    expect(screen.getByText('P')).toBeInTheDocument()
+  })
+
+  it('updates avatar initials after saving a new display name', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /profile/i }))
+    const nameInput = screen.getByDisplayValue('Phuong')
+    await userEvent.clear(nameInput)
+    await userEvent.type(nameInput, 'Minh Phuong')
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+    await waitFor(() => expect(screen.getByText('MP')).toBeInTheDocument(), { timeout: 2000 })
   })
 
   it('opens profile sheet when profile card is clicked', async () => {

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -3,8 +3,9 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MobileSettingsView from '../MobileSettingsView'
 
-const { signOutMock } = vi.hoisted(() => ({
+const { signOutMock, updateUserMock } = vi.hoisted(() => ({
   signOutMock: vi.fn().mockResolvedValue({ error: null }),
+  updateUserMock: vi.fn().mockResolvedValue({ data: { user: {} }, error: null }),
 }))
 
 vi.mock('next-intl', () => ({
@@ -21,9 +22,13 @@ vi.mock('@/app/components/navigation/NavigationContext', () => ({
   useNavigation: () => ({ setMobileTopBar: vi.fn() }),
 }))
 
+vi.mock('@/app/components/ThemeProvider', () => ({
+  useTheme: () => ({ theme: 'light', toggleTheme: vi.fn(), setTheme: vi.fn() }),
+}))
+
 vi.mock('@supabase/ssr', () => ({
   createBrowserClient: () => ({
-    auth: { signOut: signOutMock },
+    auth: { signOut: signOutMock, updateUser: updateUserMock },
   }),
 }))
 
@@ -93,6 +98,19 @@ describe('MobileSettingsView — profile sheet', () => {
     await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
     await waitFor(() =>
       expect(screen.queryByDisplayValue('phuong.tran@example.com')).not.toBeInTheDocument()
+    )
+  })
+
+  it('persists display name to Supabase when saving', async () => {
+    updateUserMock.mockClear()
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /profile/i }))
+    const nameInput = screen.getByDisplayValue('Phuong')
+    await userEvent.clear(nameInput)
+    await userEvent.type(nameInput, 'Minh')
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+    await waitFor(() =>
+      expect(updateUserMock).toHaveBeenCalledWith({ data: { display_name: 'Minh' } })
     )
   })
 })

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -71,6 +71,18 @@ describe('MobileSettingsView — profile sheet', () => {
     expect(emailInput).toBeInTheDocument()
   })
 
+  it('updates profile card name after saving', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /profile/i }))
+    const nameInput = screen.getByDisplayValue('Phuong')
+    await userEvent.clear(nameInput)
+    await userEvent.type(nameInput, 'Minh')
+    await userEvent.click(screen.getByRole('button', { name: /save/i }))
+    // After the success flash + close, the profile card should show the new name
+    await waitFor(() => expect(screen.getByText('Minh')).toBeInTheDocument(), { timeout: 2000 })
+    expect(screen.queryByText('Phuong')).not.toBeInTheDocument()
+  })
+
   it('closes profile sheet when cancel is clicked', async () => {
     render(<MobileSettingsView {...defaultProps} />)
     await userEvent.click(screen.getByRole('button', { name: /profile/i }))

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MobileSettingsView from '../MobileSettingsView'
@@ -201,9 +201,26 @@ describe('MobileSettingsView — currency sheet', () => {
   })
 })
 
+const mockOverviewResponse = {
+  netWorth: { netWorth: 100_000_000, currentValue: 95_000_000, overallProfitLoss: 5_000_000 },
+  goals: [{ id: '1' }, { id: '2' }],
+  unallocated: { totalValue: 0, funds: [], nonFunds: [] },
+  byType: { bank: 0, gold: 0, stock: 0 },
+  insurance: [],
+}
+
 // ─── Data section ──────────────────────────────────────────────────────────────
 
 describe('MobileSettingsView — data section', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify(mockOverviewResponse), { status: 200 })
+    )
+  })
+  afterEach(() => fetchSpy.mockRestore())
+
   it('renders Data section heading', () => {
     render(<MobileSettingsView {...defaultProps} />)
     expect(screen.getByText(/^data$/i)).toBeInTheDocument()
@@ -220,11 +237,17 @@ describe('MobileSettingsView — data section', () => {
     expect(screen.getByText(/portfolio report/i)).toBeInTheDocument()
   })
 
+  it('shows KPI data in report sheet after fetch', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /export data/i }))
+    await waitFor(() => expect(screen.getByText('Net worth')).toBeInTheDocument())
+    expect(screen.getByText('Current value')).toBeInTheDocument()
+  })
+
   it('closes download report sheet when backdrop is clicked', async () => {
     render(<MobileSettingsView {...defaultProps} />)
     await userEvent.click(screen.getByRole('button', { name: /export data/i }))
     expect(screen.getByText(/portfolio report/i)).toBeInTheDocument()
-    // Click the backdrop (the fixed overlay div) to close
     const backdrop = document.querySelector('[style*="position: fixed"][style*="inset: 0"]') as HTMLElement
     if (backdrop) fireEvent.click(backdrop)
     await waitFor(() =>

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MobileSettingsView from '../MobileSettingsView'
+
+const { signOutMock } = vi.hoisted(() => ({
+  signOutMock: vi.fn().mockResolvedValue({ error: null }),
+}))
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => 'en',
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  useTransition: () => [false, (fn: () => void) => fn()],
+}))
+
+vi.mock('@supabase/ssr', () => ({
+  createBrowserClient: () => ({
+    auth: { signOut: signOutMock },
+  }),
+}))
+
+const defaultProps = {
+  email: 'phuong.tran@example.com',
+  initials: 'PT',
+  displayName: 'Phuong',
+}
+
+// ─── Profile card ──────────────────────────────────────────────────────────────
+
+describe('MobileSettingsView — profile card', () => {
+  it('renders user display name', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText('Phuong')).toBeInTheDocument()
+  })
+
+  it('renders user email', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText('phuong.tran@example.com')).toBeInTheDocument()
+  })
+
+  it('renders user initials in avatar', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText('PT')).toBeInTheDocument()
+  })
+
+  it('opens profile sheet when profile card is clicked', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /profile/i }))
+    expect(screen.getByText(/profile/i)).toBeInTheDocument()
+  })
+})
+
+// ─── Profile sheet ─────────────────────────────────────────────────────────────
+
+describe('MobileSettingsView — profile sheet', () => {
+  it('shows name input prefilled with displayName', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /profile/i }))
+    const nameInput = screen.getByDisplayValue('Phuong')
+    expect(nameInput).toBeInTheDocument()
+  })
+
+  it('shows email input prefilled with email', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /profile/i }))
+    const emailInput = screen.getByDisplayValue('phuong.tran@example.com')
+    expect(emailInput).toBeInTheDocument()
+  })
+
+  it('closes profile sheet when cancel is clicked', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /profile/i }))
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    await waitFor(() =>
+      expect(screen.queryByDisplayValue('phuong.tran@example.com')).not.toBeInTheDocument()
+    )
+  })
+})
+
+// ─── Preferences section ───────────────────────────────────────────────────────
+
+describe('MobileSettingsView — preferences section', () => {
+  it('renders Preferences section heading', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getAllByText(/preferences/i).length).toBeGreaterThan(0)
+  })
+
+  it('renders Language row', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText(/language/i)).toBeInTheDocument()
+  })
+
+  it('shows current locale value on language row', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText('English')).toBeInTheDocument()
+  })
+
+  it('renders Appearance row', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText(/appearance/i)).toBeInTheDocument()
+  })
+
+  it('renders Currency row', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText(/currency/i)).toBeInTheDocument()
+  })
+
+  it('shows current currency value', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText('VND')).toBeInTheDocument()
+  })
+})
+
+// ─── Appearance sheet ──────────────────────────────────────────────────────────
+
+describe('MobileSettingsView — appearance sheet', () => {
+  it('opens appearance sheet when Appearance row is clicked', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /appearance/i }))
+    // Apply button only exists inside the AppearanceSheet — its presence confirms the sheet opened
+    expect(screen.getByRole('button', { name: /apply/i })).toBeInTheDocument()
+  })
+
+  it('closes appearance sheet when apply is clicked', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /appearance/i }))
+    await userEvent.click(screen.getByRole('button', { name: /apply/i }))
+    await waitFor(() =>
+      expect(screen.queryByRole('button', { name: /apply/i })).not.toBeInTheDocument()
+    )
+  })
+})
+
+// ─── Currency sheet ────────────────────────────────────────────────────────────
+
+describe('MobileSettingsView — currency sheet', () => {
+  it('opens currency sheet when Currency row is clicked', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /^currency$/i }))
+    expect(screen.getByText('Vietnamese Dong')).toBeInTheDocument()
+    expect(screen.getByText('US Dollar')).toBeInTheDocument()
+    expect(screen.getByText('Euro')).toBeInTheDocument()
+  })
+
+  it('closes currency sheet when apply is clicked', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /^currency$/i }))
+    await userEvent.click(screen.getByRole('button', { name: /apply/i }))
+    await waitFor(() =>
+      expect(screen.queryByText('Vietnamese Dong')).not.toBeInTheDocument()
+    )
+  })
+})
+
+// ─── Data section ──────────────────────────────────────────────────────────────
+
+describe('MobileSettingsView — data section', () => {
+  it('renders Data section heading', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText(/^data$/i)).toBeInTheDocument()
+  })
+
+  it('renders Export data row', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText(/export data/i)).toBeInTheDocument()
+  })
+})
+
+// ─── Price sync section ────────────────────────────────────────────────────────
+
+describe('MobileSettingsView — price sync section', () => {
+  it('renders Price sync section heading', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText(/price sync/i)).toBeInTheDocument()
+  })
+
+  it('renders Fund NAV row', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText(/fund nav/i)).toBeInTheDocument()
+  })
+
+  it('renders Gold price row', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText(/gold price/i)).toBeInTheDocument()
+  })
+
+  it('renders Sync now button', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByRole('button', { name: /sync now/i })).toBeInTheDocument()
+  })
+
+  it('shows last synced time', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText(/last synced/i)).toBeInTheDocument()
+  })
+
+  it('calls sync API when Sync now is clicked', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 })
+    )
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /sync now/i }))
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled())
+    fetchSpy.mockRestore()
+  })
+
+  it('disables Sync now button while syncing', async () => {
+    let resolve!: () => void
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () => new Promise(res => { resolve = () => res(new Response('{}', { status: 200 })) })
+    )
+    render(<MobileSettingsView {...defaultProps} />)
+    const btn = screen.getByRole('button', { name: /sync now/i })
+    await userEvent.click(btn)
+    expect(btn).toBeDisabled()
+    resolve()
+    fetchSpy.mockRestore()
+  })
+})
+
+// ─── Sign out ──────────────────────────────────────────────────────────────────
+
+describe('MobileSettingsView — sign out', () => {
+  it('renders Sign out button', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument()
+  })
+
+  it('calls supabase signOut when Sign out is clicked', async () => {
+    signOutMock.mockClear()
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /sign out/i }))
+    await waitFor(() => expect(signOutMock).toHaveBeenCalled())
+  })
+})
+
+// ─── Version text ──────────────────────────────────────────────────────────────
+
+describe('MobileSettingsView — version text', () => {
+  it('renders version info', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByText(/v\d/i)).toBeInTheDocument()
+  })
+})

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -17,7 +17,8 @@ function getInitials(email: string): string {
     .slice(0, 2) || email[0]?.toUpperCase() || 'U'
 }
 
-function getDisplayName(email: string): string {
+function getDisplayName(email: string, userMetaName?: string): string {
+  if (userMetaName) return userMetaName
   const localPart = email.split('@')[0]
   const firstName = localPart.split(/[._-]/)[0]
   return firstName.charAt(0).toUpperCase() + firstName.slice(1)
@@ -39,7 +40,7 @@ export default async function SettingsPage({
       initialGoalId={goal}
       email={email}
       initials={getInitials(email)}
-      displayName={getDisplayName(email)}
+      displayName={getDisplayName(email, user?.user_metadata?.display_name)}
     />
   )
 }

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,10 +1,26 @@
 import SettingsClient from './SettingsClient'
 import { getTranslations } from 'next-intl/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
 import type { Metadata } from 'next'
 
 export async function generateMetadata(): Promise<Metadata> {
   const t = await getTranslations('nav')
   return { title: t('settings') }
+}
+
+function getInitials(email: string): string {
+  const parts = email.split('@')[0].split(/[._-]/)
+  return parts
+    .slice(0, 2)
+    .map(p => p[0]?.toUpperCase() ?? '')
+    .join('')
+    .slice(0, 2) || email[0]?.toUpperCase() || 'U'
+}
+
+function getDisplayName(email: string): string {
+  const localPart = email.split('@')[0]
+  const firstName = localPart.split(/[._-]/)[0]
+  return firstName.charAt(0).toUpperCase() + firstName.slice(1)
 }
 
 export default async function SettingsPage({
@@ -13,6 +29,17 @@ export default async function SettingsPage({
   searchParams: Promise<{ tab?: string; goal?: string }>
 }) {
   const { tab, goal } = await searchParams
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  const email = user?.email ?? ''
 
-  return <SettingsClient initialTab={tab} initialGoalId={goal} />
+  return (
+    <SettingsClient
+      initialTab={tab}
+      initialGoalId={goal}
+      email={email}
+      initials={getInitials(email)}
+      displayName={getDisplayName(email)}
+    />
+  )
 }

--- a/app/assets/components/DownloadReportSheet.tsx
+++ b/app/assets/components/DownloadReportSheet.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Check } from 'lucide-react'
+import { Check, Download } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmt } from '@/lib/formatters'
 
@@ -17,6 +17,7 @@ export default function DownloadReportSheet({ open, onClose, data, onExport }: P
   const [mounted, setMounted] = useState(false)
   const [exporting, setExporting] = useState(false)
   const [success, setSuccess] = useState(false)
+  const [format, setFormat] = useState<'pdf' | 'csv'>('pdf')
 
   useEffect(() => {
     if (open) {
@@ -43,11 +44,39 @@ export default function DownloadReportSheet({ open, onClose, data, onExport }: P
 
   if (!mounted) return null
 
-  const today = new Date().toLocaleDateString(isVI ? 'vi-VN' : 'en-US', { day: 'numeric', month: 'long', year: 'numeric' })
+  const today = new Date().toLocaleDateString(isVI ? 'vi-VN' : 'en-GB', { day: 'numeric', month: 'long', year: 'numeric' })
 
-  const checklist = isVI
-    ? ['Tổng tài sản ròng', 'Chi tiết từng mục tiêu', 'Phân bổ tài sản', 'Khoản đầu tư chưa phân bổ', 'Lịch sử giao dịch']
-    : ['Net worth overview', 'Per-goal breakdown', 'Asset allocation', 'Unallocated holdings', 'Transaction history']
+  const t = isVI ? {
+    title: 'Báo cáo danh mục',
+    asOf: 'Tính đến',
+    netWorth: 'Tài sản ròng',
+    currentVal: 'Giá trị hiện tại',
+    pl: 'Lãi / Lỗ tổng',
+    goals: 'Mục tiêu đang theo dõi',
+    sections: 'Nội dung báo cáo',
+    includes: ['Tổng quan tài sản ròng', 'Chi tiết từng mục tiêu', 'Phân bổ theo loại tài sản', 'Khoản chưa phân bổ', 'Lịch sử giao dịch'],
+    format: 'Định dạng',
+    export: 'Xuất báo cáo',
+    cancel: 'Hủy',
+    done: 'Đã xuất báo cáo',
+    doneSub: 'Kiểm tra thư mục tải xuống của bạn',
+  } : {
+    title: 'Portfolio report',
+    asOf: 'As of',
+    netWorth: 'Net worth',
+    currentVal: 'Current value',
+    pl: 'Total P/L',
+    goals: 'Goals tracked',
+    sections: 'Report includes',
+    includes: ['Net worth overview', 'Per-goal breakdown', 'Asset type allocation', 'Unallocated holdings', 'Transaction history'],
+    format: 'Format',
+    export: 'Export report',
+    cancel: 'Cancel',
+    done: 'Report exported',
+    doneSub: 'Check your downloads folder',
+  }
+
+  const isPos = !data || data.totalPL >= 0
 
   return (
     <div
@@ -70,84 +99,137 @@ export default function DownloadReportSheet({ open, onClose, data, onExport }: P
       >
         <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '6px auto 0' }} />
 
-        <div style={{ padding: '14px 16px 24px' }}>
-          <p style={{ fontWeight: 700, fontSize: 17, color: 'var(--c-ink)', marginBottom: 4 }}>
-            {isVI ? 'Báo cáo danh mục' : 'Portfolio report'}
-          </p>
-          <p style={{ fontSize: 13, color: 'var(--c-muted)', marginBottom: 20 }}>
-            {isVI ? `Tính đến ${today}` : `As of ${today}`}
-          </p>
+        {/* Sheet header */}
+        <div style={{ padding: '14px 16px 0', borderBottom: '1px solid var(--c-line)', marginBottom: 16 }}>
+          <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--c-ink)', paddingBottom: 14 }}>{t.title}</div>
+        </div>
 
-          {data && (
-            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10, marginBottom: 20 }}>
-              {[
-                { label: isVI ? 'Tài sản ròng' : 'Net worth', value: fmt(data.netWorth) },
-                { label: isVI ? 'Giá trị hiện tại' : 'Current value', value: fmt(data.currentValue) },
-                {
-                  label: 'Total P/L',
-                  value: (data.totalPL >= 0 ? '+' : '') + fmt(data.totalPL),
-                  color: data.totalPL >= 0 ? 'var(--c-pos)' : 'var(--c-neg)',
-                },
-                { label: isVI ? 'Số mục tiêu' : 'Goals tracked', value: String(data.goalCount) },
-              ].map(({ label, value, color }) => (
-                <div
-                  key={label}
-                  style={{
-                    background: 'var(--c-card-2)', borderRadius: 12, padding: '12px 14px',
-                  }}
-                >
-                  <p style={{ fontSize: 11, color: 'var(--c-muted)', marginBottom: 4 }}>{label}</p>
-                  <p style={{ fontSize: 15, fontWeight: 700, color: color ?? 'var(--c-ink)' }}>{value}</p>
-                </div>
-              ))}
-            </div>
-          )}
-
-          <p style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', marginBottom: 10 }}>
-            {isVI ? 'Báo cáo bao gồm' : 'Report includes'}
-          </p>
-          <div style={{ marginBottom: 20 }}>
-            {checklist.map((item) => (
-              <div key={item} style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
-                <Check size={14} color="var(--c-pos)" />
-                <span style={{ fontSize: 13, color: 'var(--c-ink)' }}>{item}</span>
-              </div>
-            ))}
-          </div>
-
+        <div style={{ padding: '0 16px 28px' }}>
           {success ? (
-            <div data-testid="export-success" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 10, padding: '14px 0' }}>
+            <div style={{ padding: '28px 0', textAlign: 'center' }}>
               <div style={{
-                width: 32, height: 32, borderRadius: '50%',
-                background: 'var(--c-pos-tint)', display: 'flex', alignItems: 'center', justifyContent: 'center',
+                width: 56, height: 56, borderRadius: 28,
+                background: 'var(--c-pos-tint)', color: 'var(--c-pos)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 14px',
               }}>
-                <Check size={18} color="var(--c-pos)" />
+                <Check size={28} strokeWidth={2.5} />
               </div>
-              <span style={{ fontWeight: 600, fontSize: 15, color: 'var(--c-pos)' }}>
-                {isVI ? 'Đã xuất báo cáo' : 'Report exported'}
-              </span>
+              <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--c-ink)' }}>{t.done}</div>
+              <div style={{ fontSize: 12, color: 'var(--c-muted)', marginTop: 4 }}>{t.doneSub}</div>
             </div>
           ) : (
-            <button
-              data-testid="export-report-btn"
-              onClick={handleExport}
-              disabled={exporting}
-              style={{
-                width: '100%', padding: '14px 0', borderRadius: 12, border: 'none',
-                background: 'var(--c-navy)', color: '#fff',
-                fontSize: 15, fontWeight: 700,
-                cursor: exporting ? 'default' : 'pointer',
-                opacity: exporting ? 0.7 : 1,
-                display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
-              }}
-            >
-              {exporting && (
-                <span style={{ width: 16, height: 16, border: '2px solid #fff', borderTopColor: 'transparent', borderRadius: '50%', display: 'inline-block', animation: 'spin 0.6s linear infinite' }} />
+            <div style={{ display: 'grid', gap: 14 }}>
+              {/* Date */}
+              <div style={{ fontSize: 12, color: 'var(--c-muted)' }}>
+                {t.asOf}{' '}
+                <span style={{ fontWeight: 600, color: 'var(--c-ink)' }}>{today}</span>
+              </div>
+
+              {/* KPI grid */}
+              {data && (
+                <div style={{
+                  display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)',
+                  gap: 1, background: 'var(--c-line)', borderRadius: 12, overflow: 'hidden',
+                }}>
+                  {[
+                    { label: t.netWorth,   value: fmt(data.netWorth) },
+                    { label: t.currentVal, value: fmt(data.currentValue) },
+                    { label: t.pl,         value: (isPos ? '+' : '') + fmt(data.totalPL), color: isPos ? 'var(--c-pos)' : 'var(--c-neg)' },
+                    { label: t.goals,      value: String(data.goalCount) },
+                  ].map(({ label, value, color }) => (
+                    <div key={label} style={{ background: 'var(--c-card)', padding: '10px 12px' }}>
+                      <div style={{ fontSize: 10, color: 'var(--c-muted)' }}>{label}</div>
+                      <div style={{ fontSize: 14, fontWeight: 600, marginTop: 2, color: color ?? 'var(--c-ink)' }}>{value}</div>
+                    </div>
+                  ))}
+                </div>
               )}
-              {exporting
-                ? (isVI ? 'Đang xuất…' : 'Exporting…')
-                : (isVI ? 'Xuất báo cáo' : 'Export report')}
-            </button>
+
+              {/* What's included */}
+              <div>
+                <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 8 }}>
+                  {t.sections}
+                </div>
+                <div style={{ display: 'grid', gap: 6 }}>
+                  {t.includes.map((item) => (
+                    <div key={item} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                      <div style={{
+                        width: 18, height: 18, borderRadius: 9,
+                        background: 'var(--c-pos-tint)', color: 'var(--c-pos)',
+                        display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                      }}>
+                        <Check size={11} strokeWidth={2.5} />
+                      </div>
+                      <span style={{ fontSize: 13, color: 'var(--c-ink)' }}>{item}</span>
+                    </div>
+                  ))}
+                </div>
+              </div>
+
+              {/* Format picker */}
+              <div>
+                <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 8 }}>
+                  {t.format}
+                </div>
+                <div style={{ display: 'flex', gap: 8 }}>
+                  {(['pdf', 'csv'] as const).map(f => (
+                    <button
+                      key={f}
+                      onClick={() => setFormat(f)}
+                      aria-pressed={format === f}
+                      style={{
+                        flex: 1, padding: '10px', borderRadius: 10,
+                        background: format === f ? 'var(--c-btn-primary)' : 'var(--c-card)',
+                        color: format === f ? '#fff' : 'var(--c-muted)',
+                        border: `1px solid ${format === f ? 'var(--c-btn-primary)' : 'var(--c-line)'}`,
+                        fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit',
+                        textTransform: 'uppercase', letterSpacing: '0.04em',
+                        transition: 'all 120ms',
+                      }}
+                    >
+                      {f}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Actions */}
+              <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+                <button
+                  onClick={onClose}
+                  aria-label="cancel"
+                  style={{
+                    flex: 1, padding: '11px 0', fontSize: 13, fontWeight: 500,
+                    background: 'var(--c-card)', border: '1px solid var(--c-line)',
+                    borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
+                    color: 'var(--c-ink)',
+                  }}
+                >
+                  {t.cancel}
+                </button>
+                <button
+                  onClick={handleExport}
+                  disabled={exporting}
+                  aria-label={exporting ? 'exporting' : t.export}
+                  style={{
+                    flex: 2, padding: '11px 0', fontSize: 13, fontWeight: 600,
+                    background: 'var(--c-btn-primary)', border: 'none',
+                    borderRadius: 10, color: '#fff',
+                    cursor: exporting ? 'default' : 'pointer',
+                    opacity: exporting ? 0.7 : 1,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
+                    fontFamily: 'inherit', transition: 'opacity 150ms',
+                  }}
+                >
+                  {exporting ? (
+                    <span style={{ width: 14, height: 14, border: '2px solid #fff', borderTopColor: 'transparent', borderRadius: '50%', display: 'inline-block', animation: 'spin 0.6s linear infinite' }} />
+                  ) : (
+                    <Download size={14} strokeWidth={2.2} />
+                  )}
+                  {exporting ? (isVI ? 'Đang xuất…' : 'Exporting…') : t.export}
+                </button>
+              </div>
+            </div>
           )}
         </div>
       </div>

--- a/app/assets/components/DownloadReportSheet.tsx
+++ b/app/assets/components/DownloadReportSheet.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Check, Download } from 'lucide-react'
+import { Check, Download, X } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmt } from '@/lib/formatters'
 
@@ -97,14 +97,24 @@ export default function DownloadReportSheet({ open, onClose, data, onExport }: P
         }}
         onClick={(e) => e.stopPropagation()}
       >
-        <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '6px auto 0' }} />
+        <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '6px auto 14px' }} />
 
-        {/* Sheet header */}
-        <div style={{ padding: '14px 16px 0', borderBottom: '1px solid var(--c-line)', marginBottom: 16 }}>
-          <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--c-ink)', paddingBottom: 14 }}>{t.title}</div>
-        </div>
-
-        <div style={{ padding: '0 16px 28px' }}>
+        <div style={{ padding: '0 16px 16px' }}>
+          {/* Sheet header */}
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14 }}>
+            <h3 style={{ margin: 0, fontSize: 17, fontWeight: 600, color: 'var(--c-ink)' }}>{t.title}</h3>
+            <button
+              onClick={onClose}
+              aria-label="close"
+              style={{
+                padding: 6, background: 'transparent', border: 'none',
+                cursor: 'pointer', color: 'var(--c-muted)', borderRadius: 8,
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+              }}
+            >
+              <X size={18} />
+            </button>
+          </div>
           {success ? (
             <div style={{ padding: '28px 0', textAlign: 'center' }}>
               <div style={{
@@ -210,7 +220,7 @@ export default function DownloadReportSheet({ open, onClose, data, onExport }: P
                 <button
                   onClick={handleExport}
                   disabled={exporting}
-                  aria-label={exporting ? 'exporting' : t.export}
+                  aria-label={exporting ? 'exporting' : `${t.export} · ${format.toUpperCase()}`}
                   style={{
                     flex: 2, padding: '11px 0', fontSize: 13, fontWeight: 600,
                     background: 'var(--c-btn-primary)', border: 'none',
@@ -226,7 +236,9 @@ export default function DownloadReportSheet({ open, onClose, data, onExport }: P
                   ) : (
                     <Download size={14} strokeWidth={2.2} />
                   )}
-                  {exporting ? (isVI ? 'Đang xuất…' : 'Exporting…') : t.export}
+                  {exporting
+                    ? (isVI ? 'Đang xuất…' : 'Exporting…')
+                    : `${t.export} · ${format.toUpperCase()}`}
                 </button>
               </div>
             </div>

--- a/app/assets/components/DownloadReportSheet.tsx
+++ b/app/assets/components/DownloadReportSheet.tsx
@@ -116,7 +116,7 @@ export default function DownloadReportSheet({ open, onClose, data, onExport }: P
             </button>
           </div>
           {success ? (
-            <div style={{ padding: '28px 0', textAlign: 'center' }}>
+            <div data-testid="export-success" style={{ padding: '28px 0', textAlign: 'center' }}>
               <div style={{
                 width: 56, height: 56, borderRadius: 28,
                 background: 'var(--c-pos-tint)', color: 'var(--c-pos)',
@@ -220,6 +220,7 @@ export default function DownloadReportSheet({ open, onClose, data, onExport }: P
                 <button
                   onClick={handleExport}
                   disabled={exporting}
+                  data-testid="export-report-btn"
                   aria-label={exporting ? 'exporting' : `${t.export} · ${format.toUpperCase()}`}
                   style={{
                     flex: 2, padding: '11px 0', fontSize: 13, fontWeight: 600,

--- a/app/assets/components/__tests__/DownloadReportSheet.test.tsx
+++ b/app/assets/components/__tests__/DownloadReportSheet.test.tsx
@@ -87,14 +87,32 @@ describe('DownloadReportSheet — format picker', () => {
 // ─── Actions ───────────────────────────────────────────────────────────────────
 
 describe('DownloadReportSheet — actions', () => {
+  it('renders X close button in header', () => {
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
+    expect(screen.getByRole('button', { name: /close/i })).toBeInTheDocument()
+  })
+
+  it('calls onClose when X close button is clicked', async () => {
+    const onClose = vi.fn()
+    render(<DownloadReportSheet open data={null} onClose={onClose} onExport={noop} />)
+    await userEvent.click(screen.getByRole('button', { name: /close/i }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
   it('renders Cancel button', () => {
     render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
     expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument()
   })
 
-  it('renders Export report button', () => {
+  it('export button shows selected format', () => {
     render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
-    expect(screen.getByRole('button', { name: /export report/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /export report · pdf/i })).toBeInTheDocument()
+  })
+
+  it('export button updates format label when CSV is selected', async () => {
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
+    await userEvent.click(screen.getByRole('button', { name: /^csv$/i }))
+    expect(screen.getByRole('button', { name: /export report · csv/i })).toBeInTheDocument()
   })
 
   it('calls onClose when Cancel is clicked', async () => {

--- a/app/assets/components/__tests__/DownloadReportSheet.test.tsx
+++ b/app/assets/components/__tests__/DownloadReportSheet.test.tsx
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DownloadReportSheet from '../DownloadReportSheet'
+
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
+}))
+
+const sampleData = {
+  netWorth: 100_000_000,
+  currentValue: 95_000_000,
+  totalPL: 5_000_000,
+  goalCount: 3,
+}
+
+const noop = () => Promise.resolve()
+
+// ─── Structure ─────────────────────────────────────────────────────────────────
+
+describe('DownloadReportSheet — structure', () => {
+  it('renders portfolio report title', () => {
+    render(<DownloadReportSheet open data={sampleData} onClose={noop} onExport={noop} />)
+    expect(screen.getByText(/portfolio report/i)).toBeInTheDocument()
+  })
+
+  it('renders date line', () => {
+    render(<DownloadReportSheet open data={sampleData} onClose={noop} onExport={noop} />)
+    expect(screen.getByText(/as of/i)).toBeInTheDocument()
+  })
+
+  it('renders KPI grid when data is provided', () => {
+    render(<DownloadReportSheet open data={sampleData} onClose={noop} onExport={noop} />)
+    expect(screen.getByText('Net worth')).toBeInTheDocument()
+    expect(screen.getByText('Current value')).toBeInTheDocument()
+    expect(screen.getByText(/total p\/l/i)).toBeInTheDocument()
+    expect(screen.getByText(/goals tracked/i)).toBeInTheDocument()
+  })
+
+  it('hides KPI grid when data is null', () => {
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
+    expect(screen.queryByText('Current value')).not.toBeInTheDocument()
+  })
+
+  it('renders "Report includes" section with uppercase heading', () => {
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
+    expect(screen.getByText(/report includes/i)).toBeInTheDocument()
+  })
+
+  it('renders all checklist items', () => {
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
+    expect(screen.getByText(/net worth overview/i)).toBeInTheDocument()
+    expect(screen.getByText(/per-goal breakdown/i)).toBeInTheDocument()
+    expect(screen.getByText(/unallocated holdings/i)).toBeInTheDocument()
+    expect(screen.getByText(/transaction history/i)).toBeInTheDocument()
+  })
+})
+
+// ─── Format picker ─────────────────────────────────────────────────────────────
+
+describe('DownloadReportSheet — format picker', () => {
+  it('renders Format label', () => {
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
+    expect(screen.getByText(/^format$/i)).toBeInTheDocument()
+  })
+
+  it('renders PDF and CSV buttons', () => {
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
+    expect(screen.getByRole('button', { name: /^pdf$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^csv$/i })).toBeInTheDocument()
+  })
+
+  it('PDF is selected by default', () => {
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
+    const pdfBtn = screen.getByRole('button', { name: /^pdf$/i })
+    expect(pdfBtn).toHaveAttribute('aria-pressed', 'true')
+  })
+
+  it('selecting CSV updates selection', async () => {
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
+    await userEvent.click(screen.getByRole('button', { name: /^csv$/i }))
+    expect(screen.getByRole('button', { name: /^csv$/i })).toHaveAttribute('aria-pressed', 'true')
+    expect(screen.getByRole('button', { name: /^pdf$/i })).toHaveAttribute('aria-pressed', 'false')
+  })
+})
+
+// ─── Actions ───────────────────────────────────────────────────────────────────
+
+describe('DownloadReportSheet — actions', () => {
+  it('renders Cancel button', () => {
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
+    expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument()
+  })
+
+  it('renders Export report button', () => {
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
+    expect(screen.getByRole('button', { name: /export report/i })).toBeInTheDocument()
+  })
+
+  it('calls onClose when Cancel is clicked', async () => {
+    const onClose = vi.fn()
+    render(<DownloadReportSheet open data={null} onClose={onClose} onExport={noop} />)
+    await userEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('calls onExport when Export report is clicked', async () => {
+    const onExport = vi.fn().mockResolvedValue(undefined)
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={onExport} />)
+    await userEvent.click(screen.getByRole('button', { name: /export report/i }))
+    await waitFor(() => expect(onExport).toHaveBeenCalled())
+  })
+
+  it('disables Export button while exporting', async () => {
+    let resolve!: () => void
+    const onExport = vi.fn().mockImplementation(
+      () => new Promise<void>(res => { resolve = res })
+    )
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={onExport} />)
+    await userEvent.click(screen.getByRole('button', { name: /export report/i }))
+    expect(screen.getByRole('button', { name: /exporting/i })).toBeDisabled()
+    resolve()
+  })
+})
+
+// ─── Success state ─────────────────────────────────────────────────────────────
+
+describe('DownloadReportSheet — success state', () => {
+  it('shows success title after export', async () => {
+    const onExport = vi.fn().mockResolvedValue(undefined)
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={onExport} />)
+    await userEvent.click(screen.getByRole('button', { name: /export report/i }))
+    await waitFor(() => expect(screen.getByText(/report exported/i)).toBeInTheDocument())
+  })
+
+  it('shows download folder subtitle after export', async () => {
+    const onExport = vi.fn().mockResolvedValue(undefined)
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={onExport} />)
+    await userEvent.click(screen.getByRole('button', { name: /export report/i }))
+    await waitFor(() => expect(screen.getByText(/downloads folder/i)).toBeInTheDocument())
+  })
+})

--- a/app/components/ThemeProvider.tsx
+++ b/app/components/ThemeProvider.tsx
@@ -3,10 +3,12 @@
 import { createContext, useContext, useEffect, useState } from 'react'
 
 type Theme = 'light' | 'dark'
+export type ThemeChoice = Theme | 'system'
 
 interface ThemeContextValue {
   theme: Theme
   toggleTheme: () => void
+  setTheme: (choice: ThemeChoice) => void
 }
 
 const ThemeContext = createContext<ThemeContextValue | null>(null)
@@ -18,24 +20,35 @@ export function useTheme() {
 }
 
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>('light')
+  const [themeState, setThemeState] = useState<Theme>('light')
 
   useEffect(() => {
     const stored = localStorage.getItem('theme') as Theme | null
     const resolved = stored ?? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-    setTheme(resolved)
+    setThemeState(resolved)
     document.documentElement.classList.toggle('dark', resolved === 'dark')
   }, [])
 
   function toggleTheme() {
-    const next: Theme = theme === 'dark' ? 'light' : 'dark'
-    setTheme(next)
-    localStorage.setItem('theme', next)
-    document.documentElement.classList.toggle('dark', next === 'dark')
+    applyTheme(themeState === 'dark' ? 'light' : 'dark')
+  }
+
+  function applyTheme(choice: ThemeChoice) {
+    if (choice === 'system') {
+      localStorage.removeItem('theme')
+      const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+      const resolved: Theme = isDark ? 'dark' : 'light'
+      setThemeState(resolved)
+      document.documentElement.classList.toggle('dark', isDark)
+    } else {
+      setThemeState(choice)
+      localStorage.setItem('theme', choice)
+      document.documentElement.classList.toggle('dark', choice === 'dark')
+    }
   }
 
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ theme: themeState, toggleTheme, setTheme: applyTheme }}>
       {children}
     </ThemeContext.Provider>
   )

--- a/app/components/navigation/MobileBottomTabs.tsx
+++ b/app/components/navigation/MobileBottomTabs.tsx
@@ -56,32 +56,30 @@ export default function MobileBottomTabs() {
     <nav
       className="fixed bottom-0 left-0 right-0 z-40 md:hidden"
       style={{
-        background: 'rgba(255, 255, 255, 0.92)',
+        background: 'var(--c-tab-bg)',
         backdropFilter: 'saturate(140%) blur(16px)',
         WebkitBackdropFilter: 'saturate(140%) blur(16px)',
         borderTop: '1px solid var(--c-line)',
         paddingBottom: 'env(safe-area-inset-bottom, 0)',
       }}
     >
-      <div className="dark:bg-gray-900/90 dark:border-gray-700/80" style={{ borderTop: 'inherit', background: 'inherit' }}>
-        <div className="grid grid-cols-4 px-1 py-1.5">
-          {TABS.map(({ href, key, renderIcon }) => {
-            const isActive = pathname.startsWith(href)
-            return (
-              <Link
-                key={href}
-                href={href}
-                className="flex flex-col items-center gap-0.5 py-2 rounded-xl transition-colors"
-                style={{ color: isActive ? 'var(--c-navy)' : 'var(--c-muted)' }}
-              >
-                {renderIcon(isActive)}
-                <span style={{ fontSize: '10.5px', fontWeight: isActive ? 600 : 500, letterSpacing: '0.01em', lineHeight: 1 }}>
-                  {t(key)}
-                </span>
-              </Link>
-            )
-          })}
-        </div>
+      <div className="grid grid-cols-4 px-1 py-1.5">
+        {TABS.map(({ href, key, renderIcon }) => {
+          const isActive = pathname.startsWith(href)
+          return (
+            <Link
+              key={href}
+              href={href}
+              className="flex flex-col items-center gap-0.5 py-2 rounded-xl transition-colors"
+              style={{ color: isActive ? 'var(--c-navy)' : 'var(--c-muted)' }}
+            >
+              {renderIcon(isActive)}
+              <span style={{ fontSize: '10.5px', fontWeight: isActive ? 600 : 500, letterSpacing: '0.01em', lineHeight: 1 }}>
+                {t(key)}
+              </span>
+            </Link>
+          )
+        })}
       </div>
     </nav>
   )

--- a/app/globals.css
+++ b/app/globals.css
@@ -39,6 +39,11 @@
   --c-accent-fixed: #b45309;
   --c-accent-insurance: #7c3aed;
   --c-accent-other: #475569;
+  /* Primary button fill — stays dark navy in both modes so white text is always legible */
+  --c-btn-primary: #0F2A4A;
+  --c-btn-primary-hover: #1e3a63;
+  /* Tab bar frosted-glass background */
+  --c-tab-bg: rgba(255, 255, 255, 0.92);
   --r-card: 16px;
   --r-control: 10px;
   --shadow-card: 0 1px 0 rgba(15, 42, 74, 0.04), 0 1px 2px rgba(15, 42, 74, 0.05);
@@ -147,6 +152,8 @@
   --c-muted-2: #737373;
   --c-navy: #f8fafc;
   --c-navy-tint: #1a2540;
+  /* Tab bar goes dark in dark mode */
+  --c-tab-bg: rgba(22, 22, 22, 0.92);
   --c-pos-tint: rgba(4, 120, 87, 0.15);
   --c-neg-tint: rgba(185, 28, 28, 0.15);
   --c-warn-tint: rgba(180, 83, 9, 0.15);

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -4,6 +4,10 @@ import { test, expect } from '@playwright/test'
 test.use({ viewport: { width: 390, height: 844 } })
 
 test.beforeEach(async ({ page }) => {
+  // Force English locale (app defaults to 'vi' when no cookie is set)
+  const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000'
+  const hostname = new URL(baseURL).hostname
+  await page.context().addCookies([{ name: 'locale', value: 'en', domain: hostname, path: '/' }])
   await page.goto('/settings')
   await page.waitForLoadState('networkidle')
 })

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,0 +1,215 @@
+import { test, expect } from '@playwright/test'
+
+// Settings page uses md:hidden — must run at mobile viewport
+test.use({ viewport: { width: 390, height: 844 } })
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/settings')
+  await page.waitForLoadState('networkidle')
+})
+
+// ─── Page load ─────────────────────────────────────────────────────────────────
+
+test('settings page loads at /settings', async ({ page }) => {
+  await expect(page).toHaveURL(/settings/)
+})
+
+// ─── Profile card ──────────────────────────────────────────────────────────────
+
+test('profile card is visible', async ({ page }) => {
+  await expect(page.getByRole('button', { name: /profile/i })).toBeVisible()
+})
+
+test('profile card shows user email', async ({ page }) => {
+  const card = page.getByRole('button', { name: /profile/i })
+  // The test user email contains @
+  await expect(card).toContainText('@')
+})
+
+test('profile card shows avatar initials', async ({ page }) => {
+  const card = page.getByRole('button', { name: /profile/i })
+  const text = await card.innerText()
+  // Avatar initials: 1-2 uppercase letters appear somewhere in the card text
+  expect(text).toMatch(/[A-Z]{1,2}/)
+})
+
+// ─── Profile sheet ─────────────────────────────────────────────────────────────
+
+test('clicking profile card opens profile sheet', async ({ page }) => {
+  await page.getByRole('button', { name: /profile/i }).click()
+  await expect(page.getByRole('textbox').first()).toBeVisible({ timeout: 5_000 })
+})
+
+test('profile sheet prefills name and email inputs', async ({ page }) => {
+  await page.getByRole('button', { name: /profile/i }).click()
+  const nameInput = page.getByRole('textbox').first()
+  await expect(nameInput).toBeVisible({ timeout: 5_000 })
+  const nameVal = await nameInput.inputValue()
+  const emailVal = await page.getByRole('textbox').nth(1).inputValue()
+  expect(nameVal.length).toBeGreaterThan(0)
+  expect(emailVal).toContain('@')
+})
+
+test('profile sheet closes when Cancel is clicked', async ({ page }) => {
+  await page.getByRole('button', { name: /profile/i }).click()
+  await expect(page.getByRole('textbox').first()).toBeVisible({ timeout: 5_000 })
+  await page.getByRole('button', { name: /^cancel$/i }).click()
+  await expect(page.getByRole('textbox').first()).not.toBeVisible({ timeout: 5_000 })
+})
+
+test('saving a new display name updates the profile card', async ({ page }) => {
+  await page.getByRole('button', { name: /profile/i }).click()
+  const nameInput = page.getByRole('textbox').first()
+  await expect(nameInput).toBeVisible({ timeout: 5_000 })
+  await nameInput.fill('E2E Test User')
+  await page.getByRole('button', { name: /^save$/i }).click()
+  // After save + auto-close the card should show the new name
+  await expect(page.locator('text=E2E Test User').first()).toBeVisible({ timeout: 5_000 })
+})
+
+// ─── Preferences section ───────────────────────────────────────────────────────
+
+test('Preferences section heading is visible', async ({ page }) => {
+  await expect(page.locator('text=Preferences').first()).toBeVisible()
+})
+
+test('Language row is visible', async ({ page }) => {
+  await expect(page.getByRole('button', { name: /^language$/i })).toBeVisible()
+})
+
+test('Appearance row is visible', async ({ page }) => {
+  await expect(page.getByRole('button', { name: /^appearance$/i })).toBeVisible()
+})
+
+test('Currency row is visible', async ({ page }) => {
+  await expect(page.getByRole('button', { name: /^currency$/i })).toBeVisible()
+})
+
+test('Language row shows current locale', async ({ page }) => {
+  const row = page.getByRole('button', { name: /^language$/i })
+  await expect(row).toContainText('English')
+})
+
+test('Currency row shows current currency', async ({ page }) => {
+  const row = page.getByRole('button', { name: /^currency$/i })
+  await expect(row).toContainText('VND')
+})
+
+// ─── Appearance sheet ──────────────────────────────────────────────────────────
+
+test('clicking Appearance row opens appearance sheet', async ({ page }) => {
+  await page.getByRole('button', { name: /^appearance$/i }).click()
+  await expect(page.getByRole('button', { name: /^apply$/i })).toBeVisible({ timeout: 5_000 })
+})
+
+test('appearance sheet shows Light, Dark, System options', async ({ page }) => {
+  await page.getByRole('button', { name: /^appearance$/i }).click()
+  await expect(page.locator('text=Light').first()).toBeVisible({ timeout: 5_000 })
+  await expect(page.locator('text=Dark').first()).toBeVisible({ timeout: 5_000 })
+  await expect(page.locator('text=System').first()).toBeVisible({ timeout: 5_000 })
+})
+
+test('clicking Apply closes appearance sheet', async ({ page }) => {
+  await page.getByRole('button', { name: /^appearance$/i }).click()
+  await expect(page.getByRole('button', { name: /^apply$/i })).toBeVisible({ timeout: 5_000 })
+  await page.getByRole('button', { name: /^apply$/i }).click()
+  await expect(page.getByRole('button', { name: /^apply$/i })).not.toBeVisible({ timeout: 5_000 })
+})
+
+// ─── Currency sheet ────────────────────────────────────────────────────────────
+
+test('clicking Currency row opens currency sheet', async ({ page }) => {
+  await page.getByRole('button', { name: /^currency$/i }).click()
+  await expect(page.locator('text=Vietnamese Dong').first()).toBeVisible({ timeout: 5_000 })
+})
+
+test('currency sheet shows VND, USD, EUR options', async ({ page }) => {
+  await page.getByRole('button', { name: /^currency$/i }).click()
+  await expect(page.locator('text=Vietnamese Dong').first()).toBeVisible({ timeout: 5_000 })
+  await expect(page.locator('text=US Dollar').first()).toBeVisible({ timeout: 5_000 })
+  await expect(page.locator('text=Euro').first()).toBeVisible({ timeout: 5_000 })
+})
+
+test('clicking Apply closes currency sheet', async ({ page }) => {
+  await page.getByRole('button', { name: /^currency$/i }).click()
+  await expect(page.locator('text=Vietnamese Dong').first()).toBeVisible({ timeout: 5_000 })
+  await page.getByRole('button', { name: /^apply$/i }).click()
+  await expect(page.locator('text=Vietnamese Dong').first()).not.toBeVisible({ timeout: 5_000 })
+})
+
+// ─── Data / Export section ─────────────────────────────────────────────────────
+
+test('Data section heading is visible', async ({ page }) => {
+  await expect(page.locator('text=Data').first()).toBeVisible()
+})
+
+test('Export data row is visible', async ({ page }) => {
+  await expect(page.getByRole('button', { name: /export data/i })).toBeVisible()
+})
+
+test('clicking Export data opens download report sheet', async ({ page }) => {
+  await page.getByRole('button', { name: /export data/i }).click()
+  await expect(page.locator('text=Portfolio report').first()).toBeVisible({ timeout: 8_000 })
+})
+
+test('download report sheet has format picker and export button', async ({ page }) => {
+  await page.getByRole('button', { name: /export data/i }).click()
+  await expect(page.locator('text=Portfolio report').first()).toBeVisible({ timeout: 8_000 })
+  await expect(page.getByRole('button', { name: /^pdf$/i })).toBeVisible()
+  await expect(page.getByRole('button', { name: /^csv$/i })).toBeVisible()
+  await expect(page.getByRole('button', { name: /export report/i })).toBeVisible()
+})
+
+test('download report sheet closes when X close button is clicked', async ({ page }) => {
+  await page.getByRole('button', { name: /export data/i }).click()
+  await expect(page.locator('text=Portfolio report').first()).toBeVisible({ timeout: 8_000 })
+  await page.getByRole('button', { name: /^close$/i }).click()
+  await expect(page.locator('text=Portfolio report').first()).not.toBeVisible({ timeout: 5_000 })
+})
+
+// ─── Price sync section ────────────────────────────────────────────────────────
+
+test('Price sync section heading is visible', async ({ page }) => {
+  await expect(page.locator('text=Price sync').first()).toBeVisible()
+})
+
+test('Fund NAV row is visible', async ({ page }) => {
+  await expect(page.locator('text=Fund NAV').first()).toBeVisible()
+})
+
+test('Gold price row is visible', async ({ page }) => {
+  await expect(page.locator('text=/gold price/i').first()).toBeVisible()
+})
+
+test('Sync now button is visible', async ({ page }) => {
+  await expect(page.getByRole('button', { name: /sync now/i })).toBeVisible()
+})
+
+test('Last synced info is visible', async ({ page }) => {
+  await expect(page.locator('text=/last synced/i').first()).toBeVisible()
+})
+
+test('clicking Sync now triggers cron API calls', async ({ page }) => {
+  const calls: string[] = []
+  page.on('request', req => {
+    if (req.url().includes('/api/cron/refresh')) calls.push(req.url())
+  })
+  await page.getByRole('button', { name: /sync now/i }).click()
+  // Button becomes disabled while syncing
+  await expect(page.getByRole('button', { name: /sync now/i })).toBeDisabled({ timeout: 3_000 })
+  // Button re-enables after sync completes
+  await expect(page.getByRole('button', { name: /sync now/i })).toBeEnabled({ timeout: 15_000 })
+  expect(calls.length).toBeGreaterThan(0)
+})
+
+// ─── Sign out ──────────────────────────────────────────────────────────────────
+
+test('Sign out button is visible', async ({ page }) => {
+  await expect(page.getByRole('button', { name: /sign out/i })).toBeVisible()
+})
+
+// ─── Version text ──────────────────────────────────────────────────────────────
+
+test('version text is visible', async ({ page }) => {
+  await expect(page.locator('text=/v\\d/').first()).toBeVisible()
+})


### PR DESCRIPTION
## Summary

- New MobileSettingsView component: profile card, Preferences (Language/Appearance/Currency), Data (Export), Price sync, Sign out, version text
- Three BottomSheet action sheets: ProfileSheet, AppearanceSheet, CurrencySheet
- Language toggle via cookie + router.refresh(); Appearance applies dark class
- Price sync calls /api/cron/refresh-navs and /api/cron/refresh-gold with loading/done state
- Sign out via supabase.auth.signOut() with localStorage cache clear
- SettingsClient shows MobileSettingsView on mobile, existing tab UI on desktop
- settings/page.tsx passes email/initials/displayName from Supabase server client

## Test plan

- [x] 29 unit tests (TDD) covering all sections, sheet open/close, sync disable state, signOut, version text
- [x] All 164 project tests pass
- [x] TypeScript --noEmit clean
- [ ] Verify on preview deployment: profile card, sheets, language toggle, sync button, sign out on mobile viewport

Generated with Claude Code