### PR TITLE
feat(sell): redesign bank & fund withdraw/sell

### DIFF
--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -133,6 +133,8 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
   const [holdingsLoaded, setHoldingsLoaded] = useState(false)
   const [holdingKey, setHoldingKey] = useState('')
   const [sellAmount, setSellAmount] = useState('')        // fund / bank sell amount (₫)
+  const [fundSellUnits, setFundSellUnits] = useState('')  // fund sell units (linked to amount)
+  const [received, setReceived] = useState('')            // bank cash actually received (₫)
   const [goldSellQty, setGoldSellQty] = useState('')      // gold sell quantity (chỉ)
   const [goldSellPrice, setGoldSellPrice] = useState('')  // gold sale price per chỉ (₫)
 
@@ -203,6 +205,8 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
     setGoldPrice('')
     setHoldingKey('')
     setSellAmount('')
+    setFundSellUnits('')
+    setReceived('')
     setGoldSellQty('')
     setGoldSellPrice('')
     setError('')
@@ -213,6 +217,8 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
     setDir('buy')
     setHoldingKey('')
     setSellAmount('')
+    setFundSellUnits('')
+    setReceived('')
     setGoldSellQty('')
     setGoldSellPrice('')
     setError('')
@@ -222,6 +228,8 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
     setDir(d)
     setHoldingKey('')
     setSellAmount('')
+    setFundSellUnits('')
+    setReceived('')
     setGoldSellQty('')
     setGoldSellPrice('')
     setError('')
@@ -241,12 +249,17 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
   const sellOverMax = numSell > sellMax && sellMax > 0
   const sellRemaining = Math.max(0, sellMax - numSell)
   const sellNav = selectedHolding?.navPerUnit ?? null
-  const sellingUnits = sellNav && numSell ? numSell / sellNav : null
-  const sellGainLoss = (numSell && selectedHolding?.gainPct != null)
+  const sellGainLoss = (numSell && assetType === 'fund' && selectedHolding?.gainPct != null)
     ? numSell * selectedHolding.gainPct / (100 + selectedHolding.gainPct) : null
   const sellTax = assetType === 'fund' && numSell > 0 ? Math.round(numSell * 0.001) : null
-  const sellPenalty = assetType === 'bank' && numSell > 0 && selectedHolding?.interestRate
-    ? Math.round(numSell * (selectedHolding.interestRate / 100) * 0.5) : null
+
+  // Bank withdrawal: the cash received is editable (early withdrawal can cut interest).
+  // We split the principal out of the withdrawn amount so the summary can show gain/loss.
+  const numReceived = Number(received) || 0
+  const bankPrincipal = selectedHolding?.purchasePrice ?? sellMax
+  const bankFraction = sellMax > 0 ? Math.min(1, numSell / sellMax) : 0
+  const bankPrincipalPortion = Math.round(bankPrincipal * bankFraction)
+  const bankGain = assetType === 'bank' && numReceived > 0 && numSell > 0 ? numReceived - bankPrincipalPortion : null
 
   // Gold sells are quantity-based: enter chỉ to sell + the sale price per chỉ.
   const goldMaxUnits = selectedHolding?.units ?? 0
@@ -262,7 +275,11 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
 
   const sellDisabled = dir === 'sell' && (
     !selectedHolding ||
-    (assetType === 'gold' ? (numGoldSellQty <= 0 || isOverUnits) : (numSell <= 0 || sellOverMax))
+    (assetType === 'gold'
+      ? (numGoldSellQty <= 0 || isOverUnits)
+      : assetType === 'bank'
+        ? (numSell <= 0 || sellOverMax || numReceived <= 0)
+        : (numSell <= 0 || sellOverMax))
   )
 
   // Prefill the gold sale price with the holding's current price per chỉ.
