### PR TITLE
feat(overview): allocation breakdown as row-per-segment list with gold units

### DIFF
--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -137,6 +137,7 @@ export async function GET() {
   let totalAssets = 0
   let totalInvestedGlobal = 0
   const nonFundByType: Record<string, number> = { bank: 0, gold: 0, stock: 0 }
+  let goldUnits = 0  // total gold holdings in chỉ (after withdrawals)
 
   const unallocatedNonFunds: {
     transactionId: string; type: string; amount: number; currentValue: number; interestRate: number | null; expiryDate: string | null; investmentDate: string; notes: string | null; units: number | null
@@ -200,6 +201,9 @@ export async function GET() {
       totalAssets += currentValue
       totalInvestedGlobal += effectiveAmount
       if (tx.asset_type in nonFundByType) nonFundByType[tx.asset_type] += currentValue
+      if (tx.asset_type === 'gold' && effectiveUnits != null && effectiveUnits > 0) {
+        goldUnits += effectiveUnits
+      }
 
       if (tx.goal_id && goalMap.has(tx.goal_id)) {
         const goalEntry = goalMap.get(tx.goal_id)!
@@ -361,6 +365,7 @@ export async function GET() {
       nonFunds: unallocatedNonFunds,
     },
     byType: nonFundByType,
+    goldUnits,
     insurance: insuranceOutput,
   })
 }

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -95,6 +95,7 @@ export interface DashboardData {
   goals: GoalData[]
   unallocated: { totalValue: number; funds: FundBreakdownItem[]; nonFunds: NonFundUnallocatedItem[] }
   byType: { bank: number; gold: number; stock: number }
+  goldUnits?: number
   insurance: InsuranceData[]
 }
 
@@ -789,6 +790,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                   <DesktopNetWorthPanel
                     data={data}
                     allocationTotals={allocationTotals}
+                    goldUnits={data.goldUnits}
                     locale={locale}
                     refreshKey={historyKey}
                     navUpdatedAt={data.netWorth.navUpdatedAt}
@@ -811,6 +813,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                     bank: allocationTotals.bankTotal,
                     gold: allocationTotals.goldTotal,
                     stock: allocationTotals.stockTotal,
+                    goldUnits: data.goldUnits,
                   } : undefined}
                 />
               </div>

