### PR TITLE
fix(goal-detail): wire up Sell and Transaction history options on mobile

### DIFF
--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -10,6 +10,7 @@ import { useLocale } from 'next-intl'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData, FundBreakdownItem } from '../DashboardClient'
 import TransactionHistorySheet, { type PurchaseHistoryRow } from './TransactionHistorySheet'
+import { SellWithdrawSheet, type SellItem } from './SellWithdrawSheet'
 
 // Same SVG as DesktopGoalDetail.UnlinkSvg — matches design's "unlink" glyph
 function UnlinkSvg({ size = 20, color = 'currentColor' }: { size?: number; color?: string }) {
@@ -345,6 +346,34 @@ interface InvRow {
   fund: FundBreakdownItem | null
 }
 
+// Mirror of DashboardClient.openSellFund / openSellNonFund so the goal-detail
+// sell flow submits the same payload the SellWithdrawSheet expects.
+function invToSellItem(inv: InvRow): SellItem {
+  if (inv.fund) {
+    return {
+      type: 'fund',
+      name: inv.fund.fundName,
+      currentValue: inv.fund.currentValue,
+      units: inv.fund.quantity,
+      navPerUnit: inv.fund.currentNAV,
+      gainPct: inv.fund.profitLossPercentage,
+      fundId: inv.fund.fundId,
+      purchasePrice: inv.fund.purchasePrice,
+    }
+  }
+  const navPerUnit = inv.units && inv.units > 0 ? inv.value / inv.units : undefined
+  return {
+    type: inv.type as 'bank' | 'gold' | 'stock',
+    name: inv.name,
+    currentValue: inv.value,
+    units: inv.units ?? undefined,
+    navPerUnit,
+    gainPct: inv.gainPct ?? undefined,
+    transactionId: inv.id,
+    purchasePrice: inv.principal ?? inv.value,
+  }
+}
+
 function InvestmentActionSheet({
   open,
   onClose,
@@ -635,6 +664,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   const [isDeleting, setIsDeleting] = useState(false)
   const [actionInv, setActionInv] = useState<InvRow | null>(null)
   const [investActionOpen, setInvestActionOpen] = useState(false)
+  const [sellOpen, setSellOpen] = useState(false)
   const [unassignConfirmOpen, setUnassignConfirmOpen] = useState(false)
   const [unassigning, setUnassigning] = useState(false)
   const [unassignedIds, setUnassignedIds] = useState<string[]>([])
@@ -1239,9 +1269,24 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
         open={investActionOpen}
         onClose={() => setInvestActionOpen(false)}
         inv={actionInv}
-        onViewHistory={() => actionInv?.fund && openFundDetail(actionInv.fund)}
-        onSell={() => { /* SellWithdrawSheet integration point */ }}
+        onViewHistory={() => {
+          if (actionInv?.fund) openFundDetail(actionInv.fund)
+          else setActiveTab('history')
+        }}
+        onSell={() => setSellOpen(true)}
         onUnassign={() => setUnassignConfirmOpen(true)}
+      />
+
+      <SellWithdrawSheet
+        open={sellOpen}
+        item={actionInv ? invToSellItem(actionInv) : null}
+        context="goal"
+        onClose={() => setSellOpen(false)}
+        onSuccess={() => {
+          setSellOpen(false)
+          if (actionInv) setUnassignedIds((prev) => [...prev, actionInv.id])
+          onDataChanged()
+        }}
       />
 
       <UnassignConfirmSheet

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -4,7 +4,10 @@ import userEvent from '@testing-library/user-event'
 import GoalDetailSheet from '../GoalDetailSheet'
 import type { GoalData } from '../../DashboardClient'
 
-vi.mock('next-intl', () => ({ useLocale: () => 'en' }))
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
+  useTranslations: () => (k: string) => k,
+}))
 
 const mockFund = {
   fundId: 'fund-1',
@@ -248,6 +251,72 @@ describe('GoalDetailSheet — unassign from goal', () => {
       ([, init]) => init?.method === 'PATCH' || init?.method === 'PUT' || init?.method === 'DELETE'
     )
     expect(writes.length).toBe(0)
+  })
+})
+
+describe('GoalDetailSheet — investment options Sell / history (issue #224)', () => {
+  const mockBankTx = {
+    transaction_id: 'tx-bank-1',
+    transaction_type: 'investment',
+    asset_type: 'bank',
+    fund_id: null,
+    fund_name: null,
+    fund_code: null,
+    investment_date: '2026-01-01',
+    amount_vnd: 5_000_000,
+    units: null,
+    unit_price: null,
+    interest_rate: null,
+    expiry_date: null,
+    notes: 'Techcombank',
+    principal_withdrawn: null,
+    units_withdrawn: null,
+  }
+  const bankGoal: GoalData = { ...mockGoal, funds: [] }
+
+  it('opens the Sell sheet when "Sell" is tapped on a fund investment', async () => {
+    render(<GoalDetailSheet {...baseProps} />)
+    await waitFor(() => screen.getByText('VNINDEX ETF'))
+    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await waitFor(() => expect(screen.getByText('Sell')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('Sell'))
+    await waitFor(() => expect(screen.getByTestId('sell-sheet')).toBeInTheDocument())
+  })
+
+  it('opens the Withdraw sheet when "Withdraw" is tapped on a bank investment', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [mockBankTx] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+    render(<GoalDetailSheet {...baseProps} goal={bankGoal} />)
+    await waitFor(() => screen.getByText('Techcombank'))
+    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await waitFor(() => expect(screen.getByText('Withdraw')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('Withdraw'))
+    await waitFor(() => expect(screen.getByTestId('sell-sheet')).toBeInTheDocument())
+  })
+
+  it('switches to the History tab when "Transaction history" is tapped on a non-fund investment', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [mockBankTx] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+    render(<GoalDetailSheet {...baseProps} goal={bankGoal} />)
+    await waitFor(() => screen.getByText('Techcombank'))
+    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await waitFor(() => expect(screen.getByText('Transaction history')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('Transaction history'))
+
+    // Non-fund history has no per-investment sheet, so it falls back to the
+    // goal's History tab (the tab button becomes active).
+    await waitFor(() => {
+      const historyTab = screen.getByRole('button', { name: 'History' })
+      expect(historyTab.style.borderBottom).toContain('var(--c-navy)')
+    })
   })
 })
 


### PR DESCRIPTION
Fixes #224

## Summary
In the mobile Goal detail → Investments tab → per-investment Options menu, two actions did nothing:
- **Sell / Withdraw** was a literal no-op stub (`onSell={() => { /* integration point */ }}`).
- **Transaction history** only worked for fund investments (`actionInv?.fund && openFundDetail(...)`); for bank/gold it did nothing.

## Changes (`GoalDetailSheet.tsx`)
- Wired **Sell/Withdraw** to open the existing `SellWithdrawSheet` (`context="goal"`), with a new `invToSellItem` helper that maps a row to the correct `SellItem` for both fund (`fundId`, units, NAV, purchasePrice) and non-fund (`transactionId`, derived `navPerUnit`) — mirroring `DashboardClient.openSellFund/openSellNonFund`. On success it optimistically hides the row and refreshes.
- **Transaction history** now falls back to the goal's **History** tab for non-fund investments (funds still open the per-fund `TransactionHistorySheet`).

## Test plan
- [x] Unit (`GoalDetailSheet.test.tsx`, 13 pass): Sell opens the sheet for a fund; Withdraw opens it for a bank investment; non-fund "Transaction history" switches to the History tab. Existing tests still pass.
- [x] Typecheck clean.
- [ ] Verify on Vercel preview (mobile): in a goal with fund + bank/gold investments, the Options menu's Sell/Withdraw opens the sell sheet and Transaction history shows history for every type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)