### PR TITLE
fix(dark-mode): navy-fill UI issues going invisible in dark mode (#264)

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -216,7 +216,7 @@ function DcaToggle({ fund, editId, editValue, onToggle, onEditStart, onEditChang
         onClick={e => { e.stopPropagation(); onToggle() }}
         style={{
           width: 34, height: 19, borderRadius: 999,
-          background: fund.is_dca ? 'var(--c-navy)' : 'var(--c-line-strong)',
+          background: fund.is_dca ? 'var(--c-btn-primary)' : 'var(--c-line-strong)',
           border: 'none', cursor: 'pointer', position: 'relative',
           transition: 'background 180ms', flexShrink: 0,
         }}
@@ -725,10 +725,10 @@ export default function DesktopFundLibraryView() {
         )}
 
         {/* NAV info banner */}
-        <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '12px 14px', background: '#eff6ff', border: '1px solid #bfdbfe', borderRadius: 10, marginTop: 16 }}>
-          <div style={{ width: 18, height: 18, borderRadius: 9, background: '#2563eb', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, marginTop: 1, fontSize: 10, fontWeight: 700 }}>i</div>
-          <div style={{ fontSize: 12, color: '#3b82f6', lineHeight: 1.5 }}>
-            <span style={{ fontWeight: 600, color: '#1e40af' }}>About NAV updates: </span>
+        <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '12px 14px', background: 'var(--c-navy-tint)', border: '1px solid var(--c-line)', borderRadius: 10, marginTop: 16 }}>
+          <div style={{ width: 18, height: 18, borderRadius: 9, background: 'var(--c-accent-fund, #2563eb)', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, marginTop: 1, fontSize: 10, fontWeight: 700 }}>i</div>
+          <div style={{ fontSize: 12, color: 'var(--c-muted)', lineHeight: 1.5 }}>
+            <span style={{ fontWeight: 600, color: 'var(--c-navy)' }}>About NAV updates: </span>
             NAV is updated daily after market close. Click Refresh to fetch the latest prices.
           </div>
         </div>

