### PR TITLE
feat(auth): mobile redesign of sign in / sign up (#243)

### DIFF
--- a/app/auth/AuthLayout.tsx
+++ b/app/auth/AuthLayout.tsx
@@ -33,6 +33,13 @@ const authStyles = `
 .cn-auth-card {
   width: 100%;
 }
+/* On mobile the form sits directly on the canvas (no card), so the inputs take
+   a card-colored fill + stronger border to stand out — matching the prototype.
+   Without this they'd be canvas-on-canvas and look invisible. */
+.cn-auth-card .cn-input {
+  background: var(--c-card);
+  border-color: var(--c-line-strong);
+}
 .cn-auth-title {
   margin: 0 0 8px;
   font-size: 28px;
@@ -77,6 +84,12 @@ const authStyles = `
     border-radius: var(--r-card);
     box-shadow: var(--shadow-card);
     padding: 28px 24px;
+  }
+  /* Desktop: the form sits inside a white card, so inputs revert to the canvas
+     fill (the default) to stay distinct from the card surface. */
+  .cn-auth-card .cn-input {
+    background: var(--c-canvas);
+    border-color: var(--c-line);
   }
   .cn-auth-title {
     margin-bottom: 4px;

--- a/app/auth/AuthLayout.tsx
+++ b/app/auth/AuthLayout.tsx
@@ -18,6 +18,7 @@ const authStyles = `
   display: flex;
   flex-direction: column;
   gap: 28px;
+  flex: 1;
 }
 .cn-auth-brand {
   display: flex;
@@ -55,6 +56,9 @@ const authStyles = `
 }
 .cn-auth-alt {
   margin: 0;
+  /* Pin the "Don't have an account? Sign up" line to the bottom of the screen
+     on mobile (the prototype puts the form in a flex:1 region above it). */
+  margin-top: auto;
   font-size: 13px;
   color: var(--c-muted);
   text-align: center;
@@ -70,6 +74,7 @@ const authStyles = `
     max-width: 380px;
     gap: 20px;
     align-items: center;
+    flex: none;
   }
   .cn-auth-brand {
     margin-bottom: 8px;
@@ -100,6 +105,10 @@ const authStyles = `
   .cn-auth-sub {
     margin-bottom: 22px;
     font-size: 13px;
+  }
+  /* Desktop: form is a centered card, so the toggle sits directly under it. */
+  .cn-auth-alt {
+    margin-top: 0;
   }
 }
 `

--- a/app/auth/AuthLayout.tsx
+++ b/app/auth/AuthLayout.tsx
@@ -1,5 +1,95 @@
 // Shared layout for auth pages (login / signup).
-// Centered single-column: Cairn logo above the form card.
+// Mobile (issue #243): full-bleed screen — brand pinned top-left, large hero
+// heading, form flush to the top. Desktop: centered single-column card with the
+// Cairn logo above. The responsive switch lives in the scoped <style> below so
+// the page components can stay styling-light.
+
+const authStyles = `
+.cn-auth-root {
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--c-canvas);
+  padding: 74px 24px 24px;
+}
+.cn-auth-col {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+}
+.cn-auth-brand {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.cn-auth-wordmark {
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--c-navy);
+}
+.cn-auth-card {
+  width: 100%;
+}
+.cn-auth-title {
+  margin: 0 0 8px;
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1.15;
+  color: var(--c-ink);
+}
+.cn-auth-sub {
+  margin: 0 0 28px;
+  font-size: 14px;
+  color: var(--c-muted);
+}
+.cn-auth-alt {
+  margin: 0;
+  font-size: 13px;
+  color: var(--c-muted);
+  text-align: center;
+}
+
+@media (min-width: 640px) {
+  .cn-auth-root {
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+  }
+  .cn-auth-col {
+    max-width: 380px;
+    gap: 20px;
+    align-items: center;
+  }
+  .cn-auth-brand {
+    margin-bottom: 8px;
+  }
+  .cn-auth-wordmark {
+    font-size: 22px;
+    letter-spacing: -0.03em;
+  }
+  .cn-auth-card {
+    background: var(--c-card);
+    border: 1px solid var(--c-line);
+    border-radius: var(--r-card);
+    box-shadow: var(--shadow-card);
+    padding: 28px 24px;
+  }
+  .cn-auth-title {
+    margin-bottom: 4px;
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+  }
+  .cn-auth-sub {
+    margin-bottom: 22px;
+    font-size: 13px;
+  }
+}
+`
 
 function CairnMark({ size = 32, testId }: { size?: number; testId?: string }) {
   const h = Math.round(size * 0.85)
@@ -15,39 +105,13 @@ function CairnMark({ size = 32, testId }: { size?: number; testId?: string }) {
 
 export function AuthLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div
-      style={{
-        minHeight: '100vh',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        background: 'var(--c-canvas)',
-        padding: '24px',
-      }}
-    >
-      <div
-        style={{
-          width: '100%',
-          maxWidth: 380,
-          display: 'flex',
-          flexDirection: 'column',
-          gap: 20,
-          alignItems: 'center',
-        }}
-      >
+    <div className="cn-auth-root">
+      <style dangerouslySetInnerHTML={{ __html: authStyles }} />
+      <div className="cn-auth-col">
         {/* Cairn logo */}
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+        <div className="cn-auth-brand">
           <CairnMark size={32} testId="brand-mark" />
-          <span
-            style={{
-              fontSize: 22,
-              fontWeight: 700,
-              letterSpacing: '-0.03em',
-              color: 'var(--c-navy)',
-            }}
-          >
-            Cairn
-          </span>
+          <span className="cn-auth-wordmark">Cairn</span>
         </div>
 
         {children}

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -10,8 +10,8 @@ import { AuthLayout } from '../AuthLayout'
 
 const fieldLabelStyle: React.CSSProperties = {
   fontSize: 11,
-  fontWeight: 600,
-  letterSpacing: '0.05em',
+  fontWeight: 500,
+  letterSpacing: '0.02em',
   textTransform: 'uppercase',
   color: 'var(--c-muted)',
 }
@@ -57,13 +57,9 @@ function LoginForm() {
 
   return (
     <>
-      <div data-testid="auth-card" className="cn-card" style={{ width: '100%', padding: '28px 24px' }}>
-        <h1 style={{ margin: '0 0 4px', fontSize: 20, fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--c-ink)' }}>
-          {t('loginTitle')}
-        </h1>
-        <p style={{ margin: '0 0 22px', fontSize: 13, color: 'var(--c-muted)' }}>
-          {t('loginSubtitle')}
-        </p>
+      <div data-testid="auth-card" className="cn-auth-card">
+        <h1 className="cn-auth-title">{t('loginTitle')}</h1>
+        <p className="cn-auth-sub">{t('loginSubtitle')}</p>
 
         {error && (
           <div role="alert" style={{
@@ -140,8 +136,8 @@ function LoginForm() {
             className="cn-btn primary"
             style={{
               width: '100%',
-              padding: '11px',
-              marginTop: 4,
+              padding: '13px 16px',
+              marginTop: 18,
               fontSize: 14,
               fontWeight: 600,
               opacity: loading || redirecting ? 0.7 : 1,
@@ -152,7 +148,7 @@ function LoginForm() {
         </form>
       </div>
 
-      <p style={{ margin: 0, fontSize: 13, color: 'var(--c-muted)', textAlign: 'center' }}>
+      <p className="cn-auth-alt">
         {t('noAccount')}{' '}
         <Link href="/auth/signup" style={{ color: 'var(--c-navy)', fontWeight: 600, textDecoration: 'none' }}>
           {t('signupLink')}

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -10,8 +10,8 @@ import { AuthLayout } from '../AuthLayout'
 
 const fieldLabelStyle: React.CSSProperties = {
   fontSize: 11,
-  fontWeight: 600,
-  letterSpacing: '0.05em',
+  fontWeight: 500,
+  letterSpacing: '0.02em',
   textTransform: 'uppercase',
   color: 'var(--c-muted)',
 }
@@ -86,7 +86,7 @@ export default function SignupPage() {
   if (confirmSent) {
     return (
       <AuthLayout>
-        <div data-testid="auth-card" className="cn-card" style={{ width: '100%', padding: '28px 24px', textAlign: 'center' }}>
+        <div data-testid="auth-card" className="cn-auth-card" style={{ textAlign: 'center' }}>
           <div style={{
             width: 48, height: 48, borderRadius: 12,
             background: 'var(--c-navy-tint)',
@@ -95,12 +95,8 @@ export default function SignupPage() {
           }}>
             📧
           </div>
-          <h1 style={{ margin: '0 0 12px', fontSize: 20, fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--c-ink)' }}>
-            {t('checkEmailTitle')}
-          </h1>
-          <p style={{ margin: '0 0 24px', fontSize: 13, color: 'var(--c-muted)' }}>
-            {t('checkEmailMessage')}
-          </p>
+          <h1 className="cn-auth-title" style={{ marginBottom: 12 }}>{t('checkEmailTitle')}</h1>
+          <p className="cn-auth-sub" style={{ marginBottom: 24 }}>{t('checkEmailMessage')}</p>
           <Link
             href="/auth/login"
             className="cn-btn primary"
@@ -115,13 +111,9 @@ export default function SignupPage() {
 
   return (
     <AuthLayout>
-      <div data-testid="auth-card" className="cn-card" style={{ width: '100%', padding: '28px 24px' }}>
-        <h1 style={{ margin: '0 0 4px', fontSize: 20, fontWeight: 700, letterSpacing: '-0.02em', color: 'var(--c-ink)' }}>
-          {t('signupTitle')}
-        </h1>
-        <p style={{ margin: '0 0 22px', fontSize: 13, color: 'var(--c-muted)' }}>
-          {t('signupSubtitle')}
-        </p>
+      <div data-testid="auth-card" className="cn-auth-card">
+        <h1 className="cn-auth-title">{t('signupTitle')}</h1>
+        <p className="cn-auth-sub">{t('signupSubtitle')}</p>
 
         {formError && (
           <div role="alert" style={{
@@ -206,8 +198,8 @@ export default function SignupPage() {
             className="cn-btn primary"
             style={{
               width: '100%',
-              padding: '11px',
-              marginTop: 4,
+              padding: '13px 16px',
+              marginTop: 18,
               fontSize: 14,
               fontWeight: 600,
               opacity: loading ? 0.7 : 1,
@@ -218,7 +210,7 @@ export default function SignupPage() {
         </form>
       </div>
 
-      <p style={{ margin: 0, fontSize: 13, color: 'var(--c-muted)', textAlign: 'center' }}>
+      <p className="cn-auth-alt">
         {t('hasAccount')}{' '}
         <Link href="/auth/login" style={{ color: 'var(--c-navy)', fontWeight: 600, textDecoration: 'none' }}>
           {t('loginLink')}

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -130,6 +130,39 @@ test.describe('mobile input font-size', () => {
   })
 })
 
+// ─── Mobile: full-screen redesign (issue #243) ───────────────────────────────
+// On mobile the auth screen is a full-bleed layout: brand pinned top-left, a
+// large hero heading, and the form flush to the top — not a vertically-centered
+// card. These assert the user-visible result of that redesign.
+test.describe('mobile auth redesign', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('login heading renders as a large hero (>=24px) on mobile', async ({ page }) => {
+    await page.goto('/auth/login')
+    const fontSize = await page.locator('h1').first().evaluate(
+      (el) => parseFloat(getComputedStyle(el).fontSize)
+    )
+    expect(fontSize).toBeGreaterThanOrEqual(24)
+  })
+
+  test('signup heading renders as a large hero (>=24px) on mobile', async ({ page }) => {
+    await page.goto('/auth/signup')
+    const fontSize = await page.locator('h1').first().evaluate(
+      (el) => parseFloat(getComputedStyle(el).fontSize)
+    )
+    expect(fontSize).toBeGreaterThanOrEqual(24)
+  })
+
+  test('brand is pinned to the top-left, not vertically centered, on mobile', async ({ page }) => {
+    await page.goto('/auth/login')
+    const box = await page.locator('[data-testid="brand-mark"]').boundingBox()
+    expect(box).not.toBeNull()
+    // Top-left: near the left edge and in the upper portion of the screen.
+    expect(box!.x).toBeLessThan(80)
+    expect(box!.y).toBeLessThan(160)
+  })
+})
+
 // ─── Desktop centered card layout ───────────────────────────────────────────
 
 test('login form is inside a card', async ({ page }) => {

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -173,6 +173,16 @@ test.describe('mobile auth redesign', () => {
     expect(box!.x).toBeLessThan(80)
     expect(box!.y).toBeLessThan(160)
   })
+
+  test('the sign-up toggle is pinned near the bottom of the screen on mobile', async ({ page }) => {
+    await page.goto('/auth/login')
+    const link = page.getByRole('link', { name: /sign up/i })
+    const box = await link.boundingBox()
+    expect(box).not.toBeNull()
+    // 844px tall viewport — the toggle should sit in the lower portion, not up
+    // near the form. Pinned to the bottom it lands well past the halfway mark.
+    expect(box!.y).toBeGreaterThan(600)
+  })
 })
 
 // ─── Desktop centered card layout ───────────────────────────────────────────

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -153,6 +153,18 @@ test.describe('mobile auth redesign', () => {
     expect(fontSize).toBeGreaterThanOrEqual(24)
   })
 
+  test('input fields are visually distinct from the page background on mobile', async ({ page }) => {
+    await page.goto('/auth/login')
+    const emailBg = await page.locator('#email').evaluate(
+      (el) => getComputedStyle(el).backgroundColor
+    )
+    const pageBg = await page.locator('.cn-auth-root').evaluate(
+      (el) => getComputedStyle(el).backgroundColor
+    )
+    // Without a card behind the form, a canvas-on-canvas input would be invisible.
+    expect(emailBg).not.toBe(pageBg)
+  })
+
   test('brand is pinned to the top-left, not vertically centered, on mobile', async ({ page }) => {
     await page.goto('/auth/login')
     const box = await page.locator('[data-testid="brand-mark"]').boundingBox()


### PR DESCRIPTION
Closes #243.

## What
Mobile redesign of the **sign in** and **sign up** screens to match the Cairn redesign prototype (`Capnha Prototype.html` → `screen-auth.jsx`).

On **mobile** the auth screen is now full-bleed:
- Cairn mark + wordmark pinned **top-left** (utility brand, 17px wordmark)
- large **28px** hero heading, form flush to the top
- no centered-card chrome

On **desktop** (≥640px) it keeps the centered single-column **card** (brand centered above, 20px heading) — switched via a media query in a scoped `<style>` block in `AuthLayout`.

Visual-only: copy, fields, flow, and Supabase auth logic are unchanged.

## Changes
- `app/auth/AuthLayout.tsx` — responsive root/column/brand + `.cn-auth-card` / `.cn-auth-title` / `.cn-auth-sub` / `.cn-auth-alt` (full-screen mobile, card desktop).
- `app/auth/login/page.tsx`, `app/auth/signup/page.tsx` — use the new classes; field labels → weight 500 / 0.02em; primary button → 13px/16px padding, 18px top margin (per prototype). Inputs keep `cn-input` (≥16px, iOS no-zoom).
- `e2e/auth.spec.ts` — new mobile assertions: hero heading ≥24px (login & signup) and brand pinned top-left.

## Verification
⚠️ Local `tsc` / `eslint` / Playwright output could not be observed in this session due to a tool-output issue, so I'm relying on **CI** and the **Vercel preview** as the gates. Please review the preview on a mobile viewport (and desktop) before merging. Existing auth e2e (titles, brand-mark, card visibility, forgot-password, ≥16px inputs) were preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)