@@ -309,11 +326,17 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
       } else if (selectedHolding.transactionId) {
         if (!numSell) { setError(t('amountRequired')); return }
         if (sellOverMax) { setError(t('exceedsBalance')); return }
+        // Bank: cash received is what the user gets; principal portion is what leaves
+        // the deposit's principal, so the gain/loss is recorded accurately.
+        const isBankSell = selectedHolding.type === 'bank'
+        if (isBankSell && numReceived <= 0) { setError(t('amountRequired')); return }
         sellBody = {
           transaction_type: 'withdrawal', asset_type: selectedHolding.type,
           parent_transaction_id: selectedHolding.transactionId,
-          investment_date: date, amount_vnd: Math.round(numSell),
-          principal_withdrawn: Math.round(numSell), goal_id: null, notes: note || null,
+          investment_date: date,
+          amount_vnd: isBankSell ? Math.round(numReceived) : Math.round(numSell),
+          principal_withdrawn: isBankSell ? bankPrincipalPortion : Math.round(numSell),
+          goal_id: null, notes: note || null,
         }
       } else {
         setError(t('holdingRequired')); return
@@ -758,7 +781,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
                   <label style={labelStyle}>{t('pickHolding')}</label>
                   <select
                     value={selectedHolding?.key ?? ''}
-                    onChange={(e) => { setHoldingKey(e.target.value); setSellAmount('') }}
+                    onChange={(e) => { setHoldingKey(e.target.value); setSellAmount(''); setFundSellUnits(''); setReceived('') }}
                     style={inputStyle}
                   >
                     {sellHoldings.map(h => (
@@ -796,41 +819,86 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
                             type="text"
                             inputMode="numeric"
                             value={sellAmount ? Number(sellAmount).toLocaleString('en-US') : ''}
-                            onChange={(e) => setSellAmount(e.target.value.replace(/,/g, '').replace(/[^0-9]/g, ''))}
+                            onChange={(e) => {
+                              const v = e.target.value.replace(/,/g, '').replace(/[^0-9]/g, '')
+                              setSellAmount(v)
+                              const n = Number(v) || 0
+                              if (assetType === 'fund') setFundSellUnits(sellNav && n ? (n / sellNav).toFixed(2) : '')
+                              if (assetType === 'bank') setReceived(n ? String(Math.round(n)) : '')
+                            }}
                             placeholder="0"
                             style={{ flex: 1, minWidth: 0, border: 'none', outline: 'none', fontSize: 16, fontWeight: 600, fontFamily: 'inherit', background: 'transparent', color: sellOverMax ? 'var(--c-neg)' : 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}
                           />
                         </div>
-                        <button type="button" onClick={() => setSellAmount(String(Math.round(sellMax)))} style={{ padding: '8px 12px', background: 'var(--c-navy-tint)', color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)', borderRadius: 10, fontSize: 12, fontWeight: 600, cursor: 'pointer', whiteSpace: 'nowrap', fontFamily: 'inherit' }}>{t('all')}</button>
+                        <button type="button" onClick={() => {
+                          setSellAmount(String(Math.round(sellMax)))
+                          if (assetType === 'fund') setFundSellUnits(selectedHolding?.units != null ? selectedHolding.units.toFixed(2) : '')
+                          if (assetType === 'bank') setReceived(String(Math.round(sellMax)))
+                        }} style={{ padding: '8px 12px', background: 'var(--c-navy-tint)', color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)', borderRadius: 10, fontSize: 12, fontWeight: 600, cursor: 'pointer', whiteSpace: 'nowrap', fontFamily: 'inherit' }}>{t('all')}</button>
                       </div>
                       {sellOverMax && (
                         <div style={{ fontSize: 11, color: 'var(--c-neg)', marginTop: 5, display: 'flex', alignItems: 'center', gap: 4 }}>
                           <X size={12} strokeWidth={2.5} /> {t('exceedsBalance')} · {t('max')} {Math.round(sellMax).toLocaleString('vi-VN')} ₫
                         </div>
                       )}
-                      {sellingUnits != null && !sellOverMax && numSell > 0 && (
-                        <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 5 }}>
-                          ≈ <span style={{ fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{sellingUnits.toFixed(2)}</span> {t('unitsShort')}
-                        </div>
-                      )}
                     </div>
 
-                    {numSell > 0 && !sellOverMax && (
+                    {/* Fund: units to sell, two-way linked with the amount above */}
+                    {assetType === 'fund' && (
+                      <div>
+                        <label style={labelStyle}>{t('unitsToSell')}</label>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', background: 'var(--c-card)', border: '1.5px solid var(--c-navy)', borderRadius: 10 }}>
+                          <input
+                            data-testid="sell-fund-units-input"
+                            type="number"
+                            step="0.01"
+                            value={fundSellUnits}
+                            onChange={(e) => {
+                              const v = e.target.value
+                              setFundSellUnits(v)
+                              const u = Number(v) || 0
+                              setSellAmount(sellNav && u ? String(Math.round(u * sellNav)) : '')
+                            }}
+                            placeholder="0.00"
+                            style={{ flex: 1, minWidth: 0, border: 'none', outline: 'none', fontSize: 16, fontWeight: 600, fontFamily: 'inherit', background: 'transparent', color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}
+                          />
+                          <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{t('unitsShort')}</span>
+                        </div>
+                        <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 4 }}>{t('navLinkHint')}</div>
+                      </div>
+                    )}
+
+                    {/* Bank: editable cash received (early withdrawal can cut interest) */}
+                    {assetType === 'bank' && (
+                      <div>
+                        <label style={labelStyle}>{t('amountReceived')}</label>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', background: 'var(--c-card)', border: '1.5px solid var(--c-navy)', borderRadius: 10 }}>
+                          <span style={{ fontSize: 14, color: 'var(--c-muted)' }}>₫</span>
+                          <input
+                            data-testid="sell-bank-received-input"
+                            type="text"
+                            inputMode="numeric"
+                            value={received ? Number(received).toLocaleString('en-US') : ''}
+                            onChange={(e) => setReceived(e.target.value.replace(/,/g, '').replace(/[^0-9]/g, ''))}
+                            placeholder="0"
+                            style={{ flex: 1, minWidth: 0, border: 'none', outline: 'none', fontSize: 16, fontWeight: 600, fontFamily: 'inherit', background: 'transparent', color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}
+                          />
+                        </div>
+                        <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 4 }}>{t('receivedHint')}</div>
+                      </div>
+                    )}
+
+                    {/* Fund summary: remaining / gain-loss / tax */}
+                    {assetType === 'fund' && numSell > 0 && !sellOverMax && (
                       <div style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
                           <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{t('remainingAfter')}</span>
                           <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{sellRemaining.toLocaleString('vi-VN')} ₫</span>
                         </div>
                         {sellGainLoss != null && (
-                          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: (sellPenalty || sellTax) ? '1px solid var(--c-line)' : 'none' }}>
+                          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: sellTax ? '1px solid var(--c-line)' : 'none' }}>
                             <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{t('estGainLoss')}</span>
                             <span style={{ fontSize: 13, fontWeight: 600, color: sellGainLoss >= 0 ? 'var(--c-pos)' : 'var(--c-neg)', fontVariantNumeric: 'tabular-nums' }}>{sellGainLoss >= 0 ? '+' : ''}{Math.round(sellGainLoss).toLocaleString('vi-VN')} ₫</span>
-                          </div>
-                        )}
-                        {sellPenalty != null && (
-                          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: sellTax ? '1px solid var(--c-line)' : 'none' }}>
-                            <span style={{ fontSize: 12, color: 'var(--c-warn)' }}>{t('estInterestForfeited')}</span>
-                            <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-warn)', fontVariantNumeric: 'tabular-nums' }}>−{sellPenalty.toLocaleString('vi-VN')} ₫</span>
                           </div>
                         )}
                         {sellTax != null && (
@@ -839,6 +907,30 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
                             <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-muted)', fontVariantNumeric: 'tabular-nums' }}>−{sellTax.toLocaleString('vi-VN')} ₫</span>
                           </div>
                         )}
+                      </div>
+                    )}
+
+                    {/* Bank summary: principal portion / received / gain-loss / remaining */}
+                    {assetType === 'bank' && numSell > 0 && !sellOverMax && numReceived > 0 && (
+                      <div style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
+                          <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{t('principalPortion')}{bankFraction < 0.999 && <span style={{ opacity: 0.7 }}> · {Math.round(bankFraction * 100)}%</span>}</span>
+                          <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{bankPrincipalPortion.toLocaleString('vi-VN')} ₫</span>
+                        </div>
+                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
+                          <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{t('amountReceived')}</span>
+                          <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{numReceived.toLocaleString('vi-VN')} ₫</span>
+                        </div>
+                        {bankGain != null && (
+                          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '11px 14px', borderBottom: '1px solid var(--c-line)' }}>
+                            <span style={{ fontSize: 12, fontWeight: 600 }}>{t('gainLoss')}</span>
+                            <span style={{ fontSize: 15, fontWeight: 700, color: bankGain >= 0 ? 'var(--c-pos)' : 'var(--c-neg)', fontVariantNumeric: 'tabular-nums' }}>{bankGain >= 0 ? '+' : '−'}{Math.abs(bankGain).toLocaleString('vi-VN')} ₫</span>
+                          </div>
+                        )}
+                        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px' }}>
+                          <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{t('remainingAfter')}</span>
+                          <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{sellRemaining.toLocaleString('vi-VN')} ₫</span>
+                        </div>
                       </div>
                     )}
                   </>

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -757,6 +757,7 @@ function SellModal({ inv, isVi, onClose, onSuccess }: {
 
   const [amount, setAmount] = useState('')
   const [units, setUnits] = useState('')
+  const [received, setReceived] = useState('') // bank: cash actually received
   // Gold sale price per chỉ, prefilled with the current market price.
   const [salePrice, setSalePrice] = useState(() => (isGold && navPerUnit ? String(Math.round(navPerUnit)) : ''))
   const [saving, setSaving] = useState(false)
@@ -780,20 +781,25 @@ function SellModal({ inv, isVi, onClose, onSuccess }: {
   const goldRemUnits = isGold && inv.units != null ? inv.units - numUnits : null
   const isOverUnits = isGold && inv.units != null && numUnits > inv.units
 
+  // Bank: cash received is editable; split principal out of the withdrawn amount
+  // so the summary can show an accurate gain/loss.
+  const numReceived = Number(received) || 0
+  const bankPrincipal = inv.principal ?? maxAmount
+  const bankFraction = maxAmount > 0 ? Math.min(1, numAmount / maxAmount) : 0
+  const bankPrincipalPortion = Math.round(bankPrincipal * bankFraction)
+  const bankGain = isBank && numReceived > 0 && numAmount > 0 ? numReceived - bankPrincipalPortion : null
+
   const isOverMax = isGold ? isOverUnits : (numAmount > maxAmount && maxAmount > 0)
   const isValid = isGold
     ? (numUnits > 0 && !isOverUnits && numSalePrice > 0 && !saving)
-    : (numAmount > 0 && !isOverMax && !saving)
+    : isBank
+      ? (numAmount > 0 && !isOverMax && numReceived > 0 && !saving)
+      : (numAmount > 0 && !isOverMax && !saving)
 
   const gainLoss = useMemo(() => {
-    if (!numAmount || inv.gainPct == null) return null
+    if (!numAmount || isBank || inv.gainPct == null) return null
     return numAmount * inv.gainPct / (100 + inv.gainPct)
-  }, [numAmount, inv.gainPct])
-
-  const penaltyAmount = useMemo(() => {
-    if (!isBank || !numAmount || !inv.interestRate) return null
-    return Math.round(numAmount * (inv.interestRate / 100) * 0.5)
-  }, [isBank, numAmount, inv.interestRate])
+  }, [numAmount, isBank, inv.gainPct])
 
   const taxAmount = useMemo(() => {
     if (!isFund || !numAmount) return null
@@ -803,6 +809,7 @@ function SellModal({ inv, isVi, onClose, onSuccess }: {
   function handleAmountChange(val: string) {
     const raw = val.replace(/[^0-9]/g, '')
     setAmount(raw)
+    if (isBank) setReceived(raw)  // received tracks the amount until edited down
     if (navPerUnit && raw) setUnits((Number(raw) / navPerUnit).toFixed(2))
     else setUnits('')
   }
@@ -816,6 +823,7 @@ function SellModal({ inv, isVi, onClose, onSuccess }: {
   function handleSetAll() {
     if (isGold && inv.units != null) { setUnits(String(inv.units)); return }
     setAmount(String(maxAmount))
+    if (isBank) setReceived(String(Math.round(maxAmount)))
     if (navPerUnit && inv.units != null) setUnits(inv.units.toFixed(2))
   }
 
@@ -846,8 +854,9 @@ function SellModal({ inv, isVi, onClose, onSuccess }: {
           transaction_type: 'withdrawal', asset_type: inv.type,
           parent_transaction_id: inv.id, investment_date: today,
           // Gold: amount = proceeds (qty × sale price), principal = cost basis.
-          amount_vnd: isGold ? goldProceeds : Math.round(numAmount),
-          principal_withdrawn: isGold ? (goldCostSold ?? goldProceeds) : Math.round(numAmount),
+          // Bank: amount = cash received, principal = principal portion.
+          amount_vnd: isGold ? goldProceeds : isBank ? Math.round(numReceived) : Math.round(numAmount),
+          principal_withdrawn: isGold ? (goldCostSold ?? goldProceeds) : isBank ? bankPrincipalPortion : Math.round(numAmount),
           goal_id: null,
         }
         if (isGold) body.units_withdrawn = parseFloat(numUnits.toFixed(4))
@@ -858,7 +867,7 @@ function SellModal({ inv, isVi, onClose, onSuccess }: {
         })
         if (!res.ok) { const { error: e } = await res.json(); setError(e ?? (isVi ? 'Không thể xử lý' : 'Could not process')); setSaving(false); return }
       }
-      setSoldAmount(isGold ? goldProceeds : numAmount); setConfirmed(true)
+      setSoldAmount(isGold ? goldProceeds : isBank ? numReceived : numAmount); setConfirmed(true)
       setTimeout(() => { setConfirmed(false); onSuccess(); onClose() }, 2000)
     } catch { setError(isVi ? 'Lỗi kết nối' : 'Connection error') }
     setSaving(false)
@@ -929,6 +938,24 @@ function SellModal({ inv, isVi, onClose, onSuccess }: {
             )}
           </div>
 
+          {/* Bank: editable cash received (early withdrawal can cut interest) */}
+          {isBank && (
+            <div>
+              <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>{isVi ? 'Số tiền thực nhận' : "Amount you'll receive"}</div>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', background: 'var(--c-card)', border: '1.5px solid var(--c-navy)', borderRadius: 10 }}>
+                <span style={{ fontSize: 14, color: 'var(--c-muted)' }}>₫</span>
+                <input
+                  type="text" inputMode="numeric"
+                  value={received ? Number(received).toLocaleString('vi-VN') : ''}
+                  onChange={(e) => { setReceived(e.target.value.replace(/[^0-9]/g, '')); setError('') }}
+                  placeholder="0"
+                  style={{ flex: 1, border: 'none', outline: 'none', fontSize: 15, fontWeight: 600, fontFamily: 'inherit', background: 'transparent', color: 'var(--c-ink)' }}
+                />
+              </div>
+              <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 4 }}>{isVi ? 'Tạm tính theo giá trị hiện tại — sửa nếu rút sớm bị trừ lãi' : 'Pre-filled at current value — edit down if early withdrawal cuts interest'}</div>
+            </div>
+          )}
+
           {/* Units input — fund & gold only */}
           {(isFund || isGold) && inv.units != null && (
             <div>
@@ -946,25 +973,48 @@ function SellModal({ inv, isVi, onClose, onSuccess }: {
             </div>
           )}
 
-          {/* Summary strip */}
-          {numAmount > 0 && !isOverMax && (() => {
+          {/* Fund summary: remaining / gain-loss / tax */}
+          {!isBank && numAmount > 0 && !isOverMax && (() => {
             const rows = [
               { show: true, label: isVi ? 'Còn lại sau giao dịch' : 'Remaining after transaction', value: fmtCompact(Math.max(0, remaining)), color: 'var(--c-ink)' },
               { show: gainLoss != null, label: isVi ? 'Lãi/Lỗ ước tính' : 'Est. gain / loss', value: `${gainLoss! >= 0 ? '+' : ''}${fmtCompact(gainLoss!)}`, color: gainLoss! >= 0 ? 'var(--c-pos)' : 'var(--c-neg)' },
-              { show: penaltyAmount != null, label: isVi ? 'Lãi mất ước tính' : 'Est. interest forfeited', value: `−${fmtCompact(penaltyAmount!)}`, color: 'var(--c-warn)' },
               { show: taxAmount != null, label: isVi ? 'Thuế TNCN (0.1%)' : 'Personal income tax (0.1%)', value: `−${fmtCompact(taxAmount!)}`, color: 'var(--c-muted)' },
             ].filter((r) => r.show)
             return (
               <div style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
                 {rows.map((r, i) => (
                   <div key={i} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: i < rows.length - 1 ? '1px solid var(--c-line)' : 'none' }}>
-                    <span style={{ fontSize: 12, color: r.color === 'var(--c-warn)' ? 'var(--c-warn)' : 'var(--c-muted)' }}>{r.label}</span>
+                    <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{r.label}</span>
                     <span style={{ fontSize: 13, fontWeight: 600, color: r.color, fontVariantNumeric: 'tabular-nums' }}>{r.value}</span>
                   </div>
                 ))}
               </div>
             )
           })()}
+
+          {/* Bank summary: principal portion / received / gain-loss / remaining */}
+          {isBank && numAmount > 0 && !isOverMax && numReceived > 0 && (
+            <div style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
+                <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVi ? 'Tiền gốc' : 'Principal'}{bankFraction < 0.999 && <span style={{ opacity: 0.7 }}> · {Math.round(bankFraction * 100)}%</span>}</span>
+                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(bankPrincipalPortion)}</span>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
+                <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVi ? 'Số tiền thực nhận' : "Amount you'll receive"}</span>
+                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(numReceived)}</span>
+              </div>
+              {bankGain != null && (
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '11px 14px', borderBottom: '1px solid var(--c-line)' }}>
+                  <span style={{ fontSize: 12, fontWeight: 600 }}>{isVi ? 'Lãi/Lỗ' : 'Gain / Loss'}</span>
+                  <span style={{ fontSize: 15, fontWeight: 700, color: bankGain >= 0 ? 'var(--c-pos)' : 'var(--c-neg)', fontVariantNumeric: 'tabular-nums' }}>{bankGain >= 0 ? '+' : '−'}{fmtCompact(Math.abs(bankGain))}</span>
+                </div>
+              )}
+              <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px' }}>
+                <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVi ? 'Còn lại sau giao dịch' : 'Remaining after transaction'}</span>
+                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(Math.max(0, remaining))}</span>
+              </div>
+            </div>
+          )}
           </>
           ) : (
           <>
@@ -1073,6 +1123,7 @@ function SellModal({ inv, isVi, onClose, onSuccess }: {
                 ? (isVi ? (isBank ? 'Nhập số tiền rút' : isGold ? 'Nhập số lượng bán' : 'Nhập số tiền bán') : (isBank ? 'Enter withdrawal amount' : isGold ? 'Enter quantity to sell' : 'Enter sale amount'))
                 : (isGold && numSalePrice <= 0) ? (isVi ? 'Nhập giá bán' : 'Enter sale price')
                 : isOverMax ? (isVi ? (isGold ? 'Vượt quá số lượng' : 'Vượt quá số dư') : (isGold ? 'Exceeds quantity' : 'Exceeds balance'))
+                : (isBank && numReceived <= 0) ? (isVi ? 'Nhập số tiền thực nhận' : 'Enter amount received')
                 : saving ? (isVi ? 'Đang xử lý…' : 'Processing…')
                 : isBank ? (isVi ? 'Xác nhận rút' : 'Confirm withdrawal') : (isVi ? 'Xác nhận bán' : 'Confirm sale')}
             </button>

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -48,6 +48,7 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
 
   const [amount, setAmount] = useState('')
   const [units, setUnits] = useState('')
+  const [received, setReceived] = useState('') // bank: cash actually received
   const [salePrice, setSalePrice] = useState('') // gold: sale price per chỉ
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
@@ -63,6 +64,7 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
         setMounted(false)
         setAmount('')
         setUnits('')
+        setReceived('')
         setSalePrice('')
         setSaving(false)
         setError('')
@@ -95,20 +97,25 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
   const goldRemUnits = isGold && item?.units != null ? item.units - numUnits : null
   const isOverUnits = isGold && item?.units != null && numUnits > item.units
 
+  // Bank: cash received is editable; split principal out of the withdrawn amount
+  // so the summary can show an accurate gain/loss.
+  const numReceived = Number(received) || 0
+  const bankPrincipal = item?.purchasePrice ?? maxAmount
+  const bankFraction = maxAmount > 0 ? Math.min(1, numAmount / maxAmount) : 0
+  const bankPrincipalPortion = Math.round(bankPrincipal * bankFraction)
+  const bankGain = isBank && numReceived > 0 && numAmount > 0 ? numReceived - bankPrincipalPortion : null
+
   const isOverMax = isGold ? isOverUnits : (numAmount > maxAmount && maxAmount > 0)
   const isValid = isGold
     ? (numUnits > 0 && !isOverUnits && numSalePrice > 0 && !saving)
-    : (numAmount > 0 && !isOverMax && !saving)
+    : isBank
+      ? (numAmount > 0 && !isOverMax && numReceived > 0 && !saving)
+      : (numAmount > 0 && !isOverMax && !saving)
 
   const gainLoss = useMemo(() => {
-    if (!numAmount || item?.gainPct == null) return null
+    if (!numAmount || isBank || item?.gainPct == null) return null
     return numAmount * item.gainPct / (100 + item.gainPct)
-  }, [numAmount, item?.gainPct])
-
-  const penaltyAmount = useMemo(() => {
-    if (!isBank || !numAmount || !item?.interestRate) return null
-    return Math.round(numAmount * (item.interestRate / 100) * 0.5)
-  }, [isBank, numAmount, item?.interestRate])
+  }, [numAmount, isBank, item?.gainPct])
 
   const taxAmount = useMemo(() => {
     if (!isFund || !numAmount) return null
@@ -126,6 +133,7 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
     const raw = val.replace(/,/g, '').replace(/[^0-9]/g, '')
     setAmount(raw)
     setError('')
+    if (isBank) setReceived(raw)  // received tracks the amount until edited down
     if (navPerUnit && raw) {
       const u = Number(raw) / navPerUnit
       setUnits(u > 0 ? u.toFixed(2) : '')
@@ -152,6 +160,7 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
       return
     }
     setAmount(String(maxAmount))
+    if (isBank) setReceived(String(Math.round(maxAmount)))
     if (navPerUnit && item?.units != null) setUnits(item.units.toFixed(2))
     setError('')
   }
@@ -195,9 +204,9 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
           parent_transaction_id: item.transactionId,
           investment_date: today,
           // Gold: amount = proceeds (qty × sale price), principal = cost basis of
-          // the sold chỉ. Bank: amount = principal withdrawn.
-          amount_vnd: isGold ? goldProceeds : Math.round(numAmount),
-          principal_withdrawn: isGold ? (goldCostSold ?? goldProceeds) : Math.round(numAmount),
+          // the sold chỉ. Bank: amount = cash received, principal = principal portion.
+          amount_vnd: isGold ? goldProceeds : isBank ? Math.round(numReceived) : Math.round(numAmount),
+          principal_withdrawn: isGold ? (goldCostSold ?? goldProceeds) : isBank ? bankPrincipalPortion : Math.round(numAmount),
           goal_id: null,
         }
         if (isGold) {
@@ -216,7 +225,7 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
         }
       }
 
