### PR TITLE
feat(insurance): inline add-member modal + full detail panel match-to-design

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -778,6 +778,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                     ins={selectedInsurance}
                     locale={locale}
                     onClose={() => setSelectedInsurance(null)}
+                    onChanged={() => fetchData({ force: true })}
                   />
                 ) : (
                   <DesktopNetWorthPanel

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -25,6 +25,7 @@ import DesktopNetWorthPanel from './components/DesktopNetWorthPanel'
 import DesktopGoalCard from './components/DesktopGoalCard'
 import DesktopInsuranceList from './components/DesktopInsuranceList'
 import DesktopInsuranceDetail from './components/DesktopInsuranceDetail'
+import AddInsuranceMemberModal from './components/AddInsuranceMemberModal'
 import DesktopGoalDetail from './components/DesktopGoalDetail'
 
 export interface FundBreakdownItem {
@@ -238,6 +239,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
   const [showReportSheet, setShowReportSheet] = useState(false)
   const [selectedInsurance, setSelectedInsurance] = useState<InsuranceData | null>(null)
   const [desktopAddTxOpen, setDesktopAddTxOpen] = useState(false)
+  const [showAddInsurance, setShowAddInsurance] = useState(false)
   const PULL_THRESHOLD = 65
 
   const fetchDataRef = useRef<(opts?: { force?: boolean }) => Promise<void>>(async () => {})
@@ -742,7 +744,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                       insurance={data.insurance}
                       locale={locale}
                       onOpen={(ins) => setSelectedInsurance(selectedInsurance?.insuranceId === ins.insuranceId ? null : ins)}
-                      onAdd={() => window.open('/settings?tab=insurance', '_self')}
+                      onAdd={() => setShowAddInsurance(true)}
                     />
                   </section>
                 )}
@@ -1019,6 +1021,14 @@ export default function DashboardClient({ userId }: { userId: string }) {
         } : null}
         onExport={handleGenerateReport}
         desktop={isDesktop}
+      />
+
+      {/* Add Insurance Member modal (desktop) */}
+      <AddInsuranceMemberModal
+        open={showAddInsurance}
+        onClose={() => setShowAddInsurance(false)}
+        onCreated={() => fetchData({ force: true })}
+        locale={locale}
       />
     </div>
   )

--- a/app/assets/components/AddInsuranceMemberModal.tsx
+++ b/app/assets/components/AddInsuranceMemberModal.tsx
@@ -1,0 +1,255 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Plus, X } from 'lucide-react'
+import { fmtCompact } from '@/lib/formatters'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  onCreated?: () => void
+  locale: string
+}
+
+const COVERAGE_OPTIONS: { value: string; label: string; labelVi: string }[] = [
+  { value: 'Self', label: 'Self', labelVi: 'Bản thân' },
+  { value: 'Spouse', label: 'Spouse', labelVi: 'Vợ/Chồng' },
+  { value: 'Child', label: 'Child', labelVi: 'Con' },
+]
+
+export default function AddInsuranceMemberModal({ open, onClose, onCreated, locale }: Props) {
+  const isVi = locale === 'vi'
+  const [name, setName] = useState('')
+  const [coverage, setCoverage] = useState('Self')
+  const [premium, setPremium] = useState<number>(12_000_000)
+  const [startDate, setStartDate] = useState(() => new Date().toISOString().slice(0, 10))
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Reset form when reopened
+  useEffect(() => {
+    if (open) {
+      setName('')
+      setCoverage('Self')
+      setPremium(12_000_000)
+      setStartDate(new Date().toISOString().slice(0, 10))
+      setSubmitting(false)
+      setError(null)
+    }
+  }, [open])
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  const monthly = (premium || 0) / 12
+  const canSubmit = name.trim().length > 0 && premium > 0 && !submitting
+
+  const t = isVi
+    ? { title: 'Thêm thành viên BH', name: 'Họ tên', namePh: 'VD. Linh Nguyễn',
+        coverage: 'Mối quan hệ', premium: 'Phí bảo hiểm năm (₫)',
+        start: 'Ngày bắt đầu', monthly: 'Đóng góp hàng tháng',
+        save: 'Thêm thành viên', cancel: 'Hủy' }
+    : { title: 'Add insurance member', name: 'Full name', namePh: 'e.g. Linh Nguyen',
+        coverage: 'Coverage type', premium: 'Annual premium (₫)',
+        start: 'Start date', monthly: 'Monthly contribution',
+        save: 'Add member', cancel: 'Cancel' }
+
+  async function handleSubmit() {
+    if (!canSubmit) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/v1/insurance-members', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          member_name: name.trim(),
+          relationship: coverage,
+          annual_payment_vnd: premium,
+          payment_date: startDate || null,
+        }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j?.error || (isVi ? 'Không thể tạo thành viên' : 'Failed to create member'))
+      }
+      onCreated?.()
+      onClose()
+    } catch (e) {
+      setError((e as Error).message)
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      data-testid="add-insurance-modal"
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)',
+        zIndex: 200, display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: 24, backdropFilter: 'blur(2px)',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t.title}
+        style={{
+          width: '100%', maxWidth: 440,
+          maxHeight: 'calc(100vh - 48px)',
+          background: 'var(--c-card)', borderRadius: 16,
+          boxShadow: '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)',
+          display: 'flex', flexDirection: 'column', overflow: 'hidden',
+        }}
+      >
+        {/* Header */}
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0,
+        }}>
+          <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{t.title}</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={isVi ? 'Đóng' : 'Close'}
+            className="cn-btn ghost"
+            style={{ padding: 6 }}
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div style={{ padding: '18px 20px', overflowY: 'auto' }}>
+          <div style={{ display: 'grid', gap: 14 }}>
+            {/* Name */}
+            <FormField label={t.name}>
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder={t.namePh}
+                autoFocus
+                className="cn-input"
+              />
+            </FormField>
+
+            {/* Coverage */}
+            <FormField label={t.coverage}>
+              <div style={{ display: 'flex', gap: 8 }}>
+                {COVERAGE_OPTIONS.map((o) => {
+                  const active = coverage === o.value
+                  return (
+                    <button
+                      key={o.value}
+                      type="button"
+                      onClick={() => setCoverage(o.value)}
+                      style={{
+                        flex: 1, padding: 8, borderRadius: 8, fontSize: 12, fontWeight: 600,
+                        background: active ? 'var(--c-btn-primary)' : 'var(--c-card-2)',
+                        color: active ? '#fff' : 'var(--c-muted)',
+                        border: `1px solid ${active ? 'var(--c-btn-primary)' : 'var(--c-line)'}`,
+                        cursor: 'pointer', fontFamily: 'inherit', transition: 'all 120ms',
+                      }}
+                    >
+                      {isVi ? o.labelVi : o.label}
+                    </button>
+                  )
+                })}
+              </div>
+            </FormField>
+
+            {/* Premium */}
+            <FormField label={t.premium}>
+              <input
+                type="number"
+                value={premium}
+                onChange={(e) => setPremium(Number(e.target.value))}
+                className="cn-input"
+                style={{ fontVariantNumeric: 'tabular-nums' }}
+              />
+            </FormField>
+
+            {/* Monthly preview */}
+            <div style={{
+              background: 'var(--c-navy-tint)', borderRadius: 10, padding: '12px 16px',
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+            }}>
+              <div style={{
+                fontSize: 11, fontWeight: 600, letterSpacing: '0.06em',
+                textTransform: 'uppercase', color: 'var(--c-navy)',
+              }}>
+                {t.monthly}
+              </div>
+              <div style={{ fontSize: 20, fontWeight: 700, color: 'var(--c-navy)', fontVariantNumeric: 'tabular-nums' }}>
+                {fmtCompact(monthly)}
+              </div>
+            </div>
+
+            {/* Start date */}
+            <FormField label={t.start}>
+              <input
+                type="date"
+                value={startDate}
+                onChange={(e) => setStartDate(e.target.value)}
+                className="cn-input"
+              />
+            </FormField>
+
+            {error && (
+              <div role="alert" style={{ fontSize: 12, color: 'var(--c-neg)' }}>
+                {error}
+              </div>
+            )}
+
+            {/* Footer buttons */}
+            <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+              <button
+                type="button"
+                onClick={onClose}
+                className="cn-btn ghost"
+                style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}
+              >
+                {t.cancel}
+              </button>
+              <button
+                type="button"
+                onClick={handleSubmit}
+                disabled={!canSubmit}
+                className="cn-btn primary"
+                style={{ flex: 2, justifyContent: 'center', gap: 6, opacity: canSubmit ? 1 : 0.6 }}
+              >
+                <Plus size={14} strokeWidth={2.4} />
+                {t.save}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function FormField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: 'grid', gap: 6 }}>
+      <label style={{
+        fontSize: 11, fontWeight: 600, letterSpacing: '0.05em',
+        textTransform: 'uppercase', color: 'var(--c-muted)',
+      }}>
+        {label}
+      </label>
+      {children}
+    </div>
+  )
+}

