### PR TITLE
chore: remove dead code (#250, part 3)

### DIFF
--- a/app/assets/components/InsuranceCard.tsx
+++ b/app/assets/components/InsuranceCard.tsx
@@ -6,7 +6,6 @@ import { fmtCompact } from '@/lib/formatters'
 import { STATUS_COLOR, BAR_COLOR, insurancePaidState } from './insuranceShared'
 
 interface Props {
-  insuranceId: string
   insuranceName: string
   coverageType: string | null
   annualPremium: number

--- a/app/assets/components/__tests__/InsuranceCard.test.tsx
+++ b/app/assets/components/__tests__/InsuranceCard.test.tsx
@@ -9,7 +9,6 @@ vi.mock('next-intl', () => ({
 }))
 
 const baseProps = {
-  insuranceId: 'ins-1',
   insuranceName: 'John Doe',
   coverageType: 'Self',
   annualPremium: 12_000_000,

--- a/lib/scrape-gold.ts
+++ b/lib/scrape-gold.ts
@@ -1,4 +1,4 @@
-export function parseVietnameseNumber(raw: string): number {
+function parseVietnameseNumber(raw: string): number {
   const cleaned = raw.replace(/[^\d.,]/g, '').trim()
   if (/,\d{2}$/.test(cleaned)) {
     return parseFloat(cleaned.replace(/\./g, '').replace(',', '.'))


### PR DESCRIPTION
Third dead-code pass for #250 — the safe UI-layer leftovers found in a repo-wide sweep.

## Removed
- **`InsuranceCard.insuranceId`** — declared in `Props` but never destructured/used. The component receives props via `{...ins}` spread, so callers are unaffected (same situation as the `GoalCard` props removed earlier).
- **`export` on `lib/scrape-gold.ts` → `parseVietnameseNumber`** — the function is used internally in that file, but the export was unused (the test imports the identical copy from `scrape-fund-nav.ts`). Dropped just the `export` keyword.

## Verification
- `tsc --noEmit` clean
- Affected tests pass (InsuranceCard, parseVietnameseNumber)

A separate PR covers the orphaned `/api/v1` routes found in the same sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)