### PR TITLE
fix(insurance): overdue only after a missed anniversary

### DIFF
--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { calcProjectedInterest, isNavStale, insuranceStatus, insuranceReadyStatus } from '@/lib/finance'
+import { calcProjectedInterest, isNavStale, insuranceStatus, insuranceReadyStatus, isPlanMonthRealized } from '@/lib/finance'
 import { buildWithdrawalMaps } from '@/lib/withdrawalProgress'
 
 export const dynamic = 'force-dynamic'
@@ -11,7 +11,7 @@ export async function GET() {
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const [plansRes, goalsRes, txRes, insuranceRes, insuranceSavingsRes, goldPriceRes] = await Promise.all([
-    supabase.from('monthly_plans').select('id').eq('user_id', user.id),
+    supabase.from('monthly_plans').select('id, month, year').eq('user_id', user.id),
     supabase
       .from('savings_goals')
       .select('goal_id, goal_name, target_amount, target_date')
@@ -35,7 +35,11 @@ export async function GET() {
       .single(),
   ])
 
-  const planIds = (plansRes.data ?? []).map((p: { id: string }) => p.id)
+  const plans = (plansRes.data ?? []) as { id: string; month: number; year: number }[]
+  const planIds = plans.map((p) => p.id)
+  // Only plans whose month has arrived count toward real savings — a future
+  // month's allocation is budgeted, not yet saved.
+  const realizedPlans = plans.filter((p) => isPlanMonthRealized(p.year, p.month))
 
   const [insExclusionsRes, insOverridesRes] = await Promise.all([
     planIds.length > 0
@@ -304,16 +308,17 @@ export async function GET() {
     const annualPremium = m.annual_payment_vnd
     const lumpSumSaved = insuranceLumpSumMap.get(m.member_id) ?? 0
     const defaultMonthly = Math.round(annualPremium / 12)
-    const monthlySavedFromPlanning = planIds.reduce((sum, planId) => {
-      if (excludedSet.has(`${planId}::${m.member_id}`)) return sum
-      return sum + (overrideMap.get(`${planId}::${m.member_id}`) ?? defaultMonthly)
+    const monthlySavedFromPlanning = realizedPlans.reduce((sum, p) => {
+      if (excludedSet.has(`${p.id}::${m.member_id}`)) return sum
+      return sum + (overrideMap.get(`${p.id}::${m.member_id}`) ?? defaultMonthly)
     }, 0)
+    // Real saved: logged contributions + plan allocations for months that have
+    // arrived. Future months are excluded, so progress and "Ready to pay"
+    // reflect money actually set aside, not projected.
     const amountSaved = lumpSumSaved + monthlySavedFromPlanning
     const savingsProgressPercentage = annualPremium > 0 ? (amountSaved / annualPremium) * 100 : 0
     const baseStatus = insuranceStatus(m.payment_date, m.last_payment_date)
-    // "Ready to pay" is gated on the real saved amount (logged contributions),
-    // not the projected plan allocations folded into amountSaved.
-    const status = insuranceReadyStatus(baseStatus, lumpSumSaved, annualPremium)
+    const status = insuranceReadyStatus(baseStatus, amountSaved, annualPremium)
 
     return {
       insuranceId: m.member_id,

--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { calcProjectedInterest, isNavStale, insuranceStatus } from '@/lib/finance'
+import { calcProjectedInterest, isNavStale, insuranceStatus, insuranceReadyStatus } from '@/lib/finance'
 import { buildWithdrawalMaps } from '@/lib/withdrawalProgress'
 
 export const dynamic = 'force-dynamic'
@@ -311,10 +311,9 @@ export async function GET() {
     const amountSaved = lumpSumSaved + monthlySavedFromPlanning
     const savingsProgressPercentage = annualPremium > 0 ? (amountSaved / annualPremium) * 100 : 0
     const baseStatus = insuranceStatus(m.payment_date, m.last_payment_date)
-    const status: 'on_track' | 'upcoming' | 'overdue' | 'completed' | 'ready' =
-      amountSaved >= annualPremium && (baseStatus === 'on_track' || baseStatus === 'upcoming')
-        ? 'ready'
-        : baseStatus
+    // "Ready to pay" is gated on the real saved amount (logged contributions),
+    // not the projected plan allocations folded into amountSaved.
+    const status = insuranceReadyStatus(baseStatus, lumpSumSaved, annualPremium)
 
     return {
       insuranceId: m.member_id,

--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -310,7 +310,7 @@ export async function GET() {
     }, 0)
     const amountSaved = lumpSumSaved + monthlySavedFromPlanning
     const savingsProgressPercentage = annualPremium > 0 ? (amountSaved / annualPremium) * 100 : 0
-    const baseStatus = insuranceStatus(m.payment_date)
+    const baseStatus = insuranceStatus(m.payment_date, m.last_payment_date)
     const status: 'on_track' | 'upcoming' | 'overdue' | 'completed' | 'ready' =
       amountSaved >= annualPremium && (baseStatus === 'on_track' || baseStatus === 'upcoming')
         ? 'ready'

--- a/app/api/v1/insurance-members/[id]/savings/route.ts
+++ b/app/api/v1/insurance-members/[id]/savings/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateUUID } from '@/lib/validation'
+import { isPlanMonthRealized } from '@/lib/finance'
 
 type HistoryEntry = {
   id: string
@@ -78,9 +79,12 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
     })
   }
 
-  // Auto-accrued monthly contribution from each (non-excluded) plan
+  // Auto-accrued monthly contribution from each (non-excluded) plan whose month
+  // has arrived. Future months are budgeted, not yet saved, so they're excluded
+  // to reconcile with the dashboard's real "Saved" amount.
   for (const p of plans) {
     if (excludedSet.has(`${p.id}::${memberId}`)) continue
+    if (!isPlanMonthRealized(p.year, p.month)) continue
     entries.push({
       id: `plan-${p.id}`,
       amount: Number(overrideMap.get(`${p.id}::${memberId}`) ?? defaultMonthly),

--- a/app/assets/components/DesktopInsuranceDetail.tsx
+++ b/app/assets/components/DesktopInsuranceDetail.tsx
@@ -14,8 +14,8 @@ interface Props {
 }
 
 const STATUS_COLOR: Record<string, string> = {
-  on_track: 'var(--c-warn)',
-  upcoming: 'var(--c-muted)',
+  on_track: 'var(--c-muted)',
+  upcoming: 'var(--c-warn)',
   overdue: 'var(--c-neg)',
   completed: 'var(--c-pos)',
   ready: 'var(--c-navy)',
@@ -103,8 +103,8 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
 
   function statusLabel(s: string) {
     return isVi
-      ? ({ on_track: 'Sắp đến hạn', completed: 'Đã thanh toán', overdue: 'Quá hạn', upcoming: 'Chưa đến hạn', ready: 'Đã tích lũy đủ' } as Record<string, string>)[s] ?? s
-      : ({ on_track: 'Due soon', completed: 'Paid', overdue: 'Overdue', upcoming: 'Not due', ready: 'Ready to pay' } as Record<string, string>)[s] ?? s
+      ? ({ on_track: 'Chưa đến hạn', completed: 'Đã thanh toán', overdue: 'Quá hạn', upcoming: 'Sắp đến hạn', ready: 'Đã tích lũy đủ' } as Record<string, string>)[s] ?? s
+      : ({ on_track: 'Not due', completed: 'Paid', overdue: 'Overdue', upcoming: 'Due soon', ready: 'Ready to pay' } as Record<string, string>)[s] ?? s
   }
 
   // Status-aware CTA — all three settle the current cycle via mark-paid

--- a/app/assets/components/DesktopInsuranceDetail.tsx
+++ b/app/assets/components/DesktopInsuranceDetail.tsx
@@ -107,11 +107,12 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
       : ({ on_track: 'Due soon', completed: 'Paid', overdue: 'Overdue', upcoming: 'Not due', ready: 'Ready to pay' } as Record<string, string>)[s] ?? s
   }
 
-  // Status-aware CTA
-  // - overdue → "Pay now" (red) → open LogPayment
-  // - on_track → "Mark as paid" (navy) → call mark-paid
-  // - ready → "Confirm payment sent" (navy) → call mark-paid
-  // - other → "Log payment" (default) → open LogPayment
+  // Status-aware CTA — all three settle the current cycle via mark-paid
+  // (advances payment_date, records the payment, resets savings):
+  // - overdue → "Pay now" (red)
+  // - on_track → "Mark as paid" (navy)
+  // - ready → "Confirm payment sent" (navy)
+  // - other → "Log payment" (default) → open LogPayment (records a contribution)
   const showStatusCta = ['overdue', 'on_track', 'ready'].includes(ins.status)
   const ctaLabel = isVi
     ? ({ overdue: 'Thanh toán ngay', on_track: 'Đánh dấu đã thanh toán', ready: 'Xác nhận đã thanh toán' } as Record<string, string>)[ins.status]
@@ -119,11 +120,7 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
   const ctaBg = ins.status === 'overdue' ? 'var(--c-neg)' : 'var(--c-btn-primary)'
 
   async function handleStatusCta() {
-    if (ins.status === 'overdue') {
-      setShowLogPayment(true)
-      return
-    }
-    // on_track / ready → mark current cycle as paid (advances payment_date)
+    // overdue / on_track / ready → mark current cycle as paid (advances payment_date)
     try {
       const res = await fetch(`/api/v1/insurance-members/${ins.insuranceId}/mark-paid`, { method: 'POST' })
       if (res.ok) {

--- a/app/assets/components/DesktopInsuranceList.tsx
+++ b/app/assets/components/DesktopInsuranceList.tsx
@@ -45,8 +45,8 @@ export default function DesktopInsuranceList({ insurance, locale, goalCount, onO
 
   function statusLabel(s: string) {
     return isVi
-      ? ({ on_track: 'Chưa đến hạn', completed: 'Đã thanh toán', overdue: 'Quá hạn', upcoming: 'Sắp đến hạn', ready: 'Sẵn sàng' } as Record<string, string>)[s] ?? s
-      : ({ on_track: 'Not due', completed: 'Paid', overdue: 'Overdue', upcoming: 'Due soon', ready: 'Ready' } as Record<string, string>)[s] ?? s
+      ? ({ on_track: 'Chưa đến hạn', completed: 'Đã thanh toán', overdue: 'Quá hạn', upcoming: 'Sắp đến hạn', ready: 'Đã tích lũy đủ' } as Record<string, string>)[s] ?? s
+      : ({ on_track: 'Not due', completed: 'Paid', overdue: 'Overdue', upcoming: 'Due soon', ready: 'Ready to pay' } as Record<string, string>)[s] ?? s
   }
 
   return (

--- a/app/assets/components/DesktopInsuranceList.tsx
+++ b/app/assets/components/DesktopInsuranceList.tsx
@@ -16,8 +16,8 @@ interface Props {
 const DISMISS_KEY = 'cairn.insuranceCoachDismissed'
 
 const STATUS_COLOR: Record<string, string> = {
-  on_track:  'var(--c-warn)',
-  upcoming:  'var(--c-muted)',
+  on_track:  'var(--c-muted)',
+  upcoming:  'var(--c-warn)',
   overdue:   'var(--c-neg)',
   completed: 'var(--c-pos)',
   ready:     'var(--c-navy)',
@@ -45,8 +45,8 @@ export default function DesktopInsuranceList({ insurance, locale, goalCount, onO
 
   function statusLabel(s: string) {
     return isVi
-      ? ({ on_track: 'Sắp đến hạn', completed: 'Đã thanh toán', overdue: 'Quá hạn', upcoming: 'Chưa đến hạn', ready: 'Sẵn sàng' } as Record<string, string>)[s] ?? s
-      : ({ on_track: 'Due soon', completed: 'Paid', overdue: 'Overdue', upcoming: 'Not due', ready: 'Ready' } as Record<string, string>)[s] ?? s
+      ? ({ on_track: 'Chưa đến hạn', completed: 'Đã thanh toán', overdue: 'Quá hạn', upcoming: 'Sắp đến hạn', ready: 'Sẵn sàng' } as Record<string, string>)[s] ?? s
+      : ({ on_track: 'Not due', completed: 'Paid', overdue: 'Overdue', upcoming: 'Due soon', ready: 'Ready' } as Record<string, string>)[s] ?? s
   }
 
   return (

--- a/app/assets/components/InsuranceCard.tsx
+++ b/app/assets/components/InsuranceCard.tsx
@@ -17,8 +17,8 @@ interface Props {
 }
 
 const STATUS_COLOR: Record<string, string> = {
-  on_track:  'var(--c-warn)',
-  upcoming:  'var(--c-muted)',
+  on_track:  'var(--c-muted)',
+  upcoming:  'var(--c-warn)',
   overdue:   'var(--c-neg)',
   completed: 'var(--c-pos)',
   ready:     'var(--c-navy)',
@@ -43,8 +43,8 @@ export default function InsuranceCard({
   const progress = Math.min(savingsProgressPercentage, 100)
 
   const statusLabel: Record<string, string> = {
-    on_track:  t('statusDue'),
-    upcoming:  t('statusNotDue'),
+    on_track:  t('statusNotDue'),
+    upcoming:  t('statusDue'),
     overdue:   t('statusOverdue'),
     completed: t('statusCompleted'),
     ready:     t('statusReady'),

--- a/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import DesktopInsuranceDetail from '../DesktopInsuranceDetail'
 import type { InsuranceData } from '../../DashboardClient'
 
@@ -53,5 +53,36 @@ describe('DesktopInsuranceDetail — payment history (issue #223)', () => {
     const total = await screen.findByTestId('insurance-history-total')
     // 1,500,000 + 1,000,000 = 2,500,000 == amountSaved
     expect(total).toHaveTextContent(/₫\s?2\.500\.000/)
+  })
+})
+
+describe('DesktopInsuranceDetail — overdue can be settled', () => {
+  // An overdue policy must be able to settle the missed renewal. The CTA now
+  // calls mark-paid (advances the cycle + records the payment) rather than only
+  // opening the savings log, which never settled the premium.
+  it('settles via mark-paid when the overdue CTA is clicked', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (typeof url === 'string' && url.includes('/savings')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ entries: [], totalSaved: 0 }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const onChanged = vi.fn()
+    const overdue = { ...ins, status: 'overdue' } as InsuranceData
+
+    render(<DesktopInsuranceDetail ins={overdue} locale="en" onClose={vi.fn()} onChanged={onChanged} />)
+
+    fireEvent.click(screen.getByTestId('insurance-cta-status'))
+
+    await waitFor(() =>
+      expect(fetchMock).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/insurance-members/ins-1/mark-paid'),
+        expect.objectContaining({ method: 'POST' })
+      )
+    )
+    await waitFor(() => expect(onChanged).toHaveBeenCalled())
+    // Overdue no longer routes to the savings-only log modal.
+    expect(screen.queryByTestId('log-payment-modal')).not.toBeInTheDocument()
   })
 })

--- a/app/assets/components/__tests__/DesktopInsuranceList.test.tsx
+++ b/app/assets/components/__tests__/DesktopInsuranceList.test.tsx
@@ -62,3 +62,21 @@ describe('DesktopInsuranceList — empty state (desktop design)', () => {
     expect(screen.queryByText('No members yet')).not.toBeInTheDocument()
   })
 })
+
+describe('DesktopInsuranceList — status labels', () => {
+  // The labels were inverted: `upcoming` (due within 30 days) read "Not due"
+  // and `on_track` (31+ days out) read "Due soon". Labels must match meaning.
+  it('labels an upcoming (within 30 days) member "Due soon"', () => {
+    const m = { ...member, status: 'upcoming' as const }
+    render(<DesktopInsuranceList insurance={[m]} goalCount={0} locale="en" onOpen={vi.fn()} onAdd={vi.fn()} />)
+    expect(screen.getByTestId('insurance-row')).toHaveTextContent('Due soon')
+    expect(screen.queryByText('Not due')).not.toBeInTheDocument()
+  })
+
+  it('labels an on_track (far off) member "Not due"', () => {
+    const m = { ...member, status: 'on_track' as const }
+    render(<DesktopInsuranceList insurance={[m]} goalCount={0} locale="en" onOpen={vi.fn()} onAdd={vi.fn()} />)
+    expect(screen.getByTestId('insurance-row')).toHaveTextContent('Not due')
+    expect(screen.queryByText('Due soon')).not.toBeInTheDocument()
+  })
+})

--- a/app/assets/components/__tests__/DesktopInsuranceList.test.tsx
+++ b/app/assets/components/__tests__/DesktopInsuranceList.test.tsx
@@ -79,4 +79,12 @@ describe('DesktopInsuranceList — status labels', () => {
     expect(screen.getByTestId('insurance-row')).toHaveTextContent('Not due')
     expect(screen.queryByText('Due soon')).not.toBeInTheDocument()
   })
+
+  // The list said "Ready" while the detail panel and mobile card both say
+  // "Ready to pay" (the statusReady i18n string). Keep the label consistent.
+  it('labels a ready member "Ready to pay", matching the other views', () => {
+    const m = { ...member, status: 'ready' as const }
+    render(<DesktopInsuranceList insurance={[m]} goalCount={0} locale="en" onOpen={vi.fn()} onAdd={vi.fn()} />)
+    expect(screen.getByTestId('insurance-row')).toHaveTextContent('Ready to pay')
+  })
 })

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -351,3 +351,26 @@ test('insurance "Mark as Paid" updates status', async ({ page }) => {
     await page.waitForTimeout(1000)
   }
 })
+
+// Regression: a policy whose start date is in the past was incorrectly rendered
+// as "Overdue". The premium isn't due until the next anniversary, so the row
+// must show the on-track ("Due soon") status — not Overdue.
+test('a policy started in the past is not shown as Overdue', async ({ page }) => {
+  // Started ~60 days ago → next anniversary ~10 months out → on_track.
+  const start = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
+  const member = await api.createInsuranceMember({
+    member_name: 'E2E Past Start Member',
+    relationship: 'Self',
+    annual_payment_vnd: 12_000_000,
+    payment_date: start,
+  })
+  cleanup.add(() => api.deleteInsuranceMember(member.member_id))
+
+  await page.goto('/dashboard')
+  await page.waitForLoadState('networkidle')
+
+  const row = page.getByTestId('insurance-row').filter({ hasText: 'E2E Past Start Member' })
+  await expect(row).toBeVisible({ timeout: 10_000 })
+  await expect(row).not.toContainText(/Overdue|Quá hạn/)
+  await expect(row).toContainText(/Due soon|Sắp đến hạn/)
+})

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -354,7 +354,7 @@ test('insurance "Mark as Paid" updates status', async ({ page }) => {
 
 // Regression: a policy whose start date is in the past was incorrectly rendered
 // as "Overdue". The premium isn't due until the next anniversary, so the row
-// must show the on-track ("Due soon") status — not Overdue.
+// must show the on-track ("Not due") status — not Overdue.
 test('a policy started in the past is not shown as Overdue', async ({ page }) => {
   // Started ~60 days ago → next anniversary ~10 months out → on_track.
   const start = new Date(Date.now() - 60 * 24 * 60 * 60 * 1000).toISOString().split('T')[0]
@@ -372,5 +372,5 @@ test('a policy started in the past is not shown as Overdue', async ({ page }) =>
   const row = page.getByTestId('insurance-row').filter({ hasText: 'E2E Past Start Member' })
   await expect(row).toBeVisible({ timeout: 10_000 })
   await expect(row).not.toContainText(/Overdue|Quá hạn/)
-  await expect(row).toContainText(/Due soon|Sắp đến hạn/)
+  await expect(row).toContainText(/Not due|Chưa đến hạn/)
 })

--- a/lib/__tests__/finance.test.ts
+++ b/lib/__tests__/finance.test.ts
@@ -60,24 +60,70 @@ describe('insuranceStatus', () => {
   it('returns on_track when paymentDate is null', () => {
     expect(insuranceStatus(null)).toBe('on_track')
   })
-  it('returns overdue for a past date', () => {
+
+  // A policy's start date sits in the past by definition. It must NOT read as
+  // overdue — the first premium is covered at signup and the next one isn't due
+  // until the anniversary a year later.
+  it('treats a recently-started policy as on_track, not overdue', () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-04-29'))
-    expect(insuranceStatus('2026-04-01')).toBe('overdue')
+    vi.setSystemTime(new Date(2026, 4, 28)) // 28 May 2026
+    // Started 11 Nov 2025; next anniversary is 11 Nov 2026 — far away.
+    expect(insuranceStatus('2025-11-11')).toBe('on_track')
   })
-  it('returns upcoming for a date within 30 days', () => {
+
+  it('returns upcoming when the next anniversary is within 30 days', () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-04-29'))
-    expect(insuranceStatus('2026-05-15')).toBe('upcoming')
+    vi.setSystemTime(new Date(2026, 3, 29)) // 29 Apr 2026
+    // Anniversary 15 May falls 16 days out.
+    expect(insuranceStatus('2025-05-15')).toBe('upcoming')
   })
-  it('returns upcoming for a date 15 days away', () => {
+
+  it('returns on_track when the next anniversary is 31+ days away', () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-04-29T12:00:00Z'))
-    expect(insuranceStatus('2026-05-14')).toBe('upcoming')
+    vi.setSystemTime(new Date(2026, 3, 29)) // 29 Apr 2026
+    expect(insuranceStatus('2025-06-15')).toBe('on_track')
   })
-  it('returns on_track for a date 31+ days away', () => {
+
+  // Overdue requires an anniversary that came due AFTER the covered date and was
+  // never settled — i.e. a genuinely missed renewal, not just a past start date.
+  it('returns overdue once an anniversary passes unpaid', () => {
     vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-04-29'))
-    expect(insuranceStatus('2026-06-15')).toBe('on_track')
+    vi.setSystemTime(new Date(2026, 3, 29)) // 29 Apr 2026
+    // Started Apr 2025; the Apr 2026 anniversary has passed with no payment.
+    expect(insuranceStatus('2025-04-01')).toBe('overdue')
+  })
+
+  it('clears overdue when the passed anniversary was settled', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 29)) // 29 Apr 2026
+    // Same policy, but the 2026 renewal was paid on 5 Apr 2026.
+    expect(insuranceStatus('2025-04-01', '2026-04-05')).toBe('on_track')
+  })
+
+  it('stays on_track right after a future renewal date is set', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 4, 28)) // 28 May 2026
+    // mark-paid advanced the due date to next year and recorded the payment.
+    expect(insuranceStatus('2027-05-28', '2026-05-28')).toBe('on_track')
+  })
+
+  // A future payment_date with no history is the upcoming due date itself — it
+  // must not be pushed a year out by the anniversary roll-forward.
+  it('treats a near-future payment date as upcoming', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 4, 28)) // 28 May 2026
+    expect(insuranceStatus('2026-06-01')).toBe('upcoming')
+  })
+
+  it('treats a far-future payment date as on_track', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 4, 28)) // 28 May 2026
+    expect(insuranceStatus('2026-08-01')).toBe('on_track')
+  })
+
+  it('parses a timestamptz last_payment_date (date portion only)', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 3, 29)) // 29 Apr 2026
+    expect(insuranceStatus('2025-04-01', '2026-04-05T00:00:00+00:00')).toBe('on_track')
   })
 })

--- a/lib/__tests__/finance.test.ts
+++ b/lib/__tests__/finance.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { calcProjectedInterest, isNavStale, insuranceStatus, insuranceReadyStatus } from '../finance'
+import { calcProjectedInterest, isNavStale, insuranceStatus, insuranceReadyStatus, isPlanMonthRealized } from '../finance'
 
 describe('calcProjectedInterest', () => {
   it('returns 0 when rate is null', () => {
@@ -156,5 +156,33 @@ describe('insuranceReadyStatus', () => {
 
   it('does not promote when the premium is zero', () => {
     expect(insuranceReadyStatus('on_track', 0, 0)).toBe('on_track')
+  })
+})
+
+describe('isPlanMonthRealized', () => {
+  afterEach(() => vi.useRealTimers())
+
+  // A monthly plan only exists once income is set for that month. Its insurance
+  // allocation counts as saved once the month has arrived (current or past);
+  // a future month's allocation is not saved yet.
+  it('counts a past month in the current year', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 4, 28)) // May 2026
+    expect(isPlanMonthRealized(2026, 3)).toBe(true)
+  })
+  it('counts the current month', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 4, 28)) // May 2026
+    expect(isPlanMonthRealized(2026, 5)).toBe(true)
+  })
+  it('excludes a future month in the current year', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 4, 28)) // May 2026
+    expect(isPlanMonthRealized(2026, 6)).toBe(false)
+  })
+  it('counts any month of a prior year', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 4, 28)) // May 2026
+    expect(isPlanMonthRealized(2025, 12)).toBe(true)
+  })
+  it('excludes any month of a future year', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 4, 28)) // May 2026
+    expect(isPlanMonthRealized(2027, 1)).toBe(false)
   })
 })

