### PR TITLE
refactor(insurance): extract shared status helpers (#250)

### DIFF
--- a/app/assets/components/DesktopInsuranceDetail.tsx
+++ b/app/assets/components/DesktopInsuranceDetail.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react'
 import { Check, ChevronLeft, Edit2, Plus, Trash2, Calendar, X } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
-import { insurancePaidYear } from '@/lib/finance'
+import { STATUS_COLOR, BAR_COLOR_DETAIL, insurancePaidState, insuranceStatusLabel } from './insuranceShared'
 import type { InsuranceData } from '../DashboardClient'
 import LogInsurancePaymentModal from './LogInsurancePaymentModal'
 
@@ -12,22 +12,6 @@ interface Props {
   locale: string
   onClose: () => void
   onChanged?: () => void
-}
-
-const STATUS_COLOR: Record<string, string> = {
-  on_track: 'var(--c-muted)',
-  upcoming: 'var(--c-warn)',
-  overdue: 'var(--c-neg)',
-  completed: 'var(--c-pos)',
-  ready: 'var(--c-navy)',
-}
-
-const BAR_COLOR: Record<string, string> = {
-  on_track: 'var(--c-warn)',
-  upcoming: 'var(--c-warn)',
-  overdue: 'var(--c-neg)',
-  completed: 'var(--c-pos)',
-  ready: 'var(--c-navy)',
 }
 
 const COVERAGE_OPTIONS: { value: string; label: string; labelVi: string }[] = [
@@ -58,10 +42,9 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
   // Once the current year's premium is settled, the member presents a "paid"
   // state (green badge + saving-for-next-year framing) regardless of the
   // recomputed due-date status.
-  const paidYear = insurancePaidYear(ins.lastPaymentDate)
+  const { paidYear, effectiveStatus } = insurancePaidState(ins.status, ins.lastPaymentDate)
   const paidThisYear = paidYear !== null
-  const effectiveStatus = paidThisYear ? 'completed' : ins.status
-  const barColor = BAR_COLOR[effectiveStatus] ?? 'var(--c-warn)'
+  const barColor = BAR_COLOR_DETAIL[effectiveStatus] ?? 'var(--c-warn)'
   const dotColor = STATUS_COLOR[effectiveStatus] ?? 'var(--c-muted)'
 
   const [editing, setEditing] = useState(false)
@@ -110,12 +93,6 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
   }, [ins.insuranceId])
 
   useEffect(() => { loadHistory() }, [loadHistory])
-
-  function statusLabel(s: string) {
-    return isVi
-      ? ({ on_track: 'Chưa đến hạn', completed: 'Đã thanh toán', overdue: 'Quá hạn', upcoming: 'Sắp đến hạn', ready: 'Đã tích lũy đủ' } as Record<string, string>)[s] ?? s
-      : ({ on_track: 'Not due', completed: 'Paid', overdue: 'Overdue', upcoming: 'Due soon', ready: 'Ready to pay' } as Record<string, string>)[s] ?? s
-  }
 
   // Two independent actions:
   // - "Mark as paid" (shown until the year's premium is settled) → confirm the
@@ -287,7 +264,7 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
                 <span style={{ fontSize: 11, fontWeight: 600, color: dotColor }}>
                   {paidThisYear
                     ? (isVi ? `Đã thanh toán ${paidYear}` : `Paid for ${paidYear}`)
-                    : statusLabel(ins.status)}
+                    : insuranceStatusLabel(ins.status, isVi)}
                 </span>
               </div>
             </div>

--- a/app/assets/components/DesktopInsuranceList.tsx
+++ b/app/assets/components/DesktopInsuranceList.tsx
@@ -3,7 +3,7 @@
 import { useState } from 'react'
 import { Shield, Plus, AlertTriangle } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
