### PR TITLE
fix(tx-history): parse purchase date as local to avoid month shift

### DIFF
--- a/app/assets/components/TransactionHistorySheet.tsx
+++ b/app/assets/components/TransactionHistorySheet.tsx
@@ -183,6 +183,11 @@ export default function TransactionHistorySheet({
               const amountPaid = row.units != null && row.nav_at_purchase != null
                 ? Math.round(row.units * row.nav_at_purchase)
                 : null
+              // Parse the plain YYYY-MM-DD as a local date so the displayed day
+              // never shifts a month/year for users behind UTC (new Date(str)
+              // would read it as UTC midnight).
+              const [py, pm, pd] = row.purchase_date.slice(0, 10).split('-').map(Number)
+              const purchaseDate = new Date(py, (pm ?? 1) - 1, pd ?? 1)
               return (
                 <div
                   key={i}
@@ -204,7 +209,7 @@ export default function TransactionHistorySheet({
                       {isVI ? 'Mua' : 'Buy'}
                     </div>
                     <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1, fontVariantNumeric: 'tabular-nums' }}>
-                      {new Date(row.purchase_date).toLocaleDateString(isVI ? 'vi-VN' : 'en-US', { day: 'numeric', month: 'short', year: 'numeric' })}
+                      {purchaseDate.toLocaleDateString(isVI ? 'vi-VN' : 'en-US', { day: 'numeric', month: 'short', year: 'numeric' })}
                       {row.units != null && <>{' · '}{fmtUnits(row.units)} {isVI ? 'CCQ' : 'units'}</>}
                     </div>
                   </div>


### PR DESCRIPTION
## Problem
`TransactionHistorySheet` rendered each row's date with `new Date(row.purchase_date)`, which parses a plain `YYYY-MM-DD` string as **UTC midnight**. `toLocaleDateString` then renders in the viewer's local timezone, so for anyone **behind UTC** the displayed day shifts back — e.g. `2024-06-01` shows as **"May 31, 2024"**.

This also caused the `TransactionHistorySheet.test.tsx` "renders each row with Buy label and date · units" test to **pass only on UTC CI and fail locally** in behind-UTC timezones (the surfacing symptom).

## Fix
Parse the date parts into a **local** `Date` (the same idiom already used in `DesktopInsuranceDetail`), with a defensive `slice(0,10)` in case a timestamp is ever passed.

```diff
- {new Date(row.purchase_date).toLocaleDateString(...)}
+ const [py, pm, pd] = row.purchase_date.slice(0, 10).split('-').map(Number)
+ const purchaseDate = new Date(py, (pm ?? 1) - 1, pd ?? 1)
+ {purchaseDate.toLocaleDateString(...)}
```

## Verification
- Full unit suite **353 passing** (was 352 + 1 failing) — confirmed green in the UTC−7 environment that originally exposed the bug
- `tsc --noEmit` clean; no new eslint issues (the one `setState`-in-effect error at line 38 is pre-existing on `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)