### PR TITLE
fix(dashboard): greeting uses full name from user metadata

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -7,8 +7,11 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) redirect('/auth/login')
 
+  const meta = user.user_metadata ?? {}
+  const displayName = (meta.display_name || meta.full_name) as string | undefined
+
   return (
-    <AuthenticatedLayout email={user.email ?? ''}>
+    <AuthenticatedLayout email={user.email ?? ''} displayName={displayName}>
       {children}
     </AuthenticatedLayout>
   )

--- a/app/components/layouts/AuthenticatedLayout.tsx
+++ b/app/components/layouts/AuthenticatedLayout.tsx
@@ -92,7 +92,7 @@ function AuthenticatedLayoutInner({ children, email, initials }: { children: Rea
   )
 }
 
-export default function AuthenticatedLayout({ children, email }: { children: React.ReactNode; email: string }) {
+export default function AuthenticatedLayout({ children, email, displayName }: { children: React.ReactNode; email: string; displayName?: string }) {
   const router = useRouter()
 
   // Watch for session expiry (e.g. token revoked or expired)
@@ -113,7 +113,7 @@ export default function AuthenticatedLayout({ children, email }: { children: Rea
   }, [router])
 
   const initials = getInitials(email)
-  const userName = getDisplayName(email)
+  const userName = displayName || getDisplayName(email)
 
   return (
     <NavigationProvider userName={userName}>


### PR DESCRIPTION
## Summary

- Reads `display_name` (saved by Settings → Profile) or `full_name` (set at signup) from `user.user_metadata` in the server layout
- Passes it as `displayName` prop to `AuthenticatedLayout`, which feeds it into `NavigationProvider` as `userName`
- Falls back to the email-derived first name when neither metadata field is set (existing behaviour for older accounts)

## Test plan

- [ ] User with a saved display name sees "Hi, [Full Name]" on the Overview top bar
- [ ] User with no display name set still sees the email-derived first name

Generated with Claude Code