### PR TITLE
feat(goal-detail): investment options menu per investment row

### DIFF
--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -694,7 +694,7 @@ function UnassignConfirmModal({ inv, unassigning, isVi, onCancel, onConfirm }: {
     <DModal onClose={onCancel} title={isVi ? 'Bỏ gán mục tiêu?' : 'Unassign from goal?'} width={380}>
       <div style={{ display: 'grid', gap: 16 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', background: 'var(--c-card-2)', borderRadius: 10 }}>
-          <div style={{ width: 32, height: 32, borderRadius: 8, background: 'var(--c-warn-tint,#fef3c7)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+          <div style={{ width: 32, height: 32, borderRadius: 8, background: 'var(--c-warn-tint,#fef3c7)', color: 'var(--c-warn,#b45309)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
             <TypeIcon type={inv.type} size={15} />
           </div>
           <div style={{ flex: 1, minWidth: 0 }}>

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -1,10 +1,9 @@
 'use client'
 
-import { useState, useEffect } from 'react'
-import { ChevronLeft, X, TrendingUp, Building, CircleDollarSign, BarChart2, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Unlink } from 'lucide-react'
+import { useState, useEffect, useMemo } from 'react'
+import { ChevronLeft, X, TrendingUp, Building, CircleDollarSign, BarChart2, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Unlink, Check, ArrowDownToLine, Wallet, Shield } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData, FundBreakdownItem } from '../DashboardClient'
-import { SellWithdrawSheet, type SellItem } from './SellWithdrawSheet'
 
 interface InvestmentTx {
   transaction_id: string
@@ -128,33 +127,6 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
       onDataChanged()
     } finally {
       setUnassigning(false)
-    }
-  }
-
-  function buildSellItem(inv: InvRow): SellItem {
-    if (inv.fund) {
-      return {
-        type: 'fund',
-        name: inv.name,
-        currentValue: inv.value,
-        units: inv.units ?? undefined,
-        navPerUnit: inv.fund.currentNAV,
-        gainPct: inv.gainPct ?? undefined,
-        fundId: inv.fund.fundId,
-        purchasePrice: inv.fund.purchasePrice,
-      }
-    }
-    const navPerUnit = inv.units && inv.units > 0 ? inv.value / inv.units : undefined
-    return {
-      type: inv.type as 'bank' | 'gold' | 'stock',
-      name: inv.name,
-      currentValue: inv.value,
-      units: inv.units ?? undefined,
-      navPerUnit,
-      gainPct: inv.gainPct ?? undefined,
-      interestRate: inv.interestRate ?? undefined,
-      transactionId: inv.id,
-      purchasePrice: inv.principal ?? undefined,
     }
   }
 
@@ -601,14 +573,19 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
         />
       )}
 
-      {/* Sell / Withdraw sheet */}
-      <SellWithdrawSheet
-        item={actionInv && showSell ? buildSellItem(actionInv) : null}
-        open={showSell}
-        context="goal"
-        onClose={() => { setShowSell(false) }}
-        onSuccess={() => { setShowSell(false); if (actionInv) setUnassignedIds((prev) => [...prev, actionInv.id]); onDataChanged() }}
-      />
+      {/* Sell / Withdraw modal */}
+      {showSell && actionInv && (
+        <SellModal
+          inv={actionInv}
+          isVi={isVi}
+          onClose={() => setShowSell(false)}
+          onSuccess={() => {
+            setShowSell(false)
+            setUnassignedIds((prev) => [...prev, actionInv.id])
+            onDataChanged()
+          }}
+        />
+      )}
     </>
   )
 }
@@ -736,6 +713,258 @@ function UnassignConfirmModal({ inv, unassigning, isVi, onCancel, onConfirm }: {
           </button>
         </div>
       </div>
+    </DModal>
+  )
+}
+
+// ─── Desktop sell / withdraw modal ────────────────────────────────────────
+function SellModal({ inv, isVi, onClose, onSuccess }: {
+  inv: InvRow; isVi: boolean; onClose: () => void; onSuccess: () => void
+}) {
+  const [amount, setAmount] = useState('')
+  const [units, setUnits] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const [confirmed, setConfirmed] = useState(false)
+  const [soldAmount, setSoldAmount] = useState(0)
+
+  const isFund = inv.type === 'fund'
+  const isGold = inv.type === 'gold'
+  const isBank = inv.type === 'bank'
+  const navPerUnit = isFund
+    ? (inv.fund?.currentNAV ?? null)
+    : (inv.units && inv.units > 0 ? inv.value / inv.units : null)
+  const maxAmount = inv.value
+  const numAmount = Number(amount) || 0
+  const isOverMax = numAmount > maxAmount && maxAmount > 0
+  const isValid = numAmount > 0 && !isOverMax && !saving
+  const remaining = maxAmount - numAmount
+
+  const gainLoss = useMemo(() => {
+    if (!numAmount || inv.gainPct == null) return null
+    return numAmount * inv.gainPct / (100 + inv.gainPct)
+  }, [numAmount, inv.gainPct])
+
+  const penaltyAmount = useMemo(() => {
+    if (!isBank || !numAmount || !inv.interestRate) return null
+    return Math.round(numAmount * (inv.interestRate / 100) * 0.5)
+  }, [isBank, numAmount, inv.interestRate])
+
+  const taxAmount = useMemo(() => {
+    if (!isFund || !numAmount) return null
+    return Math.round(numAmount * 0.001)
+  }, [isFund, numAmount])
+
+  function handleAmountChange(val: string) {
+    const raw = val.replace(/[^0-9]/g, '')
+    setAmount(raw)
+    if (navPerUnit && raw) setUnits((Number(raw) / navPerUnit).toFixed(2))
+    else setUnits('')
+  }
+
+  function handleUnitsChange(val: string) {
+    setUnits(val)
+    if (navPerUnit && val) setAmount(Math.round(Number(val) * navPerUnit).toString())
+    else setAmount('')
+  }
+
+  function handleSetAll() {
+    setAmount(String(maxAmount))
+    if (navPerUnit && inv.units != null) setUnits(inv.units.toFixed(2))
+  }
+
+  async function handleConfirm() {
+    if (!isValid) return
+    setSaving(true); setError('')
+    try {
+      const today = new Date().toISOString().slice(0, 10)
+      if (isFund && inv.fund) {
+        const unitsWithdrawn = navPerUnit ? numAmount / navPerUnit : (inv.units ?? 0)
+        const principalWithdrawn = inv.fund.purchasePrice
+          ? Math.round((numAmount / inv.value) * (inv.fund.purchasePrice * (inv.units ?? 0)))
+          : Math.round(numAmount)
+        const res = await fetch('/api/v1/investment-transactions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            transaction_type: 'withdrawal', asset_type: 'fund',
+            fund_id: inv.fund.fundId, investment_date: today,
+            amount_vnd: Math.round(numAmount),
+            units_withdrawn: parseFloat(unitsWithdrawn.toFixed(4)),
+            principal_withdrawn: principalWithdrawn, goal_id: null,
+          }),
+        })
+        if (!res.ok) { const { error: e } = await res.json(); setError(e ?? (isVi ? 'Không thể xử lý' : 'Could not process')); setSaving(false); return }
+      } else {
+        const body: Record<string, unknown> = {
+          transaction_type: 'withdrawal', asset_type: inv.type,
+          parent_transaction_id: inv.id, investment_date: today,
+          amount_vnd: Math.round(numAmount), principal_withdrawn: Math.round(numAmount), goal_id: null,
+        }
+        if (isGold && units && navPerUnit) body.units_withdrawn = parseFloat(units)
+        const res = await fetch('/api/v1/investment-transactions', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        })
+        if (!res.ok) { const { error: e } = await res.json(); setError(e ?? (isVi ? 'Không thể xử lý' : 'Could not process')); setSaving(false); return }
+      }
+      setSoldAmount(numAmount); setConfirmed(true)
+      setTimeout(() => { setConfirmed(false); onSuccess(); onClose() }, 2000)
+    } catch { setError(isVi ? 'Lỗi kết nối' : 'Connection error') }
+    setSaving(false)
+  }
+
+  const title = isBank ? (isVi ? 'Rút tiền' : 'Withdraw') : (isVi ? 'Bán' : 'Sell')
+  const typeColor = GD_COLORS[inv.type] ?? '#94a3b8'
+
+  return (
+    <DModal onClose={onClose} title={title} width={480}>
+      {confirmed ? (
+        <div style={{ padding: '32px 0', textAlign: 'center' }}>
+          <div style={{ width: 64, height: 64, borderRadius: 32, background: 'var(--c-pos-tint)', color: 'var(--c-pos)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 16px' }}>
+            <Check size={30} strokeWidth={2.5} />
+          </div>
+          <div style={{ fontSize: 16, fontWeight: 700 }}>{isBank ? (isVi ? 'Đã rút thành công' : 'Withdrawal successful') : (isVi ? 'Đã bán thành công' : 'Sale successful')}</div>
+          <div style={{ fontSize: 13, color: 'var(--c-muted)', marginTop: 4 }}>{inv.name}</div>
+          <div style={{ fontSize: 24, fontWeight: 700, color: 'var(--c-pos)', marginTop: 12, letterSpacing: '-0.02em', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(soldAmount)}</div>
+          <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 8, lineHeight: 1.5 }}>
+            {isFund ? (isVi ? 'Tiền về tài khoản sau T+3 ngày làm việc' : 'Proceeds arrive in T+3 business days') : (isVi ? 'Tiền về tài khoản trong 1 ngày làm việc' : 'Proceeds arrive within 1 business day')}
+          </div>
+        </div>
+      ) : (
+        <div style={{ display: 'grid', gap: 14 }}>
+          {/* Item summary */}
+          <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px', background: 'var(--c-card-2)', borderRadius: 12 }}>
+            <div style={{ width: 40, height: 40, borderRadius: 10, background: 'var(--c-card)', display: 'flex', alignItems: 'center', justifyContent: 'center', color: typeColor, border: '1px solid var(--c-line)', flexShrink: 0 }}>
+              <TypeIcon type={inv.type} size={18} />
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{inv.name}</div>
+              <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2, display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+                <span>{isVi ? 'Khả dụng' : 'Available'}: <span style={{ fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(maxAmount)}</span></span>
+                {inv.units != null && <span style={{ fontVariantNumeric: 'tabular-nums' }}>{inv.units.toLocaleString('vi-VN')} {isVi ? 'phần' : 'units'}</span>}
+                {isBank && inv.interestRate && <span>{inv.interestRate}%/yr</span>}
+              </div>
+            </div>
+          </div>
+
+          {/* Amount input */}
+          <div>
+            <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>
+              {isBank ? (isVi ? 'Số tiền muốn rút' : 'Amount to withdraw') : (isVi ? 'Số tiền muốn bán' : 'Amount to sell')}
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <div style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', background: 'var(--c-card)', border: `1.5px solid ${isOverMax ? 'var(--c-neg)' : 'var(--c-navy)'}`, borderRadius: 10 }}>
+                <span style={{ fontSize: 14, color: 'var(--c-muted)' }}>₫</span>
+                <input
+                  autoFocus
+                  type="text" inputMode="numeric"
+                  value={amount ? Number(amount).toLocaleString('vi-VN') : ''}
+                  onChange={(e) => handleAmountChange(e.target.value)}
+                  placeholder="0"
+                  style={{ flex: 1, border: 'none', outline: 'none', fontSize: 15, fontWeight: 600, fontFamily: 'inherit', background: 'transparent', color: isOverMax ? 'var(--c-neg)' : 'var(--c-ink)' }}
+                />
+              </div>
+              <button onClick={handleSetAll} style={{ padding: '8px 14px', background: 'var(--c-navy-tint)', color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)', borderRadius: 10, fontSize: 12, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', whiteSpace: 'nowrap' }}>
+                {isVi ? 'Tất cả' : 'All'}
+              </button>
+            </div>
+            {isOverMax && (
+              <div style={{ fontSize: 11, color: 'var(--c-neg)', marginTop: 5, display: 'flex', alignItems: 'center', gap: 4 }}>
+                <X size={12} strokeWidth={2.5} />
+                {isVi ? 'Vượt quá số dư khả dụng' : 'Exceeds available balance'} · {isVi ? 'Tối đa' : 'Max'} {fmtCompact(maxAmount)}
+              </div>
+            )}
+          </div>
+
+          {/* Units input — fund & gold only */}
+          {(isFund || isGold) && inv.units != null && (
+            <div>
+              <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>{isVi ? 'Số phần' : 'Units'}</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 10 }}>
+                <input type="number" value={units} onChange={(e) => handleUnitsChange(e.target.value)} placeholder="0.00"
+                  style={{ flex: 1, border: 'none', outline: 'none', fontSize: 15, fontWeight: 600, fontFamily: 'inherit', background: 'transparent', color: 'var(--c-ink)' }} />
+                <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVi ? 'phần' : 'units'}</span>
+              </div>
+              {navPerUnit && (
+                <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 4 }}>
+                  NAV: <span style={{ fontWeight: 500, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(navPerUnit)}</span> / {isVi ? 'phần' : 'unit'} · {isVi ? 'Hai trường tự động liên kết' : 'Fields auto-linked'}
+                </div>
+              )}
+            </div>
+          )}
+
+          {/* Summary strip */}
+          {numAmount > 0 && !isOverMax && (() => {
+            const rows = [
+              { show: true, label: isVi ? 'Còn lại sau giao dịch' : 'Remaining after transaction', value: fmtCompact(Math.max(0, remaining)), color: 'var(--c-ink)' },
+              { show: gainLoss != null, label: isVi ? 'Lãi/Lỗ ước tính' : 'Est. gain / loss', value: `${gainLoss! >= 0 ? '+' : ''}${fmtCompact(gainLoss!)}`, color: gainLoss! >= 0 ? 'var(--c-pos)' : 'var(--c-neg)' },
+              { show: penaltyAmount != null, label: isVi ? 'Lãi mất ước tính' : 'Est. interest forfeited', value: `−${fmtCompact(penaltyAmount!)}`, color: 'var(--c-warn)' },
+              { show: taxAmount != null, label: isVi ? 'Thuế TNCN (0.1%)' : 'Personal income tax (0.1%)', value: `−${fmtCompact(taxAmount!)}`, color: 'var(--c-muted)' },
+            ].filter((r) => r.show)
+            return (
+              <div style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
+                {rows.map((r, i) => (
+                  <div key={i} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: i < rows.length - 1 ? '1px solid var(--c-line)' : 'none' }}>
+                    <span style={{ fontSize: 12, color: r.color === 'var(--c-warn)' ? 'var(--c-warn)' : 'var(--c-muted)' }}>{r.label}</span>
+                    <span style={{ fontSize: 13, fontWeight: 600, color: r.color, fontVariantNumeric: 'tabular-nums' }}>{r.value}</span>
+                  </div>
+                ))}
+              </div>
+            )
+          })()}
+
+          {/* Bank early withdrawal warning */}
+          {isBank && (
+            <div style={{ display: 'flex', gap: 10, padding: '10px 12px', background: 'var(--c-warn-tint,#fffbeb)', borderRadius: 10, border: '1px solid rgba(180,83,9,0.15)' }}>
+              <Shield size={15} color="var(--c-warn)" style={{ flexShrink: 0, marginTop: 1 }} />
+              <p style={{ margin: 0, fontSize: 12, color: 'var(--c-warn)', lineHeight: 1.5 }}>
+                {isVi ? 'Rút sớm có thể mất lãi.' : 'Early withdrawal may forfeit accrued interest.'}
+              </p>
+            </div>
+          )}
+
+          {/* Where money goes + settlement */}
+          <div style={{ display: 'grid', gap: 6 }}>
+            {[
+              { icon: <Wallet size={14} color="var(--c-muted)" />, text: isVi ? 'Tiền sẽ chuyển về mục "Chưa phân bổ"' : 'Proceeds move to Unallocated' },
+              { icon: <ArrowDownToLine size={14} color="var(--c-muted)" />, text: isFund ? (isVi ? 'Tiền về tài khoản sau T+3 ngày làm việc' : 'Proceeds arrive in T+3 business days') : (isVi ? 'Tiền về tài khoản trong 1 ngày làm việc' : 'Proceeds arrive within 1 business day') },
+            ].map((r, i) => (
+              <div key={i} style={{ display: 'flex', gap: 8, alignItems: 'flex-start', padding: '9px 12px', background: 'var(--c-card-2)', borderRadius: 8 }}>
+                <span style={{ flexShrink: 0, marginTop: 1 }}>{r.icon}</span>
+                <span style={{ fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.5 }}>{r.text}</span>
+              </div>
+            ))}
+          </div>
+
+          {error && <p style={{ margin: 0, fontSize: 12, color: 'var(--c-neg)', textAlign: 'center' }}>{error}</p>}
+
+          {/* Actions */}
+          <div style={{ display: 'flex', gap: 8, marginTop: 2 }}>
+            <button onClick={onClose} className="cn-btn ghost" style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}>
+              {isVi ? 'Hủy' : 'Cancel'}
+            </button>
+            <button onClick={isValid ? handleConfirm : undefined} disabled={!isValid} style={{
+              flex: 2, padding: '11px 14px',
+              background: isValid ? 'var(--c-neg)' : isOverMax ? 'var(--c-neg-tint)' : 'var(--c-line)',
+              color: isValid ? '#fff' : isOverMax ? 'var(--c-neg)' : 'var(--c-muted)',
+              border: isOverMax ? '1px solid var(--c-neg)' : 'none',
+              borderRadius: 10, fontSize: 13, fontWeight: 600,
+              cursor: isValid ? 'pointer' : 'default',
+              fontFamily: 'inherit', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+              transition: 'background 120ms, color 120ms',
+            }}>
+              {isBank ? <ArrowDownToLine size={15} strokeWidth={2.2} /> : <ArrowDownRight size={15} strokeWidth={2.2} />}
+              {numAmount <= 0
+                ? (isVi ? (isBank ? 'Nhập số tiền rút' : 'Nhập số tiền bán') : (isBank ? 'Enter withdrawal amount' : 'Enter sale amount'))
+                : isOverMax ? (isVi ? 'Vượt quá số dư' : 'Exceeds balance')
+                : saving ? (isVi ? 'Đang xử lý…' : 'Processing…')
+                : isBank ? (isVi ? 'Xác nhận rút' : 'Confirm withdrawal') : (isVi ? 'Xác nhận bán' : 'Confirm sale')}
+            </button>
+          </div>
+        </div>
+      )}
     </DModal>
   )
 }

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useMemo } from 'react'
-import { ChevronLeft, X, TrendingUp, Building, CircleDollarSign, BarChart2, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Link2Off, Check, ArrowDownToLine, Wallet, Shield } from 'lucide-react'
+import { ChevronLeft, X, TrendingUp, Building, CircleDollarSign, BarChart2, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData, FundBreakdownItem } from '../DashboardClient'
 
