### PR TITLE
fix(insurance): reconcile payment history with Saved amount

### DIFF
--- a/app/api/v1/insurance-members/[id]/savings/route.ts
+++ b/app/api/v1/insurance-members/[id]/savings/route.ts
@@ -2,6 +2,13 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateUUID } from '@/lib/validation'
 
+type HistoryEntry = {
+  id: string
+  amount: number
+  date: string          // YYYY-MM-DD
+  kind: 'logged' | 'plan'
+}
+
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
 
@@ -17,14 +24,73 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data, error } = await supabase
-    .from('insurance_savings')
-    .select('id, amount_saved_vnd, saved_date, created_at')
-    .eq('insurance_member_id', memberId)
-    .eq('user_id', user.id)
-    .order('saved_date', { ascending: false })
-    .order('created_at', { ascending: false })
+  // Member (for the default monthly contribution), manual savings, and the
+  // user's monthly plans (which auto-accrue toward each member). These three
+  // sources must reconcile with the dashboard's "Saved" amount, which is
+  // computed identically in app/api/v1/dashboard/overview/route.ts.
+  const [memberRes, savingsRes, plansRes] = await Promise.all([
+    supabase
+      .from('insurance_members')
+      .select('annual_payment_vnd, user_id')
+      .eq('member_id', memberId)
+      .single(),
+    supabase
+      .from('insurance_savings')
+      .select('id, amount_saved_vnd, saved_date, created_at')
+      .eq('insurance_member_id', memberId)
+      .eq('user_id', user.id),
+    supabase
+      .from('monthly_plans')
+      .select('id, month, year')
+      .eq('user_id', user.id),
+  ])
 
-  if (error) return NextResponse.json({ error: 'Failed to fetch savings' }, { status: 500 })
-  return NextResponse.json({ savings: data ?? [] })
+  if (memberRes.error || !memberRes.data) return NextResponse.json({ error: 'Insurance member not found' }, { status: 404 })
+  if (memberRes.data.user_id !== user.id) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+  if (savingsRes.error) return NextResponse.json({ error: 'Failed to fetch savings' }, { status: 500 })
+
+  const annualPremium = memberRes.data.annual_payment_vnd ?? 0
+  const defaultMonthly = Math.round(annualPremium / 12)
+  const plans = plansRes.data ?? []
+  const planIds = plans.map((p) => p.id)
+
+  const [exclRes, ovrRes] = await Promise.all([
+    planIds.length > 0
+      ? supabase.from('plan_excluded_insurance_members').select('plan_id, member_id').in('plan_id', planIds)
+      : Promise.resolve({ data: [] as { plan_id: string; member_id: string }[] }),
+    planIds.length > 0
+      ? supabase.from('plan_insurance_member_overrides').select('plan_id, member_id, monthly_amount_override_vnd').in('plan_id', planIds)
+      : Promise.resolve({ data: [] as { plan_id: string; member_id: string; monthly_amount_override_vnd: number }[] }),
+  ])
+
+  const excludedSet = new Set((exclRes.data ?? []).map((e) => `${e.plan_id}::${e.member_id}`))
+  const overrideMap = new Map((ovrRes.data ?? []).map((o) => [`${o.plan_id}::${o.member_id}`, o.monthly_amount_override_vnd]))
+
+  const entries: HistoryEntry[] = []
+
+  // Manually logged payments
+  for (const s of (savingsRes.data ?? [])) {
+    entries.push({
+      id: s.id,
+      amount: Number(s.amount_saved_vnd ?? 0),
+      date: String(s.saved_date ?? s.created_at ?? '').slice(0, 10),
+      kind: 'logged',
+    })
+  }
+
+  // Auto-accrued monthly contribution from each (non-excluded) plan
+  for (const p of plans) {
+    if (excludedSet.has(`${p.id}::${memberId}`)) continue
+    entries.push({
+      id: `plan-${p.id}`,
+      amount: Number(overrideMap.get(`${p.id}::${memberId}`) ?? defaultMonthly),
+      date: `${p.year}-${String(p.month).padStart(2, '0')}-01`,
+      kind: 'plan',
+    })
+  }
+
+  entries.sort((a, b) => b.date.localeCompare(a.date))
+  const totalSaved = entries.reduce((sum, e) => sum + e.amount, 0)
+
+  return NextResponse.json({ entries, totalSaved })
 }

--- a/app/api/v1/insurance-members/[id]/savings/route.ts
+++ b/app/api/v1/insurance-members/[id]/savings/route.ts
@@ -19,9 +19,10 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 
   const { data, error } = await supabase
     .from('insurance_savings')