--- a/lib/__tests__/finance.test.ts
+++ b/lib/__tests__/finance.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { calcProjectedInterest, isNavStale, insuranceStatus } from '../finance'
+import { calcProjectedInterest, isNavStale, insuranceStatus, insuranceReadyStatus } from '../finance'
 
 describe('calcProjectedInterest', () => {
   it('returns 0 when rate is null', () => {
@@ -125,5 +125,36 @@ describe('insuranceStatus', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date(2026, 3, 29)) // 29 Apr 2026
     expect(insuranceStatus('2025-04-01', '2026-04-05T00:00:00+00:00')).toBe('on_track')
+  })
+})
+
+describe('insuranceReadyStatus', () => {
+  const PREMIUM = 12_000_000
+
+  it('promotes on_track to ready when the premium is fully saved', () => {
+    expect(insuranceReadyStatus('on_track', PREMIUM, PREMIUM)).toBe('ready')
+  })
+
+  it('promotes upcoming to ready when the premium is fully saved', () => {
+    expect(insuranceReadyStatus('upcoming', PREMIUM, PREMIUM)).toBe('ready')
+  })
+
+  // The bug: projected plan allocations made amountSaved reach the premium even
+  // when little was actually saved. With the real saved amount short, it must
+  // stay on_track, not jump to "Ready to pay".
+  it('stays on_track when the real saved amount is short of the premium', () => {
+    expect(insuranceReadyStatus('on_track', 3_000_000, PREMIUM)).toBe('on_track')
+  })
+
+  it('never promotes an overdue policy', () => {
+    expect(insuranceReadyStatus('overdue', PREMIUM, PREMIUM)).toBe('overdue')
+  })
+
+  it('treats saved == premium as fully saved (boundary)', () => {
+    expect(insuranceReadyStatus('upcoming', PREMIUM, PREMIUM)).toBe('ready')
+  })
+
+  it('does not promote when the premium is zero', () => {
+    expect(insuranceReadyStatus('on_track', 0, 0)).toBe('on_track')
   })
 })