@@ -56,6 +56,16 @@ function calcDeadlineMonths(targetDate: string | null): number {
   const [ty, tm] = targetDate.split('-').map(Number)
   const now = new Date()
   return Math.max(1, (ty - now.getFullYear()) * 12 + (tm - 1 - now.getMonth()))
+}
+
+function UnlinkSvg({ size = 18, color = 'currentColor' }: { size?: number; color?: string }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+      <path d="M2 2l20 20" />
+    </svg>
+  )
 }
 
 export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged }: Props) {
@@ -618,7 +628,7 @@ function InvOptionsModal({ inv, isVi, onClose, onHistory, onSell, onUnassign }: 
       onClick: onSell,
     },
     {
-      icon: <Link2Off size={18} color="var(--c-warn,#b45309)" />,
+      icon: <UnlinkSvg size={18} color="var(--c-warn,#b45309)" />,
       bg: 'var(--c-warn-tint,#fef3c7)',
       label: isVi ? 'Bỏ gán mục tiêu' : 'Unassign from goal',
       sub: isVi ? 'Chuyển khoản đầu tư sang trạng thái chưa gán' : 'Move this investment to unassigned',
@@ -708,7 +718,7 @@ function UnassignConfirmModal({ inv, unassigning, isVi, onCancel, onConfirm }: {
             display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
             opacity: unassigning ? 0.6 : 1,
           }}>
-            <Link2Off size={14} />
+            <UnlinkSvg size={14} />
             {unassigning ? (isVi ? 'Đang xử lý…' : 'Unassigning…') : (isVi ? 'Bỏ gán' : 'Unassign')}
           </button>
         </div>

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useMemo } from 'react'
-import { ChevronLeft, X, TrendingUp, Building, CircleDollarSign, BarChart2, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Unlink, Check, ArrowDownToLine, Wallet, Shield } from 'lucide-react'
+import { ChevronLeft, X, TrendingUp, Building, CircleDollarSign, BarChart2, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Link2Off, Check, ArrowDownToLine, Wallet, Shield } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData, FundBreakdownItem } from '../DashboardClient'
 