-      setSoldAmount(isGold ? goldProceeds : numAmount)
+      setSoldAmount(isGold ? goldProceeds : isBank ? numReceived : numAmount)
       setConfirmed(true)
       setTimeout(() => {
         setConfirmed(false)
@@ -368,6 +377,28 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
               )}
             </div>
 
+            {/* Bank: editable cash received (early withdrawal can cut interest) */}
+            {isBank && (
+              <div>
+                <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>{isVI ? 'Số tiền thực nhận' : "Amount you'll receive"}</div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', background: 'var(--c-card)', border: '1.5px solid var(--c-navy, #1e3a5f)', borderRadius: 10 }}>
+                  <span style={{ fontSize: 14, color: 'var(--c-muted)' }}>₫</span>
+                  <input
+                    data-testid="sell-received-input"
+                    type="text"
+                    inputMode="numeric"
+                    value={received ? Number(received).toLocaleString('vi-VN') : ''}
+                    onChange={e => { setReceived(e.target.value.replace(/,/g, '').replace(/[^0-9]/g, '')); setError('') }}
+                    placeholder="0"
+                    style={{ flex: 1, border: 'none', outline: 'none', fontSize: 15, fontWeight: 600, background: 'transparent', color: 'var(--c-ink)' }}
+                  />
+                </div>
+                <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 4 }}>
+                  {isVI ? 'Tạm tính theo giá trị hiện tại — sửa nếu rút sớm bị trừ lãi' : 'Pre-filled at current value — edit down if early withdrawal cuts interest'}
+                </div>
+              </div>
+            )}
+
             {/* Units input — fund & gold only */}
             {showUnits && (
               <div>
@@ -390,25 +421,19 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
               </div>
             )}
 
