### PR TITLE
refactor(goal-detail): extract shared helpers + invRows valuation (#250)

### DIFF
--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useState, useEffect, useMemo } from 'react'
-import { ChevronLeft, X, TrendingUp, Building, CircleDollarSign, BarChart2, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield } from 'lucide-react'
+import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
-import type { GoalData, FundBreakdownItem } from '../DashboardClient'
+import type { GoalData } from '../DashboardClient'
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, type InvRow } from './goalDetailShared'
 
 interface InvestmentTx {
   transaction_id: string
@@ -20,18 +21,6 @@ interface InvestmentTx {
   units_withdrawn: number | null
 }
 
-interface InvRow {
-  id: string
-  name: string
-  type: string
-  value: number
-  gainPct: number | null
-  units: number | null
-  principal: number | null
-  interestRate: number | null
-  fund: FundBreakdownItem | null
-}
-
 interface Props {
   goal: GoalData
   locale: string
@@ -44,37 +33,6 @@ interface Props {
    * requiring a hard page reload.
    */
   refreshKey?: number
-}
-
-const GD_COLORS: Record<string, string> = {
-  fund: '#2563eb',
-  bank: '#047857',
-  gold: '#d97706',
-  stock: '#7c3aed',
-}
-
-function TypeIcon({ type, size = 13 }: { type: string; size?: number }) {
-  if (type === 'fund') return <TrendingUp size={size} />
-  if (type === 'bank') return <Building size={size} />
-  if (type === 'gold') return <CircleDollarSign size={size} />
-  return <BarChart2 size={size} />
-}
-
-function calcDeadlineMonths(targetDate: string | null): number {
-  if (!targetDate) return 12
-  const [ty, tm] = targetDate.split('-').map(Number)
-  const now = new Date()
-  return Math.max(1, (ty - now.getFullYear()) * 12 + (tm - 1 - now.getMonth()))
-}
-
-function UnlinkSvg({ size = 18, color = 'currentColor' }: { size?: number; color?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
-      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-      <path d="M2 2l20 20" />
-    </svg>
-  )
 }
 
 export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged, refreshKey }: Props) {
@@ -169,57 +127,8 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
   const isComplete = (goal.progressPercentage ?? 0) >= 100
   const progress = Math.min(goal.progressPercentage ?? 0, 100)
 
-  // Build investment rows
-  const investmentRows = transactions.filter((tx) => tx.transaction_type !== 'withdrawal')
-  const deduped = new Map<string, InvestmentTx>()
-  investmentRows.forEach((tx) => {
-    if (tx.fund_id) {
-      if (!deduped.has(tx.fund_id)) deduped.set(tx.fund_id, tx)
-    } else {
-      deduped.set(tx.transaction_id, tx)
-    }
-  })
-  const investTxRows = Array.from(deduped.values())
-  const fundMap = new Map(goal.funds.map((f) => [f.fundId, f]))
-
-  const invRows: InvRow[] = investTxRows.map((tx) => {
-    const fund = tx.fund_id ? fundMap.get(tx.fund_id) ?? null : null
-    const name = fund?.fundName ?? tx.notes ?? (
-      tx.asset_type === 'bank' ? (isVi ? 'Tiền gửi' : 'Bank deposit') :
-      tx.asset_type === 'gold' ? (isVi ? 'Vàng' : 'Gold') : tx.asset_type
-    )
-    let value: number, gainPct: number | null, units: number | null, principal: number | null
-    if (fund) {
-      value = fund.currentValue
-      gainPct = fund.profitLossPercentage
-      units = fund.quantity
-      principal = null
-    } else if (tx.asset_type === 'bank' && tx.interest_rate) {
-      const months = Math.max(0, Math.floor(
-        (Date.now() - new Date(tx.investment_date).getTime()) / (1000 * 60 * 60 * 24 * 30.44)
-      ))
-      value = Math.round(tx.amount_vnd * Math.pow(1 + tx.interest_rate / 100 / 12, months))
-      gainPct = tx.amount_vnd > 0 ? ((value - tx.amount_vnd) / tx.amount_vnd) * 100 : 0
-      units = null
-      principal = tx.amount_vnd
-    } else if (tx.asset_type === 'gold' && goldPricePerChi && tx.units) {
-      // Value remaining gold at the current market price per chỉ so the sell
-      // modal prefills today's price, not the buy price (issue #251). Mirrors
-      // the dashboard overview's gold valuation.
-      const effectiveUnits = tx.units - (tx.units_withdrawn ?? 0)
-      const effectivePrincipal = tx.amount_vnd - (tx.principal_withdrawn ?? 0)
-      value = effectiveUnits * goldPricePerChi
-      gainPct = effectivePrincipal > 0 ? ((value - effectivePrincipal) / effectivePrincipal) * 100 : null
-      units = effectiveUnits
-      principal = effectivePrincipal
-    } else {
-      value = tx.amount_vnd
-      gainPct = null
-      units = tx.units
-      principal = tx.amount_vnd
-    }
-    return { id: tx.transaction_id, name, type: tx.asset_type, value, gainPct, units, principal, interestRate: tx.interest_rate, fund: fund ?? null }
-  })
+  // Build investment rows (shared with the mobile sheet's valuation logic).
+  const invRows: InvRow[] = buildInvRows(transactions, goal.funds, goldPricePerChi, isVi)
 
   // Composition segments
   const breakdown: Record<string, number> = {}

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -3,7 +3,6 @@
 import { useState, useEffect } from 'react'
 import {
   ChevronLeft, ChevronRight, MoreHorizontal,
-  TrendingUp, Building, CircleDollarSign, BarChart2,
   Edit2, Trash2, Calendar, Download, ArrowDownRight, ArrowUpRight, Target,
 } from 'lucide-react'
 import { useLocale } from 'next-intl'
@@ -11,17 +10,7 @@ import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData, FundBreakdownItem } from '../DashboardClient'
 import TransactionHistorySheet, { type PurchaseHistoryRow } from './TransactionHistorySheet'
 import { SellWithdrawSheet, type SellItem } from './SellWithdrawSheet'