@@ -618,7 +618,7 @@ function InvOptionsModal({ inv, isVi, onClose, onHistory, onSell, onUnassign }: 
       onClick: onSell,
     },
     {
-      icon: <Unlink size={18} color="var(--c-warn,#b45309)" />,
+      icon: <Link2Off size={18} color="var(--c-warn,#b45309)" />,
       bg: 'var(--c-warn-tint,#fef3c7)',
       label: isVi ? 'Bỏ gán mục tiêu' : 'Unassign from goal',
       sub: isVi ? 'Chuyển khoản đầu tư sang trạng thái chưa gán' : 'Move this investment to unassigned',
@@ -708,7 +708,7 @@ function UnassignConfirmModal({ inv, unassigning, isVi, onCancel, onConfirm }: {
             display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
             opacity: unassigning ? 0.6 : 1,
           }}>
-            <Unlink size={14} />
+            <Link2Off size={14} />
             {unassigning ? (isVi ? 'Đang xử lý…' : 'Unassigning…') : (isVi ? 'Bỏ gán' : 'Unassign')}
           </button>
         </div>

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -144,11 +144,13 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
         purchasePrice: inv.fund.purchasePrice,
       }
     }
+    const navPerUnit = inv.units && inv.units > 0 ? inv.value / inv.units : undefined
     return {
       type: inv.type as 'bank' | 'gold' | 'stock',
       name: inv.name,
       currentValue: inv.value,
       units: inv.units ?? undefined,
+      navPerUnit,
       gainPct: inv.gainPct ?? undefined,
       interestRate: inv.interestRate ?? undefined,
       transactionId: inv.id,

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { ChevronLeft, X, TrendingUp, Building, CircleDollarSign, BarChart2, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target } from 'lucide-react'
+import { ChevronLeft, X, TrendingUp, Building, CircleDollarSign, BarChart2, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Unlink } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData, FundBreakdownItem } from '../DashboardClient'
+import SellWithdrawSheet, { type SellItem } from './SellWithdrawSheet'
 
 interface InvestmentTx {
   transaction_id: string
@@ -26,6 +27,7 @@ interface InvRow {
   gainPct: number | null
   units: number | null
   principal: number | null
+  interestRate: number | null
   fund: FundBreakdownItem | null
 }
 
@@ -68,9 +70,18 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
   const [isDeleting, setIsDeleting] = useState(false)
   const [calcAmount, setCalcAmount] = useState('')
 
+  // Investment options state
+  const [actionInv, setActionInv] = useState<InvRow | null>(null)
+  const [showInvOptions, setShowInvOptions] = useState(false)
+  const [showSell, setShowSell] = useState(false)
+  const [showUnassignConfirm, setShowUnassignConfirm] = useState(false)
+  const [unassigning, setUnassigning] = useState(false)
+  const [unassignedIds, setUnassignedIds] = useState<string[]>([])
+
   useEffect(() => {
     setTxLoading(true)
     setTab('investments')
+    setUnassignedIds([])
     fetch(`/api/v1/investment-transactions?goal_id=${goal.goalId}&limit=200`)
       .then((r) => r.ok ? r.json() : { transactions: [] })
       .then((res) => setTransactions(res.transactions ?? []))
@@ -88,11 +99,68 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
     }
   }
 
+  async function handleUnassign() {
+    if (!actionInv) return
+    setUnassigning(true)
+    try {
+      if (actionInv.fund) {
+        const res = await fetch(`/api/v1/fund-investments?fund_id=${actionInv.fund.fundId}`)
+        if (!res.ok) throw new Error('fetch failed')
+        const data = await res.json() as { investments?: Array<{ id: string }> }
+        const investments = data.investments ?? []
+        await Promise.all(investments.map((fi) =>
+          fetch(`/api/v1/fund-investments/${fi.id}/goal`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ goal_id: null }),
+          })
+        ))
+      } else {
+        await fetch(`/api/v1/investment-transactions/${actionInv.id}/assign`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ goal_id: null }),
+        })
+      }
+      setUnassignedIds((prev) => [...prev, actionInv.id])
+      setShowUnassignConfirm(false)
+      setActionInv(null)
+      onDataChanged()
+    } finally {
+      setUnassigning(false)
+    }
+  }
+
+  function buildSellItem(inv: InvRow): SellItem {
+    if (inv.fund) {
+      return {
+        type: 'fund',
+        name: inv.name,
+        currentValue: inv.value,
+        units: inv.units ?? undefined,
+        navPerUnit: inv.fund.currentNAV,
+        gainPct: inv.gainPct ?? undefined,
+        fundId: inv.fund.fundId,
+        purchasePrice: inv.fund.purchasePrice,
+      }
+    }
+    return {
+      type: inv.type as 'bank' | 'gold' | 'stock',
+      name: inv.name,
+      currentValue: inv.value,
+      units: inv.units ?? undefined,
+      gainPct: inv.gainPct ?? undefined,
+      interestRate: inv.interestRate ?? undefined,
+      transactionId: inv.id,
+      purchasePrice: inv.principal ?? undefined,
+    }
+  }
+
   const isPos = goal.profitLoss >= 0
   const isComplete = (goal.progressPercentage ?? 0) >= 100
   const progress = Math.min(goal.progressPercentage ?? 0, 100)
 
