### PR TITLE
chore(security): foundation — RLS migrations, dep upgrades, validation helpers

### DIFF
--- a/lib/__tests__/validation.test.ts
+++ b/lib/__tests__/validation.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect } from 'vitest'
+import {
+  validateAmount,
+  validateRate,
+  validateText,
+  validateNotes,
+  validateUUID,
+  validateDate,
+  validateEnum,
+  ValidationError,
+} from '../validation'
+
+describe('validateAmount', () => {
+  it('accepts a positive finite number', () => {
+    expect(validateAmount(1000, 'amount_vnd')).toBe(1000)
+  })
+
+  it('accepts zero', () => {
+    expect(validateAmount(0, 'amount_vnd')).toBe(0)
+  })
+
+  it('accepts a numeric string', () => {
+    expect(validateAmount('1500', 'amount_vnd')).toBe(1500)
+  })
+
+  it('rejects Infinity', () => {
+    expect(() => validateAmount(Infinity, 'amount_vnd')).toThrow(ValidationError)
+  })
+
+  it('rejects -Infinity', () => {
+    expect(() => validateAmount(-Infinity, 'amount_vnd')).toThrow(ValidationError)
+  })
+
+  it('rejects NaN', () => {
+    expect(() => validateAmount(NaN, 'amount_vnd')).toThrow(ValidationError)
+  })
+
+  it('rejects a negative number', () => {
+    expect(() => validateAmount(-1, 'amount_vnd')).toThrow(ValidationError)
+  })
+
+  it('rejects a non-finite string', () => {
+    expect(() => validateAmount('Infinity', 'amount_vnd')).toThrow(ValidationError)
+  })
+
+  it('rejects values above MAX_SAFE_INTEGER', () => {
+    expect(() => validateAmount(Number.MAX_SAFE_INTEGER + 1, 'amount_vnd')).toThrow(ValidationError)
+  })
+
+  it('rejects undefined / null', () => {
+    expect(() => validateAmount(undefined, 'amount_vnd')).toThrow(ValidationError)
+    expect(() => validateAmount(null, 'amount_vnd')).toThrow(ValidationError)
+  })
+
+  it('mentions the field name in the error', () => {
+    try {
+      validateAmount(-1, 'salary_vnd')
+    } catch (e) {
+      expect((e as ValidationError).message).toContain('salary_vnd')
+    }
+  })
+})
+
+describe('validateRate', () => {
+  it('accepts typical positive interest rates', () => {
+    expect(validateRate(7.5, 'interest_rate')).toBe(7.5)
+  })
+
+  it('accepts negative real rates (in the allowed range)', () => {
+    expect(validateRate(-2, 'interest_rate')).toBe(-2)
+  })
+
+  it('accepts zero', () => {
+    expect(validateRate(0, 'interest_rate')).toBe(0)
+  })
+
+  it('rejects Infinity', () => {
+    expect(() => validateRate(Infinity, 'interest_rate')).toThrow(ValidationError)
+  })
+
+  it('rejects NaN', () => {
+    expect(() => validateRate(NaN, 'interest_rate')).toThrow(ValidationError)
+  })
+
+  it('rejects rates below -100', () => {
+    expect(() => validateRate(-200, 'interest_rate')).toThrow(ValidationError)
+  })
+
+  it('rejects rates above 1000', () => {
+    expect(() => validateRate(5000, 'interest_rate')).toThrow(ValidationError)
+  })
+})
+
+describe('validateText', () => {
+  it('accepts a normal string and trims whitespace', () => {
+    expect(validateText('  hello  ', 'goal_name')).toBe('hello')
+  })
+
+  it('rejects an empty string after trim', () => {
+    expect(() => validateText('   ', 'goal_name')).toThrow(ValidationError)
+  })
+
+  it('rejects non-string types', () => {
+    expect(() => validateText(123, 'goal_name')).toThrow(ValidationError)
+    expect(() => validateText(undefined, 'goal_name')).toThrow(ValidationError)
+  })
+
+  it('rejects strings longer than max (default 255)', () => {
+    const long = 'a'.repeat(256)
+    expect(() => validateText(long, 'goal_name')).toThrow(ValidationError)
+  })
+
+  it('respects custom max', () => {
+    expect(() => validateText('abcde', 'tag', { max: 3 })).toThrow(ValidationError)
+    expect(validateText('abc', 'tag', { max: 3 })).toBe('abc')
+  })
+})
+
+describe('validateNotes', () => {
+  it('accepts a normal string', () => {
+    expect(validateNotes('Some notes here')).toBe('Some notes here')
+  })
+
+  it('returns null for empty/whitespace-only input (notes are optional)', () => {
+    expect(validateNotes('')).toBeNull()
+    expect(validateNotes('   ')).toBeNull()
+    expect(validateNotes(null)).toBeNull()
+    expect(validateNotes(undefined)).toBeNull()
+  })
+
+  it('rejects strings longer than 2000 chars', () => {
+    expect(() => validateNotes('a'.repeat(2001))).toThrow(ValidationError)
+  })
+
+  it('rejects non-string values that are not nullish', () => {
+    expect(() => validateNotes(42)).toThrow(ValidationError)
+  })
+})
+
+describe('validateUUID', () => {
+  it('accepts a v4 UUID', () => {
+    const uuid = '550e8400-e29b-41d4-a716-446655440000'
+    expect(validateUUID(uuid, 'goal_id')).toBe(uuid)
+  })
+
+  it('accepts a UUID with uppercase letters', () => {
+    const uuid = '550E8400-E29B-41D4-A716-446655440000'
+    expect(validateUUID(uuid, 'goal_id')).toBe(uuid)
+  })
+
+  it('rejects a non-UUID string', () => {
+    expect(() => validateUUID('not-a-uuid', 'goal_id')).toThrow(ValidationError)
+  })
+
+  it('rejects empty string', () => {
+    expect(() => validateUUID('', 'goal_id')).toThrow(ValidationError)
+  })
+
+  it('rejects non-string values', () => {
+    expect(() => validateUUID(123, 'goal_id')).toThrow(ValidationError)
+    expect(() => validateUUID(undefined, 'goal_id')).toThrow(ValidationError)
+  })
+
+  it('rejects a UUID with wrong segment lengths', () => {
+    expect(() => validateUUID('550e8400-e29b-41d4-a716-44665544000', 'goal_id')).toThrow(ValidationError)
+  })
+})
+
+describe('validateDate', () => {
+  it('accepts a YYYY-MM-DD date', () => {
+    expect(validateDate('2026-05-27', 'investment_date')).toBe('2026-05-27')
+  })
+
+  it('rejects a malformed date string', () => {
+    expect(() => validateDate('not-a-date', 'investment_date')).toThrow(ValidationError)
+  })
+
+  it('rejects a date with wrong format (e.g. DD/MM/YYYY)', () => {
+    expect(() => validateDate('27/05/2026', 'investment_date')).toThrow(ValidationError)
+  })
+
+  it('rejects an invalid calendar date', () => {
+    expect(() => validateDate('2026-02-30', 'investment_date')).toThrow(ValidationError)
+  })
+
+  it('rejects non-string values', () => {
+    expect(() => validateDate(20260527, 'investment_date')).toThrow(ValidationError)
+    expect(() => validateDate(undefined, 'investment_date')).toThrow(ValidationError)
+  })
+})
+
+describe('validateEnum', () => {
+  it('returns the value when it is in the allowed set', () => {
+    expect(validateEnum('fund', ['fund', 'bank', 'stock', 'gold'] as const, 'asset_type')).toBe('fund')
+  })
+
+  it('rejects a value not in the set', () => {
+    expect(() => validateEnum('crypto', ['fund', 'bank', 'stock', 'gold'] as const, 'asset_type')).toThrow(ValidationError)
+  })
+
+  it('rejects non-string values', () => {
+    expect(() => validateEnum(123, ['fund', 'bank'] as const, 'asset_type')).toThrow(ValidationError)
+  })
+})
+
+describe('ValidationError', () => {
+  it('has a status of 400', () => {
+    const err = new ValidationError('bad input')
+    expect(err.status).toBe(400)
+    expect(err.message).toBe('bad input')
+    expect(err.name).toBe('ValidationError')
+  })
+})

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,0 +1,120 @@
+// Input validators for API route handlers.
+// Throw ValidationError on bad input so handlers can convert to HTTP 400.
+
+export class ValidationError extends Error {
+  status = 400
+  constructor(message: string) {
+    super(message)
+    this.name = 'ValidationError'
+  }
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+const RATE_MIN = -100
+const RATE_MAX = 1000
+
+const DEFAULT_TEXT_MAX = 255
+const NOTES_MAX = 2000
+
+function coerceNumber(val: unknown): number | null {
+  if (typeof val === 'number') return val
+  if (typeof val === 'string' && val.trim() !== '') {
+    const n = Number(val)
+    return Number.isNaN(n) ? null : n
+  }
+  return null
+}
+
+export function validateAmount(val: unknown, field: string): number {
+  const n = coerceNumber(val)
+  if (n === null || !Number.isFinite(n)) {
+    throw new ValidationError(`${field} must be a finite number`)
+  }
+  if (n < 0) {
+    throw new ValidationError(`${field} must be non-negative`)
+  }
+  if (n > Number.MAX_SAFE_INTEGER) {
+    throw new ValidationError(`${field} exceeds maximum allowed value`)
+  }
+  return n
+}
+
+export function validateRate(val: unknown, field: string): number {
+  const n = coerceNumber(val)
+  if (n === null || !Number.isFinite(n)) {
+    throw new ValidationError(`${field} must be a finite number`)
+  }
+  if (n < RATE_MIN || n > RATE_MAX) {
+    throw new ValidationError(`${field} must be between ${RATE_MIN} and ${RATE_MAX}`)
+  }
+  return n
+}
+
+export function validateText(
+  val: unknown,
+  field: string,
+  opts: { max?: number; min?: number } = {}
+): string {
+  if (typeof val !== 'string') {
+    throw new ValidationError(`${field} must be a string`)
+  }
+  const trimmed = val.trim()
+  const min = opts.min ?? 1
+  const max = opts.max ?? DEFAULT_TEXT_MAX
+  if (trimmed.length < min) {
+    throw new ValidationError(`${field} is required`)
+  }
+  if (trimmed.length > max) {
+    throw new ValidationError(`${field} exceeds ${max} characters`)
+  }
+  return trimmed
+}
+
+export function validateNotes(val: unknown): string | null {
+  if (val === null || val === undefined) return null
+  if (typeof val !== 'string') {
+    throw new ValidationError('notes must be a string')
+  }
+  const trimmed = val.trim()
+  if (trimmed.length === 0) return null
+  if (trimmed.length > NOTES_MAX) {
+    throw new ValidationError(`notes exceeds ${NOTES_MAX} characters`)
+  }
+  return trimmed
+}
+
+export function validateUUID(val: unknown, field: string): string {
+  if (typeof val !== 'string' || !UUID_RE.test(val)) {
+    throw new ValidationError(`${field} must be a valid UUID`)
+  }
+  return val
+}
+
+export function validateDate(val: unknown, field: string): string {
+  if (typeof val !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(val)) {
+    throw new ValidationError(`${field} must be in YYYY-MM-DD format`)
+  }
+  const [y, m, d] = val.split('-').map(Number)
+  const date = new Date(Date.UTC(y, m - 1, d))
+  if (
+    Number.isNaN(date.getTime()) ||
+    date.getUTCFullYear() !== y ||
+    date.getUTCMonth() !== m - 1 ||
+    date.getUTCDate() !== d
+  ) {
+    throw new ValidationError(`${field} is not a valid calendar date`)
+  }
+  return val
+}
+
+export function validateEnum<T extends string>(
+  val: unknown,
+  allowed: readonly T[],
+  field: string
+): T {
+  if (typeof val !== 'string' || !(allowed as readonly string[]).includes(val)) {
+    throw new ValidationError(`${field} must be one of: ${allowed.join(', ')}`)
+  }
+  return val as T
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",
-        "next": "16.1.7",
+        "next": "^16.2.6",
         "next-intl": "^4.8.3",
         "react": "19.2.3",
         "react-dom": "19.2.3",
@@ -1023,47 +1023,40 @@
       "version": "0.2.11",
       "license": "MIT"
     },
-    "node_modules/@formatjs/bigdecimal": {
-      "version": "0.2.0",
-      "license": "MIT"
-    },
-    "node_modules/@formatjs/ecma402-abstract": {
-      "version": "3.2.0",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/bigdecimal": "0.2.0",
-        "@formatjs/fast-memoize": "3.1.1",
-        "@formatjs/intl-localematcher": "0.8.2"
-      }
-    },
     "node_modules/@formatjs/fast-memoize": {
-      "version": "3.1.1",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.5.tgz",
+      "integrity": "sha512-KLi3fan6WnCHmigd9pmEEN8Hid0v4wiFBW576M/d07KMWYecf1CvyMI3n34vCmHT4AoVqG2n702kiHbXjzZX2A==",
       "license": "MIT"
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "3.5.3",
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.10.tgz",
+      "integrity": "sha512-XeJihYLy1lCe19xfK1KWKG/betBOK2rB0luL8lSkjfvJj0zP+LTJvkC+RKd0jsFI8mWxN71LrarHSrEXE8xxOQ==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.2.0",
-        "@formatjs/icu-skeleton-parser": "2.1.3"
+        "@formatjs/icu-skeleton-parser": "2.1.9"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "2.1.3",
-      "license": "MIT",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "3.2.0"
-      }
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.9.tgz",
+      "integrity": "sha512-rsxswgHMfU1zUgB2byc08fesf83wLGjFnzLCEtuf00mx2doiqc6pYrf67raI37XqdRcGUviQepk2UKGqpng74Q==",
+      "license": "MIT"
     },
     "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.8.2",
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.8.tgz",
+      "integrity": "sha512-pBr2hVKWvkHVnfXegW+53NT9U2uaVQCc+EgzLPCCwXqBA3nvM5fPbK9IcJlNjV+NMKGyZ2F3ZSG78iGdxAAqbA==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/fast-memoize": "3.1.1"
+        "@formatjs/fast-memoize": "3.1.5"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.12",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1822,7 +1815,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.7",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -1834,7 +1829,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.7",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -1848,9 +1845,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.7.tgz",
-      "integrity": "sha512-zcnVaaZulS1WL0Ss38R5Q6D2gz7MtBu8GZLPfK+73D/hp4GFMrC2sudLky1QibfV7h6RJBJs/gOFvYP0X7UVlQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -1864,9 +1861,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.7.tgz",
-      "integrity": "sha512-2ant89Lux/Q3VyC8vNVg7uBaFVP9SwoK2jJOOR0L8TQnX8CAYnh4uctAScy2Hwj2dgjVHqHLORQZJ2wH6VxhSQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
       ],
