### PR TITLE
fix(settings): show real last-synced time instead of hardcoded "2h" (#267)

### DIFF
--- a/app/(app)/settings/__tests__/settingsShared.test.ts
+++ b/app/(app)/settings/__tests__/settingsShared.test.ts
@@ -5,6 +5,8 @@ import {
   refreshPrices,
   fetchOverview,
   exportPortfolioReport,
+  fetchLastSync,
+  formatLastSync,
 } from '../settingsShared'
 
 const downloadPortfolioPDF = vi.fn()
@@ -78,6 +80,72 @@ describe('fetchOverview', () => {
   it('returns null when the request throws', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')))
     expect(await fetchOverview()).toBeNull()
+  })
+})
+
+describe('fetchLastSync', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('returns the lastSync timestamp when the response is ok', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ lastSync: '2026-06-05T10:00:00.000Z' }),
+    }))
+    expect(await fetchLastSync()).toBe('2026-06-05T10:00:00.000Z')
+  })
+
+  it('returns null when the response carries no timestamp', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ lastSync: null }),
+    }))
+    expect(await fetchLastSync()).toBeNull()
+  })
+
+  it('returns null on a non-ok response', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: false }))
+    expect(await fetchLastSync()).toBeNull()
+  })
+
+  it('returns null when the request throws', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')))
+    expect(await fetchLastSync()).toBeNull()
+  })
+})
+
+describe('formatLastSync', () => {
+  // Fixed reference instant so relative output is deterministic.
+  const now = new Date('2026-06-05T12:00:00.000Z').getTime()
+  const ago = (ms: number) => new Date(now - ms).toISOString()
+
+  it('shows a loading placeholder before the timestamp has loaded', () => {
+    expect(formatLastSync(undefined, 'en', now)).toBe('…')
+    expect(formatLastSync(undefined, 'vi', now)).toBe('…')
+  })
+
+  it('shows a never-synced label when there is no timestamp', () => {
+    expect(formatLastSync(null, 'en', now)).toBe('Never')
+    expect(formatLastSync(null, 'vi', now)).toBe('Chưa đồng bộ')
+  })
+
+  it('shows "just now" for under a minute', () => {
+    expect(formatLastSync(ago(30 * 1000), 'en', now)).toBe('just now')
+    expect(formatLastSync(ago(30 * 1000), 'vi', now)).toBe('vừa xong')
+  })
+
+  it('formats minutes', () => {
+    expect(formatLastSync(ago(5 * 60 * 1000), 'en', now)).toBe('5m ago')
+    expect(formatLastSync(ago(5 * 60 * 1000), 'vi', now)).toBe('5 phút trước')
+  })
+
+  it('formats hours', () => {
+    expect(formatLastSync(ago(2 * 60 * 60 * 1000), 'en', now)).toBe('2h ago')
+    expect(formatLastSync(ago(2 * 60 * 60 * 1000), 'vi', now)).toBe('2 giờ trước')
+  })
+
+  it('formats days', () => {
+    expect(formatLastSync(ago(3 * 24 * 60 * 60 * 1000), 'en', now)).toBe('3d ago')
+    expect(formatLastSync(ago(3 * 24 * 60 * 60 * 1000), 'vi', now)).toBe('3 ngày trước')
   })
 })
 