-import { insurancePaidYear } from '@/lib/finance'
+import { STATUS_COLOR, BAR_COLOR, insurancePaidState, insuranceStatusLabel } from './insuranceShared'
 import type { InsuranceData } from '../DashboardClient'
 
 interface Props {
@@ -16,22 +16,6 @@ interface Props {
 
 const DISMISS_KEY = 'cairn.insuranceCoachDismissed'
 
-const STATUS_COLOR: Record<string, string> = {
-  on_track:  'var(--c-muted)',
-  upcoming:  'var(--c-warn)',
-  overdue:   'var(--c-neg)',
-  completed: 'var(--c-pos)',
-  ready:     'var(--c-navy)',
-}
-
-const BAR_COLOR: Record<string, string> = {
-  on_track:  'var(--c-warn)',
-  upcoming:  'var(--c-warn)',
-  overdue:   'var(--c-neg)',
-  completed: 'var(--c-pos)',
-  ready:     'var(--c-warn)',
-}
-
 export default function DesktopInsuranceList({ insurance, locale, goalCount, onOpen, onAdd }: Props) {
   const isVi = locale === 'vi'
   const isEmpty = insurance.length === 0
@@ -42,12 +26,6 @@ export default function DesktopInsuranceList({ insurance, locale, goalCount, onO
   function dismissCoach() {
     setCoachDismissed(true)
     try { localStorage.setItem(DISMISS_KEY, '1') } catch { /* ignore */ }
-  }
-
-  function statusLabel(s: string) {
-    return isVi
-      ? ({ on_track: 'Chưa đến hạn', completed: 'Đã thanh toán', overdue: 'Quá hạn', upcoming: 'Sắp đến hạn', ready: 'Đã tích lũy đủ' } as Record<string, string>)[s] ?? s
-      : ({ on_track: 'Not due', completed: 'Paid', overdue: 'Overdue', upcoming: 'Due soon', ready: 'Ready to pay' } as Record<string, string>)[s] ?? s
   }
 
   return (
@@ -147,14 +125,13 @@ export default function DesktopInsuranceList({ insurance, locale, goalCount, onO
 
       {/* Rows */}
       {insurance.map((ins, i) => {
-        const paidYear = insurancePaidYear(ins.lastPaymentDate)
-        const effectiveStatus = paidYear !== null ? 'completed' : ins.status
+        const { paidYear, effectiveStatus } = insurancePaidState(ins.status, ins.lastPaymentDate)
         const dotColor = STATUS_COLOR[effectiveStatus] ?? 'var(--c-muted)'
         const barColor = BAR_COLOR[effectiveStatus] ?? 'var(--c-warn)'
         const progress = Math.min(ins.savingsProgressPercentage, 100)
         const rowLabel = paidYear !== null
           ? (isVi ? `Đã thanh toán ${paidYear}` : `Paid for ${paidYear}`)
-          : statusLabel(ins.status)
+          : insuranceStatusLabel(ins.status, isVi)
         const isLast = i === insurance.length - 1
 
         return (

--- a/app/assets/components/InsuranceCard.tsx
+++ b/app/assets/components/InsuranceCard.tsx
@@ -3,7 +3,7 @@
 import { Shield, ChevronRight } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { fmtCompact } from '@/lib/formatters'
-import { insurancePaidYear } from '@/lib/finance'
+import { STATUS_COLOR, BAR_COLOR, insurancePaidState } from './insuranceShared'
 
 interface Props {
   insuranceId: string
@@ -18,30 +18,13 @@ interface Props {
   onClick?: () => void
 }
 
-const STATUS_COLOR: Record<string, string> = {
-  on_track:  'var(--c-muted)',
-  upcoming:  'var(--c-warn)',
-  overdue:   'var(--c-neg)',
-  completed: 'var(--c-pos)',
-  ready:     'var(--c-navy)',
-}
-
-const BAR_COLOR: Record<string, string> = {
-  on_track:  'var(--c-warn)',
-  upcoming:  'var(--c-warn)',
-  overdue:   'var(--c-neg)',
-  completed: 'var(--c-pos)',
-  ready:     'var(--c-warn)',
-}
-
 export default function InsuranceCard({
   insuranceName, coverageType, annualPremium, amountSaved,
   savingsProgressPercentage, status, lastPaymentDate, isLast, onClick,
 }: Props) {
   const t = useTranslations('dashboard')
 
-  const paidYear = insurancePaidYear(lastPaymentDate ?? null)
-  const effectiveStatus = paidYear !== null ? 'completed' : status
+  const { paidYear, effectiveStatus } = insurancePaidState(status, lastPaymentDate)
   const dotColor = STATUS_COLOR[effectiveStatus] ?? 'var(--c-muted)'
   const bar = BAR_COLOR[effectiveStatus] ?? 'var(--c-warn)'
   const progress = Math.min(savingsProgressPercentage, 100)

--- a/app/assets/components/__tests__/insuranceShared.test.ts
+++ b/app/assets/components/__tests__/insuranceShared.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import {
+  STATUS_COLOR,
+  BAR_COLOR,
+  BAR_COLOR_DETAIL,
+  insurancePaidState,
+  insuranceStatusLabel,
+} from '../insuranceShared'
+
+describe('STATUS_COLOR', () => {
+  it('maps each status to its dot/badge colour', () => {
+    expect(STATUS_COLOR.on_track).toBe('var(--c-muted)')
+    expect(STATUS_COLOR.upcoming).toBe('var(--c-warn)')
+    expect(STATUS_COLOR.overdue).toBe('var(--c-neg)')
+    expect(STATUS_COLOR.completed).toBe('var(--c-pos)')
+    expect(STATUS_COLOR.ready).toBe('var(--c-navy)')
+  })
+})
+
+describe('BAR_COLOR vs BAR_COLOR_DETAIL', () => {
+  it('paints a ready member amber in the compact list/card', () => {
+    expect(BAR_COLOR.ready).toBe('var(--c-warn)')
+  })
+  it('paints a ready member navy in the detail view', () => {
+    expect(BAR_COLOR_DETAIL.ready).toBe('var(--c-navy)')
+  })
+  it('differs only on the ready key', () => {
+    ;(['on_track', 'upcoming', 'overdue', 'completed'] as const).forEach((k) => {
+      expect(BAR_COLOR_DETAIL[k]).toBe(BAR_COLOR[k])
+    })
+  })
+})
+
+describe('insurancePaidState', () => {
+  it('keeps the original status when there is no recorded payment', () => {
+    expect(insurancePaidState('ready', null)).toEqual({ paidYear: null, effectiveStatus: 'ready' })
+    expect(insurancePaidState('overdue', undefined)).toEqual({ paidYear: null, effectiveStatus: 'overdue' })
+  })
+  it('presents a member paid in the current year as completed', () => {
+    const year = new Date().getFullYear()
+    const { paidYear, effectiveStatus } = insurancePaidState('overdue', `${year}-06-15`)
+    expect(paidYear).toBe(year)
+    expect(effectiveStatus).toBe('completed')
+  })
+})
+
+describe('insuranceStatusLabel', () => {
+  it('returns Vietnamese labels', () => {
+    expect(insuranceStatusLabel('ready', true)).toBe('Đã tích lũy đủ')
+    expect(insuranceStatusLabel('completed', true)).toBe('Đã thanh toán')
+  })
+  it('returns English labels', () => {
+    expect(insuranceStatusLabel('ready', false)).toBe('Ready to pay')
+    expect(insuranceStatusLabel('on_track', false)).toBe('Not due')
+  })
+  it('falls back to the raw status for unknown values', () => {
+    expect(insuranceStatusLabel('weird', false)).toBe('weird')
+  })
+})

--- a/app/assets/components/insuranceShared.ts
+++ b/app/assets/components/insuranceShared.ts
@@ -1,0 +1,47 @@
+// Shared helpers for the insurance views — DesktopInsuranceDetail and
+// DesktopInsuranceList (desktop) plus InsuranceCard (mobile). They render the
+// same member data with different chrome, so the status colours, the
+// "paid this year → completed" rule and the desktop status labels live here to
+// stay in sync.
+
+import { insurancePaidYear } from '@/lib/finance'
+
+// Dot / badge colour by status — identical across all insurance views.
+export const STATUS_COLOR: Record<string, string> = {
+  on_track:  'var(--c-muted)',
+  upcoming:  'var(--c-warn)',
+  overdue:   'var(--c-neg)',
+  completed: 'var(--c-pos)',
+  ready:     'var(--c-navy)',
+}
+
+// Progress-bar colour. The compact list/card paint a "ready" member amber to
+// nudge action; the detail view paints it navy to match its richer
+// "ready to pay" note (BAR_COLOR_DETAIL overrides only the ready key).
+export const BAR_COLOR: Record<string, string> = {
+  on_track:  'var(--c-warn)',
+  upcoming:  'var(--c-warn)',
+  overdue:   'var(--c-neg)',
+  completed: 'var(--c-pos)',
+  ready:     'var(--c-warn)',
+}
+
+export const BAR_COLOR_DETAIL: Record<string, string> = { ...BAR_COLOR, ready: 'var(--c-navy)' }
+
+// Once the current year's premium is settled the member presents as "completed"
+// (paid) regardless of the recomputed due-date status, and we surface the paid
+// year for "Paid for {year}" framing.
+export function insurancePaidState(status: string, lastPaymentDate?: string | null) {
+  const paidYear = insurancePaidYear(lastPaymentDate ?? null)
+  const effectiveStatus = paidYear !== null ? 'completed' : status
+  return { paidYear, effectiveStatus }
+}
+
+// Hardcoded status labels for the desktop views. The mobile InsuranceCard uses
+// next-intl instead, so it intentionally does not share this.
+export function insuranceStatusLabel(status: string, isVi: boolean): string {
+  const labels: Record<string, string> = isVi
+    ? { on_track: 'Chưa đến hạn', completed: 'Đã thanh toán', overdue: 'Quá hạn', upcoming: 'Sắp đến hạn', ready: 'Đã tích lũy đủ' }
+    : { on_track: 'Not due', completed: 'Paid', overdue: 'Overdue', upcoming: 'Due soon', ready: 'Ready to pay' }
+  return labels[status] ?? status
+}


### PR DESCRIPTION
Second dedup pass for #250 (after #260's goal-detail extraction and #269's dead-code removal). The three insurance views each carried their own copy of the status colour maps and the "paid this year → completed" rule; this extracts them into `insuranceShared.ts`, mirroring `goalDetailShared`.

## Extracted (`insuranceShared.ts`)
- `STATUS_COLOR` — dot/badge colour (was identical in all three)
- `BAR_COLOR` / `BAR_COLOR_DETAIL` — progress-bar colour
- `insurancePaidState(status, lastPaymentDate)` → `{ paidYear, effectiveStatus }`
- `insuranceStatusLabel(status, isVi)` — desktop hardcoded labels

## Behaviour preserved (pure refactor, no UI change)
- **`ready` bar colour**: the detail view paints it **navy**, list/card paint it **amber** — kept via a `BAR_COLOR_DETAIL` override (only the `ready` key differs).
- **InsuranceCard** keeps its next-intl labels; only the two desktop views share the hardcoded `insuranceStatusLabel()`.

## Tests / verification
- New `insuranceShared.test.ts` (9 cases) written first (TDD), covering both bar palettes and the paid-state rule
- `tsc --noEmit` clean, eslint clean, **352 unit tests passing**
- Net: components −72 lines / shared module +47 (the one pre-existing `TransactionHistorySheet` failure also fails on `main` — unrelated, out of scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)