### PR TITLE
fix(overview): stop spurious "Offline" error on slow dashboard load

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -17,6 +17,7 @@ import AssignGoalSheet from './components/AssignGoalSheet'
 import DownloadReportSheet from './components/DownloadReportSheet'
 import AddTransactionSheet from './components/AddTransactionSheet'
 import RecentActivityCard from './components/RecentActivityCard'
+import { loadOverview, overviewErrorText, getCachedOverview, setCachedOverview } from './overviewData'
 
 import TransactionHistorySheet from './components/TransactionHistorySheet'
 import DesktopNetWorthPanel from './components/DesktopNetWorthPanel'
@@ -97,24 +98,6 @@ export interface DashboardData {
   byType: { bank: number; gold: number; stock: number }
   goldUnits?: number
   insurance: InsuranceData[]
-}
-
-const OVERVIEW_CACHE_TTL = 2 * 60 * 1000 // 2 minutes
-
-function overviewCacheKey(userId: string) { return `dashboardOverviewCache_${userId}` }
-
-function getCachedOverview(userId: string): DashboardData | null {
-  try {
-    const raw = localStorage.getItem(overviewCacheKey(userId))
-    if (!raw) return null
-    const { data, ts } = JSON.parse(raw)
-    if (Date.now() - ts > OVERVIEW_CACHE_TTL) return null
-    return data
-  } catch { return null }
-}
-
-function setCachedOverview(userId: string, data: DashboardData) {
-  try { localStorage.setItem(overviewCacheKey(userId), JSON.stringify({ data, ts: Date.now() })) } catch { /* ignore */ }
 }
 
 // Fetch fund detail (purchase history) from investment_transactions
@@ -263,24 +246,28 @@ export default function DashboardClient({ userId }: { userId: string }) {
     // Only show skeleton on initial load — if data is already visible, refresh silently
     if (!hasDataRef.current) setLoading(true)
     setError('')
-    try {
-      const res = await fetch('/api/v1/dashboard/overview', { cache: 'no-store' })
-      if (!res.ok) {
-        const { error: e } = await res.json()
-        setError(e ?? tc('error'))
-      } else {
-        const json = await res.json()
-        setData(json)
-        hasDataRef.current = true
-        setHistoryKey((k) => k + 1)
-        setCachedOverview(userId, json)
+
+    // Resilient load: retries once on a transient failure (e.g. the service
+    // worker's synthetic "Offline" 503 from a slow cold start) and falls back to
+    // the last cached snapshot before ever surfacing an error banner.
+    const result = await loadOverview({
+      getCache: (allowStale) => getCachedOverview(userId, { allowStale }),
+      setCache: (json) => setCachedOverview(userId, json),
+    })
+
+    if (result.data) {
+      setData(result.data)
+      hasDataRef.current = true
+      setHistoryKey((k) => k + 1)
+      // Only mark a real network refresh (not a stale-cache fallback) so the PWA
+      // foreground-staleness check still triggers a true refetch later.
+      if (!result.fromCache) {
         try { localStorage.setItem('pwa_last_fetch', String(Date.now())) } catch {}
       }
-    } catch {
-      setError(tc('error'))
     }
+    setError(overviewErrorText(result, tc('error')) ?? '')
     setLoading(false)
-  }, [])
+  }, [userId, tc])
 
   useEffect(() => { fetchDataRef.current = fetchData }, [fetchData])
 

