### PR TITLE
fix(sell): pad desktop Sell modal body below the header divider (#256)

### DIFF
--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -305,8 +305,10 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess, des
           </button>
         </div>
 
-        {/* Scrollable body — wraps both success and form states */}
-        <div style={{ flex: 1, overflowY: 'auto', padding: '0 16px 32px' }}>
+        {/* Scrollable body — wraps both success and form states. Desktop adds a
+            top gap so the item card doesn't sit flush against the header divider
+            (issue #256); mobile relies on the header's own bottom padding. */}
+        <div data-testid="sell-body" style={{ flex: 1, overflowY: 'auto', padding: desktop ? '16px 16px 32px' : '0 16px 32px' }}>
         {confirmed ? (
           // ── Success state ────────────────────────────────────────────────
           <div data-testid="sell-success" style={{ padding: '32px 0', textAlign: 'center' }}>

--- a/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
+++ b/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
@@ -86,4 +86,10 @@ describe('SellWithdrawSheet — responsive presentation (#248)', () => {
     render(<SellWithdrawSheet item={item} open context="unallocated" desktop onClose={vi.fn()} onSuccess={vi.fn()} />)
     expect(screen.getByTestId('sell-sheet').style.alignItems).toBe('center')
   })
+
+  // issue #256 — on desktop the item card sat flush against the header divider.
+  it('pads the body below the header divider on desktop', () => {
+    render(<SellWithdrawSheet item={item} open context="unallocated" desktop onClose={vi.fn()} onSuccess={vi.fn()} />)
+    expect(screen.getByTestId('sell-body').style.paddingTop).toBe('16px')
+  })
 })


### PR DESCRIPTION
Fixes #256

## Problem
On desktop, the centered Sell/Withdraw modal (`SellWithdrawSheet`) rendered its scrollable body with `padding: '0 16px 32px'` — **zero top padding**. So the item summary card (e.g. the DOJI gold card) sat flush against the header divider with no breathing room, as the red arrow in the issue screenshot shows.

## Fix
Give the body a 16px top gap on desktop (`16px 16px 32px`); mobile keeps `0` top and relies on the header's own bottom padding, so the bottom-sheet layout is unchanged.

The sibling desktop goal-detail sell modal (`DModal`-based) already pads its body (`18px 20px`), so no change was needed there.

## Test (TDD)
Added a failing-first test in the `#248 responsive presentation` block asserting the desktop body's `paddingTop` is `16px`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)