### PR TITLE
perf(dashboard): only write net_worth_snapshot when value changed

### DIFF
--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { calcProjectedInterest, isNavStale, insuranceStatus, isPlanMonthRealized, isInCurrentCycle, realizedRecurringContributions } from '@/lib/finance'
 import { buildWithdrawalMaps } from '@/lib/withdrawalProgress'
+import { shouldWriteSnapshot } from '@/lib/snapshots'
 
 export const dynamic = 'force-dynamic'
 
@@ -10,7 +11,11 @@ export async function GET() {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const [plansRes, goalsRes, txRes, insuranceRes, insuranceSavingsRes, recSavingsRes, goldPriceRes] = await Promise.all([
+  // Today's date (server local) — used both to read the existing snapshot below
+  // and to upsert it at the end.
+  const today = new Date().toISOString().split('T')[0]
+
+  const [plansRes, goalsRes, txRes, insuranceRes, insuranceSavingsRes, recSavingsRes, goldPriceRes, snapshotRes] = await Promise.all([
     supabase.from('monthly_plans').select('id, month, year').eq('user_id', user.id),
     supabase
       .from('savings_goals')
@@ -37,6 +42,12 @@ export async function GET() {
       .select('price_per_chi')
       .eq('user_id', user.id)
       .single(),
+    supabase
+      .from('net_worth_snapshots')
+      .select('total_assets')
+      .eq('user_id', user.id)
+      .eq('snapshot_date', today)
+      .maybeSingle(),
   ])
 
   const plans = (plansRes.data ?? []) as { id: string; month: number; year: number }[]
@@ -402,12 +413,16 @@ export async function GET() {
 
   const hasGold = allTxsRaw.some((tx) => tx.asset_type === 'gold')
 
-  // Upsert today's snapshot for the history chart (fire-and-forget)
-  const today = new Date().toISOString().split('T')[0]
-  supabase.from('net_worth_snapshots').upsert(
-    { user_id: user.id, snapshot_date: today, total_assets: Math.round(totalAssets) },
-    { onConflict: 'user_id,snapshot_date' }
-  ).then(() => { /* ignore errors */ })
+  // Upsert today's snapshot for the history chart (fire-and-forget), but only
+  // when the rounded value actually changed. The dashboard is loaded many times
+  // a day; re-writing an identical row just burns disk I/O (WAL + dirtied page +
+  // autovacuum) for no benefit. See lib/snapshots.ts.
+  if (shouldWriteSnapshot(snapshotRes.data, totalAssets)) {
+    supabase.from('net_worth_snapshots').upsert(
+      { user_id: user.id, snapshot_date: today, total_assets: Math.round(totalAssets) },
+      { onConflict: 'user_id,snapshot_date' }
+    ).then(() => { /* ignore errors */ })
+  }
 
   return NextResponse.json({
     netWorth: {

--- a/lib/__tests__/snapshots.test.ts
+++ b/lib/__tests__/snapshots.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { shouldWriteSnapshot } from '../snapshots'
+
+describe('shouldWriteSnapshot', () => {
+  it('writes when there is no existing snapshot for today', () => {
+    expect(shouldWriteSnapshot(null, 1_000_000)).toBe(true)
+    expect(shouldWriteSnapshot(undefined, 1_000_000)).toBe(true)
+  })
+
+  it('skips the write when the rounded total is unchanged', () => {
+    expect(shouldWriteSnapshot({ total_assets: 1_000_000 }, 1_000_000)).toBe(false)
+  })
+
+  it('skips the write when the value only differs by a sub-integer fraction', () => {
+    // total_assets is stored as a rounded BIGINT, so 1_000_000.4 rounds to the
+    // same stored value and must not trigger a redundant row rewrite.
+    expect(shouldWriteSnapshot({ total_assets: 1_000_000 }, 1_000_000.4)).toBe(false)
+  })
+
+  it('writes when the rounded total changed', () => {
+    expect(shouldWriteSnapshot({ total_assets: 1_000_000 }, 1_000_001)).toBe(true)
+    expect(shouldWriteSnapshot({ total_assets: 1_000_000 }, 999_999)).toBe(true)
+  })
+})

--- a/lib/snapshots.ts
+++ b/lib/snapshots.ts
@@ -1,0 +1,17 @@
+/**
+ * Decide whether today's net-worth snapshot needs to be written.
+ *
+ * The dashboard overview is loaded many times a day, but `net_worth_snapshots`
+ * holds at most one row per user per day (UNIQUE(user_id, snapshot_date)) and
+ * stores `total_assets` as a rounded BIGINT. Re-upserting the same value just
+ * rewrites an identical row, which still generates WAL + a dirtied page +
+ * autovacuum work — pure disk I/O with no benefit. Only write when the stored
+ * value would actually change.
+ */
+export function shouldWriteSnapshot(
+  existing: { total_assets: number } | null | undefined,
+  newTotalAssets: number,
+): boolean {
+  if (!existing) return true
+  return Math.round(existing.total_assets) !== Math.round(newTotalAssets)
+}


### PR DESCRIPTION
## Problem

A Supabase **Disk IO budget** alert fired on the production project. Investigation via `pg_stat_statements` / `pg_stat_user_tables` showed the database is tiny and fully cached (`disk_blks_read ≈ 0`), so the budget is being burned by **writes** (WAL + dirtied-page writeback + autovacuum), not reads.

The single largest in-app write amplifier: `net_worth_snapshots` had **31,378 row updates against 75 live rows**. The dashboard overview route upserts today's snapshot on *every* load. The table holds one row per user per day (`UNIQUE(user_id, snapshot_date)`) and stores `total_assets` as a rounded `BIGINT`, so repeat loads on the same day just rewrite an identical row — each rewrite still produces WAL, a dirtied page, and autovacuum work.

## Fix

Read today's snapshot inside the **existing** parallel query batch (no added round-trip latency), then skip the upsert when the rounded value is unchanged. The chart still updates the moment total assets actually change.

Decision logic extracted to a pure, unit-tested function `lib/snapshots.ts` → `shouldWriteSnapshot`.

## TDD

- `lib/__tests__/snapshots.test.ts` written first (red), then implemented (green).
- Full suite: 486/486 pass, `tsc --noEmit` clean.

## Verify on preview

1. Load the dashboard twice without changing anything → only the **first** load writes a snapshot.
2. Add/remove a transaction so total assets change, reload → snapshot updates and the net-worth history chart reflects the new value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
