### PR TITLE
test(e2e): de-flake desktop withdraw "deposit disappears" tests

### DIFF
--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -63,6 +63,9 @@ test.describe('Desktop goal detail panel', () => {
   // shared goal (reliably rendered) — the Investments tab fetches transactions
   // no-store, so the row shows even though the overview may be cached.
   test('fully withdrawn bank deposit disappears from the Investments tab', async ({ page }) => {
+    // Heavy flow (two dashboard loads + a withdrawal round-trip). Tolerate a
+    // slow / IO-throttled backend rather than racing the default 30s cap.
+    test.slow()
     const tx = await api.createTransaction({
       asset_type: 'bank',
       amount_vnd: 10_000_000,
@@ -89,8 +92,17 @@ test.describe('Desktop goal detail panel', () => {
       await page.getByRole('button', { name: /^(All|Tất cả)$/ }).click()
       await page.getByRole('button', { name: /Confirm withdrawal|Xác nhận rút/i }).click()
 
-      // The fully-withdrawn deposit must no longer be listed.
-      await expect(panel.getByText('E2E TCB Deposit')).toHaveCount(0, { timeout: 15_000 })
+      // The withdrawal shows a ~2s success state (which itself displays the
+      // deposit name), then auto-closes and triggers the Investments-tab
+      // refetch. Wait for that confirmation first — it proves the withdrawal
+      // registered — then assert the row is gone. Asserting count(0) directly
+      // races both the success modal's own name text and a not-yet-settled
+      // refetch, which flakes whenever the backend is slow.
+      await expect(page.getByText(/Đã rút thành công|Withdrawal successful/)).toBeVisible({ timeout: 20_000 })
+
+      // The fully-withdrawn deposit must no longer be listed. Generous timeout
+      // so a slow post-withdrawal refetch can land instead of being raced.
+      await expect(panel.getByText('E2E TCB Deposit')).toHaveCount(0, { timeout: 30_000 })
     } finally {
       // Also removes the withdrawal row created during the test (parent FK is
       // ON DELETE SET NULL, so it would otherwise linger on the shared goal).
@@ -102,6 +114,9 @@ test.describe('Desktop goal detail panel', () => {
   // via the "Count toward goal progress" toggle (ported from the legacy
   // Settings view). Toggling it off must persist affects_progress=false.
   test('withdraw with progress toggle off stores affects_progress=false', async ({ page }) => {
+    // Heavy flow (two dashboard loads + a withdrawal round-trip). Tolerate a
+    // slow / IO-throttled backend rather than racing the default 30s cap.
+    test.slow()
     const tx = await api.createTransaction({
       asset_type: 'bank',
       amount_vnd: 10_000_000,
@@ -127,7 +142,10 @@ test.describe('Desktop goal detail panel', () => {
       await page.getByRole('button', { name: /^(All|Tất cả)$/ }).click()
       await page.getByRole('button', { name: /Confirm withdrawal|Xác nhận rút/i }).click()
 
-      await expect(panel.getByText('E2E Progress Toggle Deposit')).toHaveCount(0, { timeout: 15_000 })
+      // Same as the sibling test: wait for the success confirmation before
+      // asserting the row is gone, with a generous timeout for a slow refetch.
+      await expect(page.getByText(/Đã rút thành công|Withdrawal successful/)).toBeVisible({ timeout: 20_000 })
+      await expect(panel.getByText('E2E Progress Toggle Deposit')).toHaveCount(0, { timeout: 30_000 })
 
       // The withdrawal must have been stored with affects_progress=false.
       const { createClient } = await import('@supabase/supabase-js')


### PR DESCRIPTION
## Problem

`e2e/goal-detail-desktop.spec.ts` — *"fully withdrawn bank deposit disappears from the Investments tab"* — has been failing on **~4 of the last 5 CI runs on `main`**, which blocks the single E2E gate for **every** PR (including #307 and #308).

It's a **race, not a product bug** — the behavior passes when the backend keeps up. Traced from the failure screenshots + trace:

1. On a successful withdrawal, `SellModal` (`DesktopGoalDetail.tsx`) does:
   ```ts
   setConfirmed(true)                                  // ~2s success state...
   setTimeout(() => { setConfirmed(false); onSuccess(); onClose() }, 2000)
   ```
   The success state renders the **deposit's name** (`{inv.name}`) for ~2s, inside the `desktop-goal-detail` panel.
2. Only after 2s does `onSuccess()` bump `refreshKey`, which re-runs the fetch effect — that effect **clears the optimistic hide** and re-renders the Investments list from the server response.
3. The tests asserted `panel.getByText(name).toHaveCount(0)` *immediately* after Confirm, with a 15s window and a 30s overall test cap. So the assertion races the success-modal name text **and** a not-yet-settled refetch. On an IO-throttled backend the withdrawal POST + refetch GET are slow (screenshots show the confirm button stuck on *"Đang xử lý…"* and the success modal still up), so either the 15s window expires before the refetch lands or the 30s test cap is hit mid-flow.

This flakiness is itself partly a **symptom of the Disk IO budget issue** (PRs #307/#308): as the DB got IO-throttled, this timing-sensitive test started losing the race.

## Fix

Harden the assertion to match the real user outcome instead of racing the animation — applied to both withdrawal tests in this file:

- `test.slow()` — the flow does two dashboard loads + a withdrawal round-trip; triple the cap so a slow backend doesn't blow 30s.
- Wait for the **success confirmation** (`Đã rút thành công` / `Withdrawal successful`) first — this proves the withdrawal actually registered.
- Then assert the row is gone with a **generous 30s timeout**, so a slow post-withdrawal refetch can land instead of being raced.

This does **not** hide a bug: when the backend is fast the deposit does disappear (the test passes today in that case). It only removes the dependency on backend speed.

## Verification

- `tsc --noEmit` clean.
- E2E can only be verified on CI (this branch's run), since local E2E is now guarded away from the production project (#308) and there's no separate local test project configured. Will confirm on the CI run for this PR.

## Optional follow-up (not in this PR)

The optimistic `unassignedIds` hide in `onSuccess` is immediately cleared by the refetch effect, so it provides no real protection — a small product tweak could keep confirmed-removed ids hidden until the refetch confirms them, smoothing the UX. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