--- a/app/assets/components/DesktopInsuranceDetail.tsx
+++ b/app/assets/components/DesktopInsuranceDetail.tsx
@@ -1,122 +1,503 @@
 'use client'
 
-import { ChevronLeft, Shield } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { Check, ChevronLeft, Edit2, Plus, Trash2, Calendar, X } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
 import type { InsuranceData } from '../DashboardClient'
+import LogInsurancePaymentModal from './LogInsurancePaymentModal'
 
 interface Props {
   ins: InsuranceData
   locale: string
   onClose: () => void
+  onChanged?: () => void
 }
 
 const STATUS_COLOR: Record<string, string> = {
-  on_track:  'var(--c-warn)',
-  upcoming:  'var(--c-muted)',
-  overdue:   'var(--c-neg)',
+  on_track: 'var(--c-warn)',
+  upcoming: 'var(--c-muted)',
+  overdue: 'var(--c-neg)',
   completed: 'var(--c-pos)',
-  ready:     'var(--c-navy)',
+  ready: 'var(--c-navy)',
 }
 
 const BAR_COLOR: Record<string, string> = {
-  on_track:  'var(--c-warn)',
-  upcoming:  'var(--c-warn)',
-  overdue:   'var(--c-neg)',
+  on_track: 'var(--c-warn)',
+  upcoming: 'var(--c-warn)',
+  overdue: 'var(--c-neg)',
   completed: 'var(--c-pos)',
-  ready:     'var(--c-warn)',
+  ready: 'var(--c-navy)',
 }
 
