### PR TITLE
fix(goals): count recurring savings toward goal history & progress

### DIFF
--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -310,18 +310,23 @@ export async function GET() {
     }
   }
 
-  // Recurring savings count toward a goal once the month they apply to has
-  // arrived (real-saved model, mirroring insurance). There is no investment_
-  // transactions row for these, so add them straight to the goal totals. Equal
-  // amounts go to currentValue and totalInvested (no growth modeled), keeping
-  // P&L neutral. These are NOT added to totalAssets/netWorth — like insurance
-  // saved progress, they reflect plan fulfilment, not a verified account balance.
+  // Recurring savings count once the month they apply to has arrived (real-saved
+  // model, mirroring insurance). There is no investment_transactions row for
+  // these, so add them straight to the running totals. Equal amounts go to value
+  // and invested (no growth modeled), keeping P&L neutral. They count toward net
+  // worth (totalAssets, the bank asset-type bucket, and global invested) and,
+  // when allocated, toward their goal. They are intentionally NOT added to the
+  // Unallocated "available to assign" card — these are plan-driven balances, not
+  // loose holdings that can be assigned or sold from there.
   const recContributions = realizedRecurringContributions(
     recSavingsRes.data ?? [],
     plans,
     recOverridesRes.data ?? [],
   )
   for (const c of recContributions) {
+    totalAssets += c.amount
+    totalInvestedGlobal += c.amount
+    nonFundByType.bank += c.amount
     if (c.goalId && goalMap.has(c.goalId)) {
       const g = goalMap.get(c.goalId)!
       g.currentValue += c.amount

--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { calcProjectedInterest, isNavStale, insuranceStatus, isPlanMonthRealized, isInCurrentCycle } from '@/lib/finance'
+import { calcProjectedInterest, isNavStale, insuranceStatus, isPlanMonthRealized, isInCurrentCycle, realizedRecurringContributions } from '@/lib/finance'
 import { buildWithdrawalMaps } from '@/lib/withdrawalProgress'
 
 export const dynamic = 'force-dynamic'
@@ -10,7 +10,7 @@ export async function GET() {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const [plansRes, goalsRes, txRes, insuranceRes, insuranceSavingsRes, goldPriceRes] = await Promise.all([
+  const [plansRes, goalsRes, txRes, insuranceRes, insuranceSavingsRes, recSavingsRes, goldPriceRes] = await Promise.all([
     supabase.from('monthly_plans').select('id, month, year').eq('user_id', user.id),
     supabase
       .from('savings_goals')
@@ -29,6 +29,10 @@ export async function GET() {
       .select('insurance_member_id, amount_saved_vnd, saved_date, created_at')
       .eq('user_id', user.id),
     supabase
+      .from('recurring_savings')
+      .select('saving_id, goal_id, name, amount_vnd, effective_from, effective_to')
+      .eq('user_id', user.id),
+    supabase
       .from('gold_price_settings')
       .select('price_per_chi')
       .eq('user_id', user.id)
@@ -38,12 +42,15 @@ export async function GET() {
   const plans = (plansRes.data ?? []) as { id: string; month: number; year: number }[]
   const planIds = plans.map((p) => p.id)
 
-  const [insExclusionsRes, insOverridesRes] = await Promise.all([
+  const [insExclusionsRes, insOverridesRes, recOverridesRes] = await Promise.all([
     planIds.length > 0
       ? supabase.from('plan_excluded_insurance_members').select('plan_id, member_id').in('plan_id', planIds)
       : Promise.resolve({ data: [], error: null }),
     planIds.length > 0
       ? supabase.from('plan_insurance_member_overrides').select('plan_id, member_id, monthly_amount_override_vnd').in('plan_id', planIds)
+      : Promise.resolve({ data: [], error: null }),
+    planIds.length > 0
+      ? supabase.from('recurring_saving_overrides').select('plan_id, recurring_saving_id, monthly_amount_override_vnd').in('plan_id', planIds)
       : Promise.resolve({ data: [], error: null }),
   ])
 
@@ -300,6 +307,26 @@ export async function GET() {
     } else {
       unallocatedFunds.push({ ...fundItem, goalId: null })
       unallocatedFundValue += currentValue
+    }
+  }
+
+  // Recurring savings count toward a goal once the month they apply to has
+  // arrived (real-saved model, mirroring insurance). There is no investment_
+  // transactions row for these, so add them straight to the goal totals. Equal
+  // amounts go to currentValue and totalInvested (no growth modeled), keeping
+  // P&L neutral. These are NOT added to totalAssets/netWorth — like insurance
+  // saved progress, they reflect plan fulfilment, not a verified account balance.
+  const recContributions = realizedRecurringContributions(
+    recSavingsRes.data ?? [],
+    plans,
+    recOverridesRes.data ?? [],
+  )
+  for (const c of recContributions) {
+    if (c.goalId && goalMap.has(c.goalId)) {
+      const g = goalMap.get(c.goalId)!
+      g.currentValue += c.amount
+      g.totalInvested += c.amount
+      g.transactionCount += 1
     }
   }
 

--- a/app/api/v1/savings-goals/[id]/recurring-contributions/route.ts
+++ b/app/api/v1/savings-goals/[id]/recurring-contributions/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
+import { realizedRecurringContributions } from '@/lib/finance'
+
+// Recurring savings are plan definitions, not logged transactions, so they never
+// appear in investment_transactions. This endpoint synthesizes read-only history
+// rows for a goal's recurring savings in months that have arrived (real-saved
+// model, mirroring insurance) — the same data the dashboard adds to goal
+// progress. Rows are shaped like the investment-transactions response so the goal
+// detail History tab can merge them directly.
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+
+  let goalId: string
+  try {
+    goalId = validateUUID(id, 'goal_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const [savingsRes, plansRes] = await Promise.all([
+    supabase
+      .from('recurring_savings')
+      .select('saving_id, goal_id, name, amount_vnd, effective_from, effective_to')
+      .eq('user_id', user.id)
+      .eq('goal_id', goalId),
+    supabase
+      .from('monthly_plans')
+      .select('id, month, year')
+      .eq('user_id', user.id),
+  ])
+
+  if (savingsRes.error || plansRes.error) {
+    return NextResponse.json({ error: 'Failed to fetch recurring contributions' }, { status: 500 })
+  }
+
+  const plans = (plansRes.data ?? []) as { id: string; month: number; year: number }[]
+  const planIds = plans.map((p) => p.id)
+
+  const overridesRes = planIds.length > 0
+    ? await supabase
+        .from('recurring_saving_overrides')
+        .select('plan_id, recurring_saving_id, monthly_amount_override_vnd')
+        .in('plan_id', planIds)
+    : { data: [], error: null }
+
+  const contributions = realizedRecurringContributions(
+    savingsRes.data ?? [],
+    plans,
+    overridesRes.data ?? [],
+  )
+
+  // Shape as read-only history rows mirroring the investment-transactions response.
+  const rows = contributions.map((c) => ({
+    transaction_id: `recurring:${c.savingId}:${c.date}`,
+    transaction_type: 'investment',
+    asset_type: 'bank',
+    fund_id: null,
+    fund_name: null,
+    fund_code: null,
+    parent_transaction_id: null,
+    investment_date: c.date,
+    amount_vnd: c.amount,
+    units: null,
+    unit_price: null,
+    interest_rate: null,
+    expiry_date: null,
+    notes: c.name,
+    principal_withdrawn: null,
+    units_withdrawn: null,
+    is_recurring: true,
+  }))
+
+  return NextResponse.json({ contributions: rows })
+}

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -20,6 +20,7 @@ interface InvestmentTx {
   notes: string | null
   principal_withdrawn: number | null
   units_withdrawn: number | null
+  is_recurring?: boolean
 }
 
 interface Props {
@@ -64,9 +65,19 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
     setUnassignedIds([])
     // cache: 'no-store' — same reason as GoalDetailSheet: prevent the browser
     // from serving a stale list after an assign-from-Unallocated.
-    fetch(`/api/v1/investment-transactions?goal_id=${goal.goalId}&limit=200`, { cache: 'no-store' })
-      .then((r) => r.ok ? r.json() : { transactions: [] })
-      .then((res) => setTransactions(res.transactions ?? []))
+    // Recurring savings are plan-only (no investment_transactions row), so fetch
+    // their realized contributions separately and merge into the history list.
+    Promise.all([
+      fetch(`/api/v1/investment-transactions?goal_id=${goal.goalId}&limit=200`, { cache: 'no-store' })
+        .then((r) => r.ok ? r.json() : { transactions: [] }),
+      fetch(`/api/v1/savings-goals/${goal.goalId}/recurring-contributions`, { cache: 'no-store' })
+        .then((r) => r.ok ? r.json() : { contributions: [] }),
+    ])
+      .then(([txRes, recRes]) => {
+        const merged: InvestmentTx[] = [...(txRes.transactions ?? []), ...(recRes.contributions ?? [])]
+        merged.sort((a, b) => (a.investment_date < b.investment_date ? 1 : a.investment_date > b.investment_date ? -1 : 0))
+        setTransactions(merged)
+      })
       .catch(() => setTransactions([]))
       .finally(() => setTxLoading(false))
     // Gold is valued at the live market price per chỉ, not its purchase cost —

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -29,6 +29,7 @@ interface InvestmentTx {
   notes: string | null
   principal_withdrawn: number | null
   units_withdrawn: number | null
+  is_recurring?: boolean
 }
 
 interface Props {
@@ -651,9 +652,19 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
     setUnassignedIds([])
     // cache: 'no-store' — without it the browser can serve a stale list when
     // an investment was just (re)assigned to this goal in the same session.
-    fetch(`/api/v1/investment-transactions?goal_id=${goal.goalId}&limit=200`, { cache: 'no-store' })
-      .then((r) => r.ok ? r.json() : { transactions: [] })
-      .then((res) => setTransactions(res.transactions ?? []))
+    // Recurring savings are plan-only (no investment_transactions row), so fetch
+    // their realized contributions separately and merge into the history list.
+    Promise.all([
+      fetch(`/api/v1/investment-transactions?goal_id=${goal.goalId}&limit=200`, { cache: 'no-store' })
+        .then((r) => r.ok ? r.json() : { transactions: [] }),
+      fetch(`/api/v1/savings-goals/${goal.goalId}/recurring-contributions`, { cache: 'no-store' })
+        .then((r) => r.ok ? r.json() : { contributions: [] }),
+    ])
+      .then(([txRes, recRes]) => {
+        const merged: InvestmentTx[] = [...(txRes.transactions ?? []), ...(recRes.contributions ?? [])]
+        merged.sort((a, b) => (a.investment_date < b.investment_date ? 1 : a.investment_date > b.investment_date ? -1 : 0))
+        setTransactions(merged)
+      })
       .catch(() => setTransactions([]))
       .finally(() => setTxLoading(false))
     // Gold is valued at the live market price per chỉ, not its purchase cost —

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -33,6 +33,27 @@ export async function deleteGoal(goalId: string) {
   await supabase.from('savings_goals').delete().eq('goal_id', goalId)
 }
 
+export async function createRecurringSaving(data: {
+  name: string
+  goal_id?: string | null
+  amount_vnd: number
+  effective_from?: string | null
+  effective_to?: string | null
+}) {
+  const userId = await getTestUserId()
+  const { data: saving, error } = await supabase
+    .from('recurring_savings')
+    .insert({ user_id: userId, ...data })
+    .select()
+    .single()
+  if (error) throw error
+  return saving
+}
+
+export async function deleteRecurringSaving(savingId: string) {
+  await supabase.from('recurring_savings').delete().eq('saving_id', savingId)
+}
+
 export async function createInsuranceMember(data: {
   member_name: string
   relationship: string

--- a/e2e/recurring-savings-goal-history.spec.ts
+++ b/e2e/recurring-savings-goal-history.spec.ts
@@ -1,0 +1,51 @@
+import { test, expect } from '@playwright/test'
+import * as api from './helpers/api'
+import { makeCleanupStack } from './helpers/cleanup'
+
+// Regression: a recurring saving allocated to a goal must surface on the goal —
+// both in the History tab and in the goal's saved/progress value — for months
+// that have arrived (the real-saved model, mirroring insurance). Previously
+// recurring savings lived only in the recurring_savings table and were never
+// counted toward the goal, so they showed up nowhere on the goal detail.
+
+const cleanup = makeCleanupStack()
+test.afterEach(() => cleanup.run())
+
+const now = new Date()
+const MONTH = now.getMonth() + 1
+const YEAR = now.getFullYear()
+const MONTH_START = `${YEAR}-${String(MONTH).padStart(2, '0')}-01`
+
+test('recurring saving shows in goal history and counts toward progress', async ({ page }) => {
+  const goal = await api.createGoal({ goal_name: 'E2E Recurring Goal', target_amount: 100_000_000 })
+  cleanup.add(() => api.deleteGoal(goal.goal_id))
+
+  // The current (realized) month must have a plan for the saving to be counted.
+  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
+  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
+
+  const saving = await api.createRecurringSaving({
+    name: 'E2E VCB Recurring',
+    goal_id: goal.goal_id,
+    amount_vnd: 7_000_000,
+    effective_from: MONTH_START,
+  })
+  cleanup.add(() => api.deleteRecurringSaving(saving.saving_id))
+
+  await page.goto('/dashboard')
+  await page.waitForLoadState('networkidle')
+
+  const goalCard = page.getByText('E2E Recurring Goal').first()
+  await expect(goalCard).toBeVisible({ timeout: 10_000 })
+  await goalCard.click()
+
+  const panel = page.getByTestId('desktop-goal-detail')
+  await expect(panel).toBeVisible({ timeout: 5_000 })
+
+  // Progress: the goal's saved value reflects the realized recurring saving (7M).
+  await expect(panel.getByTestId('desktop-goal-detail-value')).toContainText('7.000.000', { timeout: 5_000 })
+
+  // History: the recurring saving is listed as a contribution row.
+  await panel.getByRole('button', { name: /^(History|Lịch sử)$/ }).click()
+  await expect(panel.getByText('E2E VCB Recurring')).toBeVisible({ timeout: 5_000 })
+})

--- a/e2e/recurring-savings-goal-history.spec.ts
+++ b/e2e/recurring-savings-goal-history.spec.ts
@@ -16,6 +16,12 @@ const MONTH = now.getMonth() + 1
 const YEAR = now.getFullYear()
 const MONTH_START = `${YEAR}-${String(MONTH).padStart(2, '0')}-01`
 
+async function netWorth(page: import('@playwright/test').Page): Promise<number> {
+  const res = await page.request.get('/api/v1/dashboard/overview')
+  expect(res.ok()).toBeTruthy()
+  return (await res.json()).netWorth.netWorth as number
+}
+
 test('recurring saving shows in goal history and counts toward progress', async ({ page }) => {
   const goal = await api.createGoal({ goal_name: 'E2E Recurring Goal', target_amount: 100_000_000 })
   cleanup.add(() => api.deleteGoal(goal.goal_id))
@@ -24,6 +30,10 @@ test('recurring saving shows in goal history and counts toward progress', async 
   const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
   cleanup.add(() => api.deleteMonthlyPlan(plan.id))
 
+  // Net worth baseline before the recurring saving exists (delta is robust to
+  // whatever else lives in the test account).
+  const before = await netWorth(page)
+
   const saving = await api.createRecurringSaving({
     name: 'E2E VCB Recurring',
     goal_id: goal.goal_id,
@@ -31,6 +41,9 @@ test('recurring saving shows in goal history and counts toward progress', async 
     effective_from: MONTH_START,
   })
   cleanup.add(() => api.deleteRecurringSaving(saving.saving_id))
+
+  // Net worth: the realized recurring saving (7M) is now counted.
+  expect(await netWorth(page)).toBe(before + 7_000_000)
 
   await page.goto('/dashboard')
   await page.waitForLoadState('networkidle')

--- a/e2e/recurring-savings-goal-history.spec.ts
+++ b/e2e/recurring-savings-goal-history.spec.ts
@@ -42,8 +42,13 @@ test('recurring saving shows in goal history and counts toward progress', async 
   })
   cleanup.add(() => api.deleteRecurringSaving(saving.saving_id))
 
-  // Net worth: the realized recurring saving (7M) is now counted.
-  expect(await netWorth(page)).toBe(before + 7_000_000)
+  // Net worth: the realized recurring saving (7M) is now counted. Use a tolerance
+  // rather than exact equality — the account's interest-bearing deposits accrue
+  // projected interest against the wall clock, so net worth drifts by a few VND
+  // between the two reads.
+  const delta = (await netWorth(page)) - before
+  expect(delta).toBeGreaterThan(6_999_000)
+  expect(delta).toBeLessThan(7_010_000)
 
   await page.goto('/dashboard')
   await page.waitForLoadState('networkidle')

--- a/lib/__tests__/recurringSavings.test.ts
+++ b/lib/__tests__/recurringSavings.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { realizedRecurringContributions } from '../finance'
+
+// "Now" is fixed to 8 Jun 2026 for every test: months <= 2026-06 are realized.
+function freezeJun2026() {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date(2026, 5, 8)) // 8 Jun 2026
+}
+
+const saving = (over: Partial<Parameters<typeof realizedRecurringContributions>[0][number]> = {}) => ({
+  saving_id: 's1',
+  goal_id: 'g1',
+  name: 'VCB Savings',
+  amount_vnd: 5_000_000,
+  effective_from: null,
+  effective_to: null,
+  ...over,
+})
+
+const plan = (id: string, year: number, month: number) => ({ id, year, month })
+
+describe('realizedRecurringContributions', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('emits one contribution per realized plan-month for an always-active saving', () => {
+    freezeJun2026()
+    const rows = realizedRecurringContributions(
+      [saving()],
+      [plan('p-may', 2026, 5), plan('p-jun', 2026, 6)],
+      [],
+    )
+    expect(rows).toHaveLength(2)
+    expect(rows.map((r) => r.date).sort()).toEqual(['2026-05-01', '2026-06-01'])
+    expect(rows.every((r) => r.amount === 5_000_000)).toBe(true)
+    expect(rows.every((r) => r.goalId === 'g1' && r.name === 'VCB Savings')).toBe(true)
+  })
+
+  it('excludes future (not-yet-realized) plan months', () => {
+    freezeJun2026()
+    const rows = realizedRecurringContributions(
+      [saving()],
+      [plan('p-jul', 2026, 7), plan('p-aug', 2026, 8)],
+      [],
+    )
+    expect(rows).toHaveLength(0)
+  })
+
+  it('respects the effective_from / effective_to window at month granularity', () => {
+    freezeJun2026()
+    const rows = realizedRecurringContributions(
+      [saving({ effective_from: '2026-05-01', effective_to: '2026-05-01' })],
+      [plan('p-apr', 2026, 4), plan('p-may', 2026, 5), plan('p-jun', 2026, 6)],
+      [],
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].date).toBe('2026-05-01')
+  })
+
+  it('treats an override of 0 as a skipped month (no row)', () => {
+    freezeJun2026()
+    const rows = realizedRecurringContributions(
+      [saving()],
+      [plan('p-may', 2026, 5), plan('p-jun', 2026, 6)],
+      [{ plan_id: 'p-may', recurring_saving_id: 's1', monthly_amount_override_vnd: 0 }],
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].date).toBe('2026-06-01')
+    expect(rows[0].amount).toBe(5_000_000)
+  })
+
+  it('uses a positive override amount in place of the base amount', () => {
+    freezeJun2026()
+    const rows = realizedRecurringContributions(
+      [saving()],
+      [plan('p-may', 2026, 5)],
+      [{ plan_id: 'p-may', recurring_saving_id: 's1', monthly_amount_override_vnd: 2_000_000 }],
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].amount).toBe(2_000_000)
+  })
+
+  it('returns unallocated savings with a null goalId', () => {
+    freezeJun2026()
+    const rows = realizedRecurringContributions(
+      [saving({ goal_id: null })],
+      [plan('p-may', 2026, 5)],
+      [],
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].goalId).toBeNull()
+  })
+
+  it('returns nothing when there are no plans', () => {
+    freezeJun2026()
+    expect(realizedRecurringContributions([saving()], [], [])).toEqual([])
+  })
+
+  it('carries the originating savingId and planId for traceability', () => {
+    freezeJun2026()
+    const rows = realizedRecurringContributions([saving()], [plan('p-may', 2026, 5)], [])
+    expect(rows[0].savingId).toBe('s1')
+    expect(rows[0].planId).toBe('p-may')
+  })
+})

--- a/lib/finance.ts
+++ b/lib/finance.ts
@@ -91,6 +91,80 @@ export function isPlanMonthRealized(year: number, month: number): boolean {
   return year < nowYear || (year === nowYear && month <= nowMonth)
 }
 
+// ─── Recurring savings — realized-saved expansion ──────────────────────────────
+// Recurring savings are plan definitions, not logged transactions. Mirroring the
+// insurance real-saved model, a recurring saving counts toward its goal once the
+// month it applies to has arrived. This expands the definitions into one
+// contribution per (realized plan-month × active saving), so the same result
+// feeds both the goal progress (dashboard) and the goal history (synthesized
+// read-only rows). A month qualifies only when a monthly plan exists for it AND
+// the month is realized — matching how insurance allocations are counted.
+
+export interface RecurringSavingDef {
+  saving_id: string
+  goal_id: string | null
+  name: string
+  amount_vnd: number
+  effective_from: string | null // 'YYYY-MM-DD' (stored as first-of-month) or null = open
+  effective_to: string | null
+}
+
+export interface RecurringPlanMonth {
+  id: string
+  year: number
+  month: number
+}
+
+export interface RecurringSavingOverrideRow {
+  plan_id: string
+  recurring_saving_id: string
+  monthly_amount_override_vnd: number
+}
+
+export interface RealizedRecurringContribution {
+  savingId: string
+  goalId: string | null
+  name: string
+  amount: number
+  date: string // 'YYYY-MM-01' — the realized month
+  planId: string
+}
+
+export function realizedRecurringContributions(
+  savings: RecurringSavingDef[],
+  plans: RecurringPlanMonth[],
+  overrides: RecurringSavingOverrideRow[],
+): RealizedRecurringContribution[] {
+  const ovMap = new Map<string, number>()
+  for (const o of overrides) {
+    ovMap.set(`${o.plan_id}::${o.recurring_saving_id}`, o.monthly_amount_override_vnd)
+  }
+
+  const out: RealizedRecurringContribution[] = []
+  for (const p of plans) {
+    if (!isPlanMonthRealized(p.year, p.month)) continue
+    const ym = `${p.year}-${String(p.month).padStart(2, '0')}`
+    for (const s of savings) {
+      // Effective window is inclusive and compared at month (YYYY-MM) granularity.
+      if (s.effective_from && s.effective_from.slice(0, 7) > ym) continue
+      if (s.effective_to && s.effective_to.slice(0, 7) < ym) continue
+      const ov = ovMap.get(`${p.id}::${s.saving_id}`)
+      // override 0 = skip this month; any other positive override replaces the base.
+      const amount = ov === 0 ? 0 : ov != null ? ov : s.amount_vnd
+      if (amount <= 0) continue
+      out.push({
+        savingId: s.saving_id,
+        goalId: s.goal_id,
+        name: s.name,
+        amount,
+        date: `${ym}-01`,
+        planId: p.id,
+      })
+    }
+  }
+  return out
+}
+
 // A contribution counts toward the CURRENT premium cycle when it was made on or
 // after the last settlement. Once a premium is marked paid, earlier savings
 // funded that (now-settled) cycle; contributions from the settlement day onward


### PR DESCRIPTION
## Problem

Recurring savings created from the **Plan page** don't show up on the **goal detail** at all — not in the **History** tab and not in the goal's **saved/progress** value.

Root cause: recurring savings live only in the `recurring_savings` table as *plan definitions*. Unlike one-off direct savings and recorded fund-DCA buys (both written to `investment_transactions`), recurring savings are never turned into a transaction and have no "record" action. The History tab queries `investment_transactions`, and the dashboard computes a goal's `currentValue` from the same table — so recurring savings touch neither.

This was also **inconsistent with insurance**, where plan allocations for *arrived* months already count toward "amount saved" (`isPlanMonthRealized` + `monthlySavedFromPlanning`).

## Fix (chosen direction: auto-count realized months)

Apply the insurance real-saved model to goals. A recurring saving counts once the month it applies to has arrived (requires a monthly plan for that month, the month is realized, the saving is within its effective window, and per-month overrides are applied — `0` = skip).

- **`lib/finance.ts`** — new pure, unit-tested `realizedRecurringContributions()` that expands recurring savings into one contribution per realized plan-month.
- **`dashboard/overview`** — adds realized recurring contributions to:
  - each allocated goal's `currentValue` / `totalInvested` (P&L-neutral), and
  - **net worth**: `totalAssets`, the `bank` asset-type bucket, and global invested.
  - They are intentionally **excluded from the Unallocated "available to assign" card** — these are plan-driven balances, not loose holdings that can be assigned/sold from there.
- **New endpoint** `GET /api/v1/savings-goals/[id]/recurring-contributions` — returns synthesized read-only history rows for a goal's realized recurring savings.
- **`GoalDetailSheet` (mobile) + `DesktopGoalDetail`** — merge those rows into the History tab, sorted by date.

## Tests (TDD)

- Unit: `lib/__tests__/recurringSavings.test.ts` — realized months, future-month exclusion, effective window, override 0 = skip, positive override, null goal, no plans, traceability (8 cases, written red-first).
- E2E: `e2e/recurring-savings-goal-history.spec.ts` — closes the loop: net-worth delta (+amount), goal saved value reflects it, and the saving appears in the goal History tab.
- Full unit suite green (468 tests); TypeScript build type-checks; no new lint errors.

## Notes for reviewer

- Because recurring savings now count for **every realized month with a plan**, a long-running open-ended saving contributes for each past plan month — matching how the Plan page shows it monthly.
- If a user *also* logs a manual deposit for the same goal/month, both count (same known characteristic as the insurance model).
- Net worth now includes realized recurring savings (per request). Please verify on the preview deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)