### PR TITLE
fix(goals): pluralize month/unit wording in goal detail (#262)

### DIFF
--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -302,7 +302,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                     </div>
                     <div style={{ fontSize: 10, color: 'var(--c-muted)', marginTop: 1, fontVariantNumeric: 'tabular-nums' }}>
                       {inv.units != null
-                        ? `${inv.units.toLocaleString('vi-VN')} ${isVi ? 'phần' : 'units'}`
+                        ? `${inv.units.toLocaleString('vi-VN')} ${isVi ? 'phần' : inv.units === 1 ? 'unit' : 'units'}`
                         : inv.principal != null
                           ? `${isVi ? 'Gốc' : 'Principal'} ${fmtCompact(inv.principal)}`
                           : ''}
@@ -388,10 +388,10 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                     {projectedDate.toLocaleDateString(isVi ? 'vi-VN' : 'en-GB', { month: 'long', year: 'numeric' })}
                   </div>
                   <div style={{ fontSize: 11, color: isOnTrack ? 'var(--c-pos)' : 'var(--c-warn)', marginTop: 4, opacity: 0.85 }}>
-                    {isVi ? `Sau ${monthsToGoal} tháng` : `In ${monthsToGoal} months`}
+                    {isVi ? `Sau ${monthsToGoal} tháng` : `In ${monthsToGoal} ${monthsToGoal === 1 ? 'month' : 'months'}`}
                     {goal.targetDate && monthsToGoal != null && (isOnTrack
-                      ? (isVi ? ` · ${monthsLeft - monthsToGoal} tháng sớm hơn` : ` · ${monthsLeft - monthsToGoal} months early`)
-                      : (isVi ? ` · ${monthsToGoal - monthsLeft} tháng trễ hạn` : ` · ${monthsToGoal - monthsLeft} months late`)
+                      ? (isVi ? ` · ${monthsLeft - monthsToGoal} tháng sớm hơn` : ` · ${monthsLeft - monthsToGoal} ${monthsLeft - monthsToGoal === 1 ? 'month' : 'months'} early`)
+                      : (isVi ? ` · ${monthsToGoal - monthsLeft} tháng trễ hạn` : ` · ${monthsToGoal - monthsLeft} ${monthsToGoal - monthsLeft === 1 ? 'month' : 'months'} late`)
                     )}
                   </div>
                 </div>
@@ -836,7 +836,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
               <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{inv.name}</div>
               <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2, display: 'flex', gap: 10, flexWrap: 'wrap' }}>
                 <span>{isVi ? 'Khả dụng' : 'Available'}: <span style={{ fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(maxAmount)}</span></span>
-                {inv.units != null && <span style={{ fontVariantNumeric: 'tabular-nums' }}>{inv.units.toLocaleString('vi-VN')} {isVi ? 'phần' : 'units'}</span>}
+                {inv.units != null && <span style={{ fontVariantNumeric: 'tabular-nums' }}>{inv.units.toLocaleString('vi-VN')} {isVi ? 'phần' : inv.units === 1 ? 'unit' : 'units'}</span>}
                 {isBank && inv.interestRate && <span>{inv.interestRate}%/yr</span>}
               </div>
             </div>
@@ -1250,7 +1250,7 @@ function EditGoalModal({ open, onClose, goal, onSaved, isVi }: {
               </div>
             </div>
             <span style={{ background: 'var(--c-card)', color: 'var(--c-navy)', fontWeight: 600, fontSize: 12, padding: '4px 10px', borderRadius: 999, border: '1px solid var(--c-line)' }}>
-              {monthsTo} {isVi ? 'tháng' : 'months'}
+              {monthsTo} {isVi ? 'tháng' : monthsTo === 1 ? 'month' : 'months'}
             </span>
           </div>
         )}

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -964,7 +964,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
                       </div>
                       <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>
                         {inv.units != null
-                          ? `${inv.units.toLocaleString('vi-VN')} ${isVI ? 'phần' : 'units'}`
+                          ? `${inv.units.toLocaleString('vi-VN')} ${isVI ? 'phần' : inv.units === 1 ? 'unit' : 'units'}`
                           : inv.principal != null
                             ? `${isVI ? 'Gốc' : 'Principal'} ${fmtCompact(inv.principal)}`
                             : ''}
@@ -1076,10 +1076,10 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
                     {projectedDate.toLocaleDateString(isVI ? 'vi-VN' : 'en-GB', { month: 'long', year: 'numeric' })}
                   </div>
                   <div style={{ fontSize: 12, color: isOnTrack ? 'var(--c-pos)' : 'var(--c-warn)', marginTop: 6, opacity: 0.85 }}>
-                    {isVI ? `Sau ${projectedMonths} tháng` : `In ${projectedMonths} months`}
+                    {isVI ? `Sau ${projectedMonths} tháng` : `In ${projectedMonths} ${projectedMonths === 1 ? 'month' : 'months'}`}
                     {goal.targetDate && (isOnTrack
-                      ? (isVI ? ` · ${monthsLeft - projectedMonths} tháng sớm hơn` : ` · ${monthsLeft - projectedMonths} months early`)
-                      : (isVI ? ` · ${projectedMonths - monthsLeft} tháng trễ hạn` : ` · ${projectedMonths - monthsLeft} months late`)
+                      ? (isVI ? ` · ${monthsLeft - projectedMonths} tháng sớm hơn` : ` · ${monthsLeft - projectedMonths} ${monthsLeft - projectedMonths === 1 ? 'month' : 'months'} early`)
+                      : (isVI ? ` · ${projectedMonths - monthsLeft} tháng trễ hạn` : ` · ${projectedMonths - monthsLeft} ${projectedMonths - monthsLeft === 1 ? 'month' : 'months'} late`)
                     )}
                   </div>
                 </div>

--- a/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DesktopGoalDetail from '../DesktopGoalDetail'
 import type { GoalData } from '../../DashboardClient'
@@ -136,5 +136,95 @@ describe('DesktopGoalDetail — bank withdrawal links to the goal (issue #261)',
 
     await waitFor(() => expect(postBody).not.toBeNull())
     expect(postBody!.affects_progress).toBe(false)
+  })
+})
+
+describe('DesktopGoalDetail — singular month wording (issue #262)', () => {
+  // 1,000,000₫ left to reach the target.
+  const nearGoal: GoalData = { ...mockGoal, targetAmount: 10_000_000, currentValue: 9_000_000, targetDate: null }
+
+  // Format a YYYY-MM string `n` months from today (deterministic regardless of run date).
+  function monthsFromNow(n: number): string {
+    const d = new Date()
+    d.setMonth(d.getMonth() + n)
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+  }
+
+  beforeEach(() => {
+    global.fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({ ok: true, json: async () => ({ transactions: [] }) }),
+    )
+  })
+
+  it('says "In 1 month" (not "1 months") when the projection is a single month', async () => {
+    render(<DesktopGoalDetail {...baseProps} goal={nearGoal} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Calculator' }))
+
+    // Contributing the full remaining amount finishes in exactly one month.
+    await userEvent.type(screen.getByPlaceholderText('0'), '1000000')
+
+    await waitFor(() => expect(screen.getByText('In 1 month')).toBeInTheDocument())
+    expect(screen.queryByText('In 1 months')).not.toBeInTheDocument()
+  })
+
+  it('says "1 month early" (not "1 months early") when finishing one month ahead', async () => {
+    // Deadline two months out; finishing in one month is one month early.
+    render(<DesktopGoalDetail {...baseProps} goal={{ ...nearGoal, targetDate: monthsFromNow(2) }} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Calculator' }))
+    await userEvent.type(screen.getByPlaceholderText('0'), '1000000')
+
+    await waitFor(() => expect(screen.getByText(/1 month early/)).toBeInTheDocument())
+    expect(screen.queryByText(/months early/)).not.toBeInTheDocument()
+  })
+
+  it('shows "1 unit" (not "1 units") for a holding of a single unit', async () => {
+    const oneUnitGold = {
+      transaction_id: 'tx-gold-1',
+      transaction_type: 'investment',
+      asset_type: 'gold',
+      fund_id: null,
+      fund_name: null,
+      investment_date: '2026-01-01',
+      amount_vnd: 9_000_000,
+      units: 1,
+      interest_rate: null,
+      notes: 'PNJ Gold',
+      principal_withdrawn: null,
+      units_withdrawn: null,
+    }
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [oneUnitGold] }) })
+      }
+      if (url.includes('gold-price')) {
+        return Promise.resolve({ ok: true, json: async () => ({ price_per_chi: 9_200_000 }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    render(<DesktopGoalDetail {...baseProps} />)
+    await waitFor(() => screen.getByText('PNJ Gold'))
+
+    expect(screen.getByText('1 unit')).toBeInTheDocument()
+    expect(screen.queryByText('1 units')).not.toBeInTheDocument()
+  })
+
+  it('shows "1 month" (not "1 months") on the edit-sheet target badge', async () => {
+    const { container } = render(<DesktopGoalDetail {...baseProps} goal={nearGoal} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Goal options' }))
+    await waitFor(() => expect(screen.getByText('Edit goal')).toBeInTheDocument())
+    await userEvent.click(screen.getByText('Edit goal'))
+
+    // A deadline one month out makes the target badge read "1 month".
+    const dateInput = await waitFor(() => {
+      const el = container.querySelector('input[type="month"]')
+      if (!el) throw new Error('date input not mounted yet')
+      return el as HTMLInputElement
+    })
+    fireEvent.change(dateInput, { target: { value: monthsFromNow(1) } })
+
+    await waitFor(() => expect(screen.getByText('1 month')).toBeInTheDocument())
+    expect(screen.queryByText('1 months')).not.toBeInTheDocument()
   })
 })

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -364,6 +364,61 @@ describe('GoalDetailSheet — gold sell uses current price (issue #251)', () => 
   })
 })
 