-    .select('id, amount_saved_vnd, created_at')
+    .select('id, amount_saved_vnd, saved_date, created_at')
     .eq('insurance_member_id', memberId)
     .eq('user_id', user.id)
+    .order('saved_date', { ascending: false })
     .order('created_at', { ascending: false })
 
   if (error) return NextResponse.json({ error: 'Failed to fetch savings' }, { status: 500 })

--- a/app/api/v1/insurance-savings/route.ts
+++ b/app/api/v1/insurance-savings/route.ts
@@ -8,15 +8,22 @@ export async function POST(request: NextRequest) {
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const body = await request.json()
-  const { insurance_member_id, amount_saved_vnd } = body
+  const { insurance_member_id, amount_saved_vnd, saved_date } = body
 
   let cleanMemberId: string
   let cleanAmount: number
+  let cleanSavedDate: string | undefined
   try {
     if (!insurance_member_id) throw new ValidationError('insurance_member_id is required')
     cleanMemberId = validateUUID(insurance_member_id, 'insurance_member_id')
     cleanAmount = validateAmount(amount_saved_vnd, 'amount_saved_vnd')
     if (cleanAmount <= 0) throw new ValidationError('Amount must be greater than 0')
+    if (saved_date !== undefined && saved_date !== null) {
+      if (typeof saved_date !== 'string' || !/^\d{4}-\d{2}-\d{2}$/.test(saved_date) || Number.isNaN(Date.parse(saved_date))) {
+        throw new ValidationError('saved_date must be a valid YYYY-MM-DD date')
+      }
+      cleanSavedDate = saved_date
+    }
   } catch (e) {
     if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
     throw e
@@ -24,8 +31,13 @@ export async function POST(request: NextRequest) {
 
   const { data, error } = await supabase
     .from('insurance_savings')
-    .insert({ user_id: user.id, insurance_member_id: cleanMemberId, amount_saved_vnd: cleanAmount })
-    .select('id, amount_saved_vnd, created_at')
+    .insert({
+      user_id: user.id,
+      insurance_member_id: cleanMemberId,
+      amount_saved_vnd: cleanAmount,
+      ...(cleanSavedDate ? { saved_date: cleanSavedDate } : {}),
+    })
+    .select('id, amount_saved_vnd, saved_date, created_at')
     .single()
 
   if (error) return NextResponse.json({ error: 'Failed to record savings' }, { status: 500 })

--- a/app/assets/components/DesktopInsuranceDetail.tsx
+++ b/app/assets/components/DesktopInsuranceDetail.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { Check, ChevronLeft, Edit2, Plus, Trash2, Calendar, X } from 'lucide-react'
-import { fmtCompact } from '@/lib/formatters'
+import { fmt, fmtCompact } from '@/lib/formatters'
 import type { InsuranceData } from '../DashboardClient'
 import LogInsurancePaymentModal from './LogInsurancePaymentModal'
 
@@ -38,6 +38,7 @@ const COVERAGE_OPTIONS: { value: string; label: string; labelVi: string }[] = [
 interface SavingsEntry {
   id: string
   amount_saved_vnd: number
+  saved_date: string | null
   created_at: string
 }
 
@@ -368,7 +369,12 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
               </div>
             ) : (
               history.map((p, i) => {
-                const dt = new Date(p.created_at)
+                // Use the dedicated saved_date column (a plain date) and parse it
+                // as a local date so it never shifts across timezones. Fall back to
+                // the created_at date portion for older records without saved_date.
+                const dateOnly = (p.saved_date ?? p.created_at).slice(0, 10)
+                const [yy, mm, dd] = dateOnly.split('-').map(Number)
+                const dt = new Date(yy, (mm ?? 1) - 1, dd ?? 1)
                 const dateStr = dt.toLocaleDateString(isVi ? 'vi-VN' : 'en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
                 const isLast = i === history.length - 1
                 return (
@@ -388,7 +394,7 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
                       <div style={{ fontSize: 12, fontWeight: 500 }}>{dateStr}</div>
                     </div>
                     <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>
-                      {fmtCompact(p.amount_saved_vnd)}
+                      {fmt(Number(p.amount_saved_vnd))}
                     </span>
                   </div>
                 )

--- a/app/assets/components/DesktopInsuranceDetail.tsx
+++ b/app/assets/components/DesktopInsuranceDetail.tsx
@@ -35,11 +35,11 @@ const COVERAGE_OPTIONS: { value: string; label: string; labelVi: string }[] = [
   { value: 'Child', label: 'Child', labelVi: 'Con' },
 ]
 
-interface SavingsEntry {
+interface HistoryEntry {
   id: string
-  amount_saved_vnd: number
-  saved_date: string | null
-  created_at: string
+  amount: number
+  date: string          // YYYY-MM-DD
+  kind: 'logged' | 'plan'
 }
 
 function initialsFor(name: string): string {
@@ -69,7 +69,7 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [deleting, setDeleting] = useState(false)
 
-  const [history, setHistory] = useState<SavingsEntry[] | null>(null)
+  const [history, setHistory] = useState<HistoryEntry[] | null>(null)
   const [historyLoading, setHistoryLoading] = useState(false)
 
   // Sync edit form when target member changes
@@ -88,7 +88,7 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
       const res = await fetch(`/api/v1/insurance-members/${ins.insuranceId}/savings`)
       if (res.ok) {
         const j = await res.json()
-        setHistory(j.savings ?? [])
+        setHistory(j.entries ?? [])
       } else {
         setHistory([])
       }
@@ -368,37 +368,55 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
                 {isVi ? 'Chưa có giao dịch' : 'No payments yet'}
               </div>
             ) : (
-              history.map((p, i) => {
-                // Use the dedicated saved_date column (a plain date) and parse it
-                // as a local date so it never shifts across timezones. Fall back to
-                // the created_at date portion for older records without saved_date.
-                const dateOnly = (p.saved_date ?? p.created_at).slice(0, 10)
-                const [yy, mm, dd] = dateOnly.split('-').map(Number)
-                const dt = new Date(yy, (mm ?? 1) - 1, dd ?? 1)
-                const dateStr = dt.toLocaleDateString(isVi ? 'vi-VN' : 'en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
-                const isLast = i === history.length - 1
-                return (
-                  <div key={p.id} style={{
-                    display: 'flex', alignItems: 'center', gap: 10,
-                    padding: '11px 16px',
-                    borderBottom: isLast ? 'none' : '1px solid var(--c-line)',
-                  }}>
-                    <div style={{
-                      width: 28, height: 28, borderRadius: 7,
-                      background: 'var(--c-pos-tint)', color: 'var(--c-pos)',
-                      display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+              <>
+                {history.map((p) => {
+                  // Parse the plain date as a local date so it never shifts across timezones.
+                  const [yy, mm, dd] = p.date.split('-').map(Number)
+                  const dt = new Date(yy, (mm ?? 1) - 1, dd ?? 1)
+                  const isPlan = p.kind === 'plan'
+                  const dateStr = isPlan
+                    ? dt.toLocaleDateString(isVi ? 'vi-VN' : 'en-GB', { month: 'short', year: 'numeric' })
+                    : dt.toLocaleDateString(isVi ? 'vi-VN' : 'en-GB', { day: '2-digit', month: 'short', year: 'numeric' })
+                  const sub = isPlan
+                    ? (isVi ? 'Kế hoạch hàng tháng' : 'Monthly plan')
+                    : (isVi ? 'Đã ghi nhận' : 'Logged payment')
+                  return (
+                    <div key={p.id} style={{
+                      display: 'flex', alignItems: 'center', gap: 10,
+                      padding: '11px 16px',
+                      borderBottom: '1px solid var(--c-line)',
                     }}>
-                      <Check size={12} strokeWidth={2.5} />
+                      <div style={{
+                        width: 28, height: 28, borderRadius: 7,
+                        background: isPlan ? 'var(--c-navy-tint)' : 'var(--c-pos-tint)',
+                        color: isPlan ? 'var(--c-navy)' : 'var(--c-pos)',
+                        display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
+                      }}>
+                        {isPlan ? <Calendar size={12} strokeWidth={2.2} /> : <Check size={12} strokeWidth={2.5} />}
+                      </div>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ fontSize: 12, fontWeight: 500 }}>{dateStr}</div>
+                        <div style={{ fontSize: 10, color: 'var(--c-muted)', marginTop: 1 }}>{sub}</div>
+                      </div>
+                      <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>
+                        {fmt(p.amount)}
+                      </span>
                     </div>
-                    <div style={{ flex: 1, minWidth: 0 }}>
-                      <div style={{ fontSize: 12, fontWeight: 500 }}>{dateStr}</div>
-                    </div>
-                    <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>
-                      {fmt(Number(p.amount_saved_vnd))}
-                    </span>
-                  </div>
-                )
-              })
+                  )
+                })}
+                {/* Total — reconciles with the "Saved" KPI above */}
+                <div data-testid="insurance-history-total" style={{
+                  display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+                  padding: '11px 16px', background: 'var(--c-card-2)',
+                }}>
+                  <span style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase', color: 'var(--c-muted)' }}>
+                    {isVi ? 'Tổng đã tích lũy' : 'Total saved'}
+                  </span>
+                  <span style={{ fontSize: 13, fontWeight: 700, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>
+                    {fmt(history.reduce((s, e) => s + e.amount, 0))}
+                  </span>
+                </div>
+              </>
             )}
           </div>
 

--- a/app/assets/components/LogInsurancePaymentModal.tsx
+++ b/app/assets/components/LogInsurancePaymentModal.tsx
@@ -55,12 +55,15 @@ export default function LogInsurancePaymentModal({ open, onClose, onSaved, ins, 
     setSubmitting(true)
     setError(null)
     try {
+      const now = new Date()
+      const savedDate = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
       const res = await fetch('/api/v1/insurance-savings', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           insurance_member_id: ins.insuranceId,
           amount_saved_vnd: amountNum,
+          saved_date: savedDate,
         }),
       })
       if (!res.ok) {

--- a/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import DesktopInsuranceDetail from '../DesktopInsuranceDetail'
+import type { InsuranceData } from '../../DashboardClient'
+
+const ins: InsuranceData = {
+  insuranceId: 'ins-1',
+  insuranceName: 'John Doe',
+  coverageType: 'Self',
+  annualPremium: 12_000_000,
+  amountSaved: 6_000_000,
+  savingsProgressPercentage: 50,
+  status: 'upcoming',
+  nextPaymentDate: '2026-08-01',
+} as InsuranceData
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn((url: string) => {
+    if (typeof url === 'string' && url.includes('/savings')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({
+          savings: [
+            // saved_date intentionally differs from created_at's day to prove
+            // the row uses saved_date, not the created_at timestamp.
+            { id: 's1', amount_saved_vnd: 1_500_000, saved_date: '2026-03-15', created_at: '2026-05-27T10:00:00+00:00' },
+          ],
+        }),
+      })
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+  }))
+})
+
+describe('DesktopInsuranceDetail — payment history (issue #223)', () => {
+  it('shows the exact logged amount, not a lossy compact value', async () => {
+    render(<DesktopInsuranceDetail ins={ins} locale="en" onClose={vi.fn()} />)
+    // exact: ₫ 1.500.000 (vi-VN grouping); NOT the compact "1.5M ₫"
+    expect(await screen.findByText(/₫\s?1\.500\.000/)).toBeInTheDocument()
+    expect(screen.queryByText('1.5M ₫')).not.toBeInTheDocument()
+  })
+
+  it('shows the saved_date for the entry, not the created_at timestamp', async () => {
+    render(<DesktopInsuranceDetail ins={ins} locale="en" onClose={vi.fn()} />)
+    expect(await screen.findByText('15 Mar 2026')).toBeInTheDocument()
+    expect(screen.queryByText(/27 May 2026/)).not.toBeInTheDocument()
+  })
+})

--- a/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
@@ -8,8 +8,8 @@ const ins: InsuranceData = {
   insuranceName: 'John Doe',
   coverageType: 'Self',
   annualPremium: 12_000_000,
-  amountSaved: 6_000_000,
-  savingsProgressPercentage: 50,
+  amountSaved: 2_500_000,
+  savingsProgressPercentage: 20.8,
   status: 'upcoming',
   nextPaymentDate: '2026-08-01',
 } as InsuranceData
@@ -20,11 +20,11 @@ beforeEach(() => {
       return Promise.resolve({
         ok: true,
         json: () => Promise.resolve({
-          savings: [
-            // saved_date intentionally differs from created_at's day to prove
-            // the row uses saved_date, not the created_at timestamp.
-            { id: 's1', amount_saved_vnd: 1_500_000, saved_date: '2026-03-15', created_at: '2026-05-27T10:00:00+00:00' },
+          entries: [
+            { id: 's1', amount: 1_500_000, date: '2026-03-15', kind: 'logged' },
+            { id: 'plan-p1', amount: 1_000_000, date: '2026-03-01', kind: 'plan' },
           ],
+          totalSaved: 2_500_000,
         }),
       })
     }
@@ -35,14 +35,23 @@ beforeEach(() => {
 describe('DesktopInsuranceDetail — payment history (issue #223)', () => {
   it('shows the exact logged amount, not a lossy compact value', async () => {
     render(<DesktopInsuranceDetail ins={ins} locale="en" onClose={vi.fn()} />)
-    // exact: ₫ 1.500.000 (vi-VN grouping); NOT the compact "1.5M ₫"
     expect(await screen.findByText(/₫\s?1\.500\.000/)).toBeInTheDocument()
     expect(screen.queryByText('1.5M ₫')).not.toBeInTheDocument()
   })
 
-  it('shows the saved_date for the entry, not the created_at timestamp', async () => {
+  it('itemizes the auto monthly plan contribution alongside logged payments', async () => {
     render(<DesktopInsuranceDetail ins={ins} locale="en" onClose={vi.fn()} />)
-    expect(await screen.findByText('15 Mar 2026')).toBeInTheDocument()
-    expect(screen.queryByText(/27 May 2026/)).not.toBeInTheDocument()
+    expect(await screen.findByText('Logged payment')).toBeInTheDocument()
+    expect(screen.getByText('Monthly plan')).toBeInTheDocument()
+    // logged uses its saved date (15 Mar), plan shows month/year
+    expect(screen.getByText('15 Mar 2026')).toBeInTheDocument()
+    expect(screen.getByText('Mar 2026')).toBeInTheDocument()
+  })
+
+  it('shows a total that reconciles with the Saved amount', async () => {
+    render(<DesktopInsuranceDetail ins={ins} locale="en" onClose={vi.fn()} />)
+    const total = await screen.findByTestId('insurance-history-total')
+    // 1,500,000 + 1,000,000 = 2,500,000 == amountSaved
+    expect(total).toHaveTextContent(/₫\s?2\.500\.000/)
   })
 })

--- a/app/assets/components/__tests__/LogInsurancePaymentModal.test.tsx
+++ b/app/assets/components/__tests__/LogInsurancePaymentModal.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import LogInsurancePaymentModal from '../LogInsurancePaymentModal'
+import type { InsuranceData } from '../../DashboardClient'
+
+const ins: InsuranceData = {
+  insuranceId: 'ins-1',
+  insuranceName: 'John Doe',
+  coverageType: 'Self',
+  annualPremium: 12_000_000,
+  amountSaved: 0,
+  savingsProgressPercentage: 0,
+  status: 'overdue',
+  nextPaymentDate: null,
+} as InsuranceData
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ id: 'x' }) }))
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+describe('LogInsurancePaymentModal (issue #223)', () => {
+  it('posts the amount and the local saved_date', async () => {
+    render(<LogInsurancePaymentModal open ins={ins} locale="en" onClose={vi.fn()} onSaved={vi.fn()} />)
+
+    await userEvent.type(screen.getByRole('textbox'), '1500000')
+    await userEvent.click(screen.getByRole('button', { name: /confirm/i }))
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse((init as RequestInit).body as string)
+    expect(body.amount_saved_vnd).toBe(1_500_000)
+
+    const now = new Date()
+    const expected = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
+    expect(body.saved_date).toBe(expected)
+  })
+})


### PR DESCRIPTION
Fixes #223

## Problem
The insurance payment history didn't reconcile with the "Saved" amount. Two issues:
1. **Total mismatch (main):** "Saved" = manually logged payments **+ auto-accrued monthly contributions** from each monthly plan (`annual ÷ 12`, minus exclusions/overrides). The history listed only the manual payments, so it could never sum to "Saved".
2. **Date/amount display:** logged rows used the `created_at` UTC timestamp (can drift a day) and a lossy compact amount (e.g. 1,550,000 → "1.6M").

## Changes
- `GET /api/v1/insurance-members/[id]/savings` now returns a **unified history**: manually logged payments + one entry per non-excluded monthly plan (monthly contribution, dated to the plan month), using the exact same formula as `dashboard/overview`. Also returns `totalSaved`.
- `DesktopInsuranceDetail` (shared by desktop + the mobile sheet) itemizes both kinds with distinct icons/labels ("Logged payment" vs "Monthly plan"), shows the **exact** amount, parses dates as local (no timezone shift), and adds a **Total saved** row that reconciles with the Saved KPI.
- Logging a payment now records the user's **local** date into the `saved_date` column (`POST /insurance-savings` accepts/validates it).

## Test plan
- [x] Unit: history shows exact amount (not compact); itemizes logged + monthly-plan entries; Total row equals the Saved amount (2.5M = 1.5M logged + 1.0M plan).
- [x] Unit: log-payment modal posts amount + local `saved_date`.
- [x] Typecheck clean.
- [ ] Verify on Vercel preview: open an insurance member with at least one monthly plan → history lists monthly-plan contributions + any logged payments, and the Total matches the Saved figure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)