### PR TITLE
fix(sell): value goal gold at current price, not buy price (#251)

### DIFF
--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -16,6 +16,8 @@ interface InvestmentTx {
   units: number | null
   interest_rate: number | null
   notes: string | null
+  principal_withdrawn: number | null
+  units_withdrawn: number | null
 }
 
 interface InvRow {
@@ -79,6 +81,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
   const isVi = locale === 'vi'
   const [tab, setTab] = useState<'investments' | 'calculator' | 'history'>('investments')
   const [transactions, setTransactions] = useState<InvestmentTx[]>([])
+  const [goldPricePerChi, setGoldPricePerChi] = useState<number | null>(null)
   const [txLoading, setTxLoading] = useState(false)
   const [actionsOpen, setActionsOpen] = useState(false)
   const [editOpen, setEditOpen] = useState(false)
@@ -107,6 +110,12 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
       .then((res) => setTransactions(res.transactions ?? []))
       .catch(() => setTransactions([]))
       .finally(() => setTxLoading(false))
+    // Gold is valued at the live market price per chỉ, not its purchase cost —
+    // without this the sell modal would prefill the stale buy price (issue #251).
+    fetch('/api/v1/gold-price', { cache: 'no-store' })
+      .then((r) => r.ok ? r.json() : null)
+      .then((res) => setGoldPricePerChi(res?.price_per_chi ?? null))
+      .catch(() => setGoldPricePerChi(null))
   }, [goal.goalId, refreshKey])
 
   // Reset tab when the selected goal itself changes.
@@ -193,6 +202,16 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
       gainPct = tx.amount_vnd > 0 ? ((value - tx.amount_vnd) / tx.amount_vnd) * 100 : 0
       units = null
       principal = tx.amount_vnd
