### PR TITLE
feat(planning): fund-DCA skip, record-buy & per-goal progress

### DIFF
--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -79,7 +79,14 @@ export interface RecurringSavingOverride {
   monthly_amount_override_vnd: number
 }
 
-export interface Fund { id: string; name: string; nav: number }
+export interface Fund {
+  id: string; name: string; nav: number
+  is_dca?: boolean
+  dca_monthly_amount_vnd?: number | null
+  dca_goal_id?: string | null
+}
+
+export interface DcaSkip { fund_id: string }
 export interface Goal { goal_id: string; goal_name: string }
 
 const PLAN_CACHE_TTL = 2 * 60 * 1000
@@ -126,6 +133,7 @@ export default function PlanningClient() {
   const [otherExpenses, setOtherExpenses] = useState<OtherExpense[]>(initialCache?.otherExpenses ?? [])
   const [recurringSavings, setRecurringSavings] = useState<RecurringSaving[]>(initialCache?.recurringSavings ?? [])
   const [recurringSavingOverrides, setRecurringSavingOverrides] = useState<RecurringSavingOverride[]>(initialCache?.recurringSavingOverrides ?? [])
+  const [dcaSkips, setDcaSkips] = useState<DcaSkip[]>(initialCache?.dcaSkips ?? [])
   const [funds, setFunds] = useState<Fund[]>(initialCache?.funds ?? [])
   const [goals, setGoals] = useState<Goal[]>(initialCache?.goals ?? [])
   const [loading, setLoading] = useState(!initialCache)
@@ -177,6 +185,7 @@ export default function PlanningClient() {
         funds: p.funds ?? [],
         recurringSavings: p.recurring_savings ?? [],
         recurringSavingOverrides: p.recurring_saving_overrides ?? [],
+        dcaSkips: p.dca_skips ?? [],
       }
       setPlanCache(month, year, fresh)
       setPlan(fresh.plan)
@@ -189,6 +198,7 @@ export default function PlanningClient() {
       setFunds(fresh.funds)
       setRecurringSavings(fresh.recurringSavings)
       setRecurringSavingOverrides(fresh.recurringSavingOverrides)
+      setDcaSkips(fresh.dcaSkips)
     } else {
       bustPlanCache(month, year)
       setPlan(null)
@@ -199,6 +209,7 @@ export default function PlanningClient() {
       setFunds([])
       setRecurringSavings([])
       setRecurringSavingOverrides([])
+      setDcaSkips([])
       // Still load fixed expenses and insurance even without a plan
       const [expRes, insRes] = await Promise.all([
         fetch('/api/v1/fixed-expenses'),
@@ -279,6 +290,7 @@ export default function PlanningClient() {
         otherExpenses={otherExpenses}
         recurringSavings={recurringSavings}
         recurringSavingOverrides={recurringSavingOverrides}
+        dcaSkips={dcaSkips}
         funds={funds}
         goals={goals}
         onPlanCreated={(p) => { setPlan(p); refetch() }}
@@ -306,6 +318,7 @@ export default function PlanningClient() {
         otherExpenses={otherExpenses}
         recurringSavings={recurringSavings}
         recurringSavingOverrides={recurringSavingOverrides}
+        dcaSkips={dcaSkips}
         funds={funds}
         goals={goals}
         loading={loading}

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -13,7 +13,7 @@ import RecurringSavingManager from './RecurringSavingManager'
 import { buildByGoal, resolveRecurringSavings, type GoalItem } from '@/lib/planning'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
-  InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, Fund, Goal,
+  InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, DcaSkip, Fund, Goal,
 } from '../PlanningClient'
 
 // ─── Pure helpers ─────────────────────────────────────────────────────────────
@@ -186,20 +186,30 @@ function DPlanRow({ primary, secondary, amount, muted, last, isVI, onSkip, onRes
   )
 }
 
-// ─── DGoalItemRow — line item under a goal (recurring savings get a kebab) ────
+// ─── DGoalItemRow — line item under a goal ───────────────────────────────────
+// Recurring savings get a kebab (save more / edit / skip). Fund DCA lines get a
+// "Buy" pill to record the actual purchase, plus skip / restore for the month.
 
-function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit }: {
+function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRecordBuy, onDcaSkip, onDcaRestore }: {
   item: GoalItem; isVI: boolean
   onSkip: () => void; onRestore: () => void; onOverride: () => void; onEdit: () => void
+  onRecordBuy: () => void; onDcaSkip: () => void; onDcaRestore: () => void
 }) {
   const [open, setOpen] = useState(false)
   const [menuPos, setMenuPos] = useState({ top: 0, right: 0 })
   const btnRef = useRef<HTMLButtonElement>(null)
   const skipped = !!item.skipped
+  const recorded = !!item.recorded
 
-  const typeLabel = item.type === 'fund'
-    ? 'Fund'
-    : item.isRecurring ? (isVI ? 'Tiết kiệm định kỳ' : 'Recurring saving') : (isVI ? 'Tiết kiệm' : 'Direct saving')
+  const sublabel = skipped
+    ? (isVI ? 'Bỏ qua tháng này' : 'Skipped this month')
+    : item.overridden
+      ? (isVI ? 'Đã ghi đè tháng này' : 'Overridden this month')
+      : recorded
+        ? (isVI ? 'Đã mua' : 'Recorded')
+        : item.type === 'fund'
+          ? 'Fund'
+          : item.isRecurring ? (isVI ? 'Tiết kiệm định kỳ' : 'Recurring saving') : (isVI ? 'Tiết kiệm' : 'Direct saving')
 
   function openMenu() {
     if (btnRef.current) {
@@ -213,18 +223,18 @@ function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit }: {
     <tr style={{ borderBottom: '1px solid var(--c-line)', background: 'var(--c-card)', opacity: skipped ? 0.5 : 1 }}>
       <td style={{ padding: '9px 16px 9px 44px', verticalAlign: 'middle' }}>
         <div style={{ fontSize: 12, fontWeight: 500, textDecoration: skipped ? 'line-through' : 'none' }}>{item.name}</div>
-        <div style={{ fontSize: 10, color: item.overridden ? 'var(--c-navy)' : 'var(--c-muted)', marginTop: 1 }}>
-          {skipped ? (isVI ? 'Bỏ qua tháng này' : 'Skipped this month') : item.overridden ? (isVI ? 'Đã ghi đè tháng này' : 'Overridden this month') : typeLabel}
+        <div style={{ fontSize: 10, color: item.overridden ? 'var(--c-navy)' : recorded ? 'var(--c-pos)' : 'var(--c-muted)', marginTop: 1 }}>
+          {sublabel}
           {item.isDCA && <span style={{ marginLeft: 6, padding: '1px 5px', borderRadius: 4, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', fontSize: 9, fontWeight: 700 }}>DCA</span>}
         </div>
       </td>
       <td style={{ padding: '9px 12px', textAlign: 'right', verticalAlign: 'middle' }}>
         <span style={{ fontSize: 12, fontWeight: 500, color: 'var(--c-muted)', fontVariantNumeric: 'tabular-nums', textDecoration: skipped ? 'line-through' : 'none' }}>{fmt(item.amount)}</span>
       </td>
-      <td style={{ padding: '9px 8px 9px 4px', textAlign: 'right', verticalAlign: 'middle', width: 36 }}>
-        {item.isRecurring && (
+      <td style={{ padding: '9px 8px 9px 4px', textAlign: 'right', verticalAlign: 'middle', width: 96 }}>
+        {item.isRecurring ? (
           <>
-            <button ref={btnRef} onClick={() => open ? setOpen(false) : openMenu()} aria-label="Saving actions" style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
+            <button ref={btnRef} onClick={() => open ? setOpen(false) : openMenu()} aria-label="Saving actions" style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex', marginLeft: 'auto' }}>
               <MoreHorizontal size={14} />
             </button>
             {open && (
@@ -245,7 +255,34 @@ function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit }: {
               </>
             )}
           </>
-        )}
+        ) : item.isFundDca && skipped ? (
+          <button onClick={onDcaRestore} aria-label="Restore DCA" style={{ padding: '4px 9px', fontSize: 11, fontWeight: 600, color: 'var(--c-muted)', background: 'transparent', border: '1px solid var(--c-line)', borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
+            <Check size={12} />{isVI ? 'Khôi phục' : 'Restore'}
+          </button>
+        ) : item.isFundDca && recorded ? (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: 'var(--c-pos)', fontSize: 11, fontWeight: 600 }}>
+            <Check size={13} />{isVI ? 'Đã mua' : 'Bought'}
+          </span>
+        ) : item.isFundDca ? (
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 2 }}>
+            <button onClick={onRecordBuy} aria-label={isVI ? 'Ghi nhận mua' : 'Record buy'} title={isVI ? 'Ghi nhận mua — giá, số CCQ, ngày' : 'Record buy — price, units, date'}
+              style={{ padding: '4px 10px', fontSize: 11, fontWeight: 600, color: 'var(--c-pos)', background: 'var(--c-pos-tint)', border: '1px solid transparent', borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4, whiteSpace: 'nowrap' }}>
+              <Plus size={12} strokeWidth={2.4} />{isVI ? 'Mua' : 'Buy'}
+            </button>
+            <button ref={btnRef} onClick={() => open ? setOpen(false) : openMenu()} aria-label="DCA actions" style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
+              <MoreHorizontal size={14} />
+            </button>
+            {open && (
+              <>
+                <div onClick={() => setOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 5 }} />
+                <div style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 200, overflow: 'hidden' }}>
+                  <MenuBtn icon={<Plus size={13} />} label={isVI ? 'Ghi nhận mua tháng này' : 'Record buy this month'} onClick={() => { onRecordBuy(); setOpen(false) }} />
+                  <MenuBtn icon={<X size={13} />} label={isVI ? 'Bỏ qua tháng này' : 'Skip this month'} onClick={() => { onDcaSkip(); setOpen(false) }} danger noBorder />
+                </div>
+              </>
+            )}
+          </div>
+        ) : null}
       </td>
     </tr>
   )
@@ -266,8 +303,8 @@ function StackedBar({ segments, total }: { segments: { color: string; value: num
 
 // ─── Allocation card (navy sidebar) ──────────────────────────────────────────
 
-function AllocationCard({ salary, totalGoalAmount, fixedTotal, insTotal, otherTotal, isVI }: {
-  salary: number; totalGoalAmount: number; fixedTotal: number; insTotal: number; otherTotal: number; isVI: boolean
+function AllocationCard({ salary, totalGoalAmount, fixedTotal, insTotal, otherTotal, contributedTotal, isVI }: {
+  salary: number; totalGoalAmount: number; fixedTotal: number; insTotal: number; otherTotal: number; contributedTotal: number; isVI: boolean
 }) {
   const totalAllocated = totalGoalAmount + fixedTotal + insTotal + otherTotal
   const remaining = salary - totalAllocated
@@ -314,6 +351,20 @@ function AllocationCard({ salary, totalGoalAmount, fixedTotal, insTotal, otherTo
           </span>
         </div>
       </div>
+
+      {totalGoalAmount > 0 && (
+        <div data-testid="planning-contributed" style={{ marginTop: 14, paddingTop: 12, borderTop: '1px solid rgba(255,255,255,0.12)' }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
+            <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.6)' }}>{isVI ? 'Đã góp tháng này' : 'Contributed this month'}</span>
+            <span style={{ fontSize: 12, fontWeight: 600, fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
+              {fmtCompact(contributedTotal)} <span style={{ color: 'rgba(255,255,255,0.45)' }}>/ {fmtCompact(totalGoalAmount)}</span>
+            </span>
+          </div>
+          <div style={{ marginTop: 8, height: 6, borderRadius: 999, background: 'rgba(255,255,255,0.12)', overflow: 'hidden' }}>
+            <div style={{ height: '100%', width: `${Math.min(100, totalGoalAmount > 0 ? Math.round(contributedTotal / totalGoalAmount * 100) : 0)}%`, background: '#86efac', borderRadius: 999, transition: 'width 200ms' }} />
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -345,6 +396,7 @@ interface Props {
   otherExpenses: OtherExpense[]
   recurringSavings: RecurringSaving[]
   recurringSavingOverrides: RecurringSavingOverride[]
+  dcaSkips: DcaSkip[]
   funds: Fund[]
   goals: Goal[]
   loading: boolean
@@ -361,7 +413,7 @@ interface Props {
 
 export default function DesktopPlanningView({
   month, year, plan, investments, savings, fixedExpenses, insuranceMembers,
-  otherExpenses, recurringSavings, recurringSavingOverrides, goals, loading,
+  otherExpenses, recurringSavings, recurringSavingOverrides, dcaSkips, funds, goals, loading,
   onPrev, onNext, onToday, onPlanCreated, onPlanDeleted, onRefresh, onToast,
 }: Props) {
   const locale = useLocale()
@@ -379,6 +431,9 @@ export default function DesktopPlanningView({
   const [otherAmt, setOtherAmt] = useState('')
   const [showFEManage, setShowFEManage] = useState(false)
   const [showRSManage, setShowRSManage] = useState(false)
+  const [buyModal, setBuyModal] = useState<{ transactionId: string; name: string; amount: number } | null>(null)
+  const [buyPrice, setBuyPrice] = useState('')
+  const [buyUnits, setBuyUnits] = useState('')
 
   // ── Derived values ──
   const goalsById = useMemo(() => new Map(goals.map(g => [g.goal_id, g.goal_name])), [goals])
@@ -386,14 +441,29 @@ export default function DesktopPlanningView({
     () => resolveRecurringSavings(recurringSavings, recurringSavingOverrides),
     [recurringSavings, recurringSavingOverrides],
   )
+  // Skipped DCA funds are no longer seeded as rows, so synthesize struck-through
+  // lines from the fund config + the plan's skip list.
+  const skippedDcaInvestments = useMemo(() => {
+    const skipped = new Set(dcaSkips.map(s => s.fund_id))
+    return funds
+      .filter(f => f.is_dca && f.dca_monthly_amount_vnd && skipped.has(f.id))
+      .map(f => ({
+        goal_id: f.dca_goal_id ?? null,
+        amount_vnd: f.dca_monthly_amount_vnd as number,
+        is_dca_seeded: true,
+        skipped: true,
+        fund_id: f.id,
+        funds: { name: f.name },
+      }))
+  }, [funds, dcaSkips])
   const byGoal = useMemo(
-    () => buildByGoal(investments, savings, resolvedRecurring, goalsById, {
+    () => buildByGoal([...investments, ...skippedDcaInvestments], savings, resolvedRecurring, goalsById, {
       unallocated: isVI ? 'Chưa phân bổ' : 'Unallocated',
-      directSaving: isVI ? 'Tiết kiệm' : 'Direct savings',
     }),
-    [investments, savings, resolvedRecurring, goalsById, isVI],
+    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI],
   )
   const totalGoalAmount = byGoal.reduce((s, g) => s + g.totalAllocated, 0)
+  const contributedTotal = byGoal.reduce((s, g) => s + g.contributed, 0)
   const fixedTotal = useMemo(() => getFixedTotal(fixedExpenses), [fixedExpenses])
   const insTotal   = useMemo(() => getInsTotal(insuranceMembers), [insuranceMembers])
   const otherTotal = otherExpenses.reduce((s, o) => s + o.amount_vnd, 0)
@@ -506,6 +576,46 @@ export default function DesktopPlanningView({
     const match = overrides.find(o => o.recurring_saving_id === item.recurringId)
     if (match) await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides/${match.id}`, { method: 'DELETE' })
     onRefresh(); onToast(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
+  }
+
+  async function handleDcaSkip(item: { fundId?: string | null; name: string }) {
+    if (!plan || !item.fundId) return
+    await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fund_id: item.fundId }),
+    })
+    onRefresh(); onToast(isVI ? `Đã bỏ qua ${item.name}` : `Skipped ${item.name}`)
+  }
+
+  async function handleDcaRestore(item: { fundId?: string | null; name: string }) {
+    if (!plan || !item.fundId) return
+    await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips/${item.fundId}`, { method: 'DELETE' })
+    onRefresh(); onToast(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
+  }
+
+  function openBuy(item: { transactionId?: string; name: string; amount: number }) {
+    if (!item.transactionId) return
+    setBuyModal({ transactionId: item.transactionId, name: item.name, amount: item.amount })
+    setBuyPrice('')
+    setBuyUnits('')
+  }
+
+  async function handleRecordBuy() {
+    if (!buyModal) return
+    const price = Number(buyPrice)
+    const units = Number(buyUnits)
+    if (!buyPrice || !buyUnits || price <= 0 || units <= 0) return
+    setSaving(true)
+    try {
+      await fetch(`/api/v1/investment-transactions/${buyModal.transactionId}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ unit_price: price, units, amount_vnd: Math.round(price * units) }),
+      })
+      setBuyModal(null)
+      onRefresh(); onToast(isVI ? 'Đã ghi nhận mua' : 'Buy recorded')
+    } finally { setSaving(false) }
   }
 
   async function handleSaveOverride() {
@@ -701,7 +811,10 @@ export default function DesktopPlanningView({
                 <tbody>
                   {byGoal.length === 0 ? (
                     <tr><td colSpan={3} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có khoản đầu tư nào' : 'No investments yet'}</td></tr>
-                  ) : byGoal.map(g => (
+                  ) : byGoal.map(g => {
+                    const pct = g.totalAllocated > 0 ? Math.min(100, Math.round(g.contributed / g.totalAllocated * 100)) : (g.contributed > 0 ? 100 : 0)
+                    const met = g.totalAllocated > 0 && g.contributed >= g.totalAllocated
+                    return (
                     <React.Fragment key={g.goalId}>
                       <tr style={{ background: 'var(--c-card-2)', borderBottom: '1px solid var(--c-line)' }}>
                         <td style={{ padding: '10px 16px' }}>
@@ -712,9 +825,20 @@ export default function DesktopPlanningView({
                             <span style={{ fontSize: 13, fontWeight: 600 }}>{g.goalName}</span>
                             <span style={{ fontSize: 11, color: 'var(--c-muted)' }}>· {g.items.length} {isVI ? 'khoản' : g.items.length === 1 ? 'item' : 'items'}</span>
                           </div>
+                          {g.totalAllocated > 0 && (
+                            <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginTop: 6, paddingLeft: 32 }}>
+                              <div style={{ flex: 1, maxWidth: 160, height: 4, borderRadius: 999, background: 'var(--c-line)', overflow: 'hidden' }}>
+                                <div style={{ height: '100%', width: `${pct}%`, background: met ? 'var(--c-pos)' : 'var(--c-navy)', borderRadius: 999, transition: 'width 200ms' }} />
+                              </div>
+                              <span style={{ fontSize: 10, color: 'var(--c-muted)', fontVariantNumeric: 'tabular-nums' }}>{pct}%</span>
+                            </div>
+                          )}
                         </td>
-                        <td style={{ padding: '10px 12px', textAlign: 'right' }}>
-                          <span style={{ fontSize: 13, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>{fmt(g.totalAllocated)}</span>
+                        <td style={{ padding: '10px 12px', textAlign: 'right', verticalAlign: 'top' }}>
+                          <div style={{ fontSize: 13, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>{fmt(g.totalAllocated)}</div>
+                          <div style={{ fontSize: 10, color: g.contributed > 0 ? 'var(--c-pos)' : 'var(--c-muted)', marginTop: 2, fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
+                            {g.contributed > 0 ? `${fmt(g.contributed)} ${isVI ? 'đã góp' : 'in'}` : (isVI ? 'Chưa góp' : 'Nothing yet')}
+                          </div>
                         </td>
                         <td />
                       </tr>
@@ -730,10 +854,14 @@ export default function DesktopPlanningView({
                             setOverrideModal({ id: inv.recurringId!, name: inv.name, defaultAmount: inv.baseAmount ?? inv.amount, type: 'rec' })
                             setOverrideVal(String(inv.baseAmount ?? inv.amount))
                           }}
+                          onRecordBuy={() => openBuy({ transactionId: inv.transactionId, name: inv.name, amount: inv.amount })}
+                          onDcaSkip={() => handleDcaSkip(inv)}
+                          onDcaRestore={() => handleDcaRestore(inv)}
                         />
                       ))}
                     </React.Fragment>
-                  ))}
+                    )
+                  })}
                 </tbody>
               </PlanTable>
 
@@ -846,6 +974,7 @@ export default function DesktopPlanningView({
               fixedTotal={fixedTotal}
               insTotal={insTotal}
               otherTotal={otherTotal}
+              contributedTotal={contributedTotal}
               isVI={isVI}
             />
           </div>
@@ -973,6 +1102,33 @@ export default function DesktopPlanningView({
       {showRSManage && (
         <DModal onClose={() => setShowRSManage(false)} title={isVI ? 'Tiết kiệm định kỳ' : 'Recurring savings'} width={460}>
           <RecurringSavingManager goals={goals} onChange={onRefresh} onToast={onToast} />
+        </DModal>
+      )}
+
+      {buyModal && (
+        <DModal onClose={() => setBuyModal(null)} title={isVI ? 'Ghi nhận mua' : 'Record buy'} width={360}>
+          <div style={{ display: 'grid', gap: 14 }}>
+            <div style={{ fontSize: 13, color: 'var(--c-muted)', fontWeight: 500 }}>{buyModal.name}</div>
+            <label style={{ display: 'grid', gap: 6 }}>
+              <span style={labelStyle}>{isVI ? 'Giá / CCQ (₫)' : 'Price / unit (₫)'}</span>
+              <input type="text" inputMode="decimal" value={buyPrice} onChange={e => setBuyPrice(e.target.value.replace(/[^0-9.]/g, ''))} autoFocus className="cn-input tabular" placeholder="0" />
+            </label>
+            <label style={{ display: 'grid', gap: 6 }}>
+              <span style={labelStyle}>{isVI ? 'Số CCQ' : 'Units'}</span>
+              <input type="text" inputMode="decimal" value={buyUnits} onChange={e => setBuyUnits(e.target.value.replace(/[^0-9.]/g, ''))} className="cn-input tabular" placeholder="0" />
+            </label>
+            {buyPrice && buyUnits && Number(buyPrice) > 0 && Number(buyUnits) > 0 && (
+              <div style={{ background: 'var(--c-navy-tint)', borderRadius: 8, padding: '6px 10px', fontSize: 12, color: 'var(--c-navy)', fontVariantNumeric: 'tabular-nums' }}>
+                {isVI ? 'Tổng' : 'Total'}: {fmt(Math.round(Number(buyPrice) * Number(buyUnits)))}
+              </div>
+            )}
+            <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+              <button onClick={() => setBuyModal(null)} style={{ ...btnBase, flex: 1, padding: '10px 14px', background: 'transparent', color: 'var(--c-ink)', border: '1px solid var(--c-line)' }}>{isVI ? 'Hủy' : 'Cancel'}</button>
+              <button onClick={handleRecordBuy} disabled={saving || !buyPrice || !buyUnits || Number(buyPrice) <= 0 || Number(buyUnits) <= 0} style={{ ...btnBase, flex: 2, padding: '10px 14px', background: 'var(--c-btn-primary)', color: '#fff', opacity: saving || !buyPrice || !buyUnits ? 0.6 : 1 }}>
+                {saving ? (isVI ? 'Đang lưu...' : 'Saving...') : (isVI ? 'Lưu' : 'Save')}
+              </button>
+            </div>
+          </div>
         </DModal>
       )}
     </div>

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -13,7 +13,7 @@ import RecurringSavingManager from './RecurringSavingManager'
 import { buildByGoal, resolveRecurringSavings, type GoalRow, type GoalItem } from '@/lib/planning'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
-  InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, Fund, Goal,
+  InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, DcaSkip, Fund, Goal,
 } from '../PlanningClient'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -29,6 +29,7 @@ interface Props {
   otherExpenses: OtherExpense[]
   recurringSavings: RecurringSaving[]
   recurringSavingOverrides: RecurringSavingOverride[]
+  dcaSkips: DcaSkip[]
   funds: Fund[]
   goals: Goal[]
   onPlanCreated: (plan: MonthlyPlan) => void
@@ -47,6 +48,7 @@ type SheetState =
   | { type: 'other-expense'; existing: OtherExpense | null }
   | { type: 'manage-fixed' }
   | { type: 'manage-recurring' }
+  | { type: 'buy'; transactionId: string; name: string }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -501,13 +503,14 @@ function SalaryCard({ amount, isVI, onEdit, onDelete }: { amount: number; isVI: 
 // ─── AllocationSummaryCard ────────────────────────────────────────────────────
 
 function AllocationSummaryCard({
-  salary, totalGoals, totalFixed, totalInsurance, totalOther, isVI,
+  salary, totalGoals, totalFixed, totalInsurance, totalOther, contributedTotal, isVI,
 }: {
   salary: number
   totalGoals: number
   totalFixed: number
   totalInsurance: number
   totalOther: number
+  contributedTotal: number
   isVI: boolean
 }) {
   const totalAllocated = totalGoals + totalFixed + totalInsurance + totalOther
@@ -570,6 +573,20 @@ function AllocationSummaryCard({
           </span>
         </div>
       </div>
+
+      {totalGoals > 0 && (
+        <div data-testid="planning-contributed" style={{ marginTop: 14, paddingTop: 12, borderTop: '1px solid rgba(255,255,255,0.12)' }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between' }}>
+            <span style={{ fontSize: 11, color: 'rgba(255,255,255,0.6)' }}>{isVI ? 'Đã góp tháng này' : 'Contributed this month'}</span>
+            <span style={{ fontSize: 12, fontWeight: 600, fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
+              {fmtCompact(contributedTotal)} <span style={{ color: 'rgba(255,255,255,0.45)' }}>/ {fmtCompact(totalGoals)}</span>
+            </span>
+          </div>
+          <div style={{ marginTop: 8, height: 6, borderRadius: 999, background: 'rgba(255,255,255,0.12)', overflow: 'hidden' }}>
+            <div style={{ height: '100%', width: `${Math.min(100, totalGoals > 0 ? Math.round(contributedTotal / totalGoals * 100) : 0)}%`, background: '#86efac', borderRadius: 999, transition: 'width 200ms' }} />
+          </div>
+        </div>
+      )}
     </div>
   )
 }
@@ -649,14 +666,19 @@ function BudgetSection({
 
 // ─── GoalAllocationRow ────────────────────────────────────────────────────────
 
-function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride, onRecEdit }: {
+function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride, onRecEdit, onRecordBuy, onDcaSkip, onDcaRestore }: {
   entry: GoalRow; isVI: boolean
   onRecSkip: (item: GoalItem) => void
   onRecRestore: (item: GoalItem) => void
   onRecOverride: (item: GoalItem) => void
   onRecEdit: () => void
+  onRecordBuy: (item: GoalItem) => void
+  onDcaSkip: (item: GoalItem) => void
+  onDcaRestore: (item: GoalItem) => void
 }) {
   const [open, setOpen] = useState(false)
+  const pct = entry.totalAllocated > 0 ? Math.min(100, Math.round(entry.contributed / entry.totalAllocated * 100)) : (entry.contributed > 0 ? 100 : 0)
+  const met = entry.totalAllocated > 0 && entry.contributed >= entry.totalAllocated
   return (
     <div>
       <button
@@ -674,9 +696,20 @@ function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride
           <div style={{ fontSize: 13, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--c-ink)' }}>
             {entry.goalName}
           </div>
-          <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1 }}>
-            {entry.items.length} {isVI ? 'khoản' : entry.items.length === 1 ? 'allocation' : 'allocations'}
-          </div>
+          {entry.totalAllocated > 0 ? (
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 4 }}>
+              <div style={{ flex: 1, maxWidth: 120, height: 4, borderRadius: 999, background: 'var(--c-line)', overflow: 'hidden' }}>
+                <div style={{ height: '100%', width: `${pct}%`, background: met ? 'var(--c-pos)' : 'var(--c-navy)', borderRadius: 999, transition: 'width 200ms' }} />
+              </div>
+              <span style={{ fontSize: 10, color: entry.contributed > 0 ? 'var(--c-pos)' : 'var(--c-muted)', fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
+                {entry.contributed > 0 ? `${fmt(entry.contributed)} ${isVI ? 'đã góp' : 'in'}` : (isVI ? 'Chưa góp' : 'Nothing yet')}
+              </span>
+            </div>
+          ) : (
+            <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1 }}>
+              {entry.items.length} {isVI ? 'khoản' : entry.items.length === 1 ? 'allocation' : 'allocations'}
+            </div>
+          )}
         </div>
         <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums', color: 'var(--c-ink)' }}>
           {fmt(entry.totalAllocated)}
@@ -692,6 +725,9 @@ function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride
           onRestore={() => onRecRestore(item)}
           onOverride={() => onRecOverride(item)}
           onEdit={onRecEdit}
+          onRecordBuy={() => onRecordBuy(item)}
+          onDcaSkip={() => onDcaSkip(item)}
+          onDcaRestore={() => onDcaRestore(item)}
         />
       ))}
     </div>
@@ -700,18 +736,26 @@ function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride
 
 // ─── GoalItemRow — one allocation under a goal (recurring savings get a kebab) ──
 
-function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit }: {
+function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRecordBuy, onDcaSkip, onDcaRestore }: {
   item: GoalItem; isVI: boolean
   onSkip: () => void; onRestore: () => void; onOverride: () => void; onEdit: () => void
+  onRecordBuy: () => void; onDcaSkip: () => void; onDcaRestore: () => void
 }) {
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPos, setMenuPos] = useState({ top: 0, right: 0 })
   const btnRef = useRef<HTMLButtonElement>(null)
   const skipped = !!item.skipped
+  const recorded = !!item.recorded
 
-  const typeLabel = item.type === 'fund'
-    ? 'Fund'
-    : item.isRecurring ? (isVI ? 'Tiết kiệm định kỳ' : 'Recurring saving') : (isVI ? 'Tiết kiệm' : 'Direct saving')
+  const sublabel = skipped
+    ? (isVI ? 'Bỏ qua tháng này' : 'Skipped this month')
+    : item.overridden
+      ? (isVI ? 'Đã ghi đè tháng này' : 'Overridden this month')
+      : recorded
+        ? (isVI ? 'Đã mua' : 'Recorded')
+        : item.type === 'fund'
+          ? 'Fund'
+          : item.isRecurring ? (isVI ? 'Tiết kiệm định kỳ' : 'Recurring saving') : (isVI ? 'Tiết kiệm' : 'Direct saving')
 
   function openMenu() {
     if (btnRef.current) {
@@ -730,8 +774,8 @@ function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit }: {
         <div style={{ fontSize: 12, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--c-ink)', textDecoration: skipped ? 'line-through' : 'none' }}>
           {item.name}
         </div>
-        <div style={{ fontSize: 10, color: item.overridden ? 'var(--c-navy)' : 'var(--c-muted)', marginTop: 1, display: 'flex', alignItems: 'center', gap: 4 }}>
-          {skipped ? (isVI ? 'Bỏ qua tháng này' : 'Skipped this month') : item.overridden ? (isVI ? 'Đã ghi đè tháng này' : 'Overridden this month') : typeLabel}
+        <div style={{ fontSize: 10, color: item.overridden ? 'var(--c-navy)' : recorded ? 'var(--c-pos)' : 'var(--c-muted)', marginTop: 1, display: 'flex', alignItems: 'center', gap: 4 }}>
+          {sublabel}
           {item.isDCA && (
             <span style={{ fontSize: 10, padding: '1px 5px', borderRadius: 4, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', fontWeight: 600 }}>DCA</span>
           )}
@@ -740,7 +784,7 @@ function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit }: {
       <span style={{ fontSize: 12, fontWeight: 500, fontVariantNumeric: 'tabular-nums', color: 'var(--c-muted)', textDecoration: skipped ? 'line-through' : 'none' }}>
         {fmt(item.amount)}
       </span>
-      {item.isRecurring && (
+      {item.isRecurring ? (
         <>
           <button ref={btnRef} onClick={() => (menuOpen ? setMenuOpen(false) : openMenu())} aria-label="Saving actions" style={{ padding: 4, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex', flexShrink: 0 }}>
             <MoreHorizontal size={14} />
@@ -763,7 +807,33 @@ function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit }: {
             </>
           )}
         </>
-      )}
+      ) : item.isFundDca && skipped ? (
+        <button onClick={onDcaRestore} aria-label="Restore DCA" style={{ padding: '4px 9px', fontSize: 11, fontWeight: 600, color: 'var(--c-muted)', background: 'transparent', border: '1px solid var(--c-line)', borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4, flexShrink: 0 }}>
+          <Check size={12} />{isVI ? 'Khôi phục' : 'Restore'}
+        </button>
+      ) : item.isFundDca && recorded ? (
+        <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: 'var(--c-pos)', fontSize: 11, fontWeight: 600, flexShrink: 0 }}>
+          <Check size={13} />{isVI ? 'Đã mua' : 'Bought'}
+        </span>
+      ) : item.isFundDca ? (
+        <>
+          <button onClick={onRecordBuy} aria-label={isVI ? 'Ghi nhận mua' : 'Record buy'} style={{ padding: '4px 9px', fontSize: 11, fontWeight: 600, color: 'var(--c-pos)', background: 'var(--c-pos-tint)', border: '1px solid transparent', borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 3, flexShrink: 0, whiteSpace: 'nowrap' }}>
+            <Plus size={12} strokeWidth={2.4} />{isVI ? 'Mua' : 'Buy'}
+          </button>
+          <button ref={btnRef} onClick={() => (menuOpen ? setMenuOpen(false) : openMenu())} aria-label="DCA actions" style={{ padding: 4, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex', flexShrink: 0 }}>
+            <MoreHorizontal size={14} />
+          </button>
+          {menuOpen && (
+            <>
+              <div onClick={() => setMenuOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 5 }} />
+              <div style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 200, overflow: 'hidden' }}>
+                <MenuItem icon={<Plus size={13} />} label={isVI ? 'Ghi nhận mua tháng này' : 'Record buy this month'} onClick={() => { onRecordBuy(); setMenuOpen(false) }} />
+                <MenuItem icon={<X size={13} />} label={isVI ? 'Bỏ qua tháng này' : 'Skip this month'} onClick={() => { onDcaSkip(); setMenuOpen(false) }} danger noBorder />
+              </div>
+            </>
+          )}
+        </>
+      ) : null}
     </div>
   )
 }
@@ -891,7 +961,7 @@ function MenuItem({ icon, label, onClick, danger, noBorder }: {
 
 export default function MobilePlanningView({
   month, year, plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,
-  recurringSavings, recurringSavingOverrides, goals,
+  recurringSavings, recurringSavingOverrides, dcaSkips, funds, goals,
   onPlanCreated, onPlanDeleted, onRefresh, onToast,
 }: Props) {
   const locale = useLocale()
@@ -908,14 +978,28 @@ export default function MobilePlanningView({
     () => resolveRecurringSavings(recurringSavings, recurringSavingOverrides),
     [recurringSavings, recurringSavingOverrides],
   )
+  // Skipped DCA funds aren't seeded as rows — synthesize struck-through lines.
+  const skippedDcaInvestments = useMemo(() => {
+    const skipped = new Set(dcaSkips.map(s => s.fund_id))
+    return funds
+      .filter(f => f.is_dca && f.dca_monthly_amount_vnd && skipped.has(f.id))
+      .map(f => ({
+        goal_id: f.dca_goal_id ?? null,
+        amount_vnd: f.dca_monthly_amount_vnd as number,
+        is_dca_seeded: true,
+        skipped: true,
+        fund_id: f.id,
+        funds: { name: f.name },
+      }))
+  }, [funds, dcaSkips])
   const byGoal = useMemo(
-    () => buildByGoal(investments, savings, resolvedRecurring, goalsById, {
+    () => buildByGoal([...investments, ...skippedDcaInvestments], savings, resolvedRecurring, goalsById, {
       unallocated: isVI ? 'Chưa phân bổ' : 'Unallocated',
-      directSaving: isVI ? 'Tiết kiệm' : 'Direct savings',
     }),
-    [investments, savings, resolvedRecurring, goalsById, isVI],
+    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI],
   )
   const totalGoals = useMemo(() => byGoal.reduce((s, g) => s + g.totalAllocated, 0), [byGoal])
+  const contributedTotal = useMemo(() => byGoal.reduce((s, g) => s + g.contributed, 0), [byGoal])
   const totalFixed = useMemo(() => getFixedTotal(fixedExpenses), [fixedExpenses])
   const totalInsurance = useMemo(() => getInsTotal(insuranceMembers), [insuranceMembers])
   const totalOther = useMemo(() => otherExpenses.reduce((s, e) => s + e.amount_vnd, 0), [otherExpenses])
@@ -992,6 +1076,40 @@ export default function MobilePlanningView({
     if (!item.recurringId) return
     setOverrideTarget({ type: 'rec', id: item.recurringId, name: item.name, defaultAmount: item.baseAmount ?? item.amount })
     setSheet({ type: 'override-rec', item })
+  }
+
+  async function handleDcaSkip(item: GoalItem) {
+    if (!plan || !item.fundId) return
+    await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fund_id: item.fundId }),
+    })
+    onToast(isVI ? `Đã bỏ qua ${item.name}` : `Skipped ${item.name}`)
+    onRefresh()
+  }
+
+  async function handleDcaRestore(item: GoalItem) {
+    if (!plan || !item.fundId) return
+    await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips/${item.fundId}`, { method: 'DELETE' })
+    onToast(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
+    onRefresh()
+  }
+
+  function openBuy(item: GoalItem) {
+    if (!item.transactionId) return
+    setSheet({ type: 'buy', transactionId: item.transactionId, name: item.name })
+  }
+
+  async function handleRecordBuy(transactionId: string, price: number, units: number) {
+    await fetch(`/api/v1/investment-transactions/${transactionId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ unit_price: price, units, amount_vnd: Math.round(price * units) }),
+    })
+    setSheet(null)
+    onToast(isVI ? 'Đã ghi nhận mua' : 'Buy recorded')
+    onRefresh()
   }
 
   // ─── Override sheet helpers ────────────────────────────────────────────────
@@ -1080,6 +1198,7 @@ export default function MobilePlanningView({
               totalFixed={totalFixed}
               totalInsurance={totalInsurance}
               totalOther={totalOther}
+              contributedTotal={contributedTotal}
               isVI={isVI}
             />
 
@@ -1117,6 +1236,9 @@ export default function MobilePlanningView({
                     onRecRestore={handleRestoreRec}
                     onRecOverride={openOverrideRec}
                     onRecEdit={() => setSheet({ type: 'manage-recurring' })}
+                    onRecordBuy={openBuy}
+                    onDcaSkip={handleDcaSkip}
+                    onDcaRestore={handleDcaRestore}
                   />
                 ))
               )}
@@ -1330,7 +1452,58 @@ export default function MobilePlanningView({
           <RecurringSavingManager goals={goals} onChange={onRefresh} onToast={onToast} variant="sheet" />
         )}
       </Sheet>
+
+      {/* ─── Record buy sheet ───────────────────────────────────────────────── */}
+      <BuySheet
+        open={sheet?.type === 'buy'}
+        onClose={() => setSheet(null)}
+        name={sheet?.type === 'buy' ? sheet.name : ''}
+        isVI={isVI}
+        onSaved={(price, units) => {
+          if (sheet?.type === 'buy') handleRecordBuy(sheet.transactionId, price, units)
+        }}
+      />
     </div>
+  )
+}
+
+// ─── BuySheet — record an actual fund purchase (price + units) ────────────────
+
+function BuySheet({ open, onClose, name, isVI, onSaved }: {
+  open: boolean; onClose: () => void; name: string; isVI: boolean
+  onSaved: (price: number, units: number) => void
+}) {
+  const [price, setPrice] = useState('')
+  const [units, setUnits] = useState('')
+  useEffect(() => { if (open) { setPrice(''); setUnits('') } }, [open])
+  if (!open) return null
+  const valid = price !== '' && units !== '' && Number(price) > 0 && Number(units) > 0
+  const total = valid ? Math.round(Number(price) * Number(units)) : 0
+  return (
+    <Sheet open={open} onClose={onClose} title={isVI ? 'Ghi nhận mua' : 'Record buy'}>
+      <div style={{ display: 'grid', gap: 14 }}>
+        <div style={{ fontSize: 13, color: 'var(--c-muted)' }}>{name}</div>
+        <div>
+          <label style={{ fontSize: 13, color: 'var(--c-muted)', display: 'block', marginBottom: 4 }}>{isVI ? 'Giá / CCQ (₫)' : 'Price / unit (₫)'}</label>
+          <input type="text" inputMode="decimal" value={price} onChange={(e) => setPrice(e.target.value.replace(/[^0-9.]/g, ''))} autoFocus placeholder="0"
+            style={{ width: '100%', padding: '10px 12px', fontSize: 16, border: '1px solid var(--c-line)', borderRadius: 10, background: 'var(--c-card-2)', color: 'var(--c-ink)', boxSizing: 'border-box', fontVariantNumeric: 'tabular-nums' }} />
+        </div>
+        <div>
+          <label style={{ fontSize: 13, color: 'var(--c-muted)', display: 'block', marginBottom: 4 }}>{isVI ? 'Số CCQ' : 'Units'}</label>
+          <input type="text" inputMode="decimal" value={units} onChange={(e) => setUnits(e.target.value.replace(/[^0-9.]/g, ''))} placeholder="0"
+            style={{ width: '100%', padding: '10px 12px', fontSize: 16, border: '1px solid var(--c-line)', borderRadius: 10, background: 'var(--c-card-2)', color: 'var(--c-ink)', boxSizing: 'border-box', fontVariantNumeric: 'tabular-nums' }} />
+        </div>
+        {valid && (
+          <div style={{ background: 'var(--c-navy-tint)', borderRadius: 10, padding: '8px 12px', fontSize: 12, color: 'var(--c-navy)', fontVariantNumeric: 'tabular-nums' }}>
+            {isVI ? 'Tổng' : 'Total'}: {fmt(total)}
+          </div>
+        )}
+        <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+          <button onClick={onClose} style={{ flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)', background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit' }}>{isVI ? 'Hủy' : 'Cancel'}</button>
+          <button onClick={() => onSaved(Number(price), Number(units))} disabled={!valid} style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', opacity: valid ? 1 : 0.6 }}>{isVI ? 'Lưu' : 'Save'}</button>
+        </div>
+      </div>
+    </Sheet>
   )
 }
 

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -87,6 +87,7 @@ const defaultProps = {
   otherExpenses: [] as OtherExpense[],
   recurringSavings: [],
   recurringSavingOverrides: [],
+  dcaSkips: [],
   funds: [],
   goals: [],
   onPlanCreated: vi.fn(),
@@ -338,21 +339,34 @@ describe('MobilePlanningView — recurring savings in By goal', () => {
     },
   ]
 
-  it('renders a recurring saving under its goal and includes it in the goal total', async () => {
+  // A planned DCA fund line (seeded, not yet bought) toward Retirement.
+  const dcaInvestments: FundInvestment[] = [
+    { ...baseInvestments[0], is_dca_seeded: true, units: null },
+  ]
+
+  it('renders a recurring saving under its goal and includes it in the planned total', async () => {
     render(
       <MobilePlanningView
         {...defaultProps}
         plan={basePlan}
-        investments={baseInvestments}
+        investments={dcaInvestments}
         recurringSavings={recurringSavings}
       />,
     )
-    // Goal total = 5M fund DCA + 2M recurring saving = 7M (full-format),
+    // Planned = 5M fund DCA + 2M recurring saving = 7M (full-format),
     // shown in the section header and the goal row.
     expect(screen.getAllByText('₫ 7000000').length).toBeGreaterThan(0)
     // Expand the Retirement goal — recurring saving name becomes visible
     await userEvent.click(screen.getByText('Retirement'))
     expect(screen.getByText('VCB Savings')).toBeInTheDocument()
+  })
+
+  it('counts a recorded fund buy as contributed, not just planned', async () => {
+    const recorded: FundInvestment[] = [{ ...baseInvestments[0], is_dca_seeded: true, units: 100 }]
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} investments={recorded} />)
+    // Contributed footer reflects the recorded 5M buy (compact format)
+    expect(screen.getByTestId('planning-contributed')).toBeInTheDocument()
+    expect(screen.getAllByText(/5\.0M ₫/).length).toBeGreaterThan(0)
   })
 
   it('shows a skipped recurring saving with a zero effective amount', async () => {
@@ -372,5 +386,27 @@ describe('MobilePlanningView — recurring savings in By goal', () => {
   it('exposes a Manage savings action on the By goal section', () => {
     render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
     expect(screen.getByTestId('mobile-manage-savings')).toBeInTheDocument()
+  })
+
+  it('shows a Buy action on a pending DCA fund line', async () => {
+    const pending: FundInvestment[] = [{ ...baseInvestments[0], is_dca_seeded: true, units: null }]
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} investments={pending} />)
+    await userEvent.click(screen.getByText('Retirement'))
+    expect(screen.getByRole('button', { name: /Record buy/i })).toBeInTheDocument()
+  })
+
+  it('renders a skipped DCA fund with a Restore action', async () => {
+    render(
+      <MobilePlanningView
+        {...defaultProps}
+        plan={basePlan}
+        goals={[{ goal_id: 'g1', goal_name: 'Retirement' }]}
+        funds={[{ id: 'f1', name: 'VFMVF1', nav: 36120, is_dca: true, dca_monthly_amount_vnd: 5_000_000, dca_goal_id: 'g1' }]}
+        dcaSkips={[{ fund_id: 'f1' }]}
+      />,
+    )
+    await userEvent.click(screen.getByText('Retirement'))
+    expect(screen.getByText('VFMVF1')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Restore DCA/i })).toBeInTheDocument()
   })
 })

--- a/app/api/v1/monthly-plans/[id]/dca-skips/[fundId]/route.ts
+++ b/app/api/v1/monthly-plans/[id]/dca-skips/[fundId]/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string; fundId: string }> }
+) {
+  const { id, fundId } = await params
+
+  let planId: string
+  let cleanFundId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+    cleanFundId = validateUUID(fundId, 'fund_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
+  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
+
+  // Removing the skip re-includes the fund; the next full plan fetch re-seeds it.
+  const { error } = await supabase
+    .from('plan_dca_skips')
+    .delete()
+    .eq('plan_id', planId)
+    .eq('fund_id', cleanFundId)
+
+  if (error) return NextResponse.json({ error: 'Skip not found' }, { status: 404 })
+  return new NextResponse(null, { status: 204 })
+}

--- a/app/api/v1/monthly-plans/[id]/dca-skips/route.ts
+++ b/app/api/v1/monthly-plans/[id]/dca-skips/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
+
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+
+  let planId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
+  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
+
+  const { data, error } = await supabase
+    .from('plan_dca_skips')
+    .select('fund_id')
+    .eq('plan_id', planId)
+
+  if (error) return NextResponse.json({ error: 'Failed to fetch DCA skips' }, { status: 500 })
+  return NextResponse.json(data)
+}
+
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await request.json()
+  const { fund_id } = body
+
+  let planId: string
+  let cleanFundId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+    if (!fund_id) throw new ValidationError('fund_id is required')
+    cleanFundId = validateUUID(fund_id, 'fund_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
+  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
+
+  const { data, error } = await supabase
+    .from('plan_dca_skips')
+    .upsert({ plan_id: planId, fund_id: cleanFundId }, { onConflict: 'plan_id,fund_id' })
+    .select()
+    .single()
+
+  if (error) return NextResponse.json({ error: 'Failed to skip DCA' }, { status: 500 })
+
+  // Remove the pending (un-recorded) seeded DCA row for this fund so the skipped
+  // contribution drops out of the plan. A recorded buy (units set) is left intact.
+  await supabase
+    .from('investment_transactions')
+    .delete()
+    .eq('plan_id', planId)
+    .eq('fund_id', cleanFundId)
+    .eq('asset_type', 'fund')
+    .eq('is_dca_seeded', true)
+    .is('units', null)
+
+  return NextResponse.json(data, { status: 201 })
+}

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
 
   if (searchParams.get('full') === 'true') {
     const planDateForActive = `${plan.year}-${String(plan.month).padStart(2, '0')}-01`
-    const [invRes, savRes, overridesRes, expRes, insRes, exclRes, insOverridesRes, goalsRes, fundsRes, otherExpRes, recSavRes, recSavOverridesRes] = await Promise.all([
+    const [invRes, savRes, overridesRes, expRes, insRes, exclRes, insOverridesRes, goalsRes, fundsRes, otherExpRes, recSavRes, recSavOverridesRes, dcaSkipsRes] = await Promise.all([
       supabase
         .from('investment_transactions')
         .select('transaction_id, plan_id, fund_id, goal_id, amount_vnd, units, unit_price, investment_date, is_dca_seeded, funds(name, nav), savings_goals(goal_name)')
@@ -77,10 +77,16 @@ export async function GET(request: NextRequest) {
       supabase
         .from('recurring_saving_overrides')
         .select('recurring_saving_id, monthly_amount_override_vnd').eq('plan_id', plan.id),
+      supabase
+        .from('plan_dca_skips')
+        .select('fund_id').eq('plan_id', plan.id),
     ])
     // Auto-seed DCA fund entries and keep pending rows in sync with current DCA amount
     const allFunds = fundsRes.data ?? []
-    const dcaFunds = allFunds.filter((f) => f.is_dca && f.dca_monthly_amount_vnd)
+    const skippedFundIds = new Set((dcaSkipsRes.data ?? []).map((s) => s.fund_id))
+    // Skipped funds are excluded from seeding this month (the skip endpoint also
+    // removes any pending row), so they drop out of the plan until restored.
+    const dcaFunds = allFunds.filter((f) => f.is_dca && f.dca_monthly_amount_vnd && !skippedFundIds.has(f.id))
     const existingInvestments = invRes.data ?? []
 
     // Insert rows for DCA funds that have no entry yet for this plan
@@ -93,6 +99,7 @@ export async function GET(request: NextRequest) {
           user_id: user.id,
           plan_id: plan.id,
           fund_id: f.id,
+          goal_id: f.dca_goal_id ?? null,
           asset_type: 'fund',
           amount_vnd: f.dca_monthly_amount_vnd,
           units: null,
@@ -103,12 +110,12 @@ export async function GET(request: NextRequest) {
       )
     }
 
-    // Update pending DCA rows whose amount no longer matches the fund's current DCA setting
-    // (happens when DCA is toggled off→on with a new amount)
+    // Keep pending DCA rows in sync with the fund's current DCA amount and goal
+    // (amount changes when DCA is re-toggled; goal changes when dca_goal_id is set).
     const staleRows = existingInvestments.filter((inv) => {
       if (!inv.is_dca_seeded || inv.units !== null) return false
       const fund = dcaFunds.find((f) => f.id === inv.fund_id)
-      return fund && fund.dca_monthly_amount_vnd !== inv.amount_vnd
+      return fund && (fund.dca_monthly_amount_vnd !== inv.amount_vnd || (fund.dca_goal_id ?? null) !== (inv.goal_id ?? null))
     })
     if (staleRows.length > 0) {
       await Promise.all(
@@ -116,7 +123,7 @@ export async function GET(request: NextRequest) {
           const fund = dcaFunds.find((f) => f.id === inv.fund_id)!
           return supabase
             .from('investment_transactions')
-            .update({ amount_vnd: fund.dca_monthly_amount_vnd })
+            .update({ amount_vnd: fund.dca_monthly_amount_vnd, goal_id: fund.dca_goal_id ?? null })
             .eq('transaction_id', inv.transaction_id)
         })
       )
@@ -144,6 +151,7 @@ export async function GET(request: NextRequest) {
       other_expenses:          otherExpRes.data ?? [],
       recurring_savings:           recSavRes.data ?? [],
       recurring_saving_overrides:  recSavOverridesRes.data ?? [],
+      dca_skips:                   dcaSkipsRes.data ?? [],
     })
   }
 

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -178,6 +178,9 @@ export async function createFund(data: {
   code: string
   fund_type: string
   nav: number
+  is_dca?: boolean
+  dca_monthly_amount_vnd?: number
+  dca_goal_id?: string
 }) {
   const userId = await getTestUserId()
   const { data: fund, error } = await supabase

--- a/e2e/planning-desktop.spec.ts
+++ b/e2e/planning-desktop.spec.ts
@@ -142,3 +142,24 @@ test('desktop planning: Manage savings opens the recurring-saving manager', asyn
   await expect(page.getByTestId('recurring-saving-manager')).toBeVisible({ timeout: 8_000 })
   await expect(page.getByTestId('rs-add')).toBeVisible()
 })
+
+test('desktop planning: a DCA fund is grouped under its goal with a Buy action and contributed footer', async ({ page }) => {
+  const goal = await api.createGoal({ goal_name: `E2E DCA Goal ${Date.now()}` })
+  cleanup.add(() => api.deleteGoal(goal.goal_id))
+  const fund = await api.createFund({
+    name: 'E2E DCA Fund', code: `EDCA${Date.now() % 100000}`, fund_type: 'equity', nav: 10000,
+    is_dca: true, dca_monthly_amount_vnd: 3_000_000, dca_goal_id: goal.goal_id,
+  })
+  cleanup.add(() => api.deleteFund(fund.id))
+  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
+  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
+
+  await goto(page)
+  const desktop = page.getByTestId('desktop-planning')
+
+  // The DCA fund is seeded under its goal (goal_id fix) and shows a Record buy pill.
+  await expect(desktop.getByText('E2E DCA Fund')).toBeVisible({ timeout: 8_000 })
+  await expect(desktop.getByRole('button', { name: /Record buy/i }).first()).toBeVisible()
+  // The allocation card shows the contributed-this-month footer.
+  await expect(desktop.getByTestId('planning-contributed')).toBeVisible()
+})

--- a/e2e/planning-desktop.spec.ts
+++ b/e2e/planning-desktop.spec.ts
@@ -158,8 +158,9 @@ test('desktop planning: a DCA fund is grouped under its goal with a Buy action a
   const desktop = page.getByTestId('desktop-planning')
 
   // The DCA fund is seeded under its goal (goal_id fix) and shows a Record buy pill.
+  // CI runs the app in Vietnamese, so match the aria-label bilingually.
   await expect(desktop.getByText('E2E DCA Fund')).toBeVisible({ timeout: 8_000 })
-  await expect(desktop.getByRole('button', { name: /Record buy/i }).first()).toBeVisible()
+  await expect(desktop.getByRole('button', { name: /Record buy|Ghi nhận mua/i }).first()).toBeVisible()
   // The allocation card shows the contributed-this-month footer.
   await expect(desktop.getByTestId('planning-contributed')).toBeVisible()
 })

--- a/lib/__tests__/planning.test.ts
+++ b/lib/__tests__/planning.test.ts
@@ -62,33 +62,77 @@ describe('recurringSavingsTotal', () => {
   })
 })
 
-describe('buildByGoal', () => {
+describe('buildByGoal — planned vs contributed', () => {
   const goalsById = new Map([['g-1', 'Retirement'], ['g-2', 'House']])
 
-  it('groups fund investments, one-off savings and recurring savings under one goal', () => {
-    const investments: GoalInvestment[] = [
-      { goal_id: 'g-1', amount_vnd: 5_000_000, is_dca_seeded: true, funds: { name: 'VESAF' }, savings_goals: { goal_name: 'Retirement' } },
-    ]
-    const directSavings: GoalDirectSaving[] = [
-      { goal_id: 'g-1', amount_vnd: 1_000_000, savings_goals: { goal_name: 'Retirement' } },
-    ]
-    const recurring = resolveRecurringSavings([saving({ goal_id: 'g-1', amount_vnd: 2_000_000 })], [])
+  function dca(o: Partial<GoalInvestment> = {}): GoalInvestment {
+    return {
+      goal_id: 'g-1',
+      amount_vnd: 5_000_000,
+      is_dca_seeded: true,
+      units: null,
+      fund_id: 'f-1',
+      transaction_id: 'tx-1',
+      funds: { name: 'VESAF' },
+      savings_goals: { goal_name: 'Retirement' },
+      ...o,
+    }
+  }
 
-    const rows = buildByGoal(investments, directSavings, recurring, goalsById)
-    expect(rows).toHaveLength(1)
-    expect(rows[0].goalName).toBe('Retirement')
-    expect(rows[0].totalAllocated).toBe(8_000_000)
-    expect(rows[0].items.map(i => i.type)).toEqual(['fund', 'bank', 'bank'])
+  it('plans fund DCA + recurring savings; recorded buys count as contributed', () => {
+    const investments = [dca({ amount_vnd: 5_000_000, units: 100 })] // recorded → contributed
+    const recurring = resolveRecurringSavings([saving({ goal_id: 'g-1', amount_vnd: 2_000_000 })], [])
+    const [row] = buildByGoal(investments, [], recurring, goalsById)
+
+    expect(row.goalName).toBe('Retirement')
+    expect(row.totalAllocated).toBe(7_000_000) // planned = DCA 5M + recurring 2M
+    expect(row.contributed).toBe(5_000_000)    // recorded DCA buy
+    expect(row.items.map(i => i.type)).toEqual(['fund', 'bank'])
+    expect(row.items[0].recorded).toBe(true)
   })
 
-  it('excludes skipped recurring savings from the goal total', () => {
+  it('a pending DCA row is planned but not yet contributed', () => {
+    const [row] = buildByGoal([dca({ units: null })], [], [], goalsById)
+    expect(row.totalAllocated).toBe(5_000_000)
+    expect(row.contributed).toBe(0)
+    expect(row.items[0].recorded).toBe(false)
+  })
+
+  it('bank deposits count as contributed but are not planned line items', () => {
+    const directSavings: GoalDirectSaving[] = [
+      { goal_id: 'g-1', amount_vnd: 3_000_000, savings_goals: { goal_name: 'Retirement' } },
+    ]
+    const [row] = buildByGoal([], directSavings, [], goalsById)
+    expect(row.totalAllocated).toBe(0)        // not planned
+    expect(row.contributed).toBe(3_000_000)   // but contributed
+    expect(row.items).toHaveLength(0)
+  })
+
+  it('ad-hoc fund buys (not DCA) contribute without being planned line items', () => {
+    const adhoc = dca({ is_dca_seeded: false, units: 50, amount_vnd: 1_000_000 })
+    const [row] = buildByGoal([adhoc], [], [], goalsById)
+    expect(row.totalAllocated).toBe(0)
+    expect(row.contributed).toBe(1_000_000)
+    expect(row.items).toHaveLength(0)
+  })
+
+  it('excludes skipped recurring savings from planned', () => {
     const recurring = resolveRecurringSavings(
       [saving({ goal_id: 'g-2', amount_vnd: 4_000_000 })],
       [{ recurring_saving_id: 's-1', monthly_amount_override_vnd: 0 }],
     )
-    const rows = buildByGoal([], [], recurring, goalsById)
-    expect(rows[0].totalAllocated).toBe(0)
-    expect(rows[0].items[0].skipped).toBe(true)
+    const [row] = buildByGoal([], [], recurring, goalsById)
+    expect(row.totalAllocated).toBe(0)
+    expect(row.items[0].skipped).toBe(true)
+  })
+
+  it('renders a skipped DCA fund as a struck line with 0 planned', () => {
+    const skipped = dca({ skipped: true, amount_vnd: 5_000_000 })
+    const [row] = buildByGoal([skipped], [], [], goalsById)
+    expect(row.totalAllocated).toBe(0)
+    expect(row.items[0].skipped).toBe(true)
+    expect(row.items[0].isFundDca).toBe(true)
+    expect(row.items[0].amount).toBe(0)
   })
 
   it('places the unallocated group (null goal) last', () => {

--- a/lib/planning.ts
+++ b/lib/planning.ts
@@ -68,7 +68,11 @@ export function recurringSavingsTotal(resolved: ResolvedSaving[]): number {
 export interface GoalInvestment {
   goal_id: string | null
   amount_vnd: number
+  units?: number | null // a recorded buy when non-null; pending DCA row when null
   is_dca_seeded?: boolean
+  skipped?: boolean // synthesized: a DCA fund skipped this month
+  fund_id?: string | null
+  transaction_id?: string
   funds?: { name: string } | null
   savings_goals?: { goal_name: string } | null
 }
@@ -85,6 +89,10 @@ export interface GoalItem {
   amount: number
   baseAmount?: number
   isDCA?: boolean
+  isFundDca?: boolean // a fund DCA plan line (gets Buy / skip actions)
+  fundId?: string | null
+  transactionId?: string
+  recorded?: boolean // the DCA buy has been logged (units set)
   isRecurring?: boolean
   recurringId?: string
   skipped?: boolean
@@ -94,23 +102,25 @@ export interface GoalItem {
 export interface GoalRow {
   goalId: string
   goalName: string
-  totalAllocated: number
+  totalAllocated: number // planned this month (DCA + recurring savings)
+  contributed: number // actually logged this month (recorded buys + bank deposits)
   isUnallocated: boolean
   items: GoalItem[]
 }
 
-// Merge fund investments, one-off direct savings and resolved recurring savings
-// into goal groups. `goalsById` resolves a goal id to its display name when the
-// row itself doesn't carry one. The Unallocated group (null goal) is sorted last.
+// Merge fund DCA plans, recorded contributions and recurring savings into goal
+// groups. PLANNED (totalAllocated) = fund DCA + recurring savings line items.
+// CONTRIBUTED = money actually logged this month: recorded fund buys (units set)
+// and bank deposits. `goalsById` resolves a goal id to its display name when the
+// row doesn't carry one. The Unallocated group (null goal) is sorted last.
 export function buildByGoal(
   investments: GoalInvestment[],
   directSavings: GoalDirectSaving[],
   recurring: ResolvedSaving[],
   goalsById: Map<string, string>,
-  labels?: { unallocated?: string; directSaving?: string },
+  labels?: { unallocated?: string },
 ): GoalRow[] {
   const unallocatedLabel = labels?.unallocated ?? 'Unallocated'
-  const directLabel = labels?.directSaving ?? 'Direct savings'
   const map = new Map<string, GoalRow>()
 
   const ensure = (goalId: string | null, name?: string | null): GoalRow => {
@@ -121,6 +131,7 @@ export function buildByGoal(
         goalId: key,
         goalName: isUnallocated ? unallocatedLabel : name || goalsById.get(goalId!) || 'Unassigned',
         totalAllocated: 0,
+        contributed: 0,
         isUnallocated,
         items: [],
       })
@@ -130,19 +141,36 @@ export function buildByGoal(
 
   for (const inv of investments) {
     const row = ensure(inv.goal_id, inv.savings_goals?.goal_name)
-    row.totalAllocated += inv.amount_vnd
-    row.items.push({
-      name: inv.funds?.name ?? 'Unknown fund',
-      type: 'fund',
-      amount: inv.amount_vnd,
-      isDCA: inv.is_dca_seeded,
-    })
+    const recorded = inv.units != null
+
+    if (inv.skipped) {
+      // A DCA fund skipped this month — show it struck through, 0 planned.
+      row.items.push({
+        name: inv.funds?.name ?? 'Unknown fund',
+        type: 'fund', amount: 0, baseAmount: inv.amount_vnd,
+        isDCA: true, isFundDca: true, fundId: inv.fund_id, skipped: true,
+      })
+      continue
+    }
+
+    if (inv.is_dca_seeded) {
+      // A planned DCA line. Counts toward planned; toward contributed once logged.
+      row.totalAllocated += inv.amount_vnd
+      row.items.push({
+        name: inv.funds?.name ?? 'Unknown fund',
+        type: 'fund', amount: inv.amount_vnd,
+        isDCA: true, isFundDca: true, fundId: inv.fund_id,
+        transactionId: inv.transaction_id, recorded,
+      })
+    }
+    // Any recorded buy (DCA or ad-hoc) is money that actually went in.
+    if (recorded) row.contributed += inv.amount_vnd
   }
 
   for (const sav of directSavings) {
+    // A bank deposit is a contribution, not a planned line.
     const row = ensure(sav.goal_id, sav.savings_goals?.goal_name)
-    row.totalAllocated += sav.amount_vnd
-    row.items.push({ name: directLabel, type: 'bank', amount: sav.amount_vnd })
+    row.contributed += sav.amount_vnd
   }
 
   for (const r of recurring) {

--- a/supabase/migrations/20260607000001_create_plan_dca_skips.sql
+++ b/supabase/migrations/20260607000001_create_plan_dca_skips.sql
@@ -1,0 +1,23 @@
+-- Per-plan fund-DCA skips — "skip this fund's DCA contribution this month".
+-- Presence of a row = the fund's DCA is skipped for that monthly plan. Mirrors
+-- the per-plan override/exclusion tables (plan-scoped RLS).
+
+CREATE TABLE IF NOT EXISTS plan_dca_skips (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  plan_id UUID NOT NULL REFERENCES monthly_plans(id) ON DELETE CASCADE,
+  fund_id UUID NOT NULL REFERENCES funds(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (plan_id, fund_id)
+);
+
+ALTER TABLE plan_dca_skips ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "plan_dca_skips_select" ON plan_dca_skips
+  FOR SELECT TO authenticated
+  USING (plan_id IN (SELECT id FROM monthly_plans WHERE user_id = auth.uid()));
+CREATE POLICY "plan_dca_skips_insert" ON plan_dca_skips
+  FOR INSERT TO authenticated
+  WITH CHECK (plan_id IN (SELECT id FROM monthly_plans WHERE user_id = auth.uid()));
+CREATE POLICY "plan_dca_skips_delete" ON plan_dca_skips
+  FOR DELETE TO authenticated
+  USING (plan_id IN (SELECT id FROM monthly_plans WHERE user_id = auth.uid()));


### PR DESCRIPTION
@
## What

PR 3 (final) of the Plan-page redesign. The "By goal" section now distinguishes **planned** (fund DCA + recurring savings) from **contributed** (actual recorded buys + bank deposits) and surfaces progress, plus fund-DCA per-month skip and a "Record buy" flow.

Builds on #298 (merged).

## Changes

**Model (`lib/planning`)**
- `buildByGoal` now returns `totalAllocated` (planned) **and** `contributed` per goal. Planned line items = fund DCA + recurring savings; bank deposits and ad-hoc fund buys count as contributions, not planned lines. Fund DCA lines carry `recorded` / `skipped` state.

**Backend**
- Migration `plan_dca_skips` (per-plan fund-DCA skip) + RLS
- API `monthly-plans/[id]/dca-skips` (upsert / delete; skipping also drops the pending seeded row)
- `monthly-plans?full=true` seeding now sets the DCA row `goal_id` from `funds.dca_goal_id` — **fixes DCA funds previously grouping under Unallocated** — keeps pending rows in sync (amount + goal) and excludes skipped funds; returns `dca_skips`

**UI (desktop + mobile)**
- Green **Buy** pill on a pending DCA line records the actual purchase (price × units → `PUT investment-transactions`)
- Fund-row **Skip this month** / **Restore**
- Per-goal progress bar with `X in` / `Nothing yet`
- **Contributed this month** footer on the allocation card

## Tests
- `lib/planning.test.ts` — planned vs contributed, recorded/pending DCA, ad-hoc buys & bank deposits as contributions, skipped DCA/recurring (12)
- `MobilePlanningView.test.tsx` — contributed footer, Buy action on pending DCA, skipped DCA → Restore (37 total)
- e2e: DCA fund grouped under its goal with a Buy action + contributed footer
- Full suite green (455), `tsc` clean, production build compiles

## Notes
- Requires the `plan_dca_skips` migration on the preview DB.
- Semantics shift (intended, matches the design): one-off bank deposits / ad-hoc buys are now **contributions**, so they appear in the contributed progress rather than the planned outflow total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@