-  // Build investment rows (same logic as GoalDetailSheet)
+  // Build investment rows
   const investmentRows = transactions.filter((tx) => tx.transaction_type !== 'withdrawal')
   const deduped = new Map<string, InvestmentTx>()
   investmentRows.forEach((tx) => {
@@ -131,7 +199,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
       units = tx.units
       principal = tx.amount_vnd
     }
-    return { id: tx.transaction_id, name, type: tx.asset_type, value, gainPct, units, principal, fund: fund ?? null }
+    return { id: tx.transaction_id, name, type: tx.asset_type, value, gainPct, units, principal, interestRate: tx.interest_rate, fund: fund ?? null }
   })
 
   // Composition segments
@@ -149,6 +217,8 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
   const projectedDate = monthsToGoal != null ? (() => { const d = new Date(); d.setMonth(d.getMonth() + monthsToGoal); return d })() : null
   const isOnTrack = calcInput > 0 && calcInput >= neededPerMonth
   const gap = Math.abs(neededPerMonth - calcInput)
+
+  const visibleInvRows = invRows.filter((inv) => !unassignedIds.includes(inv.id))
 
   return (
     <>
@@ -283,16 +353,16 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                   {isVi ? 'Đang tải…' : 'Loading…'}
                 </p>
               )}
