### PR TITLE
feat(funds): add DCA goal target to fund library (#293)

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -19,9 +19,12 @@ type Fund = {
   nav_source_url: string | null
   is_dca: boolean
   dca_monthly_amount_vnd: number | null
+  dca_goal_id: string | null
   created_at: string
   updated_at: string
 }
+
+type Goal = { goal_id: string; goal_name: string }
 
 type SortKey = 'code' | 'nav' | 'name'
 type TypeFilter = 'all' | 'equity' | 'debt' | 'balanced'
@@ -197,19 +200,23 @@ const SortTh = ({ label, sortKey, active, asc, onSort, align = 'right' }: {
 
 // ─── DCA toggle (inline) ──────────────────────────────────────────────────────
 
-function DcaToggle({ fund, editId, editValue, onToggle, onEditStart, onEditChange, onEditCommit, onEditCancel }: {
+function DcaToggle({ fund, editId, editValue, goals, goalLabel, unallocatedLabel, onToggle, onEditStart, onEditChange, onEditCommit, onEditCancel, onGoalChange }: {
   fund: Fund
   editId: string | null
   editValue: string
+  goals: Goal[]
+  goalLabel: string
+  unallocatedLabel: string
   onToggle: () => void
   onEditStart: () => void
   onEditChange: (v: string) => void
   onEditCommit: () => void
   onEditCancel: () => void
+  onGoalChange: (goalId: string | null) => void
 }) {
   const isEditing = editId === fund.id
   return (
-    <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
+    <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', justifyContent: 'center' }}>
       <button
         data-testid="dca-toggle"
         aria-label="DCA"
@@ -264,6 +271,26 @@ function DcaToggle({ fund, editId, editValue, onToggle, onEditStart, onEditChang
           </button>
         )
       )}
+      {/* Goal target — recurring contributions for this fund count toward this goal */}
+      {fund.is_dca && (
+        <select
+          data-testid={`dca-goal-${fund.id}`}
+          value={fund.dca_goal_id ?? ''}
+          title={goalLabel}
+          aria-label={goalLabel}
+          onClick={e => e.stopPropagation()}
+          onChange={e => { e.stopPropagation(); onGoalChange(e.target.value || null) }}
+          style={{
+            fontSize: 11, fontWeight: 500, padding: '3px 6px', maxWidth: 120,
+            border: '1px solid var(--c-line)', borderRadius: 6,
+            background: 'var(--c-card)', color: 'var(--c-muted)',
+            fontFamily: 'inherit', cursor: 'pointer', appearance: 'none', outline: 'none',
+          }}
+        >
+          {goals.map(g => <option key={g.goal_id} value={g.goal_id}>{g.goal_name}</option>)}
+          <option value="">{unallocatedLabel}</option>
+        </select>
+      )}
     </div>
   )
 }
@@ -288,6 +315,9 @@ export default function DesktopFundLibraryView() {
   const [funds, setFunds] = useState<Fund[]>(() => getCache() ?? [])
   const [loading, setLoading] = useState(() => !getCache())
   const [error, setError] = useState<string | null>(null)
+
+  // Savings goals (DCA target options)
+  const [goals, setGoals] = useState<Goal[]>([])
 
   // Table state
   const [query, setQuery] = useState('')
@@ -340,6 +370,16 @@ export default function DesktopFundLibraryView() {
   }, [])
 
   useEffect(() => { loadFunds() }, [loadFunds])
+
+  // Load savings goals once for the DCA target dropdown.
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/v1/savings-goals')
+      .then(res => res.ok ? res.json() : { goals: [] })
+      .then(({ goals: data }) => { if (!cancelled) setGoals(data ?? []) })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [])
 
   useEffect(() => {
     const handler = () => { if (!_suppressNotify) loadFunds(true) }
@@ -477,6 +517,25 @@ export default function DesktopFundLibraryView() {
     } catch {
       setFunds(p => p.map(f => f.id === fund.id ? { ...f, is_dca: false, dca_monthly_amount_vnd: null } : f))
       addToast('Failed to update DCA', false)
+    }
+  }
+
+  async function handleSetDcaGoal(fund: Fund, goalId: string | null) {
+    const prevGoalId = fund.dca_goal_id
+    setFunds(p => p.map(f => f.id === fund.id ? { ...f, dca_goal_id: goalId } : f))
+    try {
+      const res = await fetch(`/api/funds/${fund.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: fund.dca_monthly_amount_vnd, dca_goal_id: goalId }),
+      })
+      if (!res.ok) throw new Error()
+      bustCache()
+      await loadFunds(true)
+      notifyFundsUpdated()
+    } catch {
+      setFunds(p => p.map(f => f.id === fund.id ? { ...f, dca_goal_id: prevGoalId } : f))
+      addToast('Failed to update goal', false)
     }
   }
 
@@ -676,11 +735,15 @@ export default function DesktopFundLibraryView() {
                           fund={fund}
                           editId={dcaEditId}
                           editValue={dcaEditValue}
+                          goals={goals}
+                          goalLabel={t('dcaGoalLabel')}
+                          unallocatedLabel={t('dcaGoalUnallocated')}
                           onToggle={() => handleToggleDca(fund)}
                           onEditStart={() => { setDcaEditId(fund.id); setDcaEditValue(String(fund.dca_monthly_amount_vnd ?? '')) }}
                           onEditChange={setDcaEditValue}
                           onEditCommit={() => handleSaveDcaAmount(fund)}
                           onEditCancel={() => { setFunds(p => p.map(f => f.id === fund.id ? { ...f, is_dca: false, dca_monthly_amount_vnd: null } : f)); setDcaEditId(null) }}
+                          onGoalChange={(goalId) => handleSetDcaGoal(fund, goalId)}
                         />
                       </td>
 

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -39,9 +39,12 @@ type Fund = {
   nav_source_url: string | null
   is_dca: boolean
   dca_monthly_amount_vnd: number | null
+  dca_goal_id: string | null
   created_at: string
   updated_at: string
 }
+
+type Goal = { goal_id: string; goal_name: string }
 
 type Toast = { id: number; message: string; type: 'success' | 'error' }
 type SortKey = 'code' | 'nav' | 'name'
@@ -314,15 +317,19 @@ function FundForm({ existing, title, onClose, onSave, saving, formError }: {
 
 // ─── FundCard ────────────────────────────────────────────────────────────────
 
-function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, onEdit, onDelete, onToggleDca, onSaveDcaAmount, setDcaEditId, setDcaEditValue }: {
+function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel, unallocatedLabel, onEdit, onDelete, onToggleDca, onSaveDcaAmount, onGoalChange, setDcaEditId, setDcaEditValue }: {
   fund: Fund
   dcaEditId: string | null
   dcaEditValue: string
   togglingIds: Set<string>
+  goals: Goal[]
+  goalLabel: string
+  unallocatedLabel: string
   onEdit: () => void
   onDelete: () => void
   onToggleDca: () => void
   onSaveDcaAmount: (val: string) => void
+  onGoalChange: (goalId: string | null) => void
   setDcaEditId: (id: string | null) => void
   setDcaEditValue: (v: string) => void
 }) {
@@ -379,7 +386,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, onEdit, onDelete
           )}
         </div>
 
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
           <span style={{ fontSize: 10, color: 'var(--c-muted)', textTransform: 'uppercase', letterSpacing: '0.05em', fontWeight: 600 }}>DCA</span>
           <button
             type="button"
@@ -425,6 +432,26 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, onEdit, onDelete
               </button>
             )
           )}
+
+          {/* Goal target — recurring contributions for this fund count toward this goal */}
+          {fund.is_dca && (
+            <select
+              data-testid={`dca-goal-${fund.id}`}
+              value={fund.dca_goal_id ?? ''}
+              title={goalLabel}
+              aria-label={goalLabel}
+              onChange={(e) => onGoalChange(e.target.value || null)}
+              style={{
+                fontSize: 13, fontWeight: 500, padding: '3px 6px', maxWidth: 130,
+                border: '1px solid var(--c-line)', borderRadius: 6,
+                background: 'var(--c-card)', color: 'var(--c-muted)',
+                fontFamily: 'inherit', cursor: 'pointer', appearance: 'none', outline: 'none',
+              }}
+            >
+              {goals.map((g) => <option key={g.goal_id} value={g.goal_id}>{g.goal_name}</option>)}
+              <option value="">{unallocatedLabel}</option>
+            </select>
+          )}
         </div>
       </div>
     </div>
@@ -443,6 +470,7 @@ export default function MobileFundLibraryView() {
   const [loading, setLoading] = useState(() => !getCache())
   const [error, setError] = useState<string | null>(null)
   const [refreshing, setRefreshing] = useState(false)
+  const [goals, setGoals] = useState<Goal[]>([])
 
   // ── UI state ──────────────────────────────────────────────────────────────
   const [query, setQuery] = useState('')
@@ -493,6 +521,16 @@ export default function MobileFundLibraryView() {
   }, [])
 
   useEffect(() => { loadFunds() }, [loadFunds])
+
+  // Load savings goals once for the DCA target dropdown.
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/v1/savings-goals')
+      .then((res) => res.ok ? res.json() : { goals: [] })
+      .then(({ goals: data }) => { if (!cancelled) setGoals(data ?? []) })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [])
 
   useEffect(() => {
     const handler = () => { if (!_suppressNotify) loadFunds({ force: true }) }
@@ -664,6 +702,24 @@ export default function MobileFundLibraryView() {
     }
   }
 
+  async function handleSetDcaGoal(fund: Fund, goalId: string | null) {
+    const prevGoalId = fund.dca_goal_id
+    setFunds((prev) => prev.map((f) => f.id === fund.id ? { ...f, dca_goal_id: goalId } : f))
+    setTogglingIds((prev) => new Set([...prev, fund.id]))
+    try {
+      const res = await fetch(`/api/funds/${fund.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: fund.dca_monthly_amount_vnd, dca_goal_id: goalId }) })
+      if (!res.ok) throw new Error()
+      bustCache()
+      await loadFunds({ force: true })
+      notifyFundsUpdated()
+    } catch {
+      setFunds((prev) => prev.map((f) => f.id === fund.id ? { ...f, dca_goal_id: prevGoalId } : f))
+      addToast('Failed to update goal', 'error')
+    } finally {
+      setTogglingIds((prev) => { const s = new Set(prev); s.delete(fund.id); return s })
+    }
+  }
+
   // ── Render ────────────────────────────────────────────────────────────────
 
   return (
@@ -772,10 +828,14 @@ export default function MobileFundLibraryView() {
                 dcaEditId={dcaEditId}
                 dcaEditValue={dcaEditValue}
                 togglingIds={togglingIds}
+                goals={goals}
+                goalLabel={t('dcaGoalLabel')}
+                unallocatedLabel={t('dcaGoalUnallocated')}
                 onEdit={() => { setFormError(null); setEditFund(fund) }}
                 onDelete={() => setDeleteFund(fund)}
                 onToggleDca={() => handleToggleDca(fund)}
                 onSaveDcaAmount={(val) => handleSaveDcaAmount(fund, val)}
+                onGoalChange={(goalId) => handleSetDcaGoal(fund, goalId)}
                 setDcaEditId={setDcaEditId}
                 setDcaEditValue={setDcaEditValue}
               />

--- a/app/api/funds/[id]/route.ts
+++ b/app/api/funds/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 
 const FUND_TYPES = ['balanced', 'equity', 'debt', 'gold'] as const
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -40,7 +41,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   }
 
   const body = await request.json()
-  const { name, code, fund_type, nav, nav_source_url, is_dca, dca_monthly_amount_vnd } = body
+  const { name, code, fund_type, nav, nav_source_url, is_dca, dca_monthly_amount_vnd, dca_goal_id } = body
 
   if (!name || typeof name !== 'string' || name.trim().length === 0) {
     return NextResponse.json({ error: 'Name is required' }, { status: 400 })
@@ -61,6 +62,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   if (!nav || isNaN(navNum) || navNum < 0.01) {
     return NextResponse.json({ error: 'NAV must be greater than 0' }, { status: 400 })
   }
+  if (dca_goal_id != null && dca_goal_id !== '' && (typeof dca_goal_id !== 'string' || !UUID_RE.test(dca_goal_id))) {
+    return NextResponse.json({ error: 'Invalid goal' }, { status: 400 })
+  }
 
   const { data: fund, error } = await supabase
     .from('funds')
@@ -72,6 +76,8 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
       nav_source_url: typeof nav_source_url === 'string' && nav_source_url.trim() ? nav_source_url.trim() : null,
       is_dca: is_dca === true,
       dca_monthly_amount_vnd: is_dca === true && dca_monthly_amount_vnd ? Number(dca_monthly_amount_vnd) : null,
+      // Goal target only applies while DCA is on; cleared otherwise.
+      dca_goal_id: is_dca === true && dca_goal_id ? dca_goal_id : null,
     })
     .eq('id', id)
     .eq('user_id', user.id)

--- a/app/api/funds/route.ts
+++ b/app/api/funds/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 
 const FUND_TYPES = ['balanced', 'equity', 'debt', 'gold'] as const
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
 export async function GET() {
   const supabase = await createSupabaseServerClient()
@@ -37,7 +38,7 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await request.json()
-  const { name, code, fund_type, nav, nav_source_url, is_dca, dca_monthly_amount_vnd } = body
+  const { name, code, fund_type, nav, nav_source_url, is_dca, dca_monthly_amount_vnd, dca_goal_id } = body
 
   // Validate required fields
   if (!name || typeof name !== 'string' || name.trim().length === 0) {
@@ -59,6 +60,9 @@ export async function POST(request: NextRequest) {
   if (!nav || isNaN(navNum) || navNum < 0.01) {
     return NextResponse.json({ error: 'NAV must be greater than 0' }, { status: 400 })
   }
+  if (dca_goal_id != null && dca_goal_id !== '' && (typeof dca_goal_id !== 'string' || !UUID_RE.test(dca_goal_id))) {
+    return NextResponse.json({ error: 'Invalid goal' }, { status: 400 })
+  }
 
   const { data: fund, error } = await supabase
     .from('funds')
@@ -71,6 +75,8 @@ export async function POST(request: NextRequest) {
       nav_source_url: typeof nav_source_url === 'string' && nav_source_url.trim() ? nav_source_url.trim() : null,
       is_dca: is_dca === true,
       dca_monthly_amount_vnd: is_dca === true && dca_monthly_amount_vnd ? Number(dca_monthly_amount_vnd) : null,
+      // Goal target only applies while DCA is on; cleared otherwise.
+      dca_goal_id: is_dca === true && dca_goal_id ? dca_goal_id : null,
     })
     .select()
     .single()

--- a/e2e/funds-desktop.spec.ts
+++ b/e2e/funds-desktop.spec.ts
@@ -144,3 +144,40 @@ test('desktop funds DCA toggle enables inline amount input', async ({ page }) =>
   await row.getByTestId('dca-toggle').click()
   await expect(row.getByPlaceholder(/amount|số tiền/i)).toBeVisible({ timeout: 5_000 })
 })
+
+test('desktop funds DCA shows goal target dropdown when enabled', async ({ page }) => {
+  const fund = await api.createFund({ name: 'E2E Desktop DCA Goal', code: 'DTDCG1', fund_type: 'equity', nav: 15000 })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  const table = page.getByTestId('desktop-funds-table')
+  const row = table.getByTestId(`fund-row-${fund.id}`)
+  await row.getByTestId('dca-toggle').click()
+  const select = row.getByTestId(`dca-goal-${fund.id}`)
+  await expect(select).toBeVisible({ timeout: 5_000 })
+  await expect(select).toHaveValue('')
+})
+
+test('desktop funds DCA goal selection persists across reload', async ({ page }) => {
+  const goal = await api.createGoal({ goal_name: 'E2E Desktop DCA Goal Target' })
+  cleanup.add(() => api.deleteGoal(goal.goal_id))
+  const fund = await api.createFund({ name: 'E2E Desktop DCA Persist', code: 'DTDCP1', fund_type: 'equity', nav: 15000 })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  const table = page.getByTestId('desktop-funds-table')
+  const row = table.getByTestId(`fund-row-${fund.id}`)
+  await row.getByTestId('dca-toggle').click()
+  const select = row.getByTestId(`dca-goal-${fund.id}`)
+  await expect(select).toBeVisible({ timeout: 5_000 })
+  await select.selectOption(goal.goal_id)
+
+  await page.reload()
+  await page.waitForLoadState('networkidle')
+  const rowAfter = page.getByTestId('desktop-funds-table').getByTestId(`fund-row-${fund.id}`)
+  await expect(rowAfter.getByTestId(`dca-goal-${fund.id}`)).toHaveValue(goal.goal_id, { timeout: 8_000 })
+})

--- a/e2e/funds-desktop.spec.ts
+++ b/e2e/funds-desktop.spec.ts
@@ -174,7 +174,11 @@ test('desktop funds DCA goal selection persists across reload', async ({ page })
   await row.getByTestId('dca-toggle').click()
   const select = row.getByTestId(`dca-goal-${fund.id}`)
   await expect(select).toBeVisible({ timeout: 5_000 })
-  await select.selectOption(goal.goal_id)
+  // Wait for the persisting PUT to land before reloading (avoids racing the save).
+  await Promise.all([
+    page.waitForResponse(r => r.url().includes(`/api/funds/${fund.id}`) && r.request().method() === 'PUT' && r.ok()),
+    select.selectOption(goal.goal_id),
+  ])
 
   await page.reload()
   await page.waitForLoadState('networkidle')

--- a/e2e/funds.spec.ts
+++ b/e2e/funds.spec.ts
@@ -143,6 +143,45 @@ test('mobile funds DCA toggle shows amount input when enabled', async ({ page })
   await expect(card.getByPlaceholder(/amount/i)).toBeVisible({ timeout: 5_000 })
 })
 
+test('mobile funds DCA shows goal target dropdown when enabled', async ({ page }) => {
+  const fund = await api.createFund({ name: 'E2E DCA Goal Fund', code: 'E2EDCG', fund_type: 'equity', nav: 15000 })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  const mf = page.getByTestId('mobile-funds')
+  const card = mf.getByTestId(`fund-card-${fund.id}`)
+  await card.getByRole('button', { name: /dca/i }).click()
+  // Target picker appears; defaults to Unallocated
+  const select = card.getByTestId(`dca-goal-${fund.id}`)
+  await expect(select).toBeVisible({ timeout: 5_000 })
+  await expect(select).toHaveValue('')
+})
+
+test('mobile funds DCA goal selection persists', async ({ page }) => {
+  const goal = await api.createGoal({ goal_name: 'E2E Mobile DCA Goal Target' })
+  cleanup.add(() => api.deleteGoal(goal.goal_id))
+  const fund = await api.createFund({ name: 'E2E DCA Persist Fund', code: 'E2EDCP', fund_type: 'equity', nav: 15000 })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  const mf = page.getByTestId('mobile-funds')
+  const card = mf.getByTestId(`fund-card-${fund.id}`)
+  await card.getByRole('button', { name: /dca/i }).click()
+  const select = card.getByTestId(`dca-goal-${fund.id}`)
+  await expect(select).toBeVisible({ timeout: 5_000 })
+  await select.selectOption(goal.goal_id)
+
+  // Persisted: reload and confirm the goal is still selected
+  await page.reload()
+  await page.waitForLoadState('networkidle')
+  const cardAfter = page.getByTestId('mobile-funds').getByTestId(`fund-card-${fund.id}`)
+  await expect(cardAfter.getByTestId(`dca-goal-${fund.id}`)).toHaveValue(goal.goal_id, { timeout: 8_000 })
+})
+
 test('mobile funds shows empty state when no funds exist', async ({ page }) => {
   // We test the empty-data scenario by verifying the page loads without crashing, then rely on the no-results test above for the UI state
   await page.goto('/funds')

--- a/e2e/funds.spec.ts
+++ b/e2e/funds.spec.ts
@@ -173,7 +173,11 @@ test('mobile funds DCA goal selection persists', async ({ page }) => {
   await card.getByRole('button', { name: /dca/i }).click()
   const select = card.getByTestId(`dca-goal-${fund.id}`)
   await expect(select).toBeVisible({ timeout: 5_000 })
-  await select.selectOption(goal.goal_id)
+  // Wait for the persisting PUT to land before reloading (avoids racing the save).
+  await Promise.all([
+    page.waitForResponse(r => r.url().includes(`/api/funds/${fund.id}`) && r.request().method() === 'PUT' && r.ok()),
+    select.selectOption(goal.goal_id),
+  ])
 
   // Persisted: reload and confirm the goal is still selected
   await page.reload()

--- a/messages/en.json
+++ b/messages/en.json
@@ -563,7 +563,9 @@
     "navInfoTitle": "About NAV Updates",
     "navInfoDesc": "NAV (Net Asset Value) is updated daily by fund providers. Click \"{refreshNav}\" to fetch the latest prices. Prices are typically updated after market close.",
     "searchPlaceholder": "Search by fund name or code...",
-    "fundsCount": "{count, plural, one {# fund} other {# funds}}"
+    "fundsCount": "{count, plural, one {# fund} other {# funds}}",
+    "dcaGoalLabel": "Allocate to",
+    "dcaGoalUnallocated": "Unallocated"
   },
   "planning": {
     "title": "Monthly Plan",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -563,7 +563,9 @@
     "navInfoTitle": "Về cập nhật NAV",
     "navInfoDesc": "NAV (Giá trị tài sản ròng) được cập nhật hàng ngày bởi các công ty quản lý quỹ. Nhấn \"{refreshNav}\" để lấy giá mới nhất. Giá thường được cập nhật sau khi thị trường đóng cửa.",
     "searchPlaceholder": "Tìm theo tên hoặc mã quỹ...",
-    "fundsCount": "{count} quỹ"
+    "fundsCount": "{count} quỹ",
+    "dcaGoalLabel": "Phân bổ vào",
+    "dcaGoalUnallocated": "Chưa phân bổ"
   },
   "planning": {
     "title": "Kế hoạch Tháng",

--- a/supabase/migrations/20260605000001_add_dca_goal_to_funds.sql
+++ b/supabase/migrations/20260605000001_add_dca_goal_to_funds.sql
@@ -2,4 +2,4 @@
 -- Nullable: a DCA fund with no goal is treated as "Unallocated". ON DELETE SET
 -- NULL so removing a goal leaves the fund's DCA intact (falls back to Unallocated).
 ALTER TABLE funds
-  ADD COLUMN dca_goal_id UUID NULL REFERENCES savings_goals(goal_id) ON DELETE SET NULL;
+  ADD COLUMN IF NOT EXISTS dca_goal_id UUID NULL REFERENCES savings_goals(goal_id) ON DELETE SET NULL;

--- a/supabase/migrations/20260605000001_add_dca_goal_to_funds.sql
+++ b/supabase/migrations/20260605000001_add_dca_goal_to_funds.sql
@@ -1,0 +1,5 @@
+-- Link a DCA fund to a savings goal so recurring contributions have a target.
+-- Nullable: a DCA fund with no goal is treated as "Unallocated". ON DELETE SET
+-- NULL so removing a goal leaves the fund's DCA intact (falls back to Unallocated).
+ALTER TABLE funds
+  ADD COLUMN dca_goal_id UUID NULL REFERENCES savings_goals(goal_id) ON DELETE SET NULL;


### PR DESCRIPTION
Closes #293.

## What
When a fund has **DCA** enabled, the Funds page now lets you pick a **goal target** for those recurring contributions — a dropdown next to the monthly amount, defaulting to **Unallocated**. Implemented on both desktop (table row) and mobile (fund card), matching the prototype designs.

## How
- **Migration** `20260605000001_add_dca_goal_to_funds.sql`: adds nullable `funds.dca_goal_id` → `savings_goals(goal_id)`, `ON DELETE SET NULL` (deleting a goal leaves the DCA intact, falling back to Unallocated).
- **API** `POST`/`PUT /api/funds`: validate `dca_goal_id` (UUID or null) and persist it — only while DCA is on; cleared otherwise.
- **UI** desktop + mobile: fetch savings goals once, render a target `<select>`, persist the choice via `PUT` with optimistic update + rollback on failure.
- **i18n**: `dcaGoalLabel` / `dcaGoalUnallocated` (en + vi).

## Tests (TDD)
- Desktop + mobile e2e: enabling DCA reveals the goal dropdown (defaults to Unallocated), and a selected goal survives a page reload.
- 437 unit tests pass; `tsc` clean; build compiles + typechecks.

## ⚠️ Migration required before CI/preview
The shared Supabase project needs `supabase db push` to add `dca_goal_id` — without it the new e2e persistence tests (and the preview) will fail. See the conversation for the heads-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)