### PR TITLE
fix(funds): consistent mobile top bar position

### DIFF
--- a/app/(app)/funds/FundLibraryClient.tsx
+++ b/app/(app)/funds/FundLibraryClient.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { useTranslations } from 'next-intl'
-import MobileTopBar from '@/app/components/navigation/MobileTopBar'
 import { Plus, Edit, Trash2, RefreshCw, ArrowUpDown, Info, AlertTriangle } from 'lucide-react'
 import MobileFundLibraryView from './components/MobileFundLibraryView'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
@@ -342,7 +341,6 @@ export default function FundLibraryClient() {
       {/* Desktop view */}
       <div className="hidden md:block">
       <div className="space-y-6">
-      <MobileTopBar subtitle={t('pageSubtitle')} title={t('pageTitle')} />
       {/* Toasts */}
       <div className="fixed top-4 right-4 z-50 flex flex-col gap-2">
         {toasts.map((t) => (

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useTranslations } from 'next-intl'
 import { Plus, RefreshCw, Search, X, ChevronDown, Check } from 'lucide-react'
+import { useNavigation } from '@/app/components/navigation/NavigationContext'
 
 function fmtCompactDca(n: number): string {
   const abs = Math.abs(n)
@@ -25,8 +26,6 @@ const IconTrash = ({ size = 14, color = 'currentColor' }: { size?: number; color
     <path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" />
   </svg>
 )
-import MobileTopBar from '@/app/components/navigation/MobileTopBar'
-
 // ─── Types ───────────────────────────────────────────────────────────────────
 
 type FundType = 'balanced' | 'equity' | 'debt' | 'gold'
@@ -430,6 +429,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, onEdit, onDelete
 export default function MobileFundLibraryView() {
   const t = useTranslations('funds')
   const tc = useTranslations('common')
+  const { setMobileTopBar } = useNavigation()
 
   // ── Data ──────────────────────────────────────────────────────────────────
   const [funds, setFunds] = useState<Fund[]>(() => getCache() ?? [])
@@ -487,6 +487,50 @@ export default function MobileFundLibraryView() {
 
   useEffect(() => { loadFunds() }, [loadFunds])
 
+  const handleRefreshNav = useCallback(async () => {
+    setRefreshing(true)
+    try {
+      const res = await fetch('/api/v1/funds/refresh-nav', { method: 'POST' })
+      const { results } = await res.json()
+      const updated = results.filter((r: { nav?: number }) => r.nav !== undefined).length
+      const failed = results.filter((r: { error?: string }) => r.error).length
+      bustCache()
+      await loadFunds({ force: true })
+      addToast(`${updated} updated${failed ? `, ${failed} failed` : ''}`, failed > 0 && updated === 0 ? 'error' : 'success')
+    } catch {
+      addToast('Failed to refresh NAV', 'error')
+    } finally {
+      setRefreshing(false)
+    }
+  }, [loadFunds, addToast])
+
+  useEffect(() => {
+    setMobileTopBar({
+      title: t('pageTitle'),
+      subtitle: t('pageSubtitle'),
+      trailing: (
+        <div style={{ display: 'flex', gap: 6 }}>
+          <button
+            onClick={handleRefreshNav}
+            disabled={refreshing || !funds.some((f) => f.nav_source_url)}
+            aria-label="Refresh NAV"
+            style={{ padding: 8, background: 'transparent', border: '1px solid var(--c-line)', borderRadius: 10, cursor: 'pointer', display: 'flex', alignItems: 'center', opacity: refreshing || !funds.some((f) => f.nav_source_url) ? 0.4 : 1 }}
+          >
+            <RefreshCw size={16} color="var(--c-ink)" style={{ animation: refreshing ? 'spin 1s linear infinite' : 'none' }} />
+          </button>
+          <button
+            onClick={() => { setFormError(null); setAddOpen(true) }}
+            style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 12px', fontSize: 12, fontWeight: 600, background: 'var(--c-navy)', color: '#fff', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit' }}
+          >
+            <Plus size={14} strokeWidth={2.5} />
+            Add
+          </button>
+        </div>
+      ),
+    })
+    return () => setMobileTopBar({ title: '' })
+  }, [t, refreshing, funds, handleRefreshNav, setFormError, setAddOpen, setMobileTopBar])
+
   // ── Sorted/filtered list ──────────────────────────────────────────────────
 
   const sortedFunds = useMemo(() => {
@@ -511,23 +555,6 @@ export default function MobileFundLibraryView() {
   function handleSort(key: SortKey) {
     if (sortKey === key) setSortAsc((v) => !v)
     else { setSortKey(key); setSortAsc(true) }
-  }
-
-  async function handleRefreshNav() {
-    setRefreshing(true)
-    try {
-      const res = await fetch('/api/v1/funds/refresh-nav', { method: 'POST' })
-      const { results } = await res.json()
-      const updated = results.filter((r: { nav?: number }) => r.nav !== undefined).length
-      const failed = results.filter((r: { error?: string }) => r.error).length
-      bustCache()
-      await loadFunds({ force: true })
-      addToast(`${updated} updated${failed ? `, ${failed} failed` : ''}`, failed > 0 && updated === 0 ? 'error' : 'success')
-    } catch {
-      addToast('Failed to refresh NAV', 'error')
-    } finally {
-      setRefreshing(false)
-    }
   }
 
   async function handleSave(data: SavePayload, existingId?: string) {
@@ -632,31 +659,7 @@ export default function MobileFundLibraryView() {
         ))}
       </div>
 
-      <MobileTopBar
-        title={t('pageTitle')}
-        subtitle={t('pageSubtitle')}
-        trailing={
-          <div style={{ display: 'flex', gap: 6 }}>
-            <button
-              onClick={handleRefreshNav}
-              disabled={refreshing || !funds.some((f) => f.nav_source_url)}
-              aria-label="Refresh NAV"
-              style={{ padding: 8, background: 'transparent', border: '1px solid var(--c-line)', borderRadius: 10, cursor: 'pointer', display: 'flex', alignItems: 'center', opacity: refreshing || !funds.some((f) => f.nav_source_url) ? 0.4 : 1 }}
-            >
-              <RefreshCw size={16} color="var(--c-ink)" style={{ animation: refreshing ? 'spin 1s linear infinite' : 'none' }} />
-            </button>
-            <button
-              onClick={() => { setFormError(null); setAddOpen(true) }}
-              style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 12px', fontSize: 12, fontWeight: 600, background: 'var(--c-navy)', color: '#fff', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit' }}
-            >
-              <Plus size={14} strokeWidth={2.5} />
-              Add
-            </button>
-          </div>
-        }
-      />
-
-      <div style={{ padding: '8px 16px 96px', display: 'grid', gap: 10 }}>
+      <div style={{ padding: '0 0 96px', display: 'grid', gap: 10 }}>
         {/* Search */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 12px', background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 10 }}>
           <Search size={16} color="var(--c-muted)" style={{ flexShrink: 0 }} />

--- a/app/components/navigation/MobileTopBar.tsx
+++ b/app/components/navigation/MobileTopBar.tsx
@@ -12,6 +12,7 @@ interface MobileTopBarProps {
 export default function MobileTopBar({ title, subtitle, trailing, dense }: MobileTopBarProps) {
   return (
     <header
+      data-testid="mobile-top-bar"
       className="md:hidden"
       style={{
         position: 'sticky',

--- a/e2e/funds.spec.ts
+++ b/e2e/funds.spec.ts
@@ -12,10 +12,10 @@ test('mobile funds shows header with title and action buttons', async ({ page })
   await page.goto('/funds')
   await page.waitForLoadState('networkidle')
 
-  const mf = page.getByTestId('mobile-funds')
-  await expect(mf.getByText(/thư viện quỹ|fund library/i)).toBeVisible({ timeout: 10_000 })
-  await expect(mf.getByRole('button', { name: /add/i })).toBeVisible()
-  await expect(mf.getByRole('button', { name: /refresh/i })).toBeVisible()
+  const topBar = page.getByTestId('mobile-top-bar')
+  await expect(topBar.getByText(/thư viện quỹ|fund library/i)).toBeVisible({ timeout: 10_000 })
+  await expect(topBar.getByRole('button', { name: /add/i })).toBeVisible()
+  await expect(topBar.getByRole('button', { name: /refresh nav/i })).toBeVisible()
 })
 
 test('mobile funds shows type filter chips', async ({ page }) => {
@@ -97,8 +97,8 @@ test('mobile funds add button opens add fund sheet', async ({ page }) => {
   await page.goto('/funds')
   await page.waitForLoadState('networkidle')
 
-  const mf = page.getByTestId('mobile-funds')
-  await mf.getByRole('button', { name: /add/i }).click()
+  const topBar = page.getByTestId('mobile-top-bar')
+  await topBar.getByRole('button', { name: /add/i }).click()
   await expect(page.getByTestId('fund-sheet')).toBeVisible({ timeout: 5_000 })
   await expect(page.getByTestId('fund-sheet').getByText(/add fund|thêm quỹ/i)).toBeVisible()
 })


### PR DESCRIPTION
## Summary
- Funds page was rendering its own `<MobileTopBar>` inside `<main>`, giving it extra vertical gap (from `py-4`) and doubled horizontal padding (from `px-4`) compared to other pages
- Dashboard, Plan, and Settings all write to `NavigationContext` so `AuthenticatedLayout` renders the bar *outside* `<main>`
- Converted `MobileFundLibraryView` to the same pattern: `setMobileTopBar` in a `useEffect` with cleanup, removed local `<MobileTopBar>` render
- Wrapped `handleRefreshNav` in `useCallback` so it's stable and safe to include in the effect's deps array
- Adjusted content div padding from `'8px 16px 96px'` → `'0 0 96px'` since `<main>`'s `px-4 py-4` now handles the outer spacing

## Test plan
- [ ] Navigate to Funds page from Settings — top bar position should match Settings/Plan height exactly
- [ ] Navigate to Funds page from Plan — no stale title should appear (cleanup runs on unmount)
- [ ] Refresh NAV button and Add button in the top bar trailing area should work correctly
- [ ] Fund cards should have the same horizontal alignment as cards on other pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)