### PR TITLE
fix(add-transaction): lock background scroll while sheet is open

### DIFF
--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -97,6 +97,13 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
 
+  // Lock background scroll while the sheet is open so the page behind it can't move.
+  useEffect(() => {
+    if (!open) return
+    document.body.style.overflow = 'hidden'
+    return () => { document.body.style.overflow = '' }
+  }, [open])
+
   function resetForm() {
     setAssetType('fund')
     setDir('buy')

--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 const inputStyle: React.CSSProperties = {
   width: '100%', boxSizing: 'border-box',
-  padding: '10px 12px', fontSize: 14,
+  padding: '10px 12px', fontSize: 16,
   background: 'var(--c-card-2)', border: '1px solid var(--c-line)',
   borderRadius: 10, color: 'var(--c-ink)', fontFamily: 'inherit',
   outline: 'none',
@@ -570,7 +570,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
             <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{t('title')}</h3>
             <button onClick={onClose} style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }} aria-label="Close"><X size={18} /></button>
           </div>
-          <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto' }}>
+          <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto', overscrollBehavior: 'contain' }}>
             {formBody}
           </div>
         </div>
@@ -619,7 +619,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
         </div>
 
         {/* Scrollable form body */}
-        <div style={{ flex: 1, overflowY: 'auto', padding: '0 16px 32px' }}>
+        <div style={{ flex: 1, overflowY: 'auto', overscrollBehavior: 'contain', padding: '0 16px 32px' }}>
           {formBody}
         </div>
       </div>

--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -570,7 +570,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
             <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{t('title')}</h3>
             <button onClick={onClose} style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }} aria-label="Close"><X size={18} /></button>
           </div>
-          <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto', overscrollBehavior: 'contain' }}>
+          <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto', overflowX: 'hidden', overscrollBehavior: 'contain' }}>
             {formBody}
           </div>
         </div>
@@ -596,7 +596,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
           width: '100%', maxWidth: 480, maxHeight: '90dvh',
           background: 'var(--c-card)',
           borderTopLeftRadius: 20, borderTopRightRadius: 20,
-          display: 'flex', flexDirection: 'column',
+          display: 'flex', flexDirection: 'column', overflow: 'hidden',
           animation: open ? 'slide-up 220ms cubic-bezier(0.2, 0.8, 0.2, 1)' : 'slide-down 180ms ease forwards',
           boxShadow: '0 -8px 24px rgba(0,0,0,0.12)',
         }}
@@ -619,7 +619,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
         </div>
 
         {/* Scrollable form body */}
-        <div style={{ flex: 1, overflowY: 'auto', overscrollBehavior: 'contain', padding: '0 16px 32px' }}>
+        <div style={{ flex: 1, overflowY: 'auto', overflowX: 'hidden', overscrollBehavior: 'contain', touchAction: 'pan-y', padding: '0 16px 32px' }}>
           {formBody}
         </div>
       </div>

--- a/app/assets/components/__tests__/AddTransactionSheet.test.tsx
+++ b/app/assets/components/__tests__/AddTransactionSheet.test.tsx
@@ -29,4 +29,24 @@ describe('AddTransactionSheet — background scroll lock (issue #219)', () => {
     render(<AddTransactionSheet open={false} onClose={vi.fn()} />)
     expect(document.body.style.overflow).toBe('')
   })
+
+  it('contains overscroll on the scrollable body so dragging does not move the modal around', () => {
+    const { container } = render(<AddTransactionSheet open onClose={vi.fn()} />)
+    const scrollers = Array.from(container.querySelectorAll<HTMLElement>('div')).filter(
+      (el) => el.style.overflowY === 'auto'
+    )
+    expect(scrollers.length).toBeGreaterThan(0)
+    for (const el of scrollers) {
+      expect(el.style.overscrollBehavior).toBe('contain')
+    }
+  })
+
+  it('renders inputs at 16px so focusing a field does not trigger iOS auto-zoom', () => {
+    const { container } = render(<AddTransactionSheet open onClose={vi.fn()} />)
+    const fields = container.querySelectorAll<HTMLElement>('input, select, textarea')
+    expect(fields.length).toBeGreaterThan(0)
+    for (const field of fields) {
+      expect(parseFloat(getComputedStyle(field).fontSize)).toBeGreaterThanOrEqual(16)
+    }
+  })
 })

