### PR TITLE
ci: run E2E locally instead of in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,82 +25,17 @@ jobs:
       - name: Run unit tests
         run: npm test -- --run
 
-  e2e:
-    name: E2E Shard
-    runs-on: ubuntu-latest
-    needs: test
-
-    # Split the suite across parallel runners. Each shard runs global.setup,
-    # which provisions its own throwaway user, so the shared Supabase project
-    # stays collision-free (all data is scoped by user_id).
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3]
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Install Playwright browsers
-        run: npx playwright install chromium --with-deps
-
-      - name: Build (test Supabase env)
-        run: npm run build
-        env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
-          CRON_SECRET: e2e-placeholder
-
-      - name: Run E2E tests (shard ${{ matrix.shard }}/3)
-        run: npm run test:e2e -- --shard=${{ matrix.shard }}/3
-        env:
-          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
-          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.E2E_SUPABASE_ANON_KEY }}
-          E2E_SUPABASE_URL: ${{ secrets.E2E_SUPABASE_URL }}
-          E2E_SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.E2E_SUPABASE_SERVICE_ROLE_KEY }}
-          CRON_SECRET: e2e-placeholder
-
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: playwright-report-shard-${{ matrix.shard }}
-          path: playwright-report/
-          retention-days: 7
-
-  # Single stable gate: green only when every E2E shard passes. Lets branch
-  # protection / merge automation depend on one check name instead of N shards.
-  e2e-complete:
-    name: E2E Tests
-    runs-on: ubuntu-latest
-    needs: e2e
-    if: always()
-    steps:
-      - name: Verify all shards passed
-        run: |
-          if [ "${{ needs.e2e.result }}" != "success" ]; then
-            echo "One or more E2E shards did not pass (result: ${{ needs.e2e.result }})"
-            exit 1
-          fi
-          echo "All E2E shards passed"
+  # E2E (Playwright) runs LOCALLY, not in CI. The dedicated test Supabase project
+  # is a small NANO instance whose Disk IO budget can't sustain the suite's write
+  # load — CI runs throttled and timed out (~72 min, cascading failures). Run E2E
+  # locally against a local Supabase stack instead — see "Running E2E locally" in
+  # the README. Unit tests remain the CI gate, and the guard in e2e/helpers/guard.ts
+  # still prevents E2E from ever targeting production.
 
   # Apply pending migrations to the production Supabase project on every merge to
   # main, so schema changes ship automatically instead of needing a manual
-  # `supabase db push`. Gated on the unit-test job only: e2e runs against a
-  # *separate* test project, so gating prod migrations on e2e could deadlock —
-  # an e2e suite that needs the new schema can't go green until the migration is
-  # applied. `supabase db push` is idempotent (only applies migrations not yet in
-  # the remote history), so re-runs are safe.
+  # `supabase db push`. `supabase db push` is idempotent (only applies migrations
+  # not yet in the remote history), so re-runs are safe.
   migrate:
     name: Apply DB migrations (production)
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -72,6 +72,29 @@ Open <http://localhost:3000>.
 | `npm run test:e2e` | End-to-end tests (Playwright) |
 | `npm run test:e2e:ui` | Playwright UI mode |
 
+## Running E2E locally
+
+E2E tests (Playwright) run **locally**, not in CI — the dedicated test Supabase project is a small instance whose Disk IO budget can't sustain the suite's write load. Run them against a **local Supabase stack** (Docker) so there's no IO throttling and no risk of touching production:
+
+```bash
+supabase start            # boots local Postgres + replays all migrations
+```
+
+Then point `.env.local` at the local stack (use the keys `supabase start` prints):
+
+```
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<anon key from `supabase start`>
+E2E_SUPABASE_URL=http://127.0.0.1:54321
+E2E_SUPABASE_SERVICE_ROLE_KEY=<service_role key from `supabase start`>
+```
+
+```bash
+npm run test:e2e          # or: npm run test:e2e:ui
+```
+
+The guard in `e2e/helpers/guard.ts` refuses to run against the production project, so a misconfigured `.env.local` can't churn prod.
+
 ## Tech stack
 
 | Concern | Choice |


### PR DESCRIPTION
## Why

E2E now runs against a dedicated test Supabase project (no longer prod), but that project is a small **NANO** instance, and its Disk IO budget can't sustain the Playwright suite's write load:

- 3 parallel shards → burst budget drained fast → ~27-min throttled runs
- single serial shard (#312) → drained slower but still → **72-min run, 81/263 tests failing** with **316 "waiting for `<locator>`" timeouts** (elements never rendered because the DB was crawling), only ~4 real assertion mismatches

The failures were spread across 11 spec files with 182 tests passing — the classic throttling-over-time signature, not a test or data bug. And E2E was never a **required** check; only **Unit Tests** gates merges.

## What

- Remove the `e2e` and `e2e-complete` jobs from `.github/workflows/ci.yml`.
- Keep **Unit Tests** (the CI gate) and the **migrate-to-prod** job.
- Add a **"Running E2E locally"** section to the README: run against a **local Supabase stack** (`supabase start`) — no IO throttling, no cost, no prod risk. This is now viable because #311 made the migrations replay cleanly from scratch.

Branch protection only requires "Unit Tests", so removing the E2E jobs doesn't break merges. The `E2E_SUPABASE_*` secrets are left in place (harmless; handy if a manual on-demand E2E workflow is added later). The guard in `e2e/helpers/guard.ts` still prevents any E2E run — local or otherwise — from targeting production.

## Trade-off

E2E regression-catching becomes manual (run it locally before risky UI changes) instead of automatic per-PR. Safety nets remain: Unit Tests in CI + Vercel preview review + local E2E.

Supersedes #312 (single-shard), which is closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
