### PR TITLE
fix(goal-detail): hide investments fully withdrawn from a goal (#261)

### DIFF
--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -12,6 +12,7 @@ interface InvestmentTx {
   asset_type: string
   fund_id: string | null
   fund_name: string | null
+  parent_transaction_id: string | null
   investment_date: string
   amount_vnd: number
   units: number | null
@@ -533,6 +534,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
         <SellModal
           inv={actionInv}
           isVi={isVi}
+          goalId={goal.goalId}
           onClose={() => setShowSell(false)}
           onSuccess={() => {
             setShowSell(false)
@@ -673,8 +675,8 @@ function UnassignConfirmModal({ inv, unassigning, isVi, onCancel, onConfirm }: {
 }
 
 // ─── Desktop sell / withdraw modal ────────────────────────────────────────
-function SellModal({ inv, isVi, onClose, onSuccess }: {
-  inv: InvRow; isVi: boolean; onClose: () => void; onSuccess: () => void
+function SellModal({ inv, isVi, goalId, onClose, onSuccess }: {
+  inv: InvRow; isVi: boolean; goalId: string; onClose: () => void; onSuccess: () => void
 }) {
   const isFund = inv.type === 'fund'
   const isGold = inv.type === 'gold'
@@ -773,7 +775,7 @@ function SellModal({ inv, isVi, onClose, onSuccess }: {
             fund_id: inv.fund.fundId, investment_date: today,
             amount_vnd: Math.round(numAmount),
             units_withdrawn: parseFloat(unitsWithdrawn.toFixed(4)),
-            principal_withdrawn: principalWithdrawn, goal_id: null,
+            principal_withdrawn: principalWithdrawn, goal_id: goalId,
           }),
         })
         if (!res.ok) { const { error: e } = await res.json(); setError(e ?? (isVi ? 'Không thể xử lý' : 'Could not process')); setSaving(false); return }
@@ -785,7 +787,7 @@ function SellModal({ inv, isVi, onClose, onSuccess }: {
           // Bank: amount = cash received, principal = principal portion.
           amount_vnd: isGold ? goldProceeds : isBank ? Math.round(numReceived) : Math.round(numAmount),
           principal_withdrawn: isGold ? (goldCostSold ?? goldProceeds) : isBank ? bankPrincipalPortion : Math.round(numAmount),
-          goal_id: null,
+          goal_id: goalId,
         }
         if (isGold) body.units_withdrawn = parseFloat(numUnits.toFixed(4))
         const res = await fetch('/api/v1/investment-transactions', {

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -19,6 +19,7 @@ interface InvestmentTx {
   fund_id: string | null
   fund_name: string | null
   fund_code: string | null
+  parent_transaction_id: string | null
   investment_date: string
   amount_vnd: number
   units: number | null
@@ -1207,6 +1208,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
         open={sellOpen}
         item={actionInv ? invToSellItem(actionInv) : null}
         context="goal"
+        goalId={goal.goalId}
         onClose={() => setSellOpen(false)}
         onSuccess={() => {
           setSellOpen(false)

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -24,6 +24,10 @@ interface Props {
   item: SellItem | null
   open: boolean
   context: 'unallocated' | 'goal'
+  // When withdrawing from a goal, link the withdrawal to that goal so the
+  // goal-detail fetch (filtered by goal_id) returns it and the holding is
+  // valued net of the withdrawal (issue #261).
+  goalId?: string
   onClose: () => void
   onSuccess: () => void
   // Desktop renders a centered modal dialog; mobile keeps the bottom sheet.
@@ -44,7 +48,7 @@ const TYPE_COLOR = {
   stock: '#7c3aed',
 } as const
 
-export function SellWithdrawSheet({ item, open, context, onClose, onSuccess, desktop }: Props) {
+export function SellWithdrawSheet({ item, open, context, goalId, onClose, onSuccess, desktop }: Props) {
   const locale = useLocale()
   const t = useTranslations('Dashboard')
 
@@ -173,6 +177,10 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess, des
     setError('')
     try {
       const today = new Date().toISOString().slice(0, 10)
+      // Withdrawals from a goal carry that goal's id so the goal-detail view
+      // (which fetches by goal_id) sees them; from the unallocated list there
+      // is no goal to link to (issue #261).
+      const withdrawalGoalId = context === 'goal' ? (goalId ?? null) : null
 
       if (isFund && item.fundId) {
         const principalWithdrawn = item.purchasePrice
@@ -190,7 +198,7 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess, des
             amount_vnd: Math.round(numAmount),
             units_withdrawn: parseFloat(unitsWithdrawn.toFixed(4)),
             principal_withdrawn: principalWithdrawn,
-            goal_id: null,
+            goal_id: withdrawalGoalId,
           }),
         })
         if (!res.ok) {
@@ -209,7 +217,7 @@ export function SellWithdrawSheet({ item, open, context, onClose, onSuccess, des
           // the sold chỉ. Bank: amount = cash received, principal = principal portion.
           amount_vnd: isGold ? goldProceeds : isBank ? Math.round(numReceived) : Math.round(numAmount),
           principal_withdrawn: isGold ? (goldCostSold ?? goldProceeds) : isBank ? bankPrincipalPortion : Math.round(numAmount),
-          goal_id: null,
+          goal_id: withdrawalGoalId,
         }
         if (isGold) {
           body.units_withdrawn = parseFloat(numUnits.toFixed(4))

--- a/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
@@ -67,3 +67,55 @@ describe('DesktopGoalDetail — gold sell uses current price (issue #251)', () =
     await waitFor(() => expect((priceInput as HTMLInputElement).value).toBe('9200000'))
   })
 })
+
+describe('DesktopGoalDetail — bank withdrawal links to the goal (issue #261)', () => {
+  const mockBankTx = {
+    transaction_id: 'tx-bank-1',
+    transaction_type: 'investment',
+    asset_type: 'bank',
+    fund_id: null,
+    fund_name: null,
+    parent_transaction_id: null,
+    investment_date: '2026-01-01',
+    amount_vnd: 10_000_000,
+    units: null,
+    interest_rate: 6,
+    notes: 'Techcombank',
+    principal_withdrawn: null,
+    units_withdrawn: null,
+  }
+
+  let postBody: Record<string, unknown> | null
+
+  beforeEach(() => {
+    postBody = null
+    global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('investment-transactions') && init?.method === 'POST') {
+        postBody = JSON.parse(String(init.body))
+        return Promise.resolve({ ok: true, json: async () => ({}) })
+      }
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [mockBankTx] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+  })
+
+  it('posts the withdrawal with the goal_id so it is no longer shown at full value', async () => {
+    render(<DesktopGoalDetail {...baseProps} />)
+    await waitFor(() => screen.getByText('Techcombank'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options' }))
+    await waitFor(() => expect(screen.getByText('Withdraw')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('Withdraw'))
+
+    // Fill the full balance, then confirm the withdrawal.
+    await userEvent.click(await screen.findByRole('button', { name: 'All' }))
+    await userEvent.click(await screen.findByRole('button', { name: /Confirm withdrawal/i }))
+
+    await waitFor(() => expect(postBody).not.toBeNull())
+    expect(postBody!.transaction_type).toBe('withdrawal')
+    expect(postBody!.parent_transaction_id).toBe('tx-bank-1')
+    expect(postBody!.goal_id).toBe('goal-1')
+  })
+})

--- a/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
+++ b/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
@@ -40,6 +40,53 @@ describe('SellWithdrawSheet — bank withdraw (received + principal portion)', (
   })
 })
 
+describe('SellWithdrawSheet — links the withdrawal to its goal (issue #261)', () => {
+  it('posts goal_id when withdrawing in a goal context', async () => {
+    const fetchMock = vi.fn((_url: string, _init?: RequestInit) =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const item = {
+      type: 'bank' as const, name: 'Techcombank',
+      currentValue: 5_000_000, interestRate: 6,
+      transactionId: 't1', purchasePrice: 5_000_000,
+    }
+    render(<SellWithdrawSheet item={item} open context="goal" goalId="goal-1" onClose={vi.fn()} onSuccess={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('sell-all-btn'))
+    fireEvent.click(screen.getByTestId('sell-confirm-btn'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find((c) => String(c[0]).includes('/investment-transactions'))
+      const body = JSON.parse(String((post![1] as RequestInit).body))
+      expect(body.goal_id).toBe('goal-1')           // linked so the goal-detail fetch returns it
+      expect(body.parent_transaction_id).toBe('t1')
+    })
+  })
+
+  it('keeps goal_id null in the unallocated context', async () => {
+    const fetchMock = vi.fn((_url: string, _init?: RequestInit) =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const item = {
+      type: 'bank' as const, name: 'Techcombank',
+      currentValue: 5_000_000, interestRate: 6,
+      transactionId: 't1', purchasePrice: 5_000_000,
+    }
+    render(<SellWithdrawSheet item={item} open context="unallocated" onClose={vi.fn()} onSuccess={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('sell-all-btn'))
+    fireEvent.click(screen.getByTestId('sell-confirm-btn'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find((c) => String(c[0]).includes('/investment-transactions'))
+      const body = JSON.parse(String((post![1] as RequestInit).body))
+      expect(body.goal_id).toBeNull()
+    })
+  })
+})
+
 describe('SellWithdrawSheet — gold sell (quantity × price) (issue #232)', () => {
   it('prefills the price and posts proceeds + cost basis', async () => {
     const fetchMock = vi.fn((_url: string, _init?: RequestInit) =>

--- a/app/assets/components/__tests__/goalDetailShared.test.tsx
+++ b/app/assets/components/__tests__/goalDetailShared.test.tsx
@@ -6,6 +6,7 @@ const baseTx = (over: Partial<GoalDetailTx>): GoalDetailTx => ({
   transaction_id: 't', transaction_type: 'investment', asset_type: 'gold',
   fund_id: null, investment_date: '2026-01-01', amount_vnd: 0, units: null,
   interest_rate: null, notes: null, principal_withdrawn: null, units_withdrawn: null,
+  parent_transaction_id: null,
   ...over,
 })
 
@@ -68,6 +69,56 @@ describe('buildInvRows', () => {
     )
     expect(rows).toHaveLength(1)
     expect(rows[0].id).toBe('g1')
+  })
+
+  it('nets a partial bank withdrawal against principal (issue #261)', () => {
+    const rows = buildInvRows(
+      [
+        baseTx({ transaction_id: 'b1', asset_type: 'bank', amount_vnd: 10_000_000, interest_rate: 0 }),
+        baseTx({ transaction_id: 'w1', transaction_type: 'withdrawal', asset_type: 'bank', parent_transaction_id: 'b1', amount_vnd: 4_000_000, principal_withdrawn: 4_000_000 }),
+      ],
+      [], null, false,
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].id).toBe('b1')
+    expect(rows[0].principal).toBe(6_000_000)
+    expect(rows[0].value).toBe(6_000_000)
+  })
+
+  it('drops a fully-withdrawn bank deposit (issue #261)', () => {
+    const rows = buildInvRows(
+      [
+        baseTx({ transaction_id: 'b1', asset_type: 'bank', amount_vnd: 10_000_000, interest_rate: 6 }),
+        baseTx({ transaction_id: 'w1', transaction_type: 'withdrawal', asset_type: 'bank', parent_transaction_id: 'b1', amount_vnd: 10_500_000, principal_withdrawn: 10_000_000 }),
+      ],
+      [], null, false,
+    )
+    expect(rows).toHaveLength(0)
+  })
+
+  it('nets a partial gold sale from a withdrawal row (issue #261)', () => {
+    const rows = buildInvRows(
+      [
+        baseTx({ transaction_id: 'g1', asset_type: 'gold', amount_vnd: 18_000_000, units: 2 }),
+        baseTx({ transaction_id: 'w1', transaction_type: 'withdrawal', asset_type: 'gold', parent_transaction_id: 'g1', amount_vnd: 9_200_000, units_withdrawn: 1, principal_withdrawn: 9_000_000 }),
+      ],
+      [], 9_200_000, false,
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].units).toBe(1)
+    expect(rows[0].value).toBe(9_200_000)     // 1 chỉ left × current price
+    expect(rows[0].principal).toBe(9_000_000) // remaining cost basis
+  })
+
+  it('drops a fully-sold gold holding (issue #261)', () => {
+    const rows = buildInvRows(
+      [
+        baseTx({ transaction_id: 'g1', asset_type: 'gold', amount_vnd: 9_000_000, units: 1 }),
+        baseTx({ transaction_id: 'w1', transaction_type: 'withdrawal', asset_type: 'gold', parent_transaction_id: 'g1', amount_vnd: 9_200_000, units_withdrawn: 1, principal_withdrawn: 9_000_000 }),
+      ],
+      [], 9_200_000, false,
+    )
+    expect(rows).toHaveLength(0)
   })
 
   it('localises bank/gold names when isVi', () => {

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -57,6 +57,7 @@ export interface GoalDetailTx {
   transaction_type: string
   asset_type: string
   fund_id: string | null
+  parent_transaction_id: string | null
   investment_date: string
   amount_vnd: number
   units: number | null
@@ -68,15 +69,33 @@ export interface GoalDetailTx {
 
 // Dedup to one row per fund / per non-fund tx, then value each holding:
 // funds at their current value, bank deposits at compounded interest, gold at
-// the live price per chỉ net of any partial withdrawal (issue #251), and
-// everything else at cost. Returns rows unfiltered — callers apply their own
-// optimistic unassign filter.
+// the live price per chỉ, and everything else at cost — each net of any
+// partial withdrawals (issues #251, #261). Holdings that have been fully
+// withdrawn / sold are dropped so they no longer appear on the investment tab.
+// Returns rows otherwise unfiltered — callers apply their own optimistic
+// unassign filter.
 export function buildInvRows(
   transactions: GoalDetailTx[],
   funds: FundBreakdownItem[],
   goldPricePerChi: number | null,
   isVi: boolean,
 ): InvRow[] {
+  // Aggregate withdrawals onto their parent holding. Bank/gold withdrawals are
+  // stored as separate `withdrawal` rows linked via parent_transaction_id, so
+  // the parent investment row itself carries no withdrawn amounts — without
+  // this a withdrawn deposit would still show at full value (issue #261). All
+  // withdrawals count here (regardless of affects_progress): the tab shows what
+  // is actually still held.
+  const wdByParent = new Map<string, { principal: number; units: number }>()
+  for (const tx of transactions) {
+    if (tx.transaction_type === 'withdrawal' && tx.parent_transaction_id) {
+      const e = wdByParent.get(tx.parent_transaction_id) ?? { principal: 0, units: 0 }
+      e.principal += tx.principal_withdrawn ?? 0
+      e.units += tx.units_withdrawn ?? 0
+      wdByParent.set(tx.parent_transaction_id, e)
+    }
+  }
+
   const investmentRows = transactions.filter((tx) => tx.transaction_type !== 'withdrawal')
   const deduped = new Map<string, GoalDetailTx>()
   investmentRows.forEach((tx) => {
@@ -88,7 +107,7 @@ export function buildInvRows(
   })
   const fundMap = new Map(funds.map((f) => [f.fundId, f]))
 
-  return Array.from(deduped.values()).map((tx) => {
+  return Array.from(deduped.values()).map((tx): InvRow | null => {
     const fund = tx.fund_id ? fundMap.get(tx.fund_id) ?? null : null
     const name = fund?.fundName ?? tx.notes ?? (
       tx.asset_type === 'bank' ? (isVi ? 'Tiền gửi' : 'Bank deposit') :
@@ -101,28 +120,36 @@ export function buildInvRows(
       gainPct = fund.profitLossPercentage
       units = fund.quantity
       principal = null
-    } else if (tx.asset_type === 'bank' && tx.interest_rate) {
-      const months = Math.max(0, Math.floor(
-        (Date.now() - new Date(tx.investment_date).getTime()) / (1000 * 60 * 60 * 24 * 30.44)
-      ))
-      value = Math.round(tx.amount_vnd * Math.pow(1 + tx.interest_rate / 100 / 12, months))
-      gainPct = tx.amount_vnd > 0 ? ((value - tx.amount_vnd) / tx.amount_vnd) * 100 : 0
-      units = null
-      principal = tx.amount_vnd
-    } else if (tx.asset_type === 'gold' && goldPricePerChi && tx.units) {
-      const effectiveUnits = tx.units - (tx.units_withdrawn ?? 0)
-      const effectivePrincipal = tx.amount_vnd - (tx.principal_withdrawn ?? 0)
-      value = effectiveUnits * goldPricePerChi
-      gainPct = effectivePrincipal > 0 ? ((value - effectivePrincipal) / effectivePrincipal) * 100 : null
-      units = effectiveUnits
-      principal = effectivePrincipal
     } else {
-      value = tx.amount_vnd
-      gainPct = null
-      units = tx.units
-      principal = tx.amount_vnd
+      const wd = wdByParent.get(tx.transaction_id)
+      const effectivePrincipal = tx.amount_vnd - (wd?.principal ?? 0)
+
+      if (tx.asset_type === 'gold' && goldPricePerChi && tx.units) {
+        const effectiveUnits = tx.units - (wd?.units ?? 0)
+        if (effectiveUnits <= 0) return null // fully sold
+        value = effectiveUnits * goldPricePerChi
+        gainPct = effectivePrincipal > 0 ? ((value - effectivePrincipal) / effectivePrincipal) * 100 : null
+        units = effectiveUnits
+        principal = effectivePrincipal
+      } else {
+        if (effectivePrincipal <= 0) return null // fully withdrawn
+        if (tx.asset_type === 'bank' && tx.interest_rate) {
+          const months = Math.max(0, Math.floor(
+            (Date.now() - new Date(tx.investment_date).getTime()) / (1000 * 60 * 60 * 24 * 30.44)
+          ))
+          value = Math.round(effectivePrincipal * Math.pow(1 + tx.interest_rate / 100 / 12, months))
+          gainPct = ((value - effectivePrincipal) / effectivePrincipal) * 100
+          units = null
+          principal = effectivePrincipal
+        } else {
+          value = effectivePrincipal
+          gainPct = null
+          units = tx.units
+          principal = effectivePrincipal
+        }
+      }
     }
 
     return { id: tx.transaction_id, name, type: tx.asset_type, value, gainPct, units, principal, interestRate: tx.interest_rate ?? null, fund: fund ?? null }
-  })
+  }).filter((row): row is InvRow => row !== null)
 }

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -59,37 +59,39 @@ test.describe('Desktop goal detail panel', () => {
   })
 
   // Issue #261: after fully withdrawing a bank deposit from the goal detail,
-  // it must no longer appear on the Investments tab.
+  // it must no longer appear on the Investments tab. Attach the deposit to the
+  // shared goal (reliably rendered) — the Investments tab fetches transactions
+  // no-store, so the row shows even though the overview may be cached.
   test('fully withdrawn bank deposit disappears from the Investments tab', async ({ page }) => {
-    const goal = await api.createGoal({ goal_name: 'E2E Withdraw Hides Goal', target_amount: 100_000_000 })
     const tx = await api.createTransaction({
       asset_type: 'bank',
       amount_vnd: 10_000_000,
       investment_date: '2026-01-01',
       interest_rate: 6,
-      goal_id: goal.goal_id,
+      goal_id: goalId,
       notes: 'E2E TCB Deposit',
     })
     try {
       await page.goto('/dashboard')
       await page.waitForLoadState('networkidle')
 
-      await page.getByText('E2E Withdraw Hides Goal').first().click()
+      await page.getByText('E2E Desktop Goal').first().click()
       const panel = page.getByTestId('desktop-goal-detail')
       await expect(panel).toBeVisible({ timeout: 10_000 })
       await expect(panel.getByText('E2E TCB Deposit')).toBeVisible({ timeout: 10_000 })
 
       // Open the holding's options → Withdraw → withdraw the full balance.
       await panel.getByRole('button', { name: 'Options' }).first().click()
-      await page.getByText(/^Withdraw$/).click()
+      await page.getByText('Withdraw', { exact: true }).click()
       await page.getByRole('button', { name: 'All' }).click()
       await page.getByRole('button', { name: /Confirm withdrawal/i }).click()
 
       // The fully-withdrawn deposit must no longer be listed.
       await expect(panel.getByText('E2E TCB Deposit')).toHaveCount(0, { timeout: 15_000 })
     } finally {
-      await api.deleteTransaction(tx.transaction_id)
-      await api.deleteGoal(goal.goal_id)
+      // Also removes the withdrawal row created during the test (parent FK is
+      // ON DELETE SET NULL, so it would otherwise linger on the shared goal).
+      await api.deleteTransactionCascade(tx.transaction_id)
     }
   })
 

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -81,10 +81,11 @@ test.describe('Desktop goal detail panel', () => {
       await expect(panel.getByText('E2E TCB Deposit')).toBeVisible({ timeout: 10_000 })
 
       // Open the holding's options → Withdraw → withdraw the full balance.
+      // UI text is localised (the suite may run in Vietnamese), so match both.
       await panel.getByRole('button', { name: 'Options' }).first().click()
-      await page.getByText('Withdraw', { exact: true }).click()
-      await page.getByRole('button', { name: 'All' }).click()
-      await page.getByRole('button', { name: /Confirm withdrawal/i }).click()
+      await page.getByText(/^(Withdraw|Rút tiền)$/).click()
+      await page.getByRole('button', { name: /^(All|Tất cả)$/ }).click()
+      await page.getByRole('button', { name: /Confirm withdrawal|Xác nhận rút/i }).click()
 
       // The fully-withdrawn deposit must no longer be listed.
       await expect(panel.getByText('E2E TCB Deposit')).toHaveCount(0, { timeout: 15_000 })

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -58,6 +58,41 @@ test.describe('Desktop goal detail panel', () => {
     await expect(page.getByTestId('desktop-net-worth-panel')).toBeVisible({ timeout: 10_000 })
   })
 
+  // Issue #261: after fully withdrawing a bank deposit from the goal detail,
+  // it must no longer appear on the Investments tab.
+  test('fully withdrawn bank deposit disappears from the Investments tab', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Withdraw Hides Goal', target_amount: 100_000_000 })
+    const tx = await api.createTransaction({
+      asset_type: 'bank',
+      amount_vnd: 10_000_000,
+      investment_date: '2026-01-01',
+      interest_rate: 6,
+      goal_id: goal.goal_id,
+      notes: 'E2E TCB Deposit',
+    })
+    try {
+      await page.goto('/dashboard')
+      await page.waitForLoadState('networkidle')
+
+      await page.getByText('E2E Withdraw Hides Goal').first().click()
+      const panel = page.getByTestId('desktop-goal-detail')
+      await expect(panel).toBeVisible({ timeout: 10_000 })
+      await expect(panel.getByText('E2E TCB Deposit')).toBeVisible({ timeout: 10_000 })
+
+      // Open the holding's options → Withdraw → withdraw the full balance.
+      await panel.getByRole('button', { name: 'Options' }).first().click()
+      await page.getByText(/^Withdraw$/).click()
+      await page.getByRole('button', { name: 'All' }).click()
+      await page.getByRole('button', { name: /Confirm withdrawal/i }).click()
+
+      // The fully-withdrawn deposit must no longer be listed.
+      await expect(panel.getByText('E2E TCB Deposit')).toHaveCount(0, { timeout: 15_000 })
+    } finally {
+      await api.deleteTransaction(tx.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
   test('clicking an insurance row while goal detail is open switches to insurance detail', async ({ page }) => {
     // Bug #226: with goal detail open in the right panel, clicking an insurance
     // member did nothing because the panel prioritised the still-selected goal.

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -81,8 +81,10 @@ test.describe('Desktop goal detail panel', () => {
       await expect(panel.getByText('E2E TCB Deposit')).toBeVisible({ timeout: 10_000 })
 
       // Open the holding's options → Withdraw → withdraw the full balance.
+      // exact: true so we hit the row's "Options" button, not the hero's
+      // "Goal options" (substring matches would pick the hero first).
       // UI text is localised (the suite may run in Vietnamese), so match both.
-      await panel.getByRole('button', { name: 'Options' }).first().click()
+      await panel.getByRole('button', { name: 'Options', exact: true }).first().click()
       await page.getByText(/^(Withdraw|Rút tiền)$/).click()
       await page.getByRole('button', { name: /^(All|Tất cả)$/ }).click()
       await page.getByRole('button', { name: /Confirm withdrawal|Xác nhận rút/i }).click()

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -100,6 +100,15 @@ export async function deleteTransaction(txId: string) {
   await supabase.from('investment_transactions').delete().eq('transaction_id', txId)
 }
 
+// Delete a transaction together with any withdrawal rows that reference it.
+// The parent_transaction_id FK is ON DELETE SET NULL, so withdrawals would
+// otherwise be orphaned (and stay attached to their goal) after the parent
+// is removed.
+export async function deleteTransactionCascade(txId: string) {
+  await supabase.from('investment_transactions').delete().eq('parent_transaction_id', txId)
+  await supabase.from('investment_transactions').delete().eq('transaction_id', txId)
+}
+
 export async function createMonthlyPlan(data: {
   month: number
   year: number


### PR DESCRIPTION
Fixes #261 — *Goal detail · Bank · Investment withdraw but still shown on investment tab.*

## Problem
Withdrawing a bank deposit (or selling gold) from the goal detail left the holding visible **at its full value** on the Investments tab.

## Root cause (two parts)
1. **`buildInvRows` never netted withdrawals.** The bank branch valued the deposit from the full `amount_vnd`, ignoring withdrawals entirely, and the function never dropped fully-withdrawn holdings. (Gold *read* `tx.principal_withdrawn`/`units_withdrawn`, but those live on the separate withdrawal row, not the parent — so it was effectively broken too.)
2. **Dashboard withdrawals weren't linked to the goal.** `DesktopGoalDetail`'s `SellModal` and the shared `SellWithdrawSheet` (goal context) stored the withdrawal with `goal_id: null`. The goal-detail fetch filters by `goal_id`, so the withdrawal row was never returned — leaving `buildInvRows` nothing to net against. The settings flow already stored `goal_id`, which is why it worked there.

## Fix
- `buildInvRows` aggregates each holding's withdrawal rows by `parent_transaction_id`, values bank/gold/stock **net of withdrawals**, and **drops** holdings with nothing left.
- The dashboard sell/withdraw flows now link the withdrawal to the goal (matching the settings flow). Unallocated withdrawals stay `goal_id: null`. As a bonus, this lets the overview route net dashboard *fund* sells against the correct goal accumulator.

## Tests (TDD)
- `buildInvRows`: nets partial bank/gold withdrawals; drops fully-withdrawn bank deposits and fully-sold gold.
- `SellWithdrawSheet` + `SellModal`: post `goal_id` in goal context, stay `null` when unallocated.
- e2e: a fully-withdrawn bank deposit disappears from the Investments tab.

All 370 unit tests pass; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)