-            {/* Summary strip */}
-            {numAmount > 0 && !isOverMax && (
+            {/* Fund summary: remaining / gain-loss / tax */}
+            {!isBank && numAmount > 0 && !isOverMax && (
               <div data-testid="sell-summary-strip" style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
                   <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Còn lại sau giao dịch' : 'Remaining after transaction'}</span>
                   <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(Math.max(0, remaining), locale)}</span>
                 </div>
                 {gainLoss != null && (
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: (penaltyAmount || taxAmount) ? '1px solid var(--c-line)' : 'none' }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: taxAmount ? '1px solid var(--c-line)' : 'none' }}>
                     <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Lãi/Lỗ ước tính' : 'Est. gain / loss'}</span>
                     <span style={{ fontSize: 13, fontWeight: 600, color: gainLoss >= 0 ? 'var(--c-pos, #16a34a)' : 'var(--c-neg, #dc2626)' }}>
                       {gainLoss >= 0 ? '+' : ''}{fmtVND(gainLoss, locale)}
                     </span>
-                  </div>
-                )}
-                {penaltyAmount != null && (
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: taxAmount ? '1px solid var(--c-line)' : 'none' }}>
-                    <span style={{ fontSize: 12, color: 'var(--c-warn, #d97706)' }}>{isVI ? 'Lãi mất ước tính' : 'Est. interest forfeited'}</span>
-                    <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-warn, #d97706)' }}>−{fmtVND(penaltyAmount, locale)}</span>
                   </div>
                 )}
                 {taxAmount != null && (
@@ -417,6 +442,30 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
                     <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-muted)' }}>−{fmtVND(taxAmount, locale)}</span>
                   </div>
                 )}
