### PR TITLE
perf(auth): skip middleware getUser() on /api routes

### DIFF
--- a/__tests__/proxy.test.ts
+++ b/__tests__/proxy.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { config } from '../proxy'
+
+// The middleware matcher is a Next.js path pattern that is, in practice, a
+// regular expression. Reconstruct it to assert which paths the middleware runs
+// on. The behavioural contract we care about: API routes (which authenticate
+// themselves) must NOT trigger the middleware's getUser(), while page
+// navigations still must.
+function middlewareRunsOn(path: string): boolean {
+  const pattern = config.matcher[0]
+  return new RegExp(`^${pattern}$`).test(path)
+}
+
+describe('proxy (middleware) matcher', () => {
+  it('does NOT run on API routes — they self-authenticate, so a middleware getUser() is redundant', () => {
+    expect(middlewareRunsOn('/api/v1/dashboard/overview')).toBe(false)
+    expect(middlewareRunsOn('/api/v1/funds')).toBe(false)
+    expect(middlewareRunsOn('/api/cron/refresh-navs')).toBe(false)
+  })
+
+  it('still runs on app page navigations (needs session refresh + login redirect)', () => {
+    expect(middlewareRunsOn('/dashboard')).toBe(true)
+    expect(middlewareRunsOn('/planning')).toBe(true)
+    expect(middlewareRunsOn('/settings')).toBe(true)
+  })
+
+  it('still skips static assets, the service worker, and the offline page', () => {
+    expect(middlewareRunsOn('/_next/static/chunk.js')).toBe(false)
+    expect(middlewareRunsOn('/sw.js')).toBe(false)
+    expect(middlewareRunsOn('/~offline')).toBe(false)
+    expect(middlewareRunsOn('/icon.png')).toBe(false)
+  })
+})

--- a/proxy.ts
+++ b/proxy.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from 'next/server'
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
 
-  if (pathname === '/' || pathname.startsWith('/auth/') || pathname.startsWith('/api/cron/')) {
+  if (pathname === '/' || pathname.startsWith('/auth/')) {
     return NextResponse.next()
   }
 
@@ -43,5 +43,10 @@ export async function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: ['/((?!_next/static|_next/image|favicon\\.ico|sw\\.js|manifest\\.webmanifest|~offline|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'],
+  // Skip `/api/*`: every route handler authenticates itself (user session or
+  // CRON_SECRET) and can refresh the session cookie on its own, so running the
+  // middleware there only adds a redundant getUser() round-trip to Supabase
+  // Auth on each data fetch — and would wrongly redirect unauthenticated API
+  // calls to the login HTML instead of returning a 401.
+  matcher: ['/((?!api|_next/static|_next/image|favicon\\.ico|sw\\.js|manifest\\.webmanifest|~offline|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)'],
 }


### PR DESCRIPTION
Follow-up to #305. Independent — branched fresh off `main`.

## Problem

Every `/api` route already authenticates itself:
- user routes via `supabase.auth.getUser()` (→ 401 when absent),
- the two `/api/cron/*` routes via `CRON_SECRET`.

But the middleware (`proxy.ts`) **also** ran on `/api/*` and called `getUser()` again. So every data fetch — including the dashboard overview — paid **two round-trips to Supabase Auth**. That redundant latency is part of what pushed cold-start overview loads toward the service worker's abort timeout (the root cause behind #305's "Offline" banner).

## Change

Exclude `/api` from the middleware matcher so the redundant `getUser()` is gone:

- `proxy.ts` — add `api` to the matcher's negative lookahead; drop the now-dead `/api/cron/` early-return (the middleware no longer runs on any `/api` path).

**Side benefit:** an unauthenticated API call now returns a clean **401 JSON** from the route handler, instead of being **redirected to the login HTML** by middleware (which a `fetch()` silently follows and then fails to parse as JSON).

## Safety

- All 44 `app/api` route files self-authenticate (42 via `getUser()`, 2 cron via `CRON_SECRET`) — verified, none rely on the middleware for enforcement.
- Route handlers can write cookies, so each route's own `getUser()` still refreshes the session on API calls — no refresh regression.
- **Page navigations are unchanged** — they still run through middleware for session refresh and the login redirect (the `/dashboard` → `/auth/login` e2e is unaffected).

## Tests (TDD — written first)

`__tests__/proxy.test.ts`: the matcher skips `/api/*` (incl. cron) while still matching app pages (`/dashboard`, `/planning`, `/settings`) and still skipping static assets, `sw.js`, and `/~offline`.

Full suite: **471 passed**. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