-export default function DesktopInsuranceDetail({ ins, locale, onClose }: Props) {
+const COVERAGE_OPTIONS: { value: string; label: string; labelVi: string }[] = [
+  { value: 'Self', label: 'Self', labelVi: 'Bản thân' },
+  { value: 'Spouse', label: 'Spouse', labelVi: 'Vợ/Chồng' },
+  { value: 'Child', label: 'Child', labelVi: 'Con' },
+]
+
+interface SavingsEntry {
+  id: string
+  amount_saved_vnd: number
+  created_at: string
+}
+
+function initialsFor(name: string): string {
+  return name
+    .split(/\s+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((w) => w[0]?.toUpperCase() ?? '')
+    .join('') || '·'
+}
+
+export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged }: Props) {
   const isVi = locale === 'vi'
   const progress = Math.min(ins.savingsProgressPercentage, 100)
   const barColor = BAR_COLOR[ins.status] ?? 'var(--c-warn)'
   const dotColor = STATUS_COLOR[ins.status] ?? 'var(--c-muted)'
 
+  const [editing, setEditing] = useState(false)
+  const [editName, setEditName] = useState(ins.insuranceName)
+  const [editCoverage, setEditCoverage] = useState(ins.coverageType ?? 'Self')
+  const [editPremium, setEditPremium] = useState<number>(ins.annualPremium)
+  const [editDate, setEditDate] = useState(ins.nextPaymentDate ?? '')
+  const [saving, setSaving] = useState(false)
+  const [editError, setEditError] = useState<string | null>(null)
+
+  const [showLogPayment, setShowLogPayment] = useState(false)
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  const [history, setHistory] = useState<SavingsEntry[] | null>(null)
+  const [historyLoading, setHistoryLoading] = useState(false)
+
+  // Sync edit form when target member changes
+  useEffect(() => {
+    setEditing(false)
+    setEditName(ins.insuranceName)
+    setEditCoverage(ins.coverageType ?? 'Self')
+    setEditPremium(ins.annualPremium)
+    setEditDate(ins.nextPaymentDate ?? '')
+    setEditError(null)
+  }, [ins.insuranceId, ins.insuranceName, ins.coverageType, ins.annualPremium, ins.nextPaymentDate])
+
+  const loadHistory = useCallback(async () => {
+    setHistoryLoading(true)
+    try {
+      const res = await fetch(`/api/v1/insurance-members/${ins.insuranceId}/savings`)
+      if (res.ok) {
+        const j = await res.json()
+        setHistory(j.savings ?? [])
+      } else {
+        setHistory([])
+      }
+    } catch {
+      setHistory([])
+    } finally {
+      setHistoryLoading(false)
+    }
+  }, [ins.insuranceId])
+
+  useEffect(() => { loadHistory() }, [loadHistory])
+
   function statusLabel(s: string) {
     return isVi
-      ? ({ on_track: 'Sắp đến hạn', completed: 'Đã thanh toán', overdue: 'Quá hạn', upcoming: 'Chưa đến hạn', ready: 'Sẵn sàng' } as Record<string, string>)[s] ?? s
-      : ({ on_track: 'Due soon', completed: 'Paid', overdue: 'Overdue', upcoming: 'Not due', ready: 'Ready' } as Record<string, string>)[s] ?? s
+      ? ({ on_track: 'Sắp đến hạn', completed: 'Đã thanh toán', overdue: 'Quá hạn', upcoming: 'Chưa đến hạn', ready: 'Đã tích lũy đủ' } as Record<string, string>)[s] ?? s
+      : ({ on_track: 'Due soon', completed: 'Paid', overdue: 'Overdue', upcoming: 'Not due', ready: 'Ready to pay' } as Record<string, string>)[s] ?? s
+  }
+
+  // Status-aware CTA
+  // - overdue → "Pay now" (red) → open LogPayment
+  // - on_track → "Mark as paid" (navy) → call mark-paid
+  // - ready → "Confirm payment sent" (navy) → call mark-paid
+  // - other → "Log payment" (default) → open LogPayment
+  const showStatusCta = ['overdue', 'on_track', 'ready'].includes(ins.status)
+  const ctaLabel = isVi
+    ? ({ overdue: 'Thanh toán ngay', on_track: 'Đánh dấu đã thanh toán', ready: 'Xác nhận đã thanh toán' } as Record<string, string>)[ins.status]
+    : ({ overdue: 'Pay now', on_track: 'Mark as paid', ready: 'Confirm payment sent' } as Record<string, string>)[ins.status]
+  const ctaBg = ins.status === 'overdue' ? 'var(--c-neg)' : 'var(--c-btn-primary)'
+
+  async function handleStatusCta() {
+    if (ins.status === 'overdue') {
+      setShowLogPayment(true)
+      return
+    }
+    // on_track / ready → mark current cycle as paid (advances payment_date)
+    try {
+      const res = await fetch(`/api/v1/insurance-members/${ins.insuranceId}/mark-paid`, { method: 'POST' })
+      if (res.ok) {
+        onChanged?.()
+      }
+    } catch {
+      // ignore — silent failure surface; status reload via parent
+    }
+  }
+
+  async function handleSaveEdit() {
+    if (!editName.trim() || editPremium <= 0) return
+    setSaving(true)
+    setEditError(null)
+    try {
+      const res = await fetch(`/api/v1/insurance-members/${ins.insuranceId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          member_name: editName.trim(),
+          relationship: editCoverage,
+          annual_payment_vnd: editPremium,
+          payment_date: editDate || null,
+        }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j?.error || (isVi ? 'Không thể cập nhật' : 'Update failed'))
+      }
+      setEditing(false)
+      onChanged?.()
+    } catch (e) {
+      setEditError((e as Error).message)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDelete() {
+    setDeleting(true)
+    try {
+      const res = await fetch(`/api/v1/insurance-members/${ins.insuranceId}`, { method: 'DELETE' })
+      if (res.ok) {
+        setShowDeleteConfirm(false)
+        onChanged?.()
+        onClose()
+      }
+    } finally {
+      setDeleting(false)
+    }
   }
 
   return (
     <div data-testid="insurance-detail-panel" style={{ display: 'flex', flexDirection: 'column', gap: 14 }}>
-      {/* Back button */}
-      <button
-        onClick={onClose}
-        className="cn-btn ghost"
-        style={{ alignSelf: 'flex-start', padding: '6px 0', gap: 4, fontSize: 12, color: 'var(--c-muted)' }}
-      >
-        <ChevronLeft size={14} />
-        {isVi ? 'Quay lại' : 'Back'}
-      </button>
-
-      {/* Summary card */}
-      <div className="cn-card" style={{ padding: '16px' }}>
-        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12, marginBottom: 12 }}>
-          <div style={{
-            width: 34, height: 34, borderRadius: 9,
-            background: 'var(--c-card-2)', color: 'var(--c-accent-insurance)',
-            border: '1px solid var(--c-line)',
-            display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
-          }}>
-            <Shield size={16} />
-          </div>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--c-muted)', marginBottom: 2 }}>
-              {isVi ? 'Bảo hiểm' : 'Insurance'}
-            </div>
-            <div style={{ fontSize: 15, fontWeight: 700, letterSpacing: '-0.01em', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
-              {ins.insuranceName}
-            </div>
-            {ins.coverageType && (
-              <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2 }}>{ins.coverageType}</div>
-            )}
-          </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
-            <span style={{ width: 6, height: 6, borderRadius: 3, background: dotColor, display: 'inline-block' }} />
-            <span style={{ fontSize: 10, fontWeight: 600, color: dotColor }}>{statusLabel(ins.status)}</span>
-          </div>
-        </div>
-
-        {/* Progress */}
-        <div style={{ marginBottom: 12 }}>
-          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: 6 }}>
-            <span style={{ fontSize: 11, color: 'var(--c-muted)' }}>
-              {isVi ? 'Đã tích lũy' : 'Saved'}
-            </span>
-            <span style={{ fontSize: 11, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>
-              {Math.round(progress)}%
-            </span>
-          </div>
-          <div style={{ width: '100%', height: 6, background: 'var(--c-card-2)', borderRadius: 999, overflow: 'hidden' }}>
-            <div style={{ height: '100%', width: `${progress}%`, background: barColor, borderRadius: 999, transition: 'width 400ms ease' }} />
-          </div>
-        </div>
-
-        {/* KPIs */}
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 1, background: 'var(--c-line)', borderRadius: 10, overflow: 'hidden' }}>
-          {[
-            { l: isVi ? 'Phí hàng năm' : 'Annual premium', v: fmtCompact(ins.annualPremium) },
-            { l: isVi ? 'Đã tích lũy' : 'Saved', v: fmtCompact(ins.amountSaved) },
-            ...(ins.nextPaymentDate ? [{ l: isVi ? 'Kỳ hạn tiếp' : 'Next due', v: new Date(ins.nextPaymentDate).toLocaleDateString(isVi ? 'vi-VN' : 'en-GB') }] : []),
-            ...(ins.lastPaymentDate ? [{ l: isVi ? 'Lần trả cuối' : 'Last paid', v: new Date(ins.lastPaymentDate).toLocaleDateString(isVi ? 'vi-VN' : 'en-GB') }] : []),
-          ].map((k, i) => (
-            <div key={i} style={{ background: 'var(--c-card)', padding: '10px 12px' }}>
-              <div style={{ fontSize: 10, color: 'var(--c-muted)' }}>{k.l}</div>
-              <div style={{ fontSize: 12, fontWeight: 600, marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>{k.v}</div>
-            </div>
-          ))}
-        </div>
+      {/* Back + Edit toggle */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <button
+          onClick={onClose}
+          className="cn-btn ghost"
+          style={{ padding: '6px 0', gap: 4, fontSize: 12, color: 'var(--c-muted)' }}
+        >
+          <ChevronLeft size={14} />
+          {isVi ? 'Quay lại' : 'Back'}
+        </button>
+        {!editing && (
+          <button
+            data-testid="insurance-edit-btn"
+            onClick={() => setEditing(true)}
+            aria-label={isVi ? 'Chỉnh sửa' : 'Edit'}
+            className="cn-btn ghost"
+            style={{ padding: 6 }}
+          >
+            <Edit2 size={14} color="var(--c-muted)" />
+          </button>
+        )}
       </div>
 
-      {/* Manage link */}
-      <a
-        href="/settings?tab=insurance"
-        className="cn-btn"
-        style={{ width: '100%', justifyContent: 'center', fontSize: 13, padding: '10px 14px', textDecoration: 'none' }}
-      >
-        {isVi ? 'Quản lý bảo hiểm' : 'Manage insurance'}
-      </a>
+      {editing ? (
+        <div className="cn-card" style={{ padding: 16, display: 'grid', gap: 14 }}>
+          <Field label={isVi ? 'Họ tên' : 'Full name'}>
+            <input value={editName} onChange={(e) => setEditName(e.target.value)} className="cn-input" autoFocus />
+          </Field>
+          <Field label={isVi ? 'Mối quan hệ' : 'Coverage type'}>
+            <div style={{ display: 'flex', gap: 8 }}>
+              {COVERAGE_OPTIONS.map((o) => {
+                const active = editCoverage === o.value
+                return (
+                  <button
+                    key={o.value}
+                    type="button"
+                    onClick={() => setEditCoverage(o.value)}
+                    style={{
+                      flex: 1, padding: 8, borderRadius: 8, fontSize: 12, fontWeight: 600,
+                      background: active ? 'var(--c-btn-primary)' : 'var(--c-card-2)',
+                      color: active ? '#fff' : 'var(--c-muted)',
+                      border: `1px solid ${active ? 'var(--c-btn-primary)' : 'var(--c-line)'}`,
+                      cursor: 'pointer', fontFamily: 'inherit', transition: 'all 120ms',
+                    }}
+                  >
+                    {isVi ? o.labelVi : o.label}
+                  </button>
+                )
+              })}
+            </div>
+          </Field>
+          <Field label={isVi ? 'Phí bảo hiểm năm (₫)' : 'Annual premium (₫)'}>
+            <input type="number" value={editPremium} onChange={(e) => setEditPremium(Number(e.target.value))} className="cn-input" style={{ fontVariantNumeric: 'tabular-nums' }} />
+            <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 4 }}>
+              {fmtCompact(editPremium / 12)} / {isVi ? 'tháng' : 'month'}
+            </div>
+          </Field>
+          <Field label={isVi ? 'Ngày bắt đầu' : 'Start date'}>
+            <input type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className="cn-input" />
+          </Field>
+          {editError && <div role="alert" style={{ fontSize: 12, color: 'var(--c-neg)' }}>{editError}</div>}
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button onClick={() => setEditing(false)} className="cn-btn ghost" style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}>
+              {isVi ? 'Hủy' : 'Cancel'}
+            </button>
+            <button onClick={handleSaveEdit} disabled={saving || !editName.trim() || editPremium <= 0} className="cn-btn primary" style={{ flex: 2, justifyContent: 'center', opacity: saving ? 0.6 : 1 }}>
+              {isVi ? 'Lưu' : 'Save'}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="cn-card" style={{ padding: 16 }}>
+            {/* Avatar + name */}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
+              <div
+                data-testid="insurance-avatar"
+                style={{
+                  width: 42, height: 42, borderRadius: 21,
+                  background: 'var(--c-btn-primary)', color: '#fff',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  fontSize: 13, fontWeight: 700, flexShrink: 0,
+                  letterSpacing: '0.02em',
+                }}
+              >
+                {initialsFor(ins.insuranceName)}
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 15, fontWeight: 700, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                  {ins.insuranceName}
+                </div>
+                {ins.coverageType && (
+                  <div style={{ fontSize: 12, color: 'var(--c-muted)', marginTop: 1 }}>{ins.coverageType}</div>
+                )}
+              </div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 5, flexShrink: 0 }}>
+                <span style={{ width: 7, height: 7, borderRadius: 999, background: dotColor }} />
+                <span style={{ fontSize: 11, fontWeight: 600, color: dotColor }}>{statusLabel(ins.status)}</span>
+              </div>
+            </div>
+
+            {/* Progress */}
+            <div style={{ width: '100%', height: 6, background: 'var(--c-card-2)', borderRadius: 999, overflow: 'hidden' }}>
+              <div style={{ height: '100%', width: `${progress}%`, background: barColor, borderRadius: 999, transition: 'width 400ms ease' }} />
+            </div>
+
+            {/* KPIs — Annual / Saved / Progress / Monthly */}
+            <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 1, marginTop: 12, background: 'var(--c-line)', borderRadius: 8, overflow: 'hidden' }}>
+              {[
+                { l: isVi ? 'Phí hàng năm' : 'Annual premium', v: fmtCompact(ins.annualPremium) },
+                { l: isVi ? 'Đã tích lũy' : 'Saved', v: fmtCompact(ins.amountSaved) },
+                { l: isVi ? 'Tiến độ' : 'Progress', v: `${ins.savingsProgressPercentage.toFixed(1)}%` },
+                { l: isVi ? 'Hàng tháng' : 'Monthly', v: fmtCompact(ins.annualPremium / 12) },
+              ].map((k, i) => (
+                <div key={i} style={{ background: 'var(--c-card)', padding: '9px 12px' }}>
+                  <div style={{ fontSize: 10, color: 'var(--c-muted)' }}>{k.l}</div>
+                  <div style={{ fontSize: 13, fontWeight: 600, marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>{k.v}</div>
+                </div>
+              ))}
+            </div>
+
+            {/* Ready info note */}
+            {ins.status === 'ready' && (
+              <div style={{
+                display: 'flex', gap: 8, alignItems: 'flex-start',
+                padding: '10px 12px', background: 'var(--c-navy-tint)',
+                borderRadius: 10, marginTop: 12, border: '1px solid rgba(15,42,74,0.08)',
+              }}>
+                <Calendar size={13} color="var(--c-navy)" />
+                <p style={{ margin: 0, fontSize: 11, color: 'var(--c-navy)', lineHeight: 1.5 }}>
+                  {isVi
+                    ? 'Bạn đã tích lũy đủ số tiền. Xác nhận khi đã chuyển phí cho công ty bảo hiểm.'
+                    : "You've saved the full amount. Confirm once you've sent the payment to your insurer."}
+                </p>
+              </div>
+            )}
+
+            {/* Status-aware CTA */}
+            {showStatusCta ? (
+              <button
+                data-testid="insurance-cta-status"
+                onClick={handleStatusCta}
+                style={{
+                  width: '100%', justifyContent: 'center', marginTop: 12, gap: 6, fontSize: 12,
+                  padding: 10, background: ctaBg, color: '#fff', border: 'none',
+                  borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit', fontWeight: 600,
+                  display: 'flex', alignItems: 'center', transition: 'opacity 120ms',
+                }}
+                onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.opacity = '0.85' }}
+                onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.opacity = '1' }}
+              >
+                <Check size={13} strokeWidth={2.4} />
+                {ctaLabel}
+              </button>
+            ) : (
+              <button
+                data-testid="insurance-cta-log"
+                onClick={() => setShowLogPayment(true)}
+                className="cn-btn"
+                style={{ width: '100%', justifyContent: 'center', marginTop: 12, gap: 6, fontSize: 12 }}
+              >
+                <Plus size={13} strokeWidth={2.4} />
+                {isVi ? 'Ghi nhận thanh toán' : 'Log payment'}
+              </button>
+            )}
+          </div>
+
+          {/* Payment history */}
+          <div className="cn-card" data-testid="insurance-payment-history" style={{ overflow: 'hidden' }}>
+            <div style={{
+              padding: '12px 16px', borderBottom: '1px solid var(--c-line)',
+              fontSize: 11, fontWeight: 600, letterSpacing: '0.06em',
+              textTransform: 'uppercase', color: 'var(--c-muted)',
+            }}>
+              {isVi ? 'Lịch sử thanh toán' : 'Payment history'}
+            </div>
+            {historyLoading && history === null ? (
+              <div style={{ padding: '14px 16px', fontSize: 12, color: 'var(--c-muted)' }}>…</div>
+            ) : !history || history.length === 0 ? (
+              <div style={{ padding: '14px 16px', fontSize: 12, color: 'var(--c-muted)' }}>
+                {isVi ? 'Chưa có giao dịch' : 'No payments yet'}
+              </div>
+            ) : (
+              history.map((p, i) => {
+                const dt = new Date(p.created_at)
+                const dateStr = dt.toLocaleDateString(isVi ? 'vi-VN' : 'en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
+                const isLast = i === history.length - 1
+                return (
+                  <div key={p.id} style={{
+                    display: 'flex', alignItems: 'center', gap: 10,
+                    padding: '11px 16px',
+                    borderBottom: isLast ? 'none' : '1px solid var(--c-line)',
+                  }}>
+                    <div style={{
+                      width: 28, height: 28, borderRadius: 7,
+                      background: 'var(--c-pos-tint)', color: 'var(--c-pos)',
+                      display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                    }}>
+                      <Check size={12} strokeWidth={2.5} />
+                    </div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: 12, fontWeight: 500 }}>{dateStr}</div>
+                    </div>
+                    <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>
+                      {fmtCompact(p.amount_saved_vnd)}
+                    </span>
+                  </div>
+                )
+              })
+            )}
+          </div>
+
+          {/* Remove member */}
+          <button
+            data-testid="insurance-remove-btn"
+            onClick={() => setShowDeleteConfirm(true)}
+            style={{
+              width: '100%', padding: 11, background: 'transparent',
+              border: '1px solid var(--c-line)', borderRadius: 10,
+              color: 'var(--c-neg)', fontSize: 12, fontWeight: 600,
+              display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7,
+              cursor: 'pointer', fontFamily: 'inherit', transition: 'background 120ms',
+            }}
+            onMouseEnter={(e) => { (e.currentTarget as HTMLElement).style.background = 'var(--c-neg-tint)' }}
+            onMouseLeave={(e) => { (e.currentTarget as HTMLElement).style.background = 'transparent' }}
+          >
+            <Trash2 size={14} color="var(--c-neg)" />
+            {isVi ? 'Xóa thành viên' : 'Remove member'}
+          </button>
+        </>
+      )}
+
+      <LogInsurancePaymentModal
+        open={showLogPayment}
+        onClose={() => setShowLogPayment(false)}
+        onSaved={() => { onChanged?.(); loadHistory() }}
+        ins={ins}
+        locale={locale}
+      />
+
+      {showDeleteConfirm && (
+        <div
+          onClick={() => !deleting && setShowDeleteConfirm(false)}
+          style={{
+            position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)',
+            zIndex: 210, display: 'flex', alignItems: 'center', justifyContent: 'center',
+            padding: 24, backdropFilter: 'blur(2px)',
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-label={isVi ? 'Xóa thành viên?' : 'Remove member?'}
+            style={{
+              width: '100%', maxWidth: 380, background: 'var(--c-card)',
+              borderRadius: 16, padding: 20,
+              boxShadow: '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)',
+              display: 'flex', flexDirection: 'column', gap: 12,
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <h3 style={{ margin: 0, fontSize: 15, fontWeight: 700 }}>
+                {isVi ? 'Xóa thành viên?' : 'Remove member?'}
+              </h3>
+              <button
+                onClick={() => !deleting && setShowDeleteConfirm(false)}
+                aria-label={isVi ? 'Đóng' : 'Close'}
+                className="cn-btn ghost"
+                style={{ padding: 6 }}
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <p style={{ margin: 0, fontSize: 12, color: 'var(--c-muted)', lineHeight: 1.5 }}>
+              {isVi
+                ? `Bạn có chắc muốn xóa ${ins.insuranceName}? Mọi lịch sử thanh toán sẽ bị mất.`
+                : `Are you sure you want to remove ${ins.insuranceName}? All payment history will be lost.`}
+            </p>
+            <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+              <button
+                onClick={() => setShowDeleteConfirm(false)}
+                disabled={deleting}
+                className="cn-btn ghost"
+                style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}
+              >
+                {isVi ? 'Hủy' : 'Cancel'}
+              </button>
+              <button
+                data-testid="insurance-remove-confirm"
+                onClick={handleDelete}
+                disabled={deleting}
+                style={{
+                  flex: 2, padding: '10px 0', fontSize: 13, fontWeight: 600,
+                  background: 'var(--c-neg)', color: '#fff', border: 'none',
+                  borderRadius: 10, cursor: deleting ? 'not-allowed' : 'pointer',
+                  fontFamily: 'inherit', opacity: deleting ? 0.6 : 1,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7,
+                }}
+              >
+                <Trash2 size={14} />
+                {isVi ? 'Xóa' : 'Remove'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: 'grid', gap: 6 }}>
+      <label style={{
+        fontSize: 11, fontWeight: 600, letterSpacing: '0.05em',
+        textTransform: 'uppercase', color: 'var(--c-muted)',
+      }}>
+        {label}
+      </label>
+      {children}
     </div>
   )
 }

--- a/app/assets/components/LogInsurancePaymentModal.tsx
+++ b/app/assets/components/LogInsurancePaymentModal.tsx
@@ -1,0 +1,241 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Check, Shield, X } from 'lucide-react'
+import { fmtCompact } from '@/lib/formatters'
+import type { InsuranceData } from '../DashboardClient'
+
+interface Props {
+  open: boolean
+  onClose: () => void
+  onSaved?: () => void
+  ins: InsuranceData | null
+  locale: string
+}
+
+export default function LogInsurancePaymentModal({ open, onClose, onSaved, ins, locale }: Props) {
+  const isVi = locale === 'vi'
+  const suggested = ins ? Math.round(ins.annualPremium / 12) : 0
+  const [amount, setAmount] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+  const [done, setDone] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (open) {
+      setAmount('')
+      setSubmitting(false)
+      setDone(false)
+      setError(null)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open || !ins) return null
+
+  const amountNum = Number(amount)
+  const canSubmit = amountNum > 0 && !submitting
+
+  const t = isVi
+    ? { title: 'Ghi nhận thanh toán', amount: 'Số tiền (₫)',
+        suggest: 'Gợi ý', cancel: 'Hủy', save: 'Xác nhận', doneMsg: 'Đã ghi nhận!' }
+    : { title: 'Log payment', amount: 'Amount (₫)',
+        suggest: 'Suggested', cancel: 'Cancel', save: 'Confirm', doneMsg: 'Payment logged!' }
+
+  async function handleSave() {
+    if (!canSubmit || !ins) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/v1/insurance-savings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          insurance_member_id: ins.insuranceId,
+          amount_saved_vnd: amountNum,
+        }),
+      })
+      if (!res.ok) {
+        const j = await res.json().catch(() => ({}))
+        throw new Error(j?.error || (isVi ? 'Không thể ghi nhận' : 'Failed to log payment'))
+      }
+      setDone(true)
+      onSaved?.()
+      setTimeout(() => onClose(), 1400)
+    } catch (e) {
+      setError((e as Error).message)
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      data-testid="log-payment-modal"
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)',
+        zIndex: 200, display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: 24, backdropFilter: 'blur(2px)',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label={t.title}
+        style={{
+          width: '100%', maxWidth: 400,
+          maxHeight: 'calc(100vh - 48px)',
+          background: 'var(--c-card)', borderRadius: 16,
+          boxShadow: '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)',
+          display: 'flex', flexDirection: 'column', overflow: 'hidden',
+        }}
+      >
+        <div style={{
+          display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+          padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0,
+        }}>
+          <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{t.title}</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={isVi ? 'Đóng' : 'Close'}
+            className="cn-btn ghost"
+            style={{ padding: 6 }}
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div style={{ padding: '18px 20px', overflowY: 'auto' }}>
+          {done ? (
+            <div style={{ padding: '28px 0', textAlign: 'center' }}>
+              <div style={{
+                width: 52, height: 52, borderRadius: 26,
+                background: 'var(--c-pos-tint)', color: 'var(--c-pos)',
+                display: 'flex', alignItems: 'center', justifyContent: 'center',
+                margin: '0 auto 12px',
+              }}>
+                <Check size={26} strokeWidth={2.5} />
+              </div>
+              <div style={{ fontSize: 15, fontWeight: 600 }}>{t.doneMsg}</div>
+              <div style={{ fontSize: 12, color: 'var(--c-muted)', marginTop: 4 }}>{ins.insuranceName}</div>
+            </div>
+          ) : (
+            <div style={{ display: 'grid', gap: 14 }}>
+              {/* Member chip */}
+              <div style={{
+                display: 'flex', alignItems: 'center', gap: 10,
+                padding: '10px 14px', background: 'var(--c-card-2)', borderRadius: 10,
+              }}>
+                <div style={{
+                  width: 34, height: 34, borderRadius: 9,
+                  background: 'var(--c-card)', color: 'var(--c-accent-insurance)',
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                  flexShrink: 0, border: '1px solid var(--c-line)',
+                }}>
+                  <Shield size={15} />
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{ins.insuranceName}</div>
+                  {ins.coverageType && (
+                    <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1 }}>{ins.coverageType}</div>
+                  )}
+                </div>
+                <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-muted)', fontVariantNumeric: 'tabular-nums' }}>
+                  {fmtCompact(ins.annualPremium)}/yr
+                </div>
+              </div>
+
+              <FormField label={t.amount}>
+                <div style={{ display: 'grid', gridTemplateColumns: '1fr auto', gap: 8 }}>
+                  <div style={{
+                    display: 'flex', alignItems: 'center', gap: 8,
+                    padding: '10px 12px', background: 'var(--c-card)',
+                    border: '1.5px solid var(--c-btn-primary)', borderRadius: 10,
+                  }}>
+                    <span style={{ fontSize: 14, color: 'var(--c-muted)' }}>₫</span>
+                    <input
+                      type="number"
+                      value={amount}
+                      onChange={(e) => setAmount(e.target.value)}
+                      placeholder={suggested ? suggested.toLocaleString('vi-VN') : ''}
+                      autoFocus
+                      style={{
+                        flex: 1, minWidth: 0, border: 'none', outline: 'none',
+                        fontSize: 15, fontWeight: 600, fontFamily: 'inherit',
+                        background: 'transparent', color: 'var(--c-ink)',
+                        fontVariantNumeric: 'tabular-nums',
+                      }}
+                    />
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setAmount(String(suggested))}
+                    style={{
+                      padding: '8px 12px', background: 'var(--c-navy-tint)',
+                      color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)',
+                      borderRadius: 10, fontSize: 11, fontWeight: 600,
+                      cursor: 'pointer', fontFamily: 'inherit', whiteSpace: 'nowrap', flexShrink: 0,
+                    }}
+                  >
+                    {t.suggest}
+                  </button>
+                </div>
+              </FormField>
+
+              {error && (
+                <div role="alert" style={{ fontSize: 12, color: 'var(--c-neg)' }}>
+                  {error}
+                </div>
+              )}
+
+              <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="cn-btn ghost"
+                  style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}
+                >
+                  {t.cancel}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleSave}
+                  disabled={!canSubmit}
+                  className="cn-btn primary"
+                  style={{ flex: 2, justifyContent: 'center', gap: 6, opacity: canSubmit ? 1 : 0.6 }}
+                >
+                  <Check size={14} strokeWidth={2.4} />
+                  {t.save}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function FormField({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div style={{ display: 'grid', gap: 6 }}>
+      <label style={{
+        fontSize: 11, fontWeight: 600, letterSpacing: '0.05em',
+        textTransform: 'uppercase', color: 'var(--c-muted)',
+      }}>
+        {label}
+      </label>
+      {children}
+    </div>
+  )
+}

--- a/e2e/dashboard-desktop.spec.ts
+++ b/e2e/dashboard-desktop.spec.ts
@@ -84,4 +84,33 @@ test.describe('Desktop overview layout', () => {
     await row.click()
     await expect(page.getByTestId('insurance-detail-panel')).toBeVisible({ timeout: 5_000 })
   })
+
+  test('clicking Add insurance opens inline modal instead of navigating away', async ({ page }) => {
+    // Previously the Add button called window.open('/settings?tab=insurance')
+    // which navigated away. Now it opens an inline modal on the dashboard.
+    const startUrl = page.url()
+    const addBtn = page.getByTestId('insurance-add-btn')
+    await expect(addBtn).toBeVisible({ timeout: 10_000 })
+    await addBtn.click()
+    await expect(page.getByTestId('add-insurance-modal')).toBeVisible({ timeout: 5_000 })
+    expect(page.url()).toBe(startUrl)
+  })
+
+  test('insurance detail panel shows avatar initials, not just shield icon', async ({ page }) => {
+    const row = page.getByTestId('insurance-row').first()
+    await expect(row).toBeVisible({ timeout: 10_000 })
+    await row.click()
+    const avatar = page.getByTestId('insurance-avatar')
+    await expect(avatar).toBeVisible({ timeout: 5_000 })
+    const text = (await avatar.innerText()).trim()
+    // Initials are 1–2 uppercase letters derived from the member name
+    expect(text).toMatch(/^[A-ZÀ-Ỹ]{1,2}$/)
+  })
+
+  test('insurance detail panel exposes Remove member control', async ({ page }) => {
+    const row = page.getByTestId('insurance-row').first()
+    await expect(row).toBeVisible({ timeout: 10_000 })
+    await row.click()
+    await expect(page.getByTestId('insurance-remove-btn')).toBeVisible({ timeout: 5_000 })
+  })
 })


### PR DESCRIPTION
Resolves the remaining two desktop redesign callouts (issues #3 and #4 from the audit).

## What was broken

3. **Insurance details panel** was a stripped-down summary: shield icon, name, progress bar, 4 KPIs, and a single \"Manage insurance\" link to \`/settings?tab=insurance\`. The design has a full inline panel with edit mode, payment history, status-aware CTAs, log-payment modal, and a remove button — none of those existed.

4. **Add insurance member** on the desktop dashboard called \`window.open('/settings?tab=insurance', '_self')\`, navigating the user away to the settings tab. The design has an inline \`AddInsuranceModal\` opened from the dashboard.

## Changes

- **\`AddInsuranceMemberModal.tsx\`** (new) — desktop modal matching design's \`AddInsuranceModal\`. Fields: name, coverage type (segmented buttons: Self / Spouse / Child), annual premium (₫), monthly preview hero, start date. POSTs to \`/api/v1/insurance-members\`. Coverage buttons use \`--c-btn-primary\` so the active navy state survives dark mode.
- **\`LogInsurancePaymentModal.tsx\`** (new) — matches design's \`DesktopLogPaymentModal\`. Member chip + amount input with a \"Suggested\" shortcut (= annual / 12). POSTs to \`/api/v1/insurance-savings\`, shows the green check confirmation, auto-closes.
- **\`DesktopInsuranceDetail.tsx\`** (rebuilt) — matches design end-to-end:
  - Back + Edit toggle row
  - **View mode**: avatar with initials (\`--c-btn-primary\`), name + coverage + status dot, progress bar, **4 KPIs** (Annual, Saved, Progress, Monthly), \"Ready\" info note when \`status === 'ready'\`, **status-aware CTA**:
    - \`overdue\` → \"Pay now\" (red) → opens LogPayment modal
    - \`on_track\` → \"Mark as paid\" (navy) → calls \`/mark-paid\`
    - \`ready\` → \"Confirm payment sent\" (navy) → calls \`/mark-paid\`
    - other → \"Log payment\" (default) → opens LogPayment modal
  - **Payment history** card populated from \`/api/v1/insurance-members/:id/savings\`
  - **Remove member** button with a confirm dialog → DELETE
  - **Edit mode**: inline form (name, coverage, premium, start date) → PUT
- **\`DashboardClient.tsx\`** — replaces settings-redirect with state-driven modal open, refetches dashboard data on member create/edit/delete/payment-log.

## API endpoints used
All pre-existed; this PR is pure UI on top:
- POST \`/api/v1/insurance-members\` (create)
- PUT \`/api/v1/insurance-members/:id\` (edit)
- DELETE \`/api/v1/insurance-members/:id\` (remove)
- POST \`/api/v1/insurance-members/:id/mark-paid\` (advance cycle)
- POST \`/api/v1/insurance-savings\` (log payment)
- GET \`/api/v1/insurance-members/:id/savings\` (history)

## Test plan
- [x] 3 new e2e tests in \`dashboard-desktop.spec.ts\`:
  - Add button opens inline modal (URL unchanged after click)
  - Detail panel renders avatar with 1–2 letter initials
  - Detail panel exposes Remove member control
- [x] \`tsc --noEmit\` clean
- [x] Unit suite: 198 pass + 1 unrelated pre-existing \`TransactionHistorySheet\` failure carried over from main
- [ ] Manual on Vercel preview: open dashboard insurance row → verify avatar, KPIs, CTA per status, edit/save, log payment, remove member; verify add button opens modal not navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)