-
-// Same SVG as DesktopGoalDetail.UnlinkSvg — matches design's "unlink" glyph
-function UnlinkSvg({ size = 20, color = 'currentColor' }: { size?: number; color?: string }) {
-  return (
-    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
-      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
-      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
-      <path d="M2 2l20 20" />
-    </svg>
-  )
-}
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, type InvRow } from './goalDetailShared'
 
 interface InvestmentTx {
   transaction_id: string
@@ -53,27 +42,6 @@ interface Props {
    * without requiring a hard page reload.
    */
   refreshKey?: number
-}
-
-const GD_COLORS: Record<string, string> = {
-  fund: '#2563eb',
-  bank: '#047857',
-  gold: '#d97706',
-  stock: '#7c3aed',
-}
-
-function calcDeadlineMonths(targetDate: string | null): number {
-  if (!targetDate) return 12
-  const [ty, tm] = targetDate.split('-').map(Number)
-  const now = new Date()
-  return Math.max(1, (ty - now.getFullYear()) * 12 + (tm - 1 - now.getMonth()))
-}
-
-function TypeIcon({ type, size = 16 }: { type: string; size?: number }) {
-  if (type === 'fund') return <TrendingUp size={size} />
-  if (type === 'bank') return <Building size={size} />
-  if (type === 'gold') return <CircleDollarSign size={size} />
-  return <BarChart2 size={size} />
 }
 
 function GoalActionsSheet({
@@ -333,17 +301,6 @@ function EditGoalSheet({
       </div>
     </div>
   )
-}
-
-interface InvRow {
-  id: string
-  name: string
-  type: string
-  value: number
-  gainPct: number | null
-  units: number | null
-  principal: number | null
-  fund: FundBreakdownItem | null
 }
 
 // Mirror of DashboardClient.openSellFund / openSellNonFund so the goal-detail
@@ -778,58 +735,12 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   const exceededTarget = goal.progressPercentage !== null && goal.progressPercentage >= 100
   const isPositive = goal.profitLoss >= 0
 
-  const investmentRows = transactions.filter((tx) => tx.transaction_type !== 'withdrawal')
-  const deduped = new Map<string, InvestmentTx>()
-  investmentRows.forEach((tx) => {
-    if (tx.fund_id) {
-      if (!deduped.has(tx.fund_id)) deduped.set(tx.fund_id, tx)
-    } else {
-      deduped.set(tx.transaction_id, tx)
-    }
-  })
-  const investTxRows = Array.from(deduped.values())
+  const fundMap = new Map(goal.funds.map((f) => [f.fundId, f]))
 
-  const fundItems = goal.funds
-  const fundMap = new Map(fundItems.map((f) => [f.fundId, f]))
-
-  // Build typed investment rows for the Investments tab
-  const invRows: InvRow[] = investTxRows.map((tx) => {
-    const fund = tx.fund_id ? fundMap.get(tx.fund_id) ?? null : null
-    const name = fund?.fundName ?? tx.notes ?? (tx.asset_type === 'bank' ? (isVI ? 'Tiền gửi' : 'Bank deposit') : tx.asset_type === 'gold' ? (isVI ? 'Vàng' : 'Gold') : tx.asset_type)
-
-    let value: number, gainPct: number | null, units: number | null, principal: number | null
-    if (fund) {
-      value = fund.currentValue
-      gainPct = fund.profitLossPercentage
-      units = fund.quantity
-      principal = null
-    } else if (tx.asset_type === 'bank' && tx.interest_rate) {
-      const months = Math.max(0, Math.floor(
-        (Date.now() - new Date(tx.investment_date).getTime()) / (1000 * 60 * 60 * 24 * 30.44)
-      ))
-      value = Math.round(tx.amount_vnd * Math.pow(1 + tx.interest_rate / 100 / 12, months))
-      gainPct = tx.amount_vnd > 0 ? ((value - tx.amount_vnd) / tx.amount_vnd) * 100 : 0
-      units = null
-      principal = tx.amount_vnd
-    } else if (tx.asset_type === 'gold' && goldPricePerChi && tx.units) {
-      // Value remaining gold at the current market price per chỉ so the sell
-      // sheet prefills today's price, not the buy price (issue #251). Mirrors
-      // the dashboard overview's gold valuation.
-      const effectiveUnits = tx.units - (tx.units_withdrawn ?? 0)
-      const effectivePrincipal = tx.amount_vnd - (tx.principal_withdrawn ?? 0)
-      value = effectiveUnits * goldPricePerChi
-      gainPct = effectivePrincipal > 0 ? ((value - effectivePrincipal) / effectivePrincipal) * 100 : null
-      units = effectiveUnits
-      principal = effectivePrincipal
-    } else {
-      value = tx.amount_vnd
-      gainPct = null
-      units = tx.units
-      principal = tx.amount_vnd
-    }
-
-    return { id: tx.transaction_id, name, type: tx.asset_type, value, gainPct, units, principal, fund: fund ?? null }
-  }).filter((row) => !unassignedIds.includes(row.id))
+  // Build typed investment rows for the Investments tab, then drop any
+  // optimistically-unassigned ones.
+  const invRows: InvRow[] = buildInvRows(transactions, goal.funds, goldPricePerChi, isVI)
+    .filter((row) => !unassignedIds.includes(row.id))
 
   // Calculator
   const remaining = goal.targetAmount ? Math.max(goal.targetAmount - goal.currentValue, 0) : 0

--- a/app/assets/components/__tests__/goalDetailShared.test.tsx
+++ b/app/assets/components/__tests__/goalDetailShared.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest'
+import { buildInvRows, calcDeadlineMonths, type GoalDetailTx } from '../goalDetailShared'
+import type { FundBreakdownItem } from '../../DashboardClient'
+
+const baseTx = (over: Partial<GoalDetailTx>): GoalDetailTx => ({
+  transaction_id: 't', transaction_type: 'investment', asset_type: 'gold',
+  fund_id: null, investment_date: '2026-01-01', amount_vnd: 0, units: null,
+  interest_rate: null, notes: null, principal_withdrawn: null, units_withdrawn: null,
+  ...over,
+})
+
+const fund: FundBreakdownItem = {
+  fundId: 'f1', fundName: 'VESAF', fundType: 'equity', quantity: 100,
+  currentNAV: 25_000, currentValue: 2_500_000, purchasePrice: 22_000,
+  profitLoss: 300_000, profitLossPercentage: 13.64, goalId: 'g1',
+} as FundBreakdownItem
+
+describe('buildInvRows', () => {
+  it('values gold at the live price per chỉ, net of withdrawn units (issue #251)', () => {
+    const rows = buildInvRows(
+      [baseTx({ transaction_id: 'g1', asset_type: 'gold', amount_vnd: 9_000_000, units: 1 })],
+      [], 9_200_000, false,
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].value).toBe(9_200_000)         // 1 chỉ × current price
+    expect(rows[0].units).toBe(1)
+    expect(rows[0].principal).toBe(9_000_000)     // cost basis preserved
+  })
+
+  it('falls back to cost when no gold price is available', () => {
+    const rows = buildInvRows(
+      [baseTx({ transaction_id: 'g1', asset_type: 'gold', amount_vnd: 9_000_000, units: 1 })],
+      [], null, false,
+    )
+    expect(rows[0].value).toBe(9_000_000)
+  })
+
+  it('compounds bank interest monthly and reports principal', () => {
+    const rows = buildInvRows(
+      [baseTx({ transaction_id: 'b1', asset_type: 'bank', amount_vnd: 5_000_000, interest_rate: 6 })],
+      [], null, false,
+    )
+    expect(rows[0].value).toBeGreaterThanOrEqual(5_000_000)
+    expect(rows[0].principal).toBe(5_000_000)
+    expect(rows[0].units).toBeNull()
+  })
+
+  it('uses the fund current value and dedups multiple txs of the same fund', () => {
+    const rows = buildInvRows(
+      [
+        baseTx({ transaction_id: 'x1', asset_type: 'fund', fund_id: 'f1', amount_vnd: 1_000_000 }),
+        baseTx({ transaction_id: 'x2', asset_type: 'fund', fund_id: 'f1', amount_vnd: 1_000_000 }),
+      ],
+      [fund], null, false,
+    )
+    expect(rows).toHaveLength(1)               // one row per fund
+    expect(rows[0].value).toBe(2_500_000)      // fund.currentValue
+    expect(rows[0].fund?.fundId).toBe('f1')
+  })
+
+  it('drops withdrawal rows', () => {
+    const rows = buildInvRows(
+      [
+        baseTx({ transaction_id: 'g1', asset_type: 'gold', amount_vnd: 9_000_000, units: 1 }),
+        baseTx({ transaction_id: 'w1', transaction_type: 'withdrawal', asset_type: 'gold' }),
+      ],
+      [], 9_200_000, false,
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('g1')
+  })
+
+  it('localises bank/gold names when isVi', () => {
+    const rows = buildInvRows(
+      [baseTx({ transaction_id: 'g1', asset_type: 'gold', amount_vnd: 1, units: 1, notes: null })],
+      [], 9_200_000, true,
+    )
+    expect(rows[0].name).toBe('Vàng')
+  })
+})
+
+describe('calcDeadlineMonths', () => {
+  it('defaults to 12 when no target date', () => {
+    expect(calcDeadlineMonths(null)).toBe(12)
+  })
+  it('never returns below 1', () => {
+    expect(calcDeadlineMonths('2000-01')).toBe(1)
+  })
+})

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -1,0 +1,128 @@
+// Shared helpers for the goal-detail views (GoalDetailSheet on mobile,
+// DesktopGoalDetail on desktop). Both render the same data with different
+// chrome, so the icons, colours, deadline math and — most importantly — the
+// investment-row valuation live here to stay in sync.
+
+import { TrendingUp, Building, CircleDollarSign, BarChart2 } from 'lucide-react'
+import type { FundBreakdownItem } from '../DashboardClient'
+
+export const GD_COLORS: Record<string, string> = {
+  fund: '#2563eb',
+  bank: '#047857',
+  gold: '#d97706',
+  stock: '#7c3aed',
+}
+
+export function calcDeadlineMonths(targetDate: string | null): number {
+  if (!targetDate) return 12
+  const [ty, tm] = targetDate.split('-').map(Number)
+  const now = new Date()
+  return Math.max(1, (ty - now.getFullYear()) * 12 + (tm - 1 - now.getMonth()))
+}
+
+export function TypeIcon({ type, size = 16 }: { type: string; size?: number }) {
+  if (type === 'fund') return <TrendingUp size={size} />
+  if (type === 'bank') return <Building size={size} />
+  if (type === 'gold') return <CircleDollarSign size={size} />
+  return <BarChart2 size={size} />
+}
+
+// The design's "unlink" glyph, used by the unassign-from-goal affordance.
+export function UnlinkSvg({ size = 18, color = 'currentColor' }: { size?: number; color?: string }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke={color} strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+      <path d="M2 2l20 20" />
+    </svg>
+  )
+}
+
+export interface InvRow {
+  id: string
+  name: string
+  type: string
+  value: number
+  gainPct: number | null
+  units: number | null
+  principal: number | null
+  interestRate: number | null
+  fund: FundBreakdownItem | null
+}
+
+// Minimal shape buildInvRows needs — both views' richer InvestmentTx types
+// are structurally assignable to this.
+export interface GoalDetailTx {
+  transaction_id: string
+  transaction_type: string
+  asset_type: string
+  fund_id: string | null
+  investment_date: string
+  amount_vnd: number
+  units: number | null
+  interest_rate: number | null
+  notes: string | null
+  principal_withdrawn: number | null
+  units_withdrawn: number | null
+}
+
+// Dedup to one row per fund / per non-fund tx, then value each holding:
+// funds at their current value, bank deposits at compounded interest, gold at
+// the live price per chỉ net of any partial withdrawal (issue #251), and
+// everything else at cost. Returns rows unfiltered — callers apply their own
+// optimistic unassign filter.
+export function buildInvRows(
+  transactions: GoalDetailTx[],
+  funds: FundBreakdownItem[],
+  goldPricePerChi: number | null,
+  isVi: boolean,
+): InvRow[] {
+  const investmentRows = transactions.filter((tx) => tx.transaction_type !== 'withdrawal')
+  const deduped = new Map<string, GoalDetailTx>()
+  investmentRows.forEach((tx) => {
+    if (tx.fund_id) {
+      if (!deduped.has(tx.fund_id)) deduped.set(tx.fund_id, tx)
+    } else {
+      deduped.set(tx.transaction_id, tx)
+    }
+  })
+  const fundMap = new Map(funds.map((f) => [f.fundId, f]))
+
+  return Array.from(deduped.values()).map((tx) => {
+    const fund = tx.fund_id ? fundMap.get(tx.fund_id) ?? null : null
+    const name = fund?.fundName ?? tx.notes ?? (
+      tx.asset_type === 'bank' ? (isVi ? 'Tiền gửi' : 'Bank deposit') :
+      tx.asset_type === 'gold' ? (isVi ? 'Vàng' : 'Gold') : tx.asset_type
+    )
+
+    let value: number, gainPct: number | null, units: number | null, principal: number | null
+    if (fund) {
+      value = fund.currentValue
+      gainPct = fund.profitLossPercentage
+      units = fund.quantity
+      principal = null
+    } else if (tx.asset_type === 'bank' && tx.interest_rate) {
+      const months = Math.max(0, Math.floor(
+        (Date.now() - new Date(tx.investment_date).getTime()) / (1000 * 60 * 60 * 24 * 30.44)
+      ))
+      value = Math.round(tx.amount_vnd * Math.pow(1 + tx.interest_rate / 100 / 12, months))
+      gainPct = tx.amount_vnd > 0 ? ((value - tx.amount_vnd) / tx.amount_vnd) * 100 : 0
+      units = null
+      principal = tx.amount_vnd
+    } else if (tx.asset_type === 'gold' && goldPricePerChi && tx.units) {
+      const effectiveUnits = tx.units - (tx.units_withdrawn ?? 0)
+      const effectivePrincipal = tx.amount_vnd - (tx.principal_withdrawn ?? 0)
+      value = effectiveUnits * goldPricePerChi
+      gainPct = effectivePrincipal > 0 ? ((value - effectivePrincipal) / effectivePrincipal) * 100 : null
+      units = effectiveUnits
+      principal = effectivePrincipal
+    } else {
+      value = tx.amount_vnd
+      gainPct = null
+      units = tx.units
+      principal = tx.amount_vnd
+    }
+
+    return { id: tx.transaction_id, name, type: tx.asset_type, value, gainPct, units, principal, interestRate: tx.interest_rate ?? null, fund: fund ?? null }
+  })
+}


### PR DESCRIPTION
Part of #250 — first of the mobile/desktop dedup PRs.

`GoalDetailSheet` (mobile) and `DesktopGoalDetail` (desktop) render the same goal data with different chrome, and each carried ~100 lines of duplicated logic.

## What moved to `app/assets/components/goalDetailShared.tsx`
- `GD_COLORS`, `calcDeadlineMonths`, `TypeIcon`, `UnlinkSvg`
- the `InvRow` type
- **`buildInvRows`** — the investment-row dedup + valuation: funds at current value, bank deposits at compounded interest, gold at the live price per chỉ net of withdrawals (issue #251), everything else at cost.

Both views now import these. **No behavior change** — each view still applies its own optimistic unassign filter (mobile inline; desktop via `visibleInvRows`), and all icon call sites already pass explicit `size`.

## Net
~202 duplicated lines removed from the two components, replaced by one shared 128-line module + an 89-line unit test.

## Verification
- `tsc --noEmit` clean; `eslint` clean (no unused).
- `GoalDetailSheet`, `DesktopGoalDetail`, and the new `goalDetailShared` tests all green (23 tests) — including the issue #251 gold-sell assertions on both views, which exercise `buildInvRows` end-to-end.
- Full suite unchanged (the one `TransactionHistorySheet` failure is pre-existing on `main`, green in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)