### PR TITLE
ci(e2e): run E2E as a single shard to fit the NANO test project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,13 +30,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
 
-    # Split the suite across parallel runners. Each shard runs global.setup,
-    # which provisions its own throwaway user, so the shared Supabase project
-    # stays collision-free (all data is scoped by user_id).
+    # Run E2E as a SINGLE shard. The dedicated test Supabase project is a small
+    # (NANO) instance: 3 parallel shards generated enough concurrent write load
+    # to exhaust its Disk IO burst budget, which throttled the DB and made the
+    # whole suite time out (~27 min runs). Playwright already runs serially in
+    # CI (workers: 1, fullyParallel: false), so one shard = no DB write
+    # concurrency and no throttling. Trade more wall-clock for reliability; bump
+    # this back to multiple shards if the test project is upgraded.
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1]
 
     steps:
       - uses: actions/checkout@v4
@@ -60,8 +64,8 @@ jobs:
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
           CRON_SECRET: e2e-placeholder
 
-      - name: Run E2E tests (shard ${{ matrix.shard }}/3)
-        run: npm run test:e2e -- --shard=${{ matrix.shard }}/3
+      - name: Run E2E tests (shard ${{ matrix.shard }}/1)
+        run: npm run test:e2e -- --shard=${{ matrix.shard }}/1
         env:
           NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
           NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}


### PR DESCRIPTION
## Problem

E2E now runs against the dedicated test Supabase project (`pngjqatubhatsnulgyic`) instead of prod — but that project is a small **NANO** instance. The CI suite ran **3 shards in parallel**, and that concurrent write load exhausted the instance's **Disk IO burst budget**, throttling the database to its low baseline. The result: the whole suite crawled and timed out (a ~27-minute run with cascading failures), the same burst-budget effect that originally triggered the prod Disk IO alert.

## Fix

Run E2E as a **single shard**.

Playwright is already fully serial in CI (`workers: 1`, `fullyParallel: false` in `playwright.config.ts`), so the *only* source of DB write concurrency was the 3 parallel shard **jobs**. One shard → one runner → one worker → no concurrency → no burst-budget throttling.

```yaml
matrix:
  shard: [1]          # was [1, 2, 3]
# ...
run: npm run test:e2e -- --shard=${{ matrix.shard }}/1   # was /3
```

The `e2e-complete` gate is unchanged — it keys off `needs.e2e.result`, which works with a single-item matrix.

## Trade-off

Slower wall-clock (all tests serial in one job) in exchange for reliability. If the test project is later upgraded (e.g. Micro), bump the matrix back to multiple shards — the comment in the workflow says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
