### PR TITLE
chore(security): apply validators across API routes + security headers + audit log fix

### DIFF
--- a/app/api/v1/direct-savings/[id]/route.ts
+++ b/app/api/v1/direct-savings/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateRate, validateUUID } from '@/lib/validation'
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -12,19 +13,33 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }
 
-  if (goal_id !== undefined) updates.goal_id = goal_id || null
-  if (amount_vnd !== undefined) {
-    const n = Number(amount_vnd)
-    if (isNaN(n) || n <= 0) return NextResponse.json({ error: 'Amount is required and must be positive' }, { status: 400 })
-    updates.amount_vnd = n
+  let txId: string
+  try {
+    txId = validateUUID(id, 'transaction_id')
+
+    if (goal_id !== undefined) {
+      updates.goal_id = goal_id === null || goal_id === '' ? null : validateUUID(goal_id, 'goal_id')
+    }
+    if (amount_vnd !== undefined) {
+      const n = validateAmount(amount_vnd, 'amount_vnd')
+      if (n <= 0) throw new ValidationError('Amount is required and must be positive')
+      updates.amount_vnd = n
+    }
+    if (profit_percent !== undefined) {
+      updates.interest_rate = profit_percent === null || profit_percent === '' ? null : validateRate(profit_percent, 'profit_percent')
+    }
+    if (expiry_date !== undefined) {
+      updates.expiry_date = expiry_date === null || expiry_date === '' ? null : validateDate(expiry_date, 'expiry_date')
+    }
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
-  if (profit_percent !== undefined) updates.interest_rate = profit_percent != null ? Number(profit_percent) : null
-  if (expiry_date !== undefined) updates.expiry_date = expiry_date || null
 
   const { data, error } = await supabase
     .from('investment_transactions')
     .update(updates)
-    .eq('transaction_id', id)
+    .eq('transaction_id', txId)
     .eq('user_id', user.id)
     .select('transaction_id, plan_id, goal_id, amount_vnd, interest_rate, expiry_date, investment_date, created_at, savings_goals(goal_name)')
     .single()
@@ -45,6 +60,15 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let txId: string
+  try {
+    txId = validateUUID(id, 'transaction_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -52,7 +76,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   const { error } = await supabase
     .from('investment_transactions')
     .delete()
-    .eq('transaction_id', id)
+    .eq('transaction_id', txId)
     .eq('user_id', user.id)
 
   if (error) return NextResponse.json({ error: 'Saving not found' }, { status: 404 })

--- a/app/api/v1/direct-savings/route.ts
+++ b/app/api/v1/direct-savings/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateRate, validateUUID } from '@/lib/validation'
 
 export async function GET() {
   const supabase = await createSupabaseServerClient()
@@ -38,27 +39,43 @@ export async function POST(request: NextRequest) {
   const body = await request.json()
   const { plan_id, goal_id, amount_vnd, profit_percent, expiry_date, investment_date } = body
 
-  if (!plan_id) return NextResponse.json({ error: 'plan_id is required' }, { status: 400 })
+  let cleanPlanId: string
+  let cleanAmount: number
+  let cleanGoalId: string | null = null
+  let cleanProfit: number | null = null
+  let cleanExpiry: string | null = null
+  let cleanInvestmentDate: string
 
-  const amountNum = Number(amount_vnd)
-  if (!amount_vnd || isNaN(amountNum) || amountNum <= 0) {
-    return NextResponse.json({ error: 'Amount is required and must be positive' }, { status: 400 })
+  try {
+    if (!plan_id) throw new ValidationError('plan_id is required')
+    cleanPlanId = validateUUID(plan_id, 'plan_id')
+    cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
+    if (cleanAmount <= 0) throw new ValidationError('Amount is required and must be positive')
+    if (goal_id) cleanGoalId = validateUUID(goal_id, 'goal_id')
+    if (profit_percent != null && profit_percent !== '') cleanProfit = validateRate(profit_percent, 'profit_percent')
+    if (expiry_date) cleanExpiry = validateDate(expiry_date, 'expiry_date')
+    cleanInvestmentDate = investment_date
+      ? validateDate(investment_date, 'investment_date')
+      : new Date().toISOString().slice(0, 10)
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
 
-  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', plan_id).eq('user_id', user.id).single()
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', cleanPlanId).eq('user_id', user.id).single()
   if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
 
   const { data, error } = await supabase
     .from('investment_transactions')
     .insert({
       user_id: user.id,
-      plan_id,
-      goal_id: goal_id || null,
+      plan_id: cleanPlanId,
+      goal_id: cleanGoalId,
       asset_type: 'bank',
-      amount_vnd: amountNum,
-      interest_rate: profit_percent != null ? Number(profit_percent) : null,
-      expiry_date: expiry_date || null,
-      investment_date: investment_date || new Date().toISOString().slice(0, 10),
+      amount_vnd: cleanAmount,
+      interest_rate: cleanProfit,
+      expiry_date: cleanExpiry,
+      investment_date: cleanInvestmentDate,
     })
     .select('transaction_id, plan_id, goal_id, amount_vnd, interest_rate, expiry_date, investment_date, created_at, savings_goals(goal_name)')
     .single()

--- a/app/api/v1/fixed-expenses/[id]/route.ts
+++ b/app/api/v1/fixed-expenses/[id]/route.ts
@@ -1,5 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateText, validateUUID } from '@/lib/validation'
+
+const YM_RE = /^\d{4}-(0[1-9]|1[0-2])$/
+
+function validateYearMonth(val: unknown, field: string): string {
+  if (typeof val !== 'string' || !YM_RE.test(val)) {
+    throw new ValidationError(`${field} must be in YYYY-MM format`)
+  }
+  return val
+}
 
 function toDateCol(ym: string | undefined | null): string | null {
   if (!ym) return null
@@ -16,27 +26,32 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const { expense_name, amount_vnd, category, effective_from, effective_to } = body
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }
-  if (expense_name !== undefined) {
-    if (!expense_name || expense_name.trim().length === 0) {
-      return NextResponse.json({ error: 'Expense name is required.' }, { status: 400 })
+
+  let expenseId: string
+  try {
+    expenseId = validateUUID(id, 'expense_id')
+
+    if (expense_name !== undefined) {
+      updates.expense_name = validateText(expense_name, 'expense_name')
     }
-    updates.expense_name = expense_name.trim()
-  }
-  if (category !== undefined) {
-    if (!category || category.trim().length === 0) {
-      return NextResponse.json({ error: 'Category is required.' }, { status: 400 })
+    if (category !== undefined) {
+      updates.category = validateText(category, 'category')
     }
-    updates.category = category.trim()
-  }
-  if (amount_vnd !== undefined) {
-    const amountNum = Number(amount_vnd)
-    if (isNaN(amountNum) || amountNum <= 0) {
-      return NextResponse.json({ error: 'Amount must be greater than 0.' }, { status: 400 })
+    if (amount_vnd !== undefined) {
+      const n = validateAmount(amount_vnd, 'amount_vnd')
+      if (n <= 0) throw new ValidationError('Amount must be greater than 0.')
+      updates.amount_vnd = n
     }
-    updates.amount_vnd = amountNum
+    if ('effective_from' in body) {
+      updates.effective_from = effective_from ? toDateCol(validateYearMonth(effective_from, 'effective_from')) : null
+    }
+    if ('effective_to' in body) {
+      updates.effective_to = effective_to ? toDateCol(validateYearMonth(effective_to, 'effective_to')) : null
+    }
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
-  if ('effective_from' in body) updates.effective_from = toDateCol(effective_from)
-  if ('effective_to' in body) updates.effective_to = toDateCol(effective_to)
 
   const fromDate = (updates.effective_from ?? null) as string | null
   const toDate = (updates.effective_to ?? null) as string | null
@@ -47,7 +62,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const { data: expense, error } = await supabase
     .from('fixed_expenses')
     .update(updates)
-    .eq('expense_id', id)
+    .eq('expense_id', expenseId)
     .eq('user_id', user.id)
     .select()
     .single()
@@ -58,6 +73,15 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let expenseId: string
+  try {
+    expenseId = validateUUID(id, 'expense_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -65,7 +89,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   const { error } = await supabase
     .from('fixed_expenses')
     .delete()
-    .eq('expense_id', id)
+    .eq('expense_id', expenseId)
     .eq('user_id', user.id)
 
   if (error) return NextResponse.json({ error: 'Expense not found' }, { status: 404 })

--- a/app/api/v1/fixed-expenses/[id]/route.ts
+++ b/app/api/v1/fixed-expenses/[id]/route.ts
@@ -1,15 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { ValidationError, validateAmount, validateText, validateUUID } from '@/lib/validation'
-
-const YM_RE = /^\d{4}-(0[1-9]|1[0-2])$/
-
-function validateYearMonth(val: unknown, field: string): string {
-  if (typeof val !== 'string' || !YM_RE.test(val)) {
-    throw new ValidationError(`${field} must be in YYYY-MM format`)
-  }
-  return val
-}
+import { ValidationError, validateAmount, validateText, validateUUID, validateYearMonth } from '@/lib/validation'
 
 function toDateCol(ym: string | undefined | null): string | null {
   if (!ym) return null

--- a/app/api/v1/fixed-expenses/route.ts
+++ b/app/api/v1/fixed-expenses/route.ts
@@ -1,5 +1,15 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateText } from '@/lib/validation'
+
+const YM_RE = /^\d{4}-(0[1-9]|1[0-2])$/
+
+function validateYearMonth(val: unknown, field: string): string {
+  if (typeof val !== 'string' || !YM_RE.test(val)) {
+    throw new ValidationError(`${field} must be in YYYY-MM format`)
+  }
+  return val
+}
 
 function toDateCol(ym: string | undefined | null): string | null {
   if (!ym) return null
@@ -44,19 +54,26 @@ export async function POST(request: NextRequest) {
   const body = await request.json()
   const { expense_name, amount_vnd, category, effective_from, effective_to } = body
 
-  if (!expense_name || typeof expense_name !== 'string' || expense_name.trim().length === 0) {
-    return NextResponse.json({ error: 'Expense name is required.' }, { status: 400 })
-  }
-  if (!category || typeof category !== 'string' || category.trim().length === 0) {
-    return NextResponse.json({ error: 'Category is required.' }, { status: 400 })
-  }
-  const amountNum = Number(amount_vnd)
-  if (!amount_vnd || isNaN(amountNum) || amountNum <= 0) {
-    return NextResponse.json({ error: 'Amount must be greater than 0.' }, { status: 400 })
+  let cleanName: string
+  let cleanCategory: string
+  let cleanAmount: number
+  let cleanFromYm: string | null = null
+  let cleanToYm: string | null = null
+
+  try {
+    cleanName = validateText(expense_name, 'expense_name')
+    cleanCategory = validateText(category, 'category')
+    cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
+    if (cleanAmount <= 0) throw new ValidationError('Amount must be greater than 0.')
+    if (effective_from) cleanFromYm = validateYearMonth(effective_from, 'effective_from')
+    if (effective_to) cleanToYm = validateYearMonth(effective_to, 'effective_to')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
 
-  const fromDate = toDateCol(effective_from)
-  const toDate = toDateCol(effective_to)
+  const fromDate = toDateCol(cleanFromYm)
+  const toDate = toDateCol(cleanToYm)
   if (fromDate && toDate && fromDate > toDate) {
     return NextResponse.json({ error: '"Active from" must be before "Active until".' }, { status: 400 })
   }
@@ -65,9 +82,9 @@ export async function POST(request: NextRequest) {
     .from('fixed_expenses')
     .insert({
       user_id: user.id,
-      expense_name: expense_name.trim(),
-      amount_vnd: amountNum,
-      category: category.trim(),
+      expense_name: cleanName,
+      amount_vnd: cleanAmount,
+      category: cleanCategory,
       effective_from: fromDate,
       effective_to: toDate,
     })

--- a/app/api/v1/fixed-expenses/route.ts
+++ b/app/api/v1/fixed-expenses/route.ts
@@ -1,15 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { ValidationError, validateAmount, validateText } from '@/lib/validation'
-
-const YM_RE = /^\d{4}-(0[1-9]|1[0-2])$/
-
-function validateYearMonth(val: unknown, field: string): string {
-  if (typeof val !== 'string' || !YM_RE.test(val)) {
-    throw new ValidationError(`${field} must be in YYYY-MM format`)
-  }
-  return val
-}
+import { ValidationError, validateAmount, validateText, validateYearMonth } from '@/lib/validation'
 
 function toDateCol(ym: string | undefined | null): string | null {
   if (!ym) return null

--- a/app/api/v1/fund-investments/[id]/goal/route.ts
+++ b/app/api/v1/fund-investments/[id]/goal/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
 
 export async function PATCH(
   request: NextRequest,
@@ -13,10 +14,22 @@ export async function PATCH(
   const body = await request.json()
   const { goal_id } = body
 
+  let txId: string
+  let cleanGoalId: string | null = null
+  try {
+    txId = validateUUID(id, 'transaction_id')
+    if (goal_id !== null && goal_id !== undefined && goal_id !== '') {
+      cleanGoalId = validateUUID(goal_id, 'goal_id')
+    }
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const { data, error } = await supabase
     .from('investment_transactions')
-    .update({ goal_id: goal_id ?? null })
-    .eq('transaction_id', id)
+    .update({ goal_id: cleanGoalId })
+    .eq('transaction_id', txId)
     .eq('user_id', user.id)
     .select()
     .single()

--- a/app/api/v1/fund-investments/[id]/route.ts
+++ b/app/api/v1/fund-investments/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateUUID } from '@/lib/validation'
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -12,51 +13,73 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }
 
-  if (fund_id !== undefined) updates.fund_id = fund_id
-  if (goal_id !== undefined) updates.goal_id = goal_id || null
-  if (amount_vnd !== undefined) {
-    const n = Number(amount_vnd)
-    if (isNaN(n) || n <= 0) return NextResponse.json({ error: 'Amount and units are required and must be positive' }, { status: 400 })
-    updates.amount_vnd = n
-  }
-  if (units_purchased !== undefined) {
-    const n = Number(units_purchased)
-    if (isNaN(n) || n <= 0) return NextResponse.json({ error: 'Amount and units are required and must be positive' }, { status: 400 })
-    updates.units = n
-  }
-  if (nav_at_purchase !== undefined) {
-    const n = Number(nav_at_purchase)
-    if (isNaN(n) || n <= 0) return NextResponse.json({ error: 'NAV at purchase must be positive' }, { status: 400 })
-    updates.unit_price = n
-  }
-  if (investment_date !== undefined) updates.investment_date = investment_date || null
+  try {
+    const txId = validateUUID(id, 'transaction_id')
 
-  const { data, error } = await supabase
-    .from('investment_transactions')
-    .update(updates)
-    .eq('transaction_id', id)
-    .eq('user_id', user.id)
-    .select('transaction_id, fund_id, goal_id, amount_vnd, units, unit_price, investment_date, created_at, funds(name, nav), savings_goals(goal_name)')
-    .single()
+    if (fund_id !== undefined) {
+      updates.fund_id = fund_id === null || fund_id === '' ? null : validateUUID(fund_id, 'fund_id')
+    }
+    if (goal_id !== undefined) {
+      updates.goal_id = goal_id === null || goal_id === '' ? null : validateUUID(goal_id, 'goal_id')
+    }
+    if (amount_vnd !== undefined) {
+      const n = validateAmount(amount_vnd, 'amount_vnd')
+      if (n <= 0) throw new ValidationError('Amount and units are required and must be positive')
+      updates.amount_vnd = n
+    }
+    if (units_purchased !== undefined) {
+      const n = validateAmount(units_purchased, 'units_purchased')
+      if (n <= 0) throw new ValidationError('Amount and units are required and must be positive')
+      updates.units = n
+    }
+    if (nav_at_purchase !== undefined) {
+      const n = validateAmount(nav_at_purchase, 'nav_at_purchase')
+      if (n <= 0) throw new ValidationError('NAV at purchase must be positive')
+      updates.unit_price = n
+    }
+    if (investment_date !== undefined) {
+      updates.investment_date = investment_date === null || investment_date === '' ? null : validateDate(investment_date, 'investment_date')
+    }
 
-  if (error || !data) return NextResponse.json({ error: 'Investment not found' }, { status: 404 })
+    const { data, error } = await supabase
+      .from('investment_transactions')
+      .update(updates)
+      .eq('transaction_id', txId)
+      .eq('user_id', user.id)
+      .select('transaction_id, fund_id, goal_id, amount_vnd, units, unit_price, investment_date, created_at, funds(name, nav), savings_goals(goal_name)')
+      .single()
 
-  return NextResponse.json({
-    id: data.transaction_id,
-    fund_id: data.fund_id,
-    goal_id: data.goal_id,
-    amount_vnd: data.amount_vnd,
-    units_purchased: data.units,
-    nav_at_purchase: data.unit_price,
-    investment_date: data.investment_date,
-    created_at: data.created_at,
-    funds: data.funds,
-    savings_goals: data.savings_goals,
-  })
+    if (error || !data) return NextResponse.json({ error: 'Investment not found' }, { status: 404 })
+
+    return NextResponse.json({
+      id: data.transaction_id,
+      fund_id: data.fund_id,
+      goal_id: data.goal_id,
+      amount_vnd: data.amount_vnd,
+      units_purchased: data.units,
+      nav_at_purchase: data.unit_price,
+      investment_date: data.investment_date,
+      created_at: data.created_at,
+      funds: data.funds,
+      savings_goals: data.savings_goals,
+    })
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
 }
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let txId: string
+  try {
+    txId = validateUUID(id, 'transaction_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -64,7 +87,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   const { error } = await supabase
     .from('investment_transactions')
     .delete()
-    .eq('transaction_id', id)
+    .eq('transaction_id', txId)
     .eq('user_id', user.id)
 
   if (error) return NextResponse.json({ error: 'Investment not found' }, { status: 404 })

--- a/app/api/v1/fund-investments/route.ts
+++ b/app/api/v1/fund-investments/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateUUID } from '@/lib/validation'
 
 export async function GET(request: NextRequest) {
   const supabase = await createSupabaseServerClient()
@@ -50,24 +51,35 @@ export async function POST(request: NextRequest) {
   const body = await request.json()
   const { plan_id, fund_id, goal_id, amount_vnd, units_purchased, nav_at_purchase, investment_date } = body
 
-  if (!fund_id) return NextResponse.json({ error: 'Fund is required' }, { status: 400 })
+  let cleanFundId: string
+  let cleanAmount: number
+  let cleanUnits: number
+  let cleanNav: number
+  let cleanGoalId: string | null = null
+  let cleanPlanId: string | null = null
+  let cleanInvestmentDate: string
 
-  const amountNum = Number(amount_vnd)
-  const unitsNum = Number(units_purchased)
-  const navNum = Number(nav_at_purchase)
+  try {
+    if (!fund_id) throw new ValidationError('Fund is required')
+    cleanFundId = validateUUID(fund_id, 'fund_id')
+    cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
+    if (cleanAmount <= 0) throw new ValidationError('Amount must be greater than 0')
+    cleanUnits = validateAmount(units_purchased, 'units_purchased')
+    if (cleanUnits <= 0) throw new ValidationError('Units must be greater than 0')
+    cleanNav = validateAmount(nav_at_purchase, 'nav_at_purchase')
+    if (cleanNav <= 0) throw new ValidationError('NAV at purchase must be positive')
+    if (goal_id) cleanGoalId = validateUUID(goal_id, 'goal_id')
+    if (plan_id) cleanPlanId = validateUUID(plan_id, 'plan_id')
+    cleanInvestmentDate = investment_date
+      ? validateDate(investment_date, 'investment_date')
+      : new Date().toISOString().slice(0, 10)
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
 
-  if (!amount_vnd || isNaN(amountNum) || amountNum <= 0) {
-    return NextResponse.json({ error: 'Amount must be greater than 0' }, { status: 400 })
-  }
-  if (!units_purchased || isNaN(unitsNum) || unitsNum <= 0) {
-    return NextResponse.json({ error: 'Units must be greater than 0' }, { status: 400 })
-  }
-  if (!nav_at_purchase || isNaN(navNum) || navNum <= 0) {
-    return NextResponse.json({ error: 'NAV at purchase must be positive' }, { status: 400 })
-  }
-
-  if (plan_id) {
-    const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', plan_id).eq('user_id', user.id).single()
+  if (cleanPlanId) {
+    const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', cleanPlanId).eq('user_id', user.id).single()
     if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
   }
 
@@ -75,14 +87,14 @@ export async function POST(request: NextRequest) {
     .from('investment_transactions')
     .insert({
       user_id: user.id,
-      plan_id: plan_id || null,
-      fund_id,
-      goal_id: goal_id || null,
+      plan_id: cleanPlanId,
+      fund_id: cleanFundId,
+      goal_id: cleanGoalId,
       asset_type: 'fund',
-      amount_vnd: amountNum,
-      units: unitsNum,
-      unit_price: navNum,
-      investment_date: investment_date || new Date().toISOString().slice(0, 10),
+      amount_vnd: cleanAmount,
+      units: cleanUnits,
+      unit_price: cleanNav,
+      investment_date: cleanInvestmentDate,
     })
     .select('transaction_id, fund_id, goal_id, amount_vnd, units, unit_price, investment_date, created_at, funds(id, name, nav), savings_goals(goal_name)')
     .single()

--- a/app/api/v1/insurance-members/[id]/mark-paid/route.ts
+++ b/app/api/v1/insurance-members/[id]/mark-paid/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+import { ValidationError, validateUUID } from '@/lib/validation'
 
 function err(status: number, code: string, message: string) {
   return NextResponse.json({ error: code, message }, { status })
@@ -11,8 +10,12 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
   const { id } = await params
 
   // 400 — UUID validation
-  if (!UUID_REGEX.test(id)) {
-    return err(400, 'INVALID_MEMBER_ID', 'Invalid member ID format')
+  let memberId: string
+  try {
+    memberId = validateUUID(id, 'member_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return err(400, 'INVALID_MEMBER_ID', 'Invalid member ID format')
+    throw e
   }
 
   const supabase = await createSupabaseServerClient()
@@ -23,7 +26,7 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
   const { data: member, error: fetchError } = await supabase
     .from('insurance_members')
     .select('member_id, user_id, member_name, annual_payment_vnd, monthly_premium_vnd, payment_date, updated_at')
-    .eq('member_id', id)
+    .eq('member_id', memberId)
     .single()
 
   if (fetchError || !member) return err(404, 'NOT_FOUND', 'Insurance member not found')
@@ -45,7 +48,7 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
   const { count: savingsCount } = await supabase
     .from('insurance_savings')
     .select('*', { count: 'exact', head: true })
-    .eq('insurance_member_id', id)
+    .eq('insurance_member_id', memberId)
     .eq('user_id', user.id)
 
   // Delete all savings records first (reset balance to 0)
@@ -53,11 +56,11 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
   const { error: deleteError } = await supabase
     .from('insurance_savings')
     .delete()
-    .eq('insurance_member_id', id)
+    .eq('insurance_member_id', memberId)
     .eq('user_id', user.id)
 
   if (deleteError) {
-    console.error('[mark-paid] Failed to delete savings', { user_id: user.id, member_id: id, error: deleteError.message })
+    console.error('[mark-paid] Failed to delete savings', { user_id: user.id, member_id: memberId, error: deleteError.message })
     return err(500, 'INTERNAL_ERROR', 'An error occurred while processing your request')
   }
 
@@ -69,25 +72,26 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
       last_payment_date: todayISO,
       updated_at: now.toISOString(),
     })
-    .eq('member_id', id)
+    .eq('member_id', memberId)
     .eq('user_id', user.id)
     .select('updated_at')
     .single()
 
   if (updateError) {
-    console.error('[mark-paid] Failed to update last_payment_date', { user_id: user.id, member_id: id, error: updateError.message })
+    console.error('[mark-paid] Failed to update last_payment_date', { user_id: user.id, member_id: memberId, error: updateError.message })
     return err(500, 'INTERNAL_ERROR', 'An error occurred while processing your request')
   }
 
   const updatedAt = updated?.updated_at ?? now.toISOString()
   const deletedCount = savingsCount ?? 0
 
-  // Audit log
-  console.log(`[AUDIT] User ${user.id} marked member ${id} as paid. Deleted ${deletedCount} savings records at ${now.toISOString()}`)
+  // Audit log — log the action with deletion count, not raw user/member UUIDs.
+  // The Vercel request ID (in headers) is the trace key if we need to correlate.
+  console.log(`[AUDIT] mark-paid: deleted ${deletedCount} savings records at ${now.toISOString()}`)
 
   return NextResponse.json({
     data: {
-      member_id: id,
+      member_id: memberId,
       name: member.member_name,
       amount_saved: 0,
       payment_date: nextPaymentDate,

--- a/app/api/v1/insurance-members/[id]/route.ts
+++ b/app/api/v1/insurance-members/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateText, validateUUID } from '@/lib/validation'
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -11,32 +12,35 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const { member_name, relationship, annual_payment_vnd, payment_date } = body
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }
-  if (member_name !== undefined) {
-    if (!member_name || member_name.trim().length === 0) {
-      return NextResponse.json({ error: 'Member name is required.' }, { status: 400 })
+  let memberId: string
+
+  try {
+    memberId = validateUUID(id, 'member_id')
+
+    if (member_name !== undefined) {
+      updates.member_name = validateText(member_name, 'member_name')
     }
-    updates.member_name = member_name.trim()
-  }
-  if (relationship !== undefined) {
-    if (!relationship || relationship.trim().length === 0) {
-      return NextResponse.json({ error: 'Relationship is required.' }, { status: 400 })
+    if (relationship !== undefined) {
+      updates.relationship = validateText(relationship, 'relationship')
     }
-    updates.relationship = relationship.trim()
-  }
-  if (annual_payment_vnd !== undefined) {
-    const annualNum = Number(annual_payment_vnd)
-    if (isNaN(annualNum) || annualNum <= 0) {
-      return NextResponse.json({ error: 'Annual payment must be greater than 0.' }, { status: 400 })
+    if (annual_payment_vnd !== undefined) {
+      const n = validateAmount(annual_payment_vnd, 'annual_payment_vnd')
+      if (n <= 0) throw new ValidationError('Annual payment must be greater than 0.')
+      updates.annual_payment_vnd = n
+      // monthly_premium_vnd is a generated stored column — auto-recalculated by DB
     }
-    updates.annual_payment_vnd = annualNum
-    // monthly_premium_vnd is a generated stored column — auto-recalculated by DB
+    if (payment_date !== undefined) {
+      updates.payment_date = payment_date === null || payment_date === '' ? null : validateDate(payment_date, 'payment_date')
+    }
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
-  if (payment_date !== undefined) updates.payment_date = payment_date || null
 
   const { data: member, error } = await supabase
     .from('insurance_members')
     .update(updates)
-    .eq('member_id', id)
+    .eq('member_id', memberId)
     .eq('user_id', user.id)
     .select()
     .single()
@@ -47,6 +51,15 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let memberId: string
+  try {
+    memberId = validateUUID(id, 'member_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -54,7 +67,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   const { error } = await supabase
     .from('insurance_members')
     .delete()
-    .eq('member_id', id)
+    .eq('member_id', memberId)
     .eq('user_id', user.id)
 
   if (error) return NextResponse.json({ error: 'Member not found' }, { status: 404 })

--- a/app/api/v1/insurance-members/[id]/savings/route.ts
+++ b/app/api/v1/insurance-members/[id]/savings/route.ts
@@ -1,8 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let memberId: string
+  try {
+    memberId = validateUUID(id, 'member_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -10,7 +20,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
   const { data, error } = await supabase
     .from('insurance_savings')
     .select('id, amount_saved_vnd, created_at')
-    .eq('insurance_member_id', id)
+    .eq('insurance_member_id', memberId)
     .eq('user_id', user.id)
     .order('created_at', { ascending: false })
 

--- a/app/api/v1/insurance-members/route.ts
+++ b/app/api/v1/insurance-members/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateText } from '@/lib/validation'
 
 export async function GET() {
   const supabase = await createSupabaseServerClient()
@@ -8,7 +9,7 @@ export async function GET() {
 
   const { data: members, error } = await supabase
     .from('insurance_members')
-    .select('*, insurance_savings(id, amount_saved_vnd, saved_date, created_at)')
+    .select('member_id, member_name, relationship, annual_payment_vnd, monthly_premium_vnd, payment_date, coverage_type, last_payment_date, amount_saved_vnd, version, created_at, updated_at, insurance_savings(id, amount_saved_vnd, saved_date, created_at)')
     .eq('user_id', user.id)
     .order('created_at', { ascending: false })
 
@@ -31,25 +32,30 @@ export async function POST(request: NextRequest) {
   const body = await request.json()
   const { member_name, relationship, annual_payment_vnd, payment_date } = body
 
-  if (!member_name || typeof member_name !== 'string' || member_name.trim().length === 0) {
-    return NextResponse.json({ error: 'Member name is required.' }, { status: 400 })
-  }
-  if (!relationship || typeof relationship !== 'string' || relationship.trim().length === 0) {
-    return NextResponse.json({ error: 'Relationship is required.' }, { status: 400 })
-  }
-  const annualNum = Number(annual_payment_vnd)
-  if (!annual_payment_vnd || isNaN(annualNum) || annualNum <= 0) {
-    return NextResponse.json({ error: 'Annual payment must be greater than 0.' }, { status: 400 })
+  let cleanName: string
+  let cleanRelationship: string
+  let cleanAnnual: number
+  let cleanPaymentDate: string | null = null
+
+  try {
+    cleanName = validateText(member_name, 'member_name')
+    cleanRelationship = validateText(relationship, 'relationship')
+    cleanAnnual = validateAmount(annual_payment_vnd, 'annual_payment_vnd')
+    if (cleanAnnual <= 0) throw new ValidationError('Annual payment must be greater than 0.')
+    if (payment_date) cleanPaymentDate = validateDate(payment_date, 'payment_date')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
 
   const { data: member, error } = await supabase
     .from('insurance_members')
     .insert({
       user_id: user.id,
-      member_name: member_name.trim(),
-      relationship: relationship.trim(),
-      annual_payment_vnd: annualNum,
-      payment_date: payment_date || null,
+      member_name: cleanName,
+      relationship: cleanRelationship,
+      annual_payment_vnd: cleanAnnual,
+      payment_date: cleanPaymentDate,
     })
     .select()
     .single()

--- a/app/api/v1/insurance-savings/[id]/route.ts
+++ b/app/api/v1/insurance-savings/[id]/route.ts
@@ -1,8 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let savingId: string
+  try {
+    savingId = validateUUID(id, 'id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -10,13 +20,13 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   const { data: record } = await supabase
     .from('insurance_savings')
     .select('id, user_id')
-    .eq('id', id)
+    .eq('id', savingId)
     .single()
 
   if (!record) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   if (record.user_id !== user.id) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
 
-  const { error } = await supabase.from('insurance_savings').delete().eq('id', id)
+  const { error } = await supabase.from('insurance_savings').delete().eq('id', savingId)
   if (error) return NextResponse.json({ error: 'Failed to delete' }, { status: 500 })
   return NextResponse.json({ success: true })
 }

--- a/app/api/v1/insurance-savings/route.ts
+++ b/app/api/v1/insurance-savings/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateUUID } from '@/lib/validation'
 
 export async function POST(request: NextRequest) {
   const supabase = await createSupabaseServerClient()
@@ -9,15 +10,21 @@ export async function POST(request: NextRequest) {
   const body = await request.json()
   const { insurance_member_id, amount_saved_vnd } = body
 
-  if (!insurance_member_id) return NextResponse.json({ error: 'insurance_member_id is required' }, { status: 400 })
-  const amount = Number(amount_saved_vnd)
-  if (!amount_saved_vnd || isNaN(amount) || amount <= 0) {
-    return NextResponse.json({ error: 'Amount must be greater than 0' }, { status: 400 })
+  let cleanMemberId: string
+  let cleanAmount: number
+  try {
+    if (!insurance_member_id) throw new ValidationError('insurance_member_id is required')
+    cleanMemberId = validateUUID(insurance_member_id, 'insurance_member_id')
+    cleanAmount = validateAmount(amount_saved_vnd, 'amount_saved_vnd')
+    if (cleanAmount <= 0) throw new ValidationError('Amount must be greater than 0')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
 
   const { data, error } = await supabase
     .from('insurance_savings')
-    .insert({ user_id: user.id, insurance_member_id, amount_saved_vnd: amount })
+    .insert({ user_id: user.id, insurance_member_id: cleanMemberId, amount_saved_vnd: cleanAmount })
     .select('id, amount_saved_vnd, created_at')
     .single()
 

--- a/app/api/v1/investment-transactions/[id]/assign/route.ts
+++ b/app/api/v1/investment-transactions/[id]/assign/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -10,11 +11,23 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const body = await request.json()
   const { goal_id } = body
 
-  if (goal_id) {
+  let txId: string
+  let cleanGoalId: string | null = null
+  try {
+    txId = validateUUID(id, 'transaction_id')
+    if (goal_id !== null && goal_id !== undefined && goal_id !== '') {
+      cleanGoalId = validateUUID(goal_id, 'goal_id')
+    }
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  if (cleanGoalId) {
     const { data: goal } = await supabase
       .from('savings_goals')
       .select('goal_id')
-      .eq('goal_id', goal_id)
+      .eq('goal_id', cleanGoalId)
       .eq('user_id', user.id)
       .single()
     if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
@@ -22,8 +35,8 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
   const { data: transaction, error } = await supabase
     .from('investment_transactions')
-    .update({ goal_id: goal_id || null, updated_at: new Date().toISOString() })
-    .eq('transaction_id', id)
+    .update({ goal_id: cleanGoalId, updated_at: new Date().toISOString() })
+    .eq('transaction_id', txId)
     .eq('user_id', user.id)
     .select()
     .single()

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -1,10 +1,20 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateEnum, validateNotes, validateRate, validateUUID } from '@/lib/validation'
 
 const ASSET_TYPES = ['fund', 'bank', 'stock', 'gold'] as const
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let txId: string
+  try {
+    txId = validateUUID(id, 'transaction_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -12,7 +22,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
   const { data: transaction, error } = await supabase
     .from('investment_transactions')
     .select('*, savings_goals(goal_name)')
-    .eq('transaction_id', id)
+    .eq('transaction_id', txId)
     .eq('user_id', user.id)
     .single()
 
@@ -29,45 +39,91 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const body = await request.json()
   const { goal_id, asset_type, investment_date, amount_vnd, unit_price, units, interest_rate, expiry_date, notes, fund_id } = body
 
-  if (asset_type && !ASSET_TYPES.includes(asset_type)) {
-    return NextResponse.json({ error: 'Invalid asset type.' }, { status: 400 })
-  }
-  if (asset_type === 'fund' && fund_id === undefined) {
-    return NextResponse.json({ error: 'Fund selection is required for fund transactions.' }, { status: 400 })
-  }
-  if (investment_date && new Date(investment_date) > new Date()) {
-    return NextResponse.json({ error: 'Investment date cannot be in the future.' }, { status: 400 })
-  }
-  if (amount_vnd !== undefined && (isNaN(Number(amount_vnd)) || Number(amount_vnd) <= 0)) {
-    return NextResponse.json({ error: 'Amount must be greater than 0.' }, { status: 400 })
+  let txId: string
+  let cleanAssetType: typeof ASSET_TYPES[number] | undefined
+  let cleanInvestmentDate: string | undefined
+  let cleanAmount: number | undefined
+  let cleanUnitPrice: number | null | undefined
+  let cleanUnits: number | null | undefined
+  let cleanInterestRate: number | null | undefined
+  let cleanExpiryDate: string | null | undefined
+  let cleanNotes: string | null | undefined
+  let cleanGoalId: string | null | undefined
+  let cleanFundId: string | null | undefined
+
+  try {
+    txId = validateUUID(id, 'transaction_id')
+
+    if (asset_type !== undefined) {
+      cleanAssetType = validateEnum(asset_type, ASSET_TYPES, 'asset_type')
+    }
+    if (cleanAssetType === 'fund' && fund_id === undefined) {
+      throw new ValidationError('Fund selection is required for fund transactions.')
+    }
+    if (investment_date !== undefined && investment_date !== null && investment_date !== '') {
+      cleanInvestmentDate = validateDate(investment_date, 'investment_date')
+    }
+    if (amount_vnd !== undefined) {
+      const amt = validateAmount(amount_vnd, 'amount_vnd')
+      if (amt <= 0) throw new ValidationError('Amount must be greater than 0.')
+      cleanAmount = amt
+    }
+    if (unit_price !== undefined) {
+      cleanUnitPrice = unit_price === null || unit_price === '' ? null : validateAmount(unit_price, 'unit_price')
+    }
+    if (units !== undefined) {
+      cleanUnits = units === null || units === '' ? null : validateAmount(units, 'units')
+    }
+    if (interest_rate !== undefined) {
+      cleanInterestRate = interest_rate === null || interest_rate === '' ? null : validateRate(interest_rate, 'interest_rate')
+    }
+    if (expiry_date !== undefined) {
+      cleanExpiryDate = expiry_date === null || expiry_date === '' ? null : validateDate(expiry_date, 'expiry_date')
+    }
+    if (notes !== undefined) {
+      cleanNotes = validateNotes(notes)
+    }
+    if (goal_id !== undefined) {
+      cleanGoalId = goal_id === null || goal_id === '' ? null : validateUUID(goal_id, 'goal_id')
+    }
+    if (fund_id !== undefined) {
+      cleanFundId = fund_id === null || fund_id === '' ? null : validateUUID(fund_id, 'fund_id')
+    }
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
 
-  if (goal_id) {
+  if (cleanInvestmentDate && new Date(cleanInvestmentDate) > new Date()) {
+    return NextResponse.json({ error: 'Investment date cannot be in the future.' }, { status: 400 })
+  }
+
+  if (cleanGoalId) {
     const { data: goal } = await supabase
       .from('savings_goals')
       .select('goal_id')
-      .eq('goal_id', goal_id)
+      .eq('goal_id', cleanGoalId)
       .eq('user_id', user.id)
       .single()
     if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
   }
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }
-  if (goal_id !== undefined) updates.goal_id = goal_id || null
-  if (asset_type) updates.asset_type = asset_type
-  if (investment_date) updates.investment_date = investment_date
-  if (amount_vnd !== undefined) updates.amount_vnd = Number(amount_vnd)
-  if (unit_price !== undefined) updates.unit_price = unit_price ? Number(unit_price) : null
-  if (units !== undefined) updates.units = units ? Number(units) : null
-  if (interest_rate !== undefined) updates.interest_rate = interest_rate ? Number(interest_rate) : null
-  if (expiry_date !== undefined) updates.expiry_date = expiry_date || null
-  if (notes !== undefined) updates.notes = notes?.trim() || null
-  if (fund_id !== undefined) updates.fund_id = asset_type === 'fund' ? (fund_id || null) : null
+  if (goal_id !== undefined) updates.goal_id = cleanGoalId
+  if (cleanAssetType) updates.asset_type = cleanAssetType
+  if (cleanInvestmentDate) updates.investment_date = cleanInvestmentDate
+  if (cleanAmount !== undefined) updates.amount_vnd = cleanAmount
+  if (unit_price !== undefined) updates.unit_price = cleanUnitPrice
+  if (units !== undefined) updates.units = cleanUnits
+  if (interest_rate !== undefined) updates.interest_rate = cleanInterestRate
+  if (expiry_date !== undefined) updates.expiry_date = cleanExpiryDate
+  if (notes !== undefined) updates.notes = cleanNotes
+  if (fund_id !== undefined) updates.fund_id = cleanAssetType === 'fund' ? cleanFundId : null
 
   const { data: transaction, error } = await supabase
     .from('investment_transactions')
     .update(updates)
-    .eq('transaction_id', id)
+    .eq('transaction_id', txId)
     .eq('user_id', user.id)
     .select()
     .single()
@@ -78,6 +134,15 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let txId: string
+  try {
+    txId = validateUUID(id, 'transaction_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -85,7 +150,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   const { error } = await supabase
     .from('investment_transactions')
     .delete()
-    .eq('transaction_id', id)
+    .eq('transaction_id', txId)
     .eq('user_id', user.id)
 
   if (error) return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })

--- a/app/api/v1/investment-transactions/batch/route.ts
+++ b/app/api/v1/investment-transactions/batch/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateUUID } from '@/lib/validation'
 
 interface BatchTransaction {
   fund_id: string
@@ -24,40 +25,54 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Cannot import more than 500 transactions at once.' }, { status: 400 })
   }
 
-  // Verify all fund_ids belong to the user
-  const fundIds = [...new Set(transactions.map((t) => t.fund_id))]
-  const { data: userFunds } = await supabase
-    .from('funds')
-    .select('id')
-    .eq('user_id', user.id)
-    .in('id', fundIds)
-
-  const validFundIds = new Set((userFunds ?? []).map((f: { id: string }) => f.id))
-  const invalidFunds = fundIds.filter((id) => !validFundIds.has(id))
-  if (invalidFunds.length > 0) {
-    return NextResponse.json({ error: 'One or more fund IDs are invalid or do not belong to you.' }, { status: 403 })
-  }
-
   // Validate each row and collect errors
   const errors: { index: number; message: string }[] = []
-  const validRows: object[] = []
+  const validRows: { user_id: string; asset_type: string; fund_id: string; investment_date: string; amount_vnd: number; unit_price: number; units: number }[] = []
 
   transactions.forEach((tx, i) => {
-    if (!tx.investment_date) { errors.push({ index: i, message: 'investment_date is required' }); return }
-    if (!tx.amount_vnd || tx.amount_vnd <= 0) { errors.push({ index: i, message: 'amount_vnd must be > 0' }); return }
-    if (!tx.unit_price || tx.unit_price <= 0) { errors.push({ index: i, message: 'unit_price must be > 0' }); return }
-    if (!tx.units || tx.units <= 0) { errors.push({ index: i, message: 'units must be > 0' }); return }
+    try {
+      const fundId = validateUUID(tx.fund_id, 'fund_id')
+      const investmentDate = validateDate(tx.investment_date, 'investment_date')
+      const amount = validateAmount(tx.amount_vnd, 'amount_vnd')
+      if (amount <= 0) throw new ValidationError('amount_vnd must be > 0')
+      const unitPrice = validateAmount(tx.unit_price, 'unit_price')
+      if (unitPrice <= 0) throw new ValidationError('unit_price must be > 0')
+      const units = validateAmount(tx.units, 'units')
+      if (units <= 0) throw new ValidationError('units must be > 0')
 
-    validRows.push({
-      user_id: user.id,
-      asset_type: 'fund',
-      fund_id: tx.fund_id,
-      investment_date: tx.investment_date,
-      amount_vnd: tx.amount_vnd,
-      unit_price: tx.unit_price,
-      units: tx.units,
-    })
+      validRows.push({
+        user_id: user.id,
+        asset_type: 'fund',
+        fund_id: fundId,
+        investment_date: investmentDate,
+        amount_vnd: amount,
+        unit_price: unitPrice,
+        units: units,
+      })
+    } catch (e) {
+      if (e instanceof ValidationError) {
+        errors.push({ index: i, message: e.message })
+      } else {
+        throw e
+      }
+    }
   })
+
+  // Verify all fund_ids belong to the user (only ones that passed UUID validation)
+  const fundIds = [...new Set(validRows.map((t) => t.fund_id))]
+  if (fundIds.length > 0) {
+    const { data: userFunds } = await supabase
+      .from('funds')
+      .select('id')
+      .eq('user_id', user.id)
+      .in('id', fundIds)
+
+    const validFundIds = new Set((userFunds ?? []).map((f: { id: string }) => f.id))
+    const invalidFunds = fundIds.filter((id) => !validFundIds.has(id))
+    if (invalidFunds.length > 0) {
+      return NextResponse.json({ error: 'One or more fund IDs are invalid or do not belong to you.' }, { status: 403 })
+    }
+  }
 
   if (validRows.length === 0) {
     return NextResponse.json({ inserted: 0, errors }, { status: 400 })

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateEnum, validateNotes, validateRate, validateUUID } from '@/lib/validation'
 
 const ASSET_TYPES = ['fund', 'bank', 'stock', 'gold'] as const
 
@@ -52,46 +53,73 @@ export async function POST(request: NextRequest) {
 
   const isWithdrawal = transaction_type === 'withdrawal'
 
-  if (!['investment', 'withdrawal'].includes(transaction_type)) {
-    return NextResponse.json({ error: 'Invalid transaction type.' }, { status: 400 })
-  }
+  let cleanTxType: 'investment' | 'withdrawal'
+  let cleanAssetType: typeof ASSET_TYPES[number] | null = null
+  let cleanInvestmentDate: string
+  let cleanAmount: number
+  let cleanUnitPrice: number | null = null
+  let cleanUnits: number | null = null
+  let cleanInterestRate: number | null = null
+  let cleanNotes: string | null = null
+  let cleanGoalId: string | null = null
+  let cleanFundId: string | null = null
+  let cleanPlanId: string | null = null
+  let cleanExpiryDate: string | null = null
+  let cleanParentTxId: string | null = null
+  let cleanPrincipalWithdrawn: number | null = null
+  let cleanUnitsWithdrawn: number | null = null
 
-  if (!isWithdrawal) {
-    if (!asset_type || !ASSET_TYPES.includes(asset_type)) {
-      return NextResponse.json({ error: 'Invalid asset type.' }, { status: 400 })
+  try {
+    cleanTxType = validateEnum(transaction_type, ['investment', 'withdrawal'] as const, 'transaction_type')
+
+    if (!isWithdrawal) {
+      cleanAssetType = validateEnum(asset_type, ASSET_TYPES, 'asset_type')
+      if (cleanAssetType === 'fund' && !fund_id) {
+        throw new ValidationError('fund_id is required for fund transactions')
+      }
+    } else if (asset_type) {
+      cleanAssetType = validateEnum(asset_type, ASSET_TYPES, 'asset_type')
     }
-    if (asset_type === 'fund' && !fund_id) {
-      return NextResponse.json({ error: 'Fund selection is required for fund transactions.' }, { status: 400 })
-    }
+
+    cleanInvestmentDate = validateDate(investment_date, 'investment_date')
+    cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
+    if (cleanAmount <= 0) throw new ValidationError('amount_vnd must be positive')
+
+    if (unit_price != null && unit_price !== '') cleanUnitPrice = validateAmount(unit_price, 'unit_price')
+    if (units != null && units !== '') cleanUnits = validateAmount(units, 'units')
+    if (interest_rate != null && interest_rate !== '') cleanInterestRate = validateRate(interest_rate, 'interest_rate')
+    cleanNotes = validateNotes(notes)
+    if (goal_id) cleanGoalId = validateUUID(goal_id, 'goal_id')
+    if (fund_id) cleanFundId = validateUUID(fund_id, 'fund_id')
+    if (plan_id) cleanPlanId = validateUUID(plan_id, 'plan_id')
+    if (expiry_date) cleanExpiryDate = validateDate(expiry_date, 'expiry_date')
+    if (parent_transaction_id) cleanParentTxId = validateUUID(parent_transaction_id, 'parent_transaction_id')
+    if (principal_withdrawn != null && principal_withdrawn !== '') cleanPrincipalWithdrawn = validateAmount(principal_withdrawn, 'principal_withdrawn')
+    if (units_withdrawn != null && units_withdrawn !== '') cleanUnitsWithdrawn = validateAmount(units_withdrawn, 'units_withdrawn')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
 
-
-  if (!investment_date) {
-    return NextResponse.json({ error: 'Investment date is required.' }, { status: 400 })
-  }
   // Allow future dates within the plan month (plan_id provided); otherwise reject future dates
-  if (!plan_id && new Date(investment_date) > new Date()) {
+  if (!cleanPlanId && new Date(cleanInvestmentDate) > new Date()) {
     return NextResponse.json({ error: 'Investment date cannot be in the future.' }, { status: 400 })
-  }
-  const amountNum = Number(amount_vnd)
-  if (!amount_vnd || isNaN(amountNum) || amountNum <= 0) {
-    return NextResponse.json({ error: 'Amount must be greater than 0.' }, { status: 400 })
   }
 
   // Verify goal ownership if provided
-  if (goal_id) {
+  if (cleanGoalId) {
     const { data: goal } = await supabase
       .from('savings_goals')
       .select('goal_id')
-      .eq('goal_id', goal_id)
+      .eq('goal_id', cleanGoalId)
       .eq('user_id', user.id)
       .single()
     if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
   }
 
   // Verify plan ownership if provided
-  if (plan_id) {
-    const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', plan_id).eq('user_id', user.id).single()
+  if (cleanPlanId) {
+    const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', cleanPlanId).eq('user_id', user.id).single()
     if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
   }
 
@@ -99,21 +127,21 @@ export async function POST(request: NextRequest) {
     .from('investment_transactions')
     .insert({
       user_id: user.id,
-      goal_id: goal_id || null,
-      transaction_type,
-      asset_type: isWithdrawal ? (asset_type || null) : asset_type,
-      investment_date,
-      amount_vnd: amountNum,
-      unit_price: unit_price ? Number(unit_price) : null,
-      units: units ? Number(units) : null,
-      interest_rate: interest_rate ? Number(interest_rate) : null,
-      notes: notes?.trim() || null,
-      fund_id: asset_type === 'fund' ? (fund_id || null) : null,
-      plan_id: plan_id || null,
-      expiry_date: expiry_date || null,
-      parent_transaction_id: parent_transaction_id || null,
-      principal_withdrawn: principal_withdrawn ? Number(principal_withdrawn) : null,
-      units_withdrawn: units_withdrawn ? Number(units_withdrawn) : null,
+      goal_id: cleanGoalId,
+      transaction_type: cleanTxType,
+      asset_type: cleanAssetType,
+      investment_date: cleanInvestmentDate,
+      amount_vnd: cleanAmount,
+      unit_price: cleanUnitPrice,
+      units: cleanUnits,
+      interest_rate: cleanInterestRate,
+      notes: cleanNotes,
+      fund_id: cleanAssetType === 'fund' ? cleanFundId : null,
+      plan_id: cleanPlanId,
+      expiry_date: cleanExpiryDate,
+      parent_transaction_id: cleanParentTxId,
+      principal_withdrawn: cleanPrincipalWithdrawn,
+      units_withdrawn: cleanUnitsWithdrawn,
       affects_progress: isWithdrawal ? (affects_progress !== false) : true,
     })
     .select()

--- a/app/api/v1/monthly-plans/[id]/direct-savings/route.ts
+++ b/app/api/v1/monthly-plans/[id]/direct-savings/route.ts
@@ -1,19 +1,29 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let planId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', id).eq('user_id', user.id).single()
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
   if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
 
   const { data, error } = await supabase
     .from('investment_transactions')
     .select('transaction_id, plan_id, goal_id, amount_vnd, interest_rate, expiry_date, investment_date, savings_goals(goal_name)')
-    .eq('plan_id', id)
+    .eq('plan_id', planId)
     .eq('asset_type', 'bank')
     .eq('user_id', user.id)
     .order('investment_date', { ascending: true })

--- a/app/api/v1/monthly-plans/[id]/excluded-insurance/[memberId]/route.ts
+++ b/app/api/v1/monthly-plans/[id]/excluded-insurance/[memberId]/route.ts
@@ -1,23 +1,35 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
 
 export async function DELETE(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string; memberId: string }> }
 ) {
   const { id, memberId } = await params
+
+  let planId: string
+  let cleanMemberId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+    cleanMemberId = validateUUID(memberId, 'member_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', id).eq('user_id', user.id).single()
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
   if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
 
   const { error } = await supabase
     .from('plan_excluded_insurance_members')
     .delete()
-    .eq('plan_id', id)
-    .eq('member_id', memberId)
+    .eq('plan_id', planId)
+    .eq('member_id', cleanMemberId)
 
   if (error) return NextResponse.json({ error: 'Not found' }, { status: 404 })
   return new NextResponse(null, { status: 204 })

--- a/app/api/v1/monthly-plans/[id]/excluded-insurance/route.ts
+++ b/app/api/v1/monthly-plans/[id]/excluded-insurance/route.ts
@@ -1,19 +1,29 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let planId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', id).eq('user_id', user.id).single()
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
   if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
 
   const { data, error } = await supabase
     .from('plan_excluded_insurance_members')
     .select('id, member_id')
-    .eq('plan_id', id)
+    .eq('plan_id', planId)
 
   if (error) return NextResponse.json({ error: 'Failed to fetch exclusions' }, { status: 500 })
   return NextResponse.json(data ?? [])
@@ -25,15 +35,25 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('user_id', user.id).eq('id', id).single()
-  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
-
   const { member_id } = await request.json()
-  if (!member_id) return NextResponse.json({ error: 'member_id is required' }, { status: 400 })
+
+  let planId: string
+  let cleanMemberId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+    if (!member_id) throw new ValidationError('member_id is required')
+    cleanMemberId = validateUUID(member_id, 'member_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('user_id', user.id).eq('id', planId).single()
+  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
 
   const { data, error } = await supabase
     .from('plan_excluded_insurance_members')
-    .upsert({ plan_id: id, member_id }, { onConflict: 'plan_id,member_id' })
+    .upsert({ plan_id: planId, member_id: cleanMemberId }, { onConflict: 'plan_id,member_id' })
     .select()
     .single()
 

--- a/app/api/v1/monthly-plans/[id]/fixed-expense-overrides/[overrideId]/route.ts
+++ b/app/api/v1/monthly-plans/[id]/fixed-expense-overrides/[overrideId]/route.ts
@@ -1,23 +1,35 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
 
 export async function DELETE(
   _req: NextRequest,
   { params }: { params: Promise<{ id: string; overrideId: string }> }
 ) {
   const { id, overrideId } = await params
+
+  let planId: string
+  let cleanOverrideId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+    cleanOverrideId = validateUUID(overrideId, 'override_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', id).eq('user_id', user.id).single()
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
   if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
 
   const { error } = await supabase
     .from('fixed_expense_overrides')
     .delete()
-    .eq('id', overrideId)
-    .eq('plan_id', id)
+    .eq('id', cleanOverrideId)
+    .eq('plan_id', planId)
 
   if (error) return NextResponse.json({ error: 'Override not found' }, { status: 404 })
   return new NextResponse(null, { status: 204 })

--- a/app/api/v1/monthly-plans/[id]/fixed-expense-overrides/route.ts
+++ b/app/api/v1/monthly-plans/[id]/fixed-expense-overrides/route.ts
@@ -1,19 +1,29 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateUUID } from '@/lib/validation'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let planId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', id).eq('user_id', user.id).single()
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
   if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
 
   const { data, error } = await supabase
     .from('fixed_expense_overrides')
     .select('*, fixed_expenses(expense_name, amount_vnd)')
-    .eq('plan_id', id)
+    .eq('plan_id', planId)
     .order('created_at', { ascending: true })
 
   if (error) return NextResponse.json({ error: 'Failed to fetch overrides' }, { status: 500 })
@@ -26,23 +36,33 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', id).eq('user_id', user.id).single()
-  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
-
   const body = await request.json()
   const { fixed_expense_id, monthly_amount_override_vnd } = body
 
-  const amountNum = Number(monthly_amount_override_vnd)
-  if (!fixed_expense_id) return NextResponse.json({ error: 'fixed_expense_id is required' }, { status: 400 })
-  if (monthly_amount_override_vnd === undefined || monthly_amount_override_vnd === null || isNaN(amountNum) || amountNum < 0) {
-    return NextResponse.json({ error: 'Monthly amount must be 0 or positive' }, { status: 400 })
+  let planId: string
+  let cleanExpenseId: string
+  let cleanAmount: number
+  try {
+    planId = validateUUID(id, 'plan_id')
+    if (!fixed_expense_id) throw new ValidationError('fixed_expense_id is required')
+    cleanExpenseId = validateUUID(fixed_expense_id, 'fixed_expense_id')
+    if (monthly_amount_override_vnd === undefined || monthly_amount_override_vnd === null) {
+      throw new ValidationError('Monthly amount must be 0 or positive')
+    }
+    cleanAmount = validateAmount(monthly_amount_override_vnd, 'monthly_amount_override_vnd')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
+
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
+  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
 
   // Upsert — one override per expense per plan
   const { data, error } = await supabase
     .from('fixed_expense_overrides')
     .upsert(
-      { plan_id: id, fixed_expense_id, monthly_amount_override_vnd: amountNum, updated_at: new Date().toISOString() },
+      { plan_id: planId, fixed_expense_id: cleanExpenseId, monthly_amount_override_vnd: cleanAmount, updated_at: new Date().toISOString() },
       { onConflict: 'plan_id,fixed_expense_id' }
     )
     .select()

--- a/app/api/v1/monthly-plans/[id]/fund-investments/route.ts
+++ b/app/api/v1/monthly-plans/[id]/fund-investments/route.ts
@@ -1,19 +1,29 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let planId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', id).eq('user_id', user.id).single()
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
   if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
 
   const { data, error } = await supabase
     .from('investment_transactions')
     .select('transaction_id, plan_id, fund_id, goal_id, amount_vnd, units, unit_price, investment_date, funds(name, nav), savings_goals(goal_name)')
-    .eq('plan_id', id)
+    .eq('plan_id', planId)
     .eq('asset_type', 'fund')
     .eq('user_id', user.id)
     .order('investment_date', { ascending: true })

--- a/app/api/v1/monthly-plans/[id]/insurance-overrides/route.ts
+++ b/app/api/v1/monthly-plans/[id]/insurance-overrides/route.ts
@@ -1,19 +1,29 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateUUID } from '@/lib/validation'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let planId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', id).eq('user_id', user.id).single()
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
   if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
 
   const { data, error } = await supabase
     .from('plan_insurance_member_overrides')
     .select('id, member_id, monthly_amount_override_vnd')
-    .eq('plan_id', id)
+    .eq('plan_id', planId)
 
   if (error) return NextResponse.json({ error: 'Failed to fetch overrides' }, { status: 500 })
   return NextResponse.json(data ?? [])
@@ -25,19 +35,28 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('user_id', user.id).eq('id', id).single()
-  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
-
   const { member_id, monthly_amount_override_vnd } = await request.json()
-  if (!member_id) return NextResponse.json({ error: 'member_id is required' }, { status: 400 })
-  const amountNum = Number(monthly_amount_override_vnd)
-  if (!monthly_amount_override_vnd || isNaN(amountNum) || amountNum <= 0) {
-    return NextResponse.json({ error: 'Monthly amount must be positive' }, { status: 400 })
+
+  let planId: string
+  let cleanMemberId: string
+  let cleanAmount: number
+  try {
+    planId = validateUUID(id, 'plan_id')
+    if (!member_id) throw new ValidationError('member_id is required')
+    cleanMemberId = validateUUID(member_id, 'member_id')
+    cleanAmount = validateAmount(monthly_amount_override_vnd, 'monthly_amount_override_vnd')
+    if (cleanAmount <= 0) throw new ValidationError('Monthly amount must be positive')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
+
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('user_id', user.id).eq('id', planId).single()
+  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
 
   const { data, error } = await supabase
     .from('plan_insurance_member_overrides')
-    .upsert({ plan_id: id, member_id, monthly_amount_override_vnd: amountNum }, { onConflict: 'plan_id,member_id' })
+    .upsert({ plan_id: planId, member_id: cleanMemberId, monthly_amount_override_vnd: cleanAmount }, { onConflict: 'plan_id,member_id' })
     .select()
     .single()
 

--- a/app/api/v1/monthly-plans/[id]/other-expenses/[expenseId]/route.ts
+++ b/app/api/v1/monthly-plans/[id]/other-expenses/[expenseId]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateText, validateUUID } from '@/lib/validation'
 
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string; expenseId: string }> }) {
   const supabase = await createSupabaseServerClient()
@@ -7,31 +8,40 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const { id, expenseId } = await params
+  const body = await req.json()
+  const { description, amount_vnd } = body
+
+  let planId: string
+  let cleanExpenseId: string
+  let cleanDescription: string
+  let cleanAmount: number
+  try {
+    planId = validateUUID(id, 'plan_id')
+    cleanExpenseId = validateUUID(expenseId, 'expense_id')
+    if (!description || (typeof description === 'string' && !description.trim())) {
+      throw new ValidationError('Mô tả là bắt buộc')
+    }
+    cleanDescription = validateText(description, 'description', { max: 500 })
+    cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
+    if (cleanAmount <= 0) throw new ValidationError('Số tiền phải dương')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
 
   const { data: plan } = await supabase
     .from('monthly_plans')
     .select('id')
-    .eq('id', id)
+    .eq('id', planId)
     .eq('user_id', user.id)
     .single()
   if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
 
-  const body = await req.json()
-  const { description, amount_vnd } = body
-
-  if (!description || !description.trim()) {
-    return NextResponse.json({ error: 'Mô tả là bắt buộc' }, { status: 400 })
-  }
-  const amountNum = Number(amount_vnd)
-  if (!amount_vnd || isNaN(amountNum) || amountNum <= 0) {
-    return NextResponse.json({ error: 'Số tiền phải dương' }, { status: 400 })
-  }
-
   const { data, error } = await supabase
     .from('plan_other_expenses')
-    .update({ description: description.trim(), amount_vnd: amountNum })
-    .eq('id', expenseId)
-    .eq('plan_id', id)
+    .update({ description: cleanDescription, amount_vnd: cleanAmount })
+    .eq('id', cleanExpenseId)
+    .eq('plan_id', planId)
     .select()
     .single()
 
@@ -46,11 +56,21 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
 
   const { id, expenseId } = await params
 
+  let planId: string
+  let cleanExpenseId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+    cleanExpenseId = validateUUID(expenseId, 'expense_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   // Verify ownership via plan
   const { data: plan } = await supabase
     .from('monthly_plans')
     .select('id')
-    .eq('id', id)
+    .eq('id', planId)
     .eq('user_id', user.id)
     .single()
   if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
@@ -58,8 +78,8 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   const { error } = await supabase
     .from('plan_other_expenses')
     .delete()
-    .eq('id', expenseId)
-    .eq('plan_id', id)
+    .eq('id', cleanExpenseId)
+    .eq('plan_id', planId)
 
   if (error) return NextResponse.json({ error: 'Failed to delete' }, { status: 500 })
   return new NextResponse(null, { status: 204 })

--- a/app/api/v1/monthly-plans/[id]/other-expenses/route.ts
+++ b/app/api/v1/monthly-plans/[id]/other-expenses/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateText, validateUUID } from '@/lib/validation'
 
 async function getPlanForUser(supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>, planId: string, userId: string) {
   const { data } = await supabase
@@ -17,13 +18,22 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const { id } = await params
-  const plan = await getPlanForUser(supabase, id, user.id)
+
+  let planId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const plan = await getPlanForUser(supabase, planId, user.id)
   if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
 
   const { data, error } = await supabase
     .from('plan_other_expenses')
     .select('id, description, amount_vnd, created_at')
-    .eq('plan_id', id)
+    .eq('plan_id', planId)
     .order('created_at', { ascending: true })
 
   if (error) return NextResponse.json({ error: 'Failed to fetch' }, { status: 500 })
@@ -36,23 +46,31 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const { id } = await params
-  const plan = await getPlanForUser(supabase, id, user.id)
-  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
-
   const body = await req.json()
   const { description, amount_vnd } = body
 
-  if (!description || !description.trim()) {
-    return NextResponse.json({ error: 'Mô tả là bắt buộc' }, { status: 400 })
+  let planId: string
+  let cleanDescription: string
+  let cleanAmount: number
+  try {
+    planId = validateUUID(id, 'plan_id')
+    if (!description || (typeof description === 'string' && !description.trim())) {
+      throw new ValidationError('Mô tả là bắt buộc')
+    }
+    cleanDescription = validateText(description, 'description', { max: 500 })
+    cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
+    if (cleanAmount <= 0) throw new ValidationError('Số tiền phải dương')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
-  const amountNum = Number(amount_vnd)
-  if (!amount_vnd || isNaN(amountNum) || amountNum <= 0) {
-    return NextResponse.json({ error: 'Số tiền phải dương' }, { status: 400 })
-  }
+
+  const plan = await getPlanForUser(supabase, planId, user.id)
+  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
 
   const { data, error } = await supabase
     .from('plan_other_expenses')
-    .insert({ plan_id: id, description: description.trim(), amount_vnd: amountNum })
+    .insert({ plan_id: planId, description: cleanDescription, amount_vnd: cleanAmount })
     .select()
     .single()
 

--- a/app/api/v1/monthly-plans/[id]/route.ts
+++ b/app/api/v1/monthly-plans/[id]/route.ts
@@ -1,8 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateUUID } from '@/lib/validation'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let planId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -10,7 +20,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
   const { data: plan, error } = await supabase
     .from('monthly_plans')
     .select('*')
-    .eq('id', id)
+    .eq('id', planId)
     .eq('user_id', user.id)
     .single()
 
@@ -20,6 +30,15 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let planId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -28,7 +47,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   const { data: plan, error: fetchError } = await supabase
     .from('monthly_plans')
     .select('id, month, year, user_id')
-    .eq('id', id)
+    .eq('id', planId)
     .single()
 
   if (fetchError || !plan) return NextResponse.json({ error: 'Salary record not found' }, { status: 404 })
@@ -36,7 +55,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
 
   // Delete child records, then the plan
   // investment_transactions.plan_id has ON DELETE SET NULL — no explicit delete needed
-  const overrideDel = await supabase.from('fixed_expense_overrides').delete().eq('plan_id', id)
+  const overrideDel = await supabase.from('fixed_expense_overrides').delete().eq('plan_id', planId)
 
   if (overrideDel.error) {
     return NextResponse.json({ error: 'Failed to delete salary record. Please try again.' }, { status: 500 })
@@ -45,7 +64,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   const { error: planError } = await supabase
     .from('monthly_plans')
     .delete()
-    .eq('id', id)
+    .eq('id', planId)
     .eq('user_id', user.id)
 
   if (planError) {
@@ -53,7 +72,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   }
 
   return NextResponse.json({
-    data: { id, status: 'deleted', month: plan.month, year: plan.year },
+    data: { id: planId, status: 'deleted', month: plan.month, year: plan.year },
     message: 'Salary record deleted successfully',
   })
 }
@@ -65,16 +84,22 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const body = await request.json()
-  const salaryNum = Number(body.salary_vnd)
 
-  if (!body.salary_vnd || isNaN(salaryNum) || salaryNum <= 0) {
-    return NextResponse.json({ error: 'Salary must be positive' }, { status: 400 })
+  let planId: string
+  let cleanSalary: number
+  try {
+    planId = validateUUID(id, 'plan_id')
+    cleanSalary = validateAmount(body.salary_vnd, 'salary_vnd')
+    if (cleanSalary <= 0) throw new ValidationError('Salary must be positive')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
 
   const { data: plan, error } = await supabase
     .from('monthly_plans')
-    .update({ salary_vnd: salaryNum, updated_at: new Date().toISOString() })
-    .eq('id', id)
+    .update({ salary_vnd: cleanSalary, updated_at: new Date().toISOString() })
+    .eq('id', planId)
     .eq('user_id', user.id)
     .select()
     .single()

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount } from '@/lib/validation'
 
 export async function GET(request: NextRequest) {
   const supabase = await createSupabaseServerClient()
@@ -145,23 +146,29 @@ export async function POST(request: NextRequest) {
   const body = await request.json()
   const { month, year, salary_vnd } = body
 
-  const monthNum = parseInt(month)
-  const yearNum = parseInt(year)
-  const salaryNum = Number(salary_vnd)
+  let monthNum: number
+  let yearNum: number
+  let cleanSalary: number
 
-  if (!month || monthNum < 1 || monthNum > 12) {
-    return NextResponse.json({ error: 'Month must be between 1 and 12' }, { status: 400 })
-  }
-  if (!year || yearNum < 2000) {
-    return NextResponse.json({ error: 'Invalid year' }, { status: 400 })
-  }
-  if (!salary_vnd || isNaN(salaryNum) || salaryNum <= 0) {
-    return NextResponse.json({ error: 'Salary must be positive' }, { status: 400 })
+  try {
+    monthNum = parseInt(month)
+    yearNum = parseInt(year)
+    if (!month || !Number.isFinite(monthNum) || monthNum < 1 || monthNum > 12) {
+      throw new ValidationError('Month must be between 1 and 12')
+    }
+    if (!year || !Number.isFinite(yearNum) || yearNum < 2000 || yearNum > 9999) {
+      throw new ValidationError('Invalid year')
+    }
+    cleanSalary = validateAmount(salary_vnd, 'salary_vnd')
+    if (cleanSalary <= 0) throw new ValidationError('Salary must be positive')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
 
   const { data: plan, error } = await supabase
     .from('monthly_plans')
-    .insert({ user_id: user.id, month: monthNum, year: yearNum, salary_vnd: salaryNum })
+    .insert({ user_id: user.id, month: monthNum, year: yearNum, salary_vnd: cleanSalary })
     .select()
     .single()
 

--- a/app/api/v1/savings-goals/[id]/route.ts
+++ b/app/api/v1/savings-goals/[id]/route.ts
@@ -1,8 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateEnum, validateText, validateUUID } from '@/lib/validation'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let goalId: string
+  try {
+    goalId = validateUUID(id, 'goal_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -10,7 +20,7 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
   const { data: goal, error } = await supabase
     .from('savings_goals')
     .select('*')
-    .eq('goal_id', id)
+    .eq('goal_id', goalId)
     .eq('user_id', user.id)
     .single()
 
@@ -20,37 +30,59 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
-  const supabase = await createSupabaseServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  let goalId: string
+  let cleanGoalName: string
+  let cleanDescription: string | null = null
+  let cleanTargetAmount: number | null = null
+  let cleanTargetDate: string | null = null
+  let cleanIcon: string = 'target'
+  let cleanPriority: string = 'med'
 
   const body = await request.json()
   const { goal_name, description, target_amount, target_date, icon, priority } = body
 
-  if (!goal_name || typeof goal_name !== 'string' || goal_name.trim().length === 0) {
-    return NextResponse.json({ error: 'Goal name is required.' }, { status: 400 })
+  try {
+    goalId = validateUUID(id, 'goal_id')
+    cleanGoalName = validateText(goal_name, 'goal_name')
+    if (description != null && description !== '') {
+      cleanDescription = validateText(description, 'description', { max: 1000 })
+    }
+    if (target_amount != null && target_amount !== '') {
+      const amt = validateAmount(target_amount, 'target_amount')
+      if (amt <= 0) throw new ValidationError('target_amount must be positive')
+      cleanTargetAmount = amt
+    }
+    if (target_date) {
+      cleanTargetDate = validateDate(target_date, 'target_date')
+    }
+    if (icon != null && icon !== '') {
+      cleanIcon = validateEnum(icon, ['mountains', 'home', 'shield', 'cart', 'target'] as const, 'icon')
+    }
+    if (priority != null && priority !== '') {
+      cleanPriority = validateEnum(priority, ['low', 'med', 'high'] as const, 'priority')
+    }
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
 
-  const targetAmountVal = target_amount != null && target_amount !== '' ? Number(target_amount) : null
-  if (targetAmountVal !== null && (isNaN(targetAmountVal) || targetAmountVal <= 0)) {
-    return NextResponse.json({ error: 'Goal amount must be a positive number.' }, { status: 400 })
-  }
-
-  const VALID_ICONS = ['mountains', 'home', 'shield', 'cart', 'target']
-  const VALID_PRIORITIES = ['low', 'med', 'high']
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const { data: goal, error } = await supabase
     .from('savings_goals')
     .update({
-      goal_name: goal_name.trim(),
-      description: description?.trim() || null,
-      target_amount: targetAmountVal,
-      target_date: target_date || null,
-      icon: VALID_ICONS.includes(icon) ? icon : 'target',
-      priority: VALID_PRIORITIES.includes(priority) ? priority : 'med',
+      goal_name: cleanGoalName,
+      description: cleanDescription,
+      target_amount: cleanTargetAmount,
+      target_date: cleanTargetDate,
+      icon: cleanIcon,
+      priority: cleanPriority,
       updated_at: new Date().toISOString(),
     })
-    .eq('goal_id', id)
+    .eq('goal_id', goalId)
     .eq('user_id', user.id)
     .select()
     .single()
@@ -61,6 +93,15 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
 export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
+
+  let goalId: string
+  try {
+    goalId = validateUUID(id, 'goal_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -69,13 +110,13 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   const { count } = await supabase
     .from('investment_transactions')
     .select('*', { count: 'exact', head: true })
-    .eq('goal_id', id)
+    .eq('goal_id', goalId)
     .eq('user_id', user.id)
 
   const { error } = await supabase
     .from('savings_goals')
     .delete()
-    .eq('goal_id', id)
+    .eq('goal_id', goalId)
     .eq('user_id', user.id)
 
   if (error) return NextResponse.json({ error: 'Goal not found' }, { status: 404 })

--- a/app/api/v1/savings-goals/[id]/route.ts
+++ b/app/api/v1/savings-goals/[id]/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { ValidationError, validateAmount, validateDate, validateEnum, validateText, validateUUID } from '@/lib/validation'
+import { ValidationError, validateAmount, validateEnum, validateText, validateUUID, validateYearMonth } from '@/lib/validation'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -54,7 +54,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       cleanTargetAmount = amt
     }
     if (target_date) {
-      cleanTargetDate = validateDate(target_date, 'target_date')
+      cleanTargetDate = validateYearMonth(target_date, 'target_date')
     }
     if (icon != null && icon !== '') {
       cleanIcon = validateEnum(icon, ['mountains', 'home', 'shield', 'cart', 'target'] as const, 'icon')

--- a/app/api/v1/savings-goals/route.ts
+++ b/app/api/v1/savings-goals/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { ValidationError, validateAmount, validateDate, validateEnum, validateText } from '@/lib/validation'
+import { ValidationError, validateAmount, validateEnum, validateText, validateYearMonth } from '@/lib/validation'
 
 function calcProjectedInterest(amount: number, rate: number | null, investmentDate: string): number {
   if (!rate) return 0
@@ -107,7 +107,7 @@ export async function POST(request: NextRequest) {
       cleanTargetAmount = amt
     }
     if (target_date) {
-      cleanTargetDate = validateDate(target_date, 'target_date')
+      cleanTargetDate = validateYearMonth(target_date, 'target_date')
     }
     if (icon != null && icon !== '') {
       cleanIcon = validateEnum(icon, ['mountains', 'home', 'shield', 'cart', 'target'] as const, 'icon')

--- a/app/api/v1/savings-goals/route.ts
+++ b/app/api/v1/savings-goals/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateEnum, validateText } from '@/lib/validation'
 
 function calcProjectedInterest(amount: number, rate: number | null, investmentDate: string): number {
   if (!rate) return 0
@@ -88,28 +89,47 @@ export async function POST(request: NextRequest) {
   const body = await request.json()
   const { goal_name, description, target_amount, target_date, icon, priority } = body
 
-  if (!goal_name || typeof goal_name !== 'string' || goal_name.trim().length === 0) {
-    return NextResponse.json({ error: 'Goal name is required.' }, { status: 400 })
-  }
+  let cleanGoalName: string
+  let cleanDescription: string | null = null
+  let cleanTargetAmount: number | null = null
+  let cleanTargetDate: string | null = null
+  let cleanIcon: string = 'target'
+  let cleanPriority: string = 'med'
 
-  const targetAmountVal = target_amount != null && target_amount !== '' ? Number(target_amount) : null
-  if (targetAmountVal !== null && (isNaN(targetAmountVal) || targetAmountVal <= 0)) {
-    return NextResponse.json({ error: 'Goal amount must be a positive number.' }, { status: 400 })
+  try {
+    cleanGoalName = validateText(goal_name, 'goal_name')
+    if (description != null && description !== '') {
+      cleanDescription = validateText(description, 'description', { max: 1000 })
+    }
+    if (target_amount != null && target_amount !== '') {
+      const amt = validateAmount(target_amount, 'target_amount')
+      if (amt <= 0) throw new ValidationError('target_amount must be positive')
+      cleanTargetAmount = amt
+    }
+    if (target_date) {
+      cleanTargetDate = validateDate(target_date, 'target_date')
+    }
+    if (icon != null && icon !== '') {
+      cleanIcon = validateEnum(icon, ['mountains', 'home', 'shield', 'cart', 'target'] as const, 'icon')
+    }
+    if (priority != null && priority !== '') {
+      cleanPriority = validateEnum(priority, ['low', 'med', 'high'] as const, 'priority')
+    }
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
   }
-
-  const VALID_ICONS = ['mountains', 'home', 'shield', 'cart', 'target']
-  const VALID_PRIORITIES = ['low', 'med', 'high']
 
   const { data: goal, error } = await supabase
     .from('savings_goals')
     .insert({
       user_id: user.id,
-      goal_name: goal_name.trim(),
-      description: description?.trim() || null,
-      target_amount: targetAmountVal,
-      target_date: target_date || null,
-      icon: VALID_ICONS.includes(icon) ? icon : 'target',
-      priority: VALID_PRIORITIES.includes(priority) ? priority : 'med',
+      goal_name: cleanGoalName,
+      description: cleanDescription,
+      target_amount: cleanTargetAmount,
+      target_date: cleanTargetDate,
+      icon: cleanIcon,
+      priority: cleanPriority,
     })
     .select()
     .single()

--- a/e2e/api-validation.spec.ts
+++ b/e2e/api-validation.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test'
+
+// API-level validator rejection tests. These hit the route handlers directly
+// using Playwright's authenticated request context (storageState from setup).
+// We don't need to test every route — one canonical bad-payload per validator
+// type is enough; the validators themselves are unit-tested in
+// lib/__tests__/validation.test.ts.
+
+test.describe('API input validation', () => {
+  test('POST /api/v1/savings-goals rejects amount with Infinity (400)', async ({ request }) => {
+    const res = await request.post('/api/v1/savings-goals', {
+      data: {
+        goal_name: 'Test',
+        target_amount: 'Infinity',
+      },
+    })
+    expect(res.status()).toBe(400)
+  })
+
+  test('POST /api/v1/savings-goals rejects amount that is negative (400)', async ({ request }) => {
+    const res = await request.post('/api/v1/savings-goals', {
+      data: {
+        goal_name: 'Test',
+        target_amount: -100,
+      },
+    })
+    expect(res.status()).toBe(400)
+  })
+
+  test('POST /api/v1/savings-goals rejects oversized goal_name (400)', async ({ request }) => {
+    const res = await request.post('/api/v1/savings-goals', {
+      data: {
+        goal_name: 'a'.repeat(300),
+      },
+    })
+    expect(res.status()).toBe(400)
+  })
+
+  test('GET /api/v1/savings-goals/<bad-uuid> rejects malformed UUID (400)', async ({ request }) => {
+    const res = await request.get('/api/v1/savings-goals/not-a-uuid')
+    expect(res.status()).toBe(400)
+  })
+
+  test('PUT /api/v1/savings-goals/<bad-uuid> rejects malformed UUID (400)', async ({ request }) => {
+    const res = await request.put('/api/v1/savings-goals/not-a-uuid', {
+      data: { goal_name: 'updated' },
+    })
+    expect(res.status()).toBe(400)
+  })
+
+  test('POST /api/v1/investment-transactions rejects negative interest_rate beyond -100 (400)', async ({ request }) => {
+    const res = await request.post('/api/v1/investment-transactions', {
+      data: {
+        asset_type: 'bank',
+        amount_vnd: 1000,
+        investment_date: '2026-01-01',
+        interest_rate: -500,
+      },
+    })
+    expect(res.status()).toBe(400)
+  })
+
+  test('POST /api/v1/investment-transactions rejects malformed investment_date (400)', async ({ request }) => {
+    const res = await request.post('/api/v1/investment-transactions', {
+      data: {
+        asset_type: 'bank',
+        amount_vnd: 1000,
+        investment_date: 'not-a-date',
+      },
+    })
+    expect(res.status()).toBe(400)
+  })
+})

--- a/lib/__tests__/validation.test.ts
+++ b/lib/__tests__/validation.test.ts
@@ -6,6 +6,7 @@ import {
   validateNotes,
   validateUUID,
   validateDate,
+  validateYearMonth,
   validateEnum,
   ValidationError,
 } from '../validation'
@@ -186,6 +187,26 @@ describe('validateDate', () => {
   it('rejects non-string values', () => {
     expect(() => validateDate(20260527, 'investment_date')).toThrow(ValidationError)
     expect(() => validateDate(undefined, 'investment_date')).toThrow(ValidationError)
+  })
+})
+
+describe('validateYearMonth', () => {
+  it('accepts a YYYY-MM value', () => {
+    expect(validateYearMonth('2028-06', 'target_date')).toBe('2028-06')
+  })
+
+  it('rejects a YYYY-MM-DD value (too specific)', () => {
+    expect(() => validateYearMonth('2028-06-15', 'target_date')).toThrow(ValidationError)
+  })
+
+  it('rejects a value with an invalid month', () => {
+    expect(() => validateYearMonth('2028-13', 'target_date')).toThrow(ValidationError)
+    expect(() => validateYearMonth('2028-00', 'target_date')).toThrow(ValidationError)
+  })
+
+  it('rejects non-string values', () => {
+    expect(() => validateYearMonth(202806, 'target_date')).toThrow(ValidationError)
+    expect(() => validateYearMonth(undefined, 'target_date')).toThrow(ValidationError)
   })
 })
 

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -108,6 +108,19 @@ export function validateDate(val: unknown, field: string): string {
   return val
 }
 
+// For month-precision fields (savings goal target month, fixed-expense
+// effective_from / effective_to), accepts YYYY-MM with a real calendar month.
+export function validateYearMonth(val: unknown, field: string): string {
+  if (typeof val !== 'string' || !/^\d{4}-\d{2}$/.test(val)) {
+    throw new ValidationError(`${field} must be in YYYY-MM format`)
+  }
+  const [, m] = val.split('-').map(Number)
+  if (m < 1 || m > 12) {
+    throw new ValidationError(`${field} has an invalid month`)
+  }
+  return val
+}
+
 export function validateEnum<T extends string>(
   val: unknown,
   allowed: readonly T[],

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,7 +9,35 @@ const nextConfig: NextConfig = {
     root: __dirname,
   },
   async headers() {
+    // Permissive CSP baseline that doesn't break Supabase realtime, Google
+    // Fonts, or Next.js inline runtime scripts. Tightening to a nonce-based
+    // policy is a future follow-up.
+    const csp = [
+      "default-src 'self'",
+      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+      "font-src 'self' data: https://fonts.gstatic.com",
+      "img-src 'self' data: blob: https:",
+      "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+      "frame-ancestors 'none'",
+      "base-uri 'self'",
+      "form-action 'self'",
+    ].join('; ')
+
+    const securityHeaders = [
+      { key: 'Content-Security-Policy', value: csp },
+      { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
+      { key: 'X-Content-Type-Options', value: 'nosniff' },
+      { key: 'X-Frame-Options', value: 'DENY' },
+      { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+      { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+    ]
+
     return [
+      {
+        source: '/:path*',
+        headers: securityHeaders,
+      },
       {
         source: '/favicon.ico',
         headers: [{ key: 'Cache-Control', value: 'no-store' }],


### PR DESCRIPTION
## Summary
PR 2 of 2. Rolls out the validators from PR #215 across every body-accepting API route, adds defense-in-depth response headers, and removes raw UUIDs from one audit log line.

### Validator rollout (~25 route files in \`app/api/v1/\`)
- \`amount_vnd\` / \`nav\` / \`unit_price\` / \`target_amount\` / \`salary_vnd\` etc. → \`validateAmount\` rejects \`Infinity\`, \`NaN\`, negatives with HTTP 400 instead of silently corrupting downstream calculations.
- \`interest_rate\` → \`validateRate\` (range \`[-100, 1000]\`).
- All \`[id]\` path params + UUID body fields (\`goal_id\`, \`fund_id\`, \`plan_id\`) → \`validateUUID\` BEFORE any DB query. Malformed IDs return 400 instead of being passed into Supabase queries.
- Text fields (\`goal_name\`, \`member_name\`, etc.) → \`validateText\` with length cap.
- \`notes\` → \`validateNotes\` (cap 2000).
- Dates → \`validateDate\` (strict \`YYYY-MM-DD\`).
- Asset types / icons / priorities → \`validateEnum\`.

### Security headers (next.config.ts)
- Content-Security-Policy (baseline; tightening to nonce is a follow-up). Permissive enough not to break Supabase realtime, Google Fonts, or Next.js inline runtime.
- Strict-Transport-Security (HSTS, 2y + preload).
- X-Content-Type-Options: nosniff.
- X-Frame-Options: DENY.
- Referrer-Policy: strict-origin-when-cross-origin.
- Permissions-Policy disabling camera/mic/geolocation.

### Other
- \`insurance-members/[id]/mark-paid\`: drop raw \`user_id\` + \`member_id\` from the audit \`console.log\` line.
- \`insurance-members\` GET: \`select('*')\` → explicit field list.

## Test plan
- [x] \`npx tsc --noEmit\` clean.
- [x] \`npx vitest run\`: 248/249 passing (one pre-existing \`TransactionHistorySheet\` failure unrelated to this PR).
- [x] New \`e2e/api-validation.spec.ts\` covers the canonical bad case per validator (Infinity, oversized text, malformed UUID, out-of-range rate, bad date) → all expect 400.
- [ ] Vercel preview: smoke test that Dashboard / Planning / Funds / Settings load with no CSP-induced console errors and that all normal CRUD operations still work.
- [ ] Confirm \`docs/security\` posture documents in PR description (see PR #215).

🤖 Generated with [Claude Code](https://claude.com/claude-code)