### PR TITLE
fix(sell): center desktop Sell/Withdraw modal (#248)

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -1016,6 +1016,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
         item={sellItem}
         open={sellSheetOpen}
         context="unallocated"
+        desktop={isDesktop}
         onClose={() => setSellSheetOpen(false)}
         onSuccess={() => fetchData({ force: true })}
       />

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -26,6 +26,8 @@ interface Props {
   context: 'unallocated' | 'goal'
   onClose: () => void
   onSuccess: () => void
+  // Desktop renders a centered modal dialog; mobile keeps the bottom sheet.
+  desktop?: boolean
 }
 
 const TYPE_ICON = {
@@ -42,7 +44,7 @@ const TYPE_COLOR = {
   stock: '#7c3aed',
 } as const
 
-export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: Props) {
+export function SellWithdrawSheet({ item, open, context, onClose, onSuccess, desktop }: Props) {
   const locale = useLocale()
   const t = useTranslations('Dashboard')
 
@@ -266,29 +268,37 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess }: P
       onClick={onClose}
       style={{
         position: 'fixed', inset: 0,
-        background: 'rgba(15, 23, 42, 0.2)',
-        zIndex: 100,
-        display: 'flex', alignItems: 'flex-end', justifyContent: 'center',
+        background: desktop ? 'rgba(15, 23, 42, 0.4)' : 'rgba(15, 23, 42, 0.2)',
+        zIndex: desktop ? 200 : 100,
+        display: 'flex', alignItems: desktop ? 'center' : 'flex-end', justifyContent: 'center',
+        padding: desktop ? 24 : 0,
+        backdropFilter: desktop ? 'blur(2px)' : undefined,
         animation: open ? 'fade-in 180ms ease' : 'fade-out 180ms ease forwards',
         pointerEvents: open ? 'auto' : 'none',
       }}
     >
       <div
+        role="dialog"
+        aria-modal="true"
         onClick={(e) => e.stopPropagation()}
         style={{
-          width: '100%', maxWidth: 480, maxHeight: '90dvh',
+          width: '100%', maxWidth: 480, maxHeight: desktop ? 'calc(100vh - 48px)' : '90dvh',
           background: 'var(--c-card)',
-          borderTopLeftRadius: 20, borderTopRightRadius: 20,
+          borderRadius: desktop ? 20 : '20px 20px 0 0',
           display: 'flex', flexDirection: 'column',
-          animation: open ? 'slide-up 220ms cubic-bezier(0.2, 0.8, 0.2, 1)' : 'slide-down 180ms ease forwards',
-          boxShadow: '0 -8px 24px rgba(0,0,0,0.12)',
+          animation: open
+            ? (desktop ? 'modal-in 200ms cubic-bezier(0.2,0.8,0.2,1)' : 'slide-up 220ms cubic-bezier(0.2, 0.8, 0.2, 1)')
+            : (desktop ? 'fade-out 150ms ease forwards' : 'slide-down 180ms ease forwards'),
+          boxShadow: desktop
+            ? '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)'
+            : '0 -8px 24px rgba(0,0,0,0.12)',
         }}
       >
-        {/* Drag handle */}
-        <div style={{ width: 36, height: 4, background: 'var(--c-line-strong, #cbd5e1)', borderRadius: 999, margin: '6px auto 14px', flexShrink: 0 }} />
+        {/* Drag handle — mobile bottom-sheet affordance only */}
+        {!desktop && <div style={{ width: 36, height: 4, background: 'var(--c-line-strong, #cbd5e1)', borderRadius: 999, margin: '6px auto 14px', flexShrink: 0 }} />}
 
         {/* Header — pinned, sits outside the scrollable body */}
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 16px 16px', flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: desktop ? '18px 20px 14px' : '0 16px 16px', borderBottom: desktop ? '1px solid var(--c-line)' : undefined, flexShrink: 0 }}>
           <h3 style={{ margin: 0, fontSize: 17, fontWeight: 600 }}>{titleText}</h3>
           <button onClick={onClose} style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }}>
             <X size={18} />

--- a/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
+++ b/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
@@ -69,3 +69,21 @@ describe('SellWithdrawSheet — gold sell (quantity × price) (issue #232)', () 
     })
   })
 })
+
+describe('SellWithdrawSheet — responsive presentation (#248)', () => {
+  const item = {
+    type: 'fund' as const, name: 'VESAF',
+    currentValue: 10_000_000, units: 100, navPerUnit: 100_000,
+    fundId: 'f1', purchasePrice: 9_000_000,
+  }
+
+  it('docks to the bottom as a sheet on mobile', () => {
+    render(<SellWithdrawSheet item={item} open context="unallocated" onClose={vi.fn()} onSuccess={vi.fn()} />)
+    expect(screen.getByTestId('sell-sheet').style.alignItems).toBe('flex-end')
+  })
+
+  it('opens as a centered modal on desktop', () => {
+    render(<SellWithdrawSheet item={item} open context="unallocated" desktop onClose={vi.fn()} onSuccess={vi.fn()} />)
+    expect(screen.getByTestId('sell-sheet').style.alignItems).toBe('center')
+  })
+})


### PR DESCRIPTION
## What
Fixes #248. On desktop, the **Unallocated → Sell / Withdraw** action opened docked to the bottom of the screen (mobile bottom-sheet style). It now opens as a centered modal dialog, consistent with the other desktop add/edit modals (Add Transaction, Assign Goal, etc.).

## Why
`SellWithdrawSheet` only ever rendered the bottom-sheet layout — overlay aligned to `flex-end`, top-only rounded corners, `slide-up` animation, upward shadow — with no desktop variant. The sibling modals already take a `desktop` prop and switch to a centered dialog; `DashboardClient` had `isDesktop` available but wasn't passing it to this sheet.

## Change
- `SellWithdrawSheet.tsx`: add a `desktop?: boolean` prop. When set, the overlay centers its content, the panel gets full rounding + `modal-in` animation + an elevated shadow, the drag handle is dropped, the header gets a divider, and `role="dialog"`/`aria-modal` are added — mirroring `AssignGoalSheet`. Mobile keeps the existing bottom sheet.
- `DashboardClient.tsx`: pass `desktop={isDesktop}` to the Unallocated Sell/Withdraw sheet.

## Tests (TDD)
Added two cases to `SellWithdrawSheet.test.tsx`: the sheet docks to the bottom (`align-items: flex-end`) on mobile and centers (`align-items: center`) with `desktop`. Confirmed the desktop case failed before the change and passes after; existing tests still green. Typecheck and lint clean.

## Notes
Scope is limited to the Unallocated flow per the issue. The goal-detail Sell/Withdraw path (`GoalDetailSheet`) renders the same component and could be wired to `desktop` in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)