### PR TITLE
fix(desktop): add Overview header separator + hide mobile FAB on desktop

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -619,13 +619,16 @@ export default function DashboardClient({ userId }: { userId: string }) {
               data-testid="desktop-overview"
               style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}
             >
-              {/* Page title */}
-              <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '4px 0 20px', flexShrink: 0 }}>
+              {/* Page title — layout matches Plan / Funds / Settings.
+                  Negative margins escape <main>'s md:px-6 / py-4 so the
+                  border-bottom and background span the full content width,
+                  flush against the sidebar like the other desktop pages. */}
+              <header style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', margin: '-16px -24px 0', padding: '20px 28px 16px', borderBottom: '1px solid var(--c-line)', background: 'var(--c-canvas)', flexShrink: 0 }}>
                 <div>
                   <div data-testid="desktop-page-title" style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--c-muted)', marginBottom: 3 }}>
                     {t('overview')}
                   </div>
-                  <h1 style={{ margin: 0, fontSize: 22, fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--c-ink)', lineHeight: 1 }}>
+                  <h1 style={{ margin: 0, fontSize: 20, fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--c-ink)', lineHeight: 1.1 }}>
                     {t('greeting', { name: userName })}
                   </h1>
                 </div>

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -657,7 +657,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
               {/* Two-column body */}
               <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
               {/* Left column: goals, unallocated, insurance */}
-              <div style={{ flex: 1, minWidth: 0, paddingRight: 20 }}>
+              <div style={{ flex: 1, minWidth: 0, paddingTop: 20, paddingRight: 20 }}>
                 {/* Goals */}
                 {sortedGoals.length > 0 && (
                   <section style={{ marginBottom: 24 }}>
@@ -756,6 +756,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
               <div style={{
                 width: 300, flexShrink: 0,
                 borderLeft: '1px solid var(--c-line)',
+                paddingTop: 20,
                 paddingLeft: 20,
                 position: 'sticky',
                 top: 0,

--- a/app/components/layouts/AuthenticatedLayout.tsx
+++ b/app/components/layouts/AuthenticatedLayout.tsx
@@ -73,23 +73,26 @@ function AuthenticatedLayoutInner({ children, email, initials }: { children: Rea
         </main>
       </div>
 
-      {/* Mobile FAB — add transaction */}
-      <button
-        onClick={() => setShowAddTx(true)}
-        aria-label="Add transaction"
-        className="md:hidden"
-        style={{
-          position: 'fixed', right: 16, bottom: 80,
-          width: 52, height: 52, borderRadius: 26,
-          background: 'var(--c-navy)', color: '#fff',
-          border: 'none',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          boxShadow: '0 6px 16px rgba(15, 42, 74, 0.25), 0 2px 4px rgba(15, 42, 74, 0.1)',
-          cursor: 'pointer', zIndex: 35,
-        }}
-      >
-        <Plus size={22} strokeWidth={2.2} />
-      </button>
+      {/* Mobile FAB — add transaction.
+          The button's inline `display: flex` would override a `md:hidden` class
+          (inline > class specificity), so the wrapper handles md+ hiding. */}
+      <div className="md:hidden">
+        <button
+          onClick={() => setShowAddTx(true)}
+          aria-label="Add transaction"
+          style={{
+            position: 'fixed', right: 16, bottom: 80,
+            width: 52, height: 52, borderRadius: 26,
+            background: 'var(--c-navy)', color: '#fff',
+            border: 'none',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            boxShadow: '0 6px 16px rgba(15, 42, 74, 0.25), 0 2px 4px rgba(15, 42, 74, 0.1)',
+            cursor: 'pointer', zIndex: 35,
+          }}
+        >
+          <Plus size={22} strokeWidth={2.2} />
+        </button>
+      </div>
 
       {/* Mobile bottom tab navigation */}
       <MobileBottomTabs />

--- a/e2e/dashboard-desktop.spec.ts
+++ b/e2e/dashboard-desktop.spec.ts
@@ -52,6 +52,24 @@ test.describe('Desktop overview layout', () => {
     await expect(page.getByTestId('desktop-page-title')).toContainText(/overview|tổng quan/i)
   })
 
+  test('Overview header has horizontal separator like other desktop pages', async ({ page }) => {
+    // Plan / Funds / Settings all render their page header with a 1px
+    // border-bottom against var(--c-line). Overview's header was missing it.
+    await expect(page.getByTestId('desktop-page-title')).toBeVisible({ timeout: 10_000 })
+    const headerEl = page.getByTestId('desktop-page-title').locator('xpath=ancestor::header[1]')
+    const borderBottomWidth = await headerEl.evaluate((el) => getComputedStyle(el).borderBottomWidth)
+    expect(borderBottomWidth).toBe('1px')
+  })
+
+  test('Add-transaction FAB is hidden at desktop viewport', async ({ page }) => {
+    // The mobile FAB ("Add transaction") was leaking onto desktop because its
+    // inline `display: flex` overrode the `md:hidden` class. Each desktop page
+    // already exposes its own add buttons in the header, so the FAB must not
+    // appear on md+ viewports.
+    const fab = page.getByRole('button', { name: 'Add transaction' })
+    await expect(fab).toBeHidden()
+  })
+
   test('unallocated section shows wallet icon header inside card', async ({ page }) => {
     await expect(page.getByTestId('unallocated-card-header')).toBeVisible({ timeout: 10_000 })
   })


### PR DESCRIPTION
## Summary
Two small layout fixes for the desktop redesign:

1. **Overview header was missing the horizontal separator** — Plan / Funds / Settings all render their page header with \`padding: '20px 28px 16px'\`, a 1px \`borderBottom\` against \`var(--c-line)\`, and a \`var(--c-canvas)\` background. Overview had \`padding: '4px 0 20px'\` with no border/background, and a slightly different title size (22 → 20) and lineHeight (1 → 1.1). Matched the other pages, and used negative margins on the header to escape \`<main>\`'s \`md:px-6\` / \`py-4\` so the separator spans the full content width flush against the sidebar.

2. **Mobile FAB was visible on desktop** — the \"Add transaction\" floating button had \`className=\"md:hidden\"\` but its inline \`display: flex\` (needed for icon centering) overrode the class's \`display: none\`. Wrapped the button in a \`<div className=\"md:hidden\">\` so the wrapper handles md+ hiding while the button keeps its inline flex centering. Each desktop page already has its own add buttons in the header, so the FAB is redundant there.

## Test plan
- [x] Added 2 e2e regression tests in \`e2e/dashboard-desktop.spec.ts\`:
  - Overview header element has a 1px \`border-bottom\` width
  - Add-transaction FAB is hidden at desktop viewport (1280×800)
- [x] \`tsc --noEmit\` clean
- [x] Unit suite: 198 pass, 1 unrelated pre-existing \`TransactionHistorySheet\` failure carried over from main
- [ ] Visual check on Vercel preview: Overview header looks identical to Plan/Funds/Settings (subtitle line + h1 + flush separator), FAB no longer overlaps content on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)