-              {!txLoading && invRows.length === 0 && (
+              {!txLoading && visibleInvRows.length === 0 && (
                 <p style={{ color: 'var(--c-muted)', fontSize: 13, textAlign: 'center', padding: '20px 0' }}>
                   {isVi ? 'Chưa có khoản đầu tư nào' : 'No investments yet'}
                 </p>
               )}
-              {!txLoading && invRows.map((inv, i) => (
+              {!txLoading && visibleInvRows.map((inv, i) => (
                 <div key={inv.id} style={{
                   display: 'flex', alignItems: 'center', gap: 10,
                   padding: '11px 16px',
-                  borderBottom: i < invRows.length - 1 ? '1px solid var(--c-line)' : 'none',
+                  borderBottom: i < visibleInvRows.length - 1 ? '1px solid var(--c-line)' : 'none',
                 }}>
                   <div style={{ width: 28, height: 28, borderRadius: 7, background: 'var(--c-card-2)', color: GD_COLORS[inv.type] ?? 'var(--c-muted)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
                     <TypeIcon type={inv.type} size={13} />
@@ -317,6 +387,14 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                       </div>
                     )}
                   </div>
+                  <button
+                    onClick={() => { setActionInv(inv); setShowInvOptions(true) }}
+                    className="cn-btn ghost"
+                    style={{ padding: 5, flexShrink: 0 }}
+                    aria-label="Options"
+                  >
+                    <MoreHorizontal size={14} color="var(--c-muted)" />
+                  </button>
                 </div>
               ))}
             </>
@@ -497,10 +575,170 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
           isVi={isVi}
         />
       )}
+
+      {/* Investment options modal */}
+      {showInvOptions && actionInv && (
+        <InvOptionsModal
+          inv={actionInv}
+          isVi={isVi}
+          onClose={() => { setShowInvOptions(false) }}
+          onHistory={() => { setShowInvOptions(false); setTab('history') }}
+          onSell={() => { setShowInvOptions(false); setTimeout(() => setShowSell(true), 80) }}
+          onUnassign={() => { setShowInvOptions(false); setTimeout(() => setShowUnassignConfirm(true), 80) }}
+        />
+      )}
+
+      {/* Unassign confirmation modal */}
+      {showUnassignConfirm && actionInv && (
+        <UnassignConfirmModal
+          inv={actionInv}
+          unassigning={unassigning}
+          isVi={isVi}
+          onCancel={() => setShowUnassignConfirm(false)}
+          onConfirm={handleUnassign}
+        />
+      )}
+
+      {/* Sell / Withdraw sheet */}
+      <SellWithdrawSheet
+        item={actionInv && showSell ? buildSellItem(actionInv) : null}
+        open={showSell}
+        context="goal"
+        onClose={() => { setShowSell(false) }}
+        onSuccess={() => { setShowSell(false); if (actionInv) setUnassignedIds((prev) => [...prev, actionInv.id]); onDataChanged() }}
+      />
     </>
   )
 }
 
+// ─── Investment options modal ──────────────────────────────────────────────
+function InvOptionsModal({ inv, isVi, onClose, onHistory, onSell, onUnassign }: {
+  inv: InvRow; isVi: boolean
+  onClose: () => void; onHistory: () => void; onSell: () => void; onUnassign: () => void
+}) {
+  const isBank = inv.type === 'bank'
+  const typeColor = GD_COLORS[inv.type] ?? 'var(--c-muted)'
+
+  const actions = [
+    {
+      icon: <CalendarDays size={18} color="var(--c-muted)" />,
+      bg: 'var(--c-card-2)',
+      label: isVi ? 'Lịch sử giao dịch' : 'Transaction history',
+      sub: isVi ? 'Xem các lần mua / bán trước đây' : 'View past buys & sells',
+      onClick: onHistory,
+    },
+    {
+      icon: isBank
+        ? <ArrowDownRight size={18} color="var(--c-neg)" />
+        : <ArrowDownRight size={18} color="var(--c-neg)" />,
+      bg: 'var(--c-neg-tint)',
+      label: isBank ? (isVi ? 'Rút tiền' : 'Withdraw') : (isVi ? 'Bán' : 'Sell'),
+      sub: isBank
+        ? (isVi ? 'Rút tiền gửi khỏi mục tiêu' : 'Withdraw from goal')
+        : (isVi ? 'Bán khoản đầu tư' : 'Liquidate investment'),
+      onClick: onSell,
+    },
+    {
+      icon: <Unlink size={18} color="var(--c-warn,#b45309)" />,
+      bg: 'var(--c-warn-tint,#fef3c7)',
+      label: isVi ? 'Bỏ gán mục tiêu' : 'Unassign from goal',
+      sub: isVi ? 'Chuyển khoản đầu tư sang trạng thái chưa gán' : 'Move this investment to unassigned',
+      onClick: onUnassign,
+    },
+  ]
+
+  return (
+    <DModal onClose={onClose} title={isVi ? 'Tùy chọn' : 'Options'} width={380}>
+      <div style={{ display: 'grid', gap: 10 }}>
+        {/* Item summary */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '10px 14px', background: 'var(--c-card-2)', borderRadius: 12, marginBottom: 4 }}>
+          <div style={{ width: 36, height: 36, borderRadius: 9, background: 'var(--c-card)', color: typeColor, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, border: '1px solid var(--c-line)' }}>
+            <TypeIcon type={inv.type} size={16} />
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{inv.name}</div>
+            <div style={{ display: 'flex', gap: 8, marginTop: 2 }}>
+              <span style={{ fontSize: 12, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(inv.value)}</span>
+              {inv.gainPct != null && (
+                <span style={{
+                  fontSize: 10, fontWeight: 600, padding: '1px 6px', borderRadius: 999,
+                  background: inv.gainPct >= 0 ? 'var(--c-pos-tint)' : 'var(--c-neg-tint)',
+                  color: inv.gainPct >= 0 ? 'var(--c-pos)' : 'var(--c-neg)',
+                }}>
+                  {inv.gainPct >= 0 ? '+' : ''}{fmtPct(inv.gainPct)}
+                </span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {actions.map((a, i) => (
+          <button key={i} onClick={a.onClick} style={{
+            width: '100%', textAlign: 'left', padding: '13px 16px',
+            background: 'var(--c-card)', border: '1px solid var(--c-line)',
+            borderRadius: 14, cursor: 'pointer', fontFamily: 'inherit',
+            display: 'flex', alignItems: 'center', gap: 14, transition: 'background 120ms',
+          }}
+            onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--c-card-2)')}
+            onMouseLeave={(e) => (e.currentTarget.style.background = 'var(--c-card)')}
+          >
+            <div style={{ width: 40, height: 40, borderRadius: 10, background: a.bg, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+              {a.icon}
+            </div>
+            <div style={{ flex: 1, minWidth: 0 }}>
+              <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{a.label}</div>
+              <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2 }}>{a.sub}</div>
+            </div>
+            <ChevronRight size={14} color="var(--c-muted)" />
+          </button>
+        ))}
+      </div>
+    </DModal>
+  )
+}
+
+// ─── Unassign confirm modal ────────────────────────────────────────────────
+function UnassignConfirmModal({ inv, unassigning, isVi, onCancel, onConfirm }: {
+  inv: InvRow; unassigning: boolean; isVi: boolean; onCancel: () => void; onConfirm: () => void
+}) {
+  return (
+    <DModal onClose={onCancel} title={isVi ? 'Bỏ gán mục tiêu?' : 'Unassign from goal?'} width={380}>
+      <div style={{ display: 'grid', gap: 16 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 14px', background: 'var(--c-card-2)', borderRadius: 10 }}>
+          <div style={{ width: 32, height: 32, borderRadius: 8, background: 'var(--c-warn-tint,#fef3c7)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+            <TypeIcon type={inv.type} size={15} />
+          </div>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{inv.name}</div>
+            <div style={{ fontSize: 12, color: 'var(--c-muted)', marginTop: 1, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(inv.value)}</div>
+          </div>
+        </div>
+        <p style={{ margin: 0, fontSize: 13, color: 'var(--c-muted)', lineHeight: 1.55 }}>
+          {isVi
+            ? 'Khoản đầu tư này sẽ được chuyển sang "Chưa gán". Bạn có thể gán lại bất kỳ lúc nào từ trang Kế hoạch.'
+            : 'This investment will be moved to "Unassigned". You can re-assign it any time from the Planning page.'}
+        </p>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button onClick={onCancel} className="cn-btn ghost" style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}>
+            {isVi ? 'Hủy' : 'Cancel'}
+          </button>
+          <button onClick={onConfirm} disabled={unassigning} style={{
+            flex: 2, padding: '10px 14px', background: 'var(--c-warn,#b45309)', color: '#fff',
+            border: 'none', borderRadius: 10, fontSize: 13, fontWeight: 600,
+            cursor: unassigning ? 'default' : 'pointer', fontFamily: 'inherit',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+            opacity: unassigning ? 0.6 : 1,
+          }}>
+            <Unlink size={14} />
+            {unassigning ? (isVi ? 'Đang xử lý…' : 'Unassigning…') : (isVi ? 'Bỏ gán' : 'Unassign')}
+          </button>
+        </div>
+      </div>
+    </DModal>
+  )
+}
+
+// ─── Shared DModal ─────────────────────────────────────────────────────────
 function DModal({ onClose, title, width = 380, children }: {
   onClose: () => void; title: string; width?: number; children: React.ReactNode
 }) {
@@ -514,6 +752,8 @@ function DModal({ onClose, title, width = 380, children }: {
       }}
     >
       <div
+        role="dialog"
+        aria-modal="true"
         onClick={(e) => e.stopPropagation()}
         style={{
           width: '100%', maxWidth: width, maxHeight: 'calc(100vh - 48px)',
@@ -605,7 +845,6 @@ function EditGoalModal({ open, onClose, goal, onSaved, isVi }: {
     }
   }, [open, goal])
 
-  // Live savings calculator
   const monthsTo = (() => {
     if (!date) return 1
     const [y, m] = date.split('-').map(Number)

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect } from 'react'
 import { ChevronLeft, X, TrendingUp, Building, CircleDollarSign, BarChart2, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Unlink } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData, FundBreakdownItem } from '../DashboardClient'
-import SellWithdrawSheet, { type SellItem } from './SellWithdrawSheet'
+import { SellWithdrawSheet, type SellItem } from './SellWithdrawSheet'
 
 interface InvestmentTx {
   transaction_id: string


### PR DESCRIPTION
## Summary

- Adds a ⋯ (three-dots) button on each investment row in the desktop goal detail investments tab
- Clicking opens an options modal with: Transaction history, Sell/Withdraw, and Unassign from goal
- Unassign handles fund investments (PATCH each fund-investment record) and non-fund transactions (PUT assign API with goal_id: null)
- Optimistic removal from the list + onDataChanged() to refresh parent

## Test plan

- [ ] Each investment row shows ⋯ button in desktop goal detail Investments tab
- [ ] Options modal opens with all three actions
- [ ] Transaction history → switches to History tab
- [ ] Sell/Withdraw → opens sell sheet pre-filled
- [ ] Unassign → confirm → investment removed from list, parent refreshes

🤖 Generated with Claude Code