+              </div>
+            )}
+
+            {/* Bank summary: principal portion / received / gain-loss / remaining */}
+            {isBank && numAmount > 0 && !isOverMax && numReceived > 0 && (
+              <div data-testid="sell-summary-strip" style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
+                  <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Tiền gốc' : 'Principal'}{bankFraction < 0.999 && <span style={{ opacity: 0.7 }}> · {Math.round(bankFraction * 100)}%</span>}</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(bankPrincipalPortion, locale)}</span>
+                </div>
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
+                  <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Số tiền thực nhận' : "Amount you'll receive"}</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(numReceived, locale)}</span>
+                </div>
+                {bankGain != null && (
+                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '11px 14px', borderBottom: '1px solid var(--c-line)' }}>
+                    <span style={{ fontSize: 12, fontWeight: 600 }}>{isVI ? 'Lãi/Lỗ' : 'Gain / Loss'}</span>
+                    <span style={{ fontSize: 15, fontWeight: 700, color: bankGain >= 0 ? 'var(--c-pos, #16a34a)' : 'var(--c-neg, #dc2626)' }}>{bankGain >= 0 ? '+' : '−'}{fmtVND(Math.abs(bankGain), locale)}</span>
+                  </div>
+                )}
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px' }}>
+                  <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Còn lại sau giao dịch' : 'Remaining after transaction'}</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(Math.max(0, remaining), locale)}</span>
+                </div>
               </div>
             )}
             </>
