### PR TITLE
ci: auto-apply Supabase migrations on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main, feature/redesign-desktop]
   push:
-    branches: [feature/redesign-desktop]
+    branches: [main, feature/redesign-desktop]
 
 jobs:
   test:
@@ -93,3 +93,31 @@ jobs:
             exit 1
           fi
           echo "All E2E shards passed"
+
+  # Apply pending migrations to the production Supabase project on every merge to
+  # main, so schema changes ship automatically instead of needing a manual
+  # `supabase db push`. Gated on the unit-test job only: e2e runs against a
+  # *separate* test project, so gating prod migrations on e2e could deadlock —
+  # an e2e suite that needs the new schema can't go green until the migration is
+  # applied. `supabase db push` is idempotent (only applies migrations not yet in
+  # the remote history), so re-runs are safe.
+  migrate:
+    name: Apply DB migrations (production)
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Push migrations to the production database
+        run: |
+          supabase link --project-ref "$SUPABASE_PROJECT_REF"
+          supabase db push
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          SUPABASE_PROJECT_REF: ${{ secrets.SUPABASE_PROJECT_REF }}


### PR DESCRIPTION
@
## What

CI never ran `supabase db push`, so DB migrations only reached the hosted project through a manual push. A merged migration could silently not exist in production — exactly what caused the `recurring_savings` 500 (the table file merged in #298 but was never applied until a manual push).

This adds a **`migrate`** job that links the production Supabase project and pushes pending migrations on every push to `main`. Also adds `main` to the `push:` triggers (previously CI only ran on PRs + the old redesign branch).

## Design notes
- **Gated on the unit-test job only**, not e2e. e2e runs against a *separate* test project, so gating prod migrations on e2e could deadlock: a suite that needs the new schema can't go green until the migration is applied. Unit tests don't touch the DB, so they're a safe, reliable gate.
- `supabase db push` is **idempotent** — it only applies migrations not yet in the remote migration history, so re-runs (or a migration you already pushed manually) are no-ops.
- Runs only on `push` to `main` (`if: github.event_name == push && github.ref == refs/heads/main`), never on PRs.

## ⚠️ Required before merging — add 3 repo secrets
Settings → Secrets and variables → Actions:
- `SUPABASE_ACCESS_TOKEN` — a personal access token (Supabase dashboard → Account → Access Tokens)
- `SUPABASE_DB_PASSWORD` — the production project's database password
- `SUPABASE_PROJECT_REF` — `nradevujubvvjgcfqlby`

If these are missing, the `migrate` job fails loudly (red X on the merge commit) rather than silently skipping — but the migration won't apply, so please add them first.

## Not covered (possible follow-up)
The **e2e test project** still has no automated migration step, so new-schema e2e tests rely on that project being kept in sync manually. Happy to extend this to push migrations to the test project before e2e runs if you want — needs its own access-token/db-password secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@