### PR TITLE
test(e2e): refuse to run against the production Supabase project

### DIFF
--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -2,6 +2,7 @@ import { test as setup } from '@playwright/test'
 import { createClient } from '@supabase/supabase-js'
 import path from 'path'
 import fs from 'fs'
+import { assertSafeTestTarget } from './helpers/guard'
 
 const AUTH_FILE = path.join(__dirname, '.auth', 'session.json')
 const USER_FILE = path.join(__dirname, '.auth', 'user.json')
@@ -13,6 +14,9 @@ setup('authenticate', async ({ page }) => {
   if (!supabaseUrl || !serviceRoleKey) {
     throw new Error('E2E_SUPABASE_URL and E2E_SUPABASE_SERVICE_ROLE_KEY must be set.')
   }
+
+  // Never let the destructive E2E seed/teardown loop run against production.
+  assertSafeTestTarget(supabaseUrl, { allow: process.env.E2E_ALLOW_PROD === '1' })
 
   const admin = createClient(supabaseUrl, serviceRoleKey)
 

--- a/e2e/global.teardown.ts
+++ b/e2e/global.teardown.ts
@@ -1,11 +1,15 @@
 import { createClient } from '@supabase/supabase-js'
 import path from 'path'
 import fs from 'fs'
+import { assertSafeTestTarget } from './helpers/guard'
 
 const USER_FILE = path.join(__dirname, '.auth', 'user.json')
 
 export default async function teardown() {
   if (!fs.existsSync(USER_FILE)) return
+
+  // Never let the destructive teardown deletes run against production.
+  assertSafeTestTarget(process.env.E2E_SUPABASE_URL, { allow: process.env.E2E_ALLOW_PROD === '1' })
 
   const { userId } = JSON.parse(fs.readFileSync(USER_FILE, 'utf-8'))
   const sb = createClient(

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -1,8 +1,14 @@
 import { createClient } from '@supabase/supabase-js'
 import path from 'path'
 import fs from 'fs'
+import { assertSafeTestTarget } from './guard'
 
 const USER_FILE = path.join(__dirname, '..', '.auth', 'user.json')
+
+// Defense in depth: every spec that touches the DB imports this module, so the
+// guard runs before any client is created — even if a spec is run directly
+// without the global setup.
+assertSafeTestTarget(process.env.E2E_SUPABASE_URL, { allow: process.env.E2E_ALLOW_PROD === '1' })
 
 const supabase = createClient(
   process.env.E2E_SUPABASE_URL!,

--- a/e2e/helpers/guard.ts
+++ b/e2e/helpers/guard.ts
@@ -1,0 +1,55 @@
+// Safety guard: keep the E2E suite from ever running against the production
+// Supabase project.
+//
+// The suite signs up throwaway users and creates/deletes funds, goals,
+// transactions, plans, etc. in tight loops (see global.setup.ts and api.ts).
+// Pointed at production this churns real data and generates a large amount of
+// write I/O (WAL + autovacuum) — the root cause of a Disk IO budget alert.
+//
+// This module is intentionally dependency-free so it can be imported by both
+// the Playwright setup/helpers and the Vitest unit test (which lives outside
+// the e2e/ tree that Vitest otherwise excludes).
+
+/**
+ * Production Supabase project ref(s) the E2E suite must never target.
+ * A Supabase project ref is the subdomain of its API URL, e.g.
+ * `https://<ref>.supabase.co`. These are not secrets (they appear in public
+ * API URLs); listing them here lets the guard fail fast with no extra config.
+ */
+export const PRODUCTION_PROJECT_REFS = ['nradevujubvvjgcfqlby']
+
+/** Extract the project ref (API subdomain) from a Supabase URL, or null. */
+export function extractProjectRef(url: string | undefined | null): string | null {
+  if (!url) return null
+  const m = url.match(/^https?:\/\/([^.]+)\.supabase\./i)
+  return m ? m[1] : null
+}
+
+/** True when `url` points at a known production project. */
+export function isProductionTarget(
+  url: string | undefined | null,
+  blockedRefs: string[] = PRODUCTION_PROJECT_REFS,
+): boolean {
+  const ref = extractProjectRef(url)
+  return ref != null && blockedRefs.includes(ref)
+}
+
+/**
+ * Throw if `url` points at production, unless explicitly overridden.
+ * Pass `{ allow: true }` (wired to `E2E_ALLOW_PROD=1`) to bypass in an
+ * emergency.
+ */
+export function assertSafeTestTarget(
+  url: string | undefined | null,
+  opts: { allow?: boolean; blockedRefs?: string[] } = {},
+): void {
+  if (opts.allow) return
+  if (isProductionTarget(url, opts.blockedRefs)) {
+    throw new Error(
+      `Refusing to run E2E tests against production Supabase project ` +
+        `"${extractProjectRef(url)}". E2E seeds and deletes data in a loop and ` +
+        `must use a dedicated test project. Point E2E_SUPABASE_URL at a non-prod ` +
+        `project, or set E2E_ALLOW_PROD=1 to override.`,
+    )
+  }
+}

--- a/lib/__tests__/e2eGuard.test.ts
+++ b/lib/__tests__/e2eGuard.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import {
+  extractProjectRef,
+  isProductionTarget,
+  assertSafeTestTarget,
+  PRODUCTION_PROJECT_REFS,
+} from '../../e2e/helpers/guard'
+
+const PROD = PRODUCTION_PROJECT_REFS[0]
+
+describe('extractProjectRef', () => {
+  it('pulls the ref from a Supabase REST URL', () => {
+    expect(extractProjectRef(`https://${PROD}.supabase.co`)).toBe(PROD)
+    expect(extractProjectRef(`https://${PROD}.supabase.co/`)).toBe(PROD)
+  })
+
+  it('returns null for empty / unrecognised values', () => {
+    expect(extractProjectRef(undefined)).toBeNull()
+    expect(extractProjectRef('')).toBeNull()
+    expect(extractProjectRef('http://localhost:54321')).toBeNull()
+  })
+})
+
+describe('isProductionTarget', () => {
+  it('flags the known production project', () => {
+    expect(isProductionTarget(`https://${PROD}.supabase.co`)).toBe(true)
+  })
+
+  it('does not flag a different (test) project', () => {
+    expect(isProductionTarget('https://sometestproject1234.supabase.co')).toBe(false)
+    expect(isProductionTarget(undefined)).toBe(false)
+  })
+})
+
+describe('assertSafeTestTarget', () => {
+  it('throws when pointed at production', () => {
+    expect(() => assertSafeTestTarget(`https://${PROD}.supabase.co`)).toThrow(/production/i)
+  })
+
+  it('passes for a non-production target', () => {
+    expect(() => assertSafeTestTarget('https://sometestproject1234.supabase.co')).not.toThrow()
+  })
+
+  it('allows an explicit override (e.g. E2E_ALLOW_PROD=1)', () => {
+    expect(() => assertSafeTestTarget(`https://${PROD}.supabase.co`, { allow: true })).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Problem

While investigating the **Disk IO budget** alert on the production project, `pg_stat_user_tables` showed heavy create-and-teardown churn against tables with only single/double-digit live rows:

| Table | Inserts | Deletes | Live rows |
|---|---|---|---|
| funds | 7,427 | 7,407 | 13 |
| savings_goals | 5,355 | 5,339 | 12 |
| investment_transactions | 8,986 | 8,723 | 260 |
| monthly_plans | 2,582 | 2,541 | 9 |
| `auth.users` | 544 | 518 | 24 |

That insert-then-delete pattern matches the E2E suite exactly (`e2e/global.setup.ts` signs up a throwaway user; `e2e/helpers/api.ts` create/delete helpers; `e2e/global.teardown.ts` deletes everything). **E2E runs against the production Supabase project** — every run writes and deletes thousands of rows, generating WAL + autovacuum work.

**Confirmed:** this PR's own CI run failed fast (~2m49s) because the guard fired — proving the CI `E2E_SUPABASE_URL` secret itself points at production (`nradevujubvvjgcfqlby`), not a separate test project. During an E2E run that write storm depletes the NANO instance's Disk IO **burst budget**, dropping the DB to baseline IOPS and causing a *broad* set of unrelated E2E tests to time out (and slowing the app for real users).

## Fix

A dependency-free guard (`e2e/helpers/guard.ts`) extracts the Supabase project ref from the target URL and **throws before any client is created** if it matches a known production ref. Wired into all three DB entry points (defense in depth):

- `e2e/global.setup.ts` (user signup + seeding)
- `e2e/global.teardown.ts` (cascade deletes)
- `e2e/helpers/api.ts` (per-spec fixtures)

Override for emergencies with `E2E_ALLOW_PROD=1`.

## TDD

- `lib/__tests__/e2eGuard.test.ts` written first (red), then implemented (green). The test lives under `lib/` because Vitest excludes `e2e/**`; it imports the pure guard module directly.
- Full suite: 489/489 pass, `tsc --noEmit` clean.

## ⚠️ Required before merging: provision a dedicated E2E project

This guard will (correctly) **block all E2E** while `E2E_SUPABASE_URL` still points at prod. So repoint it to a throwaway test project first, then merge this PR **last** of the three (#309 and #307 first).

**1. Create a separate Supabase project** (free tier is fine), e.g. `cairn-e2e`. Note its project ref, URL, anon (publishable) key, and service_role (secret) key from Project Settings → API.

**2. Apply the schema to it** from a clean checkout of `main`:
```bash
# Uses an access token for the new project (Account → Access Tokens)
export SUPABASE_ACCESS_TOKEN=<token>
supabase link --project-ref <new-e2e-ref>
supabase db push          # applies every migration in supabase/migrations/
supabase migration list    # verify local & remote match
```
> Re-link back to prod afterwards if you use the CLI locally: `supabase link --project-ref nradevujubvvjgcfqlby`.

**3. Repoint the GitHub Actions secrets** (Repo → Settings → Secrets and variables → Actions) to the **new** project:
- `E2E_SUPABASE_URL`
- `E2E_SUPABASE_ANON_KEY`
- `E2E_SUPABASE_SERVICE_ROLE_KEY`

**4. Repoint your local `.env.local`** the same way, so `npm run test:e2e` never touches prod either.

**5. Verify:** re-run this PR's CI. The guard should now pass (target ≠ prod) and the suite should run against the isolated project.

**Notes**
- `migrate` job (`.github/workflows/ci.yml`) still pushes migrations to **prod** on merge to `main` — unaffected. The new project's schema is maintained via step 2 (re-run `supabase db push` against it when migrations change), or add a CI step if you want it automated.
- Update `PRODUCTION_PROJECT_REFS` in `e2e/helpers/guard.ts` if you ever add more production refs. `E2E_ALLOW_PROD=1` exists as an emergency override — do **not** set it in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
