### PR TITLE
feat(font): switch to Be Vietnam Pro

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -89,7 +89,7 @@
   --color-brand-light: var(--brand-light);
   --color-brand-dark: var(--brand-dark);
   --color-canvas: var(--c-canvas);
-  --font-sans: "DM Sans", var(--font-dm-sans), "Geist", var(--font-geist), ui-sans-serif, system-ui, sans-serif;
+  --font-sans: "Be Vietnam Pro", var(--font-be-vietnam), "Geist", var(--font-geist), ui-sans-serif, system-ui, sans-serif;
   --font-mono: ui-monospace, monospace;
   --font-heading: var(--font-sans);
   --color-sidebar-ring: var(--sidebar-ring);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata, Viewport } from 'next'
-import { DM_Sans, Geist } from 'next/font/google'
+import { Be_Vietnam_Pro, Geist } from 'next/font/google'
 import { Toaster } from 'sonner'
 import ThemeProvider from './components/ThemeProvider'
 import ServiceWorkerRegistration from './components/ServiceWorkerRegistration'
@@ -8,9 +8,9 @@ import { getMessages, getLocale } from 'next-intl/server'
 import './globals.css'
 import { cn } from "@/lib/utils";
 
-const dmSans = DM_Sans({
-  subsets: ['latin', 'latin-ext'],
-  variable: '--font-dm-sans',
+const beVietnamPro = Be_Vietnam_Pro({
+  subsets: ['latin', 'latin-ext', 'vietnamese'],
+  variable: '--font-be-vietnam',
   weight: ['400', '500', '600', '700'],
 })
 
@@ -48,11 +48,11 @@ export default async function RootLayout({
   const locale = await getLocale()
 
   return (
-    <html lang={locale} suppressHydrationWarning className={cn("font-sans", dmSans.variable, geist.variable)}>
+    <html lang={locale} suppressHydrationWarning className={cn("font-sans", beVietnamPro.variable, geist.variable)}>
       <head>
         <script dangerouslySetInnerHTML={{ __html: `try{var t=localStorage.getItem('theme');if(t==='dark'||(!t&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}` }} />
       </head>
-      <body className={`${dmSans.variable} font-sans antialiased bg-canvas dark:bg-gray-950 text-gray-900 dark:text-gray-100`}>
+      <body className={`${beVietnamPro.variable} font-sans antialiased bg-canvas dark:bg-gray-950 text-gray-900 dark:text-gray-100`}>
         <NextIntlClientProvider messages={messages} locale={locale}>
           <ThemeProvider>
             {children}


### PR DESCRIPTION
## Summary
- Design spec (`tokens.css`) defines `--font-sans: "Be Vietnam Pro", -apple-system, "Helvetica Neue", sans-serif`
- App was using DM Sans; switched to Be Vietnam Pro via `next/font/google`
- Added `vietnamese` subset alongside `latin` and `latin-ext` — Be Vietnam Pro was designed specifically for Vietnamese, so glyphs are native and high quality
- Geist kept as fallback in the CSS variable chain

## Changes
- `app/layout.tsx` — replaced `DM_Sans` with `Be_Vietnam_Pro`, added `vietnamese` subset, updated CSS variable name to `--font-be-vietnam`
- `app/globals.css` — updated `--font-sans` to reference `"Be Vietnam Pro"` and `--font-be-vietnam`

## Test plan
- [ ] Check overall app typography on the Vercel preview — headings, body text, numbers
- [ ] Check Vietnamese text renders cleanly (diacritics like ổ, ề, ụ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)