### PR TITLE
feat(planning): recurring bank savings grouped by goal

### DIFF
--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -64,6 +64,21 @@ export interface OtherExpense {
   created_at: string
 }
 
+export interface RecurringSaving {
+  saving_id: string
+  name: string
+  goal_id: string | null
+  amount_vnd: number
+  effective_from: string | null
+  effective_to: string | null
+  savings_goals: { goal_name: string } | null
+}
+
+export interface RecurringSavingOverride {
+  recurring_saving_id: string
+  monthly_amount_override_vnd: number
+}
+
 export interface Fund { id: string; name: string; nav: number }
 export interface Goal { goal_id: string; goal_name: string }
 
@@ -109,6 +124,8 @@ export default function PlanningClient() {
   const [fixedExpenses, setFixedExpenses] = useState<FixedExpense[]>(initialCache?.fixedExpenses ?? [])
   const [insuranceMembers, setInsuranceMembers] = useState<InsuranceMember[]>(initialCache?.insuranceMembers ?? [])
   const [otherExpenses, setOtherExpenses] = useState<OtherExpense[]>(initialCache?.otherExpenses ?? [])
+  const [recurringSavings, setRecurringSavings] = useState<RecurringSaving[]>(initialCache?.recurringSavings ?? [])
+  const [recurringSavingOverrides, setRecurringSavingOverrides] = useState<RecurringSavingOverride[]>(initialCache?.recurringSavingOverrides ?? [])
   const [funds, setFunds] = useState<Fund[]>(initialCache?.funds ?? [])
   const [goals, setGoals] = useState<Goal[]>(initialCache?.goals ?? [])
   const [loading, setLoading] = useState(!initialCache)
@@ -158,6 +175,8 @@ export default function PlanningClient() {
         otherExpenses: p.other_expenses ?? [],
         goals: p.goals ?? [],
         funds: p.funds ?? [],
+        recurringSavings: p.recurring_savings ?? [],
+        recurringSavingOverrides: p.recurring_saving_overrides ?? [],
       }
       setPlanCache(month, year, fresh)
       setPlan(fresh.plan)
@@ -168,6 +187,8 @@ export default function PlanningClient() {
       setOtherExpenses(fresh.otherExpenses)
       setGoals(fresh.goals)
       setFunds(fresh.funds)
+      setRecurringSavings(fresh.recurringSavings)
+      setRecurringSavingOverrides(fresh.recurringSavingOverrides)
     } else {
       bustPlanCache(month, year)
       setPlan(null)
@@ -176,6 +197,8 @@ export default function PlanningClient() {
       setOtherExpenses([])
       setGoals([])
       setFunds([])
+      setRecurringSavings([])
+      setRecurringSavingOverrides([])
       // Still load fixed expenses and insurance even without a plan
       const [expRes, insRes] = await Promise.all([
         fetch('/api/v1/fixed-expenses'),
@@ -254,6 +277,8 @@ export default function PlanningClient() {
         fixedExpenses={fixedExpenses}
         insuranceMembers={insuranceMembers}
         otherExpenses={otherExpenses}
+        recurringSavings={recurringSavings}
+        recurringSavingOverrides={recurringSavingOverrides}
         funds={funds}
         goals={goals}
         onPlanCreated={(p) => { setPlan(p); refetch() }}
@@ -279,6 +304,8 @@ export default function PlanningClient() {
         fixedExpenses={fixedExpenses}
         insuranceMembers={insuranceMembers}
         otherExpenses={otherExpenses}
+        recurringSavings={recurringSavings}
+        recurringSavingOverrides={recurringSavingOverrides}
         funds={funds}
         goals={goals}
         loading={loading}

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -4,24 +4,17 @@ import React, { useState, useMemo, useRef } from 'react'
 import {
   ChevronLeft, ChevronRight, ChevronDown, ChevronUp,
   Target, Shield, ShoppingCart,
-  MoreHorizontal, Check, RefreshCw, X, Plus, Settings,
+  MoreHorizontal, Check, RefreshCw, X, Plus, Settings, TrendingUp,
 } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import FixedExpenseManager from './FixedExpenseManager'
+import RecurringSavingManager from './RecurringSavingManager'
+import { buildByGoal, resolveRecurringSavings, type GoalItem } from '@/lib/planning'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
-  InsuranceMember, OtherExpense, Fund, Goal,
+  InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, Fund, Goal,
 } from '../PlanningClient'
-
-// ─── Types ────────────────────────────────────────────────────────────────────
-
-interface GoalRow {
-  goalId: string
-  goalName: string
-  totalAllocated: number
-  items: { name: string; type: string; amount: number; isDCA?: boolean }[]
-}
 
 // ─── Pure helpers ─────────────────────────────────────────────────────────────
 
@@ -37,27 +30,6 @@ function getInsTotal(insuranceMembers: InsuranceMember[]) {
     if (m.excluded) return s
     return s + (m.monthlyOverride ?? Math.round(m.annual_payment_vnd / 12))
   }, 0)
-}
-
-function buildByGoal(investments: FundInvestment[], savings: DirectSaving[]): GoalRow[] {
-  const map = new Map<string, GoalRow>()
-  for (const inv of investments) {
-    const goalId = inv.goal_id ?? '__unassigned__'
-    const goalName = inv.savings_goals?.goal_name ?? 'Unassigned'
-    if (!map.has(goalId)) map.set(goalId, { goalId, goalName, totalAllocated: 0, items: [] })
-    const row = map.get(goalId)!
-    row.totalAllocated += inv.amount_vnd
-    row.items.push({ name: inv.funds?.name ?? 'Unknown fund', type: 'fund', amount: inv.amount_vnd, isDCA: inv.is_dca_seeded })
-  }
-  for (const sav of savings) {
-    const goalId = sav.goal_id ?? '__unassigned__'
-    const goalName = sav.savings_goals?.goal_name ?? 'Unassigned'
-    if (!map.has(goalId)) map.set(goalId, { goalId, goalName, totalAllocated: 0, items: [] })
-    const row = map.get(goalId)!
-    row.totalAllocated += sav.amount_vnd
-    row.items.push({ name: 'Direct savings', type: 'bank', amount: sav.amount_vnd })
-  }
-  return [...map.values()].sort((a, b) => a.goalName.localeCompare(b.goalName))
 }
 
 const SHORT_MONTHS_EN = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
@@ -214,6 +186,71 @@ function DPlanRow({ primary, secondary, amount, muted, last, isVI, onSkip, onRes
   )
 }
 
+// ─── DGoalItemRow — line item under a goal (recurring savings get a kebab) ────
+
+function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit }: {
+  item: GoalItem; isVI: boolean
+  onSkip: () => void; onRestore: () => void; onOverride: () => void; onEdit: () => void
+}) {
+  const [open, setOpen] = useState(false)
+  const [menuPos, setMenuPos] = useState({ top: 0, right: 0 })
+  const btnRef = useRef<HTMLButtonElement>(null)
+  const skipped = !!item.skipped
+
+  const typeLabel = item.type === 'fund'
+    ? 'Fund'
+    : item.isRecurring ? (isVI ? 'Tiết kiệm định kỳ' : 'Recurring saving') : (isVI ? 'Tiết kiệm' : 'Direct saving')
+
+  function openMenu() {
+    if (btnRef.current) {
+      const r = btnRef.current.getBoundingClientRect()
+      setMenuPos({ top: r.bottom + 4, right: window.innerWidth - r.right })
+    }
+    setOpen(true)
+  }
+
+  return (
+    <tr style={{ borderBottom: '1px solid var(--c-line)', background: 'var(--c-card)', opacity: skipped ? 0.5 : 1 }}>
+      <td style={{ padding: '9px 16px 9px 44px', verticalAlign: 'middle' }}>
+        <div style={{ fontSize: 12, fontWeight: 500, textDecoration: skipped ? 'line-through' : 'none' }}>{item.name}</div>
+        <div style={{ fontSize: 10, color: item.overridden ? 'var(--c-navy)' : 'var(--c-muted)', marginTop: 1 }}>
+          {skipped ? (isVI ? 'Bỏ qua tháng này' : 'Skipped this month') : item.overridden ? (isVI ? 'Đã ghi đè tháng này' : 'Overridden this month') : typeLabel}
+          {item.isDCA && <span style={{ marginLeft: 6, padding: '1px 5px', borderRadius: 4, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', fontSize: 9, fontWeight: 700 }}>DCA</span>}
+        </div>
+      </td>
+      <td style={{ padding: '9px 12px', textAlign: 'right', verticalAlign: 'middle' }}>
+        <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--c-muted)', fontVariantNumeric: 'tabular-nums', textDecoration: skipped ? 'line-through' : 'none' }}>{fmt(item.amount)}</span>
+      </td>
+      <td style={{ padding: '9px 8px 9px 4px', textAlign: 'right', verticalAlign: 'middle', width: 36 }}>
+        {item.isRecurring && (
+          <>
+            <button ref={btnRef} onClick={() => open ? setOpen(false) : openMenu()} aria-label="Saving actions" style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
+              <MoreHorizontal size={14} />
+            </button>
+            {open && (
+              <>
+                <div onClick={() => setOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 5 }} />
+                <div style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 200, overflow: 'hidden' }}>
+                  {skipped ? (
+                    <MenuBtn icon={<Check size={13} />} label={isVI ? 'Bao gồm tháng này' : 'Include this month'} onClick={() => { onRestore(); setOpen(false) }} noBorder />
+                  ) : (
+                    <>
+                      <MenuBtn icon={<TrendingUp size={13} />} label={isVI ? 'Tiết kiệm thêm tháng này' : 'Save more this month'} onClick={() => { onOverride(); setOpen(false) }} />
+                      <MenuBtn icon={<EditIcon size={13} />} label={isVI ? 'Sửa kế hoạch định kỳ' : 'Edit recurring plan'} onClick={() => { onEdit(); setOpen(false) }} />
+                      {item.overridden && <MenuBtn icon={<RefreshCw size={13} />} label={isVI ? 'Khôi phục mặc định' : 'Restore default'} onClick={() => { onRestore(); setOpen(false) }} />}
+                      <MenuBtn icon={<X size={13} />} label={isVI ? 'Bỏ qua tháng này' : 'Skip this month'} onClick={() => { onSkip(); setOpen(false) }} danger noBorder />
+                    </>
+                  )}
+                </div>
+              </>
+            )}
+          </>
+        )}
+      </td>
+    </tr>
+  )
+}
+
 // ─── Stacked bar ─────────────────────────────────────────────────────────────
 
 function StackedBar({ segments, total }: { segments: { color: string; value: number }[]; total: number }) {
@@ -263,8 +300,8 @@ function AllocationCard({ salary, totalGoalAmount, fixedTotal, insTotal, otherTo
           <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <span style={{ width: 8, height: 8, borderRadius: 2, background: r.c, flexShrink: 0 }} />
             <span style={{ flex: 1, fontSize: 12, color: 'rgba(255,255,255,0.7)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.l}</span>
-            <span style={{ fontSize: 12, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(r.v)}</span>
-            <span style={{ fontSize: 10, color: 'rgba(255,255,255,0.4)', minWidth: 30, textAlign: 'right' }}>{pct(r.v)}</span>
+            <span style={{ fontSize: 12, fontWeight: 600, fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>{fmtCompact(r.v)}</span>
+            <span style={{ fontSize: 10, color: 'rgba(255,255,255,0.4)', minWidth: 30, textAlign: 'right', flexShrink: 0 }}>{pct(r.v)}</span>
           </div>
         ))}
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingTop: 8, borderTop: '1px solid rgba(255,255,255,0.12)', marginTop: 2 }}>
@@ -306,6 +343,8 @@ interface Props {
   fixedExpenses: FixedExpense[]
   insuranceMembers: InsuranceMember[]
   otherExpenses: OtherExpense[]
+  recurringSavings: RecurringSaving[]
+  recurringSavingOverrides: RecurringSavingOverride[]
   funds: Fund[]
   goals: Goal[]
   loading: boolean
@@ -322,7 +361,8 @@ interface Props {
 
 export default function DesktopPlanningView({
   month, year, plan, investments, savings, fixedExpenses, insuranceMembers,
-  otherExpenses, loading, onPrev, onNext, onToday, onPlanCreated, onPlanDeleted, onRefresh, onToast,
+  otherExpenses, recurringSavings, recurringSavingOverrides, goals, loading,
+  onPrev, onNext, onToday, onPlanCreated, onPlanDeleted, onRefresh, onToast,
 }: Props) {
   const locale = useLocale()
   const isVI = locale === 'vi'
@@ -330,7 +370,7 @@ export default function DesktopPlanningView({
   // ── Modal state ──
   const [showIncome, setShowIncome] = useState(false)
   const [showDelete, setShowDelete] = useState(false)
-  const [overrideModal, setOverrideModal] = useState<{ id: string; name: string; defaultAmount: number; type: 'fe' | 'ins' } | null>(null)
+  const [overrideModal, setOverrideModal] = useState<{ id: string; name: string; defaultAmount: number; type: 'fe' | 'ins' | 'rec' } | null>(null)
   const [overrideVal, setOverrideVal] = useState('')
   const [incomeVal, setIncomeVal] = useState('')
   const [saving, setSaving] = useState(false)
@@ -338,9 +378,21 @@ export default function DesktopPlanningView({
   const [otherDesc, setOtherDesc] = useState('')
   const [otherAmt, setOtherAmt] = useState('')
   const [showFEManage, setShowFEManage] = useState(false)
+  const [showRSManage, setShowRSManage] = useState(false)
 
   // ── Derived values ──
-  const byGoal = useMemo(() => buildByGoal(investments, savings), [investments, savings])
+  const goalsById = useMemo(() => new Map(goals.map(g => [g.goal_id, g.goal_name])), [goals])
+  const resolvedRecurring = useMemo(
+    () => resolveRecurringSavings(recurringSavings, recurringSavingOverrides),
+    [recurringSavings, recurringSavingOverrides],
+  )
+  const byGoal = useMemo(
+    () => buildByGoal(investments, savings, resolvedRecurring, goalsById, {
+      unallocated: isVI ? 'Chưa phân bổ' : 'Unallocated',
+      directSaving: isVI ? 'Tiết kiệm' : 'Direct savings',
+    }),
+    [investments, savings, resolvedRecurring, goalsById, isVI],
+  )
   const totalGoalAmount = byGoal.reduce((s, g) => s + g.totalAllocated, 0)
   const fixedTotal = useMemo(() => getFixedTotal(fixedExpenses), [fixedExpenses])
   const insTotal   = useMemo(() => getInsTotal(insuranceMembers), [insuranceMembers])
@@ -436,6 +488,26 @@ export default function DesktopPlanningView({
     onRefresh(); onToast(isVI ? `Đã khôi phục ${m.member_name}` : `Restored ${m.member_name}`)
   }
 
+  async function handleRecSkip(item: { recurringId?: string; name: string }) {
+    if (!plan || !item.recurringId) return
+    await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ recurring_saving_id: item.recurringId, monthly_amount_override_vnd: 0 }),
+    })
+    onRefresh(); onToast(isVI ? `Đã bỏ qua ${item.name}` : `Skipped ${item.name}`)
+  }
+
+  async function handleRecRestore(item: { recurringId?: string; name: string }) {
+    if (!plan || !item.recurringId) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`)
+    if (!res.ok) return
+    const overrides: Array<{ id: string; recurring_saving_id: string }> = await res.json()
+    const match = overrides.find(o => o.recurring_saving_id === item.recurringId)
+    if (match) await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides/${match.id}`, { method: 'DELETE' })
+    onRefresh(); onToast(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
+  }
+
   async function handleSaveOverride() {
     if (!overrideModal || !plan) return
     const num = Number(overrideVal)
@@ -444,10 +516,14 @@ export default function DesktopPlanningView({
     try {
       const url = overrideModal.type === 'fe'
         ? `/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`
-        : `/api/v1/monthly-plans/${plan.id}/insurance-overrides`
+        : overrideModal.type === 'rec'
+          ? `/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`
+          : `/api/v1/monthly-plans/${plan.id}/insurance-overrides`
       const body = overrideModal.type === 'fe'
         ? { fixed_expense_id: overrideModal.id, monthly_amount_override_vnd: num }
-        : { member_id: overrideModal.id, monthly_amount_override_vnd: num }
+        : overrideModal.type === 'rec'
+          ? { recurring_saving_id: overrideModal.id, monthly_amount_override_vnd: num }
+          : { member_id: overrideModal.id, monthly_amount_override_vnd: num }
       await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
       setOverrideModal(null)
       onRefresh(); onToast(isVI ? 'Đã lưu' : 'Saved')
@@ -605,7 +681,22 @@ export default function DesktopPlanningView({
               </div>
 
               {/* By goal */}
-              <PlanTable icon={<Target size={15} />} iconColor="var(--c-navy)" title={isVI ? 'Theo mục tiêu' : 'By goal'} total={totalGoalAmount}>
+              <PlanTable
+                icon={<Target size={15} />}
+                iconColor="var(--c-navy)"
+                title={isVI ? 'Theo mục tiêu' : 'By goal'}
+                total={totalGoalAmount}
+                action={
+                  <button
+                    data-testid="desktop-manage-savings"
+                    onClick={() => setShowRSManage(true)}
+                    style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '5px 10px', fontSize: 12, fontWeight: 600, color: 'var(--c-navy)', background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', borderRadius: 8 }}
+                  >
+                    <Settings size={14} />
+                    {isVI ? 'Quản lý tiết kiệm' : 'Manage savings'}
+                  </button>
+                }
+              >
                 <THead col1={isVI ? 'Mục tiêu / Khoản' : 'Goal / Allocation'} col2={isVI ? 'Tháng này' : 'This month'} />
                 <tbody>
                   {byGoal.length === 0 ? (
@@ -628,19 +719,18 @@ export default function DesktopPlanningView({
                         <td />
                       </tr>
                       {g.items.map((inv, ii) => (
-                        <tr key={g.goalId + '-' + ii} style={{ borderBottom: '1px solid var(--c-line)', background: 'var(--c-card)' }}>
-                          <td style={{ padding: '9px 16px 9px 44px', verticalAlign: 'middle' }}>
-                            <div style={{ fontSize: 12, fontWeight: 500 }}>{inv.name}</div>
-                            <div style={{ fontSize: 10, color: 'var(--c-muted)', textTransform: 'capitalize', marginTop: 1 }}>
-                              {inv.type}
-                              {inv.isDCA && <span style={{ marginLeft: 6, padding: '1px 5px', borderRadius: 4, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', fontSize: 9, fontWeight: 700 }}>DCA</span>}
-                            </div>
-                          </td>
-                          <td style={{ padding: '9px 12px', textAlign: 'right', verticalAlign: 'middle' }}>
-                            <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--c-muted)', fontVariantNumeric: 'tabular-nums' }}>{fmt(inv.amount)}</span>
-                          </td>
-                          <td />
-                        </tr>
+                        <DGoalItemRow
+                          key={g.goalId + '-' + ii}
+                          item={inv}
+                          isVI={isVI}
+                          onSkip={() => handleRecSkip(inv)}
+                          onRestore={() => handleRecRestore(inv)}
+                          onEdit={() => setShowRSManage(true)}
+                          onOverride={() => {
+                            setOverrideModal({ id: inv.recurringId!, name: inv.name, defaultAmount: inv.baseAmount ?? inv.amount, type: 'rec' })
+                            setOverrideVal(String(inv.baseAmount ?? inv.amount))
+                          }}
+                        />
                       ))}
                     </React.Fragment>
                   ))}
@@ -877,6 +967,12 @@ export default function DesktopPlanningView({
       {showFEManage && (
         <DModal onClose={() => setShowFEManage(false)} title={isVI ? 'Quản lý chi phí cố định' : 'Manage fixed expenses'} width={460}>
           <FixedExpenseManager onChange={onRefresh} onToast={onToast} />
+        </DModal>
+      )}
+
+      {showRSManage && (
+        <DModal onClose={() => setShowRSManage(false)} title={isVI ? 'Tiết kiệm định kỳ' : 'Recurring savings'} width={460}>
+          <RecurringSavingManager goals={goals} onChange={onRefresh} onToast={onToast} />
         </DModal>
       )}
     </div>

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -5,13 +5,15 @@ import { useLocale } from 'next-intl'
 import {
   Wallet, Target, Shield, ShoppingCart,
   ChevronDown, ChevronUp,
-  MoreHorizontal, Plus, Check, X, Calendar, Settings,
+  MoreHorizontal, Plus, Check, X, Calendar, Settings, RefreshCw, TrendingUp,
 } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import FixedExpenseManager from './FixedExpenseManager'
+import RecurringSavingManager from './RecurringSavingManager'
+import { buildByGoal, resolveRecurringSavings, type GoalRow, type GoalItem } from '@/lib/planning'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
-  InsuranceMember, OtherExpense, Fund, Goal,
+  InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, Fund, Goal,
 } from '../PlanningClient'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -25,6 +27,8 @@ interface Props {
   fixedExpenses: FixedExpense[]
   insuranceMembers: InsuranceMember[]
   otherExpenses: OtherExpense[]
+  recurringSavings: RecurringSaving[]
+  recurringSavingOverrides: RecurringSavingOverride[]
   funds: Fund[]
   goals: Goal[]
   onPlanCreated: (plan: MonthlyPlan) => void
@@ -33,21 +37,16 @@ interface Props {
   onToast: (msg: string) => void
 }
 
-interface GoalRow {
-  goalId: string
-  goalName: string
-  totalAllocated: number
-  items: Array<{ name: string; type: string; amount: number; isDCA?: boolean }>
-}
-
 type SheetState =
   | null
   | { type: 'salary' }
   | { type: 'delete-plan' }
   | { type: 'override-fe'; expense: FixedExpense }
   | { type: 'override-ins'; member: InsuranceMember }
+  | { type: 'override-rec'; item: GoalItem }
   | { type: 'other-expense'; existing: OtherExpense | null }
   | { type: 'manage-fixed' }
+  | { type: 'manage-recurring' }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -71,34 +70,6 @@ function getInsTotal(insuranceMembers: InsuranceMember[]) {
     if (m.excluded) return s
     return s + (m.monthlyOverride ?? Math.round(m.annual_payment_vnd / 12))
   }, 0)
-}
-
-function buildByGoal(investments: FundInvestment[], savings: DirectSaving[]): GoalRow[] {
-  const map = new Map<string, GoalRow>()
-
-  for (const inv of investments) {
-    const goalId = inv.goal_id ?? '__unassigned__'
-    const goalName = inv.savings_goals?.goal_name ?? 'Unassigned'
-    if (!map.has(goalId)) {
-      map.set(goalId, { goalId, goalName, totalAllocated: 0, items: [] })
-    }
-    const row = map.get(goalId)!
-    row.totalAllocated += inv.amount_vnd
-    row.items.push({ name: inv.funds?.name ?? 'Unknown fund', type: 'fund', amount: inv.amount_vnd, isDCA: inv.is_dca_seeded })
-  }
-
-  for (const sav of savings) {
-    const goalId = sav.goal_id ?? '__unassigned__'
-    const goalName = sav.savings_goals?.goal_name ?? 'Unassigned'
-    if (!map.has(goalId)) {
-      map.set(goalId, { goalId, goalName, totalAllocated: 0, items: [] })
-    }
-    const row = map.get(goalId)!
-    row.totalAllocated += sav.amount_vnd
-    row.items.push({ name: 'Direct savings', type: 'bank', amount: sav.amount_vnd })
-  }
-
-  return [...map.values()].sort((a, b) => a.goalName.localeCompare(b.goalName))
 }
 
 function EditIcon({ size = 16, color = 'currentColor' }: { size?: number; color?: string }) {
@@ -584,8 +555,8 @@ function AllocationSummaryCard({
           <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
             <span style={{ width: 8, height: 8, borderRadius: 2, background: r.color, flexShrink: 0 }} />
             <span style={{ flex: 1, fontSize: 12, color: 'rgba(255,255,255,0.75)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.l}</span>
-            <span style={{ fontSize: 12, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(r.v)}</span>
-            <span style={{ fontSize: 10, color: 'rgba(255,255,255,0.45)', minWidth: 30, textAlign: 'right' }}>{pct(r.v)}</span>
+            <span style={{ fontSize: 12, fontWeight: 600, fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>{fmtCompact(r.v)}</span>
+            <span style={{ fontSize: 10, color: 'rgba(255,255,255,0.45)', minWidth: 30, textAlign: 'right', flexShrink: 0 }}>{pct(r.v)}</span>
           </div>
         ))}
         {/* Remaining row */}
@@ -678,7 +649,13 @@ function BudgetSection({
 
 // ─── GoalAllocationRow ────────────────────────────────────────────────────────
 
-function GoalAllocationRow({ entry, isVI }: { entry: GoalRow; isVI: boolean }) {
+function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride, onRecEdit }: {
+  entry: GoalRow; isVI: boolean
+  onRecSkip: (item: GoalItem) => void
+  onRecRestore: (item: GoalItem) => void
+  onRecOverride: (item: GoalItem) => void
+  onRecEdit: () => void
+}) {
   const [open, setOpen] = useState(false)
   return (
     <div>
@@ -707,26 +684,86 @@ function GoalAllocationRow({ entry, isVI }: { entry: GoalRow; isVI: boolean }) {
         {open ? <ChevronUp size={14} color="var(--c-muted)" /> : <ChevronDown size={14} color="var(--c-muted)" />}
       </button>
       {open && entry.items.map((item, i) => (
-        <div key={i} style={{
-          padding: '8px 14px 8px 56px', display: 'flex', alignItems: 'center',
-          borderTop: '1px solid var(--c-line)', background: 'var(--c-card)',
-        }}>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ fontSize: 12, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--c-ink)' }}>
-              {item.name}
-            </div>
-            <div style={{ fontSize: 10, color: 'var(--c-muted)', textTransform: 'capitalize', marginTop: 1, display: 'flex', alignItems: 'center', gap: 4 }}>
-              {item.type}
-              {item.isDCA && (
-                <span style={{ fontSize: 10, padding: '1px 5px', borderRadius: 4, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', fontWeight: 600 }}>DCA</span>
-              )}
-            </div>
-          </div>
-          <span style={{ fontSize: 12, fontWeight: 500, fontVariantNumeric: 'tabular-nums', color: 'var(--c-muted)' }}>
-            {fmt(item.amount)}
-          </span>
-        </div>
+        <GoalItemRow
+          key={i}
+          item={item}
+          isVI={isVI}
+          onSkip={() => onRecSkip(item)}
+          onRestore={() => onRecRestore(item)}
+          onOverride={() => onRecOverride(item)}
+          onEdit={onRecEdit}
+        />
       ))}
+    </div>
+  )
+}
+
+// ─── GoalItemRow — one allocation under a goal (recurring savings get a kebab) ──
+
+function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit }: {
+  item: GoalItem; isVI: boolean
+  onSkip: () => void; onRestore: () => void; onOverride: () => void; onEdit: () => void
+}) {
+  const [menuOpen, setMenuOpen] = useState(false)
+  const [menuPos, setMenuPos] = useState({ top: 0, right: 0 })
+  const btnRef = useRef<HTMLButtonElement>(null)
+  const skipped = !!item.skipped
+
+  const typeLabel = item.type === 'fund'
+    ? 'Fund'
+    : item.isRecurring ? (isVI ? 'Tiết kiệm định kỳ' : 'Recurring saving') : (isVI ? 'Tiết kiệm' : 'Direct saving')
+
+  function openMenu() {
+    if (btnRef.current) {
+      const rect = btnRef.current.getBoundingClientRect()
+      setMenuPos({ top: rect.bottom + 4, right: window.innerWidth - rect.right })
+    }
+    setMenuOpen(true)
+  }
+
+  return (
+    <div style={{
+      padding: '8px 14px 8px 56px', display: 'flex', alignItems: 'center', gap: 8,
+      borderTop: '1px solid var(--c-line)', background: 'var(--c-card)', opacity: skipped ? 0.55 : 1,
+    }}>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontSize: 12, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--c-ink)', textDecoration: skipped ? 'line-through' : 'none' }}>
+          {item.name}
+        </div>
+        <div style={{ fontSize: 10, color: item.overridden ? 'var(--c-navy)' : 'var(--c-muted)', marginTop: 1, display: 'flex', alignItems: 'center', gap: 4 }}>
+          {skipped ? (isVI ? 'Bỏ qua tháng này' : 'Skipped this month') : item.overridden ? (isVI ? 'Đã ghi đè tháng này' : 'Overridden this month') : typeLabel}
+          {item.isDCA && (
+            <span style={{ fontSize: 10, padding: '1px 5px', borderRadius: 4, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', fontWeight: 600 }}>DCA</span>
+          )}
+        </div>
+      </div>
+      <span style={{ fontSize: 12, fontWeight: 500, fontVariantNumeric: 'tabular-nums', color: 'var(--c-muted)', textDecoration: skipped ? 'line-through' : 'none' }}>
+        {fmt(item.amount)}
+      </span>
+      {item.isRecurring && (
+        <>
+          <button ref={btnRef} onClick={() => (menuOpen ? setMenuOpen(false) : openMenu())} aria-label="Saving actions" style={{ padding: 4, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex', flexShrink: 0 }}>
+            <MoreHorizontal size={14} />
+          </button>
+          {menuOpen && (
+            <>
+              <div onClick={() => setMenuOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 5 }} />
+              <div style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 200, overflow: 'hidden' }}>
+                {skipped ? (
+                  <MenuItem icon={<Check size={13} />} label={isVI ? 'Bao gồm tháng này' : 'Include this month'} onClick={() => { onRestore(); setMenuOpen(false) }} noBorder />
+                ) : (
+                  <>
+                    <MenuItem icon={<TrendingUp size={13} />} label={isVI ? 'Tiết kiệm thêm tháng này' : 'Save more this month'} onClick={() => { onOverride(); setMenuOpen(false) }} />
+                    <MenuItem icon={<EditIcon size={13} />} label={isVI ? 'Sửa kế hoạch định kỳ' : 'Edit recurring plan'} onClick={() => { onEdit(); setMenuOpen(false) }} />
+                    {item.overridden && <MenuItem icon={<RefreshCw size={13} />} label={isVI ? 'Khôi phục mặc định' : 'Restore default'} onClick={() => { onRestore(); setMenuOpen(false) }} />}
+                    <MenuItem icon={<X size={13} />} label={isVI ? 'Bỏ qua tháng này' : 'Skip this month'} onClick={() => { onSkip(); setMenuOpen(false) }} danger noBorder />
+                  </>
+                )}
+              </div>
+            </>
+          )}
+        </>
+      )}
     </div>
   )
 }
@@ -834,22 +871,50 @@ function PlanLineItem({
   )
 }
 
+// ─── MenuItem — popover row used by the recurring-saving kebab ────────────────
+
+function MenuItem({ icon, label, onClick, danger, noBorder }: {
+  icon: React.ReactNode; label: string; onClick: () => void; danger?: boolean; noBorder?: boolean
+}) {
+  return (
+    <button
+      onClick={onClick}
+      style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', borderBottom: noBorder ? 'none' : '1px solid var(--c-line)', cursor: 'pointer', fontFamily: 'inherit', color: danger ? 'var(--c-neg)' : 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8 }}
+    >
+      <span style={{ color: danger ? 'var(--c-neg)' : 'var(--c-muted)', display: 'flex' }}>{icon}</span>
+      {label}
+    </button>
+  )
+}
+
 // ─── Main MobilePlanningView ──────────────────────────────────────────────────
 
 export default function MobilePlanningView({
   month, year, plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,
+  recurringSavings, recurringSavingOverrides, goals,
   onPlanCreated, onPlanDeleted, onRefresh, onToast,
 }: Props) {
   const locale = useLocale()
   const isVI = locale === 'vi'
   const [sheet, setSheet] = useState<SheetState>(null)
-  const [overrideTarget, setOverrideTarget] = useState<{ type: 'fe' | 'ins'; id: string; name: string; defaultAmount: number } | null>(null)
+  const [overrideTarget, setOverrideTarget] = useState<{ type: 'fe' | 'ins' | 'rec'; id: string; name: string; defaultAmount: number } | null>(null)
 
   const monthLabel = getMonthLabel(month, year)
 
   // ─── Computed totals ────────────────────────────────────────────────────────
 
-  const byGoal = useMemo(() => buildByGoal(investments, savings), [investments, savings])
+  const goalsById = useMemo(() => new Map(goals.map(g => [g.goal_id, g.goal_name])), [goals])
+  const resolvedRecurring = useMemo(
+    () => resolveRecurringSavings(recurringSavings, recurringSavingOverrides),
+    [recurringSavings, recurringSavingOverrides],
+  )
+  const byGoal = useMemo(
+    () => buildByGoal(investments, savings, resolvedRecurring, goalsById, {
+      unallocated: isVI ? 'Chưa phân bổ' : 'Unallocated',
+      directSaving: isVI ? 'Tiết kiệm' : 'Direct savings',
+    }),
+    [investments, savings, resolvedRecurring, goalsById, isVI],
+  )
   const totalGoals = useMemo(() => byGoal.reduce((s, g) => s + g.totalAllocated, 0), [byGoal])
   const totalFixed = useMemo(() => getFixedTotal(fixedExpenses), [fixedExpenses])
   const totalInsurance = useMemo(() => getInsTotal(insuranceMembers), [insuranceMembers])
@@ -900,6 +965,35 @@ export default function MobilePlanningView({
     onRefresh()
   }
 
+  async function handleSkipRec(item: GoalItem) {
+    if (!plan || !item.recurringId) return
+    await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ recurring_saving_id: item.recurringId, monthly_amount_override_vnd: 0 }),
+    })
+    onToast(isVI ? `Đã bỏ qua ${item.name}` : `Skipped ${item.name}`)
+    onRefresh()
+  }
+
+  async function handleRestoreRec(item: GoalItem) {
+    if (!plan || !item.recurringId) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`)
+    if (!res.ok) return
+    const overrides: Array<{ id: string; recurring_saving_id: string }> = await res.json()
+    const match = overrides.find((o) => o.recurring_saving_id === item.recurringId)
+    if (!match) return
+    await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides/${match.id}`, { method: 'DELETE' })
+    onToast(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
+    onRefresh()
+  }
+
+  function openOverrideRec(item: GoalItem) {
+    if (!item.recurringId) return
+    setOverrideTarget({ type: 'rec', id: item.recurringId, name: item.name, defaultAmount: item.baseAmount ?? item.amount })
+    setSheet({ type: 'override-rec', item })
+  }
+
   // ─── Override sheet helpers ────────────────────────────────────────────────
 
   function openOverrideFE(expense: FixedExpense) {
@@ -921,6 +1015,12 @@ export default function MobilePlanningView({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ fixed_expense_id: overrideTarget.id, monthly_amount_override_vnd: amount }),
+      })
+    } else if (overrideTarget.type === 'rec') {
+      await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ recurring_saving_id: overrideTarget.id, monthly_amount_override_vnd: amount }),
       })
     } else {
       await fetch(`/api/v1/monthly-plans/${plan.id}/insurance-overrides`, {
@@ -991,13 +1091,34 @@ export default function MobilePlanningView({
               count={`${byGoal.length} ${isVI ? 'mục tiêu' : byGoal.length === 1 ? 'goal' : 'goals'}`}
               total={totalGoals}
               testId="section-by-goal"
+              action={
+                <button
+                  data-testid="mobile-manage-savings"
+                  onClick={() => setSheet({ type: 'manage-recurring' })}
+                  aria-label={isVI ? 'Quản lý tiết kiệm định kỳ' : 'Manage recurring savings'}
+                  style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '4px 8px', fontSize: 12, fontWeight: 600, color: 'var(--c-navy)', background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', borderRadius: 6 }}
+                >
+                  <Settings size={14} />
+                  {isVI ? 'Quản lý' : 'Manage'}
+                </button>
+              }
             >
               {byGoal.length === 0 ? (
                 <div style={{ padding: '12px 14px', fontSize: 13, color: 'var(--c-muted)' }}>
                   {isVI ? 'Chưa có phân bổ' : 'No allocations yet'}
                 </div>
               ) : (
-                byGoal.map((entry) => <GoalAllocationRow key={entry.goalId} entry={entry} isVI={isVI} />)
+                byGoal.map((entry) => (
+                  <GoalAllocationRow
+                    key={entry.goalId}
+                    entry={entry}
+                    isVI={isVI}
+                    onRecSkip={handleSkipRec}
+                    onRecRestore={handleRestoreRec}
+                    onRecOverride={openOverrideRec}
+                    onRecEdit={() => setSheet({ type: 'manage-recurring' })}
+                  />
+                ))
               )}
             </BudgetSection>
 
@@ -1164,7 +1285,7 @@ export default function MobilePlanningView({
       {/* ─── Override sheet ────────────────────────────────────────────────── */}
       {overrideTarget && plan && (
         <SimpleOverrideSheet
-          open={sheet?.type === 'override-fe' || sheet?.type === 'override-ins'}
+          open={sheet?.type === 'override-fe' || sheet?.type === 'override-ins' || sheet?.type === 'override-rec'}
           onClose={() => { setSheet(null); setOverrideTarget(null) }}
           name={overrideTarget.name}
           defaultAmount={overrideTarget.defaultAmount}
@@ -1198,6 +1319,17 @@ export default function MobilePlanningView({
           <FixedExpenseManager onChange={onRefresh} onToast={onToast} variant="sheet" />
         )}
       </Sheet>
+
+      {/* ─── Manage recurring savings sheet ─────────────────────────────────── */}
+      <Sheet
+        open={sheet?.type === 'manage-recurring'}
+        onClose={() => setSheet(null)}
+        title={isVI ? 'Tiết kiệm định kỳ' : 'Recurring savings'}
+      >
+        {sheet?.type === 'manage-recurring' && (
+          <RecurringSavingManager goals={goals} onChange={onRefresh} onToast={onToast} variant="sheet" />
+        )}
+      </Sheet>
     </div>
   )
 }
@@ -1213,7 +1345,7 @@ function SimpleOverrideSheet({
   defaultAmount: number
   planId: string
   targetId: string
-  targetType: 'fe' | 'ins'
+  targetType: 'fe' | 'ins' | 'rec'
   isVI: boolean
   onSaved: (amount: number) => void
 }) {

--- a/app/(app)/planning/components/RecurringSavingManager.tsx
+++ b/app/(app)/planning/components/RecurringSavingManager.tsx
@@ -1,0 +1,384 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { useTranslations, useLocale } from 'next-intl'
+import { Plus, ChevronLeft } from 'lucide-react'
+import { fmt, fmtCompact } from '@/lib/formatters'
+import type { Goal } from '../PlanningClient'
+
+interface Saving {
+  saving_id: string
+  name: string
+  goal_id: string | null
+  amount_vnd: number
+  effective_from: string | null
+  effective_to: string | null
+  savings_goals?: { goal_name: string } | null
+}
+
+// "2026-04-01" → "2026-04" for <input type="month">
+function toMonthInput(date: string | null): string {
+  return date ? date.slice(0, 7) : ''
+}
+
+const SHORT_MONTHS_EN = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+const SHORT_MONTHS_VI = ['Th1', 'Th2', 'Th3', 'Th4', 'Th5', 'Th6', 'Th7', 'Th8', 'Th9', 'Th10', 'Th11', 'Th12']
+
+function periodLabel(s: Saving, isVI: boolean): string {
+  if (!s.effective_from && !s.effective_to) return isVI ? 'Hàng tháng' : 'Every month'
+  const months = isVI ? SHORT_MONTHS_VI : SHORT_MONTHS_EN
+  const fmtMonth = (d: string | null) => {
+    if (!d) return null
+    const [y, m] = d.split('-').map(Number)
+    return `${months[m - 1]} ${y}`
+  }
+  return `${fmtMonth(s.effective_from) || '…'} → ${fmtMonth(s.effective_to) || '∞'}`
+}
+
+const emptyForm = { name: '', goal_id: '', amount_vnd: '', effective_from: '', effective_to: '' }
+
+const inputStyle: React.CSSProperties = {
+  width: '100%', padding: '10px 12px', fontSize: 16,
+  border: '1px solid var(--c-line)', borderRadius: 10,
+  background: 'var(--c-card-2)', color: 'var(--c-ink)', boxSizing: 'border-box',
+}
+const labelStyle: React.CSSProperties = { fontSize: 13, color: 'var(--c-muted)', display: 'block', marginBottom: 4 }
+const ghostBtn: React.CSSProperties = {
+  flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)',
+  background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500,
+  cursor: 'pointer', fontFamily: 'inherit',
+}
+const primaryBtn: React.CSSProperties = {
+  flex: 2, padding: '10px 0', borderRadius: 10, border: 'none',
+  background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600,
+  cursor: 'pointer', fontFamily: 'inherit',
+}
+
+interface Props {
+  goals: Goal[]
+  onChange: () => void
+  onToast?: (msg: string) => void
+  variant?: 'modal' | 'sheet'
+}
+
+export default function RecurringSavingManager({ goals, onChange, onToast, variant = 'modal' }: Props) {
+  const tc = useTranslations('common')
+  const isVI = useLocale() === 'vi'
+
+  const [items, setItems] = useState<Saving[]>([])
+  const [loading, setLoading] = useState(true)
+  const [mode, setMode] = useState<'list' | 'form'>('list')
+  const [editing, setEditing] = useState<Saving | null>(null)
+  const [form, setForm] = useState(emptyForm)
+  const [formError, setFormError] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState<Saving | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  const unallocatedLabel = isVI ? 'Chưa phân bổ (đầu tư chung)' : 'Unallocated (general)'
+
+  const fetchList = useCallback(async () => {
+    const res = await fetch('/api/v1/recurring-savings')
+    const data = res.ok ? await res.json() : { savings: [] }
+    setItems(data.savings ?? [])
+    setLoading(false)
+  }, [])
+
+  useEffect(() => { fetchList() }, [fetchList])
+
+  function openCreate() {
+    setEditing(null)
+    setForm(emptyForm)
+    setFormError('')
+    setMode('form')
+  }
+
+  function openEdit(s: Saving) {
+    setEditing(s)
+    setForm({
+      name: s.name,
+      goal_id: s.goal_id ?? '',
+      amount_vnd: String(s.amount_vnd),
+      effective_from: toMonthInput(s.effective_from),
+      effective_to: toMonthInput(s.effective_to),
+    })
+    setFormError('')
+    setMode('form')
+  }
+
+  async function handleSave() {
+    setFormError('')
+    if (!form.name.trim()) { setFormError(isVI ? 'Cần nhập tên' : 'Name is required'); return }
+    if (!form.amount_vnd || Number(form.amount_vnd) <= 0) { setFormError(isVI ? 'Cần nhập số tiền' : 'Amount is required'); return }
+
+    setSaving(true)
+    try {
+      const url = editing ? `/api/v1/recurring-savings/${editing.saving_id}` : '/api/v1/recurring-savings'
+      const res = await fetch(url, {
+        method: editing ? 'PUT' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: form.name.trim(),
+          goal_id: form.goal_id || null,
+          amount_vnd: Number(form.amount_vnd),
+          effective_from: form.effective_from || null,
+          effective_to: form.effective_to || null,
+        }),
+      })
+      if (!res.ok) {
+        const { error } = await res.json().catch(() => ({ error: '' }))
+        setFormError(error || tc('error'))
+        return
+      }
+      onToast?.(editing ? (isVI ? 'Đã cập nhật' : 'Updated') : (isVI ? 'Đã thêm khoản định kỳ' : 'Recurring saving added'))
+      setMode('list')
+      await fetchList()
+      onChange()
+    } catch {
+      setFormError(tc('error'))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function handleDelete(s: Saving) {
+    setDeleting(true)
+    try {
+      const res = await fetch(`/api/v1/recurring-savings/${s.saving_id}`, { method: 'DELETE' })
+      if (res.ok) {
+        setConfirmDelete(null)
+        onToast?.(isVI ? 'Đã xoá khoản' : 'Saving deleted')
+        await fetchList()
+        onChange()
+      }
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  const goalName = (id: string | null, fallback?: string | null) =>
+    id ? (goals.find(g => g.goal_id === id)?.goal_name ?? fallback ?? id) : (isVI ? 'Chưa phân bổ' : 'Unallocated')
+
+  // ─── Form view ──────────────────────────────────────────────────────────────
+
+  if (mode === 'form') {
+    return (
+      <div data-testid="recurring-saving-manager" style={{ display: 'grid', gap: 14 }}>
+        <button
+          type="button"
+          onClick={() => setMode('list')}
+          style={{ alignSelf: 'flex-start', display: 'flex', alignItems: 'center', gap: 4, padding: '4px 6px', fontSize: 12, color: 'var(--c-muted)', background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit' }}
+        >
+          <ChevronLeft size={14} />{isVI ? 'Danh sách' : 'Back to list'}
+        </button>
+
+        {formError && <p style={{ color: 'var(--c-neg)', fontSize: 13, margin: 0 }}>{formError}</p>}
+
+        <div>
+          <label htmlFor="rs-goal" style={labelStyle}>{isVI ? 'Phân bổ vào' : 'Allocate to'}</label>
+          <select
+            id="rs-goal"
+            data-testid="rs-goal"
+            value={form.goal_id}
+            onChange={(e) => setForm({ ...form, goal_id: e.target.value })}
+            style={{ ...inputStyle, appearance: 'none', cursor: 'pointer' }}
+          >
+            {goals.map((g) => <option key={g.goal_id} value={g.goal_id}>{g.goal_name}</option>)}
+            <option value="">{unallocatedLabel}</option>
+          </select>
+        </div>
+
+        <div>
+          <label htmlFor="rs-name" style={labelStyle}>{isVI ? 'Ngân hàng / sản phẩm' : 'Bank / product'}</label>
+          <input
+            id="rs-name"
+            data-testid="rs-name"
+            value={form.name}
+            onChange={(e) => setForm({ ...form, name: e.target.value })}
+            placeholder={isVI ? 'VD. VCB Tiết kiệm' : 'e.g. VCB Savings'}
+            style={inputStyle}
+            autoFocus
+          />
+        </div>
+
+        <div>
+          <label htmlFor="rs-amount" style={labelStyle}>{isVI ? 'Số tiền hàng tháng (₫)' : 'Monthly amount (₫)'}</label>
+          <input
+            id="rs-amount"
+            data-testid="rs-amount"
+            type="text"
+            inputMode="numeric"
+            value={form.amount_vnd ? Number(form.amount_vnd).toLocaleString('en-US') : ''}
+            onChange={(e) => setForm({ ...form, amount_vnd: e.target.value.replace(/,/g, '').replace(/[^0-9]/g, '') })}
+            placeholder="0"
+            style={{ ...inputStyle, fontVariantNumeric: 'tabular-nums' }}
+          />
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1fr) minmax(0,1fr)', gap: 10 }}>
+          <div>
+            <label htmlFor="rs-from" style={labelStyle}>{isVI ? 'Bắt đầu từ' : 'Effective from'}</label>
+            <input
+              id="rs-from"
+              data-testid="rs-from"
+              type="month"
+              value={form.effective_from}
+              onChange={(e) => setForm({ ...form, effective_from: e.target.value })}
+              style={{ ...inputStyle, fontVariantNumeric: 'tabular-nums', minWidth: 0 }}
+            />
+          </div>
+          <div>
+            <label htmlFor="rs-to" style={labelStyle}>{isVI ? 'Kết thúc' : 'Effective to'}</label>
+            <input
+              id="rs-to"
+              data-testid="rs-to"
+              type="month"
+              value={form.effective_to}
+              onChange={(e) => setForm({ ...form, effective_to: e.target.value })}
+              style={{ ...inputStyle, fontVariantNumeric: 'tabular-nums', minWidth: 0 }}
+            />
+          </div>
+        </div>
+
+        <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: -4 }}>
+          {isVI ? 'Tự động lặp lại mỗi tháng. Bỏ trống ngày kết thúc để áp dụng vô thời hạn.' : 'Auto-repeats every month. Leave end blank to apply indefinitely.'}
+        </div>
+
+        <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+          <button type="button" onClick={() => setMode('list')} style={ghostBtn}>{tc('cancel')}</button>
+          <button type="button" data-testid="rs-save" onClick={handleSave} disabled={saving} style={{ ...primaryBtn, opacity: saving ? 0.7 : 1 }}>
+            {saving ? tc('saving') : tc('save')}
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  // ─── List view ──────────────────────────────────────────────────────────────
+
+  const total = items.reduce((s, e) => s + e.amount_vnd, 0)
+
+  return (
+    <div data-testid="recurring-saving-manager" style={{ display: 'grid', gap: 12 }}>
+      {!loading && items.length > 0 && (
+        <div style={{ fontSize: 12, color: 'var(--c-muted)' }}>
+          {items.length} {isVI ? 'khoản' : items.length === 1 ? 'item' : 'items'} · {fmt(total)}/{isVI ? 'tháng' : 'mo'}
+        </div>
+      )}
+
+      <div style={{ display: 'grid', gap: 8, maxHeight: 360, overflowY: 'auto' }}>
+        {loading ? (
+          <div style={{ padding: '24px 12px', textAlign: 'center', fontSize: 13, color: 'var(--c-muted)' }}>{tc('loading')}</div>
+        ) : items.length === 0 ? (
+          <div style={{ padding: '24px 12px', textAlign: 'center', fontSize: 13, color: 'var(--c-muted)', border: '1px dashed var(--c-line-strong)', borderRadius: 10 }}>
+            {isVI ? 'Chưa có khoản tiết kiệm định kỳ.' : 'No recurring savings yet.'}
+          </div>
+        ) : (
+          items.map((s) => (
+            <div
+              key={s.saving_id}
+              data-testid={`rs-row-${s.saving_id}`}
+              style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '11px 12px', borderRadius: 10, border: '1px solid var(--c-line)', background: 'var(--c-card)' }}
+            >
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.name}</span>
+                  <span style={{ fontSize: 10, fontWeight: 600, padding: '2px 7px', borderRadius: 999, color: 'var(--c-navy)', background: 'var(--c-navy-tint)', flexShrink: 0 }}>
+                    {goalName(s.goal_id, s.savings_goals?.goal_name)}
+                  </span>
+                </div>
+                <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 3, fontVariantNumeric: 'tabular-nums' }}>
+                  {fmt(s.amount_vnd)} · {periodLabel(s, isVI)}
+                </div>
+              </div>
+              <button
+                type="button"
+                data-testid="rs-edit"
+                aria-label="Edit"
+                onClick={() => openEdit(s)}
+                style={{ padding: 6, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}
+              >
+                <svg viewBox="0 0 24 24" width={16} height={16} fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M4 20h4l10-10-4-4L4 16z" /></svg>
+              </button>
+              <button
+                type="button"
+                data-testid="rs-delete"
+                aria-label="Delete"
+                onClick={() => setConfirmDelete(s)}
+                style={{ padding: 6, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-neg)', display: 'flex' }}
+              >
+                <svg viewBox="0 0 24 24" width={16} height={16} fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round"><path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" /></svg>
+              </button>
+            </div>
+          ))
+        )}
+      </div>
+
+      <button
+        type="button"
+        data-testid="rs-add"
+        onClick={openCreate}
+        style={{ ...primaryBtn, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '10px' }}
+      >
+        <Plus size={15} strokeWidth={2.4} />{isVI ? 'Thêm khoản định kỳ' : 'Add recurring saving'}
+      </button>
+
+      {confirmDelete && (() => {
+        const title = isVI ? 'Xoá khoản định kỳ?' : 'Delete recurring saving?'
+        const body = (
+          <>
+            <div style={{ fontSize: 13, color: 'var(--c-muted)' }}>
+              {confirmDelete.name} — {fmtCompact(confirmDelete.amount_vnd)}
+            </div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button type="button" onClick={() => setConfirmDelete(null)} style={ghostBtn}>{tc('cancel')}</button>
+              <button
+                type="button"
+                data-testid="rs-delete-confirm"
+                onClick={() => handleDelete(confirmDelete)}
+                disabled={deleting}
+                style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-neg)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', opacity: deleting ? 0.7 : 1 }}
+              >
+                {isVI ? 'Xoá' : 'Delete'}
+              </button>
+            </div>
+          </>
+        )
+
+        if (variant === 'sheet') {
+          return (
+            <div
+              data-testid="rs-delete-overlay"
+              style={{ position: 'fixed', inset: 0, zIndex: 300, background: 'rgba(15,23,42,0.4)', display: 'flex', alignItems: 'flex-end' }}
+              onClick={() => !deleting && setConfirmDelete(null)}
+            >
+              <div
+                onClick={(e) => e.stopPropagation()}
+                style={{ width: '100%', background: 'var(--c-card)', borderRadius: '16px 16px 0 0', paddingBottom: 'env(safe-area-inset-bottom,0)', animation: 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' }}
+              >
+                <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '8px auto 0' }} />
+                <div style={{ padding: '14px 16px 0' }}>
+                  <p style={{ fontWeight: 700, fontSize: 16, color: 'var(--c-ink)', margin: '0 0 16px' }}>{title}</p>
+                </div>
+                <div style={{ padding: '0 16px 24px', display: 'grid', gap: 16 }}>{body}</div>
+              </div>
+            </div>
+          )
+        }
+
+        return (
+          <div
+            data-testid="rs-delete-overlay"
+            style={{ position: 'fixed', inset: 0, zIndex: 300, background: 'rgba(15,23,42,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}
+            onClick={() => !deleting && setConfirmDelete(null)}
+          >
+            <div onClick={(e) => e.stopPropagation()} style={{ width: 360, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, boxShadow: '0 20px 50px rgba(15,23,42,0.25)', display: 'grid', gap: 16 }}>
+              <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--c-ink)' }}>{title}</div>
+              {body}
+            </div>
+          </div>
+        )
+      })()}
+    </div>
+  )
+}

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -85,6 +85,8 @@ const defaultProps = {
   fixedExpenses: [] as FixedExpense[],
   insuranceMembers: [] as InsuranceMember[],
   otherExpenses: [] as OtherExpense[],
+  recurringSavings: [],
+  recurringSavingOverrides: [],
   funds: [],
   goals: [],
   onPlanCreated: vi.fn(),
@@ -320,5 +322,55 @@ describe('MobilePlanningView — collapsible sections', () => {
     await userEvent.click(sectionBtn)
     // Items should be hidden now
     expect(screen.queryByText('Rent')).not.toBeInTheDocument()
+  })
+})
+
+describe('MobilePlanningView — recurring savings in By goal', () => {
+  const recurringSavings = [
+    {
+      saving_id: 'rs1',
+      name: 'VCB Savings',
+      goal_id: 'g1',
+      amount_vnd: 2_000_000,
+      effective_from: null,
+      effective_to: null,
+      savings_goals: { goal_name: 'Retirement' },
+    },
+  ]
+
+  it('renders a recurring saving under its goal and includes it in the goal total', async () => {
+    render(
+      <MobilePlanningView
+        {...defaultProps}
+        plan={basePlan}
+        investments={baseInvestments}
+        recurringSavings={recurringSavings}
+      />,
+    )
+    // Goal total = 5M fund DCA + 2M recurring saving = 7M (full-format),
+    // shown in the section header and the goal row.
+    expect(screen.getAllByText('₫ 7000000').length).toBeGreaterThan(0)
+    // Expand the Retirement goal — recurring saving name becomes visible
+    await userEvent.click(screen.getByText('Retirement'))
+    expect(screen.getByText('VCB Savings')).toBeInTheDocument()
+  })
+
+  it('shows a skipped recurring saving with a zero effective amount', async () => {
+    render(
+      <MobilePlanningView
+        {...defaultProps}
+        plan={basePlan}
+        recurringSavings={recurringSavings}
+        recurringSavingOverrides={[{ recurring_saving_id: 'rs1', monthly_amount_override_vnd: 0 }]}
+      />,
+    )
+    // Expand the goal — the skipped saving is labelled and struck through
+    await userEvent.click(screen.getByText('Retirement'))
+    expect(screen.getByText(/Skipped this month/i)).toBeInTheDocument()
+  })
+
+  it('exposes a Manage savings action on the By goal section', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
+    expect(screen.getByTestId('mobile-manage-savings')).toBeInTheDocument()
   })
 })

--- a/app/api/v1/monthly-plans/[id]/recurring-saving-overrides/[overrideId]/route.ts
+++ b/app/api/v1/monthly-plans/[id]/recurring-saving-overrides/[overrideId]/route.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string; overrideId: string }> }
+) {
+  const { id, overrideId } = await params
+
+  let planId: string
+  let cleanOverrideId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+    cleanOverrideId = validateUUID(overrideId, 'override_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
+  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
+
+  const { error } = await supabase
+    .from('recurring_saving_overrides')
+    .delete()
+    .eq('id', cleanOverrideId)
+    .eq('plan_id', planId)
+
+  if (error) return NextResponse.json({ error: 'Override not found' }, { status: 404 })
+  return new NextResponse(null, { status: 204 })
+}

--- a/app/api/v1/monthly-plans/[id]/recurring-saving-overrides/route.ts
+++ b/app/api/v1/monthly-plans/[id]/recurring-saving-overrides/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateUUID } from '@/lib/validation'
+
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+
+  let planId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
+  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
+
+  const { data, error } = await supabase
+    .from('recurring_saving_overrides')
+    .select('*, recurring_savings(name, amount_vnd)')
+    .eq('plan_id', planId)
+    .order('created_at', { ascending: true })
+
+  if (error) return NextResponse.json({ error: 'Failed to fetch overrides' }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await request.json()
+  const { recurring_saving_id, monthly_amount_override_vnd } = body
+
+  let planId: string
+  let cleanSavingId: string
+  let cleanAmount: number
+  try {
+    planId = validateUUID(id, 'plan_id')
+    if (!recurring_saving_id) throw new ValidationError('recurring_saving_id is required')
+    cleanSavingId = validateUUID(recurring_saving_id, 'recurring_saving_id')
+    if (monthly_amount_override_vnd === undefined || monthly_amount_override_vnd === null) {
+      throw new ValidationError('Monthly amount must be 0 or positive')
+    }
+    cleanAmount = validateAmount(monthly_amount_override_vnd, 'monthly_amount_override_vnd')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
+  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
+
+  // Upsert — one override per recurring saving per plan
+  const { data, error } = await supabase
+    .from('recurring_saving_overrides')
+    .upsert(
+      { plan_id: planId, recurring_saving_id: cleanSavingId, monthly_amount_override_vnd: cleanAmount, updated_at: new Date().toISOString() },
+      { onConflict: 'plan_id,recurring_saving_id' }
+    )
+    .select()
+    .single()
+
+  if (error) return NextResponse.json({ error: 'Failed to save override' }, { status: 500 })
+  return NextResponse.json(data, { status: 201 })
+}

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -27,7 +27,8 @@ export async function GET(request: NextRequest) {
   if (!plan) return NextResponse.json({ error: 'Plan not found for this month' }, { status: 404 })
 
   if (searchParams.get('full') === 'true') {
-    const [invRes, savRes, overridesRes, expRes, insRes, exclRes, insOverridesRes, goalsRes, fundsRes, otherExpRes] = await Promise.all([
+    const planDateForActive = `${plan.year}-${String(plan.month).padStart(2, '0')}-01`
+    const [invRes, savRes, overridesRes, expRes, insRes, exclRes, insOverridesRes, goalsRes, fundsRes, otherExpRes, recSavRes, recSavOverridesRes] = await Promise.all([
       supabase
         .from('investment_transactions')
         .select('transaction_id, plan_id, fund_id, goal_id, amount_vnd, units, unit_price, investment_date, is_dca_seeded, funds(name, nav), savings_goals(goal_name)')
@@ -63,10 +64,19 @@ export async function GET(request: NextRequest) {
         .select('goal_id, goal_name').eq('user_id', user.id).order('created_at', { ascending: false }),
       supabase
         .from('funds')
-        .select('id, name, nav, is_dca, dca_monthly_amount_vnd').eq('user_id', user.id).order('name', { ascending: true }),
+        .select('id, name, nav, is_dca, dca_monthly_amount_vnd, dca_goal_id').eq('user_id', user.id).order('name', { ascending: true }),
       supabase
         .from('plan_other_expenses')
         .select('id, description, amount_vnd, created_at').eq('plan_id', plan.id).order('created_at', { ascending: true }),
+      supabase
+        .from('recurring_savings')
+        .select('saving_id, name, goal_id, amount_vnd, effective_from, effective_to, savings_goals(goal_name)')
+        .eq('user_id', user.id)
+        .or(`effective_from.is.null,effective_from.lte.${planDateForActive}`)
+        .or(`effective_to.is.null,effective_to.gte.${planDateForActive}`),
+      supabase
+        .from('recurring_saving_overrides')
+        .select('recurring_saving_id, monthly_amount_override_vnd').eq('plan_id', plan.id),
     ])
     // Auto-seed DCA fund entries and keep pending rows in sync with current DCA amount
     const allFunds = fundsRes.data ?? []
@@ -132,6 +142,8 @@ export async function GET(request: NextRequest) {
       goals:                   goalsRes.data ?? [],
       funds:                   fundsRes.data ?? [],
       other_expenses:          otherExpRes.data ?? [],
+      recurring_savings:           recSavRes.data ?? [],
+      recurring_saving_overrides:  recSavOverridesRes.data ?? [],
     })
   }
 

--- a/app/api/v1/recurring-savings/[id]/route.ts
+++ b/app/api/v1/recurring-savings/[id]/route.ts
@@ -1,0 +1,88 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateText, validateUUID, validateYearMonth } from '@/lib/validation'
+
+function toDateCol(ym: string | undefined | null): string | null {
+  if (!ym) return null
+  return `${ym}-01`
+}
+
+export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await request.json()
+  const { name, goal_id, amount_vnd, effective_from, effective_to } = body
+
+  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }
+
+  let savingId: string
+  try {
+    savingId = validateUUID(id, 'saving_id')
+
+    if (name !== undefined) {
+      updates.name = validateText(name, 'name')
+    }
+    if ('goal_id' in body) {
+      updates.goal_id = goal_id ? validateUUID(goal_id, 'goal_id') : null
+    }
+    if (amount_vnd !== undefined) {
+      const n = validateAmount(amount_vnd, 'amount_vnd')
+      if (n <= 0) throw new ValidationError('Amount must be greater than 0.')
+      updates.amount_vnd = n
+    }
+    if ('effective_from' in body) {
+      updates.effective_from = effective_from ? toDateCol(validateYearMonth(effective_from, 'effective_from')) : null
+    }
+    if ('effective_to' in body) {
+      updates.effective_to = effective_to ? toDateCol(validateYearMonth(effective_to, 'effective_to')) : null
+    }
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const fromDate = (updates.effective_from ?? null) as string | null
+  const toDate = (updates.effective_to ?? null) as string | null
+  if (fromDate && toDate && fromDate > toDate) {
+    return NextResponse.json({ error: '"Active from" must be before "Active until".' }, { status: 400 })
+  }
+
+  const { data: saving, error } = await supabase
+    .from('recurring_savings')
+    .update(updates)
+    .eq('saving_id', savingId)
+    .eq('user_id', user.id)
+    .select('saving_id, name, goal_id, amount_vnd, effective_from, effective_to, savings_goals(goal_name)')
+    .single()
+
+  if (error || !saving) return NextResponse.json({ error: 'Recurring saving not found' }, { status: 404 })
+  return NextResponse.json(saving)
+}
+
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+
+  let savingId: string
+  try {
+    savingId = validateUUID(id, 'saving_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { error } = await supabase
+    .from('recurring_savings')
+    .delete()
+    .eq('saving_id', savingId)
+    .eq('user_id', user.id)
+
+  if (error) return NextResponse.json({ error: 'Recurring saving not found' }, { status: 404 })
+  return NextResponse.json({ message: 'Recurring saving deleted.' })
+}

--- a/app/api/v1/recurring-savings/route.ts
+++ b/app/api/v1/recurring-savings/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateText, validateUUID, validateYearMonth } from '@/lib/validation'
+
+function toDateCol(ym: string | undefined | null): string | null {
+  if (!ym) return null
+  return `${ym}-01`
+}
+
+export async function GET(request: NextRequest) {
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { searchParams } = new URL(request.url)
+  const month = searchParams.get('month')
+  const year = searchParams.get('year')
+
+  let query = supabase
+    .from('recurring_savings')
+    .select('saving_id, name, goal_id, amount_vnd, effective_from, effective_to, savings_goals(goal_name)')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false })
+
+  if (month && year) {
+    const planDate = `${year}-${String(month).padStart(2, '0')}-01`
+    query = query
+      .or(`effective_from.is.null,effective_from.lte.${planDate}`)
+      .or(`effective_to.is.null,effective_to.gte.${planDate}`)
+  }
+
+  const { data: savings, error } = await query
+  if (error) return NextResponse.json({ error: 'Failed to fetch recurring savings' }, { status: 500 })
+  return NextResponse.json({ savings })
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await request.json()
+  const { name, goal_id, amount_vnd, effective_from, effective_to } = body
+
+  let cleanName: string
+  let cleanGoalId: string | null = null
+  let cleanAmount: number
+  let cleanFromYm: string | null = null
+  let cleanToYm: string | null = null
+
+  try {
+    cleanName = validateText(name, 'name')
+    cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
+    if (cleanAmount <= 0) throw new ValidationError('Amount must be greater than 0.')
+    if (goal_id) cleanGoalId = validateUUID(goal_id, 'goal_id')
+    if (effective_from) cleanFromYm = validateYearMonth(effective_from, 'effective_from')
+    if (effective_to) cleanToYm = validateYearMonth(effective_to, 'effective_to')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const fromDate = toDateCol(cleanFromYm)
+  const toDate = toDateCol(cleanToYm)
+  if (fromDate && toDate && fromDate > toDate) {
+    return NextResponse.json({ error: '"Active from" must be before "Active until".' }, { status: 400 })
+  }
+
+  const { data: saving, error } = await supabase
+    .from('recurring_savings')
+    .insert({
+      user_id: user.id,
+      name: cleanName,
+      goal_id: cleanGoalId,
+      amount_vnd: cleanAmount,
+      effective_from: fromDate,
+      effective_to: toDate,
+    })
+    .select('saving_id, name, goal_id, amount_vnd, effective_from, effective_to, savings_goals(goal_name)')
+    .single()
+
+  if (error) return NextResponse.json({ error: 'Failed to create recurring saving' }, { status: 500 })
+  return NextResponse.json(saving, { status: 201 })
+}

--- a/e2e/planning-desktop.spec.ts
+++ b/e2e/planning-desktop.spec.ts
@@ -129,3 +129,16 @@ test('desktop planning: collapsible sections visible when plan exists', async ({
   await expect(desktop.getByText(/Fixed expenses|Chi phí cố định/i).first()).toBeVisible()
   await expect(desktop.getByText(/Insurance|Bảo hiểm/i).first()).toBeVisible()
 })
+
+test('desktop planning: Manage savings opens the recurring-saving manager', async ({ page }) => {
+  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
+  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
+
+  await goto(page)
+  const desktop = page.getByTestId('desktop-planning')
+
+  await desktop.getByTestId('desktop-manage-savings').click()
+  // Manager renders its list view (Add button) regardless of how many rules exist
+  await expect(page.getByTestId('recurring-saving-manager')).toBeVisible({ timeout: 8_000 })
+  await expect(page.getByTestId('rs-add')).toBeVisible()
+})

--- a/lib/__tests__/planning.test.ts
+++ b/lib/__tests__/planning.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect } from 'vitest'
+import {
+  resolveRecurringSavings,
+  recurringSavingsTotal,
+  buildByGoal,
+  type RecurringSaving,
+  type RecurringSavingOverride,
+  type GoalInvestment,
+  type GoalDirectSaving,
+} from '../planning'
+
+function saving(o: Partial<RecurringSaving> = {}): RecurringSaving {
+  return {
+    saving_id: 's-1',
+    name: 'VCB Savings',
+    goal_id: 'g-1',
+    amount_vnd: 2_000_000,
+    savings_goals: { goal_name: 'Retirement' },
+    ...o,
+  }
+}
+
+describe('resolveRecurringSavings', () => {
+  it('uses the base amount when there is no override', () => {
+    const [r] = resolveRecurringSavings([saving()], [])
+    expect(r.amount).toBe(2_000_000)
+    expect(r.skipped).toBe(false)
+    expect(r.overridden).toBe(false)
+  })
+
+  it('marks a 0 override as skipped with effective amount 0', () => {
+    const ov: RecurringSavingOverride = { recurring_saving_id: 's-1', monthly_amount_override_vnd: 0 }
+    const [r] = resolveRecurringSavings([saving()], [ov])
+    expect(r.skipped).toBe(true)
+    expect(r.amount).toBe(0)
+  })
+
+  it('applies a positive override and flags it overridden', () => {
+    const ov: RecurringSavingOverride = { recurring_saving_id: 's-1', monthly_amount_override_vnd: 5_000_000 }
+    const [r] = resolveRecurringSavings([saving()], [ov])
+    expect(r.amount).toBe(5_000_000)
+    expect(r.overridden).toBe(true)
+    expect(r.skipped).toBe(false)
+  })
+
+  it('does not flag overridden when the override equals the base amount', () => {
+    const ov: RecurringSavingOverride = { recurring_saving_id: 's-1', monthly_amount_override_vnd: 2_000_000 }
+    const [r] = resolveRecurringSavings([saving()], [ov])
+    expect(r.overridden).toBe(false)
+  })
+})
+
+describe('recurringSavingsTotal', () => {
+  it('sums effective amounts and excludes skipped rows', () => {
+    const savings = [
+      saving({ saving_id: 's-1', amount_vnd: 2_000_000 }),
+      saving({ saving_id: 's-2', amount_vnd: 3_000_000 }),
+    ]
+    const overrides = [{ recurring_saving_id: 's-2', monthly_amount_override_vnd: 0 }]
+    const resolved = resolveRecurringSavings(savings, overrides)
+    expect(recurringSavingsTotal(resolved)).toBe(2_000_000)
+  })
+})
+
+describe('buildByGoal', () => {
+  const goalsById = new Map([['g-1', 'Retirement'], ['g-2', 'House']])
+
+  it('groups fund investments, one-off savings and recurring savings under one goal', () => {
+    const investments: GoalInvestment[] = [
+      { goal_id: 'g-1', amount_vnd: 5_000_000, is_dca_seeded: true, funds: { name: 'VESAF' }, savings_goals: { goal_name: 'Retirement' } },
+    ]
+    const directSavings: GoalDirectSaving[] = [
+      { goal_id: 'g-1', amount_vnd: 1_000_000, savings_goals: { goal_name: 'Retirement' } },
+    ]
+    const recurring = resolveRecurringSavings([saving({ goal_id: 'g-1', amount_vnd: 2_000_000 })], [])
+
+    const rows = buildByGoal(investments, directSavings, recurring, goalsById)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].goalName).toBe('Retirement')
+    expect(rows[0].totalAllocated).toBe(8_000_000)
+    expect(rows[0].items.map(i => i.type)).toEqual(['fund', 'bank', 'bank'])
+  })
+
+  it('excludes skipped recurring savings from the goal total', () => {
+    const recurring = resolveRecurringSavings(
+      [saving({ goal_id: 'g-2', amount_vnd: 4_000_000 })],
+      [{ recurring_saving_id: 's-1', monthly_amount_override_vnd: 0 }],
+    )
+    const rows = buildByGoal([], [], recurring, goalsById)
+    expect(rows[0].totalAllocated).toBe(0)
+    expect(rows[0].items[0].skipped).toBe(true)
+  })
+
+  it('places the unallocated group (null goal) last', () => {
+    const recurring = resolveRecurringSavings(
+      [
+        saving({ saving_id: 's-u', goal_id: null, name: 'General', amount_vnd: 1_000_000, savings_goals: null }),
+        saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 2_000_000 }),
+      ],
+      [],
+    )
+    const rows = buildByGoal([], [], recurring, goalsById)
+    expect(rows.map(r => r.isUnallocated)).toEqual([false, true])
+  })
+})

--- a/lib/planning.ts
+++ b/lib/planning.ts
@@ -1,0 +1,168 @@
+// Pure planning helpers for the Monthly Plan "By goal" section.
+//
+// The plan groups recurring contributions by goal: fund investments (incl. DCA),
+// one-off direct savings, and recurring bank savings — the new named rules that
+// auto-recur each month within an effective period, with per-month skip/override
+// layered on top (mirrors fixed expenses). Server-side filters recurring savings
+// to those active in the selected month; this module resolves overrides, groups
+// by goal, and keeps the Unallocated group (null goal) last.
+
+const UNALLOCATED = '__unallocated__'
+
+// ─── Recurring savings ─────────────────────────────────────────────────────────
+
+export interface RecurringSaving {
+  saving_id: string
+  name: string
+  goal_id: string | null
+  amount_vnd: number
+  savings_goals?: { goal_name: string } | null
+}
+
+export interface RecurringSavingOverride {
+  recurring_saving_id: string
+  monthly_amount_override_vnd: number
+}
+
+export interface ResolvedSaving {
+  id: string
+  name: string
+  goalId: string | null
+  goalName: string | null
+  baseAmount: number
+  amount: number // effective amount this month (0 when skipped)
+  skipped: boolean
+  overridden: boolean
+}
+
+// Apply per-month overrides to the active recurring savings. An override of 0
+// means "skip this month"; any other positive value replaces the base amount.
+export function resolveRecurringSavings(
+  savings: RecurringSaving[],
+  overrides: RecurringSavingOverride[],
+): ResolvedSaving[] {
+  const ovMap = new Map(overrides.map(o => [o.recurring_saving_id, o.monthly_amount_override_vnd]))
+  return savings.map(s => {
+    const ov = ovMap.get(s.saving_id)
+    const hasOv = ov !== undefined
+    const skipped = ov === 0
+    return {
+      id: s.saving_id,
+      name: s.name,
+      goalId: s.goal_id,
+      goalName: s.savings_goals?.goal_name ?? null,
+      baseAmount: s.amount_vnd,
+      amount: skipped ? 0 : hasOv ? ov! : s.amount_vnd,
+      skipped,
+      overridden: hasOv && ov! > 0 && ov !== s.amount_vnd,
+    }
+  })
+}
+
+export function recurringSavingsTotal(resolved: ResolvedSaving[]): number {
+  return resolved.reduce((s, r) => s + r.amount, 0)
+}
+
+// ─── By-goal grouping ───────────────────────────────────────────────────────────
+
+export interface GoalInvestment {
+  goal_id: string | null
+  amount_vnd: number
+  is_dca_seeded?: boolean
+  funds?: { name: string } | null
+  savings_goals?: { goal_name: string } | null
+}
+
+export interface GoalDirectSaving {
+  goal_id: string | null
+  amount_vnd: number
+  savings_goals?: { goal_name: string } | null
+}
+
+export interface GoalItem {
+  name: string
+  type: 'fund' | 'bank'
+  amount: number
+  baseAmount?: number
+  isDCA?: boolean
+  isRecurring?: boolean
+  recurringId?: string
+  skipped?: boolean
+  overridden?: boolean
+}
+
+export interface GoalRow {
+  goalId: string
+  goalName: string
+  totalAllocated: number
+  isUnallocated: boolean
+  items: GoalItem[]
+}
+
+// Merge fund investments, one-off direct savings and resolved recurring savings
+// into goal groups. `goalsById` resolves a goal id to its display name when the
+// row itself doesn't carry one. The Unallocated group (null goal) is sorted last.
+export function buildByGoal(
+  investments: GoalInvestment[],
+  directSavings: GoalDirectSaving[],
+  recurring: ResolvedSaving[],
+  goalsById: Map<string, string>,
+  labels?: { unallocated?: string; directSaving?: string },
+): GoalRow[] {
+  const unallocatedLabel = labels?.unallocated ?? 'Unallocated'
+  const directLabel = labels?.directSaving ?? 'Direct savings'
+  const map = new Map<string, GoalRow>()
+
+  const ensure = (goalId: string | null, name?: string | null): GoalRow => {
+    const key = goalId ?? UNALLOCATED
+    if (!map.has(key)) {
+      const isUnallocated = goalId == null
+      map.set(key, {
+        goalId: key,
+        goalName: isUnallocated ? unallocatedLabel : name || goalsById.get(goalId!) || 'Unassigned',
+        totalAllocated: 0,
+        isUnallocated,
+        items: [],
+      })
+    }
+    return map.get(key)!
+  }
+
+  for (const inv of investments) {
+    const row = ensure(inv.goal_id, inv.savings_goals?.goal_name)
+    row.totalAllocated += inv.amount_vnd
+    row.items.push({
+      name: inv.funds?.name ?? 'Unknown fund',
+      type: 'fund',
+      amount: inv.amount_vnd,
+      isDCA: inv.is_dca_seeded,
+    })
+  }
+
+  for (const sav of directSavings) {
+    const row = ensure(sav.goal_id, sav.savings_goals?.goal_name)
+    row.totalAllocated += sav.amount_vnd
+    row.items.push({ name: directLabel, type: 'bank', amount: sav.amount_vnd })
+  }
+
+  for (const r of recurring) {
+    const row = ensure(r.goalId, r.goalName)
+    row.totalAllocated += r.amount
+    row.items.push({
+      name: r.name,
+      type: 'bank',
+      amount: r.amount,
+      baseAmount: r.baseAmount,
+      isRecurring: true,
+      recurringId: r.id,
+      skipped: r.skipped,
+      overridden: r.overridden,
+    })
+  }
+
+  return [...map.values()].sort((a, b) => {
+    if (a.isUnallocated) return 1
+    if (b.isUnallocated) return -1
+    return a.goalName.localeCompare(b.goalName)
+  })
+}

--- a/supabase/migrations/20260605000002_create_recurring_savings.sql
+++ b/supabase/migrations/20260605000002_create_recurring_savings.sql
@@ -1,0 +1,55 @@
+-- Recurring bank savings — the master list of recurring direct-saving rules
+-- (named bank/product, target goal, monthly amount, optional effective period).
+-- Mirrors fixed_expenses: definitions persist across months, and the Plan's
+-- per-month skip/override sit on top in recurring_saving_overrides (NOT here).
+
+-- recurring_savings
+CREATE TABLE IF NOT EXISTS recurring_savings (
+  saving_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  goal_id UUID REFERENCES savings_goals(goal_id) ON DELETE SET NULL,
+  amount_vnd BIGINT NOT NULL CHECK (amount_vnd > 0),
+  effective_from DATE,
+  effective_to DATE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (effective_from IS NULL OR effective_to IS NULL OR effective_from <= effective_to)
+);
+
+ALTER TABLE recurring_savings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "recurring_savings_select" ON recurring_savings
+  FOR SELECT TO authenticated USING (user_id = auth.uid());
+CREATE POLICY "recurring_savings_insert" ON recurring_savings
+  FOR INSERT TO authenticated WITH CHECK (user_id = auth.uid());
+CREATE POLICY "recurring_savings_update" ON recurring_savings
+  FOR UPDATE TO authenticated USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "recurring_savings_delete" ON recurring_savings
+  FOR DELETE TO authenticated USING (user_id = auth.uid());
+
+-- recurring_saving_overrides — per-plan amount override / skip (0 = skip this month)
+CREATE TABLE IF NOT EXISTS recurring_saving_overrides (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  plan_id UUID NOT NULL REFERENCES monthly_plans(id) ON DELETE CASCADE,
+  recurring_saving_id UUID NOT NULL REFERENCES recurring_savings(saving_id) ON DELETE CASCADE,
+  monthly_amount_override_vnd BIGINT NOT NULL CHECK (monthly_amount_override_vnd >= 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (plan_id, recurring_saving_id)
+);
+
+ALTER TABLE recurring_saving_overrides ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "recurring_saving_overrides_select" ON recurring_saving_overrides
+  FOR SELECT TO authenticated
+  USING (plan_id IN (SELECT id FROM monthly_plans WHERE user_id = auth.uid()));
+CREATE POLICY "recurring_saving_overrides_insert" ON recurring_saving_overrides
+  FOR INSERT TO authenticated
+  WITH CHECK (plan_id IN (SELECT id FROM monthly_plans WHERE user_id = auth.uid()));
+CREATE POLICY "recurring_saving_overrides_update" ON recurring_saving_overrides
+  FOR UPDATE TO authenticated
+  USING (plan_id IN (SELECT id FROM monthly_plans WHERE user_id = auth.uid()));
+CREATE POLICY "recurring_saving_overrides_delete" ON recurring_saving_overrides
+  FOR DELETE TO authenticated
+  USING (plan_id IN (SELECT id FROM monthly_plans WHERE user_id = auth.uid()));


### PR DESCRIPTION
@
## What

PR 2 of the Plan-page redesign. Adds **recurring bank savings** as first-class named rules with effective periods (modeled on fixed expenses), surfaced in the "By goal" section alongside fund DCA, with per-month skip/override.

This is the headline data-model change from the new design. The page already implemented most of the design's visuals (summary strip, navy allocation card, by-goal table) in a prior iteration, so the remaining pure-visual gap — the allocation-card legend currency-symbol wrap — is folded into this PR.

## Changes

**Backend**
- Migration `recurring_savings` + `recurring_saving_overrides` (RLS mirrors `fixed_expenses` / `fixed_expense_overrides`; override `0` = skip this month)
- API: `recurring-savings` CRUD + `[id]`, per-plan `recurring-saving-overrides` upsert/delete
- `monthly-plans?full=true` now returns active-in-month recurring savings + overrides, and `funds.dca_goal_id`

**Frontend**
- `lib/planning.ts` — centralized, unit-tested `buildByGoal` + recurring-override resolver (replaces the helper duplicated across both views)
- Desktop + mobile: "Manage savings" manager (mirrors the fixed-expense manager), recurring-row kebab (save more / edit / skip / restore), skipped styling
- Fix: allocation-card legend amount no longer wraps the `₫` to a second line

## Tests
- `lib/__tests__/planning.test.ts` — override resolution, totals, by-goal grouping + ordering (8 tests)
- `MobilePlanningView.test.tsx` — recurring saving renders under its goal, skipped label, Manage action (3 tests)
- e2e: Manage savings opens the manager
- Full suite green (450 unit/component), `tsc` clean, production build compiles

## Notes / follow-ups
- Requires the migration to be applied to the preview DB.
- Deferred to a later PR (per agreed plan): per-goal progress bars + "contributed this month" reconciliation, and fund-DCA per-month skip + "Record buy" from the plan (PR 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@