### PR TITLE
fix(insurance): open detail view when tapping insurance row on mobile

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -13,6 +13,7 @@ import NetWorthCard from './components/NetWorthCard'
 import GoalCard from './components/GoalCard'
 import UnallocatedSection from './components/UnallocatedSection'
 import InsuranceCard from './components/InsuranceCard'
+import InsuranceDetailSheet from './components/InsuranceDetailSheet'
 import { SellWithdrawSheet, type SellItem } from './components/SellWithdrawSheet'
 import GoalDetailSheet from './components/GoalDetailSheet'
 import AssignGoalSheet from './components/AssignGoalSheet'
@@ -915,6 +916,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                         key={ins.insuranceId}
                         {...ins}
                         isLast={idx === data.insurance.length - 1}
+                        onClick={() => setSelectedInsurance(ins)}
                       />
                     ))}
                   </div>
@@ -1043,6 +1045,15 @@ export default function DashboardClient({ userId }: { userId: string }) {
         onClose={() => setShowAddInsurance(false)}
         onCreated={() => fetchData({ force: true })}
         locale={locale}
+      />
+
+      {/* Mobile: Insurance detail sheet */}
+      <InsuranceDetailSheet
+        open={!isDesktop && !!selectedInsurance}
+        ins={selectedInsurance}
+        locale={locale}
+        onClose={() => setSelectedInsurance(null)}
+        onChanged={() => fetchData({ force: true })}
       />
     </div>
   )

--- a/app/assets/components/InsuranceCard.tsx
+++ b/app/assets/components/InsuranceCard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Shield } from 'lucide-react'
+import { Shield, ChevronRight } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { fmtCompact } from '@/lib/formatters'
 