--- a/lib/finance.ts
+++ b/lib/finance.ts
@@ -17,16 +17,53 @@ export function isNavStale(updatedAt: string): boolean {
   return diffMs / (1000 * 60 * 60 * 24) > 1
 }
 
+// Parse a YYYY-MM-DD (or timestamptz) string as a LOCAL midnight date so a plain
+// date never slips across a timezone boundary. Only the date portion is used.
+function parseLocalDate(value: string): Date | null {
+  const [y, m, d] = value.slice(0, 10).split('-').map(Number)
+  if (!y || !m || !d) return null
+  const dt = new Date(y, m - 1, d)
+  return isNaN(dt.getTime()) ? null : dt
+}
+
+// Premiums renew on the anniversary of `paymentDate` (its month/day). The status
+// reflects the *next* due date, so a policy whose start date is in the past does
+// not read as overdue — it only becomes overdue once a renewal anniversary has
+// come due and was never settled.
 export function insuranceStatus(
-  paymentDate: string | null
+  paymentDate: string | null,
+  lastPaymentDate: string | null = null
 ): 'on_track' | 'upcoming' | 'overdue' | 'completed' {
   if (!paymentDate) return 'on_track'
-  const payment = new Date(paymentDate)
+  const anchor = parseLocalDate(paymentDate)
+  if (!anchor) return 'on_track'
+
   const today = new Date()
   today.setHours(0, 0, 0, 0)
+  const last = lastPaymentDate ? parseLocalDate(lastPaymentDate) : null
+
+  // Work out the next due date.
+  let nextDue: Date
+  if (last) {
+    // Paid through `last` — the next premium is the first anniversary after it.
+    nextDue = new Date(last.getFullYear(), anchor.getMonth(), anchor.getDate())
+    if (nextDue <= last) nextDue.setFullYear(nextDue.getFullYear() + 1)
+  } else if (anchor >= today) {
+    // A future date with no payment history is the upcoming due date itself.
+    nextDue = anchor
+  } else {
+    // A past date with no history is the start: the premium is covered through
+    // signup and the first renewal falls one anniversary later. (That renewal
+    // may itself be in the past — then it's a genuinely missed payment.)
+    nextDue = new Date(anchor)
+    nextDue.setFullYear(anchor.getFullYear() + 1)
+  }
+
+  // Overdue only once the next due date has actually passed without being settled.
+  if (nextDue < today) return 'overdue'
+
   const thirtyDaysLater = new Date(today)
   thirtyDaysLater.setDate(today.getDate() + 30)
-  if (payment < today) return 'overdue'
-  if (payment <= thirtyDaysLater) return 'upcoming'
+  if (nextDue <= thirtyDaysLater) return 'upcoming'
   return 'on_track'
 }

