### PR TITLE
test(e2e): share one read-only fund fixture in dashboard.spec

### DIFF
--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -5,6 +5,27 @@ import { makeCleanupStack } from './helpers/cleanup'
 const cleanup = makeCleanupStack()
 test.afterEach(() => cleanup.run())
 
+// Shared, read-only unallocated fund fixture. The sell-sheet tests below only
+// OPEN the action / sell sheet to inspect UI (they never confirm a sale), so
+// they can reuse one fund + transaction instead of each creating and tearing
+// down their own — trimming several fund+tx create/delete cycles of DB churn
+// per run. Tests that actually mutate the holding (assign / confirm sell) keep
+// their own per-test fixtures via the cleanup stack.
+let sharedFund: Awaited<ReturnType<typeof api.createFund>>
+
+test.beforeAll(async () => {
+  sharedFund = await api.createFund({ name: 'E2E Shared Sell Fund', code: 'E2ESHSELL', fund_type: 'equity', nav: 10000 })
+  await api.createTransaction({
+    asset_type: 'fund', amount_vnd: 5_000_000, investment_date: '2026-01-01',
+    units: 500, unit_price: sharedFund.nav, fund_id: sharedFund.id,
+  })
+})
+
+test.afterAll(async () => {
+  // deleteFund also removes the fund's transactions (see helpers/api.ts).
+  if (sharedFund) await api.deleteFund(sharedFund.id)
+})
+
 async function gotoFreshDashboard(page: Page) {
   // Navigate to any other page first to fully unmount DashboardClient
   await page.goto('/settings')
@@ -79,23 +100,10 @@ test('clicking a goal card opens goal detail panel', async ({ page }) => {
 })
 
 test('tapping unallocated row opens action sheet', async ({ page }) => {
-  const fund = await api.createFund({ name: 'E2E Test Fund', code: 'E2ETESTFUND', fund_type: 'equity', nav: 10000 })
-  cleanup.add(() => api.deleteFund(fund.id))
-
-  const tx = await api.createTransaction({
-    asset_type: 'fund',
-    amount_vnd: 5_000_000,
-    investment_date: '2026-01-01',
-    units: 200,
-    unit_price: fund.nav,
-    fund_id: fund.id,
-  })
-  cleanup.add(() => api.deleteTransaction(tx.transaction_id))
-
   await gotoFreshDashboard(page)
 
   // Row is a tappable button — tap it to open action sheet
-  const row = page.getByTestId('unallocated-row').filter({ hasText: fund.name }).first()
+  const row = page.getByTestId('unallocated-row').filter({ hasText: sharedFund.name }).first()
   await expect(row).toBeVisible({ timeout: 10_000 })
   await row.click()
 
@@ -110,22 +118,9 @@ test('tapping unallocated row opens action sheet', async ({ page }) => {
 })
 
 test('tapping unallocated fund history opens TransactionHistorySheet', async ({ page }) => {
-  const fund = await api.createFund({ name: 'E2E Test Fund', code: 'E2ETESTFUND', fund_type: 'equity', nav: 10000 })
-  cleanup.add(() => api.deleteFund(fund.id))
-
-  const tx = await api.createTransaction({
-    asset_type: 'fund',
-    amount_vnd: 5_000_000,
-    investment_date: '2026-01-01',
-    units: 200,
-    unit_price: fund.nav,
-    fund_id: fund.id,
-  })
-  cleanup.add(() => api.deleteTransaction(tx.transaction_id))
-
   await gotoFreshDashboard(page)
 
-  const row = page.getByTestId('unallocated-row').filter({ hasText: fund.name }).first()
+  const row = page.getByTestId('unallocated-row').filter({ hasText: sharedFund.name }).first()
   await expect(row).toBeVisible({ timeout: 10_000 })
   await row.click()
 
@@ -134,11 +129,11 @@ test('tapping unallocated fund history opens TransactionHistorySheet', async ({ 
   await page.getByTestId('action-history').click()
 
   // TransactionHistorySheet should open — fund name is the h1
-  await expect(page.getByRole('heading', { name: fund.name })).toBeVisible({ timeout: 5_000 })
+  await expect(page.getByRole('heading', { name: sharedFund.name })).toBeVisible({ timeout: 5_000 })
 
   // Close via Back button
   await page.getByTestId('history-back-btn').click()
-  await expect(page.getByRole('heading', { name: fund.name })).not.toBeVisible()
+  await expect(page.getByRole('heading', { name: sharedFund.name })).not.toBeVisible()
 })
 
 test('assign unallocated fund to a goal via action sheet', async ({ page }) => {
@@ -210,16 +205,8 @@ test('sell unallocated fund via action sheet', async ({ page }) => {
 })
 
 test('sell fund sheet shows remaining amount in summary strip', async ({ page }) => {
-  const fund = await api.createFund({ name: 'E2E Summary Fund', code: 'E2ESUMFUND', fund_type: 'equity', nav: 10000 })
-  cleanup.add(() => api.deleteFund(fund.id))
-  const tx = await api.createTransaction({
-    asset_type: 'fund', amount_vnd: 5_000_000, investment_date: '2026-01-01',
-    units: 500, unit_price: fund.nav, fund_id: fund.id,
-  })
-  cleanup.add(() => api.deleteTransaction(tx.transaction_id))
-
   await gotoFreshDashboard(page)
-  const row = page.getByTestId('unallocated-row').filter({ hasText: fund.name }).first()
+  const row = page.getByTestId('unallocated-row').filter({ hasText: sharedFund.name }).first()
   await expect(row).toBeVisible({ timeout: 10_000 })
   await row.click()
   await page.getByTestId('action-sell').click()
@@ -230,16 +217,8 @@ test('sell fund sheet shows remaining amount in summary strip', async ({ page })
 })
 
 test('sell fund shows 0.1% tax estimate in summary strip', async ({ page }) => {
-  const fund = await api.createFund({ name: 'E2E Tax Fund', code: 'E2ETAXFUND', fund_type: 'equity', nav: 10000 })
-  cleanup.add(() => api.deleteFund(fund.id))
-  const tx = await api.createTransaction({
-    asset_type: 'fund', amount_vnd: 5_000_000, investment_date: '2026-01-01',
-    units: 500, unit_price: fund.nav, fund_id: fund.id,
-  })
-  cleanup.add(() => api.deleteTransaction(tx.transaction_id))
-
   await gotoFreshDashboard(page)
-  const row = page.getByTestId('unallocated-row').filter({ hasText: fund.name }).first()
+  const row = page.getByTestId('unallocated-row').filter({ hasText: sharedFund.name }).first()
   await expect(row).toBeVisible({ timeout: 10_000 })
   await row.click()
   await page.getByTestId('action-sell').click()
@@ -251,16 +230,8 @@ test('sell fund shows 0.1% tax estimate in summary strip', async ({ page }) => {
 })
 
 test('"All" button fills the full available amount', async ({ page }) => {
-  const fund = await api.createFund({ name: 'E2E All Fund', code: 'E2EALLFUND', fund_type: 'equity', nav: 10000 })
-  cleanup.add(() => api.deleteFund(fund.id))
-  const tx = await api.createTransaction({
-    asset_type: 'fund', amount_vnd: 5_000_000, investment_date: '2026-01-01',
-    units: 500, unit_price: fund.nav, fund_id: fund.id,
-  })
-  cleanup.add(() => api.deleteTransaction(tx.transaction_id))
-
   await gotoFreshDashboard(page)
-  const row = page.getByTestId('unallocated-row').filter({ hasText: fund.name }).first()
+  const row = page.getByTestId('unallocated-row').filter({ hasText: sharedFund.name }).first()
   await expect(row).toBeVisible({ timeout: 10_000 })
   await row.click()
   await page.getByTestId('action-sell').click()
@@ -311,19 +282,8 @@ test('sell success state appears after confirm', async ({ page }) => {
 })
 
 test('allocation bar renders when investments exist', async ({ page }) => {
-  const fund = await api.createFund({ name: 'E2E Alloc Fund', code: 'E2EALLOCFUND', fund_type: 'equity', nav: 15000 })
-  cleanup.add(() => api.deleteFund(fund.id))
-
-  const tx = await api.createTransaction({
-    asset_type: 'fund',
-    amount_vnd: 10_000_000,
-    investment_date: '2026-01-01',
-    units: 500,
-    unit_price: fund.nav,
-    fund_id: fund.id,
-  })
-  cleanup.add(() => api.deleteTransaction(tx.transaction_id))
-
+  // Uses the shared unallocated fund fixture for the "investments exist"
+  // precondition instead of creating its own.
   await gotoFreshDashboard(page)
 
   await expect(page.getByTestId('allocation-bar')).toBeVisible({ timeout: 10_000 })


### PR DESCRIPTION
## Problem

E2E write churn against the (currently production) Supabase project feeds the Disk IO budget drain. In `dashboard.spec.ts`, **six** tests each created *and* deleted a near-identical unallocated fund + transaction purely to **open** the action/sell sheet and inspect UI — they never confirm a sale, so the fixture is read-only:

- `tapping unallocated row opens action sheet`
- `tapping unallocated fund history opens TransactionHistorySheet`
- `sell fund sheet shows remaining amount in summary strip`
- `sell fund shows 0.1% tax estimate in summary strip`
- `"All" button fills the full available amount`
- `allocation bar renders when investments exist`

That's 6 fund inserts + 6 fund-transaction inserts + their deletes every run, for data none of them mutate.

## Fix

Consolidate those six onto a **single `beforeAll`/`afterAll` shared fund + transaction** (`E2E Shared Sell Fund`). `deleteFund` cascades the transaction, so teardown is one call. Net: ~5 fewer fund+tx create/delete cycles per run for this file.

The three tests that **mutate** the holding (`assign … to a goal`, `sell … via action sheet`, `sell success state`) and the bank-warning test keep their own per-test fixtures, so isolation is preserved — a shared fixture is only used where the holding is read-only.

This is a **secondary** trim. The dominant per-test write reduction is **#307**, which removes a `net_worth_snapshots` write on *every* dashboard navigation across the whole suite.

## Safety / verification

- `tsc --noEmit` clean — and it's the real safety net here: any leftover reference to a removed `fund`/`tx` would be a compile error, and there are none. The only remaining per-test fixtures are the intentional mutating/bank ones.
- **Behavioral verification is on CI**, not local: E2E can't run here since it's now guarded away from the production project (#308) and there's no separate local test project yet. This should be validated on a CI run once `E2E_SUPABASE_URL` points at a dedicated test project (see #308).
- Independent of #307/#308/#309 (PR-isolation); branches off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
