### PR TITLE
fix(auth): land on dashboard after login when a stale session cookie is present

### DIFF
--- a/app/auth/login/__tests__/LoginPage.test.tsx
+++ b/app/auth/login/__tests__/LoginPage.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import LoginPage from '../page'
+
+const { signInMock, pushMock, refreshMock } = vi.hoisted(() => ({
+  signInMock: vi.fn(),
+  pushMock: vi.fn(),
+  refreshMock: vi.fn(),
+}))
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+  useSearchParams: () => ({ get: () => null }),
+}))
+
+vi.mock('@supabase/ssr', () => ({
+  createBrowserClient: () => ({
+    auth: { signInWithPassword: signInMock },
+  }),
+}))
+
+async function submitLogin() {
+  await userEvent.type(screen.getByLabelText(/email/i), 'user@example.com')
+  await userEvent.type(screen.getByLabelText(/password/i), 'secret123')
+  await userEvent.click(screen.getByRole('button', { name: /loginBtn/i }))
+}
+
+describe('LoginPage — navigation after successful sign-in', () => {
+  let assignMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    signInMock.mockReset()
+    pushMock.mockReset()
+    refreshMock.mockReset()
+    // jsdom does not implement navigation; replace location with a spy so we can
+    // observe a full-page navigation without it throwing.
+    assignMock = vi.fn()
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, assign: assignMock, href: 'http://localhost/auth/login' },
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('navigates to /dashboard via a full-page load (not a soft router.push) on success', async () => {
+    // Sign-in succeeds — this is the exact state where the button flips to
+    // "redirecting". A soft router.push() here can race with auth-cookie
+    // propagation and bounce back to /login when a stale session cookie was
+    // present, leaving the user stuck. A full-page navigation forces the server
+    // to re-read the fresh cookies, so the user actually lands on the dashboard.
+    signInMock.mockResolvedValue({ error: null })
+
+    render(<LoginPage />)
+    await submitLogin()
+
+    await waitFor(() => {
+      expect(assignMock).toHaveBeenCalledWith('/dashboard')
+    })
+    // A soft client-side push must NOT be the mechanism that moves the user off
+    // the login route — that is the bug being fixed.
+    expect(pushMock).not.toHaveBeenCalled()
+  })
+
+  it('stays on the login page and shows an error when credentials are invalid', async () => {
+    signInMock.mockResolvedValue({ error: { message: 'Invalid login credentials' } })
+
+    render(<LoginPage />)
+    await submitLogin()
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument()
+    })
+    expect(assignMock).not.toHaveBeenCalled()
+    expect(pushMock).not.toHaveBeenCalled()
+  })
+})

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { useSearchParams } from 'next/navigation'
 import { useState, Suspense } from 'react'
 import { createBrowserClient } from '@supabase/ssr'
 import { useTranslations } from 'next-intl'