+describe('GoalDetailSheet — singular month wording (issue #262)', () => {
+  // 1,000,000₫ left to reach the target, no deadline.
+  const nearGoal: GoalData = { ...mockGoal, targetAmount: 10_000_000, currentValue: 9_000_000, targetDate: null, funds: [] }
+
+  it('says "In 1 month" (not "1 months") when the projection is a single month', async () => {
+    global.fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({ ok: true, json: async () => ({ transactions: [] }) }),
+    )
+
+    render(<GoalDetailSheet {...baseProps} goal={nearGoal} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Calculator' }))
+
+    // Contributing the full remaining amount finishes in exactly one month.
+    await userEvent.type(screen.getByPlaceholderText('0'), '1000000')
+
+    await waitFor(() => expect(screen.getByText('In 1 month')).toBeInTheDocument())
+    expect(screen.queryByText('In 1 months')).not.toBeInTheDocument()
+  })
+
+  it('shows "1 unit" (not "1 units") for a holding of a single unit', async () => {
+    const oneUnitGold = {
+      transaction_id: 'tx-gold-1',
+      transaction_type: 'investment',
+      asset_type: 'gold',
+      fund_id: null,
+      fund_name: null,
+      fund_code: null,
+      investment_date: '2026-01-01',
+      amount_vnd: 9_000_000,
+      units: 1,
+      unit_price: 9_000_000,
+      interest_rate: null,
+      expiry_date: null,
+      notes: 'PNJ Gold',
+      principal_withdrawn: null,
+      units_withdrawn: null,
+    }
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [oneUnitGold] }) })
+      }
+      if (url.includes('gold-price')) {
+        return Promise.resolve({ ok: true, json: async () => ({ price_per_chi: 9_200_000 }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    render(<GoalDetailSheet {...baseProps} goal={nearGoal} />)
+    await waitFor(() => screen.getByText('PNJ Gold'))
+
+    expect(screen.getByText('1 unit')).toBeInTheDocument()
+    expect(screen.queryByText('1 units')).not.toBeInTheDocument()
+  })
+})
+
 describe('GoalDetailSheet — refreshKey triggers refetch', () => {
   it('refetches /investment-transactions when refreshKey changes', async () => {
     const fetchMock = vi.fn().mockImplementation((url: string) => {


### PR DESCRIPTION
## Issue

Closes #262 — "Goal detail - check plural".

## Problem

The goal-detail views always used the plural English noun, so counts of 1 read awkwardly:

- The savings calculator showed **"In 1 months"** / **"1 months early"** / **"1 months late"**.
- The desktop edit-goal badge showed **"1 months"**.
- An investment row for a single-unit holding (e.g. 1 chỉ of gold) showed **"1 units"**.

## Fix

Apply the codebase's standard `n === 1 ? singular : plural` convention to the `month` and `unit` labels in both the mobile `GoalDetailSheet` and the `DesktopGoalDetail` views. Vietnamese strings are untouched — Vietnamese has no plural inflection.

## Tests (TDD)

Added tests that assert the **rendered** outcome, not just the data:

- `In 1 month` (calculator projection)
- `1 month early` (ahead-of-deadline projection)
- `1 month` (desktop edit-sheet target badge)
- `1 unit` (single-unit investment row)

Each was confirmed to fail before the fix. Full unit suite (391 tests) and `tsc --noEmit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