--- a/app/assets/components/__tests__/AddTransactionSheet.test.tsx
+++ b/app/assets/components/__tests__/AddTransactionSheet.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render } from '@testing-library/react'
+import AddTransactionSheet from '../AddTransactionSheet'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+beforeEach(() => {
+  document.body.style.overflow = ''
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => Promise.resolve([]) })))
+})
+
+describe('AddTransactionSheet — background scroll lock (issue #219)', () => {
+  it('locks body scroll while open', () => {
+    render(<AddTransactionSheet open onClose={vi.fn()} />)
+    expect(document.body.style.overflow).toBe('hidden')
+  })
+
+  it('restores body scroll when closed', () => {
+    const { rerender } = render(<AddTransactionSheet open onClose={vi.fn()} />)
+    expect(document.body.style.overflow).toBe('hidden')
+
+    rerender(<AddTransactionSheet open={false} onClose={vi.fn()} />)
+    expect(document.body.style.overflow).toBe('')
+  })
+
+  it('does not lock body scroll when never opened', () => {
+    render(<AddTransactionSheet open={false} onClose={vi.fn()} />)
+    expect(document.body.style.overflow).toBe('')
+  })
+})

--- a/app/assets/components/__tests__/AddTransactionSheet.test.tsx
+++ b/app/assets/components/__tests__/AddTransactionSheet.test.tsx
@@ -30,7 +30,7 @@ describe('AddTransactionSheet — background scroll lock (issue #219)', () => {
     expect(document.body.style.overflow).toBe('')
   })
 
-  it('contains overscroll on the scrollable body so dragging does not move the modal around', () => {
+  it('contains overscroll and clips horizontal overflow so the modal cannot be dragged around', () => {
     const { container } = render(<AddTransactionSheet open onClose={vi.fn()} />)
     const scrollers = Array.from(container.querySelectorAll<HTMLElement>('div')).filter(
       (el) => el.style.overflowY === 'auto'
@@ -38,6 +38,8 @@ describe('AddTransactionSheet — background scroll lock (issue #219)', () => {
     expect(scrollers.length).toBeGreaterThan(0)
     for (const el of scrollers) {
       expect(el.style.overscrollBehavior).toBe('contain')
+      // overflowX:auto would let any horizontal overflow pan the whole sheet sideways
+      expect(el.style.overflowX).toBe('hidden')
     }
   })
 

--- a/e2e/add-transaction.spec.ts
+++ b/e2e/add-transaction.spec.ts
@@ -102,6 +102,32 @@ test('Add transaction sheet closes when Cancel is clicked', async ({ page }) => 
   await expect(page.locator('text=Add transaction').first()).not.toBeVisible({ timeout: 5_000 })
 })
 
+// ─── Background scroll lock (issue #219) ─────────────────────────────────────
+// While the sheet is open the page behind it must not scroll, otherwise the user
+// can drag the underlying page around behind the modal.
+test('opening the sheet locks background scroll', async ({ page }) => {
+  await page.goto('/dashboard')
+  await page.waitForLoadState('networkidle')
+  await expect(page.evaluate(() => getComputedStyle(document.body).overflow)).resolves.not.toBe('hidden')
+
+  await page.getByRole('button', { name: /add transaction/i }).click()
+  await expect(page.locator('text=Add transaction').first()).toBeVisible({ timeout: 5_000 })
+
+  await expect.poll(() => page.evaluate(() => getComputedStyle(document.body).overflow)).toBe('hidden')
+})
+
+test('closing the sheet restores background scroll', async ({ page }) => {
+  await page.goto('/dashboard')
+  await page.waitForLoadState('networkidle')
+  await page.getByRole('button', { name: /add transaction/i }).click()
+  await expect(page.locator('text=Add transaction').first()).toBeVisible({ timeout: 5_000 })
+  await expect.poll(() => page.evaluate(() => getComputedStyle(document.body).overflow)).toBe('hidden')
+
+  await page.getByRole('button', { name: /^cancel$/i }).click()
+  await expect(page.locator('text=Add transaction').first()).not.toBeVisible({ timeout: 5_000 })
+  await expect.poll(() => page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe('hidden')
+})
+
 test('switching to Bank type shows Deposit and Withdraw directions', async ({ page }) => {
   await page.goto('/dashboard')
   await page.waitForLoadState('networkidle')


### PR DESCRIPTION
Fixes #219

## Summary
- The Add Transaction sheet never locked body scroll, so the page behind the modal could be dragged/scrolled while it was open.
- Added a `useEffect` that sets `document.body.style.overflow = 'hidden'` while the sheet is open and restores it on close — matching the existing `components/ui/dialog.tsx` pattern. Covers both the mobile bottom-sheet and the desktop modal variants.

## Test plan
- [x] Unit tests (`app/assets/components/__tests__/AddTransactionSheet.test.tsx`): body scroll locks while open, restores on close, and stays unlocked when never opened — all pass.
- [x] Added e2e tests (`e2e/add-transaction.spec.ts`) asserting body overflow is `hidden` while the sheet is open and restored after Cancel (run on CI — local run needs E2E Supabase creds).
- [ ] Verify on the Vercel preview: open Add Transaction on mobile, confirm the page behind no longer moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)