--- a/app/assets/__tests__/overviewData.test.ts
+++ b/app/assets/__tests__/overviewData.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import {
+  loadOverview,
+  overviewErrorText,
+  getCachedOverview,
+  setCachedOverview,
+  type OverviewLoadResult,
+} from '../overviewData'
+import type { DashboardData } from '../DashboardClient'
+
+const sample = (assets: number): DashboardData =>
+  ({
+    netWorth: {
+      totalAssets: assets,
+      totalLiabilities: 0,
+      netWorth: assets,
+      totalInvested: assets,
+      currentValue: assets,
+      overallProfitLoss: 0,
+      overallProfitLossPercentage: 0,
+      navStale: false,
+      hasGold: false,
+      navUpdatedAt: null,
+    },
+    goals: [],
+    unallocated: { totalValue: 0, funds: [], nonFunds: [] },
+    byType: { bank: 0, gold: 0, stock: 0 },
+    insurance: [],
+  }) as DashboardData
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+// The service worker's synthetic abort response for a slow /api/v1 request.
+const swOffline = () => jsonResponse({ error: 'Offline', cached: false }, 503)
+
+describe('loadOverview', () => {
+  const noCache = { getCache: () => null, setCache: () => {} }
+
+  it('returns and caches the data on a 200', async () => {
+    const data = sample(100)
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse(data))
+    const setCache = vi.fn()
+
+    const result = await loadOverview({ fetchFn: fetchFn as never, getCache: () => null, setCache })
+
+    expect(result.data).toEqual(data)
+    expect(result.error).toBeNull()
+    expect(result.fromCache).toBe(false)
+    expect(setCache).toHaveBeenCalledWith(data)
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries once on a transient 503 and then succeeds', async () => {
+    const data = sample(200)
+    const fetchFn = vi
+      .fn()
+      .mockResolvedValueOnce(swOffline())
+      .mockResolvedValueOnce(jsonResponse(data))
+
+    const result = await loadOverview({ fetchFn: fetchFn as never, ...noCache })
+
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect(result.data).toEqual(data)
+    expect(result.error).toBeNull()
+  })
+
+  it('falls back to the stale cache when retries are exhausted (no error surfaced)', async () => {
+    const cached = sample(300)
+    const fetchFn = vi.fn().mockResolvedValue(swOffline())
+
+    const result = await loadOverview({
+      fetchFn: fetchFn as never,
+      getCache: (allowStale) => (allowStale ? cached : null),
+      setCache: () => {},
+    })
+
+    expect(fetchFn).toHaveBeenCalledTimes(2) // initial + 1 retry
+    expect(result.data).toEqual(cached)
+    expect(result.fromCache).toBe(true)
+    expect(result.transient).toBe(true)
+  })
+
+  it('reports a transient error only when there is no cache to fall back to', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(swOffline())
+
+    const result = await loadOverview({ fetchFn: fetchFn as never, ...noCache })
+
+    expect(result.data).toBeNull()
+    expect(result.transient).toBe(true)
+  })
+
+  it('retries on a network rejection, then falls back to cache', async () => {
+    const cached = sample(400)
+    const fetchFn = vi.fn().mockRejectedValue(new TypeError('Failed to fetch'))
+
+    const result = await loadOverview({
+      fetchFn: fetchFn as never,
+      getCache: () => cached,
+      setCache: () => {},
+    })
+
+    expect(fetchFn).toHaveBeenCalledTimes(2)
+    expect(result.data).toEqual(cached)
+    expect(result.fromCache).toBe(true)
+  })
+
+  it('does not retry a non-transient 4xx and surfaces its error', async () => {
+    const fetchFn = vi.fn().mockResolvedValue(jsonResponse({ error: 'Unauthorized' }, 401))
+
+    const result = await loadOverview({ fetchFn: fetchFn as never, ...noCache })
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    expect(result.transient).toBe(false)
+    expect(result.error).toBe('Unauthorized')
+  })
+})
+
+describe('overviewErrorText', () => {
+  const base: OverviewLoadResult = { data: null, error: null, transient: false, fromCache: false }
+
+  it('shows no banner when data is present (even from stale cache)', () => {
+    const result = { ...base, data: sample(1), transient: true, fromCache: true }
+    expect(overviewErrorText(result, 'Có lỗi xảy ra')).toBeNull()
+  })
+
+  it('never surfaces the raw "Offline" string for a transient failure', () => {
+    const result = { ...base, error: 'Offline', transient: true }
+    expect(overviewErrorText(result, 'Có lỗi xảy ra')).toBe('Có lỗi xảy ra')
+  })
+
+  it('surfaces a real (non-transient) server error message', () => {
+    const result = { ...base, error: 'Failed to fetch dashboard data', transient: false }
+    expect(overviewErrorText(result, 'Có lỗi xảy ra')).toBe('Failed to fetch dashboard data')
+  })
+})
+
+describe('getCachedOverview / setCachedOverview', () => {
+  const userId = 'user-1'
+  beforeEach(() => localStorage.clear())
+
+  it('returns null for an entry past its TTL unless stale is allowed', () => {
+    const data = sample(500)
+    // Hand-write an entry with an old timestamp.
+    localStorage.setItem(
+      `dashboardOverviewCache_${userId}`,
+      JSON.stringify({ data, ts: Date.now() - 10 * 60 * 1000 }),
+    )
+
+    expect(getCachedOverview(userId)).toBeNull()
+    expect(getCachedOverview(userId, { allowStale: true })).toEqual(data)
+  })
+
+  it('round-trips a fresh entry', () => {
+    const data = sample(600)
+    setCachedOverview(userId, data)
+    expect(getCachedOverview(userId)).toEqual(data)
+  })
+})