--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -556,7 +556,7 @@ export default function DesktopFundLibraryView() {
                 style={{
                   padding: '6px 12px', borderRadius: 999, fontSize: 11, fontWeight: 500,
                   background: typeFilter === f.v ? 'var(--c-ink)' : 'var(--c-card)',
-                  color: typeFilter === f.v ? '#fff' : 'var(--c-muted)',
+                  color: typeFilter === f.v ? 'var(--c-card)' : 'var(--c-muted)',
                   border: '1px solid ' + (typeFilter === f.v ? 'var(--c-ink)' : 'var(--c-line)'),
                   cursor: 'pointer', fontFamily: 'inherit', whiteSpace: 'nowrap',
                   transition: 'all 120ms',

--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -29,10 +29,10 @@ type TypeFilter = 'all' | 'equity' | 'debt' | 'balanced'
 // ─── Design constants ─────────────────────────────────────────────────────────
 
 const TYPE_META: Record<FundType, { label: string; labelVi: string; color: string; bg: string }> = {
-  equity:   { label: 'Stock',    labelVi: 'Cổ phiếu',   color: '#16a34a', bg: 'oklch(0.97 0.04 150)' },
-  debt:     { label: 'Bond',     labelVi: 'Trái phiếu', color: '#2563eb', bg: '#eff6ff' },
-  balanced: { label: 'Balanced', labelVi: 'Cân bằng',   color: '#7c3aed', bg: '#f5f3ff' },
-  gold:     { label: 'Gold',     labelVi: 'Vàng',       color: '#b45309', bg: '#fef7e6' },
+  equity:   { label: 'Stock',    labelVi: 'Cổ phiếu',   color: 'var(--c-fund-equity)',   bg: 'var(--c-fund-equity-bg)' },
+  debt:     { label: 'Bond',     labelVi: 'Trái phiếu', color: 'var(--c-fund-debt)',     bg: 'var(--c-fund-debt-bg)' },
+  balanced: { label: 'Balanced', labelVi: 'Cân bằng',   color: 'var(--c-fund-balanced)', bg: 'var(--c-fund-balanced-bg)' },
+  gold:     { label: 'Gold',     labelVi: 'Vàng',       color: 'var(--c-fund-gold)',     bg: 'var(--c-fund-gold-bg)' },
 }
 
 const TYPE_FILTERS: { v: TypeFilter; label: string; labelVi: string }[] = [

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -386,7 +386,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, onEdit, onDelete
             onClick={onToggleDca}
             disabled={toggling}
             aria-label={fund.is_dca ? 'Disable DCA' : 'Enable DCA'}
-            style={{ width: 36, height: 20, borderRadius: 10, background: fund.is_dca ? 'var(--c-navy)' : 'var(--c-line-strong)', border: 'none', cursor: toggling ? 'not-allowed' : 'pointer', position: 'relative', transition: 'background 180ms', flexShrink: 0, opacity: toggling ? 0.5 : 1 }}
+            style={{ width: 36, height: 20, borderRadius: 10, background: fund.is_dca ? 'var(--c-btn-primary)' : 'var(--c-line-strong)', border: 'none', cursor: toggling ? 'not-allowed' : 'pointer', position: 'relative', transition: 'background 180ms', flexShrink: 0, opacity: toggling ? 0.5 : 1 }}
           >
             <span style={{ position: 'absolute', top: 2, left: fund.is_dca ? 18 : 2, width: 16, height: 16, borderRadius: 8, background: '#fff', boxShadow: '0 1px 3px rgba(0,0,0,0.2)', transition: 'left 180ms' }} />
           </button>
@@ -534,7 +534,7 @@ export default function MobileFundLibraryView() {
           </button>
           <button
             onClick={() => { setFormError(null); setAddOpen(true) }}
-            style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 12px', fontSize: 12, fontWeight: 600, background: 'var(--c-navy)', color: '#fff', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit' }}
+            style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 12px', fontSize: 12, fontWeight: 600, background: 'var(--c-btn-primary)', color: '#fff', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit' }}
           >
             <Plus size={14} strokeWidth={2.5} />
             Add
@@ -701,7 +701,7 @@ export default function MobileFundLibraryView() {
               <button
                 key={f.v}
                 onClick={() => setFilter(f.v)}
-                style={{ padding: '5px 10px', borderRadius: 999, fontSize: 11, fontWeight: 500, background: filter === f.v ? 'var(--c-ink)' : 'var(--c-card)', color: filter === f.v ? '#fff' : 'var(--c-muted)', border: '1px solid ' + (filter === f.v ? 'var(--c-ink)' : 'var(--c-line)'), cursor: 'pointer', whiteSpace: 'nowrap', fontFamily: 'inherit', transition: 'background 150ms, color 150ms' }}
+                style={{ padding: '5px 10px', borderRadius: 999, fontSize: 11, fontWeight: 500, background: filter === f.v ? 'var(--c-ink)' : 'var(--c-card)', color: filter === f.v ? 'var(--c-card)' : 'var(--c-muted)', border: '1px solid ' + (filter === f.v ? 'var(--c-ink)' : 'var(--c-line)'), cursor: 'pointer', whiteSpace: 'nowrap', fontFamily: 'inherit', transition: 'background 150ms, color 150ms' }}
               >
                 {f.l}
               </button>
@@ -736,7 +736,7 @@ export default function MobileFundLibraryView() {
         {!loading && error && (
           <div style={{ padding: '32px 20px', textAlign: 'center', background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 16 }}>
             <p style={{ color: 'var(--c-neg)', fontSize: 13, margin: '0 0 12px' }}>{error}</p>
-            <button onClick={() => loadFunds()} style={{ padding: '8px 16px', fontSize: 13, fontWeight: 600, background: 'var(--c-navy)', color: '#fff', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit' }}>
+            <button onClick={() => loadFunds()} style={{ padding: '8px 16px', fontSize: 13, fontWeight: 600, background: 'var(--c-btn-primary)', color: '#fff', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit' }}>
               Retry
             </button>
           </div>
@@ -748,7 +748,7 @@ export default function MobileFundLibraryView() {
             <div style={{ fontSize: 32, marginBottom: 10 }}>📚</div>
             <h3 style={{ margin: '0 0 4px', fontSize: 15, fontWeight: 600, color: 'var(--c-ink)' }}>{t('empty')}</h3>
             <p style={{ margin: '0 0 14px', fontSize: 12, color: 'var(--c-muted)' }}>{t('emptyDesc')}</p>
-            <button onClick={() => { setFormError(null); setAddOpen(true) }} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '8px 14px', fontSize: 13, fontWeight: 600, background: 'var(--c-navy)', color: '#fff', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit' }}>
+            <button onClick={() => { setFormError(null); setAddOpen(true) }} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '8px 14px', fontSize: 13, fontWeight: 600, background: 'var(--c-btn-primary)', color: '#fff', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit' }}>
               <Plus size={14} />
               {t('add')}
             </button>
@@ -785,11 +785,11 @@ export default function MobileFundLibraryView() {
 
         {/* NAV info banner */}
         {!loading && (
-          <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '12px 14px', background: '#eff6ff', border: '1px solid #bfdbfe', borderRadius: 10, marginTop: 4 }}>
-            <div style={{ width: 20, height: 20, borderRadius: 10, background: '#2563eb', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, marginTop: 1, fontSize: 11, fontWeight: 700 }}>i</div>
+          <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '12px 14px', background: 'var(--c-navy-tint)', border: '1px solid var(--c-line)', borderRadius: 10, marginTop: 4 }}>
+            <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-accent-fund, #2563eb)', color: '#fff', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, marginTop: 1, fontSize: 11, fontWeight: 700 }}>i</div>
             <div>
-              <div style={{ fontSize: 12, fontWeight: 600, color: '#1e40af', marginBottom: 2 }}>{t('navInfoTitle')}</div>
-              <div style={{ fontSize: 11, color: '#3b82f6', lineHeight: 1.5 }}>{t('navInfoDesc', { refreshNav: t('refreshNav') })}</div>
+              <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-navy)', marginBottom: 2 }}>{t('navInfoTitle')}</div>
+              <div style={{ fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.5 }}>{t('navInfoDesc', { refreshNav: t('refreshNav') })}</div>
             </div>
           </div>
         )}

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -70,10 +70,10 @@ function bustCache() {
 }
 
 const TYPE_META: Record<FundType, { label: string; color: string; bg: string }> = {
-  equity:   { label: 'Stock',    color: '#16a34a', bg: '#f0fdf4' },
-  debt:     { label: 'Bond',     color: '#2563eb', bg: '#eff6ff' },
-  balanced: { label: 'Balanced', color: '#7c3aed', bg: '#f5f3ff' },
-  gold:     { label: 'Gold',     color: '#b45309', bg: '#fef7e6' },
+  equity:   { label: 'Stock',    color: 'var(--c-fund-equity)',   bg: 'var(--c-fund-equity-bg)' },
+  debt:     { label: 'Bond',     color: 'var(--c-fund-debt)',     bg: 'var(--c-fund-debt-bg)' },
+  balanced: { label: 'Balanced', color: 'var(--c-fund-balanced)', bg: 'var(--c-fund-balanced-bg)' },
+  gold:     { label: 'Gold',     color: 'var(--c-fund-gold)',     bg: 'var(--c-fund-gold-bg)' },
 }
 
 const TYPE_FILTERS: Array<{ v: 'all' | FundType; l: string }> = [

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -244,7 +244,7 @@ function AllocationCard({ salary, totalGoalAmount, fixedTotal, insTotal, otherTo
   ]
 
   return (
-    <div data-testid="planning-alloc-card" style={{ padding: '18px 20px', background: 'var(--c-navy)', color: '#fff', borderRadius: 16, boxShadow: 'var(--shadow-card)' }}>
+    <div data-testid="planning-alloc-card" style={{ padding: '18px 20px', background: 'var(--c-btn-primary)', color: '#fff', borderRadius: 16, boxShadow: 'var(--shadow-card)' }}>
       <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.6)', marginBottom: 4 }}>
         {isVI ? 'Phân bổ tháng này' : "This month's allocation"}
       </div>
@@ -790,7 +790,7 @@ export default function DesktopPlanningView({
             )}
             <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
               <button onClick={() => setShowIncome(false)} style={{ ...btnBase, flex: 1, padding: '10px 14px', background: 'transparent', color: 'var(--c-ink)', border: '1px solid var(--c-line)' }}>{isVI ? 'Hủy' : 'Cancel'}</button>
-              <button onClick={handleSetIncome} disabled={saving || !incomeVal || Number(incomeVal) <= 0} style={{ ...btnBase, flex: 2, padding: '10px 14px', background: 'var(--c-navy)', color: '#fff', opacity: saving || !incomeVal || Number(incomeVal) <= 0 ? 0.6 : 1 }}>
+              <button onClick={handleSetIncome} disabled={saving || !incomeVal || Number(incomeVal) <= 0} style={{ ...btnBase, flex: 2, padding: '10px 14px', background: 'var(--c-btn-primary)', color: '#fff', opacity: saving || !incomeVal || Number(incomeVal) <= 0 ? 0.6 : 1 }}>
                 {saving ? (isVI ? 'Đang lưu...' : 'Saving...') : (isVI ? 'Lưu' : 'Save')}
               </button>
             </div>
@@ -836,7 +836,7 @@ export default function DesktopPlanningView({
             </button>
             <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
               <button onClick={() => setOverrideModal(null)} style={{ ...btnBase, flex: 1, padding: '10px 14px', background: 'transparent', color: 'var(--c-ink)', border: '1px solid var(--c-line)' }}>{isVI ? 'Hủy' : 'Cancel'}</button>
-              <button onClick={handleSaveOverride} disabled={saving || !overrideVal || Number(overrideVal) <= 0} style={{ ...btnBase, flex: 2, padding: '10px 14px', background: 'var(--c-navy)', color: '#fff', opacity: saving || !overrideVal || Number(overrideVal) <= 0 ? 0.6 : 1 }}>
+              <button onClick={handleSaveOverride} disabled={saving || !overrideVal || Number(overrideVal) <= 0} style={{ ...btnBase, flex: 2, padding: '10px 14px', background: 'var(--c-btn-primary)', color: '#fff', opacity: saving || !overrideVal || Number(overrideVal) <= 0 ? 0.6 : 1 }}>
                 {saving ? (isVI ? 'Đang lưu...' : 'Saving...') : (isVI ? 'Lưu' : 'Save')}
               </button>
             </div>
@@ -866,7 +866,7 @@ export default function DesktopPlanningView({
             )}
             <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
               <button onClick={() => setOtherModal(null)} style={{ ...btnBase, flex: 1, padding: '10px 14px', background: 'transparent', color: 'var(--c-ink)', border: '1px solid var(--c-line)' }}>{isVI ? 'Hủy' : 'Cancel'}</button>
-              <button onClick={handleOtherSave} disabled={saving || !otherDesc.trim() || !otherAmt || Number(otherAmt) <= 0} style={{ ...btnBase, flex: 2, padding: '10px 14px', background: 'var(--c-navy)', color: '#fff', opacity: saving || !otherDesc.trim() || !otherAmt || Number(otherAmt) <= 0 ? 0.6 : 1 }}>
+              <button onClick={handleOtherSave} disabled={saving || !otherDesc.trim() || !otherAmt || Number(otherAmt) <= 0} style={{ ...btnBase, flex: 2, padding: '10px 14px', background: 'var(--c-btn-primary)', color: '#fff', opacity: saving || !otherDesc.trim() || !otherAmt || Number(otherAmt) <= 0 ? 0.6 : 1 }}>
                 {saving ? (isVI ? 'Đang lưu...' : 'Saving...') : (isVI ? 'Lưu' : 'Save')}
               </button>
             </div>

--- a/app/(app)/planning/components/FixedExpenseManager.tsx
+++ b/app/(app)/planning/components/FixedExpenseManager.tsx
@@ -62,7 +62,7 @@ const ghostBtn: React.CSSProperties = {
 }
 const primaryBtn: React.CSSProperties = {
   flex: 2, padding: '10px 0', borderRadius: 10, border: 'none',
-  background: 'var(--c-navy)', color: '#fff', fontSize: 14, fontWeight: 600,
+  background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600,
   cursor: 'pointer', fontFamily: 'inherit',
 }
 

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -236,7 +236,7 @@ function SalarySheet({
             disabled={saving}
             style={{
               flex: 2, padding: '10px 0', borderRadius: 10, border: 'none',
-              background: 'var(--c-navy)', color: '#fff', fontSize: 14, fontWeight: 600,
+              background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600,
               cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit', opacity: saving ? 0.7 : 1,
             }}
           >
@@ -412,7 +412,7 @@ function OtherExpenseSheet({
             disabled={saving}
             style={{
               flex: 2, padding: '10px 0', borderRadius: 10, border: 'none',
-              background: 'var(--c-navy)', color: '#fff', fontSize: 14, fontWeight: 600,
+              background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600,
               cursor: 'pointer', fontFamily: 'inherit',
             }}
           >
@@ -468,7 +468,7 @@ function NoPlanState({ monthLabel, onSetSalary, isVI }: { monthLabel: string; on
         style={{
           display: 'inline-flex', alignItems: 'center', gap: 6,
           padding: '9px 16px', borderRadius: 10, border: 'none',
-          background: 'var(--c-navy)', color: '#fff', fontSize: 13, fontWeight: 600,
+          background: 'var(--c-btn-primary)', color: '#fff', fontSize: 13, fontWeight: 600,
           cursor: 'pointer', fontFamily: 'inherit',
         }}
       >
@@ -554,7 +554,7 @@ function AllocationSummaryCard({
 
   return (
     <div style={{
-      background: 'var(--c-navy)', color: '#fff',
+      background: 'var(--c-btn-primary)', color: '#fff',
       borderRadius: 16, padding: 16,
       border: '1px solid var(--c-line)', boxShadow: 'var(--shadow-card)',
     }}>
@@ -1275,7 +1275,7 @@ function SimpleOverrideSheet({
           <button
             onClick={handleSave}
             disabled={saving}
-            style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-navy)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit' }}
+            style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit' }}
           >
             {isVI ? 'Lưu' : 'Save'}
           </button>

--- a/app/__tests__/darkModeNavyFill.test.tsx
+++ b/app/__tests__/darkModeNavyFill.test.tsx
@@ -79,6 +79,34 @@ describe('issue #264 — no navy-fill + white-foreground (invisible in dark mode
   })
 })
 
+describe('issue #264 — fund-type chips are theme-tokenized', () => {
+  // The fund-type palette (equity/debt/balanced/gold) drove chip + icon-tile
+  // colours from hardcoded light-pastel hex, which stayed light on the dark
+  // canvas. Both the surface and the accent text must come from flipping
+  // tokens instead.
+  for (const rel of [
+    '(app)/funds/components/MobileFundLibraryView.tsx',
+    '(app)/funds/components/DesktopFundLibraryView.tsx',
+  ]) {
+    it(`${rel} TYPE_META uses CSS tokens, not hardcoded hex`, () => {
+      const src = readFileSync(path.join(APP_DIR, rel), 'utf8')
+      const block = src.match(/const TYPE_META[^=]*=\s*\{([\s\S]*?)\n\}/)
+      expect(block, 'TYPE_META block not found').not.toBeNull()
+      expect(block![1], 'TYPE_META still has a hardcoded hex colour').not.toMatch(/#[0-9a-fA-F]{6}/)
+    })
+  }
+
+  it('globals.css defines fund-type tokens with dark-mode overrides', () => {
+    const css = readFileSync(path.join(process.cwd(), 'app/globals.css'), 'utf8')
+    const root = css.slice(css.indexOf(':root'), css.indexOf('@theme inline'))
+    const dark = css.slice(css.indexOf('.dark {'), css.indexOf('@layer base'))
+    for (const token of ['--c-fund-equity', '--c-fund-debt', '--c-fund-balanced', '--c-fund-gold']) {
+      expect(root, `${token} missing from :root`).toContain(token)
+      expect(dark, `${token} not overridden in .dark`).toContain(token)
+    }
+  })
+})
+
 describe('issue #264 — --c-btn-primary stays navy in both themes', () => {
   it('globals.css does not redefine --c-btn-primary inside the .dark block', () => {
     const css = readFileSync(path.join(process.cwd(), 'app/globals.css'), 'utf8')

--- a/app/__tests__/darkModeNavyFill.test.tsx
+++ b/app/__tests__/darkModeNavyFill.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi } from 'vitest'
+import { readdirSync, readFileSync, statSync } from 'fs'
+import path from 'path'
+import { render, screen } from '@testing-library/react'
+import { CreateGoalSheet } from '../assets/components/CreateGoalSheet'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => 'en',
+}))
+
+// ── Background ───────────────────────────────────────────────────────────────
+// `--c-navy` flips to a light cream (#f8fafc) in dark mode (see globals.css
+// `.dark`). A *fill* painted with `var(--c-navy)` that carries white text or a
+// white icon therefore becomes white-on-white and disappears in dark mode.
+// The design system provides `--c-btn-primary`, which stays dark navy in both
+// themes precisely so white foreground stays legible. This is GitHub issue #264.
+
+const APP_DIR = path.resolve(process.cwd(), 'app')
+
+function collectTsx(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      if (entry === '__tests__' || entry === 'node_modules') continue
+      out.push(...collectTsx(full))
+    } else if (entry.endsWith('.tsx')) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+// Matches `background: 'var(--c-navy)'` including a leading ternary condition,
+// e.g. `background: cond ? 'var(--c-navy)' : '...'`. Does NOT match
+// `var(--c-navy-tint)` (different token) or `color: 'var(--c-navy)'` (text,
+// which flips correctly on tinted surfaces).
+const NAVY_FILL = /background:\s*(?:[^,{}\n]*\?\s*)?'var\(--c-navy\)'/
+
+describe('issue #264 — no navy-fill + white-foreground (invisible in dark mode)', () => {
+  it('no component fills a surface with var(--c-navy) except the sidebar accent bar', () => {
+    const offenders: string[] = []
+    for (const file of collectTsx(APP_DIR)) {
+      // The sidebar's 3px active-indicator bar is the one allowed use: it
+      // carries no foreground content and must stay --c-navy so it reads as a
+      // light accent on the dark sidebar (navy would vanish there).
+      if (file.replace(/\\/g, '/').endsWith('navigation/Sidebar.tsx')) continue
+      const lines = readFileSync(file, 'utf8').split('\n')
+      lines.forEach((line, i) => {
+        if (NAVY_FILL.test(line)) {
+          offenders.push(`${path.relative(APP_DIR, file)}:${i + 1}`)
+        }
+      })
+    }
+    expect(offenders).toEqual([])
+  })
+
+  it('fund filter chip uses an inverting token (not hardcoded white) for the active label', () => {
+    const src = readFileSync(
+      path.join(APP_DIR, '(app)/funds/components/MobileFundLibraryView.tsx'),
+      'utf8',
+    )
+    // Active chip background is --c-ink (flips to light in dark mode), so the
+    // active label must invert too — `var(--c-card)`, not `#fff`.
+    expect(src).not.toMatch(/filter === f\.v \? '#fff'/)
+  })
+
+  it('NAV info banner uses theme tokens, not hardcoded light blue', () => {
+    for (const rel of [
+      '(app)/funds/components/MobileFundLibraryView.tsx',
+      '(app)/funds/components/DesktopFundLibraryView.tsx',
+    ]) {
+      const src = readFileSync(path.join(APP_DIR, rel), 'utf8')
+      // Only the banner's surface fill is in scope (the light-blue fund-type
+      // chip palette uses a `bg:` key and is a separate, still-legible case).
+      expect(src, `${rel} still hardcodes the light-blue banner background`).not.toContain("background: '#eff6ff'")
+    }
+  })
+})
+
+describe('issue #264 — --c-btn-primary stays navy in both themes', () => {
+  it('globals.css does not redefine --c-btn-primary inside the .dark block', () => {
+    const css = readFileSync(path.join(process.cwd(), 'app/globals.css'), 'utf8')
+    const darkBlock = css.slice(css.indexOf('.dark {'), css.indexOf('@layer base'))
+    expect(darkBlock).not.toContain('--c-btn-primary')
+  })
+})
+
+describe('issue #264 — CreateGoalSheet (new goal modal)', () => {
+  it('Create button uses --c-btn-primary so white label survives dark mode', () => {
+    render(<CreateGoalSheet open onClose={() => {}} onSuccess={() => {}} />)
+    const createBtn = screen.getByRole('button', { name: 'createBtn' })
+    expect(createBtn.style.background).toContain('--c-btn-primary')
+    expect(createBtn.style.background).not.toContain('--c-navy')
+    // Border was also navy and must track the fill.
+    expect(createBtn.style.border).not.toContain('--c-navy')
+  })
+
+  it('selected goal-icon button uses --c-btn-primary, not --c-navy', () => {
+    render(<CreateGoalSheet open onClose={() => {}} onSuccess={() => {}} />)
+    // 'target' is the default selected icon.
+    const activeIcon = screen.getByTestId('goal-icon-btn-target')
+    expect(activeIcon.style.background).toContain('--c-btn-primary')
+    expect(activeIcon.style.background).not.toContain('--c-navy')
+  })
+})

--- a/app/__tests__/darkModeNavyFill.test.tsx
+++ b/app/__tests__/darkModeNavyFill.test.tsx
@@ -56,14 +56,17 @@ describe('issue #264 — no navy-fill + white-foreground (invisible in dark mode
     expect(offenders).toEqual([])
   })
 
-  it('fund filter chip uses an inverting token (not hardcoded white) for the active label', () => {
-    const src = readFileSync(
-      path.join(APP_DIR, '(app)/funds/components/MobileFundLibraryView.tsx'),
-      'utf8',
-    )
-    // Active chip background is --c-ink (flips to light in dark mode), so the
-    // active label must invert too — `var(--c-card)`, not `#fff`.
-    expect(src).not.toMatch(/filter === f\.v \? '#fff'/)
+  it('fund filter pills use an inverting token (not hardcoded white) for the active label', () => {
+    // Active pill background is --c-ink (flips to light in dark mode), so the
+    // active label must invert too — `var(--c-card)`, not `#fff`. Covers both
+    // the mobile (`filter`) and desktop (`typeFilter`) view variable names.
+    for (const rel of [
+      '(app)/funds/components/MobileFundLibraryView.tsx',
+      '(app)/funds/components/DesktopFundLibraryView.tsx',
+    ]) {
+      const src = readFileSync(path.join(APP_DIR, rel), 'utf8')
+      expect(src, `${rel} still hardcodes white for the active filter label`).not.toMatch(/=== f\.v \? '#fff'/)
+    }
   })
 
   it('NAV info banner uses theme tokens, not hardcoded light blue', () => {

--- a/app/assets/components/AssignGoalSheet.tsx
+++ b/app/assets/components/AssignGoalSheet.tsx
@@ -195,7 +195,7 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, item, deskto
                     </div>
                   )}
                   {isSel && (
-                    <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                    <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-btn-primary)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
                       <Check size={12} strokeWidth={2.5} color="#fff" />
                     </div>
                   )}

--- a/app/assets/components/CreateGoalSheet.tsx
+++ b/app/assets/components/CreateGoalSheet.tsx
@@ -206,7 +206,7 @@ export function CreateGoalSheet({ open, onClose, onSuccess, desktop }: Props) {
                       title={label}
                       style={{
                         width: 44, height: 44, borderRadius: 10,
-                        background: active ? 'var(--c-navy)' : 'var(--c-card-2)',
+                        background: active ? 'var(--c-btn-primary)' : 'var(--c-card-2)',
                         color: active ? '#fff' : 'var(--c-muted)',
                         border: `1px solid ${active ? 'var(--c-navy)' : 'var(--c-line)'}`,
                         display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -277,7 +277,7 @@ export function CreateGoalSheet({ open, onClose, onSuccess, desktop }: Props) {
               disabled={saving}
               style={{
                 flex: 2, padding: '11px 0', borderRadius: 10,
-                background: 'var(--c-navy)', border: '1px solid var(--c-navy)',
+                background: 'var(--c-btn-primary)', border: '1px solid var(--c-btn-primary)',
                 color: '#fff', fontSize: 14, fontWeight: 500,
                 cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit',
                 display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -364,7 +364,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                       return (
                         <button key={mul} onClick={() => setCalcAmount(String(preset))} style={{
                           padding: '4px 10px', borderRadius: 999, fontSize: 11, fontWeight: 500,
-                          background: Number(calcAmount) === preset ? 'var(--c-navy)' : 'var(--c-card-2)',
+                          background: Number(calcAmount) === preset ? 'var(--c-btn-primary)' : 'var(--c-card-2)',
                           color: Number(calcAmount) === preset ? '#fff' : 'var(--c-muted)',
                           border: '1px solid var(--c-line)', cursor: 'pointer', fontFamily: 'inherit', transition: 'all 120ms',
                         }}>{fmtCompact(preset)}</button>

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -290,7 +290,7 @@ function EditGoalSheet({
               disabled={saving}
               style={{
                 flex: 1, padding: '12px 0', borderRadius: 10, border: 'none',
-                background: 'var(--c-navy)', color: '#fff', fontSize: 15,
+                background: 'var(--c-btn-primary)', color: '#fff', fontSize: 15,
                 cursor: saving ? 'default' : 'pointer', opacity: saving ? 0.7 : 1,
                 fontFamily: 'inherit',
               }}
@@ -1048,7 +1048,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
                           onClick={() => setMonthlyContrib(String(preset))}
                           style={{
                             padding: '4px 10px', borderRadius: 999, fontSize: 11, fontWeight: 500,
-                            background: isActive ? 'var(--c-navy)' : 'var(--c-card-2)',
+                            background: isActive ? 'var(--c-btn-primary)' : 'var(--c-card-2)',
                             color: isActive ? '#fff' : 'var(--c-muted)',
                             border: '1px solid var(--c-line)', cursor: 'pointer',
                             fontFamily: 'inherit', transition: 'all 120ms',

--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -537,7 +537,7 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
                 const active = txForm.asset_type === v
                 return (
                   <button key={v} type="button" onClick={() => setTxForm((f) => ({ ...f, asset_type: v, fund_id: '', unit_price: '', units: '', interest_rate: '', expiry_date: '' }))}
-                    style={{ padding: '7px 12px', borderRadius: 8, fontSize: 12, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', background: active ? 'var(--c-navy)' : 'var(--c-card-2)', color: active ? '#fff' : 'var(--c-muted)', border: `1px solid ${active ? 'var(--c-navy)' : 'var(--c-line)'}`, transition: 'all 120ms' }}>
+                    style={{ padding: '7px 12px', borderRadius: 8, fontSize: 12, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', background: active ? 'var(--c-btn-primary)' : 'var(--c-card-2)', color: active ? '#fff' : 'var(--c-muted)', border: `1px solid ${active ? 'var(--c-btn-primary)' : 'var(--c-line)'}`, transition: 'all 120ms' }}>
                     {assetLabelOf(v)}
                   </button>
                 )

--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -83,7 +83,7 @@ function DesktopAssignPicker({
                     </div>
                   </div>
                   {g.progressPercent != null && <div style={{ fontSize: 12, fontWeight: 600, color: isSel ? 'var(--c-navy)' : 'var(--c-ink)', flexShrink: 0 }}>{Math.round(g.progressPercent)}%</div>}
-                  {isSel && <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}><Check size={12} strokeWidth={2.5} color="#fff" /></div>}
+                  {isSel && <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-btn-primary)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}><Check size={12} strokeWidth={2.5} color="#fff" /></div>}
                 </div>
                 {g.progressPercent != null && (
                   <div style={{ height: 4, background: 'var(--c-card-2)', borderRadius: 999, overflow: 'hidden', marginTop: 8 }}>

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -51,7 +51,7 @@ function Switch({ checked, onChange }: { checked: boolean; onChange: (v: boolean
       onClick={() => onChange(!checked)}
       style={{
         width: w, height: h, flexShrink: 0, padding: 2, border: 'none', borderRadius: 999,
-        background: checked ? 'var(--c-navy)' : 'var(--c-line-strong, #cbd5e1)',
+        background: checked ? 'var(--c-btn-primary)' : 'var(--c-line-strong, #cbd5e1)',
         cursor: 'pointer', display: 'inline-flex', alignItems: 'center', transition: 'background 180ms ease',
       }}
     >

--- a/app/components/layouts/AuthenticatedLayout.tsx
+++ b/app/components/layouts/AuthenticatedLayout.tsx
@@ -83,7 +83,7 @@ function AuthenticatedLayoutInner({ children, email, initials }: { children: Rea
           style={{
             position: 'fixed', right: 16, bottom: 80,
             width: 52, height: 52, borderRadius: 26,
-            background: 'var(--c-navy)', color: '#fff',
+            background: 'var(--c-btn-primary)', color: '#fff',
             border: 'none',
             display: 'flex', alignItems: 'center', justifyContent: 'center',
             boxShadow: '0 6px 16px rgba(15, 42, 74, 0.25), 0 2px 4px rgba(15, 42, 74, 0.1)',

--- a/app/globals.css
+++ b/app/globals.css
@@ -39,6 +39,13 @@
   --c-accent-fixed: #b45309;
   --c-accent-insurance: #7c3aed;
   --c-accent-other: #475569;
+  /* Fund-type palette (equity/debt/balanced/gold). Each pairs an accent text
+     colour with a tinted surface; both flip in dark mode (see .dark) so the
+     chips/icon tiles adapt to the dark canvas instead of staying pastel. */
+  --c-fund-equity: #16a34a;   --c-fund-equity-bg: #f0fdf4;
+  --c-fund-debt: #2563eb;     --c-fund-debt-bg: #eff6ff;
+  --c-fund-balanced: #7c3aed; --c-fund-balanced-bg: #f5f3ff;
+  --c-fund-gold: #b45309;     --c-fund-gold-bg: #fef7e6;
   /* Primary button fill — stays dark navy in both modes so white text is always legible */
   --c-btn-primary: #0F2A4A;
   --c-btn-primary-hover: #1e3a63;
@@ -152,6 +159,11 @@
   --c-muted-2: #737373;
   --c-navy: #f8fafc;
   --c-navy-tint: #1a2540;
+  /* Fund-type palette — lightened accents on translucent tints for dark mode */
+  --c-fund-equity: #4ade80;   --c-fund-equity-bg: rgba(22, 163, 74, 0.18);
+  --c-fund-debt: #60a5fa;     --c-fund-debt-bg: rgba(37, 99, 235, 0.18);
+  --c-fund-balanced: #a78bfa; --c-fund-balanced-bg: rgba(124, 58, 237, 0.18);
+  --c-fund-gold: #fbbf24;     --c-fund-gold-bg: rgba(180, 83, 9, 0.22);
   /* Tab bar goes dark in dark mode */
   --c-tab-bg: rgba(22, 22, 22, 0.92);
   --c-pos-tint: rgba(4, 120, 87, 0.15);


### PR DESCRIPTION
@
Fixes #264.

## Root cause
`--c-navy` and `--c-ink` **flip to light colors** in dark mode (cream / near-white — see `globals.css` `.dark`). Many components fill a surface with `var(--c-navy)` and hardcode `color: #fff` for the text/icon. In dark mode that becomes **white-on-near-white → invisible/unreadable**. The design system already documents `--c-btn-primary` as staying dark navy in both themes "so white text is always legible" — that is the correct token for these fills.

## What changed
Swapped every navy **fill that carries white foreground** to `--c-btn-primary`. This covers all 8 areas listed in the issue plus the same bug found in sibling components (root-cause fix, per discussion):

| Area | File |
|---|---|
| Add-transaction FAB (mobile) | `AuthenticatedLayout.tsx` |
| DCA toggle (mobile + desktop) | `Mobile/DesktopFundLibraryView.tsx` |
| Add fund / refresh / empty-state buttons | `MobileFundLibraryView.tsx` |
| Selected fund filter chip | `MobileFundLibraryView.tsx` (keeps `--c-ink` fill, inverts label to `--c-card`) |
| NAV info banner | `Mobile/DesktopFundLibraryView.tsx` (off hardcoded light-blue onto tokens) |
| Add income / override / other-expense save | `DesktopPlanningView.tsx` |
| Allocation summary card (mobile + desktop) | `Mobile/DesktopPlanningView.tsx` |
| Mobile plan save / set-salary buttons | `MobilePlanningView.tsx` |
| Fixed-expense primary button | `FixedExpenseManager.tsx` |
| New-goal modal: create btn, active icon | `CreateGoalSheet.tsx` |
| Goal preset chips + save | `GoalDetailSheet.tsx`, `DesktopGoalDetail.tsx` |
| Affects-progress toggle | `goalDetailShared.tsx` |
| Assign-goal / unallocated checkmarks | `AssignGoalSheet.tsx`, `UnallocatedSection.tsx` |
| Transaction-ledger asset-type tabs | `TransactionLedgerSheet.tsx` |

**Intentionally left alone:** `color: var(--c-navy)` used as *text* on tinted surfaces (flips correctly, e.g. income preview chips); the sidebar 3px accent bar (a decorative fill with no foreground — navy/cream both read fine).

## Tests (TDD)
New `app/__tests__/darkModeNavyFill.test.tsx`, written red-first:
- Render test on the new-goal modal asserting the create button + active icon use `--c-btn-primary`.
- A **static invariant** asserting no component pairs a `var(--c-navy)` fill with white foreground (this caught 5 sites a manual grep missed) + the filter-chip and NAV-banner specifics + a guard that `.dark` never redefines `--c-btn-primary`.

Full suite: **397 passed**, `tsc --noEmit` clean. The 8 areas are best confirmed visually on the preview deploy (the issue had no screenshots).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@