### PR TITLE
fix(dashboard): translate greeting on mobile top bar

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -347,7 +347,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
 
   useEffect(() => {
     setMobileTopBar({
-      title: `Hi, ${userName}`,
+      title: t('greeting', { name: userName }),
       subtitle: t('overview'),
       trailing: (
         <button

--- a/messages/en.json
+++ b/messages/en.json
@@ -342,6 +342,7 @@
   "dashboard": {
     "title": "Asset Overview",
     "overview": "Overview",
+    "greeting": "Hi, {name}",
     "sortManual": "Manual",
     "sortProgressDesc": "Progress ↓",
     "sortProgressAsc": "Progress ↑",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -342,7 +342,7 @@
   "dashboard": {
     "title": "Tổng Quan Tài Sản",
     "overview": "Tổng quan",
-    "greeting": "Chào, {name}",
+    "greeting": "Xin chào, {name}",
     "sortManual": "Thủ công",
     "sortProgressDesc": "Tiến độ ↓",
     "sortProgressAsc": "Tiến độ ↑",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -342,6 +342,7 @@
   "dashboard": {
     "title": "Tổng Quan Tài Sản",
     "overview": "Tổng quan",
+    "greeting": "Chào, {name}",
     "sortManual": "Thủ công",
     "sortProgressDesc": "Tiến độ ↓",
     "sortProgressAsc": "Tiến độ ↑",


### PR DESCRIPTION
## Summary
- \"Hi\" in the mobile top bar greeting was hardcoded English
- Added `greeting` key to both `en.json` (`"Hi, {name}"`) and `vi.json` (`"Chào, {name}"`)
- Updated `DashboardClient.tsx` to use `t('greeting', { name: userName })`

## Test plan
- [ ] In English locale: top bar shows "Hi, [Name]"
- [ ] In Vietnamese locale: top bar shows "Chào, [Tên]"

🤖 Generated with [Claude Code](https://claude.com/claude-code)