### PR TITLE
fix(db): make migrations replayable from scratch

### DIFF
--- a/supabase/migrations/20260318000001_create_monthly_planning_tables.sql
+++ b/supabase/migrations/20260318000001_create_monthly_planning_tables.sql
@@ -31,6 +31,11 @@ CREATE TABLE IF NOT EXISTS fund_investments (
   amount_vnd BIGINT NOT NULL CHECK (amount_vnd > 0),
   units_purchased NUMERIC NOT NULL CHECK (units_purchased > 0),
   nav_at_purchase NUMERIC NOT NULL CHECK (nav_at_purchase > 0),
+  -- investment_date existed on the live fund_investments table but this create
+  -- omitted it (out-of-band drift). The unify migration SELECTs it, so a
+  -- from-scratch replay needs it. This table is dropped by that migration, so
+  -- the column only affects replayability, not the final schema.
+  investment_date DATE,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/supabase/migrations/20260321000001_unify_investments.sql
+++ b/supabase/migrations/20260321000001_unify_investments.sql
@@ -1,5 +1,11 @@
--- Add new columns to investment_transactions
+-- Add new columns to investment_transactions.
+-- fund_id links a fund transaction to its fund. It exists on the live database
+-- but no committed migration ever created it (it was added out-of-band), so a
+-- from-scratch replay (`supabase db reset` / fresh env / CI test project) failed
+-- when the INSERT below references fund_id. Add it here so the migrations
+-- faithfully reproduce production. Matches prod exactly: nullable uuid, no FK.
 ALTER TABLE investment_transactions
+  ADD COLUMN IF NOT EXISTS fund_id UUID,
   ADD COLUMN IF NOT EXISTS plan_id UUID REFERENCES monthly_plans(id) ON DELETE SET NULL,
   ADD COLUMN IF NOT EXISTS expiry_date DATE;
 

--- a/supabase/migrations/20260527000001_secure_health_check.sql
+++ b/supabase/migrations/20260527000001_secure_health_check.sql
@@ -1,3 +1,19 @@
+-- The health_check liveness-probe table exists on the live database but was
+-- created out-of-band (no committed migration created it), so a from-scratch
+-- replay (`supabase db reset` / fresh env / CI test project) failed when the
+-- ALTER below runs. Create it here (idempotently) to make the migrations
+-- faithfully reproduce production. Matches prod: 3 columns, no constraints,
+-- and one heartbeat row.
+CREATE TABLE IF NOT EXISTS public.health_check (
+  id UUID DEFAULT gen_random_uuid(),
+  status TEXT DEFAULT 'ok',
+  created_at TIMESTAMP DEFAULT now()
+);
+
+INSERT INTO public.health_check (status)
+SELECT 'ok'
+WHERE NOT EXISTS (SELECT 1 FROM public.health_check);
+
 -- Enable Row Level Security on health_check.
 -- Before this change the table was exposed to the anon role (which has the
 -- public NEXT_PUBLIC_SUPABASE_ANON_KEY), allowing anyone to INSERT/UPDATE/DELETE


### PR DESCRIPTION
## Problem

The committed migrations **could not rebuild the database from scratch**. `supabase db reset` (and therefore any fresh environment or CI test-project setup) failed partway through, because three objects exist on production but were **never created by a migration** — they were added out-of-band, and since prod was built up incrementally it never noticed the gap. A from-scratch replay does.

Discovered while provisioning a dedicated E2E Supabase project (to stop E2E running against prod). The replay failed in three places, fixed here:

| Object | Symptom on replay | Fix |
|---|---|---|
| `investment_transactions.fund_id` (uuid) | unify migration's data-copy `INSERT … fund_id …` → *column does not exist* | added to that migration's `ALTER` (nullable uuid, no FK — matches prod) |
| `fund_investments.investment_date` (date) | unify `SELECT … investment_date … FROM fund_investments` → *column does not exist* | added to the table's `CREATE` (table is dropped by unify, so replay-only) |
| `public.health_check` | `secure_health_check` `ALTER`s/policies it → *relation does not exist* | created idempotently (with its heartbeat row) before the ALTER |

All three were verified against the **live prod schema** (exact column types / shape).

## Safety

- These migrations are **already applied to prod**, so the CI `migrate` job (`supabase db push`) **skips them** — prod is untouched. The edits only affect from-scratch replays (fresh envs, the E2E test project, future `db reset`).
- Verified end-to-end: a clean `supabase db reset` against the new E2E project now replays **all 26 migrations** successfully and `migration list` shows Local == Remote.

## Why it matters

Beyond unblocking the E2E test project, this means anyone can now stand up the schema from zero (onboarding, ephemeral preview DBs, CI) — previously impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
