### PR TITLE
fix(auth): prevent iOS auto-zoom on mobile login inputs

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -301,3 +301,7 @@
   transition: border-color 120ms;
 }
 .cn-input:focus { border-color: var(--c-navy); }
+/* iOS Safari zooms on focus when an input is < 16px and never resets the zoom. */
+@media (max-width: 768px) {
+  .cn-input { font-size: 16px; }
+}

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -107,6 +107,29 @@ test('login page has link to signup', async ({ page }) => {
   await expect(page.getByRole('link', { name: /sign up/i })).toBeVisible()
 })
 
+// ─── Mobile: prevent iOS auto-zoom on input focus ────────────────────────────
+// iOS Safari zooms the viewport when a focused input has font-size < 16px, and
+// never resets it — leaving subsequent pages (e.g. Overview after login) zoomed.
+test.describe('mobile input font-size', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('login email input renders at >=16px to avoid iOS zoom', async ({ page }) => {
+    await page.goto('/auth/login')
+    const fontSize = await page.locator('#email').evaluate(
+      (el) => parseFloat(getComputedStyle(el).fontSize)
+    )
+    expect(fontSize).toBeGreaterThanOrEqual(16)
+  })
+
+  test('login password input renders at >=16px to avoid iOS zoom', async ({ page }) => {
+    await page.goto('/auth/login')
+    const fontSize = await page.locator('#password').evaluate(
+      (el) => parseFloat(getComputedStyle(el).fontSize)
+    )
+    expect(fontSize).toBeGreaterThanOrEqual(16)
+  })
+})
+
 // ─── Desktop centered card layout ───────────────────────────────────────────
 
 test('login form is inside a card', async ({ page }) => {


### PR DESCRIPTION
## Summary
- On mobile, tapping the login email/password field auto-zoomed iOS Safari, and the zoom persisted onto the Overview page after login.
- Root cause: `.cn-input` used `font-size: 13px`. iOS Safari auto-zooms any focused input under 16px and never resets the zoom.
- Fix: a `@media (max-width: 768px)` rule bumps `.cn-input` to `16px`; desktop keeps the compact 13px.

## Test plan
- [x] Added e2e tests (`e2e/auth.spec.ts`) asserting the login email and password inputs render at ≥16px on a 390px viewport — both pass.
- [ ] Verify on the Vercel preview on a real iOS device: tap email field, log in, confirm the Overview page is not zoomed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)