### PR TITLE
test(e2e): harden flaky insurance/investments waits for sharded CI

### DIFF
--- a/e2e/insurance.spec.ts
+++ b/e2e/insurance.spec.ts
@@ -31,8 +31,16 @@ test('can add an insurance member', async ({ page }) => {
 
   await page.locator('#annual_payment_vnd').fill('12000000')
 
-  await page.getByRole('dialog').getByRole('button', { name: /save|add|lưu/i }).click()
-  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5_000 })
+  // Tie the dialog-close assertion to the actual create request so a slow
+  // shared DB (parallel CI shards) can't trip a fixed timeout.
+  await Promise.all([
+    page.waitForResponse(
+      r => r.url().includes('/api/v1/insurance-members') && r.request().method() === 'POST' && r.status() < 400,
+      { timeout: 20_000 }
+    ),
+    page.getByRole('dialog').getByRole('button', { name: /save|add|lưu/i }).click(),
+  ])
+  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 10_000 })
 
   // Scope to table row (avoids hidden sm:hidden mobile cards)
   const memberRow = page.locator('tr').filter({ hasText: 'E2E Insurance Member' }).first()
@@ -65,8 +73,14 @@ test('can edit insurance member annual premium', async ({ page }) => {
   await annualInput.clear()
   await annualInput.fill('24000000')
 
-  await page.getByRole('button', { name: /save|lưu/i }).click()
-  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5_000 })
+  await Promise.all([
+    page.waitForResponse(
+      r => r.url().includes('/api/v1/insurance-members/') && r.request().method() === 'PUT' && r.status() < 400,
+      { timeout: 20_000 }
+    ),
+    page.getByRole('button', { name: /save|lưu/i }).click(),
+  ])
+  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 10_000 })
 
   // Monthly should now be 24,000,000 / 12 = 2,000,000
   const updatedRow = page.locator('tr').filter({ hasText: 'E2E Edit Insurance' }).first()

--- a/e2e/investments.spec.ts
+++ b/e2e/investments.spec.ts
@@ -13,9 +13,11 @@ async function openTransactionsTab(page: import('@playwright/test').Page) {
   await page.evaluate(() => {
     Object.keys(localStorage).filter(k => k.includes('transaction') || k.includes('Transaction')).forEach(k => localStorage.removeItem(k))
   })
-  // Wait for the API response to ensure the table is populated before any assertion
+  // Wait for the API response to ensure the table is populated before any
+  // assertion. Generous timeout + ok() (any 2xx) keeps this robust when the
+  // shared test DB is under concurrent load from parallel CI shards.
   await Promise.all([
-    page.waitForResponse(r => r.url().includes('/api/v1/investment-transactions') && r.status() === 200, { timeout: 20_000 }),
+    page.waitForResponse(r => r.url().includes('/api/v1/investment-transactions') && r.ok(), { timeout: 30_000 }),
     page.goto('/settings?tab=transactions'),
   ])
   await page.waitForSelector('[data-testid="create-btn"]', { timeout: 15_000 })


### PR DESCRIPTION
Follow-up to #276 (E2E sharding). Sharding ~halved E2E wall-clock but put the shared Supabase project under **3× concurrent load**, occasionally pushing requests past tight fixed timeouts. Two tests flaked on #276's first run (passed on re-run, unchanged):
- `insurance.spec.ts:21 "can add an insurance member"` — save dialog didn't close in 5s
- `investments.spec.ts:115 "filter by asset type"` — `/api/v1/investment-transactions` didn't respond in 20s

## Fix — wait on the actual response, not a fixed race
- **`openTransactionsTab` helper** (feeds 6 investment tests): response wait 20s→30s and match any 2xx via `r.ok()` instead of strict `=== 200`.
- **insurance add + edit** (the two save-dialog spots): wrap the Save click in `Promise.all` with `waitForResponse` for the `POST`/`PUT` to `/api/v1/insurance-members` (up to 20s), then assert the dialog closes with a 10s buffer.

Same assertions, no behaviour change — just tied to network completion so a slow shared DB can't trip them.

## Verification
- eslint clean on both specs
- Cannot run E2E locally (needs the E2E Supabase secrets; `helpers/api.ts` instantiates the client at import) — **the sharded CI run on this PR is the validation**. Expectation: all 3 `E2E Shard` jobs + the `E2E Tests` gate go green on the first try.

🤖 Generated with [Claude Code](https://claude.com/claude-code)