--- a/lib/finance.ts
+++ b/lib/finance.ts
@@ -81,3 +81,13 @@ export function insuranceReadyStatus(
   if (fullySaved && (baseStatus === 'on_track' || baseStatus === 'upcoming')) return 'ready'
   return baseStatus
 }
+
+// A monthly plan exists only once income is set for that month, and its
+// insurance allocation counts as saved once the month has arrived — the current
+// month or any past month. A future month's allocation is not saved yet.
+export function isPlanMonthRealized(year: number, month: number): boolean {
+  const now = new Date()
+  const nowYear = now.getFullYear()
+  const nowMonth = now.getMonth() + 1
+  return year < nowYear || (year === nowYear && month <= nowMonth)
+}

--- a/lib/finance.ts
+++ b/lib/finance.ts
@@ -67,3 +67,17 @@ export function insuranceStatus(
   if (nextDue <= thirtyDaysLater) return 'upcoming'
   return 'on_track'
 }
+
+// Promote a not-yet-due policy to "ready" (the premium is saved, just confirm
+// the payment was sent) only when it has been GENUINELY saved — i.e. real
+// logged contributions, not amounts merely projected from monthly plans. This
+// keeps "Ready to pay" meaning the money is actually there.
+export function insuranceReadyStatus(
+  baseStatus: 'on_track' | 'upcoming' | 'overdue' | 'completed',
+  savedVnd: number,
+  annualPremiumVnd: number
+): 'on_track' | 'upcoming' | 'overdue' | 'completed' | 'ready' {
+  const fullySaved = annualPremiumVnd > 0 && savedVnd >= annualPremiumVnd
+  if (fullySaved && (baseStatus === 'on_track' || baseStatus === 'upcoming')) return 'ready'
+  return baseStatus
+}