+    } else if (tx.asset_type === 'gold' && goldPricePerChi && tx.units) {
+      // Value remaining gold at the current market price per chỉ so the sell
+      // modal prefills today's price, not the buy price (issue #251). Mirrors
+      // the dashboard overview's gold valuation.
+      const effectiveUnits = tx.units - (tx.units_withdrawn ?? 0)
+      const effectivePrincipal = tx.amount_vnd - (tx.principal_withdrawn ?? 0)
+      value = effectiveUnits * goldPricePerChi
+      gainPct = effectivePrincipal > 0 ? ((value - effectivePrincipal) / effectivePrincipal) * 100 : null
+      units = effectiveUnits
+      principal = effectivePrincipal
     } else {
       value = tx.amount_vnd
       gainPct = null
@@ -1041,7 +1060,7 @@ function SellModal({ inv, isVi, onClose, onSuccess }: {
             <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>{isVi ? 'Giá bán mỗi chỉ' : 'Sale price per chỉ'}</div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 10 }}>
               <span style={{ fontSize: 14, color: 'var(--c-muted)' }}>₫</span>
-              <input type="number" value={salePrice} onChange={(e) => { setSalePrice(e.target.value); setError('') }} placeholder="0"
+              <input data-testid="sell-gold-price-input" type="number" value={salePrice} onChange={(e) => { setSalePrice(e.target.value); setError('') }} placeholder="0"
                 style={{ flex: 1, border: 'none', outline: 'none', fontSize: 15, fontWeight: 600, fontFamily: 'inherit', background: 'transparent', color: 'var(--c-ink)' }} />
               <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>/chỉ</span>
             </div>

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -658,6 +658,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   const [mounted, setMounted] = useState(false)
   const [activeTab, setActiveTab] = useState<'investments' | 'calculator' | 'history'>('investments')
   const [transactions, setTransactions] = useState<InvestmentTx[]>([])
+  const [goldPricePerChi, setGoldPricePerChi] = useState<number | null>(null)
   const [txLoading, setTxLoading] = useState(false)
   const [actionsOpen, setActionsOpen] = useState(false)
   const [editOpen, setEditOpen] = useState(false)
@@ -697,6 +698,12 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
       .then((res) => setTransactions(res.transactions ?? []))
       .catch(() => setTransactions([]))
       .finally(() => setTxLoading(false))
+    // Gold is valued at the live market price per chỉ, not its purchase cost —
+    // without this the sell sheet would prefill the stale buy price (issue #251).
+    fetch('/api/v1/gold-price', { cache: 'no-store' })
+      .then((r) => r.ok ? r.json() : null)
+      .then((res) => setGoldPricePerChi(res?.price_per_chi ?? null))
+      .catch(() => setGoldPricePerChi(null))
   }, [open, goal, refreshKey])
 
   async function handleDelete() {
@@ -804,6 +811,16 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
       gainPct = tx.amount_vnd > 0 ? ((value - tx.amount_vnd) / tx.amount_vnd) * 100 : 0
       units = null
       principal = tx.amount_vnd
+    } else if (tx.asset_type === 'gold' && goldPricePerChi && tx.units) {
+      // Value remaining gold at the current market price per chỉ so the sell
+      // sheet prefills today's price, not the buy price (issue #251). Mirrors
+      // the dashboard overview's gold valuation.
+      const effectiveUnits = tx.units - (tx.units_withdrawn ?? 0)
+      const effectivePrincipal = tx.amount_vnd - (tx.principal_withdrawn ?? 0)
+      value = effectiveUnits * goldPricePerChi
+      gainPct = effectivePrincipal > 0 ? ((value - effectivePrincipal) / effectivePrincipal) * 100 : null
+      units = effectiveUnits
+      principal = effectivePrincipal
     } else {
       value = tx.amount_vnd
       gainPct = null

--- a/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DesktopGoalDetail from '../DesktopGoalDetail'
+import type { GoalData } from '../../DashboardClient'
+
+const mockGoal: GoalData = {
+  goalId: 'goal-1',
+  goalName: 'House Fund',
+  targetAmount: 500_000_000,
+  targetDate: null,
+  currentValue: 9_000_000,
+  totalInvested: 9_000_000,
+  profitLoss: 0,
+  profitLossPercentage: 0,
+  progressPercentage: 1.8,
+  transactionCount: 1,
+  funds: [],
+}
+
+const baseProps = {
+  goal: mockGoal,
+  locale: 'en',
+  onClose: vi.fn(),
+  onDataChanged: vi.fn(),
+}
+
+describe('DesktopGoalDetail — gold sell uses current price (issue #251)', () => {
+  // Bought 1 chỉ at 9,000,000. Current market price is 9,200,000.
+  const mockGoldTx = {
+    transaction_id: 'tx-gold-1',
+    transaction_type: 'investment',
+    asset_type: 'gold',
+    fund_id: null,
+    fund_name: null,
+    investment_date: '2026-01-01',
+    amount_vnd: 9_000_000,
+    units: 1,
+    interest_rate: null,
+    notes: 'PNJ Gold',
+    principal_withdrawn: null,
+    units_withdrawn: null,
+  }
+
+  beforeEach(() => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [mockGoldTx] }) })
+      }
+      if (url.includes('gold-price')) {
+        return Promise.resolve({ ok: true, json: async () => ({ price_per_chi: 9_200_000 }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+  })
+
+  it('prefills the sale price with the current gold price, not the buy price', async () => {
+    render(<DesktopGoalDetail {...baseProps} />)
+    await waitFor(() => screen.getByText('PNJ Gold'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options' }))
+    await waitFor(() => expect(screen.getByText('Sell')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('Sell'))
+
+    const priceInput = await screen.findByTestId('sell-gold-price-input')
+    // Must be the live market price (9,200,000), not the 9,000,000 buy price.
+    await waitFor(() => expect((priceInput as HTMLInputElement).value).toBe('9200000'))
+  })
+})

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -320,6 +320,50 @@ describe('GoalDetailSheet — investment options Sell / history (issue #224)', (
   })
 })
 
+describe('GoalDetailSheet — gold sell uses current price (issue #251)', () => {
+  // Bought 1 chỉ at 9,000,000. Current market price is 9,200,000.
+  const mockGoldTx = {
+    transaction_id: 'tx-gold-1',
+    transaction_type: 'investment',
+    asset_type: 'gold',
+    fund_id: null,
+    fund_name: null,
+    fund_code: null,
+    investment_date: '2026-01-01',
+    amount_vnd: 9_000_000,
+    units: 1,
+    unit_price: 9_000_000,
+    interest_rate: null,
+    expiry_date: null,
+    notes: 'PNJ Gold',
+    principal_withdrawn: null,
+    units_withdrawn: null,
+  }
+  const goldGoal: GoalData = { ...mockGoal, funds: [] }
+
+  it('prefills the sale price with the current gold price, not the buy price', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [mockGoldTx] }) })
+      }
+      if (url.includes('gold-price')) {
+        return Promise.resolve({ ok: true, json: async () => ({ price_per_chi: 9_200_000 }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    render(<GoalDetailSheet {...baseProps} goal={goldGoal} />)
+    await waitFor(() => screen.getByText('PNJ Gold'))
+    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await waitFor(() => expect(screen.getByText('Sell')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('Sell'))
+
+    const priceInput = await screen.findByTestId('sell-gold-price-input')
+    // Must be the live market price (9,200,000), not the 9,000,000 buy price.
+    await waitFor(() => expect((priceInput as HTMLInputElement).value).toBe('9200000'))
+  })
+})
+
 describe('GoalDetailSheet — refreshKey triggers refetch', () => {
   it('refetches /investment-transactions when refreshKey changes', async () => {
     const fetchMock = vi.fn().mockImplementation((url: string) => {


### PR DESCRIPTION
Fixes #251

## Problem
In the goal-detail **Sell** sheet, selling gold prefilled the sale price with the **buy price** per chỉ instead of the current market price.

`GoalDetailSheet` builds its investment rows from raw transactions and derived `navPerUnit = amount_vnd / units` — i.e. the original purchase cost. Unlike the dashboard overview (which values gold at the live `gold_price_settings.price_per_chi`), it never fetched the current gold price, so the sell sheet's prefilled price was stale.

## Fix
- Fetch `/api/v1/gold-price` when the sheet opens.
- Value remaining gold at the current price per chỉ (`effectiveUnits × price_per_chi`), accounting for any partial withdrawals — mirroring the dashboard overview's gold valuation.
- This makes `navPerUnit` (and the prefilled sale price) the live market price. Cost basis still uses the original purchase principal for gain/loss.

## Test (TDD)
Added a failing-first test in `GoalDetailSheet.test.tsx` that opens the gold Sell sheet and asserts `sell-gold-price-input` prefills with the current price (9,200,000) rather than the 9,000,000 buy price.

🤖 Generated with [Claude Code](https://claude.com/claude-code)