@@ -18,7 +18,6 @@ const fieldLabelStyle: React.CSSProperties = {
 
 function LoginForm() {
   const t = useTranslations('auth')
-  const router = useRouter()
   const searchParams = useSearchParams()
   const expired = searchParams.get('expired') === 'true'
 
@@ -46,8 +45,13 @@ function LoginForm() {
         setLoading(false)
       } else {
         setRedirecting(true)
-        router.push('/dashboard')
-        router.refresh()
+        // Full-page navigation rather than router.push(): this forces the
+        // server (middleware in proxy.ts + the (app) layout) to re-read the
+        // freshly-set auth cookies on a clean request. A soft client-side push
+        // can race with auth-cookie propagation and get bounced straight back
+        // to /auth/login by getUser() — especially when a stale/expired session
+        // cookie was already present — leaving the button stuck on "redirecting".
+        window.location.assign('/dashboard')
       }
     } catch {
       setError(t('cannotConnect'))

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import { createClient } from '@supabase/supabase-js'
 import path from 'path'
 import fs from 'fs'
 
@@ -70,6 +71,54 @@ test('unauthenticated access to /dashboard redirects to /auth/login', async ({ p
   await page.goto('/dashboard')
   await page.waitForURL('**/auth/login', { timeout: 10_000 })
   await expect(page).toHaveURL(/auth\/login/)
+})
+
+// Regression: a stale/server-invalid Supabase session cookie left over from a
+// previous session (e.g. token revoked, project restarted) must not block a
+// fresh login. Previously the browser client would fail to refresh with
+// "Invalid Refresh Token: Refresh Token Not Found", and a soft router.push()
+// after sign-in bounced straight back to /auth/login — the button stuck on
+// "redirecting", never reaching Overview. See fix in app/auth/login/page.tsx.
+test('login succeeds even when a stale/invalid session cookie is present', async ({ page }) => {
+  const adminUrl = process.env.E2E_SUPABASE_URL
+  const serviceRoleKey = process.env.E2E_SUPABASE_SERVICE_ROLE_KEY
+  test.skip(!adminUrl || !serviceRoleKey, 'requires E2E Supabase admin credentials')
+
+  const admin = createClient(adminUrl!, serviceRoleKey!)
+
+  // Create a throwaway user and sign them in through the real form so the
+  // browser ends up with a genuine, correctly-formatted @supabase/ssr auth
+  // cookie — then delete the user so that cookie's refresh token no longer
+  // exists on the server. This reproduces the exact "Refresh Token Not Found"
+  // state the user hit, without hand-crafting cookie internals.
+  const staleEmail = `e2e-stale-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@test.invalid`
+  const stalePassword = 'TestPass123!'
+  const { data: created, error: createErr } = await admin.auth.admin.createUser({
+    email: staleEmail,
+    password: stalePassword,
+    email_confirm: true,
+  })
+  if (createErr || !created.user) throw createErr ?? new Error('Failed to create stale user')
+
+  await page.goto('/auth/login')
+  await page.locator('#email').fill(staleEmail)
+  await page.locator('#password').fill(stalePassword)
+  await page.locator('button[type="submit"]').click()
+  await page.waitForURL('**/dashboard', { timeout: 15_000 })
+
+  // Invalidate the session server-side — the cookie now holds an orphaned
+  // refresh token.
+  await admin.auth.admin.deleteUser(created.user.id)
+
+  // Now log in as the real test user. With the stale cookie present this must
+  // still land on the dashboard rather than getting stuck on the login page.
+  const { email, password } = getTestCredentials()
+  await page.goto('/auth/login')
+  await page.locator('#email').fill(email)
+  await page.locator('#password').fill(password)
+  await page.locator('button[type="submit"]').click()
+  await page.waitForURL('**/dashboard', { timeout: 15_000 })
+  await expect(page).toHaveURL(/dashboard/)
 })
 
 // ─── Signup page structure ──────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Logging in got **stuck**: the submit button flipped to "redirecting" but the app stayed on `/auth/login` and never reached Overview. The browser console showed:

```
Failed to load resource: .../token?grant_type=refresh_token  400
AuthApiError: Invalid Refresh Token: Refresh Token Not Found
```

## Root cause

When a **stale / server-invalid Supabase session cookie** is present (token revoked, project restarted, old session), the browser client fails its background refresh with "Refresh Token Not Found". The password sign-in itself still *succeeds* (hence the button reaching "redirecting"), but the follow-up **soft** `router.push("/dashboard")` + `router.refresh()` races with auth-cookie propagation. `getUser()` in the middleware (`proxy.ts`) and the `(app)` layout doesn't see the new session yet and bounces the navigation straight back to `/auth/login`.

A fresh browser (e.g. the Playwright `global.setup`) never hits this because there is no poisoned cookie — which is why it only reproduced in real browsers with leftover state.

## Fix

After a successful sign-in, navigate with a **full-page load** (`window.location.assign('/dashboard')`) instead of a soft client-side push. This forces the server to re-read the freshly-set auth cookies on a clean request, so the user actually lands on the dashboard. (Removed the now-unused `useRouter`.)

## Tests (TDD)

- **Unit** `app/auth/login/__tests__/LoginPage.test.tsx` — asserts a successful sign-in performs a full-page nav to `/dashboard` (not a soft `router.push`), and that invalid credentials stay on the page with an error. Written first; failed against the old `router.push` code, passes now.
- **E2E** `e2e/auth.spec.ts` — seeds a *real but orphaned* session cookie (sign in a throwaway user via the form, then delete that user so its refresh token is gone) and asserts a fresh login still reaches the dashboard. Skips locally without E2E admin creds; runs in CI.

Full unit suite: 439 passing. Lint + typecheck clean.

## Verify on preview

Please confirm on the Vercel preview with the affected browser (the one currently showing the refresh-token error) that login now reaches Overview. The existing stale cookie should no longer block sign-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
