### PR TITLE
fix(overview): net-worth line chart now responds to 1M/3M range pills (#266)

### DIFF
--- a/app/api/v1/dashboard/history/route.ts
+++ b/app/api/v1/dashboard/history/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { rangeStartDate } from '@/lib/historyRange'
 
 export const dynamic = 'force-dynamic'
 
@@ -11,13 +12,7 @@ export async function GET(request: Request) {
   const { searchParams } = new URL(request.url)
   const range = searchParams.get('range') ?? 'all'
 
-  const fromDate = (() => {
-    const now = new Date()
-    if (range === '6m') { now.setMonth(now.getMonth() - 6); return now.toISOString().split('T')[0] }
-    if (range === '1y') { now.setFullYear(now.getFullYear() - 1); return now.toISOString().split('T')[0] }
-    if (range === '3y') { now.setFullYear(now.getFullYear() - 3); return now.toISOString().split('T')[0] }
-    return null
-  })()
+  const fromDate = rangeStartDate(range)
 
   let snapshotQuery = supabase
     .from('net_worth_snapshots')

--- a/lib/__tests__/historyRange.test.ts
+++ b/lib/__tests__/historyRange.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest'
+import { rangeStartDate } from '../historyRange'
+
+// Issue #266 — the Overview line chart did not change when a different time
+// range was selected. Root cause: the history API only computed a cutoff for
+// 6m / 1y / 3y, so '1m' and '3m' (sent by the range pills) fell through to
+// "no lower bound" and returned the full dataset — identical to 'All'.
+
+const NOW = new Date('2026-06-15T00:00:00Z')
+
+describe('rangeStartDate', () => {
+  it('1m → one month back', () => {
+    expect(rangeStartDate('1m', NOW)).toBe('2026-05-15')
+  })
+  it('3m → three months back', () => {
+    expect(rangeStartDate('3m', NOW)).toBe('2026-03-15')
+  })
+  it('6m → six months back', () => {
+    expect(rangeStartDate('6m', NOW)).toBe('2025-12-15')
+  })
+  it('1y → one year back', () => {
+    expect(rangeStartDate('1y', NOW)).toBe('2025-06-15')
+  })
+  it('all → null (no lower bound)', () => {
+    expect(rangeStartDate('all', NOW)).toBeNull()
+  })
+  it('unknown range → null (defensive default)', () => {
+    expect(rangeStartDate('bogus', NOW)).toBeNull()
+  })
+
+  it('every selectable range yields a distinct cutoff (the bug: 1m/3m collapsed to All)', () => {
+    const cutoffs = ['1m', '3m', '6m', '1y'].map((r) => rangeStartDate(r, NOW))
+    expect(cutoffs).toEqual(['2026-05-15', '2026-03-15', '2025-12-15', '2025-06-15'])
+    expect(new Set(cutoffs).size).toBe(4)
+    // None of them collapse to the "All" (null) bound.
+    expect(cutoffs.every((c) => c !== null)).toBe(true)
+  })
+})

--- a/lib/historyRange.ts
+++ b/lib/historyRange.ts
@@ -1,0 +1,18 @@
+// Maps a Net-worth history range token (sent by the Overview range pills) to the
+// inclusive lower-bound date (YYYY-MM-DD) used to filter snapshots. Returns null
+// for "all" / unknown, meaning no lower bound.
+//
+// UTC methods keep the cutoff deterministic regardless of server timezone — the
+// result is compared against date-only strings (snapshot_date / YYYY-MM).
+export function rangeStartDate(range: string, now: Date = new Date()): string | null {
+  const d = new Date(now)
+  switch (range) {
+    case '1m': d.setUTCMonth(d.getUTCMonth() - 1); break
+    case '3m': d.setUTCMonth(d.getUTCMonth() - 3); break
+    case '6m': d.setUTCMonth(d.getUTCMonth() - 6); break
+    case '1y': d.setUTCFullYear(d.getUTCFullYear() - 1); break
+    case '3y': d.setUTCFullYear(d.getUTCFullYear() - 3); break
+    default: return null // 'all' or anything unrecognised
+  }
+  return d.toISOString().split('T')[0]
+}


### PR DESCRIPTION
@
Closes #266.

## Problem
On the Overview, the net-worth line chart did not change when selecting a different time range (e.g. 1M vs 3M vs All all showed the same line).

**Root cause:** the range pills send `1m / 3m / 6m / 1y / all`, but the history API (`app/api/v1/dashboard/history`) only computed a cutoff date for `6m / 1y / 3y`. `1m` and `3m` fell through to "no lower bound", returning the full dataset — identical to `All`.

## Fix
- Extracted the range→cutoff mapping into a pure `rangeStartDate()` helper (`lib/historyRange.ts`) covering every selectable range.
- Computed the cutoff in **UTC** so it is deterministic regardless of server timezone (the result is compared against date-only strings).
- Wired it into the history route, replacing the incomplete inline logic. Both the snapshot path and the synthetic-from-transactions fallback now honour `1m`/`3m`.

## Tests (TDD)
Added `lib/__tests__/historyRange.test.ts` (red → green): asserts each range maps to the correct cutoff and that **every selectable range yields a distinct cutoff** (directly pinning the bug where 1m/3m collapsed to All). `tsc --noEmit` clean.

> Note: the visible chart still depends on having ≥2 snapshots in the selected window; this PR fixes the range filtering, which was the cause of the identical lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@