--- a/app/(app)/settings/components/DesktopSettingsView.tsx
+++ b/app/(app)/settings/components/DesktopSettingsView.tsx
@@ -13,7 +13,7 @@ import {
 import { toast } from 'sonner'
 import DownloadReportSheet from '@/app/assets/components/DownloadReportSheet'
 import type { DashboardData } from '@/app/assets/DashboardClient'
-import { clearAppCaches, setLocaleCookie, refreshPrices, fetchOverview, exportPortfolioReport } from '../settingsShared'
+import { clearAppCaches, setLocaleCookie, refreshPrices, fetchOverview, exportPortfolioReport, fetchLastSync, formatLastSync } from '../settingsShared'
 
 interface Props {
   email: string
@@ -157,7 +157,9 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
   // Price sync
   const [syncing, setSyncing] = useState(false)
   const [syncDone, setSyncDone] = useState(false)
-  const [lastSync, setLastSync] = useState('2h')
+  // undefined = loading, null = never synced, otherwise the last-sync ISO time.
+  const [lastSyncIso, setLastSyncIso] = useState<string | null | undefined>(undefined)
+  useEffect(() => { fetchLastSync().then(setLastSyncIso) }, [])
 
   // Export
   const [showReport, setShowReport] = useState(false)
@@ -181,7 +183,7 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
     await refreshPrices()
     setSyncing(false)
     setSyncDone(true)
-    setLastSync(isVI ? 'Vừa xong' : 'Just now')
+    setLastSyncIso(new Date().toISOString())
     setTimeout(() => setSyncDone(false), 3000)
   }
 
@@ -402,7 +404,7 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
                       ? (isVI ? 'Đang tải…' : 'Updating…')
                       : syncDone
                       ? (isVI ? '✓ Đã cập nhật' : '✓ Updated')
-                      : (isVI ? `Lần cuối: ${lastSync} trước` : `Last synced: ${lastSync} ago`)}
+                      : `${isVI ? 'Lần cuối: ' : 'Last synced: '}${formatLastSync(lastSyncIso, locale)}`}
                   </div>
                 </div>
                 <button

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -13,7 +13,7 @@ import { toast } from 'sonner'
 import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import DownloadReportSheet from '@/app/assets/components/DownloadReportSheet'
 import type { DashboardData } from '@/app/assets/DashboardClient'
-import { clearAppCaches, setLocaleCookie, refreshPrices, fetchOverview, exportPortfolioReport } from '../settingsShared'
+import { clearAppCaches, setLocaleCookie, refreshPrices, fetchOverview, exportPortfolioReport, fetchLastSync, formatLastSync } from '../settingsShared'
 
 interface Props {
   email: string
@@ -379,7 +379,9 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
 
   const [syncing, setSyncing] = useState(false)
   const [syncDone, setSyncDone] = useState(false)
-  const [lastSync, setLastSync] = useState('2h')
+  // undefined = loading, null = never synced, otherwise the last-sync ISO time.
+  const [lastSyncIso, setLastSyncIso] = useState<string | null | undefined>(undefined)
+  useEffect(() => { fetchLastSync().then(setLastSyncIso) }, [])
 
   const isVI = locale === 'vi'
 
@@ -402,7 +404,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
     await refreshPrices()
     setSyncing(false)
     setSyncDone(true)
-    setLastSync(isVI ? 'Vừa xong' : 'Just now')
+    setLastSyncIso(new Date().toISOString())
     setTimeout(() => setSyncDone(false), 3000)
   }
 
@@ -526,7 +528,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
                     ? (isVI ? 'Đang tải...' : 'Updating…')
                     : syncDone
                     ? (isVI ? '✓ Đã cập nhật' : '✓ Updated')
-                    : (isVI ? `Lần cuối: ${lastSync} trước` : `Last synced: ${lastSync} ago`)}
+                    : `${isVI ? 'Lần cuối: ' : 'Last synced: '}${formatLastSync(lastSyncIso, locale)}`}
                 </div>
               </div>
               <button

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -246,8 +246,10 @@ describe('MobileSettingsView — data section', () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>
 
   beforeEach(() => {
-    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response(JSON.stringify(mockOverviewResponse), { status: 200 })
+    // Fresh Response per call: the component also fetches the last-sync time on
+    // mount, and a Response body can only be read once.
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () => new Response(JSON.stringify(mockOverviewResponse), { status: 200 })
     )
   })
   afterEach(() => fetchSpy.mockRestore())

--- a/app/(app)/settings/settingsShared.ts
+++ b/app/(app)/settings/settingsShared.ts
@@ -39,6 +39,42 @@ export async function refreshPrices(): Promise<void> {
   }
 }
 
