### PR TITLE
fix(overview): right detail panel margin matches Plan page (#230)

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -773,7 +773,9 @@ export default function DashboardClient({ userId }: { userId: string }) {
                 width: 300, flexShrink: 0,
                 borderLeft: '1px solid var(--c-line)',
                 overflowY: 'auto',
-                padding: '20px 28px 40px 20px',
+                // Match the Plan page's right panel: content sits ~flush to the
+                // divider, no extra left/right margin (issue #230).
+                padding: '20px 20px 40px 4px',
               }}>
                 {selectedGoal ? (
                   <DesktopGoalDetail


### PR DESCRIPTION
Fixes #230 — the desktop Overview right‑side detail panel had a margin the Plan page doesn't.

## Cause
The two right‑side panels used different inner padding:
- **Plan** (`DesktopPlanningView.tsx`): `padding: 20px 20px 40px 4px` — content sits ~flush to the divider.
- **Overview** (`DashboardClient.tsx`): `padding: 20px 28px 40px 20px` — extra 20px left + 28px right, indenting the detail (goal / insurance / net‑worth).

## Fix
Match the Overview right panel to the Plan page: `padding: 20px 20px 40px 4px`. No other layout changes (the border, width, and left column are untouched).

## Notes
- Used the Plan page as the reference (per the issue: "same with Plan page"), so no external design was needed. If you intended a different spacing, let me know.
- tsc + lint clean; no tests reference the old value.

Please eyeball the Overview right panel (net‑worth / goal / insurance detail) against the Plan page on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)