### PR TITLE
fix(add-tx): show interest user receives by maturity, not interest/yr (#245)

### DIFF
--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -653,17 +653,24 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop }:
                   />
                 </div>
               )}
-              {depositType === 'term' && Number(bankAmount) > 0 && Number(rate) > 0 && (
-                <div style={{
-                  background: 'var(--c-pos-tint)', borderRadius: 10, padding: '9px 14px',
-                  display: 'flex', justifyContent: 'space-between', alignItems: 'center',
-                }}>
-                  <span style={{ fontSize: 12, color: 'var(--c-pos)', fontWeight: 500 }}>{t('estInterestYr')}</span>
-                  <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--c-pos)', fontVariantNumeric: 'tabular-nums' }}>
-                    +{Math.round(Number(bankAmount) * Number(rate) / 100).toLocaleString('vi-VN')} ₫
-                  </span>
-                </div>
-              )}
+              {depositType === 'term' && Number(bankAmount) > 0 && Number(rate) > 0 && maturity && (() => {
+                // Interest the user actually receives by maturity, prorated over
+                // the term (deposit date → maturity) — not the full-year figure.
+                const termDays = (Date.parse(maturity) - Date.parse(date)) / 86_400_000
+                if (!(termDays > 0)) return null
+                const interest = Math.round((Number(bankAmount) * Number(rate) / 100) * termDays / 365)
+                return (
+                  <div style={{
+                    background: 'var(--c-pos-tint)', borderRadius: 10, padding: '9px 14px',
+                    display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+                  }}>
+                    <span style={{ fontSize: 12, color: 'var(--c-pos)', fontWeight: 500 }}>{t('estInterestReceivable')}</span>
+                    <span style={{ fontSize: 14, fontWeight: 600, color: 'var(--c-pos)', fontVariantNumeric: 'tabular-nums' }}>
+                      +{interest.toLocaleString('vi-VN')} ₫
+                    </span>
+                  </div>
+                )
+              })()}
             </>
           )}
 

--- a/app/assets/components/__tests__/AddTransactionSheet.test.tsx
+++ b/app/assets/components/__tests__/AddTransactionSheet.test.tsx
@@ -227,6 +227,47 @@ describe('AddTransactionSheet — gold sell (quantity × price) (issue #232)', (
   })
 })
 
+describe('AddTransactionSheet — bank term interest receivable (issue #245)', () => {
+  // The box should show the interest the user actually receives by maturity,
+  // prorated over the deposit term — not the full-year interest.
+  it('prorates interest to the maturity date instead of showing interest/yr', () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { container } = render(<AddTransactionSheet open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('Bank'))   // asset type = bank ('term' is default)
+    fireEvent.change(screen.getByPlaceholderText('10,000,000'), { target: { value: '100000000' } })
+    fireEvent.change(screen.getByPlaceholderText('5.5'), { target: { value: '6' } })
+
+    // DOM order: [0] = maturity (bank section), [1] = transaction date (footer)
+    const dateInputs = container.querySelectorAll<HTMLInputElement>('input[type="date"]')
+    fireEvent.change(dateInputs[1], { target: { value: '2026-01-01' } })
+    fireEvent.change(dateInputs[0], { target: { value: '2026-07-01' } })
+
+    const termDays = (Date.parse('2026-07-01') - Date.parse('2026-01-01')) / 86_400_000  // 181
+    const expected = Math.round((100_000_000 * 6 / 100) * termDays / 365)
+    expect(screen.getByText('estInterestReceivable')).toBeInTheDocument()
+    expect(screen.getByText(`+${expected.toLocaleString('vi-VN')} ₫`)).toBeInTheDocument()
+    // The old per-year figure (6,000,000 ₫) must NOT be shown.
+    expect(screen.queryByText(`+${(6_000_000).toLocaleString('vi-VN')} ₫`)).not.toBeInTheDocument()
+    expect(screen.queryByText('estInterestYr')).not.toBeInTheDocument()
+  })
+
+  it('hides the interest box until a maturity date is set', () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<AddTransactionSheet open onClose={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('Bank'))
+    fireEvent.change(screen.getByPlaceholderText('10,000,000'), { target: { value: '100000000' } })
+    fireEvent.change(screen.getByPlaceholderText('5.5'), { target: { value: '6' } })
+
+    expect(screen.queryByText('estInterestReceivable')).not.toBeInTheDocument()
+  })
+})
+
 describe('AddTransactionSheet — gold unit (issue #232)', () => {
   // Gold is valued per chỉ, so a lượng entry must be normalized: 1 lượng = 10 chỉ.
   it('normalizes a lượng entry to chỉ on save', async () => {

--- a/messages/en.json
+++ b/messages/en.json
@@ -24,7 +24,7 @@
     "pricePerChi": "Price/chỉ (₫)",
     "pricePerLuong": "Price/lượng (₫)",
     "pricePerUnit": "Price/chỉ (₫)",
-    "estInterestYr": "Est. interest/yr",
+    "estInterestReceivable": "Est. interest you'll receive",
     "total": "Total",
     "date": "Date",
     "note": "Note",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -24,7 +24,7 @@
     "pricePerChi": "Giá/chỉ (₫)",
     "pricePerLuong": "Giá/lượng (₫)",
     "pricePerUnit": "Giá/chỉ (₫)",
-    "estInterestYr": "Lãi/năm ước tính",
+    "estInterestReceivable": "Lãi ước tính nhận được",
     "total": "Tổng tiền",
     "date": "Ngày",
     "note": "Ghi chú",


### PR DESCRIPTION
## Summary
Closes #245.

When adding a **bank term deposit**, the summary box previously showed **"Est. interest/yr"** — the full-year interest (`principal × rate`). It now shows **"Est. interest you'll receive"**: the interest actually receivable by the maturity date, prorated over the deposit term.

## Change
- Interest = `principal × rate/100 × termDays / 365`, where `termDays` = deposit date → maturity.
- The box now only appears once a **maturity date** is set (the term is required to compute the receivable amount).
- Added `estInterestReceivable` translation (EN/VI); removed the now-unused `estInterestYr` key.

## Test plan (TDD)
- New unit test: asserts the rendered figure is the prorated amount, **not** the per-year value, and that the box is hidden until maturity is set.
- Full `AddTransactionSheet` suite: 14/14 pass. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)