### PR DESCRIPTION
Fixes the insurance status + savings indicators end-to-end.

## 1. "Overdue" for any past date
`insuranceStatus` compared the raw `payment_date` to today, so a policy started in the past (e.g. Nov 2025) showed Overdue even though the next premium isn't due until the anniversary a year later.

**Fix** (`lib/finance.ts`): treat `payment_date` as the renewal **anchor** (month/day); derive status from the computed next due date. Last payment → next due is the first anniversary after it; future anchor with no history → the upcoming due date itself; past anchor with no history → start date, first renewal one anniversary later (may itself be past → genuinely missed → overdue). `last_payment_date` is threaded through from the overview route.

## 2. Overdue could never be settled
The overdue "Pay now" CTA opened the savings-log modal (records a contribution, never advances the cycle). **Fix** (`DesktopInsuranceDetail.tsx`): route overdue through `mark-paid` like `on_track`/`ready`.

## 3. "Due soon" / "Not due" labels + colours were swapped
`upcoming` (≤30 days) showed "Not due" in grey; `on_track` (31+ days) showed "Due soon" in orange. **Fix**: swap label + dot-colour mappings across list, detail, card → `upcoming → "Due soon" (warn)`, `on_track → "Not due" (muted)`.

## 4. List `ready` label inconsistent
List said "Ready"; detail and card say "Ready to pay". **Fix**: align the list.

