### PR TITLE
feat(plan): goal-header "+" log-contribution and recurring-bank "Saved" deposit (desktop + mobile)

### DIFF
--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -10,7 +10,7 @@ import { useLocale } from 'next-intl'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import FixedExpenseManager from './FixedExpenseManager'
 import RecurringSavingManager from './RecurringSavingManager'
-import AddTransactionSheet, { type EditableTransaction } from '@/app/assets/components/AddTransactionSheet'
+import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import { buildByGoal, resolveRecurringSavings, type GoalItem } from '@/lib/planning'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
@@ -191,10 +191,10 @@ function DPlanRow({ primary, secondary, amount, muted, last, isVI, onSkip, onRes
 // Recurring savings get a kebab (save more / edit / skip). Fund DCA lines get a
 // "Buy" pill to record the actual purchase, plus skip / restore for the month.
 
-function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRecordBuy, onDcaSkip, onDcaRestore }: {
+function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRecordBuy, onRecordDeposit, onDcaSkip, onDcaRestore }: {
   item: GoalItem; isVI: boolean
   onSkip: () => void; onRestore: () => void; onOverride: () => void; onEdit: () => void
-  onRecordBuy: () => void; onDcaSkip: () => void; onDcaRestore: () => void
+  onRecordBuy: () => void; onRecordDeposit: () => void; onDcaSkip: () => void; onDcaRestore: () => void
 }) {
   const [open, setOpen] = useState(false)
   const [menuPos, setMenuPos] = useState({ top: 0, right: 0 })
@@ -234,8 +234,14 @@ function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRec
       </td>
       <td style={{ padding: '9px 8px 9px 4px', textAlign: 'right', verticalAlign: 'middle', width: 96 }}>
         {item.isRecurring ? (
-          <>
-            <button ref={btnRef} onClick={() => open ? setOpen(false) : openMenu()} aria-label="Saving actions" style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex', marginLeft: 'auto' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 2 }}>
+            {!skipped && (
+              <button onClick={onRecordDeposit} aria-label={isVI ? 'Ghi nhận đã gửi' : 'Record deposit'} title={isVI ? 'Ghi nhận đã gửi — số tiền, ngày' : 'Record deposit — amount, date'}
+                style={{ padding: '4px 10px', fontSize: 11, fontWeight: 600, color: 'var(--c-pos)', background: 'var(--c-pos-tint)', border: '1px solid transparent', borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4, whiteSpace: 'nowrap' }}>
+                <Plus size={12} strokeWidth={2.4} />{isVI ? 'Đã gửi' : 'Saved'}
+              </button>
+            )}
+            <button ref={btnRef} onClick={() => open ? setOpen(false) : openMenu()} aria-label="Saving actions" style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
               <MoreHorizontal size={14} />
             </button>
             {open && (
@@ -246,6 +252,7 @@ function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRec
                     <MenuBtn icon={<Check size={13} />} label={isVI ? 'Bao gồm tháng này' : 'Include this month'} onClick={() => { onRestore(); setOpen(false) }} noBorder />
                   ) : (
                     <>
+                      <MenuBtn icon={<Plus size={13} />} label={isVI ? 'Ghi nhận đã gửi tháng này' : 'Record deposit this month'} onClick={() => { onRecordDeposit(); setOpen(false) }} />
                       <MenuBtn icon={<TrendingUp size={13} />} label={isVI ? 'Tiết kiệm thêm tháng này' : 'Save more this month'} onClick={() => { onOverride(); setOpen(false) }} />
                       <MenuBtn icon={<EditIcon size={13} />} label={isVI ? 'Sửa kế hoạch định kỳ' : 'Edit recurring plan'} onClick={() => { onEdit(); setOpen(false) }} />
                       {item.overridden && <MenuBtn icon={<RefreshCw size={13} />} label={isVI ? 'Khôi phục mặc định' : 'Restore default'} onClick={() => { onRestore(); setOpen(false) }} />}
@@ -255,7 +262,7 @@ function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRec
                 </div>
               </>
             )}
-          </>
+          </div>
         ) : item.isFundDca && skipped ? (
           <button onClick={onDcaRestore} aria-label="Restore DCA" style={{ padding: '4px 9px', fontSize: 11, fontWeight: 600, color: 'var(--c-muted)', background: 'transparent', border: '1px solid var(--c-line)', borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4 }}>
             <Check size={12} />{isVI ? 'Khôi phục' : 'Restore'}
@@ -436,6 +443,9 @@ export default function DesktopPlanningView({
   // pre-filled from the planned investment. Saving completes the same planned
   // row (PUT), so it never double-counts against the goal.
   const [buyEdit, setBuyEdit] = useState<EditableTransaction | null>(null)
+  // Logging a contribution from a goal header, or recording a recurring bank
+  // deposit, opens the same sheet in create mode (POST) pre-filled with the goal.
+  const [prefillTx, setPrefillTx] = useState<PrefillTransaction | null>(null)
 
   // ── Derived values ──
   const goalsById = useMemo(() => new Map(goals.map(g => [g.goal_id, g.goal_name])), [goals])
@@ -612,6 +622,17 @@ export default function DesktopPlanningView({
       notes: null,
       fund_id: inv.fund_id,
       goal_id: inv.goal_id,
+    })
+  }
+
+  // Open the Add-Transaction sheet in create mode, pre-filled toward a goal.
+  // Used by the goal-header "+" (log any contribution) and the recurring-bank
+  // "Saved" pill (record this month's deposit at the planned amount).
+  function openContribution(g: { goalId: string; isUnallocated: boolean }, prefill?: Partial<PrefillTransaction>) {
+    setPrefillTx({
+      goal_id: g.isUnallocated ? null : g.goalId,
+      investment_date: new Date().toISOString().slice(0, 10),
+      ...prefill,
     })
   }
 
@@ -837,7 +858,16 @@ export default function DesktopPlanningView({
                             {g.contributed > 0 ? `${fmt(g.contributed)} ${isVI ? 'đã góp' : 'in'}` : (isVI ? 'Chưa góp' : 'Nothing yet')}
                           </div>
                         </td>
-                        <td />
+                        <td style={{ padding: '10px 12px 10px 4px', textAlign: 'right', verticalAlign: 'top', width: 40 }}>
+                          <button
+                            onClick={() => openContribution(g)}
+                            aria-label={isVI ? 'Ghi nhận đóng góp' : 'Log contribution'}
+                            title={isVI ? 'Ghi nhận đóng góp' : 'Log contribution'}
+                            style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-pos)', display: 'flex', marginLeft: 'auto' }}
+                          >
+                            <Plus size={15} strokeWidth={2.4} />
+                          </button>
+                        </td>
                       </tr>
                       {g.items.map((inv, ii) => (
                         <DGoalItemRow
@@ -852,6 +882,7 @@ export default function DesktopPlanningView({
                             setOverrideVal(String(inv.baseAmount ?? inv.amount))
                           }}
                           onRecordBuy={() => openBuy(inv.transactionId)}
+                          onRecordDeposit={() => openContribution(g, { asset_type: 'bank', amount_vnd: inv.amount })}
                           onDcaSkip={() => handleDcaSkip(inv)}
                           onDcaRestore={() => handleDcaRestore(inv)}
                         />
@@ -1105,11 +1136,16 @@ export default function DesktopPlanningView({
       {/* Record buy → the canonical Add-Transaction sheet, opened in edit mode on
           the planned DCA row so saving completes that same transaction. */}
       <AddTransactionSheet
-        open={!!buyEdit}
+        open={!!buyEdit || !!prefillTx}
         existing={buyEdit}
+        prefill={prefillTx}
         desktop
-        onClose={() => setBuyEdit(null)}
-        onSaved={() => { setBuyEdit(null); onRefresh(); onToast(isVI ? 'Đã ghi nhận mua' : 'Buy recorded') }}
+        onClose={() => { setBuyEdit(null); setPrefillTx(null) }}
+        onSaved={() => {
+          const wasBuy = !!buyEdit
+          setBuyEdit(null); setPrefillTx(null); onRefresh()
+          onToast(wasBuy ? (isVI ? 'Đã ghi nhận mua' : 'Buy recorded') : (isVI ? 'Đã ghi nhận đóng góp' : 'Contribution logged'))
+        }}
       />
     </div>
   )

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -10,7 +10,7 @@ import {
 import { fmt, fmtCompact } from '@/lib/formatters'
 import FixedExpenseManager from './FixedExpenseManager'
 import RecurringSavingManager from './RecurringSavingManager'
-import AddTransactionSheet, { type EditableTransaction } from '@/app/assets/components/AddTransactionSheet'
+import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import { buildByGoal, resolveRecurringSavings, type GoalRow, type GoalItem } from '@/lib/planning'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
@@ -666,13 +666,15 @@ function BudgetSection({
 
 // ─── GoalAllocationRow ────────────────────────────────────────────────────────
 
-function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride, onRecEdit, onRecordBuy, onDcaSkip, onDcaRestore }: {
+function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride, onRecEdit, onRecordBuy, onRecordDeposit, onLogContribution, onDcaSkip, onDcaRestore }: {
   entry: GoalRow; isVI: boolean
   onRecSkip: (item: GoalItem) => void
   onRecRestore: (item: GoalItem) => void
   onRecOverride: (item: GoalItem) => void
   onRecEdit: () => void
   onRecordBuy: (item: GoalItem) => void
+  onRecordDeposit: (item: GoalItem) => void
+  onLogContribution: () => void
   onDcaSkip: (item: GoalItem) => void
   onDcaRestore: (item: GoalItem) => void
 }) {
@@ -681,41 +683,55 @@ function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride
   const met = entry.totalAllocated > 0 && entry.contributed >= entry.totalAllocated
   return (
     <div>
-      <button
-        onClick={() => setOpen((o) => !o)}
-        style={{
-          width: '100%', textAlign: 'left', background: 'transparent', border: 'none', cursor: 'pointer',
-          padding: '12px 14px', display: 'flex', alignItems: 'center', gap: 10,
-          borderTop: '1px solid var(--c-line)', fontFamily: 'inherit',
-        }}
-      >
-        <div style={{ width: 28, height: 28, borderRadius: 6, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-          <Target size={14} />
-        </div>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div style={{ fontSize: 13, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--c-ink)' }}>
-            {entry.goalName}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 14px', borderTop: '1px solid var(--c-line)' }}>
+        <button
+          onClick={() => setOpen((o) => !o)}
+          style={{
+            flex: 1, minWidth: 0, textAlign: 'left', background: 'transparent', border: 'none', cursor: 'pointer',
+            padding: 0, display: 'flex', alignItems: 'center', gap: 10, fontFamily: 'inherit',
+          }}
+        >
+          <div style={{ width: 28, height: 28, borderRadius: 6, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+            <Target size={14} />
           </div>
-          {entry.totalAllocated > 0 ? (
-            <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 4 }}>
-              <div style={{ flex: 1, maxWidth: 120, height: 4, borderRadius: 999, background: 'var(--c-line)', overflow: 'hidden' }}>
-                <div style={{ height: '100%', width: `${pct}%`, background: met ? 'var(--c-pos)' : 'var(--c-navy)', borderRadius: 999, transition: 'width 200ms' }} />
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{ fontSize: 13, fontWeight: 500, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', color: 'var(--c-ink)' }}>
+              {entry.goalName}
+            </div>
+            {entry.totalAllocated > 0 ? (
+              <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginTop: 4 }}>
+                <div style={{ flex: 1, maxWidth: 120, height: 4, borderRadius: 999, background: 'var(--c-line)', overflow: 'hidden' }}>
+                  <div style={{ height: '100%', width: `${pct}%`, background: met ? 'var(--c-pos)' : 'var(--c-navy)', borderRadius: 999, transition: 'width 200ms' }} />
+                </div>
+                <span style={{ fontSize: 10, color: entry.contributed > 0 ? 'var(--c-pos)' : 'var(--c-muted)', fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
+                  {entry.contributed > 0 ? `${fmt(entry.contributed)} ${isVI ? 'đã góp' : 'in'}` : (isVI ? 'Chưa góp' : 'Nothing yet')}
+                </span>
               </div>
-              <span style={{ fontSize: 10, color: entry.contributed > 0 ? 'var(--c-pos)' : 'var(--c-muted)', fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
-                {entry.contributed > 0 ? `${fmt(entry.contributed)} ${isVI ? 'đã góp' : 'in'}` : (isVI ? 'Chưa góp' : 'Nothing yet')}
-              </span>
-            </div>
-          ) : (
-            <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1 }}>
-              {entry.items.length} {isVI ? 'khoản' : entry.items.length === 1 ? 'allocation' : 'allocations'}
-            </div>
-          )}
-        </div>
-        <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums', color: 'var(--c-ink)' }}>
-          {fmt(entry.totalAllocated)}
-        </span>
-        {open ? <ChevronUp size={14} color="var(--c-muted)" /> : <ChevronDown size={14} color="var(--c-muted)" />}
-      </button>
+            ) : (
+              <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1 }}>
+                {entry.items.length} {isVI ? 'khoản' : entry.items.length === 1 ? 'allocation' : 'allocations'}
+              </div>
+            )}
+          </div>
+          <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums', color: 'var(--c-ink)' }}>
+            {fmt(entry.totalAllocated)}
+          </span>
+        </button>
+        <button
+          onClick={onLogContribution}
+          aria-label={isVI ? 'Ghi nhận đóng góp' : 'Log contribution'}
+          style={{ padding: 4, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-pos)', display: 'flex', flexShrink: 0 }}
+        >
+          <Plus size={16} strokeWidth={2.4} />
+        </button>
+        <button
+          onClick={() => setOpen((o) => !o)}
+          aria-label={isVI ? 'Mở/đóng mục tiêu' : 'Toggle goal'}
+          style={{ border: 'none', background: 'transparent', cursor: 'pointer', display: 'flex', color: 'var(--c-muted)', padding: 0, flexShrink: 0 }}
+        >
+          {open ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </button>
+      </div>
       {open && entry.items.map((item, i) => (
         <GoalItemRow
           key={i}
@@ -726,6 +742,7 @@ function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride
           onOverride={() => onRecOverride(item)}
           onEdit={onRecEdit}
           onRecordBuy={() => onRecordBuy(item)}
+          onRecordDeposit={() => onRecordDeposit(item)}
           onDcaSkip={() => onDcaSkip(item)}
           onDcaRestore={() => onDcaRestore(item)}
         />
@@ -736,10 +753,10 @@ function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride
 
 // ─── GoalItemRow — one allocation under a goal (recurring savings get a kebab) ──
 
-function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRecordBuy, onDcaSkip, onDcaRestore }: {
+function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRecordBuy, onRecordDeposit, onDcaSkip, onDcaRestore }: {
   item: GoalItem; isVI: boolean
   onSkip: () => void; onRestore: () => void; onOverride: () => void; onEdit: () => void
-  onRecordBuy: () => void; onDcaSkip: () => void; onDcaRestore: () => void
+  onRecordBuy: () => void; onRecordDeposit: () => void; onDcaSkip: () => void; onDcaRestore: () => void
 }) {
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPos, setMenuPos] = useState({ top: 0, right: 0 })
@@ -786,6 +803,11 @@ function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onReco
       </span>
       {item.isRecurring ? (
         <>
+          {!skipped && (
+            <button onClick={onRecordDeposit} aria-label={isVI ? 'Ghi nhận đã gửi' : 'Record deposit'} style={{ padding: '4px 9px', fontSize: 11, fontWeight: 600, color: 'var(--c-pos)', background: 'var(--c-pos-tint)', border: '1px solid transparent', borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 3, flexShrink: 0, whiteSpace: 'nowrap' }}>
+              <Plus size={12} strokeWidth={2.4} />{isVI ? 'Đã gửi' : 'Saved'}
+            </button>
+          )}
           <button ref={btnRef} onClick={() => (menuOpen ? setMenuOpen(false) : openMenu())} aria-label="Saving actions" style={{ padding: 4, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex', flexShrink: 0 }}>
             <MoreHorizontal size={14} />
           </button>
@@ -797,6 +819,7 @@ function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onReco
                   <MenuItem icon={<Check size={13} />} label={isVI ? 'Bao gồm tháng này' : 'Include this month'} onClick={() => { onRestore(); setMenuOpen(false) }} noBorder />
                 ) : (
                   <>
+                    <MenuItem icon={<Plus size={13} />} label={isVI ? 'Ghi nhận đã gửi tháng này' : 'Record deposit this month'} onClick={() => { onRecordDeposit(); setMenuOpen(false) }} />
                     <MenuItem icon={<TrendingUp size={13} />} label={isVI ? 'Tiết kiệm thêm tháng này' : 'Save more this month'} onClick={() => { onOverride(); setMenuOpen(false) }} />
                     <MenuItem icon={<EditIcon size={13} />} label={isVI ? 'Sửa kế hoạch định kỳ' : 'Edit recurring plan'} onClick={() => { onEdit(); setMenuOpen(false) }} />
                     {item.overridden && <MenuItem icon={<RefreshCw size={13} />} label={isVI ? 'Khôi phục mặc định' : 'Restore default'} onClick={() => { onRestore(); setMenuOpen(false) }} />}
@@ -971,6 +994,7 @@ export default function MobilePlanningView({
   // pre-filled from the planned investment, so saving completes that same
   // planned row (PUT) rather than adding a duplicate contribution.
   const [buyEdit, setBuyEdit] = useState<EditableTransaction | null>(null)
+  const [prefillTx, setPrefillTx] = useState<PrefillTransaction | null>(null)
   const [overrideTarget, setOverrideTarget] = useState<{ type: 'fe' | 'ins' | 'rec'; id: string; name: string; defaultAmount: number } | null>(null)
 
   const monthLabel = getMonthLabel(month, year)
@@ -1098,6 +1122,17 @@ export default function MobilePlanningView({
     await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips/${item.fundId}`, { method: 'DELETE' })
     onToast(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
     onRefresh()
+  }
+
+  // Open the Add-Transaction sheet in create mode, pre-filled toward a goal —
+  // the goal-header "+" (log any contribution) and the recurring-bank "Saved"
+  // pill (record this month's deposit at the planned amount).
+  function openContribution(entry: GoalRow, prefill?: Partial<PrefillTransaction>) {
+    setPrefillTx({
+      goal_id: entry.isUnallocated ? null : entry.goalId,
+      investment_date: new Date().toISOString().slice(0, 10),
+      ...prefill,
+    })
   }
 
   function openBuy(item: GoalItem) {
@@ -1244,6 +1279,8 @@ export default function MobilePlanningView({
                     onRecOverride={openOverrideRec}
                     onRecEdit={() => setSheet({ type: 'manage-recurring' })}
                     onRecordBuy={openBuy}
+                    onRecordDeposit={(item) => openContribution(entry, { asset_type: 'bank', amount_vnd: item.amount })}
+                    onLogContribution={() => openContribution(entry)}
                     onDcaSkip={handleDcaSkip}
                     onDcaRestore={handleDcaRestore}
                   />
@@ -1460,12 +1497,18 @@ export default function MobilePlanningView({
         )}
       </Sheet>
 
-      {/* ─── Record buy → canonical Add-Transaction sheet (edit mode) ───────── */}
+      {/* ─── Record buy (edit) / log contribution (create) → Add-Transaction ── */}
       <AddTransactionSheet
-        open={!!buyEdit}
+        open={!!buyEdit || !!prefillTx}
         existing={buyEdit}
-        onClose={() => setBuyEdit(null)}
-        onSaved={() => { setBuyEdit(null); onToast(isVI ? 'Đã ghi nhận mua' : 'Buy recorded'); onRefresh() }}
+        prefill={prefillTx}
+        onClose={() => { setBuyEdit(null); setPrefillTx(null) }}
+        onSaved={() => {
+          const wasBuy = !!buyEdit
+          setBuyEdit(null); setPrefillTx(null)
+          onToast(wasBuy ? (isVI ? 'Đã ghi nhận mua' : 'Buy recorded') : (isVI ? 'Đã ghi nhận đóng góp' : 'Contribution logged'))
+          onRefresh()
+        }}
       />
     </div>
   )

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DesktopPlanningView from '../DesktopPlanningView'
+import type { MonthlyPlan, FundInvestment, DirectSaving, RecurringSaving } from '../../PlanningClient'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+
+vi.mock('@/lib/formatters', () => ({
+  fmt: (n: number) => `₫ ${n}`,
+  fmtCompact: (n: number) => {
+    const abs = Math.abs(n)
+    const sign = n < 0 ? '-' : ''
+    if (abs >= 1_000_000_000) return sign + (abs / 1_000_000_000).toFixed(1) + 'B ₫'
+    if (abs >= 1_000_000) return sign + (abs / 1_000_000).toFixed(1) + 'M ₫'
+    return `₫ ${n}`
+  },
+}))
+
+const basePlan: MonthlyPlan = { id: 'plan-1', month: 5, year: 2026, salary_vnd: 45_000_000 }
+
+const recurringSavings: RecurringSaving[] = [
+  {
+    saving_id: 'rs1',
+    name: 'VCB Savings',
+    goal_id: 'g1',
+    amount_vnd: 2_000_000,
+    effective_from: null,
+    effective_to: null,
+    savings_goals: { goal_name: 'Retirement' },
+  },
+]
+
+const defaultProps = {
+  month: 5,
+  year: 2026,
+  plan: null as MonthlyPlan | null,
+  investments: [] as FundInvestment[],
+  savings: [] as DirectSaving[],
+  fixedExpenses: [],
+  insuranceMembers: [],
+  otherExpenses: [],
+  recurringSavings: [] as RecurringSaving[],
+  recurringSavingOverrides: [],
+  dcaSkips: [],
+  funds: [],
+  goals: [],
+  loading: false,
+  onPrev: vi.fn(),
+  onNext: vi.fn(),
+  onToday: vi.fn(),
+  onPlanCreated: vi.fn(),
+  onPlanDeleted: vi.fn(),
+  onRefresh: vi.fn(),
+  onToast: vi.fn(),
+}
+
+describe('DesktopPlanningView — goal header "+" log contribution', () => {
+  it('renders a Log contribution button on each goal header', () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
+    expect(screen.getByRole('button', { name: /Log contribution/i })).toBeInTheDocument()
+  })
+
+  it('opens the Add-Transaction sheet when the goal "+" is clicked', async () => {
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(String(url).includes('savings-goals') ? { goals: [] } : []),
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    try {
+      render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
+      await userEvent.click(screen.getByRole('button', { name: /Log contribution/i }))
+      // The canonical sheet exposes the asset-type picker (Fund / Bank / Gold).
+      expect(await screen.findByText('Gold')).toBeInTheDocument()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})
+
+describe('DesktopPlanningView — recurring bank "Saved" deposit', () => {
+  it('renders a Saved button on a recurring bank saving row', () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
+    expect(screen.getByText('VCB Savings')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Record deposit/i })).toBeInTheDocument()
+  })
+
+  it('does not render a Saved button on a skipped recurring saving', () => {
+    render(
+      <DesktopPlanningView
+        {...defaultProps}
+        plan={basePlan}
+        recurringSavings={recurringSavings}
+        recurringSavingOverrides={[{ recurring_saving_id: 'rs1', monthly_amount_override_vnd: 0 }]}
+      />,
+    )
+    expect(screen.queryByRole('button', { name: /Record deposit/i })).not.toBeInTheDocument()
+  })
+
+  it('opens the Add-Transaction sheet when Saved is clicked', async () => {
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(String(url).includes('savings-goals') ? { goals: [] } : []),
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    try {
+      render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
+      await userEvent.click(screen.getByRole('button', { name: /Record deposit/i }))
+      expect(await screen.findByText('Gold')).toBeInTheDocument()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -418,6 +418,47 @@ describe('MobilePlanningView — recurring savings in By goal', () => {
     }
   })
 
+  it('renders a Log contribution "+" on the goal header', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
+    expect(screen.getByRole('button', { name: /Log contribution/i })).toBeInTheDocument()
+  })
+
+  it('opens the Add-Transaction sheet when the goal "+" is clicked', async () => {
+    const fetchMock = vi.fn((url: string) =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(String(url).includes('savings-goals') ? { goals: [] } : []),
+      }),
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    try {
+      render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
+      await userEvent.click(screen.getByRole('button', { name: /Log contribution/i }))
+      expect(await screen.findByText('Gold')).toBeInTheDocument()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('shows a Saved/deposit action on a recurring bank saving', async () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
+    await userEvent.click(screen.getByText('Retirement'))
+    expect(screen.getByRole('button', { name: /Record deposit/i })).toBeInTheDocument()
+  })
+
+  it('hides the Saved action on a skipped recurring saving', async () => {
+    render(
+      <MobilePlanningView
+        {...defaultProps}
+        plan={basePlan}
+        recurringSavings={recurringSavings}
+        recurringSavingOverrides={[{ recurring_saving_id: 'rs1', monthly_amount_override_vnd: 0 }]}
+      />,
+    )
+    await userEvent.click(screen.getByText('Retirement'))
+    expect(screen.queryByRole('button', { name: /Record deposit/i })).not.toBeInTheDocument()
+  })
+
   it('renders a skipped DCA fund with a Restore action', async () => {
     render(
       <MobilePlanningView

--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -81,12 +81,23 @@ export interface EditableTransaction {
   goal_id: string | null
 }
 
+// When set (and `existing` is not), the sheet opens in create mode with these
+// fields pre-filled — e.g. logging a contribution toward a goal, or recording a
+// recurring bank deposit. Saving still issues a POST (a brand-new transaction).
+export interface PrefillTransaction {
+  asset_type?: string | null
+  amount_vnd?: number | null
+  goal_id?: string | null
+  investment_date?: string | null
+}
+
 interface Props {
   open: boolean
   onClose: () => void
   onSaved?: () => void
   desktop?: boolean
   existing?: EditableTransaction | null
+  prefill?: PrefillTransaction | null
 }
 
 const inputStyle: React.CSSProperties = {
@@ -125,7 +136,7 @@ function groupThousands(value: string): string {
   return dot === -1 ? grouped : `${grouped}.${decPart}`
 }
 
-export default function AddTransactionSheet({ open, onClose, onSaved, desktop, existing }: Props) {
+export default function AddTransactionSheet({ open, onClose, onSaved, desktop, existing, prefill }: Props) {
   const t = useTranslations('addTx')
   const tc = useTranslations('common')
 
@@ -229,6 +240,23 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, existing])
+
+  // Create mode with prefilled defaults (e.g. logging a contribution from the
+  // Plan page). Unlike `existing`, this stays a POST — it just seeds the form.
+  useEffect(() => {
+    if (!open || existing || !prefill) return
+    const at: AssetType = prefill.asset_type === 'bank' || prefill.asset_type === 'gold' ? prefill.asset_type : 'fund'
+    setAssetType(at)
+    setDir('buy')
+    if (prefill.goal_id != null) setGoalId(prefill.goal_id)
+    if (prefill.investment_date) setDate(prefill.investment_date)
+    if (prefill.amount_vnd != null) {
+      const amt = String(prefill.amount_vnd)
+      if (at === 'bank') setBankAmount(amt)
+      else if (at === 'fund') setAmount(amt)
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, existing, prefill])
 
   // Lazily load sellable holdings from the overview the first time the user
   // switches to "Sell" — most opens are buys, so we don't pay for it up front.


### PR DESCRIPTION
## What

Brings the **Plan → By goal** section in line with the redesign (`Cairn Desktop.html` / `desktop-plan.jsx`), on **both desktop and mobile**:

1. **"+" on each goal header** — a green *Log contribution* button. Opens the canonical Add-Transaction sheet pre-filled with that goal, so you can record a real contribution toward it without leaving the plan.
2. **"Saved" pill on recurring bank savings** — mirrors the fund DCA *Buy* pill. Records this month's deposit at the planned amount (bank asset + goal pre-filled). Also added as a *Record deposit this month* entry in the row's kebab menu. Hidden when the saving is skipped this month.

Both flows open the Add-Transaction sheet in **create mode** (POST a new transaction); the By-goal view then reconciles the logged amount as *contributed* automatically on refresh.

## How

- `AddTransactionSheet`: new optional `prefill` prop (`PrefillTransaction`) that seeds the create form (`asset_type`, `goal_id`, `amount_vnd`, `investment_date`) **without** engaging the edit/PUT path used by `existing`. The DCA *Buy* flow still uses `existing` (it completes a pre-seeded planned row).
- `DesktopPlanningView` & `MobilePlanningView`: a single `openContribution(goal, prefill?)` helper drives both buttons; the existing Add-Transaction sheet now handles both `buyEdit` (edit) and `prefillTx` (create).
- Mobile goal header was a single toggle `<button>`; split into separate toggle / "+" / chevron buttons to avoid nested-button markup.

## Tests (TDD)

- New `DesktopPlanningView.test.tsx` (5 tests) — goal "+" and recurring "Saved" render & open the sheet; "Saved" hidden when skipped.
- `MobilePlanningView.test.tsx` — 4 new tests covering the same on mobile.
- All planning + assets suites pass (247 tests); `tsc --noEmit` clean. No new lint errors introduced.

## Scope notes

Other design deltas in `desktop-plan.jsx` (collapsible desktop goal groups, goal pace hints, *Delete recurring* in the kebab) are left as optional follow-ups to keep this PR focused on the two requested actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)