### PR TITLE
ci: shard E2E across 3 parallel runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,17 @@ jobs:
         run: npm test -- --run
 
   e2e:
-    name: E2E Tests
+    name: E2E Shard
     runs-on: ubuntu-latest
     needs: test
+
+    # Split the suite across parallel runners. Each shard runs global.setup,
+    # which provisions its own throwaway user, so the shared Supabase project
+    # stays collision-free (all data is scoped by user_id).
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     steps:
       - uses: actions/checkout@v4
@@ -52,8 +60,8 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
           CRON_SECRET: e2e-placeholder
 
-      - name: Run E2E tests
-        run: npm run test:e2e
+      - name: Run E2E tests (shard ${{ matrix.shard }}/3)
+        run: npm run test:e2e -- --shard=${{ matrix.shard }}/3
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
@@ -66,6 +74,22 @@ jobs:
         uses: actions/upload-artifact@v4
         if: failure()
         with:
-          name: playwright-report
+          name: playwright-report-shard-${{ matrix.shard }}
           path: playwright-report/
           retention-days: 7
+
+  # Single stable gate: green only when every E2E shard passes. Lets branch
+  # protection / merge automation depend on one check name instead of N shards.
+  e2e-complete:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: e2e
+    if: always()
+    steps:
+      - name: Verify all shards passed
+        run: |
+          if [ "${{ needs.e2e.result }}" != "success" ]; then
+            echo "One or more E2E shards did not pass (result: ${{ needs.e2e.result }})"
+            exit 1
+          fi
+          echo "All E2E shards passed"

--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -16,8 +16,10 @@ setup('authenticate', async ({ page }) => {
 
   const admin = createClient(supabaseUrl, serviceRoleKey)
 
-  // Create a throwaway test user — admin API bypasses email verification
-  const email = `e2e-${Date.now()}@test.invalid`
+  // Create a throwaway test user — admin API bypasses email verification.
+  // The random suffix keeps the email unique across parallel CI shards, which
+  // each run this setup against the shared Supabase project.
+  const email = `e2e-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@test.invalid`
   const password = 'TestPass123!'
 
   const { data, error } = await admin.auth.admin.createUser({


### PR DESCRIPTION
## Why E2E is slow
The E2E job runs ~350 tests **serially** (`workers: 1`, `fullyParallel: false`) on a single runner because they share one Supabase test DB. The desktop redesign ~doubled the suite (mobile + `*-desktop` spec pairs), so the serial wall-clock grew to ~12–15 min.

## Change
Split the E2E job into a **3-way matrix shard** (`--shard=N/3`). Each shard is its own runner, so the test phase runs ~3× faster — **no coverage loss, no tests deleted**.

Safety:
- Each shard runs `global.setup` independently → provisions **its own throwaway user**. All tables are scoped by `user_id`, so the shared Supabase project stays collision-free across shards. (`global.teardown` already deletes strictly by that user's id.)
- Hardened the test-user email with a random suffix so two shards starting in the same millisecond can't collide.
- Renamed the matrix job to **`E2E Shard`** and added an **`E2E Tests`** aggregator job that is green only when all shards pass — one stable check name for branch protection / merge automation to depend on.

## Expected result
PR checks will show `E2E Shard (1/2/3)` + a single `E2E Tests` gate. Per-shard wall-clock ≈ build + ~⅓ of the tests.

## Notes
- This is CI config; it can only be fully validated by the run on **this PR** (sharding needs the real E2E Supabase secrets, which aren't available locally — `playwright --list` can't enumerate locally because `helpers/api.ts` instantiates the client at import time).
- ⚠️ If "E2E Tests" was configured as a **required** status check in branch protection, it still works (the new aggregator job keeps that exact name). The three `E2E Shard` checks are informational.
- Build still runs per shard (needed for `npm start`); shards run in parallel so wall-clock is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)