### PR TITLE
feat(desktop): Assign to Goal as centered modal

### DIFF
--- a/app/api/v1/savings-goals/route.ts
+++ b/app/api/v1/savings-goals/route.ts
@@ -70,7 +70,11 @@ export async function GET(request: NextRequest) {
 
   const goalsWithStats = (goals ?? []).map((g) => {
     const stats = statsMap.get(g.goal_id) ?? { count: 0, invested: 0, interest: 0 }
-    return { ...g, transactionCount: stats.count, totalInvested: stats.invested, projectedInterest: stats.interest }
+    const current_value = stats.invested + stats.interest
+    const progress_percentage = g.target_amount && g.target_amount > 0
+      ? Math.min(100, (current_value / g.target_amount) * 100)
+      : null
+    return { ...g, transactionCount: stats.count, totalInvested: stats.invested, projectedInterest: stats.interest, current_value, progress_percentage }
   })
 
   return NextResponse.json({ goals: goalsWithStats })

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -217,11 +217,13 @@ export default function DashboardClient({ userId }: { userId: string }) {
   const [error, setError] = useState('')
   const [fundDetailId, setFundDetailId] = useState<string | null>(null)
   const [goalPickerFundId, setGoalPickerFundId] = useState<string | null>(null)
+  const [goalPickerFundItem, setGoalPickerFundItem] = useState<{ name: string; value: number; type: string } | null>(null)
   const [assignLoading, setAssignLoading] = useState(false)
   const [assignError, setAssignError] = useState('')
   const [purchaseHistory, setPurchaseHistory] = useState<PurchaseHistory[]>([])
   const [historyLoading, setHistoryLoading] = useState(false)
   const [nonFundPickerTxId, setNonFundPickerTxId] = useState<string | null>(null)
+  const [nonFundPickerItem, setNonFundPickerItem] = useState<{ name: string; value: number; type: string } | null>(null)
   const [nonFundAssignLoading, setNonFundAssignLoading] = useState(false)
   const [nonFundAssignError, setNonFundAssignError] = useState('')
   const [goalSort, setGoalSort] = useState<SortValue>('manual')
@@ -702,9 +704,9 @@ export default function DashboardClient({ userId }: { userId: string }) {
                       funds={data.unallocated.funds}
                       nonFunds={data.unallocated.nonFunds}
                       onFundClick={handleFundClick}
-                      onAssignToGoal={(fundId) => setGoalPickerFundId(fundId)}
+                      onAssignToGoal={(fundId, name, value, type) => { setGoalPickerFundId(fundId); setGoalPickerFundItem({ name, value, type }) }}
                       onSellFund={openSellFund}
-                      onAssignNonFundToGoal={(txId) => setNonFundPickerTxId(txId)}
+                      onAssignNonFundToGoal={(txId, name, value, type) => { setNonFundPickerTxId(txId); setNonFundPickerItem({ name, value, type }) }}
                       onSellNonFund={openSellNonFund}
                       desktopCard
                     />
@@ -833,9 +835,9 @@ export default function DashboardClient({ userId }: { userId: string }) {
                   funds={data.unallocated.funds}
                   nonFunds={data.unallocated.nonFunds}
                   onFundClick={handleFundClick}
-                  onAssignToGoal={(fundId) => setGoalPickerFundId(fundId)}
+                  onAssignToGoal={(fundId, name, value, type) => { setGoalPickerFundId(fundId); setGoalPickerFundItem({ name, value, type }) }}
                   onSellFund={openSellFund}
-                  onAssignNonFundToGoal={(txId) => setNonFundPickerTxId(txId)}
+                  onAssignNonFundToGoal={(txId, name, value, type) => { setNonFundPickerTxId(txId); setNonFundPickerItem({ name, value, type }) }}
                   onSellNonFund={openSellNonFund}
                 />
               )}
@@ -910,7 +912,8 @@ export default function DashboardClient({ userId }: { userId: string }) {
       {/* Assign Goal Sheet — funds */}
       <AssignGoalSheet
         open={!!goalPickerFundId}
-        onClose={() => { setGoalPickerFundId(null); fetchData({ force: true }) }}
+        onClose={() => { setGoalPickerFundId(null); setGoalPickerFundItem(null); fetchData({ force: true }) }}
+        item={goalPickerFundItem ?? undefined}
         desktop={isDesktop}
         onConfirm={async (goalId) => {
           if (!goalPickerFundId) return
@@ -932,7 +935,8 @@ export default function DashboardClient({ userId }: { userId: string }) {
       {/* Assign Goal Sheet — non-funds */}
       <AssignGoalSheet
         open={!!nonFundPickerTxId}
-        onClose={() => { setNonFundPickerTxId(null); fetchData({ force: true }) }}
+        onClose={() => { setNonFundPickerTxId(null); setNonFundPickerItem(null); fetchData({ force: true }) }}
+        item={nonFundPickerItem ?? undefined}
         desktop={isDesktop}
         onConfirm={async (goalId) => {
           if (!nonFundPickerTxId) return

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -709,6 +709,31 @@ export default function DashboardClient({ userId }: { userId: string }) {
                       onAssignNonFundToGoal={(txId, name, value, type) => { setNonFundPickerTxId(txId); setNonFundPickerItem({ name, value, type }) }}
                       onSellNonFund={openSellNonFund}
                       desktopCard
+                      onDesktopAssign={async (kind, id, goalId) => {
+                        if (kind === 'fund') {
+                          const res = await fetch(`/api/v1/fund-investments?fund_id=${id}`)
+                          if (!res.ok) throw new Error('Failed to fetch fund investments')
+                          const investments = await res.json() as Array<{ id: string }>
+                          await Promise.all(investments.map((inv) =>
+                            fetch(`/api/v1/fund-investments/${inv.id}/goal`, {
+                              method: 'PATCH',
+                              headers: { 'Content-Type': 'application/json' },
+                              body: JSON.stringify({ goal_id: goalId }),
+                            }).then((r) => { if (!r.ok) throw new Error('Failed to assign') })
+                          ))
+                        } else {
+                          const res = await fetch(`/api/v1/investment-transactions/${id}/assign`, {
+                            method: 'PUT',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ goal_id: goalId }),
+                          })
+                          if (!res.ok) {
+                            const { error: e } = await res.json().catch(() => ({ error: 'Failed to assign' }))
+                            throw new Error(e ?? 'Failed to assign')
+                          }
+                        }
+                        fetchData({ force: true })
+                      }}
                     />
                   </div>
                 )}

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -911,6 +911,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
       <AssignGoalSheet
         open={!!goalPickerFundId}
         onClose={() => { setGoalPickerFundId(null); fetchData({ force: true }) }}
+        desktop={isDesktop}
         onConfirm={async (goalId) => {
           if (!goalPickerFundId) return
           const res = await fetch(`/api/v1/fund-investments?fund_id=${goalPickerFundId}`)
@@ -932,6 +933,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
       <AssignGoalSheet
         open={!!nonFundPickerTxId}
         onClose={() => { setNonFundPickerTxId(null); fetchData({ force: true }) }}
+        desktop={isDesktop}
         onConfirm={async (goalId) => {
           if (!nonFundPickerTxId) return
           const res = await fetch(`/api/v1/investment-transactions/${nonFundPickerTxId}/assign`, {

--- a/app/assets/components/AssignGoalSheet.tsx
+++ b/app/assets/components/AssignGoalSheet.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Check, X, TrendingUp, Building2, Coins } from 'lucide-react'
+import { Check, X, TrendingUp, Building2, Coins, ArrowRight } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmt, fmtCompact } from '@/lib/formatters'
 
@@ -32,6 +32,12 @@ const TYPE_ICON: Record<string, React.ElementType> = {
   fund:  TrendingUp,
   bank:  Building2,
   gold:  Coins,
+}
+const TYPE_COLOR: Record<string, string> = {
+  fund:  '#2563eb',
+  bank:  '#047857',
+  gold:  '#d97706',
+  stock: '#7c3aed',
 }
 
 export default function AssignGoalSheet({ open, onClose, onConfirm, item, desktop }: Props) {
@@ -94,6 +100,7 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, item, deskto
   const selectedGoal = goals.find((g) => g.id === selected)
 
   const ItemIcon = item ? (TYPE_ICON[item.type] ?? TrendingUp) : null
+  const itemIconColor = item ? (TYPE_COLOR[item.type] ?? 'var(--c-navy)') : 'var(--c-navy)'
 
   const body = success ? (
     <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '32px 0', textAlign: 'center' }}>
@@ -114,14 +121,14 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, item, deskto
       {/* Item chip */}
       {item && ItemIcon && (
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 12px', background: 'var(--c-card-2)', borderRadius: 10 }}>
-          <div style={{ width: 32, height: 32, borderRadius: 8, background: 'var(--c-card)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--c-navy)', border: '1px solid var(--c-line)', flexShrink: 0 }}>
+          <div style={{ width: 32, height: 32, borderRadius: 8, background: 'var(--c-card)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: itemIconColor, border: '1px solid var(--c-line)', flexShrink: 0 }}>
             <ItemIcon size={15} strokeWidth={1.8} />
           </div>
           <div style={{ flex: 1, minWidth: 0 }}>
             <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--c-ink)' }}>{item.name}</div>
             <div style={{ fontSize: 11, color: 'var(--c-muted)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(item.value)}</div>
           </div>
-          <div style={{ color: 'var(--c-muted)', display: 'flex' }}>→</div>
+          <ArrowRight size={14} color="var(--c-muted)" />
           <div style={{
             fontSize: 12, fontWeight: 600, padding: '4px 10px',
             background: selectedGoal ? 'var(--c-navy-tint)' : 'var(--c-line)',
@@ -194,7 +201,7 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, item, deskto
                   )}
                 </div>
                 {g.progressPercent != null && (
-                  <div style={{ height: 4, background: 'var(--c-line)', borderRadius: 999, overflow: 'hidden', marginTop: 8 }}>
+                  <div style={{ height: 4, background: 'var(--c-card-2)', borderRadius: 999, overflow: 'hidden', marginTop: 8 }}>
                     <div style={{
                       height: '100%', borderRadius: 999,
                       width: `${Math.min(100, Math.max(0, g.progressPercent))}%`,
@@ -212,25 +219,16 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, item, deskto
       <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
         <button
           onClick={onClose}
-          style={{
-            flex: 1, padding: '12px 0', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
-            background: 'transparent', border: '1px solid var(--c-line)', color: 'var(--c-ink)',
-            fontSize: 14, fontWeight: 500,
-          }}
+          className="cn-btn"
+          style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}
         >
           {isVI ? 'Hủy' : 'Cancel'}
         </button>
         <button
           onClick={handleConfirm}
           disabled={!selected || confirming}
-          style={{
-            flex: 2, padding: '12px 0', borderRadius: 10, border: 'none', cursor: selected && !confirming ? 'pointer' : 'default',
-            background: selected ? 'var(--c-navy)' : 'var(--c-line)',
-            color: selected ? '#fff' : 'var(--c-muted)',
-            fontSize: 14, fontWeight: 600, fontFamily: 'inherit',
-            opacity: confirming ? 0.7 : 1, transition: 'background 0.15s',
-            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
-          }}
+          className={selected && !confirming ? 'cn-btn primary' : 'cn-btn'}
+          style={{ flex: 2, justifyContent: 'center', opacity: !selected || confirming ? 0.5 : 1 }}
         >
           {confirming ? (isVI ? 'Đang xử lý…' : 'Assigning…') : (
             <>

--- a/app/assets/components/AssignGoalSheet.tsx
+++ b/app/assets/components/AssignGoalSheet.tsx
@@ -1,15 +1,22 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Check, X } from 'lucide-react'
+import { Check, X, TrendingUp, Building2, Coins } from 'lucide-react'
 import { useLocale } from 'next-intl'
-import { fmt } from '@/lib/formatters'
+import { fmt, fmtCompact } from '@/lib/formatters'
 
 interface GoalOption {
   id: string
   name: string
   currentValue: number
+  targetAmount: number | null
   progressPercent: number | null
+}
+
+interface AssignItem {
+  name: string
+  value: number
+  type: string
 }
 
 interface Props {
@@ -17,10 +24,17 @@ interface Props {
   onClose: () => void
   /** Called with the selected goalId. Should throw on failure. */
   onConfirm: (goalId: string) => Promise<void>
+  item?: AssignItem
   desktop?: boolean
 }
 
-export default function AssignGoalSheet({ open, onClose, onConfirm, desktop }: Props) {
+const TYPE_ICON: Record<string, React.ElementType> = {
+  fund:  TrendingUp,
+  bank:  Building2,
+  gold:  Coins,
+}
+
+export default function AssignGoalSheet({ open, onClose, onConfirm, item, desktop }: Props) {
   const isVI = useLocale() === 'vi'
   const [mounted, setMounted] = useState(false)
   const [goals, setGoals] = useState<GoalOption[]>([])
@@ -40,12 +54,13 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, desktop }: P
       setGoalsLoading(true)
       fetch('/api/v1/savings-goals')
         .then((r) => r.ok ? r.json() : { goals: [] })
-        .then((res: { goals?: Array<{ goal_id: string; goal_name: string; current_value?: number; progress_percentage?: number | null }> }) => {
+        .then((res: { goals?: Array<{ goal_id: string; goal_name: string; current_value?: number; target_amount?: number | null; progress_percentage?: number | null }> }) => {
           const rows = res.goals ?? []
           setGoals(rows.map((g) => ({
             id: g.goal_id,
             name: g.goal_name,
             currentValue: g.current_value ?? 0,
+            targetAmount: g.target_amount ?? null,
             progressPercent: g.progress_percentage ?? null,
           })))
         })
@@ -76,93 +91,157 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, desktop }: P
   if (desktop ? !open : !mounted) return null
 
   const title = isVI ? 'Gán vào mục tiêu' : 'Assign to goal'
+  const selectedGoal = goals.find((g) => g.id === selected)
+
+  const ItemIcon = item ? (TYPE_ICON[item.type] ?? TrendingUp) : null
 
   const body = success ? (
-          <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '32px 16px' }}>
-            <div style={{
-              width: 56, height: 56, borderRadius: '50%',
-              background: 'var(--c-pos-tint)', display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 12,
-            }}>
-              <Check size={28} color="var(--c-pos)" />
-            </div>
-            <p style={{ fontWeight: 700, fontSize: 15, color: 'var(--c-ink)' }}>
-              {isVI ? `Đã gán vào ${successName}` : `Assigned to ${successName}`}
-            </p>
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '32px 0', textAlign: 'center' }}>
+      <div style={{
+        width: 56, height: 56, borderRadius: '50%',
+        background: 'var(--c-pos-tint)', color: 'var(--c-pos)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 12,
+      }}>
+        <Check size={28} strokeWidth={2.5} />
+      </div>
+      <p style={{ fontWeight: 700, fontSize: 15, color: 'var(--c-ink)', margin: '0 0 4px' }}>
+        {isVI ? 'Đã gán thành công' : 'Assigned successfully'}
+      </p>
+      <p style={{ fontSize: 13, color: 'var(--c-navy)', fontWeight: 600, margin: 0 }}>{successName}</p>
+    </div>
+  ) : (
+    <div style={{ display: 'grid', gap: 14 }}>
+      {/* Item chip */}
+      {item && ItemIcon && (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 12px', background: 'var(--c-card-2)', borderRadius: 10 }}>
+          <div style={{ width: 32, height: 32, borderRadius: 8, background: 'var(--c-card)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--c-navy)', border: '1px solid var(--c-line)', flexShrink: 0 }}>
+            <ItemIcon size={15} strokeWidth={1.8} />
           </div>
-        ) : (
-          <>
-            {error && (
-              <p style={{ fontSize: 13, color: 'var(--c-neg)', padding: '8px 16px 0' }}>{error}</p>
-            )}
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--c-ink)' }}>{item.name}</div>
+            <div style={{ fontSize: 11, color: 'var(--c-muted)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(item.value)}</div>
+          </div>
+          <div style={{ color: 'var(--c-muted)', display: 'flex' }}>→</div>
+          <div style={{
+            fontSize: 12, fontWeight: 600, padding: '4px 10px',
+            background: selectedGoal ? 'var(--c-navy-tint)' : 'var(--c-line)',
+            color: selectedGoal ? 'var(--c-navy)' : 'var(--c-muted)',
+            borderRadius: 8, whiteSpace: 'nowrap', maxWidth: 100, overflow: 'hidden', textOverflow: 'ellipsis',
+          }}>
+            {selectedGoal ? selectedGoal.name : (isVI ? 'Chọn...' : 'Choose…')}
+          </div>
+        </div>
+      )}
 
-            <div style={{ flex: 1, overflowY: 'auto', padding: '12px 16px 0' }}>
-              {goalsLoading && (
-                <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0' }}>
-                  {isVI ? 'Đang tải…' : 'Loading…'}
-                </p>
-              )}
-              {!goalsLoading && goals.length === 0 && (
-                <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0' }}>
-                  {isVI ? 'Chưa có mục tiêu nào' : 'No goals yet'}
-                </p>
-              )}
-              {!goalsLoading && goals.map((g) => {
-                const isSelected = selected === g.id
-                return (
-                  <button
-                    key={g.id}
-                    onClick={() => setSelected(g.id)}
-                    style={{
-                      display: 'block', width: '100%', textAlign: 'left',
-                      padding: '12px 14px', marginBottom: 8, borderRadius: 12, cursor: 'pointer',
-                      border: `2px solid ${isSelected ? 'var(--c-navy)' : 'var(--c-line)'}`,
-                      background: isSelected ? 'var(--c-navy-tint)' : 'var(--c-card)',
-                    }}
-                  >
-                    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                      <p style={{ fontWeight: 600, fontSize: 14, color: 'var(--c-ink)' }}>{g.name}</p>
-                      {g.progressPercent != null && (
-                        <p style={{ fontSize: 12, color: 'var(--c-muted)' }}>
-                          {Math.round(g.progressPercent)}%
-                        </p>
-                      )}
-                    </div>
-                    <p style={{ fontSize: 12, color: 'var(--c-muted)', marginTop: 2 }}>{fmt(g.currentValue)}</p>
-                    {g.progressPercent != null && (
-                      <div style={{ height: 4, background: 'var(--c-line)', borderRadius: 999, overflow: 'hidden', marginTop: 8 }}>
-                        <div style={{
-                          height: '100%', borderRadius: 999,
-                          width: `${Math.min(100, Math.max(0, g.progressPercent))}%`,
-                          background: 'var(--c-navy)',
-                        }} />
-                      </div>
-                    )}
-                  </button>
-                )
-              })}
-            </div>
+      {error && (
+        <p style={{ fontSize: 13, color: 'var(--c-neg)', margin: 0 }}>{error}</p>
+      )}
 
-            <div style={{ padding: '12px 16px 16px', flexShrink: 0 }}>
+      {/* Goal list */}
+      <div>
+        <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 10 }}>
+          {isVI ? 'Chọn mục tiêu' : 'Choose a goal'}
+        </div>
+        <div style={{ display: 'grid', gap: 8 }}>
+          {goalsLoading && (
+            <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0', margin: 0 }}>
+              {isVI ? 'Đang tải…' : 'Loading…'}
+            </p>
+          )}
+          {!goalsLoading && goals.length === 0 && (
+            <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0', margin: 0 }}>
+              {isVI ? 'Chưa có mục tiêu nào' : 'No goals yet'}
+            </p>
+          )}
+          {!goalsLoading && goals.map((g) => {
+            const isSel = selected === g.id
+            const isComplete = g.progressPercent != null && g.progressPercent >= 100
+            const remaining = g.targetAmount != null ? Math.max(0, g.targetAmount - g.currentValue) : null
+            return (
               <button
-                onClick={handleConfirm}
-                disabled={!selected || confirming}
+                key={g.id}
+                onClick={() => setSelected(g.id)}
                 style={{
-                  width: '100%', padding: '14px 0', borderRadius: 12, border: 'none',
-                  background: selected ? 'var(--c-navy)' : 'var(--c-line)',
-                  color: selected ? '#fff' : 'var(--c-muted)',
-                  fontSize: 15, fontWeight: 700,
-                  cursor: selected && !confirming ? 'pointer' : 'default',
-                  opacity: confirming ? 0.7 : 1,
-                  transition: 'background 0.15s',
+                  width: '100%', textAlign: 'left', padding: '12px 14px',
+                  background: isSel ? 'var(--c-navy-tint)' : 'var(--c-card)',
+                  border: `1.5px solid ${isSel ? 'var(--c-navy)' : 'var(--c-line)'}`,
+                  borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit',
+                  transition: 'border-color 120ms, background 120ms',
                 }}
               >
-                {confirming
-                  ? (isVI ? 'Đang xử lý…' : 'Assigning…')
-                  : (isVI ? 'Xác nhận gán' : 'Confirm assignment')}
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 13, fontWeight: 600, color: isSel ? 'var(--c-navy)' : 'var(--c-ink)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {g.name}
+                    </div>
+                    <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>
+                      {isComplete
+                        ? (isVI ? 'Đã hoàn thành' : 'Completed')
+                        : remaining != null
+                          ? `${fmtCompact(remaining)} ${isVI ? 'còn lại' : 'remaining'}`
+                          : fmt(g.currentValue)}
+                    </div>
+                  </div>
+                  {g.progressPercent != null && (
+                    <div style={{ fontSize: 12, fontWeight: 600, color: isSel ? 'var(--c-navy)' : 'var(--c-ink)', flexShrink: 0 }}>
+                      {Math.round(g.progressPercent)}%
+                    </div>
+                  )}
+                  {isSel && (
+                    <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                      <Check size={12} strokeWidth={2.5} color="#fff" />
+                    </div>
+                  )}
+                </div>
+                {g.progressPercent != null && (
+                  <div style={{ height: 4, background: 'var(--c-line)', borderRadius: 999, overflow: 'hidden', marginTop: 8 }}>
+                    <div style={{
+                      height: '100%', borderRadius: 999,
+                      width: `${Math.min(100, Math.max(0, g.progressPercent))}%`,
+                      background: isComplete ? 'var(--c-pos)' : 'var(--c-navy)',
+                    }} />
+                  </div>
+                )}
               </button>
-            </div>
-          </>
-        )
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+        <button
+          onClick={onClose}
+          style={{
+            flex: 1, padding: '12px 0', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
+            background: 'transparent', border: '1px solid var(--c-line)', color: 'var(--c-ink)',
+            fontSize: 14, fontWeight: 500,
+          }}
+        >
+          {isVI ? 'Hủy' : 'Cancel'}
+        </button>
+        <button
+          onClick={handleConfirm}
+          disabled={!selected || confirming}
+          style={{
+            flex: 2, padding: '12px 0', borderRadius: 10, border: 'none', cursor: selected && !confirming ? 'pointer' : 'default',
+            background: selected ? 'var(--c-navy)' : 'var(--c-line)',
+            color: selected ? '#fff' : 'var(--c-muted)',
+            fontSize: 14, fontWeight: 600, fontFamily: 'inherit',
+            opacity: confirming ? 0.7 : 1, transition: 'background 0.15s',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+          }}
+        >
+          {confirming ? (isVI ? 'Đang xử lý…' : 'Assigning…') : (
+            <>
+              <Check size={14} strokeWidth={2.4} />
+              {isVI ? 'Xác nhận gán' : 'Confirm assignment'}
+            </>
+          )}
+        </button>
+      </div>
+    </div>
+  )
 
   if (desktop) {
     return (
@@ -190,7 +269,7 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, desktop }: P
             <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{title}</h3>
             <button onClick={onClose} aria-label="Close" style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }}><X size={18} /></button>
           </div>
-          <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto', display: 'flex', flexDirection: 'column' }}>
+          <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto' }}>
             {body}
           </div>
         </div>
@@ -223,10 +302,12 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, desktop }: P
         <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '6px auto 0', flexShrink: 0 }} />
 
         <div style={{ padding: '14px 16px 0', flexShrink: 0 }}>
-          <p style={{ fontWeight: 700, fontSize: 16, color: 'var(--c-ink)' }}>{title}</p>
+          <p style={{ fontWeight: 700, fontSize: 16, color: 'var(--c-ink)', margin: 0 }}>{title}</p>
         </div>
 
-        {body}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '12px 16px 16px' }}>
+          {body}
+        </div>
       </div>
     </div>
   )

--- a/app/assets/components/AssignGoalSheet.tsx
+++ b/app/assets/components/AssignGoalSheet.tsx
@@ -58,7 +58,7 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, item, deskto
       setError('')
       setSuccess(false)
       setGoalsLoading(true)
-      fetch('/api/v1/savings-goals')
+      fetch('/api/v1/savings-goals?stats=true')
         .then((r) => r.ok ? r.json() : { goals: [] })
         .then((res: { goals?: Array<{ goal_id: string; goal_name: string; current_value?: number; target_amount?: number | null; progress_percentage?: number | null }> }) => {
           const rows = res.goals ?? []

--- a/app/assets/components/AssignGoalSheet.tsx
+++ b/app/assets/components/AssignGoalSheet.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { Check } from 'lucide-react'
+import { Check, X } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmt } from '@/lib/formatters'
 
@@ -17,9 +17,10 @@ interface Props {
   onClose: () => void
   /** Called with the selected goalId. Should throw on failure. */
   onConfirm: (goalId: string) => Promise<void>
+  desktop?: boolean
 }
 
-export default function AssignGoalSheet({ open, onClose, onConfirm }: Props) {
+export default function AssignGoalSheet({ open, onClose, onConfirm, desktop }: Props) {
   const isVI = useLocale() === 'vi'
   const [mounted, setMounted] = useState(false)
   const [goals, setGoals] = useState<GoalOption[]>([])
@@ -72,39 +73,11 @@ export default function AssignGoalSheet({ open, onClose, onConfirm }: Props) {
     setConfirming(false)
   }
 
-  if (!mounted) return null
+  if (desktop ? !open : !mounted) return null
 
-  return (
-    <div
-      style={{
-        position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.2)',
-        zIndex: 100, pointerEvents: open ? 'auto' : 'none',
-      }}
-      onClick={onClose}
-    >
-      <div
-        role="dialog"
-        aria-modal="true"
-        style={{
-          position: 'absolute', bottom: 0, left: 0, right: 0,
-          background: 'var(--c-card)', borderRadius: '16px 16px 0 0',
-          padding: '0 0 env(safe-area-inset-bottom,0)',
-          maxHeight: '80vh', display: 'flex', flexDirection: 'column',
-          animation: open
-            ? 'slide-up 220ms cubic-bezier(0.2, 0.8, 0.2, 1)'
-            : 'slide-down 180ms ease forwards',
-        }}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '6px auto 0', flexShrink: 0 }} />
+  const title = isVI ? 'Gán vào mục tiêu' : 'Assign to goal'
 
-        <div style={{ padding: '14px 16px 0', flexShrink: 0 }}>
-          <p style={{ fontWeight: 700, fontSize: 16, color: 'var(--c-ink)' }}>
-            {isVI ? 'Gán vào mục tiêu' : 'Assign to goal'}
-          </p>
-        </div>
-
-        {success ? (
+  const body = success ? (
           <div style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '32px 16px' }}>
             <div style={{
               width: 56, height: 56, borderRadius: '50%',
@@ -189,7 +162,71 @@ export default function AssignGoalSheet({ open, onClose, onConfirm }: Props) {
               </button>
             </div>
           </>
-        )}
+        )
+
+  if (desktop) {
+    return (
+      <div
+        onClick={onClose}
+        style={{
+          position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)', zIndex: 200,
+          display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24,
+          animation: 'fade-in 150ms ease', backdropFilter: 'blur(2px)',
+        }}
+      >
+        <div
+          role="dialog"
+          aria-modal="true"
+          onClick={(e) => e.stopPropagation()}
+          style={{
+            width: '100%', maxWidth: 460, maxHeight: 'calc(100vh - 48px)',
+            background: 'var(--c-card)', borderRadius: 16,
+            boxShadow: '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)',
+            display: 'flex', flexDirection: 'column',
+            animation: 'modal-in 200ms cubic-bezier(0.2,0.8,0.2,1)', overflow: 'hidden',
+          }}
+        >
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0 }}>
+            <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{title}</h3>
+            <button onClick={onClose} aria-label="Close" style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }}><X size={18} /></button>
+          </div>
+          <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto', display: 'flex', flexDirection: 'column' }}>
+            {body}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.2)',
+        zIndex: 100, pointerEvents: open ? 'auto' : 'none',
+      }}
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        style={{
+          position: 'absolute', bottom: 0, left: 0, right: 0,
+          background: 'var(--c-card)', borderRadius: '16px 16px 0 0',
+          padding: '0 0 env(safe-area-inset-bottom,0)',
+          maxHeight: '80vh', display: 'flex', flexDirection: 'column',
+          animation: open
+            ? 'slide-up 220ms cubic-bezier(0.2, 0.8, 0.2, 1)'
+            : 'slide-down 180ms ease forwards',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '6px auto 0', flexShrink: 0 }} />
+
+        <div style={{ padding: '14px 16px 0', flexShrink: 0 }}>
+          <p style={{ fontWeight: 700, fontSize: 16, color: 'var(--c-ink)' }}>{title}</p>
+        </div>
+
+        {body}
       </div>
     </div>
   )

--- a/app/assets/components/AssignGoalSheet.tsx
+++ b/app/assets/components/AssignGoalSheet.tsx
@@ -111,8 +111,8 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, item, deskto
       }}>
         <Check size={28} strokeWidth={2.5} />
       </div>
-      <p style={{ fontWeight: 700, fontSize: 15, color: 'var(--c-ink)', margin: '0 0 4px' }}>
-        {isVI ? 'Đã gán thành công' : 'Assigned successfully'}
+      <p style={{ fontWeight: 600, fontSize: 15, color: 'var(--c-ink)', margin: '0 0 4px' }}>
+        {isVI ? 'Đã gán vào' : 'Assigned to'}
       </p>
       <p style={{ fontSize: 13, color: 'var(--c-navy)', fontWeight: 600, margin: 0 }}>{successName}</p>
     </div>

--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -195,7 +195,7 @@ export default function UnallocatedSection({
     setAssignSelected(null)
     setAssignError('')
     setAssignSuccess(false)
-    fetch('/api/v1/savings-goals')
+    fetch('/api/v1/savings-goals?stats=true')
       .then((r) => r.ok ? r.json() : { goals: [] })
       .then((res: { goals?: Array<{ goal_id: string; goal_name: string; current_value?: number; target_amount?: number | null; progress_percentage?: number | null }> }) => {
         const rows = res.goals ?? []

--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -35,8 +35,8 @@ function DesktopAssignPicker({
       <div style={{ width: 56, height: 56, borderRadius: '50%', background: 'var(--c-pos-tint)', color: 'var(--c-pos)', display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 12 }}>
         <Check size={28} strokeWidth={2.5} />
       </div>
-      <p style={{ fontWeight: 700, fontSize: 15, color: 'var(--c-ink)', margin: '0 0 4px' }}>
-        {isVI ? 'Đã gán thành công' : 'Assigned successfully'}
+      <p style={{ fontWeight: 600, fontSize: 15, color: 'var(--c-ink)', margin: '0 0 4px' }}>
+        {isVI ? 'Đã gán vào' : 'Assigned to'}
       </p>
       <p style={{ fontSize: 13, color: 'var(--c-navy)', fontWeight: 600, margin: 0 }}>{successName}</p>
     </div>

--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { ChevronDown, ChevronUp, ChevronRight, Target, Building, CircleDollarSign, TrendingUp, BarChart2, Clock, ArrowDownToLine, ArrowDownRight, Wallet, Check, X } from 'lucide-react'
+import { ChevronDown, ChevronUp, ChevronRight, Target, Building, CircleDollarSign, TrendingUp, BarChart2, Clock, ArrowDownToLine, ArrowDownRight, ArrowRight, Wallet, Check, X } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { useLocale } from 'next-intl'
 import type { FundBreakdownItem, NonFundUnallocatedItem } from '../DashboardClient'
@@ -53,7 +53,7 @@ function DesktopAssignPicker({
           <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--c-ink)' }}>{actionName}</div>
           <div style={{ fontSize: 11, color: 'var(--c-muted)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(actionValue)}</div>
         </div>
-        <span style={{ color: 'var(--c-muted)', fontSize: 14 }}>→</span>
+        <ArrowRight size={14} color="var(--c-muted)" />
         <div style={{ fontSize: 12, fontWeight: 600, padding: '4px 10px', background: selectedGoal ? 'var(--c-navy-tint)' : 'var(--c-line)', color: selectedGoal ? 'var(--c-navy)' : 'var(--c-muted)', borderRadius: 8, whiteSpace: 'nowrap', maxWidth: 110, overflow: 'hidden', textOverflow: 'ellipsis' }}>
           {selectedGoal ? selectedGoal.name : (isVI ? 'Chọn...' : 'Choose…')}
         </div>
@@ -86,7 +86,7 @@ function DesktopAssignPicker({
                   {isSel && <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}><Check size={12} strokeWidth={2.5} color="#fff" /></div>}
                 </div>
                 {g.progressPercent != null && (
-                  <div style={{ height: 4, background: 'var(--c-line)', borderRadius: 999, overflow: 'hidden', marginTop: 8 }}>
+                  <div style={{ height: 4, background: 'var(--c-card-2)', borderRadius: 999, overflow: 'hidden', marginTop: 8 }}>
                     <div style={{ height: '100%', borderRadius: 999, width: `${Math.min(100, Math.max(0, g.progressPercent))}%`, background: isComplete ? 'var(--c-pos)' : 'var(--c-navy)' }} />
                   </div>
                 )}
@@ -98,10 +98,10 @@ function DesktopAssignPicker({
 
       {/* Actions */}
       <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
-        <button onClick={onBack} style={{ flex: 1, padding: '12px 0', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit', background: 'transparent', border: '1px solid var(--c-line)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500 }}>
+        <button onClick={onBack} className="cn-btn" style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}>
           {isVI ? 'Quay lại' : 'Back'}
         </button>
-        <button onClick={onConfirm} disabled={!selected || confirming} style={{ flex: 2, padding: '12px 0', borderRadius: 10, border: 'none', cursor: selected && !confirming ? 'pointer' : 'default', background: selected ? 'var(--c-navy)' : 'var(--c-line)', color: selected ? '#fff' : 'var(--c-muted)', fontSize: 14, fontWeight: 600, fontFamily: 'inherit', opacity: confirming ? 0.7 : 1, transition: 'background 0.15s', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
+        <button onClick={onConfirm} disabled={!selected || confirming} className={selected && !confirming ? 'cn-btn primary' : 'cn-btn'} style={{ flex: 2, justifyContent: 'center', opacity: !selected || confirming ? 0.5 : 1 }}>
           {confirming ? (isVI ? 'Đang xử lý…' : 'Assigning…') : <><Check size={14} strokeWidth={2.4} />{isVI ? 'Xác nhận gán' : 'Confirm assignment'}</>}
         </button>
       </div>

--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -28,9 +28,9 @@ interface Props {
   funds: FundBreakdownItem[]
   nonFunds: NonFundUnallocatedItem[]
   onFundClick: (fundId: string) => void
-  onAssignToGoal: (fundId: string) => void
+  onAssignToGoal: (fundId: string, name: string, value: number, type: string) => void
   onSellFund: (fund: FundBreakdownItem) => void
-  onAssignNonFundToGoal: (transactionId: string) => void
+  onAssignNonFundToGoal: (transactionId: string, name: string, value: number, type: string) => void
   onSellNonFund: (item: NonFundUnallocatedItem) => void
   desktopCard?: boolean
 }
@@ -234,8 +234,14 @@ export default function UnallocatedSection({
           data-testid="action-assign"
           onClick={() => {
             closeAction()
-            if (actionTarget.kind === 'fund') onAssignToGoal(actionTarget.fund.fundId)
-            else onAssignNonFundToGoal(actionTarget.item.transactionId)
+            if (actionTarget.kind === 'fund') {
+              const f = actionTarget.fund
+              onAssignToGoal(f.fundId, f.fundName, f.currentValue, 'fund')
+            } else {
+              const it = actionTarget.item
+              const name = it.notes || typeLabelMap[it.type] || it.type
+              onAssignNonFundToGoal(it.transactionId, name, it.currentValue, it.type)
+            }
           }}
           style={{
             width: '100%', textAlign: 'left', padding: '14px 16px',

--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -1,10 +1,121 @@
 'use client'
 
 import { useState } from 'react'
-import { ChevronDown, ChevronUp, ChevronRight, Target, Building, CircleDollarSign, TrendingUp, BarChart2, Clock, ArrowDownToLine, ArrowDownRight, Wallet } from 'lucide-react'
+import { ChevronDown, ChevronUp, ChevronRight, Target, Building, CircleDollarSign, TrendingUp, BarChart2, Clock, ArrowDownToLine, ArrowDownRight, Wallet, Check, X } from 'lucide-react'
 import { useTranslations } from 'next-intl'
+import { useLocale } from 'next-intl'
 import type { FundBreakdownItem, NonFundUnallocatedItem } from '../DashboardClient'
 import { fmtCompact, fmtNav, fmtPct } from '@/lib/formatters'
+
+function DesktopAssignPicker({
+  item, goals, loading, selected, onSelect, confirming, error, success, successName,
+  isVI, onBack, onConfirm, actionName, actionValue, actionType,
+}: {
+  item: { kind: 'fund' | 'nonFund' }
+  goals: GoalOption[]
+  loading: boolean
+  selected: string | null
+  onSelect: (id: string) => void
+  confirming: boolean
+  error: string
+  success: boolean
+  successName: string
+  isVI: boolean
+  onBack: () => void
+  onConfirm: () => void
+  actionName: string
+  actionValue: number
+  actionType: string
+}) {
+  const ItemIcon = { fund: TrendingUp, bank: Building, gold: CircleDollarSign, stock: BarChart2 }[actionType] ?? TrendingUp
+  const selectedGoal = goals.find((g) => g.id === selected)
+
+  if (success) return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', padding: '32px 0', textAlign: 'center' }}>
+      <div style={{ width: 56, height: 56, borderRadius: '50%', background: 'var(--c-pos-tint)', color: 'var(--c-pos)', display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 12 }}>
+        <Check size={28} strokeWidth={2.5} />
+      </div>
+      <p style={{ fontWeight: 700, fontSize: 15, color: 'var(--c-ink)', margin: '0 0 4px' }}>
+        {isVI ? 'Đã gán thành công' : 'Assigned successfully'}
+      </p>
+      <p style={{ fontSize: 13, color: 'var(--c-navy)', fontWeight: 600, margin: 0 }}>{successName}</p>
+    </div>
+  )
+
+  return (
+    <div style={{ display: 'grid', gap: 14 }}>
+      {/* Item chip */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 12px', background: 'var(--c-card-2)', borderRadius: 10 }}>
+        <div style={{ width: 32, height: 32, borderRadius: 8, background: 'var(--c-card)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'var(--c-navy)', border: '1px solid var(--c-line)', flexShrink: 0 }}>
+          <ItemIcon size={15} strokeWidth={1.8} />
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--c-ink)' }}>{actionName}</div>
+          <div style={{ fontSize: 11, color: 'var(--c-muted)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(actionValue)}</div>
+        </div>
+        <span style={{ color: 'var(--c-muted)', fontSize: 14 }}>→</span>
+        <div style={{ fontSize: 12, fontWeight: 600, padding: '4px 10px', background: selectedGoal ? 'var(--c-navy-tint)' : 'var(--c-line)', color: selectedGoal ? 'var(--c-navy)' : 'var(--c-muted)', borderRadius: 8, whiteSpace: 'nowrap', maxWidth: 110, overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {selectedGoal ? selectedGoal.name : (isVI ? 'Chọn...' : 'Choose…')}
+        </div>
+      </div>
+
+      {error && <p style={{ fontSize: 13, color: 'var(--c-neg)', margin: 0 }}>{error}</p>}
+
+      {/* Goal list */}
+      <div>
+        <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 10 }}>
+          {isVI ? 'Chọn mục tiêu' : 'Choose a goal'}
+        </div>
+        <div style={{ display: 'grid', gap: 8 }}>
+          {loading && <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0', margin: 0 }}>{isVI ? 'Đang tải…' : 'Loading…'}</p>}
+          {!loading && goals.length === 0 && <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0', margin: 0 }}>{isVI ? 'Chưa có mục tiêu nào' : 'No goals yet'}</p>}
+          {!loading && goals.map((g) => {
+            const isSel = selected === g.id
+            const isComplete = g.progressPercent != null && g.progressPercent >= 100
+            const remaining = g.targetAmount != null ? Math.max(0, g.targetAmount - g.currentValue) : null
+            return (
+              <button key={g.id} onClick={() => onSelect(g.id)} style={{ width: '100%', textAlign: 'left', padding: '12px 14px', background: isSel ? 'var(--c-navy-tint)' : 'var(--c-card)', border: `1.5px solid ${isSel ? 'var(--c-navy)' : 'var(--c-line)'}`, borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit', transition: 'border-color 120ms, background 120ms' }}>
+                <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+                  <div style={{ flex: 1, minWidth: 0 }}>
+                    <div style={{ fontSize: 13, fontWeight: 600, color: isSel ? 'var(--c-navy)' : 'var(--c-ink)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{g.name}</div>
+                    <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>
+                      {isComplete ? (isVI ? 'Đã hoàn thành' : 'Completed') : remaining != null ? `${fmtCompact(remaining)} ${isVI ? 'còn lại' : 'remaining'}` : fmtCompact(g.currentValue)}
+                    </div>
+                  </div>
+                  {g.progressPercent != null && <div style={{ fontSize: 12, fontWeight: 600, color: isSel ? 'var(--c-navy)' : 'var(--c-ink)', flexShrink: 0 }}>{Math.round(g.progressPercent)}%</div>}
+                  {isSel && <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}><Check size={12} strokeWidth={2.5} color="#fff" /></div>}
+                </div>
+                {g.progressPercent != null && (
+                  <div style={{ height: 4, background: 'var(--c-line)', borderRadius: 999, overflow: 'hidden', marginTop: 8 }}>
+                    <div style={{ height: '100%', borderRadius: 999, width: `${Math.min(100, Math.max(0, g.progressPercent))}%`, background: isComplete ? 'var(--c-pos)' : 'var(--c-navy)' }} />
+                  </div>
+                )}
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+        <button onClick={onBack} style={{ flex: 1, padding: '12px 0', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit', background: 'transparent', border: '1px solid var(--c-line)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500 }}>
+          {isVI ? 'Quay lại' : 'Back'}
+        </button>
+        <button onClick={onConfirm} disabled={!selected || confirming} style={{ flex: 2, padding: '12px 0', borderRadius: 10, border: 'none', cursor: selected && !confirming ? 'pointer' : 'default', background: selected ? 'var(--c-navy)' : 'var(--c-line)', color: selected ? '#fff' : 'var(--c-muted)', fontSize: 14, fontWeight: 600, fontFamily: 'inherit', opacity: confirming ? 0.7 : 1, transition: 'background 0.15s', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
+          {confirming ? (isVI ? 'Đang xử lý…' : 'Assigning…') : <><Check size={14} strokeWidth={2.4} />{isVI ? 'Xác nhận gán' : 'Confirm assignment'}</>}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+interface GoalOption {
+  id: string
+  name: string
+  currentValue: number
+  targetAmount: number | null
+  progressPercent: number | null
+}
 
 const TYPE_ICON: Record<string, React.ElementType> = {
   fund:  TrendingUp,
@@ -32,6 +143,8 @@ interface Props {
   onSellFund: (fund: FundBreakdownItem) => void
   onAssignNonFundToGoal: (transactionId: string, name: string, value: number, type: string) => void
   onSellNonFund: (item: NonFundUnallocatedItem) => void
+  /** Desktop-only: called when user confirms assignment in the inline two-step modal */
+  onDesktopAssign?: (kind: 'fund' | 'nonFund', id: string, goalId: string) => Promise<void>
   desktopCard?: boolean
 }
 
@@ -39,13 +152,25 @@ export default function UnallocatedSection({
   unallocatedAmount, funds, nonFunds,
   onFundClick, onAssignToGoal, onSellFund,
   onAssignNonFundToGoal, onSellNonFund,
+  onDesktopAssign,
   desktopCard = false,
 }: Props) {
   const t = useTranslations('dashboard')
   const tt = useTranslations('transactions')
   const tg = useTranslations('goals')
+  const isVI = useLocale() === 'vi'
   const [open, setOpen] = useState(true)
   const [actionTarget, setActionTarget] = useState<ActionTarget | null>(null)
+
+  // Desktop two-step assign flow
+  const [desktopStep, setDesktopStep] = useState<'actions' | 'assign'>('actions')
+  const [assignGoals, setAssignGoals] = useState<GoalOption[]>([])
+  const [assignLoading, setAssignLoading] = useState(false)
+  const [assignSelected, setAssignSelected] = useState<string | null>(null)
+  const [assignConfirming, setAssignConfirming] = useState(false)
+  const [assignError, setAssignError] = useState('')
+  const [assignSuccess, setAssignSuccess] = useState(false)
+  const [assignSuccessName, setAssignSuccessName] = useState('')
 
   const typeLabelMap: Record<string, string> = {
     fund:  tt('assetFund'),
@@ -56,7 +181,53 @@ export default function UnallocatedSection({
 
   const totalItems = funds.length + nonFunds.length
 
-  function closeAction() { setActionTarget(null) }
+  function closeAction() {
+    setActionTarget(null)
+    setDesktopStep('actions')
+    setAssignSelected(null)
+    setAssignError('')
+    setAssignSuccess(false)
+  }
+
+  function startDesktopAssign() {
+    setDesktopStep('assign')
+    setAssignLoading(true)
+    setAssignSelected(null)
+    setAssignError('')
+    setAssignSuccess(false)
+    fetch('/api/v1/savings-goals')
+      .then((r) => r.ok ? r.json() : { goals: [] })
+      .then((res: { goals?: Array<{ goal_id: string; goal_name: string; current_value?: number; target_amount?: number | null; progress_percentage?: number | null }> }) => {
+        const rows = res.goals ?? []
+        setAssignGoals(rows.map((g) => ({
+          id: g.goal_id,
+          name: g.goal_name,
+          currentValue: g.current_value ?? 0,
+          targetAmount: g.target_amount ?? null,
+          progressPercent: g.progress_percentage ?? null,
+        })))
+      })
+      .catch(() => setAssignGoals([]))
+      .finally(() => setAssignLoading(false))
+  }
+
+  async function handleDesktopAssignConfirm() {
+    if (!assignSelected || !actionTarget || !onDesktopAssign) return
+    setAssignConfirming(true)
+    setAssignError('')
+    try {
+      const kind = actionTarget.kind === 'fund' ? 'fund' as const : 'nonFund' as const
+      const id = actionTarget.kind === 'fund' ? actionTarget.fund.fundId : actionTarget.item.transactionId
+      await onDesktopAssign(kind, id, assignSelected)
+      const goalName = assignGoals.find((g) => g.id === assignSelected)?.name ?? ''
+      setAssignSuccessName(goalName)
+      setAssignSuccess(true)
+      setTimeout(() => closeAction(), 1500)
+    } catch (e: unknown) {
+      setAssignError(e instanceof Error ? e.message : (isVI ? 'Lỗi kết nối' : 'Connection error'))
+    }
+    setAssignConfirming(false)
+  }
 
   const canSell = actionTarget?.kind === 'fund' || (
     actionTarget?.kind === 'nonFund' && (actionTarget.item.type === 'bank' || actionTarget.item.type === 'gold')
@@ -233,14 +404,18 @@ export default function UnallocatedSection({
         <button
           data-testid="action-assign"
           onClick={() => {
-            closeAction()
-            if (actionTarget.kind === 'fund') {
-              const f = actionTarget.fund
-              onAssignToGoal(f.fundId, f.fundName, f.currentValue, 'fund')
+            if (desktopCard && onDesktopAssign) {
+              startDesktopAssign()
             } else {
-              const it = actionTarget.item
-              const name = it.notes || typeLabelMap[it.type] || it.type
-              onAssignNonFundToGoal(it.transactionId, name, it.currentValue, it.type)
+              closeAction()
+              if (actionTarget.kind === 'fund') {
+                const f = actionTarget.fund
+                onAssignToGoal(f.fundId, f.fundName, f.currentValue, 'fund')
+              } else {
+                const it = actionTarget.item
+                const name = it.notes || typeLabelMap[it.type] || it.type
+                onAssignNonFundToGoal(it.transactionId, name, it.currentValue, it.type)
+              }
             }
           }}
           style={{
@@ -375,19 +550,54 @@ export default function UnallocatedSection({
               zIndex: 300,
               display: 'flex', alignItems: 'center', justifyContent: 'center',
               padding: 24,
+              animation: 'fade-in 150ms ease',
+              backdropFilter: 'blur(2px)',
             }}
           >
             <div
               onClick={(e) => e.stopPropagation()}
               style={{
-                width: '100%', maxWidth: 460,
+                width: '100%', maxWidth: 460, maxHeight: 'calc(100vh - 48px)',
                 background: 'var(--c-card)',
                 borderRadius: 16,
-                padding: '18px 20px',
-                boxShadow: '0 24px 48px rgba(15,23,42,0.18)',
+                boxShadow: '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)',
+                display: 'flex', flexDirection: 'column',
+                animation: 'modal-in 200ms cubic-bezier(0.2,0.8,0.2,1)',
+                overflow: 'hidden',
               }}
             >
-              {actionPopupContent}
+              {/* Modal header */}
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0 }}>
+                <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>
+                  {desktopStep === 'assign' ? (isVI ? 'Gán vào mục tiêu' : 'Assign to goal') : (isVI ? 'Tùy chọn' : 'Options')}
+                </h3>
+                <button onClick={closeAction} aria-label="Close" style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }}>
+                  <X size={18} />
+                </button>
+              </div>
+
+              {/* Modal body */}
+              <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto' }}>
+                {desktopStep === 'assign' ? (
+                  <DesktopAssignPicker
+                    item={actionTarget}
+                    goals={assignGoals}
+                    loading={assignLoading}
+                    selected={assignSelected}
+                    onSelect={setAssignSelected}
+                    confirming={assignConfirming}
+                    error={assignError}
+                    success={assignSuccess}
+                    successName={assignSuccessName}
+                    isVI={isVI}
+                    onBack={() => setDesktopStep('actions')}
+                    onConfirm={handleDesktopAssignConfirm}
+                    actionName={actionName}
+                    actionValue={actionValue}
+                    actionType={actionType}
+                  />
+                ) : actionPopupContent}
+              </div>
             </div>
           </div>
         )}

--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -555,6 +555,8 @@ export default function UnallocatedSection({
             }}
           >
             <div
+              role="dialog"
+              aria-modal="true"
               onClick={(e) => e.stopPropagation()}
               style={{
                 width: '100%', maxWidth: 460, maxHeight: 'calc(100vh - 48px)',

--- a/e2e/assign-goal-desktop.spec.ts
+++ b/e2e/assign-goal-desktop.spec.ts
@@ -1,0 +1,163 @@
+import { test, expect } from '@playwright/test'
+import * as api from './helpers/api'
+import { makeCleanupStack } from './helpers/cleanup'
+
+// Desktop Chrome (1280×800) — unallocated section uses the two-step inline
+// DModal flow (desktopCard + onDesktopAssign) introduced in PR #199.
+
+const cleanup = makeCleanupStack()
+test.afterEach(() => cleanup.run())
+
+// Pre-clean any stale E2E goals from a previous interrupted run
+test.beforeAll(async () => {
+  const names = [
+    'E2E Assign Picker Test Goal',
+    'E2E Pct Goal',
+    'E2E Back Button Goal',
+    'E2E Confirm Disabled Goal',
+    'E2E Select Enables Confirm Goal',
+    'E2E Success State Goal',
+  ]
+  for (const name of names) {
+    const existing = await api.findGoalByName(name)
+    if (existing) await api.deleteGoal(existing.goal_id)
+  }
+  await api.deleteAllTransactionsByNotes('E2E Success State TX')
+})
+
+test.describe('Desktop assign-to-goal two-step modal (PR #199)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/dashboard')
+    await page.waitForLoadState('networkidle')
+  })
+
+  test('clicking unallocated row opens Options modal', async ({ page }) => {
+    const row = page.getByTestId('unallocated-row').first()
+    await expect(row).toBeVisible({ timeout: 10_000 })
+    await row.click()
+
+    const sheet = page.getByTestId('action-sheet')
+    await expect(sheet).toBeVisible({ timeout: 5_000 })
+    await expect(sheet.locator('h3').filter({ hasText: /options|tùy chọn/i })).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('Options modal shows Assign to goal action button', async ({ page }) => {
+    await page.getByTestId('unallocated-row').first().click()
+    await expect(page.getByTestId('action-assign')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('Assign to goal transitions the modal to the goal picker step', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Assign Picker Test Goal', target_amount: 50_000_000 })
+    cleanup.add(() => api.deleteGoal(goal.goal_id))
+
+    await page.getByTestId('unallocated-row').first().click()
+    await page.getByTestId('action-assign').click()
+
+    const sheet = page.getByTestId('action-sheet')
+    await expect(sheet.locator('h3').filter({ hasText: /assign to goal|gán vào mục tiêu/i })).toBeVisible({ timeout: 5_000 })
+    await expect(sheet.getByText('E2E Assign Picker Test Goal')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('goal picker shows progress percentage for goals with a target amount', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Pct Goal', target_amount: 50_000_000 })
+    cleanup.add(() => api.deleteGoal(goal.goal_id))
+
+    await page.getByTestId('unallocated-row').first().click()
+    await page.getByTestId('action-assign').click()
+
+    const sheet = page.getByTestId('action-sheet')
+    await expect(sheet.getByText('E2E Pct Goal')).toBeVisible({ timeout: 5_000 })
+    // 0% shown because no investments are assigned yet
+    await expect(sheet.getByText('0%')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('Back button returns to the Options step', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Back Button Goal', target_amount: 50_000_000 })
+    cleanup.add(() => api.deleteGoal(goal.goal_id))
+
+    await page.getByTestId('unallocated-row').first().click()
+    await page.getByTestId('action-assign').click()
+
+    const sheet = page.getByTestId('action-sheet')
+    await expect(sheet.locator('h3').filter({ hasText: /assign to goal|gán vào mục tiêu/i })).toBeVisible({ timeout: 5_000 })
+
+    await sheet.getByRole('button', { name: /back|quay lại/i }).click()
+
+    await expect(sheet.locator('h3').filter({ hasText: /options|tùy chọn/i })).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('Confirm button is disabled until a goal is selected', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Confirm Disabled Goal', target_amount: 50_000_000 })
+    cleanup.add(() => api.deleteGoal(goal.goal_id))
+
+    await page.getByTestId('unallocated-row').first().click()
+    await page.getByTestId('action-assign').click()
+
+    const sheet = page.getByTestId('action-sheet')
+    await expect(sheet.getByText('E2E Confirm Disabled Goal')).toBeVisible({ timeout: 5_000 })
+    await expect(sheet.getByRole('button', { name: /confirm assignment|xác nhận gán/i })).toBeDisabled()
+  })
+
+  test('selecting a goal enables the Confirm button', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Select Enables Confirm Goal', target_amount: 50_000_000 })
+    cleanup.add(() => api.deleteGoal(goal.goal_id))
+
+    await page.getByTestId('unallocated-row').first().click()
+    await page.getByTestId('action-assign').click()
+
+    const sheet = page.getByTestId('action-sheet')
+    await sheet.getByText('E2E Select Enables Confirm Goal').click()
+    await expect(sheet.getByRole('button', { name: /confirm assignment|xác nhận gán/i })).not.toBeDisabled()
+  })
+
+  test('confirming shows "Assigned to" success state with the goal name', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Success State Goal', target_amount: 50_000_000 })
+    cleanup.add(() => api.deleteGoal(goal.goal_id))
+
+    // Create a dedicated unallocated tx so the global-setup bank tx remains unallocated
+    const tx = await api.createTransaction({
+      asset_type: 'bank',
+      amount_vnd: 3_000_000,
+      investment_date: '2026-02-01',
+      interest_rate: 5,
+      notes: 'E2E Success State TX',
+    })
+    cleanup.add(() => api.deleteTransaction(tx.transaction_id))
+
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+
+    const targetRow = page.getByTestId('unallocated-row').filter({ hasText: 'E2E Success State TX' })
+    await expect(targetRow).toBeVisible({ timeout: 10_000 })
+    await targetRow.click()
+
+    const sheet = page.getByTestId('action-sheet')
+    await page.getByTestId('action-assign').click()
+    await sheet.getByText('E2E Success State Goal').click()
+    await sheet.getByRole('button', { name: /confirm assignment|xác nhận gán/i }).click()
+
+    // Success state: "Assigned to" + goal name
+    await expect(sheet.getByText(/assigned to|đã gán vào/i)).toBeVisible({ timeout: 8_000 })
+    await expect(sheet.getByText('E2E Success State Goal')).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('backdrop click closes the Options modal', async ({ page }) => {
+    await page.getByTestId('unallocated-row').first().click()
+    const sheet = page.getByTestId('action-sheet')
+    await expect(sheet.locator('h3').filter({ hasText: /options|tùy chọn/i })).toBeVisible({ timeout: 5_000 })
+
+    await page.mouse.click(10, 10)
+
+    await expect(sheet).not.toBeVisible({ timeout: 3_000 })
+  })
+
+  test('X button dismisses the Options modal', async ({ page }) => {
+    await page.getByTestId('unallocated-row').first().click()
+    const sheet = page.getByTestId('action-sheet')
+    await expect(sheet.locator('h3').filter({ hasText: /options|tùy chọn/i })).toBeVisible({ timeout: 5_000 })
+
+    await sheet.getByRole('button', { name: /close/i }).click()
+
+    await expect(sheet).not.toBeVisible({ timeout: 3_000 })
+  })
+})

--- a/e2e/assign-goal-desktop.spec.ts
+++ b/e2e/assign-goal-desktop.spec.ts
@@ -22,7 +22,6 @@ test.beforeAll(async () => {
     const existing = await api.findGoalByName(name)
     if (existing) await api.deleteGoal(existing.goal_id)
   }
-  await api.deleteAllTransactionsByNotes('E2E Success State TX')
 })
 
 test.describe('Desktop assign-to-goal two-step modal (PR #199)', () => {
@@ -112,24 +111,12 @@ test.describe('Desktop assign-to-goal two-step modal (PR #199)', () => {
 
   test('confirming shows "Assigned to" success state with the goal name', async ({ page }) => {
     const goal = await api.createGoal({ goal_name: 'E2E Success State Goal', target_amount: 50_000_000 })
+    // Goal cleanup alone is enough: ON DELETE SET NULL on goal_id FK returns the seed tx to unallocated
     cleanup.add(() => api.deleteGoal(goal.goal_id))
 
-    // Create a dedicated unallocated tx so the global-setup bank tx remains unallocated
-    const tx = await api.createTransaction({
-      asset_type: 'bank',
-      amount_vnd: 3_000_000,
-      investment_date: '2026-02-01',
-      interest_rate: 5,
-      notes: 'E2E Success State TX',
-    })
-    cleanup.add(() => api.deleteTransaction(tx.transaction_id))
-
-    await page.reload()
-    await page.waitForLoadState('networkidle')
-
-    const targetRow = page.getByTestId('unallocated-row').filter({ hasText: 'E2E Success State TX' })
-    await expect(targetRow).toBeVisible({ timeout: 10_000 })
-    await targetRow.click()
+    const row = page.getByTestId('unallocated-row').first()
+    await expect(row).toBeVisible({ timeout: 10_000 })
+    await row.click()
 
     const sheet = page.getByTestId('action-sheet')
     await page.getByTestId('action-assign').click()


### PR DESCRIPTION
## Summary

- `AssignGoalSheet` now accepts a `desktop?: boolean` prop
- When `desktop={true}`, renders as a centered DModal (width 460, `modal-in` animation, X close button) instead of a bottom sheet
- Both usages in `DashboardClient` (fund and non-fund assign flows) pass `desktop={isDesktop}`
- Mobile bottom sheet behavior is unchanged

## Test plan

- [ ] On desktop (≥768px): clicking "Assign to goal" on an unallocated fund → centered modal opens with goal list
- [ ] On desktop: clicking "Assign to goal" on an unallocated non-fund holding → centered modal opens
- [ ] Selecting a goal and confirming assigns it correctly
- [ ] Success state shows check icon + goal name
- [ ] Close via X button works
- [ ] Close via backdrop click works
- [ ] On mobile (≤767px): still opens as bottom sheet

🤖 Generated with [Claude Code](https://claude.com/claude-code)