### PR TITLE
fix(pwa): reload to fresh build when a new service worker activates

### DIFF
--- a/app/components/ServiceWorkerRegistration.tsx
+++ b/app/components/ServiceWorkerRegistration.tsx
@@ -4,11 +4,28 @@ import { useEffect } from 'react'
 
 export default function ServiceWorkerRegistration() {
   useEffect(() => {
-    if ('serviceWorker' in navigator && process.env.NODE_ENV === 'production') {
-      navigator.serviceWorker
-        .register('/sw.js')
-        .catch((err) => console.error('[SW] Registration failed:', err))
+    if (!('serviceWorker' in navigator) || process.env.NODE_ENV !== 'production') return
+
+    // When a controller already exists, the page is driven by an older worker.
+    // A controllerchange then means a freshly deployed worker has taken over, so
+    // reload once to drop the stale content-hashed chunks it was running. We skip
+    // this on first install (no prior controller) since that page is already fresh.
+    let refreshing = false
+    const onControllerChange = () => {
+      if (refreshing) return
+      refreshing = true
+      window.location.reload()
     }
+    if (navigator.serviceWorker.controller) {
+      navigator.serviceWorker.addEventListener('controllerchange', onControllerChange)
+    }
+
+    navigator.serviceWorker
+      .register('/sw.js')
+      .then((registration) => registration.update())
+      .catch((err) => console.error('[SW] Registration failed:', err))
+
+    return () => navigator.serviceWorker.removeEventListener('controllerchange', onControllerChange)
   }, [])
 
   return null

--- a/app/components/__tests__/ServiceWorkerRegistration.test.tsx
+++ b/app/components/__tests__/ServiceWorkerRegistration.test.tsx
@@ -1,0 +1,68 @@
+import { render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ServiceWorkerRegistration from '../ServiceWorkerRegistration'
+
+describe('ServiceWorkerRegistration', () => {
+  let listeners: Record<string, Array<() => void>>
+  let register: ReturnType<typeof vi.fn>
+  let update: ReturnType<typeof vi.fn>
+  let reload: ReturnType<typeof vi.fn>
+
+  function setupServiceWorker({ controller }: { controller: object | null }) {
+    listeners = {}
+    update = vi.fn()
+    register = vi.fn().mockResolvedValue({ update })
+    const sw = {
+      controller,
+      register,
+      addEventListener: (type: string, cb: () => void) => {
+        ;(listeners[type] ??= []).push(cb)
+      },
+      removeEventListener: (type: string, cb: () => void) => {
+        listeners[type] = (listeners[type] ?? []).filter((l) => l !== cb)
+      },
+    }
+    Object.defineProperty(navigator, 'serviceWorker', { value: sw, configurable: true })
+  }
+
+  function fireControllerChange() {
+    ;(listeners['controllerchange'] ?? []).forEach((cb) => cb())
+  }
+
+  beforeEach(() => {
+    vi.stubEnv('NODE_ENV', 'production')
+    reload = vi.fn()
+    Object.defineProperty(window, 'location', {
+      value: { href: 'http://localhost/', reload },
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  it('registers the service worker in production', () => {
+    setupServiceWorker({ controller: null })
+    render(<ServiceWorkerRegistration />)
+    expect(register).toHaveBeenCalledWith('/sw.js')
+  })
+
+  it('reloads once when a new worker takes control after an update', () => {
+    // A controller already exists → this page is controlled by an old worker,
+    // so a controllerchange means a new version has activated.
+    setupServiceWorker({ controller: {} })
+    render(<ServiceWorkerRegistration />)
+    fireControllerChange()
+    fireControllerChange()
+    expect(reload).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reload on the very first install (no prior controller)', () => {
+    setupServiceWorker({ controller: null })
+    render(<ServiceWorkerRegistration />)
+    fireControllerChange()
+    expect(reload).not.toHaveBeenCalled()
+  })
+})

--- a/next.config.ts
+++ b/next.config.ts
@@ -39,6 +39,12 @@ const nextConfig: NextConfig = {
         headers: securityHeaders,
       },
       {
+        // Always revalidate the worker script so new deploys are detected
+        // promptly instead of being masked by the HTTP cache.
+        source: '/sw.js',
+        headers: [{ key: 'Cache-Control', value: 'no-cache, no-store, must-revalidate' }],
+      },
+      {
         source: '/favicon.ico',
         headers: [{ key: 'Cache-Control', value: 'no-store' }],
       },

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v4'
+const CACHE_VERSION = 'v5'
 const API_CACHE = `api-v1-${CACHE_VERSION}`
 const STATIC_CACHE = `static-assets-${CACHE_VERSION}`
 const PAGE_CACHE = `pages-${CACHE_VERSION}`


### PR DESCRIPTION
## Summary
- The PWA service worker cached content-hashed chunks (CacheFirst), but `ServiceWorkerRegistration` never handled updates. An already-open app kept running the **old bundle** after a deploy until the user manually cleared site data.
- This surfaced as stale UI — most recently the add-insurance modal rendering as a **desktop dialog on mobile** even though the bottom-sheet fix (#41203f2) had already shipped. Confirmed in DevTools at 390px: unregistering the SW + clearing site data made it a bottom sheet again, proving the source was correct and the running bundle was stale.

## Changes
- **`ServiceWorkerRegistration.tsx`** — reload the page once on `controllerchange` when a prior controller exists (a freshly deployed worker has taken over). Skips the very first install, where the page is already fresh. Also calls `registration.update()`.
- **`next.config.ts`** — serve `/sw.js` with `Cache-Control: no-cache, no-store, must-revalidate` so new deploys are detected instead of masked by the HTTP cache.
- **`public/sw.js`** — bump `CACHE_VERSION` `v4`→`v5` so the new worker's `activate` purges stale page/static caches.

## Test plan
- [x] Unit tests (`ServiceWorkerRegistration.test.tsx`): registers in prod; reloads exactly once when a new worker takes control with a prior controller; does **not** reload on first install. TDD red→green.
- [ ] Deploy preview, open on mobile, confirm the add-insurance modal is a bottom sheet **without** manually clearing site data.
- [ ] Verify a subsequent deploy auto-reloads an already-open tab to the new build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)