### PR TITLE
feat(goal-detail): add "count toward goal progress" toggle to dashboard withdraw

### DIFF
--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, type InvRow } from './goalDetailShared'
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, AffectsProgressControl, type InvRow } from './goalDetailShared'
 
 interface InvestmentTx {
   transaction_id: string
@@ -535,6 +535,8 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
           inv={actionInv}
           isVi={isVi}
           goalId={goal.goalId}
+          goalCurrentValue={goal.currentValue}
+          goalTargetAmount={goal.targetAmount}
           onClose={() => setShowSell(false)}
           onSuccess={() => {
             setShowSell(false)
@@ -675,8 +677,8 @@ function UnassignConfirmModal({ inv, unassigning, isVi, onCancel, onConfirm }: {
 }
 
 // ─── Desktop sell / withdraw modal ────────────────────────────────────────
-function SellModal({ inv, isVi, goalId, onClose, onSuccess }: {
-  inv: InvRow; isVi: boolean; goalId: string; onClose: () => void; onSuccess: () => void
+function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onClose, onSuccess }: {
+  inv: InvRow; isVi: boolean; goalId: string; goalCurrentValue: number; goalTargetAmount: number | null; onClose: () => void; onSuccess: () => void
 }) {
   const isFund = inv.type === 'fund'
   const isGold = inv.type === 'gold'
@@ -694,6 +696,7 @@ function SellModal({ inv, isVi, goalId, onClose, onSuccess }: {
   const [error, setError] = useState('')
   const [confirmed, setConfirmed] = useState(false)
   const [soldAmount, setSoldAmount] = useState(0)
+  const [affectsProgress, setAffectsProgress] = useState(true)
 
   const maxAmount = inv.value
   const numAmount = Number(amount) || 0
@@ -776,6 +779,7 @@ function SellModal({ inv, isVi, goalId, onClose, onSuccess }: {
             amount_vnd: Math.round(numAmount),
             units_withdrawn: parseFloat(unitsWithdrawn.toFixed(4)),
             principal_withdrawn: principalWithdrawn, goal_id: goalId,
+            affects_progress: affectsProgress,
           }),
         })
         if (!res.ok) { const { error: e } = await res.json(); setError(e ?? (isVi ? 'Không thể xử lý' : 'Could not process')); setSaving(false); return }
@@ -788,6 +792,7 @@ function SellModal({ inv, isVi, goalId, onClose, onSuccess }: {
           amount_vnd: isGold ? goldProceeds : isBank ? Math.round(numReceived) : Math.round(numAmount),
           principal_withdrawn: isGold ? (goldCostSold ?? goldProceeds) : isBank ? bankPrincipalPortion : Math.round(numAmount),
           goal_id: goalId,
+          affects_progress: affectsProgress,
         }
         if (isGold) body.units_withdrawn = parseFloat(numUnits.toFixed(4))
         const res = await fetch('/api/v1/investment-transactions', {
@@ -1007,6 +1012,16 @@ function SellModal({ inv, isVi, goalId, onClose, onSuccess }: {
           )}
           </>
           )}
+
+          {/* Count toward goal progress — SellModal is always goal-scoped */}
+          <AffectsProgressControl
+            checked={affectsProgress}
+            onChange={setAffectsProgress}
+            isVi={isVi}
+            currentValue={goalCurrentValue}
+            targetAmount={goalTargetAmount}
+            withdrawnValue={isGold ? goldProceeds : numAmount}
+          />
 
           {/* Bank early withdrawal warning */}
           {isBank && (

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -1209,6 +1209,8 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
         item={actionInv ? invToSellItem(actionInv) : null}
         context="goal"
         goalId={goal.goalId}
+        goalCurrentValue={goal.currentValue}
+        goalTargetAmount={goal.targetAmount}
         onClose={() => setSellOpen(false)}
         onSuccess={() => {
           setSellOpen(false)

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { useLocale, useTranslations } from 'next-intl'
 import { ArrowDownRight, ArrowDownToLine, Building, Check, CircleDollarSign, Shield, TrendingUp, Wallet, X } from 'lucide-react'
 import { fmt } from '@/lib/formatters'
+import { AffectsProgressControl } from './goalDetailShared'
 const fmtVND = (n: number, _locale?: string) => fmt(n)
 
 export interface SellItem {
@@ -28,6 +29,10 @@ interface Props {
   // goal-detail fetch (filtered by goal_id) returns it and the holding is
   // valued net of the withdrawal (issue #261).
   goalId?: string
+  // Goal value & target drive the "count toward goal progress" preview. Only
+  // used in the 'goal' context.
+  goalCurrentValue?: number
+  goalTargetAmount?: number | null
   onClose: () => void
   onSuccess: () => void
   // Desktop renders a centered modal dialog; mobile keeps the bottom sheet.
@@ -48,7 +53,7 @@ const TYPE_COLOR = {
   stock: '#7c3aed',
 } as const
 
-export function SellWithdrawSheet({ item, open, context, goalId, onClose, onSuccess, desktop }: Props) {
+export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValue, goalTargetAmount, onClose, onSuccess, desktop }: Props) {
   const locale = useLocale()
   const t = useTranslations('Dashboard')
 
@@ -60,6 +65,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, onClose, onSucc
   const [error, setError] = useState('')
   const [confirmed, setConfirmed] = useState(false)
   const [soldAmount, setSoldAmount] = useState(0)
+  const [affectsProgress, setAffectsProgress] = useState(true)
   const [mounted, setMounted] = useState(open)
 
   useEffect(() => {
@@ -76,6 +82,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, onClose, onSucc
         setError('')
         setConfirmed(false)
         setSoldAmount(0)
+        setAffectsProgress(true)
       }, 220) // matches slide-down animation duration
       return () => clearTimeout(timer)
     }
@@ -199,6 +206,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, onClose, onSucc
             units_withdrawn: parseFloat(unitsWithdrawn.toFixed(4)),
             principal_withdrawn: principalWithdrawn,
             goal_id: withdrawalGoalId,
+            affects_progress: context === 'goal' ? affectsProgress : true,
           }),
         })
         if (!res.ok) {
@@ -218,6 +226,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, onClose, onSucc
           amount_vnd: isGold ? goldProceeds : isBank ? Math.round(numReceived) : Math.round(numAmount),
           principal_withdrawn: isGold ? (goldCostSold ?? goldProceeds) : isBank ? bankPrincipalPortion : Math.round(numAmount),
           goal_id: withdrawalGoalId,
+          affects_progress: context === 'goal' ? affectsProgress : true,
         }
         if (isGold) {
           body.units_withdrawn = parseFloat(numUnits.toFixed(4))
@@ -567,6 +576,18 @@ export function SellWithdrawSheet({ item, open, context, goalId, onClose, onSucc
               </div>
             )}
             </>
+            )}
+
+            {/* Count toward goal progress — only when withdrawing from a goal */}
+            {context === 'goal' && (
+              <AffectsProgressControl
+                checked={affectsProgress}
+                onChange={setAffectsProgress}
+                isVi={isVI}
+                currentValue={goalCurrentValue ?? 0}
+                targetAmount={goalTargetAmount ?? null}
+                withdrawnValue={isGold ? goldProceeds : numAmount}
+              />
             )}
 
             {/* Bank early-withdrawal warning */}

--- a/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
@@ -117,5 +117,24 @@ describe('DesktopGoalDetail — bank withdrawal links to the goal (issue #261)',
     expect(postBody!.transaction_type).toBe('withdrawal')
     expect(postBody!.parent_transaction_id).toBe('tx-bank-1')
     expect(postBody!.goal_id).toBe('goal-1')
+    // Count-toward-progress defaults ON.
+    expect(postBody!.affects_progress).toBe(true)
+  })
+
+  it('posts affects_progress=false when the progress toggle is switched off', async () => {
+    render(<DesktopGoalDetail {...baseProps} />)
+    await waitFor(() => screen.getByText('Techcombank'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options' }))
+    await waitFor(() => expect(screen.getByText('Withdraw')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('Withdraw'))
+
+    // Switch off "Count toward goal progress", then withdraw the full balance.
+    await userEvent.click(await screen.findByTestId('affects-progress-switch'))
+    await userEvent.click(await screen.findByRole('button', { name: 'All' }))
+    await userEvent.click(await screen.findByRole('button', { name: /Confirm withdrawal/i }))
+
+    await waitFor(() => expect(postBody).not.toBeNull())
+    expect(postBody!.affects_progress).toBe(false)
   })
 })

--- a/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
+++ b/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
@@ -87,6 +87,54 @@ describe('SellWithdrawSheet — links the withdrawal to its goal (issue #261)', 
   })
 })
 
+describe('SellWithdrawSheet — count toward goal progress toggle', () => {
+  const bankItem = {
+    type: 'bank' as const, name: 'Techcombank',
+    currentValue: 5_000_000, interestRate: 6,
+    transactionId: 't1', purchasePrice: 5_000_000,
+  }
+
+  it('shows the toggle in goal context and posts affects_progress=true by default', async () => {
+    const fetchMock = vi.fn((_url: string, _init?: RequestInit) => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<SellWithdrawSheet item={bankItem} open context="goal" goalId="g1" goalCurrentValue={20_000_000} goalTargetAmount={50_000_000} onClose={vi.fn()} onSuccess={vi.fn()} />)
+
+    expect(screen.getByTestId('affects-progress-control')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('sell-all-btn'))
+    fireEvent.click(screen.getByTestId('sell-confirm-btn'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find((c) => String(c[0]).includes('/investment-transactions'))
+      const body = JSON.parse(String((post![1] as RequestInit).body))
+      expect(body.affects_progress).toBe(true)
+    })
+  })
+
+  it('posts affects_progress=false after toggling the switch off', async () => {
+    const fetchMock = vi.fn((_url: string, _init?: RequestInit) => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<SellWithdrawSheet item={bankItem} open context="goal" goalId="g1" goalCurrentValue={20_000_000} goalTargetAmount={50_000_000} onClose={vi.fn()} onSuccess={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('affects-progress-switch'))
+    fireEvent.click(screen.getByTestId('sell-all-btn'))
+    fireEvent.click(screen.getByTestId('sell-confirm-btn'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find((c) => String(c[0]).includes('/investment-transactions'))
+      const body = JSON.parse(String((post![1] as RequestInit).body))
+      expect(body.affects_progress).toBe(false)
+    })
+  })
+
+  it('hides the toggle in the unallocated context', () => {
+    render(<SellWithdrawSheet item={bankItem} open context="unallocated" onClose={vi.fn()} onSuccess={vi.fn()} />)
+    expect(screen.queryByTestId('affects-progress-control')).not.toBeInTheDocument()
+  })
+})
+
 describe('SellWithdrawSheet — gold sell (quantity × price) (issue #232)', () => {
   it('prefills the price and posts proceeds + cost basis', async () => {
     const fetchMock = vi.fn((_url: string, _init?: RequestInit) =>

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -3,7 +3,8 @@
 // chrome, so the icons, colours, deadline math and — most importantly — the
 // investment-row valuation live here to stay in sync.
 
-import { TrendingUp, Building, CircleDollarSign, BarChart2 } from 'lucide-react'
+import { TrendingUp, Building, CircleDollarSign, BarChart2, Target } from 'lucide-react'
+import { fmtCompact } from '@/lib/formatters'
 import type { FundBreakdownItem } from '../DashboardClient'
 
 export const GD_COLORS: Record<string, string> = {
@@ -35,6 +36,112 @@ export function UnlinkSvg({ size = 18, color = 'currentColor' }: { size?: number
       <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
       <path d="M2 2l20 20" />
     </svg>
+  )
+}
+
+// iOS-style toggle, mirroring the redesign's Switch primitive.
+function Switch({ checked, onChange }: { checked: boolean; onChange: (v: boolean) => void }) {
+  const w = 42, h = 24, knob = h - 4
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      data-testid="affects-progress-switch"
+      onClick={() => onChange(!checked)}
+      style={{
+        width: w, height: h, flexShrink: 0, padding: 2, border: 'none', borderRadius: 999,
+        background: checked ? 'var(--c-navy)' : 'var(--c-line-strong, #cbd5e1)',
+        cursor: 'pointer', display: 'inline-flex', alignItems: 'center', transition: 'background 180ms ease',
+      }}
+    >
+      <span style={{
+        width: knob, height: knob, borderRadius: 999, background: '#fff',
+        boxShadow: '0 1px 3px rgba(15,23,42,0.3)',
+        transform: checked ? `translateX(${w - knob - 4}px)` : 'translateX(0)',
+        transition: 'transform 180ms cubic-bezier(0.2,0.8,0.2,1)',
+      }} />
+    </button>
+  )
+}
+
+// "Count toward goal progress" toggle + a live progress-impact preview, shown
+// only when withdrawing from within a goal. Default ON: the withdrawal lowers
+// the goal's tracked progress. OFF (affects_progress=false) is for rebalancing
+// or moving money within the goal — the holding still leaves, but progress is
+// held steady. The preview animates current% → resulting% so the consequence
+// is visible before confirming.
+export function AffectsProgressControl({
+  checked, onChange, isVi, currentValue, targetAmount, withdrawnValue = 0,
+}: {
+  checked: boolean
+  onChange: (v: boolean) => void
+  isVi: boolean
+  currentValue: number
+  targetAmount: number | null
+  withdrawnValue?: number
+}) {
+  const t = isVi ? {
+    label: 'Tính vào tiến độ mục tiêu',
+    on: 'Khoản rút này sẽ làm giảm tiến độ của mục tiêu.',
+    off: 'Tiến độ giữ nguyên — dùng khi cân đối lại hoặc luân chuyển trong mục tiêu.',
+    title: 'Tiến độ mục tiêu', unchanged: 'Giữ nguyên', offGoalValue: 'khỏi giá trị mục tiêu',
+  } : {
+    label: 'Count toward goal progress',
+    on: 'This withdrawal lowers your tracked progress for this goal.',
+    off: 'Progress stays the same — for rebalancing or moving money within the goal.',
+    title: 'Goal progress', unchanged: 'Unchanged', offGoalValue: 'off goal value',
+  }
+
+  const hasTarget = targetAmount != null && targetAmount > 0
+  const target = targetAmount ?? 0
+  const curPct = hasTarget ? Math.min(100, Math.max(0, (currentValue / target) * 100)) : 0
+  const afterVal = Math.max(0, currentValue - (withdrawnValue || 0))
+  const afterPct = hasTarget ? Math.min(100, Math.max(0, (afterVal / target) * 100)) : 0
+  const fillPct = checked ? afterPct : curPct
+  const willDrop = checked && (curPct - afterPct) > 0.05
+  const drop = Math.min(currentValue, withdrawnValue || 0)
+
+  return (
+    <div data-testid="affects-progress-control" style={{ border: '1px solid var(--c-line)', borderRadius: 12, overflow: 'hidden', background: 'var(--c-card)' }}>
+      {/* Toggle row */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px' }}>
+        <div style={{ width: 34, height: 34, borderRadius: 9, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+          <Target size={16} />
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{t.label}</div>
+          <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2, lineHeight: 1.45 }}>{checked ? t.on : t.off}</div>
+        </div>
+        <Switch checked={checked} onChange={onChange} />
+      </div>
+
+      {/* Live progress-impact preview */}
+      {hasTarget && (
+        <div style={{ borderTop: '1px solid var(--c-line)', background: 'var(--c-card-2)', padding: '10px 14px' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+            <span style={{ fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--c-muted)' }}>{t.title}</span>
+            <span style={{ fontSize: 11, fontWeight: 600, display: 'inline-flex', alignItems: 'center', gap: 5 }}>
+              <span style={{ color: 'var(--c-ink)' }}>{Math.round(curPct)}%</span>
+              {willDrop && (<>
+                <span style={{ color: 'var(--c-muted)' }}>→</span>
+                <span style={{ color: afterPct >= 100 ? 'var(--c-pos)' : 'var(--c-neg)' }}>{Math.round(afterPct)}%</span>
+              </>)}
+              {!checked && <span style={{ color: 'var(--c-muted)', fontWeight: 500 }}>· {t.unchanged}</span>}
+            </span>
+          </div>
+          <div style={{ position: 'relative', height: 8, marginTop: 8, borderRadius: 999, background: 'var(--c-card)', border: '1px solid var(--c-line)', overflow: 'hidden' }}>
+            {/* Faded slice being relinquished, shown only when progress drops */}
+            <div style={{ position: 'absolute', top: 0, bottom: 0, left: 0, width: `${curPct}%`, background: willDrop ? 'var(--c-neg-tint)' : 'transparent' }} />
+            {/* Solid resulting progress */}
+            <div style={{ position: 'absolute', top: 0, bottom: 0, left: 0, width: `${fillPct}%`, background: fillPct >= 100 ? 'var(--c-pos)' : 'var(--c-navy)', borderRadius: 999, transition: 'width 320ms ease' }} />
+          </div>
+          {willDrop && (
+            <div style={{ fontSize: 10, color: 'var(--c-muted)', marginTop: 6 }}>−{fmtCompact(drop)} {t.offGoalValue}</div>
+          )}
+        </div>
+      )}
+    </div>
   )
 }
 

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -98,6 +98,52 @@ test.describe('Desktop goal detail panel', () => {
     }
   })
 
+  // Withdrawing from the goal detail can opt out of affecting goal progress
+  // via the "Count toward goal progress" toggle (ported from the legacy
+  // Settings view). Toggling it off must persist affects_progress=false.
+  test('withdraw with progress toggle off stores affects_progress=false', async ({ page }) => {
+    const tx = await api.createTransaction({
+      asset_type: 'bank',
+      amount_vnd: 10_000_000,
+      investment_date: '2026-01-01',
+      interest_rate: 6,
+      goal_id: goalId,
+      notes: 'E2E Progress Toggle Deposit',
+    })
+    try {
+      await page.goto('/dashboard')
+      await page.waitForLoadState('networkidle')
+
+      await page.getByText('E2E Desktop Goal').first().click()
+      const panel = page.getByTestId('desktop-goal-detail')
+      await expect(panel).toBeVisible({ timeout: 10_000 })
+      await expect(panel.getByText('E2E Progress Toggle Deposit')).toBeVisible({ timeout: 10_000 })
+
+      await panel.getByRole('button', { name: 'Options', exact: true }).first().click()
+      await page.getByText(/^(Withdraw|Rút tiền)$/).click()
+
+      // Switch off "Count toward goal progress", then withdraw the full balance.
+      await page.getByTestId('affects-progress-switch').click()
+      await page.getByRole('button', { name: /^(All|Tất cả)$/ }).click()
+      await page.getByRole('button', { name: /Confirm withdrawal|Xác nhận rút/i }).click()
+
+      await expect(panel.getByText('E2E Progress Toggle Deposit')).toHaveCount(0, { timeout: 15_000 })
+
+      // The withdrawal must have been stored with affects_progress=false.
+      const { createClient } = await import('@supabase/supabase-js')
+      const supabase = createClient(process.env.E2E_SUPABASE_URL!, process.env.E2E_SUPABASE_SERVICE_ROLE_KEY!)
+      const { data: withdrawals } = await supabase
+        .from('investment_transactions')
+        .select('affects_progress')
+        .eq('parent_transaction_id', tx.transaction_id)
+        .eq('transaction_type', 'withdrawal')
+      expect(withdrawals).toHaveLength(1)
+      expect(withdrawals![0].affects_progress).toBe(false)
+    } finally {
+      await api.deleteTransactionCascade(tx.transaction_id)
+    }
+  })
+
   test('clicking an insurance row while goal detail is open switches to insurance detail', async ({ page }) => {
     // Bug #226: with goal detail open in the right panel, clicking an insurance
     // member did nothing because the panel prioritised the still-selected goal.


### PR DESCRIPTION
Adds the **affects-progress** control to the dashboard goal-detail withdraw flow, per the [Cairn redesign](https://api.anthropic.com/v1/design/h/VRKDyWOE3Gf8hvntEQsPNQ?open_file=Cairn+Desktop.html). This was previously only available in the legacy Settings goals view — the last parity gap before that view can be removed.

## What
A shared **`AffectsProgressControl`** (in `goalDetailShared.tsx`):
- iOS-style **`Switch`** + a **live progress-impact preview** — a mini goal-progress bar that animates `current% → resulting%`, fades the relinquished slice, and shows a "−X off goal value" caption (matches the designer's spec).
- Shown only when withdrawing **from a goal**; hidden for unallocated sells. Default **ON**.
- Reuses the existing copy: EN "Count toward goal progress" / VI "Tính vào tiến độ mục tiêu".

Wired into both withdraw surfaces:
- **Desktop** — `DesktopGoalDetail` → `SellModal`
- **Mobile** — shared `SellWithdrawSheet` (goal context), value/target passed from `GoalDetailSheet`

The withdrawal `POST` now sends `affects_progress` (true by default, false when toggled off). For unallocated sells it stays `true`.

## Tests
- `SellWithdrawSheet`: toggle visible in goal context, hidden when unallocated; posts `affects_progress` true by default / false when switched off.
- `DesktopGoalDetail` `SellModal`: posts `true` by default and `false` when toggled.
- e2e: withdraw from the dashboard with the toggle off → asserts `affects_progress=false` persisted.

All 374 unit tests pass; `tsc` clean.

## Follow-up
Next PR removes the legacy Settings goals view (and migrates/trims its e2e), now that the dashboard has full parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)