### PR TITLE
fix(plan): recurring "Saved" deposit counts toward the goal

### DIFF
--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -207,7 +207,7 @@ function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRec
     : item.overridden
       ? (isVI ? 'Đã ghi đè tháng này' : 'Overridden this month')
       : recorded
-        ? (isVI ? 'Đã mua' : 'Recorded')
+        ? item.type === 'bank' ? (isVI ? 'Đã gửi tháng này' : 'Deposited this month') : (isVI ? 'Đã mua' : 'Recorded')
         : item.type === 'fund'
           ? 'Fund'
           : item.isRecurring ? (isVI ? 'Tiết kiệm định kỳ' : 'Recurring saving') : (isVI ? 'Tiết kiệm' : 'Direct saving')
@@ -235,7 +235,11 @@ function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRec
       <td style={{ padding: '9px 8px 9px 4px', textAlign: 'right', verticalAlign: 'middle', width: 96 }}>
         {item.isRecurring ? (
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 2 }}>
-            {!skipped && (
+            {recorded ? (
+              <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: 'var(--c-pos)', fontSize: 11, fontWeight: 600 }}>
+                <Check size={13} />{isVI ? 'Đã gửi' : 'Saved'}
+              </span>
+            ) : !skipped && (
               <button onClick={onRecordDeposit} aria-label={isVI ? 'Ghi nhận đã gửi' : 'Record deposit'} title={isVI ? 'Ghi nhận đã gửi — số tiền, ngày' : 'Record deposit — amount, date'}
                 style={{ padding: '4px 10px', fontSize: 11, fontWeight: 600, color: 'var(--c-pos)', background: 'var(--c-pos-tint)', border: '1px solid transparent', borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4, whiteSpace: 'nowrap' }}>
                 <Plus size={12} strokeWidth={2.4} />{isVI ? 'Đã gửi' : 'Saved'}
@@ -631,6 +635,7 @@ export default function DesktopPlanningView({
   function openContribution(g: { goalId: string; isUnallocated: boolean }, prefill?: Partial<PrefillTransaction>) {
     setPrefillTx({
       goal_id: g.isUnallocated ? null : g.goalId,
+      plan_id: plan?.id ?? null,
       investment_date: new Date().toISOString().slice(0, 10),
       ...prefill,
     })

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -769,7 +769,7 @@ function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onReco
     : item.overridden
       ? (isVI ? 'Đã ghi đè tháng này' : 'Overridden this month')
       : recorded
-        ? (isVI ? 'Đã mua' : 'Recorded')
+        ? item.type === 'bank' ? (isVI ? 'Đã gửi tháng này' : 'Deposited this month') : (isVI ? 'Đã mua' : 'Recorded')
         : item.type === 'fund'
           ? 'Fund'
           : item.isRecurring ? (isVI ? 'Tiết kiệm định kỳ' : 'Recurring saving') : (isVI ? 'Tiết kiệm' : 'Direct saving')
@@ -803,7 +803,11 @@ function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onReco
       </span>
       {item.isRecurring ? (
         <>
-          {!skipped && (
+          {recorded ? (
+            <span style={{ display: 'inline-flex', alignItems: 'center', gap: 4, color: 'var(--c-pos)', fontSize: 11, fontWeight: 600, flexShrink: 0 }}>
+              <Check size={13} />{isVI ? 'Đã gửi' : 'Saved'}
+            </span>
+          ) : !skipped && (
             <button onClick={onRecordDeposit} aria-label={isVI ? 'Ghi nhận đã gửi' : 'Record deposit'} style={{ padding: '4px 9px', fontSize: 11, fontWeight: 600, color: 'var(--c-pos)', background: 'var(--c-pos-tint)', border: '1px solid transparent', borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 3, flexShrink: 0, whiteSpace: 'nowrap' }}>
               <Plus size={12} strokeWidth={2.4} />{isVI ? 'Đã gửi' : 'Saved'}
             </button>
@@ -1130,6 +1134,7 @@ export default function MobilePlanningView({
   function openContribution(entry: GoalRow, prefill?: Partial<PrefillTransaction>) {
     setPrefillTx({
       goal_id: entry.isUnallocated ? null : entry.goalId,
+      plan_id: plan?.id ?? null,
       investment_date: new Date().toISOString().slice(0, 10),
       ...prefill,
     })

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -103,6 +103,21 @@ describe('DesktopPlanningView — recurring bank "Saved" deposit', () => {
     expect(screen.queryByRole('button', { name: /Record deposit/i })).not.toBeInTheDocument()
   })
 
+  it('shows the recurring saving as done (no Record deposit button) once a matching deposit is logged, and fills the goal progress', () => {
+    const savings: DirectSaving[] = [
+      {
+        transaction_id: 'd1', plan_id: 'plan-1', goal_id: 'g1', amount_vnd: 2_000_000,
+        interest_rate: null, expiry_date: null, investment_date: '2026-05-10',
+        savings_goals: { goal_name: 'Retirement' },
+      },
+    ]
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} savings={savings} />)
+    // The line is recorded → the prominent Record deposit pill is gone.
+    expect(screen.queryByRole('button', { name: /Record deposit/i })).not.toBeInTheDocument()
+    // The goal progress reflects the logged contribution (2M of 2M planned).
+    expect(screen.getByText('100%')).toBeInTheDocument()
+  })
+
   it('opens the Add-Transaction sheet when Saved is clicked', async () => {
     const fetchMock = vi.fn((url: string) =>
       Promise.resolve({

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -459,6 +459,22 @@ describe('MobilePlanningView — recurring savings in By goal', () => {
     expect(screen.queryByRole('button', { name: /Record deposit/i })).not.toBeInTheDocument()
   })
 
+  it('shows the recurring saving as done once a matching deposit is logged', async () => {
+    const savings: DirectSaving[] = [
+      {
+        transaction_id: 'd1', plan_id: 'plan-1', goal_id: 'g1', amount_vnd: 2_000_000,
+        interest_rate: null, expiry_date: null, investment_date: '2026-05-10',
+        savings_goals: { goal_name: 'Retirement' },
+      },
+    ]
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} savings={savings} />)
+    // Goal header reflects the logged contribution (2M in).
+    expect(screen.getByText(/₫ 2000000 in/)).toBeInTheDocument()
+    // Expand the goal — the line is recorded, so no Record deposit button.
+    await userEvent.click(screen.getByText('Retirement'))
+    expect(screen.queryByRole('button', { name: /Record deposit/i })).not.toBeInTheDocument()
+  })
+
   it('renders a skipped DCA fund with a Restore action', async () => {
     render(
       <MobilePlanningView

--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -329,10 +329,21 @@ export async function GET() {
   // when allocated, toward their goal. They are intentionally NOT added to the
   // Unallocated "available to assign" card — these are plan-driven balances, not
   // loose holdings that can be assigned or sold from there.
+  // Real bank deposits already counted via the holdings aggregation above. When
+  // one matches a recurring saving (month + goal + amount), suppress the
+  // synthesized contribution so it isn't double-counted into net worth / goals.
+  const loggedRecurringDeposits = investments
+    .filter((tx) => tx.asset_type === 'bank')
+    .map((tx) => ({
+      month: String(tx.investment_date).slice(0, 7),
+      goalId: tx.goal_id,
+      amount: tx.amount_vnd,
+    }))
   const recContributions = realizedRecurringContributions(
     recSavingsRes.data ?? [],
     plans,
     recOverridesRes.data ?? [],
+    loggedRecurringDeposits,
   )
   for (const c of recContributions) {
     totalAssets += c.amount

--- a/app/api/v1/savings-goals/[id]/recurring-contributions/route.ts
+++ b/app/api/v1/savings-goals/[id]/recurring-contributions/route.ts
@@ -43,17 +43,36 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
   const plans = (plansRes.data ?? []) as { id: string; month: number; year: number }[]
   const planIds = plans.map((p) => p.id)
 
-  const overridesRes = planIds.length > 0
-    ? await supabase
-        .from('recurring_saving_overrides')
-        .select('plan_id, recurring_saving_id, monthly_amount_override_vnd')
-        .in('plan_id', planIds)
-    : { data: [], error: null }
+  const [overridesRes, depositsRes] = await Promise.all([
+    planIds.length > 0
+      ? supabase
+          .from('recurring_saving_overrides')
+          .select('plan_id, recurring_saving_id, monthly_amount_override_vnd')
+          .in('plan_id', planIds)
+      : Promise.resolve({ data: [], error: null }),
+    // Real bank deposits logged toward this goal — used to suppress the
+    // synthesized recurring row when the user has recorded the actual deposit
+    // (otherwise the History tab would show both).
+    supabase
+      .from('investment_transactions')
+      .select('goal_id, amount_vnd, investment_date')
+      .eq('user_id', user.id)
+      .eq('goal_id', goalId)
+      .eq('asset_type', 'bank')
+      .eq('transaction_type', 'investment'),
+  ])
+
+  const loggedDeposits = (depositsRes.data ?? []).map((d) => ({
+    month: String(d.investment_date).slice(0, 7),
+    goalId: d.goal_id,
+    amount: d.amount_vnd,
+  }))
 
   const contributions = realizedRecurringContributions(
     savingsRes.data ?? [],
     plans,
     overridesRes.data ?? [],
+    loggedDeposits,
   )
 
   // Shape as read-only history rows mirroring the investment-transactions response.

--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -89,6 +89,9 @@ export interface PrefillTransaction {
   amount_vnd?: number | null
   goal_id?: string | null
   investment_date?: string | null
+  // Associates the new transaction with a monthly plan so it counts toward that
+  // month's By-goal contributions (the plan queries transactions by plan_id).
+  plan_id?: string | null
 }
 
 interface Props {
@@ -520,6 +523,9 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
       investment_date: date,
       notes: note || null,
       goal_id: goalId || null,
+      // Logging from the Plan page ties the transaction to the month's plan so
+      // the By-goal view counts it as contributed.
+      plan_id: prefill?.plan_id ?? null,
     }
 
     if (assetType === 'fund') {

--- a/app/assets/components/__tests__/AddTransactionSheet.test.tsx
+++ b/app/assets/components/__tests__/AddTransactionSheet.test.tsx
@@ -351,3 +351,34 @@ describe('AddTransactionSheet — gold unit (issue #232)', () => {
     })
   })
 })
+
+describe('AddTransactionSheet — prefill create mode (plan contribution)', () => {
+  it('posts a new bank deposit carrying plan_id and goal_id', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [{ goal_id: 'g1', goal_name: 'Retirement' }] }) })
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <AddTransactionSheet
+        open
+        onClose={vi.fn()}
+        onSaved={vi.fn()}
+        prefill={{ asset_type: 'bank', goal_id: 'g1', amount_vnd: 2_000_000, plan_id: 'plan-1', investment_date: '2026-06-01' }}
+      />,
+    )
+
+    fireEvent.click(await screen.findByText('save'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find((c) => String(c[0]).includes('/investment-transactions') && (c[1] as RequestInit)?.method === 'POST')
+      expect(post).toBeTruthy()
+      const body = JSON.parse(String((post![1] as RequestInit).body))
+      expect(body.asset_type).toBe('bank')
+      expect(body.plan_id).toBe('plan-1')
+      expect(body.goal_id).toBe('g1')
+      expect(body.amount_vnd).toBe(2_000_000)
+    })
+  })
+})

--- a/app/assets/components/__tests__/AddTransactionSheet.test.tsx
+++ b/app/assets/components/__tests__/AddTransactionSheet.test.tsx
@@ -354,7 +354,7 @@ describe('AddTransactionSheet — gold unit (issue #232)', () => {
 
 describe('AddTransactionSheet — prefill create mode (plan contribution)', () => {
   it('posts a new bank deposit carrying plan_id and goal_id', async () => {
-    const fetchMock = vi.fn((url: string) => {
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [{ goal_id: 'g1', goal_name: 'Retirement' }] }) })
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
     })

--- a/lib/__tests__/finance.test.ts
+++ b/lib/__tests__/finance.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { calcProjectedInterest, isNavStale, insuranceStatus, insurancePaidYear, isPlanMonthRealized, isInCurrentCycle } from '../finance'
+import { calcProjectedInterest, isNavStale, insuranceStatus, insurancePaidYear, isPlanMonthRealized, isInCurrentCycle, realizedRecurringContributions } from '../finance'
 
 describe('calcProjectedInterest', () => {
   it('returns 0 when rate is null', () => {
@@ -173,6 +173,45 @@ describe('plan allocation counting after a payment (combined gates)', () => {
     const paid = '2026-05-29'
     expect(counts(2027, 1, paid)).toBe(true)   // Jan 2027 arrived → counts
     expect(counts(2027, 3, paid)).toBe(false)  // Mar 2027 not arrived
+  })
+})
+
+describe('realizedRecurringContributions — dedup against logged deposits', () => {
+  afterEach(() => vi.useRealTimers())
+
+  const saving = { saving_id: 's1', goal_id: 'g1', name: 'Vikki', amount_vnd: 2_000_000, effective_from: null, effective_to: null }
+  const plan = { id: 'p1', year: 2026, month: 5 }
+
+  it('synthesizes a realized contribution when no deposit is logged', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 4, 15)) // May 2026
+    const out = realizedRecurringContributions([saving], [plan], [])
+    expect(out).toHaveLength(1)
+    expect(out[0].amount).toBe(2_000_000)
+  })
+
+  it('suppresses the synthesized contribution when a matching deposit was logged', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 4, 15))
+    const out = realizedRecurringContributions([saving], [plan], [], [
+      { month: '2026-05', goalId: 'g1', amount: 2_000_000 },
+    ])
+    expect(out).toHaveLength(0) // the real deposit represents it — no duplicate
+  })
+
+  it('does not suppress when the logged deposit differs in amount', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 4, 15))
+    const out = realizedRecurringContributions([saving], [plan], [], [
+      { month: '2026-05', goalId: 'g1', amount: 1_000_000 },
+    ])
+    expect(out).toHaveLength(1)
+  })
+
+  it('suppresses one synthesized row per matching deposit (two savings, one deposit)', () => {
+    vi.useFakeTimers(); vi.setSystemTime(new Date(2026, 4, 15))
+    const s2 = { ...saving, saving_id: 's2' }
+    const out = realizedRecurringContributions([saving, s2], [plan], [], [
+      { month: '2026-05', goalId: 'g1', amount: 2_000_000 },
+    ])
+    expect(out).toHaveLength(1) // one suppressed, one still synthesized
   })
 })
 

--- a/lib/__tests__/planning.test.ts
+++ b/lib/__tests__/planning.test.ts
@@ -108,6 +108,37 @@ describe('buildByGoal — planned vs contributed', () => {
     expect(row.items).toHaveLength(0)
   })
 
+  it('marks a recurring saving recorded when a matching deposit was logged this month', () => {
+    const recurring = resolveRecurringSavings([saving({ goal_id: 'g-1', amount_vnd: 2_000_000 })], [])
+    const directSavings: GoalDirectSaving[] = [
+      { goal_id: 'g-1', amount_vnd: 2_000_000, savings_goals: { goal_name: 'Retirement' } },
+    ]
+    const [row] = buildByGoal([], directSavings, recurring, goalsById)
+    expect(row.totalAllocated).toBe(2_000_000)  // still planned
+    expect(row.contributed).toBe(2_000_000)     // deposit logged this month
+    expect(row.items).toHaveLength(1)
+    expect(row.items[0].isRecurring).toBe(true)
+    expect(row.items[0].recorded).toBe(true)    // line reflects the deposit
+  })
+
+  it('leaves a recurring saving unrecorded when no matching deposit exists', () => {
+    const recurring = resolveRecurringSavings([saving({ goal_id: 'g-1', amount_vnd: 2_000_000 })], [])
+    const [row] = buildByGoal([], [], recurring, goalsById)
+    expect(row.items[0].recorded).toBeFalsy()
+  })
+
+  it('matches one deposit per recurring line (greedy, by amount)', () => {
+    const recurring = resolveRecurringSavings([
+      saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 2_000_000 }),
+      saving({ saving_id: 's-2', goal_id: 'g-1', amount_vnd: 2_000_000 }),
+    ], [])
+    const directSavings: GoalDirectSaving[] = [
+      { goal_id: 'g-1', amount_vnd: 2_000_000, savings_goals: { goal_name: 'Retirement' } },
+    ]
+    const [row] = buildByGoal([], directSavings, recurring, goalsById)
+    expect(row.items.filter(i => i.recorded).length).toBe(1)
+  })
+
   it('ad-hoc fund buys (not DCA) contribute without being planned line items', () => {
     const adhoc = dca({ is_dca_seeded: false, units: 50, amount_vnd: 1_000_000 })
     const [row] = buildByGoal([adhoc], [], [], goalsById)

--- a/lib/finance.ts
+++ b/lib/finance.ts
@@ -130,14 +130,33 @@ export interface RealizedRecurringContribution {
   planId: string
 }
 
+// A real bank deposit logged toward a goal for a given month (from the Plan
+// page's "Saved" action). When one matches a recurring saving's month + goal +
+// amount, it *is* that contribution — so the synthesized row is suppressed to
+// avoid double-counting it against the goal and net worth.
+export interface LoggedRecurringDeposit {
+  month: string // 'YYYY-MM'
+  goalId: string | null
+  amount: number
+}
+
 export function realizedRecurringContributions(
   savings: RecurringSavingDef[],
   plans: RecurringPlanMonth[],
   overrides: RecurringSavingOverrideRow[],
+  loggedDeposits: LoggedRecurringDeposit[] = [],
 ): RealizedRecurringContribution[] {
   const ovMap = new Map<string, number>()
   for (const o of overrides) {
     ovMap.set(`${o.plan_id}::${o.recurring_saving_id}`, o.monthly_amount_override_vnd)
+  }
+
+  // Consumable pool of logged deposits keyed by month::goal::amount. Each logged
+  // deposit cancels one synthesized contribution (greedy, one-for-one).
+  const depositPool = new Map<string, number>()
+  for (const d of loggedDeposits) {
+    const k = `${d.month}::${d.goalId ?? ''}::${d.amount}`
+    depositPool.set(k, (depositPool.get(k) ?? 0) + 1)
   }
 
   const out: RealizedRecurringContribution[] = []
@@ -152,6 +171,11 @@ export function realizedRecurringContributions(
       // override 0 = skip this month; any other positive override replaces the base.
       const amount = ov === 0 ? 0 : ov != null ? ov : s.amount_vnd
       if (amount <= 0) continue
+      // A logged deposit for the same month + goal + amount already represents
+      // this contribution — consume it and skip the synthesized duplicate.
+      const k = `${ym}::${s.goal_id ?? ''}::${amount}`
+      const pooled = depositPool.get(k)
+      if (pooled) { depositPool.set(k, pooled - 1); continue }
       out.push({
         savingId: s.saving_id,
         goalId: s.goal_id,

--- a/lib/planning.ts
+++ b/lib/planning.ts
@@ -167,15 +167,31 @@ export function buildByGoal(
     if (recorded) row.contributed += inv.amount_vnd
   }
 
+  // Logged bank deposits, pooled per goal by amount. They count as contributed
+  // and also let us mark the matching recurring-saving line as recorded this
+  // month (the deposit isn't linked to a specific saving, so we match greedily
+  // on goal + amount — one deposit completes one planned line).
+  const depositPool = new Map<string, number[]>()
   for (const sav of directSavings) {
-    // A bank deposit is a contribution, not a planned line.
     const row = ensure(sav.goal_id, sav.savings_goals?.goal_name)
     row.contributed += sav.amount_vnd
+    const key = sav.goal_id ?? UNALLOCATED
+    const pool = depositPool.get(key)
+    if (pool) pool.push(sav.amount_vnd)
+    else depositPool.set(key, [sav.amount_vnd])
   }
 
   for (const r of recurring) {
     const row = ensure(r.goalId, r.goalName)
     row.totalAllocated += r.amount
+    // A non-skipped recurring line is "recorded" once a deposit of the same
+    // amount toward the same goal has been logged this month.
+    let recorded = false
+    if (!r.skipped) {
+      const pool = depositPool.get(r.goalId ?? UNALLOCATED)
+      const i = pool ? pool.indexOf(r.amount) : -1
+      if (pool && i !== -1) { pool.splice(i, 1); recorded = true }
+    }
     row.items.push({
       name: r.name,
       type: 'bank',
@@ -185,6 +201,7 @@ export function buildByGoal(
       recurringId: r.id,
       skipped: r.skipped,
       overridden: r.overridden,
+      recorded,
     })
   }
 

--- a/supabase/migrations/20260609000002_link_recurring_bank_deposits_to_plans.sql
+++ b/supabase/migrations/20260609000002_link_recurring_bank_deposits_to_plans.sql
@@ -1,0 +1,28 @@
+-- Backfill: link past recurring-saving bank deposits to their month's plan.
+--
+-- The Plan page's "Saved" action (PR #314) recorded a bank deposit toward a goal
+-- but, before #315, POSTed it without a plan_id. The plan's By-goal view loads
+-- contributions filtered by plan_id, so those deposits never counted — the goal
+-- progress didn't move and the line still showed the "Saved" action.
+--
+-- Link only deposits that match a recurring-saving plan exactly (same user, goal
+-- and amount) and fall in a month the user has a plan for. This is deliberately
+-- conservative: manual term deposits / one-off savings that don't correspond to
+-- a recurring plan are left untouched. Idempotent — re-running links nothing new
+-- because matched rows no longer have a NULL plan_id.
+UPDATE investment_transactions t
+SET plan_id = p.id
+FROM monthly_plans p
+WHERE t.plan_id IS NULL
+  AND t.transaction_type = 'investment'
+  AND t.asset_type = 'bank'
+  AND t.goal_id IS NOT NULL
+  AND p.user_id = t.user_id
+  AND p.month = EXTRACT(MONTH FROM t.investment_date)
+  AND p.year  = EXTRACT(YEAR  FROM t.investment_date)
+  AND EXISTS (
+    SELECT 1 FROM recurring_savings r
+    WHERE r.user_id = t.user_id
+      AND r.goal_id IS NOT DISTINCT FROM t.goal_id
+      AND r.amount_vnd = t.amount_vnd
+  );


### PR DESCRIPTION
## Problem

After clicking **Saved** on a recurring bank saving and adding the transaction, nothing visible changed — the goal progress stayed put and the *Saved* button remained. (Reported after #314.)

**Root cause:** the deposit was POSTed via the create flow *without* a `plan_id`. The Plan page's By-goal section loads `direct_savings` filtered by `.eq('plan_id', plan.id)`, so an orphaned deposit never showed up for that month. The fund DCA *Buy* flow works because it edits a pre-seeded transaction that already carries `plan_id`.

## Fix

1. **`AddTransactionSheet`** — `PrefillTransaction` gains `plan_id`, now included in the create `POST` body. The server already accepts and stores it.
2. **`DesktopPlanningView` / `MobilePlanningView`** — `openContribution` passes the current `plan.id`, so both the goal-header "+" and the recurring "Saved" pill tie their transaction to the month's plan.
3. **`buildByGoal`** — a non-skipped recurring line is marked `recorded` once a deposit of the **same amount toward the same goal** has been logged this month (greedy: one deposit completes one planned line). Recorded lines render a **"Saved ✓"** done state (mirroring the fund **Bought** state) instead of the action pill, and the goal progress bar fills.

## Backfill migration (existing data)

Deposits logged via "Saved" *before* this fix were orphaned (`plan_id NULL`) and still showed as not-saved. `20260609000002_link_recurring_bank_deposits_to_plans.sql` links the conservative set — bank deposits whose **user + goal + amount match a recurring-saving plan**, in a month that has a plan — to that plan. Idempotent; manual term deposits with no matching recurring plan are left untouched. (Scope chosen by the owner: "exact recurring matches only".) Verified via dry-run to match exactly the one pre-existing deposit.

> Note: the Supabase MCP is read-only, so the migration was **not** applied from here — it runs on deploy (and on the local E2E stack).

## Tests (TDD, red→green)

- `lib/planning.test.ts` — recorded-matching: marks on match, leaves unrecorded with no match, one-deposit-per-line greedy.
- `AddTransactionSheet.test.tsx` — a prefilled bank deposit POSTs with `plan_id` + `goal_id`.
- `DesktopPlanningView` / `MobilePlanningView` tests — assert the **rendered** outcome: once a matching deposit exists, the line shows done (no *Record deposit* button) and the goal progress reads 100% / "2M in".

All planning + assets suites pass (**265 tests**); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)