### PR TITLE
feat(planning): desktop redesign — two-panel Cairn layout

### DIFF
--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -4,14 +4,8 @@ import { useState, useEffect, useCallback } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useTranslations, useLocale } from 'next-intl'
 import { useNavigation } from '@/app/components/navigation/NavigationContext'
-import SalaryInput from './components/SalaryInput'
-import FundInvestmentsSection from './components/FundInvestmentsSection'
-import DirectSavingsSection from './components/DirectSavingsSection'
-import FixedExpensesSection from './components/FixedExpensesSection'
-import InsuranceSection from './components/InsuranceSection'
-import OtherExpensesSection from './components/OtherExpensesSection'
-import AllocationSummary from './components/AllocationSummary'
 import MobilePlanningView from './components/MobilePlanningView'
+import DesktopPlanningView from './components/DesktopPlanningView'
 
 export interface MonthlyPlan {
   id: string
@@ -197,12 +191,6 @@ export default function PlanningClient() {
 
   useEffect(() => { fetchPlan() }, [fetchPlan])
 
-  function navigate(dir: 'prev' | 'next') {
-    const { m, y } = dir === 'prev' ? prevMonth(month, year) : nextMonth(month, year)
-    setMonth(m)
-    setYear(y)
-  }
-
   const refetch = useCallback(() => fetchPlan({ force: true }), [fetchPlan])
 
   const navigatePrev = useCallback(() => {
@@ -276,115 +264,32 @@ export default function PlanningClient() {
       />
 
       {/* Desktop view — hidden on mobile */}
-      <div className="hidden md:block space-y-6" data-testid="desktop-planning">
-      {/* Month navigation */}
-      <div className="flex items-center gap-3">
-        <button
-          data-testid="prev-month"
-          onClick={() => navigate('prev')}
-          className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400 transition-colors"
-        >
-          <ChevronLeft className="h-4 w-4" />
-        </button>
-        <span className="text-2xl font-semibold text-gray-900 dark:text-gray-100 min-w-[160px] text-center">
-          {MONTHS[month - 1]} {year}
-        </span>
-        <button
-          data-testid="next-month"
-          onClick={() => navigate('next')}
-          className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-400 transition-colors"
-        >
-          <ChevronRight className="h-4 w-4" />
-        </button>
-      </div>
-
-      {/* Toast */}
-      {toast && (
-        <div className="fixed top-4 right-4 z-50 px-4 py-3 bg-green-600 text-white text-sm font-medium rounded-lg shadow-lg">
-          {toast}
-        </div>
-      )}
-
-      {loading ? (
-        <div className="text-center py-20 text-gray-400 dark:text-gray-500">{t('loading')}</div>
-      ) : (
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Left col: salary + sections */}
-          <div className="lg:col-span-2 space-y-6 order-2 lg:order-1">
-            <SalaryInput
-              plan={plan}
-              month={month}
-              year={year}
-              onPlanCreated={(p) => { setPlan(p); refetch() }}
-              onPlanDeleted={() => {
-                const deletedMonth = MONTHS[month - 1]
-                const deletedYear = year
-                bustPlanCache(month, year)
-                setPlan(null)
-                setInvestments([])
-                setSavings([])
-                setFixedExpenses([])
-                showToast(t('deletedToast', { month: deletedMonth, year: deletedYear }))
-              }}
-            />
-
-            {plan ? (
-              <>
-                <FundInvestmentsSection
-                  plan={plan}
-                  investments={investments}
-                  funds={funds}
-                  goals={goals}
-                  onRefresh={refetch}
-                  onToast={showToast}
-                />
-                <DirectSavingsSection
-                  plan={plan}
-                  savings={savings}
-                  goals={goals}
-                  onRefresh={refetch}
-                  onToast={showToast}
-                />
-                <FixedExpensesSection
-                  plan={plan}
-                  fixedExpenses={fixedExpenses}
-                  onRefresh={refetch}
-                  onToast={showToast}
-                />
-                <InsuranceSection
-                  plan={plan}
-                  insuranceMembers={insuranceMembers}
-                  onRefresh={refetch}
-                  onToast={showToast}
-                />
-                <OtherExpensesSection
-                  plan={plan}
-                  otherExpenses={otherExpenses}
-                  onRefresh={refetch}
-                  onToast={showToast}
-                />
-              </>
-            ) : (
-              <div className="text-center py-8 text-gray-400 dark:text-gray-500 text-sm">
-                {t('enterPlanPrompt')}
-              </div>
-            )}
-          </div>
-
-          {/* Right col: allocation summary */}
-          <div className="order-1 lg:order-2">
-            <AllocationSummary
-              plan={plan}
-              investments={investments}
-              savings={savings}
-              fixedExpenses={fixedExpenses}
-              insuranceMembers={insuranceMembers}
-              otherExpenses={otherExpenses}
-            />
-          </div>
-        </div>
-      )}
-      </div>
+      <DesktopPlanningView
+        month={month}
+        year={year}
+        plan={plan}
+        investments={investments}
+        savings={savings}
+        fixedExpenses={fixedExpenses}
+        insuranceMembers={insuranceMembers}
+        otherExpenses={otherExpenses}
+        funds={funds}
+        goals={goals}
+        loading={loading}
+        onPrev={navigatePrev}
+        onNext={navigateNext}
+        onPlanCreated={(p) => { setPlan(p); refetch() }}
+        onPlanDeleted={() => {
+          bustPlanCache(month, year)
+          setPlan(null)
+          setInvestments([])
+          setSavings([])
+          setFixedExpenses([])
+          showToast(t('deletedToast', { month: MONTHS[month - 1], year }))
+        }}
+        onRefresh={refetch}
+        onToast={showToast}
+      />
     </>
   )
 }

--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -213,8 +213,8 @@ export default function PlanningClient() {
     const shortMonths = isVI ? SHORT_MONTHS_VI : SHORT_MONTHS_EN
     const shortLabel = `${shortMonths[month - 1]} ${year}`
     setMobileTopBar({
-      title: isVI ? 'Ngân sách' : 'Budget',
-      subtitle: isVI ? 'Kế hoạch tháng' : 'Monthly plan',
+      title: isVI ? 'Kế hoạch Tháng' : 'Monthly Plan',
+      subtitle: isVI ? 'Kế hoạch' : 'Planning',
       trailing: (
         <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: 3, background: 'var(--c-card-2)', border: '1px solid var(--c-line)', borderRadius: 10 }}>
           <button

--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -203,6 +203,12 @@ export default function PlanningClient() {
     setMonth(m); setYear(y)
   }, [month, year])
 
+  const navigateToday = useCallback(() => {
+    const now = new Date()
+    setMonth(now.getMonth() + 1)
+    setYear(now.getFullYear())
+  }, [])
+
   useEffect(() => {
     const shortMonths = isVI ? SHORT_MONTHS_VI : SHORT_MONTHS_EN
     const shortLabel = `${shortMonths[month - 1]} ${year}`
@@ -278,6 +284,7 @@ export default function PlanningClient() {
         loading={loading}
         onPrev={navigatePrev}
         onNext={navigateNext}
+        onToday={navigateToday}
         onPlanCreated={(p) => { setPlan(p); refetch() }}
         onPlanDeleted={() => {
           bustPlanCache(month, year)

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useMemo } from 'react'
+import React, { useState, useMemo } from 'react'
 import {
   ChevronLeft, ChevronRight, ChevronDown, ChevronUp,
   Target, Building, Shield, ShoppingCart,
@@ -72,16 +72,16 @@ function DModal({ onClose, title, width = 400, children }: {
   return (
     <div
       onClick={onClose}
-      style={{ position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)', zIndex: 200, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24, backdropFilter: 'blur(2px)' }}
+      style={{ position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)', zIndex: 200, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24, backdropFilter: 'blur(2px)', animation: 'fade-in 150ms ease' }}
     >
       <div
         role="dialog"
         aria-modal="true"
         onClick={e => e.stopPropagation()}
-        style={{ width: '100%', maxWidth: width, maxHeight: 'calc(100vh - 48px)', background: 'var(--c-card)', borderRadius: 16, boxShadow: '0 24px 48px rgba(15,23,42,0.18)', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+        style={{ width: '100%', maxWidth: width, maxHeight: 'calc(100vh - 48px)', background: 'var(--c-card)', borderRadius: 16, boxShadow: '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)', display: 'flex', flexDirection: 'column', overflow: 'hidden', animation: 'modal-in 200ms cubic-bezier(0.2,0.8,0.2,1)' }}
       >
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0 }}>
-          <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700 }}>{title}</h3>
+          <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{title}</h3>
           <button onClick={onClose} aria-label="Close" style={{ padding: 6, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
             <X size={18} />
           </button>
@@ -100,7 +100,7 @@ function PlanTable({ icon, iconColor, title, total, defaultOpen = true, children
 }) {
   const [open, setOpen] = useState(defaultOpen)
   return (
-    <div style={{ background: 'var(--c-card)', borderRadius: 12, border: '1px solid var(--c-line)', overflow: 'hidden', marginBottom: 12 }}>
+    <div style={{ background: 'var(--c-card)', borderRadius: 16, border: '1px solid var(--c-line)', boxShadow: 'var(--shadow-card)', overflow: 'hidden', marginBottom: 12 }}>
       <button
         onClick={() => setOpen(o => !o)}
         style={{ width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer', background: 'transparent', fontFamily: 'inherit', display: 'flex', alignItems: 'center', gap: 12, padding: '13px 16px', borderBottom: open ? '1px solid var(--c-line)' : 'none' }}
@@ -213,13 +213,13 @@ function AllocationCard({ salary, totalGoalAmount, fixedTotal, insTotal, otherTo
 
   const rows = [
     { l: isVI ? 'Đầu tư & tiết kiệm' : 'Invest & save', v: totalGoalAmount, c: 'var(--c-accent-fund,#2563eb)' },
-    ...(fixedTotal > 0 ? [{ l: isVI ? 'Chi phí cố định' : 'Fixed expenses', v: fixedTotal, c: 'var(--c-accent-fixed,#f59e0b)' }] : []),
-    ...(insTotal > 0   ? [{ l: isVI ? 'Bảo hiểm' : 'Insurance',      v: insTotal,  c: 'var(--c-accent-insurance,#8b5cf6)' }] : []),
-    ...(otherTotal > 0 ? [{ l: isVI ? 'Khoản khác' : 'Other',         v: otherTotal,c: 'var(--c-accent-other,#ec4899)' }] : []),
+    ...(fixedTotal > 0 ? [{ l: isVI ? 'Chi phí cố định' : 'Fixed expenses', v: fixedTotal, c: 'var(--c-accent-fixed,#b45309)' }] : []),
+    ...(insTotal > 0   ? [{ l: isVI ? 'Bảo hiểm' : 'Insurance',      v: insTotal,  c: 'var(--c-accent-insurance,#7c3aed)' }] : []),
+    ...(otherTotal > 0 ? [{ l: isVI ? 'Khoản khác' : 'Other',         v: otherTotal,c: 'var(--c-accent-other,#475569)' }] : []),
   ]
 
   return (
-    <div data-testid="planning-alloc-card" style={{ padding: '18px 20px', background: 'var(--c-navy)', color: '#fff', borderRadius: 12 }}>
+    <div data-testid="planning-alloc-card" style={{ padding: '18px 20px', background: 'var(--c-navy)', color: '#fff', borderRadius: 16, boxShadow: 'var(--shadow-card)' }}>
       <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.6)', marginBottom: 4 }}>
         {isVI ? 'Phân bổ tháng này' : "This month's allocation"}
       </div>
@@ -261,15 +261,6 @@ function AllocationCard({ salary, totalGoalAmount, fixedTotal, insTotal, otherTo
 const btnBase: React.CSSProperties = {
   border: 'none', cursor: 'pointer', fontFamily: 'inherit', borderRadius: 10,
   fontSize: 13, fontWeight: 600, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
-}
-
-// ─── Input style ──────────────────────────────────────────────────────────────
-
-const inputStyle: React.CSSProperties = {
-  display: 'block', width: '100%', padding: '9px 12px', fontSize: 13,
-  background: 'var(--c-canvas)', border: '1px solid var(--c-line)', borderRadius: 8,
-  color: 'var(--c-ink)', outline: 'none', boxSizing: 'border-box',
-  fontVariantNumeric: 'tabular-nums', fontFamily: 'inherit',
 }
 
 // ─── Label style ──────────────────────────────────────────────────────────────
@@ -562,8 +553,8 @@ export default function DesktopPlanningView({
                   {byGoal.length === 0 ? (
                     <tr><td colSpan={3} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có khoản đầu tư nào' : 'No investments yet'}</td></tr>
                   ) : byGoal.map(g => (
-                    <>
-                      <tr key={g.goalId + '-hd'} style={{ background: 'var(--c-card-2)', borderBottom: '1px solid var(--c-line)' }}>
+                    <React.Fragment key={g.goalId}>
+                      <tr style={{ background: 'var(--c-card-2)', borderBottom: '1px solid var(--c-line)' }}>
                         <td style={{ padding: '10px 16px' }}>
                           <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
                             <div style={{ width: 24, height: 24, borderRadius: 6, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
@@ -593,13 +584,13 @@ export default function DesktopPlanningView({
                           <td />
                         </tr>
                       ))}
-                    </>
+                    </React.Fragment>
                   ))}
                 </tbody>
               </PlanTable>
 
               {/* Fixed expenses */}
-              <PlanTable icon={<Building size={15} />} iconColor="var(--c-accent-fixed,#f59e0b)" title={isVI ? 'Chi phí cố định' : 'Fixed expenses'} total={fixedTotal}>
+              <PlanTable icon={<Building size={15} />} iconColor="var(--c-accent-fixed,#b45309)" title={isVI ? 'Chi phí cố định' : 'Fixed expenses'} total={fixedTotal}>
                 <THead col1={isVI ? 'Chi phí' : 'Expense'} col2={isVI ? 'Số tiền' : 'Amount'} />
                 <tbody>
                   {fixedExpenses.length === 0 ? (
@@ -627,7 +618,7 @@ export default function DesktopPlanningView({
               </PlanTable>
 
               {/* Insurance */}
-              <PlanTable icon={<Shield size={15} />} iconColor="var(--c-accent-insurance,#8b5cf6)" title={isVI ? 'Bảo hiểm' : 'Insurance'} total={insTotal}>
+              <PlanTable icon={<Shield size={15} />} iconColor="var(--c-accent-insurance,#7c3aed)" title={isVI ? 'Bảo hiểm' : 'Insurance'} total={insTotal}>
                 <THead col1={isVI ? 'Thành viên' : 'Member'} col2={isVI ? 'Đóng góp' : 'Contribution'} />
                 <tbody>
                   {insuranceMembers.length === 0 ? (
@@ -654,7 +645,7 @@ export default function DesktopPlanningView({
               </PlanTable>
 
               {/* Other expenses */}
-              <PlanTable icon={<ShoppingCart size={15} />} iconColor="var(--c-accent-other,#ec4899)" title={isVI ? 'Khoản khác' : 'Other'} total={otherTotal} defaultOpen={false}>
+              <PlanTable icon={<ShoppingCart size={15} />} iconColor="var(--c-accent-other,#475569)" title={isVI ? 'Khoản khác' : 'Other'} total={otherTotal} defaultOpen={false}>
                 <tbody>
                   {otherExpenses.map((o, i) => (
                     <tr key={o.id} style={{ borderBottom: i < otherExpenses.length - 1 ? '1px solid var(--c-line)' : 'none', background: 'var(--c-card)' }}>
@@ -709,7 +700,7 @@ export default function DesktopPlanningView({
           <div style={{ display: 'grid', gap: 14 }}>
             <label style={{ display: 'grid', gap: 6 }}>
               <span style={labelStyle}>{isVI ? 'Thu nhập tháng (₫)' : 'Monthly income (₫)'}</span>
-              <input type="number" value={incomeVal} onChange={e => setIncomeVal(e.target.value)} autoFocus placeholder="e.g. 45000000" style={inputStyle} />
+              <input type="number" value={incomeVal} onChange={e => setIncomeVal(e.target.value)} autoFocus placeholder="e.g. 45000000" className="cn-input tabular" />
             </label>
             {incomeVal && Number(incomeVal) > 0 && (
               <div style={{ background: 'var(--c-navy-tint)', borderRadius: 8, padding: '6px 10px', fontSize: 12, color: 'var(--c-navy)', fontVariantNumeric: 'tabular-nums' }}>
@@ -752,7 +743,7 @@ export default function DesktopPlanningView({
             <div style={{ fontSize: 13, color: 'var(--c-muted)', fontWeight: 500 }}>{overrideModal.name}</div>
             <label style={{ display: 'grid', gap: 6 }}>
               <span style={labelStyle}>{isVI ? 'Số tiền tháng này (₫)' : 'Amount this month (₫)'}</span>
-              <input type="number" value={overrideVal} onChange={e => setOverrideVal(e.target.value)} autoFocus style={inputStyle} />
+              <input type="number" value={overrideVal} onChange={e => setOverrideVal(e.target.value)} autoFocus className="cn-input tabular" />
             </label>
             <button onClick={() => setOverrideVal(String(overrideModal.defaultAmount))} style={{ alignSelf: 'flex-start', fontSize: 11, padding: '4px 8px', background: 'transparent', border: '1px solid var(--c-line)', borderRadius: 6, color: 'var(--c-navy)', cursor: 'pointer', fontFamily: 'inherit', fontWeight: 500 }}>
               {isVI ? 'Mặc định' : 'Default'}: {fmtCompact(overrideModal.defaultAmount)}

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -7,7 +7,7 @@ import {
   MoreHorizontal, Edit2, Trash2, Check, RefreshCw, X, Plus, Calendar,
 } from 'lucide-react'
 import { useLocale } from 'next-intl'
-import { fmtCompact, fmt } from '@/lib/formatters'
+import { fmtCompact } from '@/lib/formatters'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
   InsuranceMember, OtherExpense, Fund, Goal,
@@ -732,7 +732,7 @@ export default function DesktopPlanningView({
             </label>
             {incomeVal && Number(incomeVal) > 0 && (
               <div style={{ background: 'var(--c-navy-tint)', borderRadius: 8, padding: '6px 10px', fontSize: 12, color: 'var(--c-navy)', fontVariantNumeric: 'tabular-nums' }}>
-                {fmt(Number(incomeVal))}
+                {Math.round(Number(incomeVal)).toLocaleString('vi-VN')} ₫
               </div>
             )}
             <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -1,0 +1,766 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import {
+  ChevronLeft, ChevronRight, ChevronDown, ChevronUp,
+  Target, Building, Shield, ShoppingCart,
+  MoreHorizontal, Edit2, Trash2, Check, RefreshCw, X, Plus, Calendar,
+} from 'lucide-react'
+import { useLocale } from 'next-intl'
+import { fmtCompact, fmt } from '@/lib/formatters'
+import type {
+  MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
+  InsuranceMember, OtherExpense, Fund, Goal,
+} from '../PlanningClient'
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface GoalRow {
+  goalId: string
+  goalName: string
+  totalAllocated: number
+  items: { name: string; type: string; amount: number; isDCA?: boolean }[]
+}
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+function getFixedTotal(fixedExpenses: FixedExpense[]) {
+  return fixedExpenses.reduce((s, e) => {
+    if (e.override === 0) return s
+    return s + (e.override ?? e.amount_vnd)
+  }, 0)
+}
+
+function getInsTotal(insuranceMembers: InsuranceMember[]) {
+  return insuranceMembers.reduce((s, m) => {
+    if (m.excluded) return s
+    return s + (m.monthlyOverride ?? Math.round(m.annual_payment_vnd / 12))
+  }, 0)
+}
+
+function buildByGoal(investments: FundInvestment[], savings: DirectSaving[]): GoalRow[] {
+  const map = new Map<string, GoalRow>()
+  for (const inv of investments) {
+    const goalId = inv.goal_id ?? '__unassigned__'
+    const goalName = inv.savings_goals?.goal_name ?? 'Unassigned'
+    if (!map.has(goalId)) map.set(goalId, { goalId, goalName, totalAllocated: 0, items: [] })
+    const row = map.get(goalId)!
+    row.totalAllocated += inv.amount_vnd
+    row.items.push({ name: inv.funds?.name ?? 'Unknown fund', type: 'fund', amount: inv.amount_vnd, isDCA: inv.is_dca_seeded })
+  }
+  for (const sav of savings) {
+    const goalId = sav.goal_id ?? '__unassigned__'
+    const goalName = sav.savings_goals?.goal_name ?? 'Unassigned'
+    if (!map.has(goalId)) map.set(goalId, { goalId, goalName, totalAllocated: 0, items: [] })
+    const row = map.get(goalId)!
+    row.totalAllocated += sav.amount_vnd
+    row.items.push({ name: 'Direct savings', type: 'bank', amount: sav.amount_vnd })
+  }
+  return [...map.values()].sort((a, b) => a.goalName.localeCompare(b.goalName))
+}
+
+const SHORT_MONTHS_EN = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
+const SHORT_MONTHS_VI = ['Th1','Th2','Th3','Th4','Th5','Th6','Th7','Th8','Th9','Th10','Th11','Th12']
+const LONG_MONTHS_EN  = ['January','February','March','April','May','June','July','August','September','October','November','December']
+const LONG_MONTHS_VI  = ['Tháng 1','Tháng 2','Tháng 3','Tháng 4','Tháng 5','Tháng 6','Tháng 7','Tháng 8','Tháng 9','Tháng 10','Tháng 11','Tháng 12']
+
+// ─── DModal ───────────────────────────────────────────────────────────────────
+
+function DModal({ onClose, title, width = 400, children }: {
+  onClose: () => void; title: string; width?: number; children: React.ReactNode
+}) {
+  return (
+    <div
+      onClick={onClose}
+      style={{ position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)', zIndex: 200, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24, backdropFilter: 'blur(2px)' }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        onClick={e => e.stopPropagation()}
+        style={{ width: '100%', maxWidth: width, maxHeight: 'calc(100vh - 48px)', background: 'var(--c-card)', borderRadius: 16, boxShadow: '0 24px 48px rgba(15,23,42,0.18)', display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0 }}>
+          <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700 }}>{title}</h3>
+          <button onClick={onClose} aria-label="Close" style={{ padding: 6, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
+            <X size={18} />
+          </button>
+        </div>
+        <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto' }}>{children}</div>
+      </div>
+    </div>
+  )
+}
+
+// ─── PlanTable — collapsible section ─────────────────────────────────────────
+
+function PlanTable({ icon, iconColor, title, total, defaultOpen = true, children }: {
+  icon: React.ReactNode; iconColor: string; title: string; total: number
+  defaultOpen?: boolean; children: React.ReactNode
+}) {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <div style={{ background: 'var(--c-card)', borderRadius: 12, border: '1px solid var(--c-line)', overflow: 'hidden', marginBottom: 12 }}>
+      <button
+        onClick={() => setOpen(o => !o)}
+        style={{ width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer', background: 'transparent', fontFamily: 'inherit', display: 'flex', alignItems: 'center', gap: 12, padding: '13px 16px', borderBottom: open ? '1px solid var(--c-line)' : 'none' }}
+      >
+        <div style={{ width: 32, height: 32, borderRadius: 8, background: 'var(--c-card-2)', color: iconColor, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+          {icon}
+        </div>
+        <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--c-ink)', flex: 1 }}>{title}</span>
+        <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(total)}</span>
+        {open ? <ChevronUp size={15} color="var(--c-muted)" /> : <ChevronDown size={15} color="var(--c-muted)" />}
+      </button>
+      {open && (
+        <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+          {children}
+        </table>
+      )}
+    </div>
+  )
+}
+
+// ─── Table header row ─────────────────────────────────────────────────────────
+
+function THead({ col1, col2 }: { col1: string; col2: string }) {
+  return (
+    <thead>
+      <tr style={{ background: 'var(--c-card-2)', borderBottom: '1px solid var(--c-line)' }}>
+        <th style={{ padding: '8px 16px', textAlign: 'left', fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase' as const, color: 'var(--c-muted)' }}>{col1}</th>
+        <th style={{ padding: '8px 12px', textAlign: 'right', fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase' as const, color: 'var(--c-muted)' }}>{col2}</th>
+        <th style={{ width: 40 }} />
+      </tr>
+    </thead>
+  )
+}
+
+// ─── DPlanRow — table row with kebab menu ────────────────────────────────────
+
+function MenuBtn({ icon, label, onClick, danger }: {
+  icon: React.ReactNode; label: string; onClick: () => void; danger?: boolean
+}) {
+  return (
+    <button onClick={onClick} style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', color: danger ? 'var(--c-neg)' : 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8, borderBottom: '1px solid var(--c-line)' }}>
+      <span style={{ color: danger ? 'var(--c-neg)' : 'var(--c-muted)' }}>{icon}</span>
+      {label}
+    </button>
+  )
+}
+
+function DPlanRow({ primary, secondary, amount, muted, last, isVI, onSkip, onRestore, onOverride }: {
+  primary: string; secondary?: string | null; amount: number; muted?: boolean
+  last?: boolean; isVI: boolean; onSkip?: () => void; onRestore?: () => void; onOverride?: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  return (
+    <tr style={{ borderBottom: last ? 'none' : '1px solid var(--c-line)', background: 'var(--c-card)', opacity: muted ? 0.5 : 1 }}>
+      <td style={{ padding: '11px 16px', verticalAlign: 'middle' }}>
+        <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--c-ink)', textDecoration: muted ? 'line-through' : 'none' }}>{primary}</div>
+        {secondary && <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1 }}>{secondary}</div>}
+      </td>
+      <td style={{ padding: '11px 12px', textAlign: 'right', verticalAlign: 'middle' }}>
+        <span style={{ fontSize: 13, fontWeight: 600, color: muted ? 'var(--c-muted)' : 'var(--c-ink)', textDecoration: muted ? 'line-through' : 'none', fontVariantNumeric: 'tabular-nums' }}>
+          {fmtCompact(amount)}
+        </span>
+      </td>
+      <td style={{ padding: '11px 8px 11px 4px', textAlign: 'right', verticalAlign: 'middle', position: 'relative', width: 36 }}>
+        <button onClick={() => setOpen(o => !o)} aria-label="More options" style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
+          <MoreHorizontal size={14} />
+        </button>
+        {open && (
+          <>
+            <div onClick={() => setOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 5 }} />
+            <div style={{ position: 'absolute', top: '100%', right: 8, marginTop: 2, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 170, overflow: 'hidden' }}>
+              {muted ? (
+                <MenuBtn icon={<Check size={13} />} label={isVI ? 'Bao gồm tháng này' : 'Include this month'} onClick={() => { onRestore?.(); setOpen(false) }} />
+              ) : (
+                <>
+                  <MenuBtn icon={<Edit2 size={13} />} label={isVI ? 'Ghi đè số tiền' : 'Override amount'} onClick={() => { onOverride?.(); setOpen(false) }} />
+                  {onRestore && <MenuBtn icon={<RefreshCw size={13} />} label={isVI ? 'Khôi phục mặc định' : 'Restore default'} onClick={() => { onRestore(); setOpen(false) }} />}
+                  <MenuBtn icon={<X size={13} />} label={isVI ? 'Bỏ qua tháng này' : 'Skip this month'} onClick={() => { onSkip?.(); setOpen(false) }} danger />
+                </>
+              )}
+            </div>
+          </>
+        )}
+      </td>
+    </tr>
+  )
+}
+
+// ─── Stacked bar ─────────────────────────────────────────────────────────────
+
+function StackedBar({ segments, total }: { segments: { color: string; value: number }[]; total: number }) {
+  if (total <= 0) return <div style={{ height: 8, borderRadius: 999, background: 'rgba(255,255,255,0.15)' }} />
+  return (
+    <div style={{ height: 8, borderRadius: 999, display: 'flex', overflow: 'hidden' }}>
+      {segments.map((s, i) => (
+        <div key={i} style={{ width: `${Math.min(100, (s.value / total) * 100)}%`, background: s.color, flexShrink: 0 }} />
+      ))}
+    </div>
+  )
+}
+
+// ─── Allocation card (navy sidebar) ──────────────────────────────────────────
+
+function AllocationCard({ salary, totalGoalAmount, fixedTotal, insTotal, otherTotal, isVI }: {
+  salary: number; totalGoalAmount: number; fixedTotal: number; insTotal: number; otherTotal: number; isVI: boolean
+}) {
+  const totalAllocated = totalGoalAmount + fixedTotal + insTotal + otherTotal
+  const remaining = salary - totalAllocated
+  const pct = (v: number) => salary > 0 ? `${Math.round(v / salary * 100)}%` : '—'
+
+  const rows = [
+    { l: isVI ? 'Đầu tư & tiết kiệm' : 'Invest & save', v: totalGoalAmount, c: 'var(--c-accent-fund,#2563eb)' },
+    ...(fixedTotal > 0 ? [{ l: isVI ? 'Chi phí cố định' : 'Fixed expenses', v: fixedTotal, c: 'var(--c-accent-fixed,#f59e0b)' }] : []),
+    ...(insTotal > 0   ? [{ l: isVI ? 'Bảo hiểm' : 'Insurance',      v: insTotal,  c: 'var(--c-accent-insurance,#8b5cf6)' }] : []),
+    ...(otherTotal > 0 ? [{ l: isVI ? 'Khoản khác' : 'Other',         v: otherTotal,c: 'var(--c-accent-other,#ec4899)' }] : []),
+  ]
+
+  return (
+    <div data-testid="planning-alloc-card" style={{ padding: '18px 20px', background: 'var(--c-navy)', color: '#fff', borderRadius: 12 }}>
+      <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.6)', marginBottom: 4 }}>
+        {isVI ? 'Phân bổ tháng này' : "This month's allocation"}
+      </div>
+      <div style={{ fontSize: 26, fontWeight: 700, letterSpacing: '-0.03em', fontVariantNumeric: 'tabular-nums' }}>
+        {fmtCompact(totalAllocated)}
+      </div>
+      <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.55)', marginTop: 2 }}>
+        {pct(totalAllocated)} {isVI ? 'thu nhập' : 'of income'}
+        {remaining < 0 && <span style={{ color: '#fca5a5', marginLeft: 8 }}>⚠ {isVI ? 'Vượt ngân sách' : 'Over budget'}</span>}
+      </div>
+      <div style={{ marginTop: 14, padding: 2, background: 'rgba(255,255,255,0.08)', borderRadius: 999 }}>
+        <StackedBar segments={rows.map(r => ({ color: r.c, value: r.v }))} total={salary} />
+      </div>
+      <div style={{ marginTop: 14, display: 'grid', gap: 7 }}>
+        {rows.map((r, i) => (
+          <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+            <span style={{ width: 8, height: 8, borderRadius: 2, background: r.c, flexShrink: 0 }} />
+            <span style={{ flex: 1, fontSize: 12, color: 'rgba(255,255,255,0.7)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.l}</span>
+            <span style={{ fontSize: 12, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(r.v)}</span>
+            <span style={{ fontSize: 10, color: 'rgba(255,255,255,0.4)', minWidth: 30, textAlign: 'right' }}>{pct(r.v)}</span>
+          </div>
+        ))}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingTop: 8, borderTop: '1px solid rgba(255,255,255,0.12)', marginTop: 2 }}>
+          <span style={{ width: 8, height: 8, borderRadius: 2, background: remaining >= 0 ? 'rgba(255,255,255,0.25)' : '#fca5a5', flexShrink: 0 }} />
+          <span style={{ flex: 1, fontSize: 12, fontWeight: 600, color: remaining >= 0 ? 'rgba(255,255,255,0.8)' : '#fca5a5' }}>
+            {isVI ? 'Còn lại' : 'Remaining'}
+          </span>
+          <span style={{ fontSize: 13, fontWeight: 700, color: remaining >= 0 ? '#86efac' : '#fca5a5', fontVariantNumeric: 'tabular-nums' }}>
+            {remaining >= 0 ? '+' : ''}{fmtCompact(remaining)}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Shared button style ──────────────────────────────────────────────────────
+
+const btnBase: React.CSSProperties = {
+  border: 'none', cursor: 'pointer', fontFamily: 'inherit', borderRadius: 10,
+  fontSize: 13, fontWeight: 600, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+}
+
+// ─── Input style ──────────────────────────────────────────────────────────────
+
+const inputStyle: React.CSSProperties = {
+  display: 'block', width: '100%', padding: '9px 12px', fontSize: 13,
+  background: 'var(--c-canvas)', border: '1px solid var(--c-line)', borderRadius: 8,
+  color: 'var(--c-ink)', outline: 'none', boxSizing: 'border-box',
+  fontVariantNumeric: 'tabular-nums', fontFamily: 'inherit',
+}
+
+// ─── Label style ──────────────────────────────────────────────────────────────
+
+const labelStyle: React.CSSProperties = {
+  fontSize: 11, fontWeight: 600, letterSpacing: '0.05em',
+  textTransform: 'uppercase', color: 'var(--c-muted)',
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+interface Props {
+  month: number
+  year: number
+  plan: MonthlyPlan | null
+  investments: FundInvestment[]
+  savings: DirectSaving[]
+  fixedExpenses: FixedExpense[]
+  insuranceMembers: InsuranceMember[]
+  otherExpenses: OtherExpense[]
+  funds: Fund[]
+  goals: Goal[]
+  loading: boolean
+  onPrev: () => void
+  onNext: () => void
+  onPlanCreated: (p: MonthlyPlan) => void
+  onPlanDeleted: () => void
+  onRefresh: () => void
+  onToast: (msg: string) => void
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
+
+export default function DesktopPlanningView({
+  month, year, plan, investments, savings, fixedExpenses, insuranceMembers,
+  otherExpenses, loading, onPrev, onNext, onPlanCreated, onPlanDeleted, onRefresh, onToast,
+}: Props) {
+  const locale = useLocale()
+  const isVI = locale === 'vi'
+
+  // ── Modal state ──
+  const [showIncome, setShowIncome] = useState(false)
+  const [showDelete, setShowDelete] = useState(false)
+  const [overrideModal, setOverrideModal] = useState<{ id: string; name: string; defaultAmount: number; type: 'fe' | 'ins' } | null>(null)
+  const [overrideVal, setOverrideVal] = useState('')
+  const [incomeVal, setIncomeVal] = useState('')
+  const [saving, setSaving] = useState(false)
+
+  // ── Derived values ──
+  const byGoal = useMemo(() => buildByGoal(investments, savings), [investments, savings])
+  const totalGoalAmount = byGoal.reduce((s, g) => s + g.totalAllocated, 0)
+  const fixedTotal = useMemo(() => getFixedTotal(fixedExpenses), [fixedExpenses])
+  const insTotal   = useMemo(() => getInsTotal(insuranceMembers), [insuranceMembers])
+  const otherTotal = otherExpenses.reduce((s, o) => s + o.amount_vnd, 0)
+  const totalOutflow = totalGoalAmount + fixedTotal + insTotal + otherTotal
+  const remaining    = plan ? plan.salary_vnd - totalOutflow : 0
+  const savedPct     = plan && plan.salary_vnd > 0 ? Math.round(totalGoalAmount / plan.salary_vnd * 100) : 0
+
+  const shortMonths = isVI ? SHORT_MONTHS_VI : SHORT_MONTHS_EN
+  const longMonths  = isVI ? LONG_MONTHS_VI  : LONG_MONTHS_EN
+  const monthLabel  = `${longMonths[month - 1]} ${year}`
+  const shortLabel  = `${shortMonths[month - 1]} ${year}`
+
+  // ── API handlers ──
+
+  async function handleSetIncome() {
+    const num = Number(incomeVal)
+    if (!incomeVal || isNaN(num) || num <= 0) return
+    setSaving(true)
+    try {
+      if (plan) {
+        const res = await fetch(`/api/v1/monthly-plans/${plan.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ salary_vnd: num }),
+        })
+        if (res.ok) { setShowIncome(false); onRefresh(); onToast(isVI ? 'Đã cập nhật thu nhập' : 'Income updated') }
+      } else {
+        const res = await fetch('/api/v1/monthly-plans', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ month, year, salary_vnd: num }),
+        })
+        if (res.ok) {
+          const p = await res.json()
+          setShowIncome(false)
+          onPlanCreated({ id: p.id, month: p.month, year: p.year, salary_vnd: p.salary_vnd })
+        }
+      }
+    } finally { setSaving(false) }
+  }
+
+  async function handleDeletePlan() {
+    if (!plan) return
+    setSaving(true)
+    try {
+      await fetch(`/api/v1/monthly-plans/${plan.id}`, { method: 'DELETE' })
+      setShowDelete(false)
+      onPlanDeleted()
+      onToast(isVI ? `Đã xoá kế hoạch ${monthLabel}` : `Plan for ${monthLabel} deleted`)
+    } finally { setSaving(false) }
+  }
+
+  async function handleFESkip(fe: FixedExpense) {
+    if (!plan) return
+    await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fixed_expense_id: fe.expense_id, monthly_amount_override_vnd: 0 }),
+    })
+    onRefresh(); onToast(isVI ? `Đã bỏ qua ${fe.expense_name}` : `Skipped ${fe.expense_name}`)
+  }
+
+  async function handleFERestore(fe: FixedExpense) {
+    if (!plan) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`)
+    if (!res.ok) return
+    const overrides: Array<{ id: string; fixed_expense_id: string }> = await res.json()
+    const match = overrides.find(o => o.fixed_expense_id === fe.expense_id)
+    if (match) await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides/${match.id}`, { method: 'DELETE' })
+    onRefresh(); onToast(isVI ? `Đã khôi phục ${fe.expense_name}` : `Restored ${fe.expense_name}`)
+  }
+
+  async function handleInsSkip(m: InsuranceMember) {
+    if (!plan) return
+    await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ member_id: m.member_id }),
+    })
+    onRefresh(); onToast(isVI ? `Đã bỏ qua ${m.member_name}` : `Skipped ${m.member_name}`)
+  }
+
+  async function handleInsRestore(m: InsuranceMember) {
+    if (!plan) return
+    await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance/${m.member_id}`, { method: 'DELETE' })
+    const oRes = await fetch(`/api/v1/monthly-plans/${plan.id}/insurance-overrides`)
+    if (oRes.ok) {
+      const overrides: Array<{ id: string; member_id: string }> = await oRes.json()
+      const match = overrides.find(o => o.member_id === m.member_id)
+      if (match) await fetch(`/api/v1/monthly-plans/${plan.id}/insurance-overrides/${match.id}`, { method: 'DELETE' })
+    }
+    onRefresh(); onToast(isVI ? `Đã khôi phục ${m.member_name}` : `Restored ${m.member_name}`)
+  }
+
+  async function handleSaveOverride() {
+    if (!overrideModal || !plan) return
+    const num = Number(overrideVal)
+    if (!overrideVal || isNaN(num) || num <= 0) return
+    setSaving(true)
+    try {
+      const url = overrideModal.type === 'fe'
+        ? `/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`
+        : `/api/v1/monthly-plans/${plan.id}/insurance-overrides`
+      const body = overrideModal.type === 'fe'
+        ? { fixed_expense_id: overrideModal.id, monthly_amount_override_vnd: num }
+        : { member_id: overrideModal.id, monthly_amount_override_vnd: num }
+      await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
+      setOverrideModal(null)
+      onRefresh(); onToast(isVI ? 'Đã lưu' : 'Saved')
+    } finally { setSaving(false) }
+  }
+
+  // ─────────────────────────────────────────────────────────────────────────────
+
+  return (
+    <div
+      data-testid="desktop-planning"
+      className="hidden md:flex"
+      style={{ flexDirection: 'column', flex: 1, minHeight: 0, overflow: 'hidden' }}
+    >
+      {/* ── DTopBar ─────────────────────────────────────────────────────────── */}
+      <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '20px 28px 0', flexShrink: 0 }}>
+        <div>
+          <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--c-muted)', marginBottom: 3 }}>
+            {isVI ? 'Kế hoạch tháng' : 'Monthly plan'}
+          </div>
+          <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--c-ink)', lineHeight: 1 }}>
+            {isVI ? 'Ngân sách' : 'Budget'}
+          </h1>
+        </div>
+
+        {/* Month picker */}
+        <div
+          data-testid="desktop-month-picker"
+          style={{ display: 'flex', alignItems: 'center', gap: 4, padding: 3, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 10 }}
+        >
+          <button
+            data-testid="prev-month"
+            onClick={onPrev}
+            aria-label="Previous month"
+            style={{ padding: '5px 8px', border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}
+          >
+            <ChevronLeft size={15} />
+          </button>
+          <span style={{ padding: '5px 14px', minWidth: 90, textAlign: 'center', background: 'var(--c-canvas)', border: '1px solid var(--c-line)', borderRadius: 7, fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>
+            {shortLabel}
+          </span>
+          <button
+            data-testid="next-month"
+            onClick={onNext}
+            aria-label="Next month"
+            style={{ padding: '5px 8px', border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}
+          >
+            <ChevronRight size={15} />
+          </button>
+        </div>
+      </header>
+
+      {/* ── Two-panel body ───────────────────────────────────────────────────── */}
+      <div style={{ flex: 1, display: 'flex', minHeight: 0, overflow: 'hidden', marginTop: 20 }}>
+
+        {/* Left — main scrollable content */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '0 24px 40px', minWidth: 0 }}>
+          {loading ? (
+            <div style={{ textAlign: 'center', padding: '60px 20px', color: 'var(--c-muted)' }}>
+              {isVI ? 'Đang tải...' : 'Loading...'}
+            </div>
+          ) : !plan ? (
+            /* Empty state */
+            <div
+              data-testid="planning-empty-state"
+              style={{ padding: '60px 20px', textAlign: 'center', background: 'var(--c-card)', border: '1px dashed var(--c-line)', borderRadius: 16, maxWidth: 480, margin: '0 auto' }}
+            >
+              <div style={{ width: 52, height: 52, borderRadius: 26, background: 'var(--c-card-2)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', marginBottom: 14, color: 'var(--c-muted)' }}>
+                <Calendar size={24} />
+              </div>
+              <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700 }}>
+                {isVI ? `Chưa có kế hoạch cho ${monthLabel}` : `No plan for ${monthLabel}`}
+              </h3>
+              <p style={{ margin: '6px 0 18px', fontSize: 13, color: 'var(--c-muted)' }}>
+                {isVI ? 'Nhập thu nhập để bắt đầu phân bổ.' : 'Enter your income to start allocating.'}
+              </p>
+              <button
+                onClick={() => { setIncomeVal(''); setShowIncome(true) }}
+                style={{ ...btnBase, padding: '10px 18px', background: 'var(--c-navy)', color: '#fff' }}
+              >
+                <Plus size={14} strokeWidth={2.4} />
+                {isVI ? 'Thêm thu nhập' : 'Set income'}
+              </button>
+            </div>
+          ) : (
+            <>
+              {/* Summary strip */}
+              <div
+                data-testid="planning-summary-strip"
+                style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 1, background: 'var(--c-line)', borderRadius: 12, overflow: 'hidden', marginBottom: 20 }}
+              >
+                {([
+                  {
+                    l: isVI ? 'Thu nhập' : 'Income',
+                    v: plan.salary_vnd,
+                    c: 'var(--c-ink)',
+                    extra: (
+                      <div style={{ display: 'flex', gap: 4 }}>
+                        <button onClick={() => { setIncomeVal(String(plan.salary_vnd)); setShowIncome(true) }} aria-label="Edit income" style={{ padding: 6, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
+                          <Edit2 size={15} />
+                        </button>
+                        <button onClick={() => setShowDelete(true)} aria-label="Delete plan" style={{ padding: 6, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-neg)', display: 'flex' }}>
+                          <Trash2 size={15} />
+                        </button>
+                      </div>
+                    ),
+                  },
+                  { l: isVI ? 'Tổng chi' : 'Outflow',    v: totalOutflow, c: 'var(--c-ink)' },
+                  { l: isVI ? 'Còn lại'  : 'Remaining',  v: remaining,    c: remaining >= 0 ? 'var(--c-pos)' : 'var(--c-neg)' },
+                  { l: isVI ? '% Tiết kiệm' : 'Saved %', v: null as number | null, c: 'var(--c-navy)', custom: `${savedPct}%` },
+                ] as Array<{ l: string; v: number | null; c: string; custom?: string; extra?: React.ReactNode }>).map((k, i) => (
+                  <div key={i} style={{ background: 'var(--c-card)', padding: '14px 18px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <div>
+                      <div style={{ fontSize: 11, color: 'var(--c-muted)' }}>{k.l}</div>
+                      <div style={{ fontSize: 18, fontWeight: 700, color: k.c, marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>
+                        {k.custom ?? fmtCompact(k.v!)}
+                      </div>
+                    </div>
+                    {k.extra}
+                  </div>
+                ))}
+              </div>
+
+              {/* By goal */}
+              <PlanTable icon={<Target size={15} />} iconColor="var(--c-navy)" title={isVI ? 'Theo mục tiêu' : 'By goal'} total={totalGoalAmount}>
+                <THead col1={isVI ? 'Mục tiêu / Khoản' : 'Goal / Allocation'} col2={isVI ? 'Tháng này' : 'This month'} />
+                <tbody>
+                  {byGoal.length === 0 ? (
+                    <tr><td colSpan={3} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có khoản đầu tư nào' : 'No investments yet'}</td></tr>
+                  ) : byGoal.map(g => (
+                    <>
+                      <tr key={g.goalId + '-hd'} style={{ background: 'var(--c-card-2)', borderBottom: '1px solid var(--c-line)' }}>
+                        <td style={{ padding: '10px 16px' }}>
+                          <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                            <div style={{ width: 24, height: 24, borderRadius: 6, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                              <Target size={12} />
+                            </div>
+                            <span style={{ fontSize: 13, fontWeight: 600 }}>{g.goalName}</span>
+                            <span style={{ fontSize: 11, color: 'var(--c-muted)' }}>· {g.items.length} {isVI ? 'khoản' : 'items'}</span>
+                          </div>
+                        </td>
+                        <td style={{ padding: '10px 12px', textAlign: 'right' }}>
+                          <span style={{ fontSize: 13, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(g.totalAllocated)}</span>
+                        </td>
+                        <td />
+                      </tr>
+                      {g.items.map((inv, ii) => (
+                        <tr key={g.goalId + '-' + ii} style={{ borderBottom: '1px solid var(--c-line)', background: 'var(--c-card)' }}>
+                          <td style={{ padding: '9px 16px 9px 44px', verticalAlign: 'middle' }}>
+                            <div style={{ fontSize: 12, fontWeight: 500 }}>{inv.name}</div>
+                            <div style={{ fontSize: 10, color: 'var(--c-muted)', textTransform: 'capitalize', marginTop: 1 }}>
+                              {inv.type}
+                              {inv.isDCA && <span style={{ marginLeft: 6, padding: '1px 5px', borderRadius: 4, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', fontSize: 9, fontWeight: 700 }}>DCA</span>}
+                            </div>
+                          </td>
+                          <td style={{ padding: '9px 12px', textAlign: 'right', verticalAlign: 'middle' }}>
+                            <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--c-muted)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(inv.amount)}</span>
+                          </td>
+                          <td />
+                        </tr>
+                      ))}
+                    </>
+                  ))}
+                </tbody>
+              </PlanTable>
+
+              {/* Fixed expenses */}
+              <PlanTable icon={<Building size={15} />} iconColor="var(--c-accent-fixed,#f59e0b)" title={isVI ? 'Chi phí cố định' : 'Fixed expenses'} total={fixedTotal}>
+                <THead col1={isVI ? 'Chi phí' : 'Expense'} col2={isVI ? 'Số tiền' : 'Amount'} />
+                <tbody>
+                  {fixedExpenses.length === 0 ? (
+                    <tr><td colSpan={3} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có chi phí cố định' : 'No fixed expenses'}</td></tr>
+                  ) : fixedExpenses.map((fe, i) => {
+                    const skipped    = fe.override === 0
+                    const isOverridden = !skipped && fe.override != null && fe.override !== fe.amount_vnd
+                    const amount     = skipped ? 0 : (fe.override ?? fe.amount_vnd)
+                    return (
+                      <DPlanRow
+                        key={fe.expense_id}
+                        primary={fe.expense_name}
+                        secondary={skipped ? (isVI ? 'Bỏ qua tháng này' : 'Skipped') : isOverridden ? (isVI ? '(đã ghi đè)' : '(overridden)') : null}
+                        amount={amount}
+                        muted={skipped}
+                        last={i === fixedExpenses.length - 1}
+                        isVI={isVI}
+                        onSkip={() => handleFESkip(fe)}
+                        onRestore={fe.override != null ? () => handleFERestore(fe) : undefined}
+                        onOverride={() => { setOverrideModal({ id: fe.expense_id, name: fe.expense_name, defaultAmount: fe.amount_vnd, type: 'fe' }); setOverrideVal(String(fe.override ?? fe.amount_vnd)) }}
+                      />
+                    )
+                  })}
+                </tbody>
+              </PlanTable>
+
+              {/* Insurance */}
+              <PlanTable icon={<Shield size={15} />} iconColor="var(--c-accent-insurance,#8b5cf6)" title={isVI ? 'Bảo hiểm' : 'Insurance'} total={insTotal}>
+                <THead col1={isVI ? 'Thành viên' : 'Member'} col2={isVI ? 'Đóng góp' : 'Contribution'} />
+                <tbody>
+                  {insuranceMembers.length === 0 ? (
+                    <tr><td colSpan={3} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có bảo hiểm' : 'No insurance members'}</td></tr>
+                  ) : insuranceMembers.map((m, i) => {
+                    const monthly    = m.monthlyOverride ?? Math.round(m.annual_payment_vnd / 12)
+                    const isOverridden = !m.excluded && m.monthlyOverride != null
+                    return (
+                      <DPlanRow
+                        key={m.member_id}
+                        primary={m.member_name}
+                        secondary={m.excluded ? (isVI ? 'Bỏ qua tháng này' : 'Skipped') : isOverridden ? (isVI ? '(đã ghi đè)' : '(overridden)') : (isVI ? 'Đóng góp tháng' : 'Monthly contribution')}
+                        amount={m.excluded ? 0 : monthly}
+                        muted={m.excluded}
+                        last={i === insuranceMembers.length - 1}
+                        isVI={isVI}
+                        onSkip={() => handleInsSkip(m)}
+                        onRestore={m.excluded ? () => handleInsRestore(m) : undefined}
+                        onOverride={() => { const d = Math.round(m.annual_payment_vnd / 12); setOverrideModal({ id: m.member_id, name: m.member_name, defaultAmount: d, type: 'ins' }); setOverrideVal(String(m.monthlyOverride ?? d)) }}
+                      />
+                    )
+                  })}
+                </tbody>
+              </PlanTable>
+
+              {/* Other expenses */}
+              <PlanTable icon={<ShoppingCart size={15} />} iconColor="var(--c-accent-other,#ec4899)" title={isVI ? 'Khoản khác' : 'Other'} total={otherTotal} defaultOpen={false}>
+                <tbody>
+                  {otherExpenses.map((o, i) => (
+                    <tr key={o.id} style={{ borderBottom: i < otherExpenses.length - 1 ? '1px solid var(--c-line)' : 'none', background: 'var(--c-card)' }}>
+                      <td style={{ padding: '10px 16px', fontSize: 13, fontWeight: 500 }}>{o.description}</td>
+                      <td style={{ padding: '10px 12px', textAlign: 'right' }}>
+                        <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(o.amount_vnd)}</span>
+                      </td>
+                      <td style={{ padding: '10px 8px 10px 4px', textAlign: 'right', width: 36 }}>
+                        <button aria-label="Edit" style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
+                          <Edit2 size={13} />
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                  <tr style={{ background: 'var(--c-card)' }}>
+                    <td colSpan={3} style={{ padding: '10px 16px' }}>
+                      <button style={{ padding: '4px 0', fontSize: 12, color: 'var(--c-navy)', border: 'none', background: 'transparent', cursor: 'pointer', fontFamily: 'inherit', display: 'flex', alignItems: 'center', gap: 4, fontWeight: 500 }}>
+                        <Plus size={12} strokeWidth={2.4} />
+                        {isVI ? 'Thêm khoản' : 'Add item'}
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </PlanTable>
+            </>
+          )}
+        </div>
+
+        {/* Right — allocation sidebar */}
+        {plan && (
+          <div style={{ width: 280, flexShrink: 0, overflowY: 'auto', padding: '0 20px 40px 4px', borderLeft: '1px solid var(--c-line)' }}>
+            <AllocationCard
+              salary={plan.salary_vnd}
+              totalGoalAmount={totalGoalAmount}
+              fixedTotal={fixedTotal}
+              insTotal={insTotal}
+              otherTotal={otherTotal}
+              isVI={isVI}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* ── Modals ──────────────────────────────────────────────────────────── */}
+
+      {showIncome && (
+        <DModal
+          onClose={() => setShowIncome(false)}
+          title={plan ? (isVI ? 'Sửa thu nhập' : 'Edit income') : (isVI ? 'Thêm thu nhập' : 'Set income')}
+          width={380}
+        >
+          <div style={{ display: 'grid', gap: 14 }}>
+            <label style={{ display: 'grid', gap: 6 }}>
+              <span style={labelStyle}>{isVI ? 'Thu nhập tháng (₫)' : 'Monthly income (₫)'}</span>
+              <input type="number" value={incomeVal} onChange={e => setIncomeVal(e.target.value)} autoFocus placeholder="e.g. 45000000" style={inputStyle} />
+            </label>
+            {incomeVal && Number(incomeVal) > 0 && (
+              <div style={{ background: 'var(--c-navy-tint)', borderRadius: 8, padding: '6px 10px', fontSize: 12, color: 'var(--c-navy)', fontVariantNumeric: 'tabular-nums' }}>
+                {fmt(Number(incomeVal))}
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+              <button onClick={() => setShowIncome(false)} style={{ ...btnBase, flex: 1, padding: '10px 14px', background: 'transparent', color: 'var(--c-ink)', border: '1px solid var(--c-line)' }}>{isVI ? 'Hủy' : 'Cancel'}</button>
+              <button onClick={handleSetIncome} disabled={saving || !incomeVal || Number(incomeVal) <= 0} style={{ ...btnBase, flex: 2, padding: '10px 14px', background: 'var(--c-navy)', color: '#fff', opacity: saving || !incomeVal || Number(incomeVal) <= 0 ? 0.6 : 1 }}>
+                {saving ? (isVI ? 'Đang lưu...' : 'Saving...') : (isVI ? 'Lưu' : 'Save')}
+              </button>
+            </div>
+          </div>
+        </DModal>
+      )}
+
+      {showDelete && (
+        <DModal onClose={() => setShowDelete(false)} title={isVI ? 'Xoá kế hoạch tháng?' : 'Delete monthly plan?'} width={400}>
+          <div style={{ display: 'grid', gap: 16 }}>
+            <div style={{ padding: '12px 14px', background: 'var(--c-neg-tint,#fef2f2)', borderRadius: 10, display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+              <X size={16} color="var(--c-neg)" strokeWidth={2.2} style={{ flexShrink: 0, marginTop: 1 }} />
+              <p style={{ margin: 0, fontSize: 13, color: 'var(--c-neg)', lineHeight: 1.5 }}>
+                {isVI ? `Toàn bộ dữ liệu kế hoạch cho ${monthLabel} sẽ bị xoá vĩnh viễn.` : `All plan data for ${monthLabel} will be permanently deleted.`}
+              </p>
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button onClick={() => setShowDelete(false)} style={{ ...btnBase, flex: 1, padding: '10px 14px', background: 'transparent', color: 'var(--c-ink)', border: '1px solid var(--c-line)' }}>{isVI ? 'Huỷ' : 'Cancel'}</button>
+              <button onClick={handleDeletePlan} disabled={saving} style={{ ...btnBase, flex: 2, padding: '10px 14px', background: 'var(--c-neg)', color: '#fff' }}>
+                <Trash2 size={14} />
+                {saving ? (isVI ? 'Đang xoá...' : 'Deleting...') : (isVI ? 'Xoá kế hoạch' : 'Delete plan')}
+              </button>
+            </div>
+          </div>
+        </DModal>
+      )}
+
+      {overrideModal && (
+        <DModal onClose={() => setOverrideModal(null)} title={isVI ? 'Ghi đè số tiền' : 'Override amount'} width={340}>
+          <div style={{ display: 'grid', gap: 14 }}>
+            <div style={{ fontSize: 13, color: 'var(--c-muted)', fontWeight: 500 }}>{overrideModal.name}</div>
+            <label style={{ display: 'grid', gap: 6 }}>
+              <span style={labelStyle}>{isVI ? 'Số tiền tháng này (₫)' : 'Amount this month (₫)'}</span>
+              <input type="number" value={overrideVal} onChange={e => setOverrideVal(e.target.value)} autoFocus style={inputStyle} />
+            </label>
+            <button onClick={() => setOverrideVal(String(overrideModal.defaultAmount))} style={{ alignSelf: 'flex-start', fontSize: 11, padding: '4px 8px', background: 'transparent', border: '1px solid var(--c-line)', borderRadius: 6, color: 'var(--c-navy)', cursor: 'pointer', fontFamily: 'inherit', fontWeight: 500 }}>
+              {isVI ? 'Mặc định' : 'Default'}: {fmtCompact(overrideModal.defaultAmount)}
+            </button>
+            <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+              <button onClick={() => setOverrideModal(null)} style={{ ...btnBase, flex: 1, padding: '10px 14px', background: 'transparent', color: 'var(--c-ink)', border: '1px solid var(--c-line)' }}>{isVI ? 'Hủy' : 'Cancel'}</button>
+              <button onClick={handleSaveOverride} disabled={saving || !overrideVal || Number(overrideVal) <= 0} style={{ ...btnBase, flex: 2, padding: '10px 14px', background: 'var(--c-navy)', color: '#fff', opacity: saving || !overrideVal || Number(overrideVal) <= 0 ? 0.6 : 1 }}>
+                {saving ? (isVI ? 'Đang lưu...' : 'Saving...') : (isVI ? 'Lưu' : 'Save')}
+              </button>
+            </div>
+          </div>
+        </DModal>
+      )}
+    </div>
+  )
+}

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -462,7 +462,7 @@ export default function DesktopPlanningView({
       style={{ flexDirection: 'column', flex: 1, minHeight: 0, overflow: 'hidden' }}
     >
       {/* ── DTopBar ─────────────────────────────────────────────────────────── */}
-      <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '20px 28px 0', flexShrink: 0 }}>
+      <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '20px 28px 16px', flexShrink: 0, borderBottom: '1px solid var(--c-line)', background: 'var(--c-canvas)' }}>
         <div>
           <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--c-muted)', marginBottom: 3 }}>
             {isVI ? 'Kế hoạch' : 'Planning'}
@@ -504,10 +504,10 @@ export default function DesktopPlanningView({
       </header>
 
       {/* ── Two-panel body ───────────────────────────────────────────────────── */}
-      <div style={{ flex: 1, display: 'flex', minHeight: 0, overflow: 'hidden', marginTop: 20 }}>
+      <div style={{ flex: 1, display: 'flex', minHeight: 0, overflow: 'hidden' }}>
 
         {/* Left — main scrollable content */}
-        <div style={{ flex: 1, overflowY: 'auto', padding: '0 24px 40px', minWidth: 0 }}>
+        <div style={{ flex: 1, overflowY: 'auto', padding: '20px 24px 40px', minWidth: 0 }}>
           {loading ? (
             <div style={{ textAlign: 'center', padding: '60px 20px', color: 'var(--c-muted)' }}>
               {isVI ? 'Đang tải...' : 'Loading...'}
@@ -708,7 +708,7 @@ export default function DesktopPlanningView({
 
         {/* Right — allocation sidebar */}
         {plan && (
-          <div style={{ width: 280, flexShrink: 0, overflowY: 'auto', padding: '0 20px 40px 4px', borderLeft: '1px solid var(--c-line)' }}>
+          <div style={{ width: 280, flexShrink: 0, overflowY: 'auto', padding: '20px 20px 40px 4px', borderLeft: '1px solid var(--c-line)' }}>
             <AllocationCard
               salary={plan.salary_vnd}
               totalGoalAmount={totalGoalAmount}

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -137,11 +137,11 @@ function THead({ col1, col2 }: { col1: string; col2: string }) {
 
 // ─── DPlanRow — table row with kebab menu ────────────────────────────────────
 
-function MenuBtn({ icon, label, onClick, danger }: {
-  icon: React.ReactNode; label: string; onClick: () => void; danger?: boolean
+function MenuBtn({ icon, label, onClick, danger, noBorder }: {
+  icon: React.ReactNode; label: string; onClick: () => void; danger?: boolean; noBorder?: boolean
 }) {
   return (
-    <button onClick={onClick} style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', color: danger ? 'var(--c-neg)' : 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8, borderBottom: '1px solid var(--c-line)' }}>
+    <button onClick={onClick} style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', borderBottom: noBorder ? 'none' : '1px solid var(--c-line)', cursor: 'pointer', fontFamily: 'inherit', color: danger ? 'var(--c-neg)' : 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8 }}>
       <span style={{ color: danger ? 'var(--c-neg)' : 'var(--c-muted)' }}>{icon}</span>
       {label}
     </button>
@@ -173,12 +173,12 @@ function DPlanRow({ primary, secondary, amount, muted, last, isVI, onSkip, onRes
             <div onClick={() => setOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 5 }} />
             <div style={{ position: 'absolute', top: '100%', right: 8, marginTop: 2, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 170, overflow: 'hidden' }}>
               {muted ? (
-                <MenuBtn icon={<Check size={13} />} label={isVI ? 'Bao gồm tháng này' : 'Include this month'} onClick={() => { onRestore?.(); setOpen(false) }} />
+                <MenuBtn icon={<Check size={13} />} label={isVI ? 'Bao gồm tháng này' : 'Include this month'} onClick={() => { onRestore?.(); setOpen(false) }} noBorder />
               ) : (
                 <>
                   <MenuBtn icon={<Edit2 size={13} />} label={isVI ? 'Ghi đè số tiền' : 'Override amount'} onClick={() => { onOverride?.(); setOpen(false) }} />
                   {onRestore && <MenuBtn icon={<RefreshCw size={13} />} label={isVI ? 'Khôi phục mặc định' : 'Restore default'} onClick={() => { onRestore(); setOpen(false) }} />}
-                  <MenuBtn icon={<X size={13} />} label={isVI ? 'Bỏ qua tháng này' : 'Skip this month'} onClick={() => { onSkip?.(); setOpen(false) }} danger />
+                  <MenuBtn icon={<X size={13} />} label={isVI ? 'Bỏ qua tháng này' : 'Skip this month'} onClick={() => { onSkip?.(); setOpen(false) }} danger noBorder />
                 </>
               )}
             </div>
@@ -295,6 +295,7 @@ interface Props {
   loading: boolean
   onPrev: () => void
   onNext: () => void
+  onToday: () => void
   onPlanCreated: (p: MonthlyPlan) => void
   onPlanDeleted: () => void
   onRefresh: () => void
@@ -305,7 +306,7 @@ interface Props {
 
 export default function DesktopPlanningView({
   month, year, plan, investments, savings, fixedExpenses, insuranceMembers,
-  otherExpenses, loading, onPrev, onNext, onPlanCreated, onPlanDeleted, onRefresh, onToast,
+  otherExpenses, loading, onPrev, onNext, onToday, onPlanCreated, onPlanDeleted, onRefresh, onToast,
 }: Props) {
   const locale = useLocale()
   const isVI = locale === 'vi'
@@ -465,9 +466,13 @@ export default function DesktopPlanningView({
           >
             <ChevronLeft size={15} />
           </button>
-          <span style={{ padding: '5px 14px', minWidth: 90, textAlign: 'center', background: 'var(--c-canvas)', border: '1px solid var(--c-line)', borderRadius: 7, fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>
+          <button
+            onClick={onToday}
+            aria-label="Jump to current month"
+            style={{ padding: '5px 14px', minWidth: 90, textAlign: 'center', background: 'var(--c-canvas)', border: '1px solid var(--c-line)', borderRadius: 7, fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', cursor: 'pointer', fontFamily: 'inherit' }}
+          >
             {shortLabel}
-          </span>
+          </button>
           <button
             data-testid="next-month"
             onClick={onNext}
@@ -492,7 +497,7 @@ export default function DesktopPlanningView({
             /* Empty state */
             <div
               data-testid="planning-empty-state"
-              style={{ padding: '60px 20px', textAlign: 'center', background: 'var(--c-card)', border: '1px dashed var(--c-line)', borderRadius: 16, maxWidth: 480, margin: '0 auto' }}
+              style={{ padding: '60px 20px', textAlign: 'center', background: 'var(--c-card)', border: '1px dashed var(--c-line-strong)', borderRadius: 16, maxWidth: 480, margin: '0 auto' }}
             >
               <div style={{ width: 52, height: 52, borderRadius: 26, background: 'var(--c-card-2)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', marginBottom: 14, color: 'var(--c-muted)' }}>
                 <Calendar size={24} />
@@ -640,7 +645,7 @@ export default function DesktopPlanningView({
                         last={i === insuranceMembers.length - 1}
                         isVI={isVI}
                         onSkip={() => handleInsSkip(m)}
-                        onRestore={m.excluded ? () => handleInsRestore(m) : undefined}
+                        onRestore={m.excluded || m.monthlyOverride != null ? () => handleInsRestore(m) : undefined}
                         onOverride={() => { const d = Math.round(m.annual_payment_vnd / 12); setOverrideModal({ id: m.member_id, name: m.member_name, defaultAmount: d, type: 'ins' }); setOverrideVal(String(m.monthlyOverride ?? d)) }}
                       />
                     )

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -309,6 +309,9 @@ export default function DesktopPlanningView({
   const [overrideVal, setOverrideVal] = useState('')
   const [incomeVal, setIncomeVal] = useState('')
   const [saving, setSaving] = useState(false)
+  const [otherModal, setOtherModal] = useState<OtherExpense | Record<string, never> | null>(null)
+  const [otherDesc, setOtherDesc] = useState('')
+  const [otherAmt, setOtherAmt] = useState('')
 
   // ── Derived values ──
   const byGoal = useMemo(() => buildByGoal(investments, savings), [investments, savings])
@@ -422,6 +425,31 @@ export default function DesktopPlanningView({
       await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
       setOverrideModal(null)
       onRefresh(); onToast(isVI ? 'Đã lưu' : 'Saved')
+    } finally { setSaving(false) }
+  }
+
+  function openOtherModal(o?: OtherExpense) {
+    setOtherModal(o ?? {})
+    setOtherDesc(o?.description ?? '')
+    setOtherAmt(o ? String(o.amount_vnd) : '')
+  }
+
+  async function handleOtherSave() {
+    if (!plan || !otherDesc.trim() || !otherAmt || Number(otherAmt) <= 0) return
+    setSaving(true)
+    try {
+      const isEdit = otherModal && 'id' in otherModal && otherModal.id
+      const url = isEdit
+        ? `/api/v1/monthly-plans/${plan.id}/other-expenses/${(otherModal as OtherExpense).id}`
+        : `/api/v1/monthly-plans/${plan.id}/other-expenses`
+      await fetch(url, {
+        method: isEdit ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ description: otherDesc.trim(), amount_vnd: Number(otherAmt) }),
+      })
+      setOtherModal(null)
+      onRefresh()
+      onToast(isVI ? 'Đã lưu' : 'Saved')
     } finally { setSaving(false) }
   }
 
@@ -654,7 +682,7 @@ export default function DesktopPlanningView({
                         <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(o.amount_vnd)}</span>
                       </td>
                       <td style={{ padding: '10px 8px 10px 4px', textAlign: 'right', width: 36 }}>
-                        <button aria-label="Edit" style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
+                        <button aria-label="Edit" onClick={() => openOtherModal(o)} style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
                           <Edit2 size={13} />
                         </button>
                       </td>
@@ -662,7 +690,7 @@ export default function DesktopPlanningView({
                   ))}
                   <tr style={{ background: 'var(--c-card)' }}>
                     <td colSpan={3} style={{ padding: '10px 16px' }}>
-                      <button style={{ padding: '4px 0', fontSize: 12, color: 'var(--c-navy)', border: 'none', background: 'transparent', cursor: 'pointer', fontFamily: 'inherit', display: 'flex', alignItems: 'center', gap: 4, fontWeight: 500 }}>
+                      <button onClick={() => openOtherModal()} style={{ padding: '4px 0', fontSize: 12, color: 'var(--c-navy)', border: 'none', background: 'transparent', cursor: 'pointer', fontFamily: 'inherit', display: 'flex', alignItems: 'center', gap: 4, fontWeight: 500 }}>
                         <Plus size={12} strokeWidth={2.4} />
                         {isVI ? 'Thêm khoản' : 'Add item'}
                       </button>
@@ -751,6 +779,31 @@ export default function DesktopPlanningView({
             <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
               <button onClick={() => setOverrideModal(null)} style={{ ...btnBase, flex: 1, padding: '10px 14px', background: 'transparent', color: 'var(--c-ink)', border: '1px solid var(--c-line)' }}>{isVI ? 'Hủy' : 'Cancel'}</button>
               <button onClick={handleSaveOverride} disabled={saving || !overrideVal || Number(overrideVal) <= 0} style={{ ...btnBase, flex: 2, padding: '10px 14px', background: 'var(--c-navy)', color: '#fff', opacity: saving || !overrideVal || Number(overrideVal) <= 0 ? 0.6 : 1 }}>
+                {saving ? (isVI ? 'Đang lưu...' : 'Saving...') : (isVI ? 'Lưu' : 'Save')}
+              </button>
+            </div>
+          </div>
+        </DModal>
+      )}
+
+      {otherModal !== null && (
+        <DModal
+          onClose={() => setOtherModal(null)}
+          title={'id' in otherModal && otherModal.id ? (isVI ? 'Sửa khoản chi' : 'Edit expense') : (isVI ? 'Thêm khoản chi' : 'Add expense')}
+          width={380}
+        >
+          <div style={{ display: 'grid', gap: 14 }}>
+            <label style={{ display: 'grid', gap: 6 }}>
+              <span style={labelStyle}>{isVI ? 'Mô tả' : 'Description'}</span>
+              <input value={otherDesc} onChange={e => setOtherDesc(e.target.value)} autoFocus placeholder={isVI ? 'VD. Mua laptop...' : 'e.g. Buy laptop...'} className="cn-input" />
+            </label>
+            <label style={{ display: 'grid', gap: 6 }}>
+              <span style={labelStyle}>{isVI ? 'Số tiền (₫)' : 'Amount (₫)'}</span>
+              <input type="number" value={otherAmt} onChange={e => setOtherAmt(e.target.value)} placeholder="0" className="cn-input tabular" />
+            </label>
+            <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+              <button onClick={() => setOtherModal(null)} style={{ ...btnBase, flex: 1, padding: '10px 14px', background: 'transparent', color: 'var(--c-ink)', border: '1px solid var(--c-line)' }}>{isVI ? 'Hủy' : 'Cancel'}</button>
+              <button onClick={handleOtherSave} disabled={saving || !otherDesc.trim() || !otherAmt || Number(otherAmt) <= 0} style={{ ...btnBase, flex: 2, padding: '10px 14px', background: 'var(--c-navy)', color: '#fff', opacity: saving || !otherDesc.trim() || !otherAmt || Number(otherAmt) <= 0 ? 0.6 : 1 }}>
                 {saving ? (isVI ? 'Đang lưu...' : 'Saving...') : (isVI ? 'Lưu' : 'Save')}
               </button>
             </div>

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -465,10 +465,10 @@ export default function DesktopPlanningView({
       <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '20px 28px 0', flexShrink: 0 }}>
         <div>
           <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--c-muted)', marginBottom: 3 }}>
-            {isVI ? 'Kế hoạch tháng' : 'Monthly plan'}
+            {isVI ? 'Kế hoạch' : 'Planning'}
           </div>
-          <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--c-ink)', lineHeight: 1 }}>
-            {isVI ? 'Ngân sách' : 'Budget'}
+          <h1 style={{ margin: 0, fontSize: 20, fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--c-ink)', lineHeight: 1.1 }}>
+            {isVI ? 'Kế hoạch Tháng' : 'Monthly Plan'}
           </h1>
         </div>
 

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useMemo } from 'react'
+import React, { useState, useMemo, useRef } from 'react'
 import {
   ChevronLeft, ChevronRight, ChevronDown, ChevronUp,
   Target, Shield, ShoppingCart,
@@ -160,6 +160,17 @@ function DPlanRow({ primary, secondary, amount, muted, last, isVI, onSkip, onRes
   last?: boolean; isVI: boolean; onSkip?: () => void; onRestore?: () => void; onOverride?: () => void
 }) {
   const [open, setOpen] = useState(false)
+  const [menuPos, setMenuPos] = useState({ top: 0, right: 0 })
+  const btnRef = useRef<HTMLButtonElement>(null)
+
+  function openMenu() {
+    if (btnRef.current) {
+      const r = btnRef.current.getBoundingClientRect()
+      setMenuPos({ top: r.bottom + 4, right: window.innerWidth - r.right })
+    }
+    setOpen(true)
+  }
+
   return (
     <tr style={{ borderBottom: last ? 'none' : '1px solid var(--c-line)', background: 'var(--c-card)', opacity: muted ? 0.5 : 1 }}>
       <td style={{ padding: '11px 16px', verticalAlign: 'middle' }}>
@@ -171,14 +182,14 @@ function DPlanRow({ primary, secondary, amount, muted, last, isVI, onSkip, onRes
           {fmtCompact(amount)}
         </span>
       </td>
-      <td style={{ padding: '11px 8px 11px 4px', textAlign: 'right', verticalAlign: 'middle', position: 'relative', width: 36 }}>
-        <button onClick={() => setOpen(o => !o)} aria-label="More options" style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
+      <td style={{ padding: '11px 8px 11px 4px', textAlign: 'right', verticalAlign: 'middle', width: 36 }}>
+        <button ref={btnRef} onClick={() => open ? setOpen(false) : openMenu()} aria-label="More options" style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
           <MoreHorizontal size={14} />
         </button>
         {open && (
           <>
             <div onClick={() => setOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 5 }} />
-            <div style={{ position: 'absolute', top: '100%', right: 8, marginTop: 2, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 170, overflow: 'hidden' }}>
+            <div style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 170, overflow: 'hidden' }}>
               {muted ? (
                 <MenuBtn icon={<Check size={13} />} label={isVI ? 'Bao gồm tháng này' : 'Include this month'} onClick={() => { onRestore?.(); setOpen(false) }} noBorder />
               ) : (

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -771,8 +771,13 @@ export default function DesktopPlanningView({
             <div style={{ fontSize: 13, color: 'var(--c-muted)', fontWeight: 500 }}>{overrideModal.name}</div>
             <label style={{ display: 'grid', gap: 6 }}>
               <span style={labelStyle}>{isVI ? 'Số tiền tháng này (₫)' : 'Amount this month (₫)'}</span>
-              <input type="number" value={overrideVal} onChange={e => setOverrideVal(e.target.value)} autoFocus className="cn-input tabular" />
+              <input type="text" inputMode="numeric" value={overrideVal ? Number(overrideVal).toLocaleString('en-US') : ''} onChange={e => setOverrideVal(e.target.value.replace(/,/g, '').replace(/[^0-9]/g, ''))} autoFocus className="cn-input tabular" />
             </label>
+            {overrideVal && Number(overrideVal) > 0 && (
+              <div style={{ background: 'var(--c-navy-tint)', borderRadius: 8, padding: '6px 10px', fontSize: 12, color: 'var(--c-navy)', fontVariantNumeric: 'tabular-nums' }}>
+                {Math.round(Number(overrideVal)).toLocaleString('vi-VN')} ₫
+              </div>
+            )}
             <button onClick={() => setOverrideVal(String(overrideModal.defaultAmount))} style={{ alignSelf: 'flex-start', fontSize: 11, padding: '4px 8px', background: 'transparent', border: '1px solid var(--c-line)', borderRadius: 6, color: 'var(--c-navy)', cursor: 'pointer', fontFamily: 'inherit', fontWeight: 500 }}>
               {isVI ? 'Mặc định' : 'Default'}: {fmtCompact(overrideModal.defaultAmount)}
             </button>

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useMemo } from 'react'
 import {
   ChevronLeft, ChevronRight, ChevronDown, ChevronUp,
-  Target, Building, Shield, ShoppingCart,
+  Target, Shield, ShoppingCart,
   MoreHorizontal, Edit2, Trash2, Check, RefreshCw, X, Plus, Calendar,
 } from 'lucide-react'
 import { useLocale } from 'next-intl'
@@ -618,7 +618,7 @@ export default function DesktopPlanningView({
               </PlanTable>
 
               {/* Fixed expenses */}
-              <PlanTable icon={<Building size={15} />} iconColor="var(--c-accent-fixed,#b45309)" title={isVI ? 'Chi phí cố định' : 'Fixed expenses'} total={fixedTotal}>
+              <PlanTable icon={<svg viewBox="0 0 24 24" width={15} height={15} fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><rect x="4" y="3" width="16" height="18" rx="1" /><path d="M9 8h2M13 8h2M9 12h2M13 12h2M9 16h2M13 16h2" /></svg>} iconColor="var(--c-accent-fixed,#b45309)" title={isVI ? 'Chi phí cố định' : 'Fixed expenses'} total={fixedTotal}>
                 <THead col1={isVI ? 'Chi phí' : 'Expense'} col2={isVI ? 'Số tiền' : 'Amount'} />
                 <tbody>
                   {fixedExpenses.length === 0 ? (

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -799,8 +799,13 @@ export default function DesktopPlanningView({
             </label>
             <label style={{ display: 'grid', gap: 6 }}>
               <span style={labelStyle}>{isVI ? 'Số tiền (₫)' : 'Amount (₫)'}</span>
-              <input type="number" value={otherAmt} onChange={e => setOtherAmt(e.target.value)} placeholder="0" className="cn-input tabular" />
+              <input type="text" inputMode="numeric" value={otherAmt ? Number(otherAmt).toLocaleString('en-US') : ''} onChange={e => setOtherAmt(e.target.value.replace(/,/g, '').replace(/[^0-9]/g, ''))} placeholder="0" className="cn-input tabular" />
             </label>
+            {otherAmt && Number(otherAmt) > 0 && (
+              <div style={{ background: 'var(--c-navy-tint)', borderRadius: 8, padding: '6px 10px', fontSize: 12, color: 'var(--c-navy)', fontVariantNumeric: 'tabular-nums' }}>
+                {Math.round(Number(otherAmt)).toLocaleString('vi-VN')} ₫
+              </div>
+            )}
             <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
               <button onClick={() => setOtherModal(null)} style={{ ...btnBase, flex: 1, padding: '10px 14px', background: 'transparent', color: 'var(--c-ink)', border: '1px solid var(--c-line)' }}>{isVI ? 'Hủy' : 'Cancel'}</button>
               <button onClick={handleOtherSave} disabled={saving || !otherDesc.trim() || !otherAmt || Number(otherAmt) <= 0} style={{ ...btnBase, flex: 2, padding: '10px 14px', background: 'var(--c-navy)', color: '#fff', opacity: saving || !otherDesc.trim() || !otherAmt || Number(otherAmt) <= 0 ? 0.6 : 1 }}>

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -589,7 +589,7 @@ export default function DesktopPlanningView({
                               <Target size={12} />
                             </div>
                             <span style={{ fontSize: 13, fontWeight: 600 }}>{g.goalName}</span>
-                            <span style={{ fontSize: 11, color: 'var(--c-muted)' }}>· {g.items.length} {isVI ? 'khoản' : 'items'}</span>
+                            <span style={{ fontSize: 11, color: 'var(--c-muted)' }}>· {g.items.length} {isVI ? 'khoản' : g.items.length === 1 ? 'item' : 'items'}</span>
                           </div>
                         </td>
                         <td style={{ padding: '10px 12px', textAlign: 'right' }}>

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -4,7 +4,7 @@ import React, { useState, useMemo } from 'react'
 import {
   ChevronLeft, ChevronRight, ChevronDown, ChevronUp,
   Target, Shield, ShoppingCart,
-  MoreHorizontal, Edit2, Trash2, Check, RefreshCw, X, Plus, Calendar,
+  MoreHorizontal, Edit2, Trash2, Check, RefreshCw, X, Plus,
 } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmtCompact } from '@/lib/formatters'
@@ -519,7 +519,10 @@ export default function DesktopPlanningView({
               style={{ padding: '60px 20px', textAlign: 'center', background: 'var(--c-card)', border: '1px dashed var(--c-line-strong)', borderRadius: 16, maxWidth: 480, margin: '0 auto' }}
             >
               <div style={{ width: 52, height: 52, borderRadius: 26, background: 'var(--c-card-2)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', marginBottom: 14, color: 'var(--c-muted)' }}>
-                <Calendar size={24} />
+                <svg viewBox="0 0 24 24" width={24} height={24} fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+                  <rect x="3" y="5" width="18" height="16" rx="2" />
+                  <path d="M3 9h18M8 3v4M16 3v4" />
+                </svg>
               </div>
               <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700 }}>
                 {isVI ? `Chưa có kế hoạch cho ${monthLabel}` : `No plan for ${monthLabel}`}
@@ -529,7 +532,8 @@ export default function DesktopPlanningView({
               </p>
               <button
                 onClick={() => { setIncomeVal(''); setShowIncome(true) }}
-                style={{ ...btnBase, padding: '10px 18px', background: 'var(--c-navy)', color: '#fff' }}
+                className="cn-btn primary"
+                style={{ padding: '10px 18px' }}
               >
                 <Plus size={14} strokeWidth={2.4} />
                 {isVI ? 'Thêm thu nhập' : 'Set income'}

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -4,7 +4,7 @@ import React, { useState, useMemo } from 'react'
 import {
   ChevronLeft, ChevronRight, ChevronDown, ChevronUp,
   Target, Shield, ShoppingCart,
-  MoreHorizontal, Edit2, Trash2, Check, RefreshCw, X, Plus,
+  MoreHorizontal, Check, RefreshCw, X, Plus,
 } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmtCompact } from '@/lib/formatters'
@@ -135,6 +135,13 @@ function THead({ col1, col2 }: { col1: string; col2: string }) {
   )
 }
 
+function EditIcon({ size = 16, color = 'currentColor' }: { size?: number; color?: string }) {
+  return <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke={color} strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M4 20h4l10-10-4-4L4 16z" /></svg>
+}
+function TrashIcon({ size = 16, color = 'currentColor' }: { size?: number; color?: string }) {
+  return <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke={color} strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" /></svg>
+}
+
 // ─── DPlanRow — table row with kebab menu ────────────────────────────────────
 
 function MenuBtn({ icon, label, onClick, danger, noBorder }: {
@@ -176,7 +183,7 @@ function DPlanRow({ primary, secondary, amount, muted, last, isVI, onSkip, onRes
                 <MenuBtn icon={<Check size={13} />} label={isVI ? 'Bao gồm tháng này' : 'Include this month'} onClick={() => { onRestore?.(); setOpen(false) }} noBorder />
               ) : (
                 <>
-                  <MenuBtn icon={<Edit2 size={13} />} label={isVI ? 'Ghi đè số tiền' : 'Override amount'} onClick={() => { onOverride?.(); setOpen(false) }} />
+                  <MenuBtn icon={<EditIcon size={13} />} label={isVI ? 'Ghi đè số tiền' : 'Override amount'} onClick={() => { onOverride?.(); setOpen(false) }} />
                   {onRestore && <MenuBtn icon={<RefreshCw size={13} />} label={isVI ? 'Khôi phục mặc định' : 'Restore default'} onClick={() => { onRestore(); setOpen(false) }} />}
                   <MenuBtn icon={<X size={13} />} label={isVI ? 'Bỏ qua tháng này' : 'Skip this month'} onClick={() => { onSkip?.(); setOpen(false) }} danger noBorder />
                 </>
@@ -554,10 +561,10 @@ export default function DesktopPlanningView({
                     extra: (
                       <div style={{ display: 'flex', gap: 4 }}>
                         <button onClick={() => { setIncomeVal(String(plan.salary_vnd)); setShowIncome(true) }} aria-label="Edit income" style={{ padding: 6, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
-                          <Edit2 size={15} />
+                          <EditIcon size={15} />
                         </button>
                         <button onClick={() => setShowDelete(true)} aria-label="Delete plan" style={{ padding: 6, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-neg)', display: 'flex' }}>
-                          <Trash2 size={15} />
+                          <TrashIcon size={15} />
                         </button>
                       </div>
                     ),
@@ -687,7 +694,7 @@ export default function DesktopPlanningView({
                       </td>
                       <td style={{ padding: '10px 8px 10px 4px', textAlign: 'right', width: 36 }}>
                         <button aria-label="Edit" onClick={() => openOtherModal(o)} style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
-                          <Edit2 size={13} />
+                          <EditIcon size={13} />
                         </button>
                       </td>
                     </tr>
@@ -761,7 +768,7 @@ export default function DesktopPlanningView({
             <div style={{ display: 'flex', gap: 8 }}>
               <button onClick={() => setShowDelete(false)} style={{ ...btnBase, flex: 1, padding: '10px 14px', background: 'transparent', color: 'var(--c-ink)', border: '1px solid var(--c-line)' }}>{isVI ? 'Huỷ' : 'Cancel'}</button>
               <button onClick={handleDeletePlan} disabled={saving} style={{ ...btnBase, flex: 2, padding: '10px 14px', background: 'var(--c-neg)', color: '#fff' }}>
-                <Trash2 size={14} />
+                <TrashIcon size={14} />
                 {saving ? (isVI ? 'Đang xoá...' : 'Deleting...') : (isVI ? 'Xoá kế hoạch' : 'Delete plan')}
               </button>
             </div>

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -5,7 +5,7 @@ import { useLocale } from 'next-intl'
 import {
   Wallet, Target, Shield, ShoppingCart,
   ChevronDown, ChevronUp,
-  MoreHorizontal, Plus, Edit2, Trash2, Check, RefreshCw, X, Calendar,
+  MoreHorizontal, Plus, Check, RefreshCw, X, Calendar,
 } from 'lucide-react'
 import { fmtCompact, fmt } from '@/lib/formatters'
 import type {
@@ -97,6 +97,13 @@ function buildByGoal(investments: FundInvestment[], savings: DirectSaving[]): Go
   }
 
   return [...map.values()].sort((a, b) => a.goalName.localeCompare(b.goalName))
+}
+
+function EditIcon({ size = 16, color = 'currentColor' }: { size?: number; color?: string }) {
+  return <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke={color} strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M4 20h4l10-10-4-4L4 16z" /></svg>
+}
+function TrashIcon({ size = 16, color = 'currentColor' }: { size?: number; color?: string }) {
+  return <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke={color} strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" /></svg>
 }
 
 // ─── Shared sheet overlay wrapper ─────────────────────────────────────────────
@@ -294,7 +301,7 @@ function DeletePlanSheet({
               display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
             }}
           >
-            <Trash2 size={14} />
+            <TrashIcon size={14} />
             {deleting ? (isVI ? 'Đang xoá...' : 'Deleting...') : (isVI ? 'Xoá kế hoạch' : 'Delete plan')}
           </button>
         </div>
@@ -597,7 +604,7 @@ function SalaryCard({ amount, isVI, onEdit, onDelete }: { amount: number; isVI: 
           onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--c-card-2)')}
           onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
         >
-          <Edit2 size={16} color="var(--c-muted)" />
+          <EditIcon size={16} color="var(--c-muted)" />
         </button>
         <button
           onClick={onDelete}
@@ -606,7 +613,7 @@ function SalaryCard({ amount, isVI, onEdit, onDelete }: { amount: number; isVI: 
           onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--c-card-2)')}
           onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
         >
-          <Trash2 size={16} color="var(--c-neg)" />
+          <TrashIcon size={16} color="var(--c-neg)" />
         </button>
       </div>
     </div>
@@ -892,7 +899,7 @@ function PlanLineItem({
                   onClick={() => { onOverride?.(); setMenuOpen(false) }}
                   style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', color: 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8, borderBottom: '1px solid var(--c-line)' }}
                 >
-                  <Edit2 size={14} color="var(--c-muted)" />
+                  <EditIcon size={14} color="var(--c-muted)" />
                   {isVI ? 'Ghi đè số tiền' : 'Override amount'}
                 </button>
                 <button
@@ -1180,7 +1187,7 @@ export default function MobilePlanningView({
                     aria-label="Edit expense"
                     style={{ padding: 4, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 4, display: 'flex', alignItems: 'center' }}
                   >
-                    <Edit2 size={14} color="var(--c-muted)" />
+                    <EditIcon size={14} color="var(--c-muted)" />
                   </button>
                 </div>
               ))}

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -3,7 +3,7 @@
 import { useState, useMemo, useEffect, useRef } from 'react'
 import { useLocale } from 'next-intl'
 import {
-  Wallet, Target, Building, Shield, ShoppingCart,
+  Wallet, Target, Shield, ShoppingCart,
   ChevronDown, ChevronUp,
   MoreHorizontal, Plus, Edit2, Trash2, Check, RefreshCw, X, Calendar,
 } from 'lucide-react'
@@ -689,6 +689,15 @@ function AllocationSummaryCard({
   )
 }
 
+function FixedExpIcon({ size = 16 }: { size?: number }) {
+  return (
+    <svg viewBox="0 0 24 24" width={size} height={size} fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+      <rect x="4" y="3" width="16" height="18" rx="1" />
+      <path d="M9 8h2M13 8h2M9 12h2M13 12h2M9 16h2M13 16h2" />
+    </svg>
+  )
+}
+
 // ─── BudgetSection ────────────────────────────────────────────────────────────
 
 function BudgetSection({
@@ -1074,7 +1083,7 @@ export default function MobilePlanningView({
             {/* Fixed expenses section */}
             {fixedExpenses.length > 0 && (
               <BudgetSection
-                icon={Building}
+                icon={FixedExpIcon}
                 iconColor="var(--c-accent-fixed)"
                 title={isVI ? 'Chi phí cố định' : 'Fixed expenses'}
                 count={`${fixedExpenses.length} ${isVI ? 'khoản' : fixedExpenses.length === 1 ? 'item' : 'items'}`}

--- a/app/components/layouts/AuthenticatedLayout.tsx
+++ b/app/components/layouts/AuthenticatedLayout.tsx
@@ -30,7 +30,7 @@ function getDisplayName(email: string): string {
 
 // Pages that provide their own desktop top bar and don't need the shared Header.
 // Checked synchronously via usePathname so there is no flash on hard refresh.
-const PAGES_WITH_OWN_HEADER = new Set(['/dashboard'])
+const PAGES_WITH_OWN_HEADER = new Set(['/dashboard', '/planning'])
 
 function AuthenticatedLayoutInner({ children, email, initials }: { children: React.ReactNode; email: string; initials: string }) {
   const { mobileTopBar } = useNavigation()

--- a/app/components/layouts/AuthenticatedLayout.tsx
+++ b/app/components/layouts/AuthenticatedLayout.tsx
@@ -32,11 +32,15 @@ function getDisplayName(email: string): string {
 // Checked synchronously via usePathname so there is no flash on hard refresh.
 const PAGES_WITH_OWN_HEADER = new Set(['/dashboard', '/planning'])
 
+// Pages that manage their own full-height desktop layout (no <main> padding/scroll on md+).
+const PAGES_WITH_FULL_HEIGHT_DESKTOP = new Set(['/planning'])
+
 function AuthenticatedLayoutInner({ children, email, initials }: { children: React.ReactNode; email: string; initials: string }) {
   const { mobileTopBar } = useNavigation()
   const [showAddTx, setShowAddTx] = useState(false)
   const pathname = usePathname()
   const hideDesktopHeader = PAGES_WITH_OWN_HEADER.has(pathname)
+  const isFullHeightDesktop = PAGES_WITH_FULL_HEIGHT_DESKTOP.has(pathname)
 
   return (
     <div className="flex h-screen bg-canvas dark:bg-gray-950 overflow-hidden">
@@ -64,7 +68,7 @@ function AuthenticatedLayoutInner({ children, email, initials }: { children: Rea
             />
           </div>
         )}
-        <main className="flex-1 overflow-y-auto px-4 md:px-6 py-4 pb-20 md:pb-4">
+        <main className={`flex-1 overflow-y-auto px-4 py-4 pb-20 md:pb-4${isFullHeightDesktop ? ' md:p-0 md:overflow-hidden md:flex md:flex-col' : ' md:px-6'}`}>
           {children}
         </main>
       </div>

--- a/e2e/planning-desktop.spec.ts
+++ b/e2e/planning-desktop.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect, type Page } from '@playwright/test'
+import * as api from './helpers/api'
+import { makeCleanupStack } from './helpers/cleanup'
+
+// Force desktop viewport for every test in this file
+test.use({ viewport: { width: 1280, height: 800 } })
+
+const cleanup = makeCleanupStack()
+test.afterEach(() => cleanup.run())
+
+const today = new Date()
+const MONTH = today.getMonth() + 1
+const YEAR = today.getFullYear()
+const PREV_MONTH = MONTH === 1 ? 12 : MONTH - 1
+const PREV_YEAR = MONTH === 1 ? YEAR - 1 : YEAR
+
+async function goto(page: Page) {
+  await page.goto('/planning')
+  await page.waitForLoadState('networkidle')
+}
+
+// ─── Layout ────────────────────────────────────────────────────────────────────
+
+test('desktop planning: DTopBar shows Budget title', async ({ page }) => {
+  await goto(page)
+  const desktop = page.getByTestId('desktop-planning')
+  await expect(desktop).toBeVisible()
+  await expect(desktop.getByText(/Budget|Ngân sách/i).first()).toBeVisible({ timeout: 5_000 })
+})
+
+test('desktop planning: month picker is visible', async ({ page }) => {
+  await goto(page)
+  const desktop = page.getByTestId('desktop-planning')
+  await expect(desktop.getByTestId('desktop-month-picker')).toBeVisible()
+  await expect(desktop.getByTestId('prev-month')).toBeVisible()
+  await expect(desktop.getByTestId('next-month')).toBeVisible()
+  // Picker shows current year
+  await expect(desktop.getByTestId('desktop-month-picker')).toContainText(String(YEAR))
+})
+
+// ─── Navigation ───────────────────────────────────────────────────────────────
+
+test('desktop planning: prev/next month buttons update displayed month', async ({ page }) => {
+  await goto(page)
+  const picker = page.getByTestId('desktop-month-picker')
+
+  await page.getByTestId('prev-month').click()
+  await page.waitForTimeout(300)
+  // Prev-month year (may differ on January)
+  await expect(picker).toContainText(String(PREV_YEAR))
+
+  await page.getByTestId('next-month').click()
+  await page.waitForTimeout(300)
+  await expect(picker).toContainText(String(YEAR))
+})
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+test('desktop planning: empty state has Set-income button for month without plan', async ({ page }) => {
+  await goto(page)
+  const desktop = page.getByTestId('desktop-planning')
+
+  // Navigate far back to a month that almost certainly has no plan
+  for (let i = 0; i < 6; i++) {
+    await desktop.getByTestId('prev-month').click()
+    await page.waitForTimeout(150)
+  }
+  await page.waitForTimeout(500)
+
+  const emptyState = desktop.getByTestId('planning-empty-state')
+  if (await emptyState.isVisible({ timeout: 4_000 })) {
+    await expect(emptyState.getByRole('button', { name: /Set income|Thêm thu nhập/i })).toBeVisible()
+  }
+})
+
+// ─── With plan ────────────────────────────────────────────────────────────────
+
+test('desktop planning: summary strip shows Income / Outflow / Remaining when plan exists', async ({ page }) => {
+  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
+  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
+
+  await goto(page)
+  const desktop = page.getByTestId('desktop-planning')
+  const strip = desktop.getByTestId('planning-summary-strip')
+
+  await expect(strip).toBeVisible({ timeout: 8_000 })
+  await expect(strip.getByText(/Income|Thu nhập/i).first()).toBeVisible()
+  await expect(strip.getByText(/Outflow|Tổng chi/i).first()).toBeVisible()
+  await expect(strip.getByText(/Remaining|Còn lại/i).first()).toBeVisible()
+})
+
+test('desktop planning: allocation card is visible in right panel', async ({ page }) => {
+  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
+  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
+
+  await goto(page)
+  const desktop = page.getByTestId('desktop-planning')
+  await expect(desktop.getByTestId('planning-alloc-card')).toBeVisible({ timeout: 8_000 })
+})
+
+test('desktop planning: collapsible sections visible when plan exists', async ({ page }) => {
+  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
+  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
+
+  await goto(page)
+  await page.waitForLoadState('networkidle')
+  const desktop = page.getByTestId('desktop-planning')
+
+  // At least one of the section headers must be visible
+  const byGoal = desktop.getByText(/By goal|Theo mục tiêu/i).first()
+  const fixed  = desktop.getByText(/Fixed expenses|Chi phí cố định/i).first()
+  const ins    = desktop.getByText(/Insurance|Bảo hiểm/i).first()
+  await expect(byGoal.or(fixed).or(ins)).toBeVisible({ timeout: 8_000 })
+})

--- a/e2e/planning-desktop.spec.ts
+++ b/e2e/planning-desktop.spec.ts
@@ -21,11 +21,11 @@ async function goto(page: Page) {
 
 // ─── Layout ────────────────────────────────────────────────────────────────────
 
-test('desktop planning: DTopBar shows Budget title', async ({ page }) => {
+test('desktop planning: DTopBar shows Monthly Plan title', async ({ page }) => {
   await goto(page)
   const desktop = page.getByTestId('desktop-planning')
   await expect(desktop).toBeVisible()
-  await expect(desktop.getByText(/Budget|Ngân sách/i).first()).toBeVisible({ timeout: 5_000 })
+  await expect(desktop.getByText(/Monthly Plan|Kế hoạch Tháng/i).first()).toBeVisible({ timeout: 5_000 })
 })
 
 test('desktop planning: month picker is visible', async ({ page }) => {

--- a/e2e/planning-desktop.spec.ts
+++ b/e2e/planning-desktop.spec.ts
@@ -106,9 +106,7 @@ test('desktop planning: collapsible sections visible when plan exists', async ({
   await page.waitForLoadState('networkidle')
   const desktop = page.getByTestId('desktop-planning')
 
-  // At least one of the section headers must be visible
-  const byGoal = desktop.getByText(/By goal|Theo mục tiêu/i).first()
-  const fixed  = desktop.getByText(/Fixed expenses|Chi phí cố định/i).first()
-  const ins    = desktop.getByText(/Insurance|Bảo hiểm/i).first()
-  await expect(byGoal.or(fixed).or(ins)).toBeVisible({ timeout: 8_000 })
+  await expect(desktop.getByText(/By goal|Theo mục tiêu/i).first()).toBeVisible({ timeout: 8_000 })
+  await expect(desktop.getByText(/Fixed expenses|Chi phí cố định/i).first()).toBeVisible()
+  await expect(desktop.getByText(/Insurance|Bảo hiểm/i).first()).toBeVisible()
 })

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -14,11 +14,12 @@ export const fmtShort = (n: number) => {
   return n.toLocaleString('vi-VN')
 }
 
-// Compact money for dense lists: 15.5M ₫, 1.2B ₫
+// Compact money for dense lists: 15.5M ₫, 350K ₫, 1.2B ₫
 export const fmtCompact = (n: number) => {
   const abs = Math.abs(n)
   const sign = n < 0 ? '-' : ''
   if (abs >= 1_000_000_000) return sign + (abs / 1_000_000_000).toFixed(1) + 'B ₫'
   if (abs >= 1_000_000) return sign + (abs / 1_000_000).toFixed(1) + 'M ₫'
-  return fmt(n)
+  if (abs >= 1_000) return sign + (abs / 1_000).toFixed(0) + 'K ₫'
+  return sign + Math.round(abs).toLocaleString('vi-VN') + ' ₫'
 }


### PR DESCRIPTION
## Summary

- Adds `DesktopPlanningView` — the new desktop planning page following the Cairn design system
  - **Left panel**: summary strip (Income / Outflow / Remaining / Saved %) + collapsible PlanTable sections (By goal, Fixed expenses, Insurance, Other expenses)
  - **Right panel**: navy `AllocationCard` sidebar with StackedBar, category breakdown, and remaining balance
  - **DModal dialogs**: set/edit income, delete plan confirmation, and override amount
- Wires `DesktopPlanningView` into `PlanningClient.tsx`, replacing the old desktop grid layout
- Suppresses the shared `Header` on `/planning` (added to `PAGES_WITH_OWN_HEADER`) so the DTopBar inside the new view is the only header shown — eliminating the double-header flash
- Adds `e2e/planning-desktop.spec.ts` (TDD spec written first) covering: DTopBar title, month picker, prev/next navigation, empty state, summary strip, allocation card, and collapsible sections

## Test plan

- [ ] Visit `/planning` on desktop (≥ 768px) — two-panel layout renders, no shared Header above it
- [ ] Month picker shows current month/year; prev/next buttons update the picker
- [ ] Navigate to a past month with no plan — empty state shows "Set income" button
- [ ] Navigate to a month with a plan — summary strip shows Income / Outflow / Remaining; AllocationCard visible in right panel
- [ ] At least one of By goal / Fixed expenses / Insurance section headers is visible
- [ ] E2E: `npx playwright test e2e/planning-desktop.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)