@@ -13,6 +13,7 @@ interface Props {
   savingsProgressPercentage: number
   status: 'on_track' | 'upcoming' | 'overdue' | 'completed' | 'ready'
   isLast?: boolean
+  onClick?: () => void
 }
 
 const STATUS_COLOR: Record<string, string> = {
@@ -33,7 +34,7 @@ const BAR_COLOR: Record<string, string> = {
 
 export default function InsuranceCard({
   insuranceName, coverageType, annualPremium, amountSaved,
-  savingsProgressPercentage, status, isLast,
+  savingsProgressPercentage, status, isLast, onClick,
 }: Props) {
   const t = useTranslations('dashboard')
 
@@ -50,10 +51,18 @@ export default function InsuranceCard({
   }
 
   return (
-    <div style={{
-      padding: '12px 14px', display: 'flex', alignItems: 'center', gap: 12,
-      borderBottom: isLast ? 'none' : '1px solid var(--c-line)',
-    }}>
+    <div
+      onClick={onClick}
+      role={onClick ? 'button' : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onKeyDown={onClick ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick() } } : undefined}
+      style={{
+        padding: '12px 14px', display: 'flex', alignItems: 'center', gap: 12,
+        borderBottom: isLast ? 'none' : '1px solid var(--c-line)',
+        cursor: onClick ? 'pointer' : undefined,
+        WebkitTapHighlightColor: 'transparent',
+      }}
+    >
       <div style={{
         width: 32, height: 32, borderRadius: 8, flexShrink: 0,
         background: 'var(--c-card-2)',
@@ -86,6 +95,10 @@ export default function InsuranceCard({
           {fmtCompact(amountSaved)} / {fmtCompact(annualPremium)}
         </div>
       </div>
+
+      {onClick && (
+        <ChevronRight size={16} style={{ flexShrink: 0, color: 'var(--c-muted)' }} />
+      )}
     </div>
   )
 }

--- a/app/assets/components/InsuranceDetailSheet.tsx
+++ b/app/assets/components/InsuranceDetailSheet.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import type { InsuranceData } from '../DashboardClient'
+import DesktopInsuranceDetail from './DesktopInsuranceDetail'
+
+interface Props {
+  ins: InsuranceData | null
+  open: boolean
+  locale: string
+  onClose: () => void
+  onChanged?: () => void
+}
+
+/**
+ * Mobile full-screen detail view for an insurance member. Reuses the
+ * self-contained DesktopInsuranceDetail panel (edit / pay / history / delete)
+ * inside a slide-in overlay so tapping an insurance row on mobile opens its
+ * details instead of doing nothing.
+ */
+export default function InsuranceDetailSheet({ ins, open, locale, onClose, onChanged }: Props) {
+  const [mounted, setMounted] = useState(open)
+
+  useEffect(() => {
+    if (open) {
+      setMounted(true)
+    } else {
+      const t = setTimeout(() => setMounted(false), 200)
+      return () => clearTimeout(t)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    document.body.style.overflow = 'hidden'
+    return () => { document.body.style.overflow = '' }
+  }, [open])
+
+  if (!mounted || !ins) return null
+
+  return (
+    <div
+      data-testid="insurance-detail-sheet"
+      style={{
+        position: 'fixed', inset: 0, zIndex: 120,
+        background: 'var(--c-canvas, #faf9f7)',
+        overflowY: 'auto', overflowX: 'hidden',
+        overscrollBehavior: 'contain',
+        animation: open
+          ? 'pop-in 220ms cubic-bezier(0.2, 0.8, 0.2, 1)'
+          : 'fade-out 180ms ease forwards',
+      }}
+    >
+      <div style={{ padding: '16px 16px 40px' }}>
+        <DesktopInsuranceDetail
+          ins={ins}
+          locale={locale}
+          onClose={onClose}
+          onChanged={onChanged}
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/assets/components/__tests__/InsuranceCard.test.tsx
+++ b/app/assets/components/__tests__/InsuranceCard.test.tsx
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import InsuranceCard from '../InsuranceCard'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+const baseProps = {
+  insuranceId: 'ins-1',
+  insuranceName: 'John Doe',
+  coverageType: 'Self',
+  annualPremium: 12_000_000,
+  amountSaved: 6_000_000,
+  savingsProgressPercentage: 50,
+  status: 'on_track' as const,
+}
+
+describe('InsuranceCard — tappable on mobile (issue #222)', () => {
+  it('calls onClick when the row is tapped', async () => {
+    const onClick = vi.fn()
+    render(<InsuranceCard {...baseProps} onClick={onClick} />)
+    await userEvent.click(screen.getByText('John Doe'))
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('exposes the row as an interactive button when onClick is provided', () => {
+    render(<InsuranceCard {...baseProps} onClick={vi.fn()} />)
+    expect(screen.getByRole('button', { name: /john doe/i })).toBeInTheDocument()
+  })
+})

--- a/app/assets/components/__tests__/InsuranceDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/InsuranceDetailSheet.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import InsuranceDetailSheet from '../InsuranceDetailSheet'
+import type { InsuranceData } from '../../DashboardClient'
+
+const ins: InsuranceData = {
+  insuranceId: 'ins-1',
+  insuranceName: 'John Doe',
+  coverageType: 'Self',
+  annualPremium: 12_000_000,
+  amountSaved: 6_000_000,
+  savingsProgressPercentage: 50,
+  status: 'on_track',
+  nextPaymentDate: '2026-08-01',
+} as InsuranceData
+
+beforeEach(() => {
+  document.body.style.overflow = ''
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ savings: [] }) })))
+})
+
+describe('InsuranceDetailSheet (issue #222)', () => {
+  it('renders nothing when closed', () => {
+    const { container } = render(
+      <InsuranceDetailSheet ins={ins} open={false} locale="en" onClose={vi.fn()} />
+    )
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('shows the insurance member details when open', () => {
+    render(<InsuranceDetailSheet ins={ins} open locale="en" onClose={vi.fn()} />)
+    expect(screen.getByTestId('insurance-detail-sheet')).toBeInTheDocument()
+    expect(screen.getByText('John Doe')).toBeInTheDocument()
+    // KPI details from DesktopInsuranceDetail
+    expect(screen.getByText('Annual premium')).toBeInTheDocument()
+    expect(screen.getByText('Saved')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #222

## Summary
- On mobile, tapping an insurance row did nothing: the `InsuranceCard` had no click handler and there was no mobile detail view (only `DesktopInsuranceDetail`, used in the desktop two-column layout).
- Made the mobile `InsuranceCard` tappable (click + keyboard, with a chevron affordance).
- Added `InsuranceDetailSheet` — a full-screen mobile sheet that reuses the existing, fully-featured `DesktopInsuranceDetail` panel (edit, pay / mark-as-paid, payment history, remove member), so no detail logic is duplicated.
- Wired it in `DashboardClient` using the existing `selectedInsurance` state, gated to mobile (`!isDesktop`).

## Test plan
- [x] Unit tests: `InsuranceCard` fires `onClick` and exposes a button role; `InsuranceDetailSheet` renders nothing when closed and shows member details (name + KPIs) when open. All pass.
- [ ] Verify on the Vercel preview (mobile): tap an insurance member on the dashboard → detail sheet opens with KPIs, payment history, and edit/pay/remove actions; Back closes it.

Note: one pre-existing unit test (`TransactionHistorySheet`) fails locally on Windows due to a locale date-format difference; it is unrelated to this change and passes on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)