--- a/app/assets/overviewData.ts
+++ b/app/assets/overviewData.ts
@@ -1,0 +1,110 @@
+import type { DashboardData } from './DashboardClient'
+
+const OVERVIEW_ENDPOINT = '/api/v1/dashboard/overview'
+
+export const OVERVIEW_CACHE_TTL = 2 * 60 * 1000 // 2 minutes
+
+export function overviewCacheKey(userId: string) {
+  return `dashboardOverviewCache_${userId}`
+}
+
+/**
+ * Read the cached overview snapshot. Returns null past its TTL unless
+ * `allowStale` is set — callers fall back to a stale snapshot when a refresh
+ * fails so a transient network/cold-start blip never blanks the dashboard.
+ */
+export function getCachedOverview(
+  userId: string,
+  opts?: { allowStale?: boolean },
+): DashboardData | null {
+  try {
+    const raw = localStorage.getItem(overviewCacheKey(userId))
+    if (!raw) return null
+    const { data, ts } = JSON.parse(raw)
+    if (!opts?.allowStale && Date.now() - ts > OVERVIEW_CACHE_TTL) return null
+    return data
+  } catch {
+    return null
+  }
+}
+
+export function setCachedOverview(userId: string, data: DashboardData) {
+  try {
+    localStorage.setItem(overviewCacheKey(userId), JSON.stringify({ data, ts: Date.now() }))
+  } catch {
+    /* ignore */
+  }
+}
+
+export interface OverviewLoadResult {
+  data: DashboardData | null
+  /** Raw error string from the response body, if any (untranslated). */
+  error: string | null
+  /** True when the failure was a 5xx / network reject (incl. the SW's synthetic 503). */
+  transient: boolean
+  /** True when `data` came from the stale cache rather than a fresh response. */
+  fromCache: boolean
+}
+
+/**
+ * Load the dashboard overview with resilience against slow cold starts.
+ *
+ * The service worker aborts a slow `/api/v1` request and substitutes a
+ * synthetic `{ error: 'Offline' }` 503. A single such hiccup used to blank the
+ * dashboard to a hard error. Here we retry once (the retry hits a now-warm
+ * function) and, if it still fails transiently, fall back to the last cached
+ * snapshot — surfacing an error only when there is genuinely nothing to show.
+ */
+export async function loadOverview(deps: {
+  fetchFn?: typeof fetch
+  getCache: (allowStale: boolean) => DashboardData | null
+  setCache: (data: DashboardData) => void
+  retries?: number
+}): Promise<OverviewLoadResult> {
+  const fetchFn = deps.fetchFn ?? fetch
+  const retries = deps.retries ?? 1
+
+  let lastError: string | null = null
+
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetchFn(OVERVIEW_ENDPOINT, { cache: 'no-store' })
+      if (res.ok) {
+        const data = (await res.json()) as DashboardData
+        deps.setCache(data)
+        return { data, error: null, transient: false, fromCache: false }
+      }
+
+      const body = (await res.json().catch(() => ({}))) as { error?: string }
+      lastError = body.error ?? null
+      // 5xx (including the SW's synthetic 503) is transient → worth a retry.
+      // A 4xx is a definitive answer (e.g. 401) — surface it immediately.
+      if (res.status < 500) {
+        return { data: null, error: lastError, transient: false, fromCache: false }
+      }
+      if (attempt < retries) continue
+      break // transient but out of retries → fall through to the cache
+    } catch {
+      // Network rejection — transient.
+      lastError = null
+      if (attempt < retries) continue
+      break
+    }
+  }
+
+  // All attempts failed transiently. Prefer a stale snapshot over an error screen.
+  const cached = deps.getCache(true)
+  if (cached) return { data: cached, error: null, transient: true, fromCache: true }
+  return { data: null, error: lastError, transient: true, fromCache: false }
+}
+
+/**
+ * Decide the banner text for a load result. Returns null when there is data to
+ * show (no banner). Transient failures map to the localized generic error so
+ * the raw service-worker "Offline" string never reaches the user.
+ */
+export function overviewErrorText(result: OverviewLoadResult, genericError: string): string | null {
+  if (result.data) return null
+  if (result.transient) return genericError
+  return result.error ?? genericError
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = 'v6'
+const CACHE_VERSION = 'v7'
 const API_CACHE = `api-v1-${CACHE_VERSION}`
 const STATIC_CACHE = `static-assets-${CACHE_VERSION}`
 const PAGE_CACHE = `pages-${CACHE_VERSION}`
@@ -39,9 +39,14 @@ self.addEventListener('fetch', (event) => {
   // Skip non-GET requests and chrome-extension / non-http(s) requests
   if (request.method !== 'GET' || !url.protocol.startsWith('http')) return
 
-  // API routes — NetworkFirst, 24 h cache, 10 s timeout
+  // API routes — NetworkFirst, 24 h cache. The timeout exists only to fall back
+  // to cache when the network is dead; a real offline fetch rejects almost
+  // immediately, so this window should be generous enough to never abort a
+  // slow-but-alive response (e.g. a cold serverless start aggregating the
+  // dashboard overview). 10 s was too tight and surfaced spurious "Offline"
+  // errors on good connections.
   if (url.pathname.startsWith('/api/v1/')) {
-    event.respondWith(networkFirst(event, request, API_CACHE, 10_000))
+    event.respondWith(networkFirst(event, request, API_CACHE, 30_000))
     return
   }
 


### PR DESCRIPTION
## Problem

The Overview page (`/dashboard`) intermittently shows a **red "Offline" error banner** with a "Try again" link — even on a stable wired/wifi connection.

## Root cause

It isn't connectivity. The literal `"Offline"` string exists only in `public/sw.js`. The chain:

1. `/dashboard` fetches `/api/v1/dashboard/overview`.
2. The service worker's `networkFirst` handler guards `/api/v1/*` with a **10 s `AbortController` timeout**.
3. The overview endpoint runs **10 Supabase queries** (7 + 3 waves) plus `auth.getUser()` — which runs **twice per load** (`proxy.ts` + the route). On a **cold serverless start** this occasionally crosses 10 s.
4. The SW aborts the *still-healthy* request and returns a synthetic `{ error: "Offline" }` 503, which the dashboard renders as the red banner.

A manual "Try again" then hits a now-warm function and succeeds — exactly the intermittent pattern.

The 10 s timeout was also self-defeating: a genuinely offline `fetch` rejects almost immediately, so that window only ever aborts **slow-but-alive** responses — the one case where you'd rather wait.

## Fix (App + SW)

- **`public/sw.js`** — raise the `/api/v1` timeout **10 s → 30 s** so cold starts aren't falsely aborted; bump cache version `v6 → v7` to roll the worker out.
- **`app/assets/overviewData.ts`** (new) — a resilient loader that **retries once** on a transient failure (the retry hits a now-warm function) and **falls back to the last cached snapshot** before surfacing any error. Transient failures map to the localized generic error, so the raw `"Offline"` string never reaches the user.
- **`DashboardClient.tsx`** — use the resilient loader; only update `pwa_last_fetch` on a real network refresh (not a stale-cache fallback), preserving the PWA foreground-staleness check.

## Tests (TDD — written first)

11 cases in `app/assets/__tests__/overviewData.test.ts`: 200 success + cache write, retry-once-then-succeed, retries-exhausted → stale-cache fallback (no banner), transient error with no cache, network-reject retry, non-transient 4xx surfaced as-is, error-text mapping (data → no banner; transient → generic, never raw "Offline"; real error preserved), and cache TTL/stale behavior.

Full suite: **479 passed**. Typecheck + lint clean.

## How to verify on preview

The SW change only takes effect after the new worker activates — clear site data (or hard-reload twice) on the preview to drop the old `v6` worker. To confirm the app-side resilience without a real cold start, throttle the overview request in DevTools; the dashboard should show cached data / retry rather than the "Offline" banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
