### PR TITLE
fix(gold): unify Gold asset icon & colour across the app (#268)

### DIFF
--- a/app/(app)/settings/components/DesktopSettingsView.tsx
+++ b/app/(app)/settings/components/DesktopSettingsView.tsx
@@ -8,7 +8,7 @@ import { useTheme, type ThemeChoice } from '@/app/components/ThemeProvider'
 import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import {
   Sun, Moon, Settings, RefreshCw, TrendingUp,
-  CircleDollarSign, LogOut, Download, X, Check, Edit2,
+  Coins, LogOut, Download, X, Check, Edit2,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import DownloadReportSheet from '@/app/assets/components/DownloadReportSheet'
@@ -424,7 +424,7 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
               <div style={{ display: 'grid', gap: 10, paddingTop: 12, borderTop: '1px solid var(--c-line)' }}>
                 {[
                   { icon: <TrendingUp size={13} />, color: '#2563eb', label: isVI ? 'NAV quỹ đầu tư' : 'Fund NAV',         note: isVI ? 'Tự động đồng bộ lúc 18:00' : 'Auto-syncs daily at 6:00 PM' },
-                  { icon: <CircleDollarSign size={13} />, color: '#d97706', label: isVI ? 'Giá vàng DOJI' : 'Gold price (DOJI)', note: isVI ? 'Tự động đồng bộ lúc 09:00' : 'Auto-syncs daily at 9:00 AM' },
+                  { icon: <Coins size={13} />, color: 'var(--c-fund-gold)', label: isVI ? 'Giá vàng DOJI' : 'Gold price (DOJI)', note: isVI ? 'Tự động đồng bộ lúc 09:00' : 'Auto-syncs daily at 9:00 AM' },
                 ].map((row, i) => (
                   <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                     <div style={{ width: 28, height: 28, borderRadius: 7, background: 'var(--c-card-2)', color: row.color, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -7,7 +7,7 @@ import { createBrowserClient } from '@supabase/ssr'
 import { useTheme, type ThemeChoice } from '@/app/components/ThemeProvider'
 import {
   Globe, Sun, Wallet, Download, RefreshCw,
-  TrendingUp, CircleDollarSign, LogOut, ChevronRight, Check,
+  TrendingUp, Coins, LogOut, ChevronRight, Check,
 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useNavigation } from '@/app/components/navigation/NavigationContext'
@@ -559,8 +559,8 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
                   note: isVI ? 'Tự động đồng bộ lúc 18:00 mỗi ngày' : 'Auto-syncs daily at 6:00 PM',
                 },
                 {
-                  icon: <CircleDollarSign size={14} />,
-                  color: '#d97706',
+                  icon: <Coins size={14} />,
+                  color: 'var(--c-fund-gold)',
                   label: isVI ? 'Giá vàng DOJI' : 'Gold price (DOJI)',
                   note: isVI ? 'Tự động đồng bộ lúc 09:00 mỗi ngày' : 'Auto-syncs daily at 9:00 AM',
                 },

--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -106,7 +106,7 @@ const labelStyle: React.CSSProperties = {
 const ASSET_TYPES = [
   { v: 'fund', Icon: TrendingUp, enLabel: 'Fund', viLabel: 'Quỹ',       color: '#2563eb', bg: 'rgba(37,99,235,0.10)' },
   { v: 'bank', Icon: Building2,  enLabel: 'Bank', viLabel: 'Ngân hàng', color: '#047857', bg: 'rgba(4,120,87,0.10)' },
-  { v: 'gold', Icon: Coins,      enLabel: 'Gold', viLabel: 'Vàng',      color: '#b45309', bg: 'rgba(180,83,9,0.10)' },
+  { v: 'gold', Icon: Coins,      enLabel: 'Gold', viLabel: 'Vàng',      color: 'var(--c-fund-gold)', bg: 'rgba(180,83,9,0.10)' },
 ] as const
 
 type AssetType = typeof ASSET_TYPES[number]['v']

--- a/app/assets/components/AssignGoalSheet.tsx
+++ b/app/assets/components/AssignGoalSheet.tsx
@@ -36,7 +36,7 @@ const TYPE_ICON: Record<string, React.ElementType> = {
 const TYPE_COLOR: Record<string, string> = {
   fund:  '#2563eb',
   bank:  '#047857',
-  gold:  '#d97706',
+  gold:  'var(--c-fund-gold)',
   stock: '#7c3aed',
 }
 

--- a/app/assets/components/DesktopNetWorthPanel.tsx
+++ b/app/assets/components/DesktopNetWorthPanel.tsx
@@ -54,7 +54,7 @@ function Sparkline({ data, positive }: { data: ChartPoint[]; positive: boolean }
 const ALLOC_COLORS: Record<string, { color: string; label: string; labelVi: string }> = {
   fund:  { color: '#2563eb', label: 'Funds',   labelVi: 'Quỹ' },
   bank:  { color: '#047857', label: 'Savings', labelVi: 'Tiết kiệm' },
-  gold:  { color: '#d97706', label: 'Gold',    labelVi: 'Vàng' },
+  gold:  { color: 'var(--c-fund-gold)', label: 'Gold',    labelVi: 'Vàng' },
   stock: { color: '#7c3aed', label: 'Stock',   labelVi: 'Cổ phiếu' },
 }
 

--- a/app/assets/components/NetWorthCard.tsx
+++ b/app/assets/components/NetWorthCard.tsx
@@ -44,7 +44,7 @@ function Sparkline({ data, positive }: { data: ChartPoint[]; positive: boolean }
 const ALLOC_COLORS = {
   fund:  '#2563eb',
   bank:  '#047857',
-  gold:  '#d97706',
+  gold:  'var(--c-fund-gold)',
   stock: '#7c3aed',
 } as const
 

--- a/app/assets/components/RecentActivityCard.tsx
+++ b/app/assets/components/RecentActivityCard.tsx
@@ -19,7 +19,7 @@ const ASSET_BADGE: Record<AssetType, string> = {
   fund: '#2563eb',
   bank: '#047857',
   stock: '#7c3aed',
-  gold: '#b45309',
+  gold: 'var(--c-fund-gold)',
 }
 
 interface Props {

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from 'react'
 import { useLocale, useTranslations } from 'next-intl'
-import { ArrowDownRight, ArrowDownToLine, Building, Check, CircleDollarSign, Shield, TrendingUp, Wallet, X } from 'lucide-react'
+import { ArrowDownRight, ArrowDownToLine, Building, Check, Coins, Shield, TrendingUp, Wallet, X } from 'lucide-react'
 import { fmt } from '@/lib/formatters'
 import { AffectsProgressControl } from './goalDetailShared'
 const fmtVND = (n: number, _locale?: string) => fmt(n)
@@ -42,14 +42,14 @@ interface Props {
 const TYPE_ICON = {
   fund: TrendingUp,
   bank: Building,
-  gold: CircleDollarSign,
+  gold: Coins,
   stock: TrendingUp,
 } as const
 
 const TYPE_COLOR = {
   fund: '#2563eb',
   bank: '#047857',
-  gold: '#d97706',
+  gold: 'var(--c-fund-gold)',
   stock: '#7c3aed',
 } as const
 

--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { ChevronDown, ChevronUp, ChevronRight, Target, Building, CircleDollarSign, TrendingUp, BarChart2, Clock, ArrowDownToLine, ArrowDownRight, ArrowRight, Wallet, Check, X } from 'lucide-react'
+import { ChevronDown, ChevronUp, ChevronRight, Target, Building, Coins, TrendingUp, BarChart2, Clock, ArrowDownToLine, ArrowDownRight, ArrowRight, Wallet, Check, X } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { useLocale } from 'next-intl'
 import type { FundBreakdownItem, NonFundUnallocatedItem } from '../DashboardClient'
@@ -27,7 +27,7 @@ function DesktopAssignPicker({
   actionValue: number
   actionType: string
 }) {
-  const ItemIcon = { fund: TrendingUp, bank: Building, gold: CircleDollarSign, stock: BarChart2 }[actionType] ?? TrendingUp
+  const ItemIcon = { fund: TrendingUp, bank: Building, gold: Coins, stock: BarChart2 }[actionType] ?? TrendingUp
   const selectedGoal = goals.find((g) => g.id === selected)
 
   if (success) return (
@@ -120,13 +120,13 @@ interface GoalOption {
 const TYPE_ICON: Record<string, React.ElementType> = {
   fund:  TrendingUp,
   bank:  Building,
-  gold:  CircleDollarSign,
+  gold:  Coins,
   stock: BarChart2,
 }
 const TYPE_COLOR: Record<string, string> = {
   fund:  '#2563eb',
   bank:  '#047857',
-  gold:  '#d97706',
+  gold:  'var(--c-fund-gold)',
   stock: '#7c3aed',
 }
 

--- a/app/assets/components/__tests__/goldIconConsistency.test.tsx
+++ b/app/assets/components/__tests__/goldIconConsistency.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+import { render } from '@testing-library/react'
+import { TypeIcon } from '../goalDetailShared'
+
+// ── Issue #268 — "Check Gold icon to update consistence across apps" ──────────
+// The gold asset type was drawn two different ways: lucide `Coins` in some
+// surfaces and `CircleDollarSign` in others, and its colour was a hardcoded
+// amber (#d97706 / #b45309) that stays dark in dark mode. The canonical look is
+// the `Coins` glyph tinted with the dark-mode-aware `--c-fund-gold` token.
+
+const APP = path.resolve(process.cwd(), 'app')
+const read = (rel: string) => readFileSync(path.join(APP, rel.replace(/\//g, path.sep)), 'utf8')
+
+describe('issue #268 — gold icon is the Coins glyph everywhere', () => {
+  it('TypeIcon renders Coins for gold (the user-visible glyph), not CircleDollarSign', () => {
+    const { container } = render(<TypeIcon type="gold" />)
+    const cls = container.querySelector('svg')?.getAttribute('class') ?? ''
+    expect(cls).toContain('lucide-coins')
+    expect(cls).not.toContain('circle-dollar-sign')
+  })
+
+  // Every surface that draws a gold glyph must map gold → Coins, never
+  // CircleDollarSign — in either object-map or inline-JSX form.
+  const ICON_FILES = [
+    'assets/components/goalDetailShared.tsx',
+    'assets/components/SellWithdrawSheet.tsx',
+    'assets/components/UnallocatedSection.tsx',
+    '(app)/settings/components/DesktopSettingsView.tsx',
+    '(app)/settings/components/MobileSettingsView.tsx',
+  ]
+  for (const rel of ICON_FILES) {
+    it(`${rel} never maps gold to CircleDollarSign`, () => {
+      const src = read(rel)
+      expect(src, 'gold object-map still uses CircleDollarSign').not.toMatch(/gold:\s*CircleDollarSign/)
+      expect(src, 'gold JSX still uses CircleDollarSign').not.toMatch(/type === 'gold'\s*\)\s*return\s*<CircleDollarSign/)
+      // Settings gold-price rows render the glyph inline next to the DOJI label.
+      if (rel.includes('Settings')) {
+        expect(src, 'Gold price row still uses CircleDollarSign').not.toMatch(/<CircleDollarSign[^>]*\/>,\s*\n?\s*color/)
+      }
+    })
+  }
+})
+
+describe('issue #268 — gold colour is the --c-fund-gold token everywhere', () => {
+  // Hardcoded amber stays dark on the dark canvas; the token flips (light:
+  // #b45309, dark: #fbbf24). One canonical, theme-aware gold across the app.
+  const GOLD_COLOR_LINES: Array<[string, RegExp]> = [
+    ['assets/components/goalDetailShared.tsx', /gold:\s*'#d97706'/],
+    ['assets/components/NetWorthCard.tsx', /gold:\s*'#d97706'/],
+    ['assets/components/DesktopNetWorthPanel.tsx', /gold:\s*\{\s*color:\s*'#d97706'/],
+    ['assets/components/AssignGoalSheet.tsx', /gold:\s*'#d97706'/],
+    ['assets/components/SellWithdrawSheet.tsx', /gold:\s*'#d97706'/],
+    ['assets/components/RecentActivityCard.tsx', /gold:\s*'#b45309'/],
+    ['assets/components/UnallocatedSection.tsx', /gold:\s*'#d97706'/],
+  ]
+  for (const [rel, re] of GOLD_COLOR_LINES) {
+    it(`${rel} uses the token for the gold colour`, () => {
+      const src = read(rel)
+      expect(src, `${rel} still hardcodes the gold colour`).not.toMatch(re)
+      expect(src, `${rel} missing --c-fund-gold token`).toContain('var(--c-fund-gold)')
+    })
+  }
+
+  it('AddTransactionSheet gold chip uses the token, not hardcoded amber', () => {
+    const line = read('assets/components/AddTransactionSheet.tsx')
+      .split('\n')
+      .find((l) => l.includes("v: 'gold'"))
+    expect(line, "gold chip definition not found").toBeDefined()
+    expect(line!).not.toContain('#b45309')
+    expect(line!).toContain('var(--c-fund-gold)')
+  })
+
+  it('settings gold-price rows use the token for the gold colour', () => {
+    for (const rel of [
+      '(app)/settings/components/DesktopSettingsView.tsx',
+      '(app)/settings/components/MobileSettingsView.tsx',
+    ]) {
+      expect(read(rel), `${rel} still hardcodes the gold-price colour`).not.toMatch(/color:\s*'#d97706'/)
+    }
+  })
+})

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -3,14 +3,14 @@
 // chrome, so the icons, colours, deadline math and — most importantly — the
 // investment-row valuation live here to stay in sync.
 
-import { TrendingUp, Building, CircleDollarSign, BarChart2, Target } from 'lucide-react'
+import { TrendingUp, Building, Coins, BarChart2, Target } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
 import type { FundBreakdownItem } from '../DashboardClient'
 
 export const GD_COLORS: Record<string, string> = {
   fund: '#2563eb',
   bank: '#047857',
-  gold: '#d97706',
+  gold: 'var(--c-fund-gold)',
   stock: '#7c3aed',
 }
 
@@ -24,7 +24,7 @@ export function calcDeadlineMonths(targetDate: string | null): number {
 export function TypeIcon({ type, size = 16 }: { type: string; size?: number }) {
   if (type === 'fund') return <TrendingUp size={size} />
   if (type === 'bank') return <Building size={size} />
-  if (type === 'gold') return <CircleDollarSign size={size} />
+  if (type === 'gold') return <Coins size={size} />
   return <BarChart2 size={size} />
 }
 


### PR DESCRIPTION
@
Closes #268.

## Problem
The Gold asset type was rendered inconsistently:
- **Icon:** lucide `Coins` in Add Transaction + Assign Goal, but `CircleDollarSign` in Sell/Withdraw, Goal Detail, the Unallocated list, and Settings (gold-price row).
- **Colour:** a hardcoded amber (`#d97706` / `#b45309`) that stays dark in dark mode, hurting legibility.

## Fix
- Standardise on the **`Coins`** glyph for gold everywhere.
- Tint gold with the dark-mode-aware **`--c-fund-gold`** token (light `#b45309`, dark `#fbbf24`) so it flips with the theme — same approach as the fund-type palette from #264.

Surfaces touched: Goal Detail (mobile + desktop), Sell/Withdraw, Assign Goal, Add Transaction, Unallocated list, Net Worth card + desktop panel, Recent Activity, and Settings (gold-price sync row).

The `--c-warn` warning Shield in Sell/Withdraw keeps its `#d97706` fallback — it is not the gold asset colour and is out of scope.

## Tests (TDD)
Added `goldIconConsistency.test.tsx`:
- Renders `TypeIcon` and asserts the gold glyph is `lucide-coins` (user-visible outcome), not `circle-dollar-sign`.
- Source-scans every gold-asset surface to assert gold maps to `Coins` and uses `var(--c-fund-gold)`, so the two forms cannot drift apart again.

All 248 tests across the affected suites pass; `tsc --noEmit` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@