@@ -1883,9 +1880,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.7.tgz",
-      "integrity": "sha512-uufcze7LYv0FQg9GnNeZ3/whYfo+1Q3HnQpm16o6Uyi0OVzLlk2ZWoY7j07KADZFY8qwDbsmFnMQP3p3+Ftprw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
       ],
@@ -1902,9 +1899,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.7.tgz",
-      "integrity": "sha512-KWVf2gxYvHtvuT+c4MBOGxuse5TD7DsMFYSxVxRBnOzok/xryNeQSjXgxSv9QpIVlaGzEn/pIuI6Koosx8CGWA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
       ],
@@ -1921,9 +1918,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.7.tgz",
-      "integrity": "sha512-HguhaGwsGr1YAGs68uRKc4aGWxLET+NevJskOcCAwXbwj0fYX0RgZW2gsOCzr9S11CSQPIkxmoSbuVaBp4Z3dA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
       ],
@@ -1940,9 +1937,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.7.tgz",
-      "integrity": "sha512-S0n3KrDJokKTeFyM/vGGGR8+pCmXYrjNTk2ZozOL1C/JFdfUIL9O1ATaJOl5r2POe56iRChbsszrjMAdWSv7kQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -1956,9 +1953,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.7",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.7.tgz",
-      "integrity": "sha512-mwgtg8CNZGYm06LeEd+bNnOUfwOyNem/rOiP14Lsz+AnUY92Zq/LXwtebtUiaeVkhbroRCQ0c8GlR4UT1U+0yg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -2894,6 +2891,8 @@
     },
     "node_modules/@schummar/icu-type-parser": {
       "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
       "license": "MIT"
     },
     "node_modules/@sec-ant/readable-stream": {
@@ -3603,7 +3602,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.5",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -3963,7 +3964,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4914,7 +4917,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6580,10 +6585,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -6643,7 +6650,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -6771,7 +6780,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7162,7 +7173,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.11",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7263,7 +7276,9 @@
       }
     },
     "node_modules/icu-minify": {
-      "version": "4.8.3",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.12.0.tgz",
+      "integrity": "sha512-zDmM05uav3t3+kxSfRrNlmyXOdj2b+uHA+p04CG32eJabtaHbugXujuL+YfRkwP9joAnf0Uh+RMGCKD5NLa5rQ==",
       "funding": [
         {
           "type": "individual",
@@ -7345,16 +7360,19 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "11.2.0",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.7.tgz",
+      "integrity": "sha512-+q6Ktg119nULZEpZ8YTuGOst9MyEzFtjD63FTGBlN1mLz0Z/MOUYDIvnpVKwq17eezIEh+cfJIebfJoCetpiNw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "3.2.0",
-        "@formatjs/fast-memoize": "3.1.1",
-        "@formatjs/icu-messageformat-parser": "3.5.3"
+        "@formatjs/fast-memoize": "3.1.5",
+        "@formatjs/icu-messageformat-parser": "3.5.10"
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -8764,10 +8782,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.1.7",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.1.7",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -8781,15 +8801,15 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.7",
-        "@next/swc-darwin-x64": "16.1.7",
-        "@next/swc-linux-arm64-gnu": "16.1.7",
-        "@next/swc-linux-arm64-musl": "16.1.7",
-        "@next/swc-linux-x64-gnu": "16.1.7",
-        "@next/swc-linux-x64-musl": "16.1.7",
-        "@next/swc-win32-arm64-msvc": "16.1.7",
-        "@next/swc-win32-x64-msvc": "16.1.7",
-        "sharp": "^0.34.4"
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
+        "sharp": "^0.34.5"
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0",
@@ -8815,7 +8835,9 @@
       }
     },
     "node_modules/next-intl": {
-      "version": "4.8.3",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.12.0.tgz",
+      "integrity": "sha512-v8KpppWG0yLLlChJ3Of6uoPew9LeRDBAtY6vpJmF7YJmBZlHEzzoEL4w1g1dAU+VleEPNoXNm9hg1eEsKWV5hw==",
       "funding": [
         {
           "type": "individual",
@@ -8827,16 +8849,15 @@
         "@formatjs/intl-localematcher": "^0.8.1",
         "@parcel/watcher": "^2.4.1",
         "@swc/core": "^1.15.2",
-        "icu-minify": "^4.8.3",
+        "icu-minify": "^4.12.0",
         "negotiator": "^1.0.0",
-        "next-intl-swc-plugin-extractor": "^4.8.3",
+        "next-intl-swc-plugin-extractor": "^4.12.0",
         "po-parser": "^2.1.1",
-        "use-intl": "^4.8.3"
+        "use-intl": "^4.12.0"
       },
       "peerDependencies": {
         "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0",
-        "typescript": "^5.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -8845,7 +8866,9 @@
       }
     },
     "node_modules/next-intl-swc-plugin-extractor": {
-      "version": "4.8.3",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.12.0.tgz",
+      "integrity": "sha512-jUxVEu1Nryjt4YgaDktSys7ioOgQfcNPF/SF2dbPNxbVb6U+P1INRgHeCVN+EC59H2rnTFIQwbddmOCrUWFr3g==",
       "license": "MIT"
     },
     "node_modules/next-intl/node_modules/@swc/core": {
@@ -9371,7 +9394,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -9629,7 +9654,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -11262,7 +11289,9 @@
       }
     },
     "node_modules/use-intl": {
-      "version": "4.8.3",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.12.0.tgz",
+      "integrity": "sha512-r+qVb7UI1+kiOhjYsmsNUCY+jrnjVopwGeFlmMyQj4YInlwZzgMeMSv9n8MqnWWy77HL5BVM8K2WgX50SbtcpA==",
       "funding": [
         {
           "type": "individual",
@@ -11273,7 +11302,7 @@
       "dependencies": {
         "@formatjs/fast-memoize": "^3.1.0",
         "@schummar/icu-type-parser": "1.21.5",
-        "icu-minify": "^4.8.3",
+        "icu-minify": "^4.12.0",
         "intl-messageformat": "^11.1.0"
       },
       "peerDependencies": {
@@ -12008,7 +12037,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.577.0",
-    "next": "16.1.7",
+    "next": "^16.2.6",
     "next-intl": "^4.8.3",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/supabase/migrations/20260527000001_secure_health_check.sql
+++ b/supabase/migrations/20260527000001_secure_health_check.sql
@@ -1,0 +1,16 @@
+-- Enable Row Level Security on health_check.
+-- Before this change the table was exposed to the anon role (which has the
+-- public NEXT_PUBLIC_SUPABASE_ANON_KEY), allowing anyone to INSERT/UPDATE/DELETE
+-- rows. The table is for liveness probes only, so we keep SELECT open to all
+-- roles via an explicit policy but block writes entirely.
+
+ALTER TABLE public.health_check ENABLE ROW LEVEL SECURITY;
+
+-- Anyone (anon + authenticated) can read the heartbeat row; no other
+-- policies are added, so INSERT/UPDATE/DELETE are denied for everyone except
+-- the service role.
+CREATE POLICY "health_check_public_read"
+  ON public.health_check
+  FOR SELECT
+  TO anon, authenticated
+  USING (true);

--- a/supabase/migrations/20260527000002_add_insurance_savings.sql
+++ b/supabase/migrations/20260527000002_add_insurance_savings.sql
@@ -1,0 +1,41 @@
+-- Backfill: insurance_savings table already exists in the production database
+-- (created out-of-band) and is correctly secured with RLS, but it was never
+-- captured in a migration. This file documents the schema so future fresh
+-- environments stay in sync. CREATE TABLE IF NOT EXISTS + IF NOT EXISTS on
+-- the policies makes it a safe no-op against the live database.
+
+CREATE TABLE IF NOT EXISTS public.insurance_savings (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id             uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  insurance_member_id uuid NOT NULL REFERENCES public.insurance_members(member_id) ON DELETE CASCADE,
+  amount_saved_vnd    numeric NOT NULL CHECK (amount_saved_vnd > 0::numeric),
+  saved_date          date NOT NULL DEFAULT CURRENT_DATE,
+  created_at          timestamptz DEFAULT now()
+);
+
+ALTER TABLE public.insurance_savings ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'insurance_savings' AND policyname = 'insurance_savings_select') THEN
+    CREATE POLICY "insurance_savings_select" ON public.insurance_savings
+      FOR SELECT TO authenticated USING (user_id = auth.uid());
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'insurance_savings' AND policyname = 'insurance_savings_insert') THEN
+    CREATE POLICY "insurance_savings_insert" ON public.insurance_savings
+      FOR INSERT TO authenticated WITH CHECK (user_id = auth.uid());
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'insurance_savings' AND policyname = 'insurance_savings_update') THEN
+    CREATE POLICY "insurance_savings_update" ON public.insurance_savings
+      FOR UPDATE TO authenticated
+      USING (user_id = auth.uid())
+      WITH CHECK (user_id = auth.uid());
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_policies WHERE schemaname = 'public' AND tablename = 'insurance_savings' AND policyname = 'insurance_savings_delete') THEN
+    CREATE POLICY "insurance_savings_delete" ON public.insurance_savings
+      FOR DELETE TO authenticated USING (user_id = auth.uid());
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary
PR 1 of 2 in a security hardening pass. Lays the foundation; **PR 2** will roll the new validators out across all API routes.

### Migrations
- **\`20260527000001_secure_health_check.sql\`** — \`public.health_check\` had RLS disabled, so anyone holding the public anon key could write/delete rows. Enable RLS + explicit anon+authenticated SELECT-only policy. Liveness probes still work; writes now require service role.
- **\`20260527000002_add_insurance_savings.sql\`** — backfill migration documenting the \`insurance_savings\` schema that exists in production but was never tracked. Uses \`CREATE TABLE IF NOT EXISTS\` + idempotent policy guards — safe no-op against the live DB.

### Dependencies
- \`npm audit fix\` + bump Next.js \`16.1.7\` → \`16.2.6\`.
- **Cleared:** 4 high-severity (fast-uri path traversal, picomatch ReDoS, postcss XSS chain) and 8 of 9 moderate transitive vulnerabilities.
- **Remaining:** 1 moderate postcss vuln nested inside Next — not exploitable for our usage (we don't process untrusted CSS) and waits on a Next bump.

### New validators (\`lib/validation.ts\` + 42 unit tests)
- \`validateAmount\` — closes the Infinity/NaN gap on \`amount_vnd\`/\`nav\`/\`unit_price\`/etc. Finite, non-negative, ≤ \`MAX_SAFE_INTEGER\`.
- \`validateRate\` — finite, range \`[-100, 1000]\` for \`interest_rate\`.
- \`validateText\` / \`validateNotes\` — string, trimmed, length-capped (255 / 2000).
- \`validateUUID\` — strict UUID regex for path params.
- \`validateDate\` — \`YYYY-MM-DD\` with calendar validation.
- \`validateEnum\` — formalizes the existing whitelist pattern.
- \`ValidationError(status=400)\` so handlers can catch + return HTTP 400.

## Test plan
- [x] \`npm test -- --run\` — 42 new validator tests pass; existing 206 unchanged (one pre-existing failure in \`TransactionHistorySheet.test.tsx\` is unrelated).
- [x] \`npx tsc --noEmit\` clean.
- [x] \`npm audit\` shows 1 moderate (was 4 high + 9 moderate).
- [ ] Apply migrations to production via Supabase CLI after merge:
  \`\`\`
  supabase db push
  \`\`\`
- [ ] Verify \`health_check\` still selectable post-migration; writes from anon key now rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)