@@ -555,6 +604,8 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
                   ? (isVI ? 'Nhập giá bán' : 'Enter sale price')
                   : isOverMax
                   ? (isVI ? (isGold ? 'Vượt quá số lượng' : 'Vượt quá số dư') : (isGold ? 'Exceeds quantity' : 'Exceeds balance'))
+                  : (isBank && numReceived <= 0)
+                  ? (isVI ? 'Nhập số tiền thực nhận' : 'Enter amount received')
                   : saving
                   ? (isVI ? 'Đang xử lý…' : 'Processing…')
                   : confirmLabel}

--- a/app/assets/components/__tests__/AddTransactionSheet.test.tsx
+++ b/app/assets/components/__tests__/AddTransactionSheet.test.tsx
@@ -105,6 +105,71 @@ describe('AddTransactionSheet — sell flow (issue #232)', () => {
   })
 })
 
+describe('AddTransactionSheet — fund sell units field (two-way linked)', () => {
+  it('entering units fills the amount and posts the matching withdrawal', async () => {
+    const overview = {
+      goals: [{ goalName: 'Goal A', funds: [{ fundId: 'f1', fundName: 'VESAF', quantity: 100, currentNAV: 20000, currentValue: 2_000_000, purchasePrice: 18000, profitLossPercentage: 11.11 }] }],
+      unallocated: { funds: [], nonFunds: [] },
+    }
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
+      if (String(url).includes('/dashboard/overview')) return Promise.resolve({ ok: true, json: () => Promise.resolve(overview) })
+      if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [] }) })
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<AddTransactionSheet open onClose={vi.fn()} onSaved={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('sell'))
+    await screen.findAllByText(/VESAF/)
+    fireEvent.change(screen.getByTestId('sell-fund-units-input'), { target: { value: '50' } })  // 50 units
+    fireEvent.click(screen.getByText('confirmSale'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find((c) => String(c[0]).includes('/investment-transactions'))
+      expect(post).toBeTruthy()
+      const body = JSON.parse(String((post![1] as RequestInit).body))
+      expect(body.asset_type).toBe('fund')
+      expect(body.amount_vnd).toBe(1_000_000)        // 50 × 20,000 NAV
+      expect(body.units_withdrawn).toBe(50)
+      expect(body.principal_withdrawn).toBe(900_000)  // 50% of cost basis
+    })
+  })
+})
+
+describe('AddTransactionSheet — bank withdraw (received + principal portion)', () => {
+  it('defaults received to current value and posts received + principal portion', async () => {
+    const overview = {
+      goals: [{ goalName: 'Goal A', funds: [], nonFunds: [{ transactionId: 't1', type: 'bank', amount: 5_000_000, currentValue: 5_200_000, interestRate: 6, units: null, notes: 'Techcombank' }] }],
+      unallocated: { funds: [], nonFunds: [] },
+    }
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
+      if (String(url).includes('/dashboard/overview')) return Promise.resolve({ ok: true, json: () => Promise.resolve(overview) })
+      if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [] }) })
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<AddTransactionSheet open onClose={vi.fn()} onSaved={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('Bank'))
+    fireEvent.click(screen.getByText('withdraw'))
+    await screen.findAllByText(/Techcombank/)
+    fireEvent.click(screen.getByText('all'))   // amount = 5,200,000 → received defaults to 5,200,000
+    fireEvent.click(screen.getByText('confirmWithdrawal'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find((c) => String(c[0]).includes('/investment-transactions'))
+      expect(post).toBeTruthy()
+      const body = JSON.parse(String((post![1] as RequestInit).body))
+      expect(body.asset_type).toBe('bank')
+      expect(body.parent_transaction_id).toBe('t1')
+      expect(body.amount_vnd).toBe(5_200_000)         // cash received
+      expect(body.principal_withdrawn).toBe(5_000_000) // full principal removed
+    })
+  })
+})
+
 describe('AddTransactionSheet — sell lists goal-allocated bank/gold (issue #232)', () => {
   it('includes bank/gold holdings attributed to a goal, not just unallocated', async () => {
     const overview = {

--- a/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
+++ b/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
@@ -12,6 +12,34 @@ beforeEach(() => {
   vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })))
 })
 
+describe('SellWithdrawSheet — bank withdraw (received + principal portion)', () => {
+  it('defaults received to current value and posts received + principal portion', async () => {
+    const fetchMock = vi.fn((_url: string, _init?: RequestInit) =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const item = {
+      type: 'bank' as const, name: 'Techcombank',
+      currentValue: 5_200_000, interestRate: 6,
+      transactionId: 't1', purchasePrice: 5_000_000,
+    }
+    render(<SellWithdrawSheet item={item} open context="unallocated" onClose={vi.fn()} onSuccess={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('sell-all-btn'))   // amount + received = 5,200,000
+    fireEvent.click(screen.getByTestId('sell-confirm-btn'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find((c) => String(c[0]).includes('/investment-transactions'))
+      expect(post).toBeTruthy()
+      const body = JSON.parse(String((post![1] as RequestInit).body))
+      expect(body.asset_type).toBe('bank')
+      expect(body.parent_transaction_id).toBe('t1')
+      expect(body.amount_vnd).toBe(5_200_000)         // cash received
+      expect(body.principal_withdrawn).toBe(5_000_000) // full principal removed
+    })
+  })
+})
+
 describe('SellWithdrawSheet — gold sell (quantity × price) (issue #232)', () => {
   it('prefills the price and posts proceeds + cost basis', async () => {
     const fetchMock = vi.fn((_url: string, _init?: RequestInit) =>

--- a/messages/en.json
+++ b/messages/en.json
@@ -64,7 +64,13 @@
     "totalReceived": "Total received",
     "yourCost": "Your cost",
     "profitLoss": "Profit / Loss",
-    "chiShort": "chỉ"
+    "chiShort": "chỉ",
+    "unitsToSell": "Units to sell",
+    "navLinkHint": "Enter an amount or units — they stay in sync",
+    "amountReceived": "Amount you'll receive",
+    "receivedHint": "Pre-filled at current value — edit down if early withdrawal cuts interest",
+    "principalPortion": "Principal",
+    "gainLoss": "Gain / Loss"
   },
   "common": {
     "save": "Save",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -64,7 +64,13 @@
     "totalReceived": "Tổng tiền nhận được",
     "yourCost": "Giá vốn",
     "profitLoss": "Lãi/Lỗ",
-    "chiShort": "chỉ"
+    "chiShort": "chỉ",
+    "unitsToSell": "Số phần muốn bán",
+    "navLinkHint": "Nhập số tiền hoặc số phần — tự động đồng bộ",
+    "amountReceived": "Số tiền thực nhận",
+    "receivedHint": "Tạm tính theo giá trị hiện tại — sửa nếu rút sớm bị trừ lãi",
+    "principalPortion": "Tiền gốc",
+    "gainLoss": "Lãi/Lỗ"
   },
   "common": {
     "save": "Lưu",


### PR DESCRIPTION
Applies the redesigned **bank & fund** withdraw/sell flow ([design](https://api.anthropic.com/v1/design/h/l2BKtCVdghRDQxPOPJFBAQ)) consistently across all three sell surfaces:

- `AddTransactionSheet` (mobile sheet + desktop add-tx modal)
- `SellWithdrawSheet` (holding-card bottom sheet)
- `SellModal` inside `DesktopGoalDetail` (desktop goal holdings)

### Fund
- New **"Units to sell"** field, two-way linked with the amount (enter either, both stay in sync). "All" fills both.

### Bank
- New editable **"Amount you'll receive"** field, pre-filled to the current value — edit it down when an early withdrawal cuts accrued interest.
- New summary: **Principal (portion %) → Amount you'll receive → Gain / Loss → Remaining**, replacing the old guessed "interest forfeited" penalty estimate.
- Withdrawal payload now records `amount_vnd` = cash received and `principal_withdrawn` = the principal portion (cost-basis fraction). This reduces the deposit principal accurately (overview subtracts `principal_withdrawn` from the original deposit) and records a real gain/loss instead of removing the full withdrawn amount as principal.

### Tests (TDD)
- `AddTransactionSheet`: fund units field fills amount and posts matching withdrawal; bank withdraw defaults received to current value and posts `amount_vnd` = received, `principal_withdrawn` = principal portion.
- `SellWithdrawSheet`: bank withdraw posts received + principal portion.
- Existing fund/gold sell + e2e selectors (`sell-amount-input`, `sell-summary-strip`, `sell-tax-row`, `sell-all-btn`, gold qty/price) preserved.

Out of scope: the settings-page `GoalDetailView` withdraw modal (separate, older affects-progress flow) is unchanged.

Note: a pre-existing `TransactionHistorySheet` unit test fails on `main` independent of this change (date-dependent); not touched here.