--- a/app/assets/components/DesktopNetWorthPanel.tsx
+++ b/app/assets/components/DesktopNetWorthPanel.tsx
@@ -71,13 +71,14 @@ interface AllocationTotals {
 interface Props {
   data: DashboardData
   allocationTotals: AllocationTotals | null
+  goldUnits?: number
   locale: string
   refreshKey?: number
   navUpdatedAt?: string | null
   onDownloadReport: () => void
 }
 
-export default function DesktopNetWorthPanel({ data, allocationTotals, locale, refreshKey, navUpdatedAt, onDownloadReport }: Props) {
+export default function DesktopNetWorthPanel({ data, allocationTotals, goldUnits, locale, refreshKey, navUpdatedAt, onDownloadReport }: Props) {
   const { netWorth } = data
   const isPos = netWorth.overallProfitLoss >= 0
   const isVi = locale === 'vi'
@@ -190,12 +191,12 @@ export default function DesktopNetWorthPanel({ data, allocationTotals, locale, r
           ))}
         </div>
 
-        {/* Allocation bar */}
+        {/* Allocation bar + breakdown */}
         {segments.length > 0 && (
           <div style={{ marginTop: 16 }}>
             <div
               data-testid="allocation-bar"
-              style={{ display: 'flex', height: 7, borderRadius: 999, overflow: 'hidden', gap: 1.5 }}
+              style={{ display: 'flex', height: 7, borderRadius: 999, overflow: 'hidden', gap: 1.5, background: 'var(--c-card-2)' }}
             >
               {segments.map((seg, i) => (
                 <div
@@ -212,12 +213,30 @@ export default function DesktopNetWorthPanel({ data, allocationTotals, locale, r
                 />
               ))}
             </div>
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px 14px', marginTop: 10 }}>
-              {segments.map(seg => (
-                <div key={seg.type} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-                  <div style={{ width: 7, height: 7, borderRadius: 2, background: seg.color, flexShrink: 0 }} />
-                  <span style={{ fontSize: 11, color: 'var(--c-muted)' }}>{seg.label}</span>
-                  <span style={{ fontSize: 11, fontWeight: 600 }}>{seg.pct.toFixed(0)}%</span>
+            {/* Breakdown — one row per segment */}
+            <div style={{ display: 'flex', flexDirection: 'column', marginTop: 10 }}>
+              {segments.map((seg, i) => (
+                <div
+                  key={seg.type}
+                  style={{
+                    display: 'grid',
+                    gridTemplateColumns: 'auto 1fr auto auto',
+                    alignItems: 'center',
+                    gap: 8,
+                    padding: '7px 0',
+                    borderTop: i === 0 ? 'none' : '1px solid var(--c-line)',
+                  }}
+                >
+                  <div style={{ width: 8, height: 8, borderRadius: 2, background: seg.color, flexShrink: 0 }} />
+                  <span style={{ fontSize: 12, color: 'var(--c-ink)', fontWeight: 500 }}>{seg.label}</span>
+                  <span style={{ fontSize: 11, color: 'var(--c-muted)', fontVariantNumeric: 'tabular-nums', minWidth: 32, textAlign: 'right' }}>
+                    {seg.pct.toFixed(seg.pct < 10 ? 1 : 0)}%
+                  </span>
+                  <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums', minWidth: 64, textAlign: 'right' }}>
+                    {seg.type === 'gold' && goldUnits != null && goldUnits > 0
+                      ? (isVi ? `${goldUnits.toFixed(goldUnits < 10 ? 1 : 0)} chỉ` : `${goldUnits.toFixed(goldUnits < 10 ? 1 : 0)} ${goldUnits === 1 ? 'unit' : 'units'}`)
+                      : fmtCompact(seg.value)}
+                  </span>
                 </div>
               ))}
             </div>

--- a/app/assets/components/NetWorthCard.tsx
+++ b/app/assets/components/NetWorthCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import { TrendingUp, TrendingDown } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 
@@ -48,34 +48,69 @@ const ALLOC_COLORS = {
   stock: '#7c3aed',
 } as const
 
-function AllocationBar({ fund, bank, gold, stock }: { fund: number; bank: number; gold: number; stock: number }) {
+function AllocationBar({ fund, bank, gold, stock, goldUnits, locale }: { fund: number; bank: number; gold: number; stock: number; goldUnits?: number; locale: string }) {
+  const isVi = locale === 'vi'
   const total = fund + bank + gold + stock
   if (total <= 0) return null
   const segments = [
-    { key: 'fund',  value: fund,  color: ALLOC_COLORS.fund,  label: 'Funds' },
-    { key: 'bank',  value: bank,  color: ALLOC_COLORS.bank,  label: 'Bank' },
-    { key: 'gold',  value: gold,  color: ALLOC_COLORS.gold,  label: 'Gold' },
-    { key: 'stock', value: stock, color: ALLOC_COLORS.stock, label: 'Stock' },
+    { key: 'fund',  value: fund,  color: ALLOC_COLORS.fund,  label: isVi ? 'Quỹ'       : 'Fund' },
+    { key: 'bank',  value: bank,  color: ALLOC_COLORS.bank,  label: isVi ? 'Tiết kiệm' : 'Bank' },
+    { key: 'gold',  value: gold,  color: ALLOC_COLORS.gold,  label: isVi ? 'Vàng'      : 'Gold' },
+    { key: 'stock', value: stock, color: ALLOC_COLORS.stock, label: isVi ? 'Cổ phiếu'  : 'Stock' },
   ].filter((s) => s.value > 0)
+
+  const formatDetail = (key: string, value: number) => {
+    if (key === 'gold' && goldUnits != null && goldUnits > 0) {
+      const u = goldUnits.toFixed(goldUnits < 10 ? 1 : 0)
+      if (isVi) return `${u} chỉ`
+      return `${u} ${goldUnits === 1 ? 'unit' : 'units'}`
+    }
+    return fmtCompact(value)
+  }
+
   return (
     <div data-testid="allocation-bar" style={{ marginTop: 14 }}>
       {/* Bar */}
-      <div style={{ height: 8, borderRadius: 999, overflow: 'hidden', display: 'flex', gap: 1 }}>
-        {segments.map((s) => (
-          <div key={s.key} style={{ flex: s.value / total, background: s.color, minWidth: 4 }} />
+      <div style={{ height: 8, borderRadius: 999, overflow: 'hidden', display: 'flex', gap: 1, background: 'var(--c-card-2)' }}>
+        {segments.map((s, i) => (
+          <div
+            key={s.key}
+            style={{
+              flex: s.value / total,
+              background: s.color,
+              minWidth: 4,
+              borderRadius: i === 0 ? '999px 0 0 999px' : i === segments.length - 1 ? '0 999px 999px 0' : 0,
+            }}
+          />
         ))}
       </div>
-      {/* Legend */}
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px 12px', marginTop: 8 }}>
-        {segments.map((s) => (
-          <div key={s.key} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-            <span style={{ width: 8, height: 8, borderRadius: 2, background: s.color, display: 'inline-block', flexShrink: 0 }} />
-            <span style={{ fontSize: 11, color: 'var(--c-muted)' }}>{s.label}</span>
-            <span style={{ fontSize: 11, fontWeight: 500, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>
-              {Math.round((s.value / total) * 100)}%
-            </span>
-          </div>
-        ))}
+      {/* Breakdown — one row per segment */}
+      <div style={{ display: 'flex', flexDirection: 'column', marginTop: 10 }}>
+        {segments.map((s, i) => {
+          const pct = (s.value / total) * 100
+          return (
+            <div
+              key={s.key}
+              style={{
+                display: 'grid',
+                gridTemplateColumns: 'auto 1fr auto auto',
+                alignItems: 'center',
+                gap: 8,
+                padding: '8px 0',
+                borderTop: i === 0 ? 'none' : '1px solid var(--c-line)',
+              }}
+            >
+              <span style={{ width: 8, height: 8, borderRadius: 2, background: s.color, display: 'inline-block', flexShrink: 0 }} />
+              <span style={{ fontSize: 13, color: 'var(--c-ink)', fontWeight: 500 }}>{s.label}</span>
+              <span style={{ fontSize: 12, color: 'var(--c-muted)', fontVariantNumeric: 'tabular-nums', minWidth: 36, textAlign: 'right' }}>
+                {pct.toFixed(pct < 10 ? 1 : 0)}%
+              </span>
+              <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums', minWidth: 64, textAlign: 'right' }}>
+                {formatDetail(s.key, s.value)}
+              </span>
+            </div>
+          )
+        })}
       </div>
     </div>
   )
@@ -89,7 +124,7 @@ interface Props {
   currentValue: number
   overallProfitLoss: number
   overallProfitLossPercentage: number
-  allocationBar?: { fund: number; bank: number; gold: number; stock: number }
+  allocationBar?: { fund: number; bank: number; gold: number; stock: number; goldUnits?: number }
   refreshKey?: number
 }
 
@@ -97,6 +132,7 @@ export default function NetWorthCard({
   totalAssets, totalLiabilities, netWorth, totalInvested, currentValue,
   overallProfitLoss, overallProfitLossPercentage, allocationBar, refreshKey,
 }: Props) {
+  const locale = useLocale()
   const t = useTranslations('dashboard')
   const plPositive = overallProfitLoss >= 0
   const [timeRange, setTimeRange] = useState<TimeRange>('1Y')
@@ -216,7 +252,7 @@ export default function NetWorthCard({
       </div>
 
       {/* Allocation bar */}
-      {allocationBar && <AllocationBar {...allocationBar} />}
+      {allocationBar && <AllocationBar {...allocationBar} locale={locale} />}
     </div>
   )
 }

--- a/app/assets/components/__tests__/NetWorthCard.test.tsx
+++ b/app/assets/components/__tests__/NetWorthCard.test.tsx
@@ -2,7 +2,10 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import NetWorthCard from '../NetWorthCard'
 
-vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }))
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => 'en',
+}))
 
 global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => [] })
 
@@ -36,5 +39,24 @@ describe('NetWorthCard', () => {
     render(<NetWorthCard {...baseProps} overallProfitLoss={-50_000_000} overallProfitLossPercentage={-10} />)
     const plEl = screen.getByText(/-50\.0M/)
     expect(plEl).toHaveStyle({ color: 'var(--c-neg)' })
+  })
+
+  it('renders allocation breakdown with amount column per segment', () => {
+    render(<NetWorthCard {...baseProps} allocationBar={{ fund: 300_000_000, bank: 110_000_000, gold: 0, stock: 40_000_000 }} />)
+    // Distinct values that don't collide with P/L (100M) so getByText is unambiguous
+    expect(screen.getByText(/300\.0M/)).toBeInTheDocument()
+    expect(screen.getByText(/110\.0M/)).toBeInTheDocument()
+    expect(screen.getByText(/40\.0M/)).toBeInTheDocument()
+  })
+
+  it('renders gold row with units (chỉ) when goldUnits provided', () => {
+    render(<NetWorthCard {...baseProps} allocationBar={{ fund: 100_000_000, bank: 0, gold: 80_000_000, stock: 0, goldUnits: 12 }} />)
+    expect(screen.getByText('12 units')).toBeInTheDocument()
+  })
+
+  it('falls back to monetary value for gold when goldUnits not provided', () => {
+    render(<NetWorthCard {...baseProps} allocationBar={{ fund: 100_000_000, bank: 0, gold: 80_000_000, stock: 0 }} />)
+    // No goldUnits → shows the compact value (80.0M)
+    expect(screen.getByText(/80\.0M/)).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary
Updates the asset-allocation widget on the Overview page (both mobile and desktop) to match the latest design.

### What changed
- **Layout**: wrap-flex chip legend → vertical row-per-segment list with 4 columns (dot · label · % · amount), 1px row separators, tabular-nums alignment.
- **Gold**: shows physical units (\`12 chỉ\` / \`12 units\`) instead of VND when the API provides \`goldUnits\`.
- **Percentages**: 1 decimal under 10%, integer otherwise.
- **i18n**: localized fund/bank/gold/stock labels (vi/en).

### API
- \`app/api/v1/dashboard/overview/route.ts\`: new \`goldUnits\` field — sum of \`effectiveUnits\` across all gold transactions (post-withdrawal). Threaded through \`DashboardClient\` → \`NetWorthCard\` / \`DesktopNetWorthPanel\`.

### Tests
- \`NetWorthCard.test.tsx\`: \`useLocale\` added to next-intl mock (the component now reads locale). 3 new tests covering the amount-per-segment column, gold-units display, and fallback to monetary when units absent.

## Test plan
- [x] \`npm test -- --run\` — 255/256 passing (one pre-existing \`TransactionHistorySheet\` failure unrelated).
- [x] \`npx tsc --noEmit\` clean.
- [ ] Vercel preview: open Overview on mobile + desktop, confirm:
  - 4-column breakdown rows render with separators
  - Gold row shows units (chỉ in VI, units in EN) if you hold any gold
  - Bar above the breakdown still spans 4 colors correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)