+// Fetch the most recent price-sync time for the current user — the latest
+// updated_at across their funds (NAV) and gold price. Returns an ISO string, or
+// null when nothing has synced yet or the request fails.
+export async function fetchLastSync(): Promise<string | null> {
+  try {
+    const res = await fetch('/api/v1/prices/last-sync', { cache: 'no-store' })
+    if (!res.ok) return null
+    const json = await res.json()
+    return json?.lastSync ?? null
+  } catch {
+    return null
+  }
+}
+
+// Format a price-sync timestamp into a compact, bilingual relative phrase for
+// the Price sync card (e.g. "2h ago" / "2 giờ trước"). `now` is injectable for
+// deterministic tests. `undefined` renders a loading placeholder; `null` (never
+// synced) renders a distinct label.
+export function formatLastSync(
+  iso: string | null | undefined,
+  locale: string,
+  now: number = Date.now(),
+): string {
+  const isVI = locale === 'vi'
+  if (iso === undefined) return '…'
+  if (iso === null) return isVI ? 'Chưa đồng bộ' : 'Never'
+
+  const mins = Math.floor((now - new Date(iso).getTime()) / 60000)
+  if (mins < 1) return isVI ? 'vừa xong' : 'just now'
+  if (mins < 60) return isVI ? `${mins} phút trước` : `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) return isVI ? `${hours} giờ trước` : `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return isVI ? `${days} ngày trước` : `${days}d ago`
+}
+
 // Prefetch the dashboard overview for the report sheet. Returns null on any
 // failure (the export path re-fetches and surfaces the error itself).
 export async function fetchOverview(): Promise<DashboardData | null> {

--- a/app/api/v1/prices/last-sync/route.ts
+++ b/app/api/v1/prices/last-sync/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+
+// Returns the most recent price-sync time for the current user: the latest
+// updated_at across their funds (NAV) and gold price settings. Powers the
+// Settings → Price sync card's "Last synced: …" line (replaces a hardcoded
+// value). Returns { lastSync: null } when the user has no priced data yet.
+export async function GET() {
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const [funds, gold] = await Promise.all([
+    supabase
+      .from('funds')
+      .select('updated_at')
+      .eq('user_id', user.id)
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle(),
+    supabase
+      .from('gold_price_settings')
+      .select('updated_at')
+      .eq('user_id', user.id)
+      .maybeSingle(),
+  ])
+
+  const times = [funds.data?.updated_at, gold.data?.updated_at].filter(Boolean) as string[]
+  const lastSync = times.length
+    ? times.reduce((a, b) => (new Date(a) > new Date(b) ? a : b))
+    : null
+
+  return NextResponse.json({ lastSync })
+}


### PR DESCRIPTION
## Problem

Fixes #267. The Settings → **Price sync** card always rendered a hardcoded `Last synced: 2h ago`, regardless of when prices actually synced.

## Fix

- **New endpoint** `GET /api/v1/prices/last-sync` — returns the most recent `updated_at` across the current user's `funds` (NAV) and `gold_price_settings` (both per-user, RLS-scoped), or `null` if nothing has synced.
- **`settingsShared.ts`** — adds `fetchLastSync()` (fetches the endpoint, best-effort) and `formatLastSync()` (pure, bilingual, compact relative phrase like `2h ago` / `2 giờ trước`, with distinct **loading** `…` and **never-synced** `Never` / `Chưa đồng bộ` states).
- **Both settings views** (desktop + mobile) fetch the time on mount and optimistically set it to *now* right after a manual sync.

## Tests (TDD)

- `formatLastSync` — loading / never / just-now / minutes / hours / days, both locales.
- `fetchLastSync` — ok / null payload / non-ok / network error.
- Updated the Mobile fetch mock to return a fresh `Response` per call (the new mount fetch consumes a body, which a shared `Response` only allows once).

All 57 settings tests pass; `tsc --noEmit` clean; no new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
