### PR TITLE
fix(layout): eliminate old header flash on desktop refresh

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -210,7 +210,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
   const tc = useTranslations('common')
   const tg = useTranslations('goals')
   const locale = useLocale()
-  const { userName, setMobileTopBar, setHideDesktopHeader } = useNavigation()
+  const { userName, setMobileTopBar } = useNavigation()
   const isDesktop = useIsDesktop()
   const [data, setData] = useState<DashboardData | null>(null)
   const [loading, setLoading] = useState(true)
@@ -367,11 +367,6 @@ export default function DashboardClient({ userId }: { userId: string }) {
     }
   }
 
-  useEffect(() => {
-    setHideDesktopHeader(true)
-    return () => setHideDesktopHeader(false)
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   useEffect(() => {
     setMobileTopBar({

--- a/app/components/layouts/AuthenticatedLayout.tsx
+++ b/app/components/layouts/AuthenticatedLayout.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { useRouter, usePathname } from 'next/navigation'
 import { createBrowserClient } from '@supabase/ssr'
 import { toast } from 'sonner'
 import { Plus } from 'lucide-react'
@@ -28,9 +28,15 @@ function getDisplayName(email: string): string {
   return firstName.charAt(0).toUpperCase() + firstName.slice(1)
 }
 
+// Pages that provide their own desktop top bar and don't need the shared Header.
+// Checked synchronously via usePathname so there is no flash on hard refresh.
+const PAGES_WITH_OWN_HEADER = new Set(['/dashboard'])
+
 function AuthenticatedLayoutInner({ children, email, initials }: { children: React.ReactNode; email: string; initials: string }) {
-  const { mobileTopBar, hideDesktopHeader } = useNavigation()
+  const { mobileTopBar } = useNavigation()
   const [showAddTx, setShowAddTx] = useState(false)
+  const pathname = usePathname()
+  const hideDesktopHeader = PAGES_WITH_OWN_HEADER.has(pathname)
 
   return (
     <div className="flex h-screen bg-canvas dark:bg-gray-950 overflow-hidden">
@@ -41,7 +47,7 @@ function AuthenticatedLayoutInner({ children, email, initials }: { children: Rea
 
       {/* Main area */}
       <div className="flex flex-col flex-1 min-w-0 overflow-hidden">
-        {/* Desktop header */}
+        {/* Desktop header — hidden for pages that provide their own DTopBar */}
         {!hideDesktopHeader && (
           <div className="hidden md:block">
             <Header />

--- a/app/components/navigation/NavigationContext.tsx
+++ b/app/components/navigation/NavigationContext.tsx
@@ -17,8 +17,6 @@ interface NavigationContextValue {
   userName: string
   mobileTopBar: MobileTopBarOpts
   setMobileTopBar: (opts: MobileTopBarOpts) => void
-  hideDesktopHeader: boolean
-  setHideDesktopHeader: (v: boolean) => void
 }
 
 const NavigationContext = createContext<NavigationContextValue>({
@@ -29,15 +27,12 @@ const NavigationContext = createContext<NavigationContextValue>({
   userName: '',
   mobileTopBar: { title: '' },
   setMobileTopBar: () => {},
-  hideDesktopHeader: false,
-  setHideDesktopHeader: () => {},
 })
 
 export function NavigationProvider({ children, userName }: { children: React.ReactNode; userName: string }) {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false)
   const [mobileTopBar, setMobileTopBarState] = useState<MobileTopBarOpts>({ title: '' })
-  const [hideDesktopHeader, setHideDesktopHeader] = useState(false)
 
   const setMobileTopBar = useCallback((opts: MobileTopBarOpts) => {
     setMobileTopBarState(opts)
@@ -49,7 +44,6 @@ export function NavigationProvider({ children, userName }: { children: React.Rea
       sidebarCollapsed, setSidebarCollapsed,
       userName,
       mobileTopBar, setMobileTopBar,
-      hideDesktopHeader, setHideDesktopHeader,
     }}>
       {children}
     </NavigationContext.Provider>


### PR DESCRIPTION
## Root cause
`hideDesktopHeader` was a React state value (default `false`) that `DashboardClient` corrected to `true` inside a `useEffect`. Effects run **after** the browser paints, so the SSR-rendered header was visible for one frame on every hard refresh.

## Fix
Replace the effect-driven pattern with a synchronous `usePathname` check directly in `AuthenticatedLayoutInner`. Since `usePathname` is available during SSR, the layout never emits the header HTML for redesigned pages — no flash possible.

A `PAGES_WITH_OWN_HEADER` set in the layout file lists the pages that provide their own `DTopBar` (currently `/dashboard`). Adding a redesigned page is a one-line addition to that set.

`hideDesktopHeader` / `setHideDesktopHeader` removed from `NavigationContext` entirely — no longer needed.

## Test plan
- [ ] Hard-refresh `/dashboard` on desktop — old header (page title / sign-out / theme toggle) must not flash
- [ ] Navigate to `/planning`, `/funds`, `/settings` — old header still visible as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)