## 5. Saved progress counted projected, not real, money
The saved amount folded in the monthly-plan allocation for *every* plan, including future months only budgeted — inflating the progress bar and triggering "Ready to pay" prematurely.

**Fix** (`lib/finance.ts`, overview route, savings-history endpoint): a monthly plan exists only once income is set for that month; its allocation counts toward saved progress only when the month has **arrived** (current or past). Added `isPlanMonthRealized`, applied in both the dashboard aggregation and the savings-history endpoint (so they reconcile), and gated "Ready to pay" on this real saved amount. Future months are excluded.

## Tests (TDD)
- `lib/__tests__/finance.test.ts` — `insuranceStatus` anniversary semantics; `insuranceReadyStatus` (real-saved gate, no overdue promotion, zero-premium guard); `isPlanMonthRealized` (past/current count, future excluded).
- `DesktopInsuranceDetail.test.tsx` — overdue CTA calls `mark-paid`, not the savings modal.
- `DesktopInsuranceList.test.tsx` — `upcoming → "Due soon"`, `on_track → "Not due"`, `ready → "Ready to pay"`.
- `e2e/dashboard.spec.ts` — a policy started ~60 days ago renders "Not due", not "Overdue".

All unit tests green (the one unrelated pre-existing `TransactionHistorySheet` failure also fails on `main`). Typecheck + lint clean.

> Notes:
> - Branched off `main`. The "Paid for {year}" UI and "re-render panel after mark-paid" work are in a separate open PR; this fix is independent.
> - Route handlers have no unit-test harness here, so the realized-month logic is covered by `isPlanMonthRealized` unit tests + the shared helper used by both routes, rather than an endpoint test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)