### PR TITLE
fix(nav): clear mobile top bar title on page unmount

### DIFF
--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -243,6 +243,7 @@ export default function PlanningClient() {
         </div>
       ),
     })
+    return () => setMobileTopBar({ title: '' })
   }, [month, year, isVI, navigatePrev, navigateNext, setMobileTopBar])
 
   return (

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -387,6 +387,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
       title: isVI ? 'Tùy chọn' : 'Preferences',
       subtitle: isVI ? 'Cài đặt' : 'Settings',
     })
+    return () => setMobileTopBar({ title: '' })
   }, [isVI, setMobileTopBar])
 
   function switchLocale(next: string) {

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -364,6 +364,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
         </button>
       ),
     })
+    return () => setMobileTopBar({ title: '' })
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userName, data])
 


### PR DESCRIPTION
## Problem

Navigating from Settings or Plan to the Funds page left the previous page's title (e.g. "Preferences" or "Budget") visible in the global mobile top bar, because the Funds page renders its own local top bar and never resets the NavigationContext title.

## Fix

Added `return () => setMobileTopBar({ title: '' })` cleanup to the `useEffect` in all three pages that write to the global top bar (Dashboard, Plan, Settings). When any of these pages unmounts during navigation, the context title is cleared so the next page starts with a blank slot.

## Test plan

- [ ] Settings → Funds: no stale "Preferences" header above the Funds list
- [ ] Plan → Funds: no stale "Budget" header above the Funds list
- [ ] Overview → Funds: same
- [ ] Funds → Overview/Plan/Settings: those pages still show their own titles correctly

Generated with Claude Code