### PR TITLE
fix(dashboard): open insurance detail when goal detail is active

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -755,7 +755,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                     <DesktopInsuranceList
                       insurance={data.insurance}
                       locale={locale}
-                      onOpen={(ins) => setSelectedInsurance(selectedInsurance?.insuranceId === ins.insuranceId ? null : ins)}
+                      onOpen={(ins) => { setSelectedGoalId(null); setSelectedInsurance(selectedInsurance?.insuranceId === ins.insuranceId ? null : ins) }}
                       onAdd={() => setShowAddInsurance(true)}
                     />
                   </section>

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -57,4 +57,15 @@ test.describe('Desktop goal detail panel', () => {
     await expect(page.getByTestId('desktop-goal-detail')).not.toBeVisible()
     await expect(page.getByTestId('desktop-net-worth-panel')).toBeVisible({ timeout: 10_000 })
   })
+
+  test('clicking an insurance row while goal detail is open switches to insurance detail', async ({ page }) => {
+    // Bug #226: with goal detail open in the right panel, clicking an insurance
+    // member did nothing because the panel prioritised the still-selected goal.
+    await page.getByText('E2E Desktop Goal').first().click()
+    await expect(page.getByTestId('desktop-goal-detail')).toBeVisible({ timeout: 5_000 })
+
+    await page.getByTestId('insurance-row').first().click()
+    await expect(page.getByTestId('insurance-detail-panel')).toBeVisible({ timeout: 5_000 })
+    await expect(page.getByTestId('desktop-goal-detail')).not.toBeVisible()
+  })
 })


### PR DESCRIPTION
## Summary
- Fixes #226 — clicking an insurance member while a goal detail panel was open did nothing on the desktop dashboard.
- Root cause: the right panel renders goal detail with priority over insurance detail (`selectedGoal ? ... : selectedInsurance ? ...`). The insurance `onOpen` handler set `selectedInsurance` but never cleared `selectedGoalId`, so the panel kept showing the goal.
- Fix: clear `selectedGoalId` when opening insurance detail (mirrors the goal card handler, which already clears the selected insurance).

## Test plan
- [x] Added E2E test in `e2e/goal-detail-desktop.spec.ts`: open goal detail → click insurance row → assert insurance detail panel visible and goal detail hidden.
- [x] `tsc --noEmit` passes.
- [ ] Verify on Vercel preview: open a goal, then click an insurance member — detail panel should switch immediately (no need to go back first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)