### PR TITLE
chore(e2e): enable local E2E against a WSL2 Supabase stack

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,25 @@ This applies to both new features and bug fixes. Never write implementation code
 
 **TDD lesson learned:** Tests must assert the *user-visible outcome*, not just the data that enables it. For example, testing that a flag is stored correctly in the DB is necessary but not sufficient — the E2E test must also assert the rendered result (e.g. the progress bar percentage is unchanged). A passing test that only checks storage can miss bugs in a separate code path that computes the same value locally. Always close the loop: UI action → assert the rendered outcome.
 
+## What to run before opening a PR
+
+E2E was removed from CI (PR #313) and runs **locally only** — so local checks are
+the only automated gate before the Vercel preview. Scale the checks to the change:
+
+- **Always:** `npm test -- --run` (Vitest unit tests) and `npm run lint`. Fast, every PR.
+- **Targeted E2E** — when the change touches a feature area, run that area's specs,
+  e.g. `npx playwright test e2e/planning.spec.ts --project=chromium`. This is the
+  common case.
+- **Full E2E** (`npm run test:e2e`, ~8 min serial) — before merging anything broad or
+  risky: auth, layout, the dashboard overview API, shared components, a DB migration,
+  or env/config changes. Also run it after touching E2E selectors / DOM attributes /
+  i18n strings (grep `e2e/` for the old value first).
+
+Keep the local Supabase stack running for the session so spec runs are instant — see
+[Running E2E locally](README.md#running-e2e-locally). A few specs key off the current
+real date (e.g. planning's June-2026 fixtures), so they can fail as the calendar moves
+— unrelated to your change.
+
 ## Git & PR Workflow
 
 **Never push code directly to `main`.** Every change — no matter how small — must go through a branch and PR.

--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ E2E tests (Playwright) run **locally**, not in CI — the dedicated test Supabas
 supabase start            # boots local Postgres + replays all migrations
 ```
 
-Then point `.env.local` at the local stack (use the keys `supabase start` prints):
+Then create **`.env.e2e`** (gitignored, loaded by `playwright.config.ts` for non-CI
+runs) pointing both the app and the harness at the local stack, using the keys
+`supabase start` (or `supabase status -o env`) prints:
 
 ```
 NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
@@ -93,7 +95,22 @@ E2E_SUPABASE_SERVICE_ROLE_KEY=<service_role key from `supabase start`>
 npm run test:e2e          # or: npm run test:e2e:ui
 ```
 
-The guard in `e2e/helpers/guard.ts` refuses to run against the production project, so a misconfigured `.env.local` can't churn prod.
+The guard in `e2e/helpers/guard.ts` refuses to run against the production project, so a misconfigured env can't churn prod. The suite shares one auth user, so it runs serially (`workers: 1`).
+
+### Windows / WSL2 (no Docker Desktop)
+
+On Windows where Docker Desktop can't be installed (e.g. LTSC builds below 19045),
+run the Docker engine **inside WSL2** instead — same containers, still fully local:
+
+1. `wsl --install` (reboot), then complete Ubuntu's first-run user setup.
+2. Inside WSL: install Docker Engine (`get.docker.com`) and the Supabase CLI, then
+   run `supabase start` from this repo via `/mnt/...`. WSL2 forwards
+   `127.0.0.1:54321` to Windows localhost, so the app + Playwright run on Windows.
+3. If Playwright's bundled Chromium download stalls, add `PLAYWRIGHT_CHANNEL=msedge`
+   to `.env.e2e` to run against system-installed Edge (see `playwright.config.ts`).
+
+`supabase/config.toml` disables services the app doesn't use (studio, analytics,
+realtime, storage, edge functions, inbucket) to keep the stack light.
 
 ## Tech stack
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,13 +12,23 @@ const nextConfig: NextConfig = {
     // Permissive CSP baseline that doesn't break Supabase realtime, Google
     // Fonts, or Next.js inline runtime scripts. Tightening to a nonce-based
     // policy is a future follow-up.
+
+    // When pointed at a local Supabase stack (E2E against `supabase start`),
+    // allow that origin in connect-src — otherwise the browser blocks all
+    // auth/data fetches. Only added for http://localhost|127.0.0.1 URLs, so
+    // the production CSP (https://*.supabase.co only) is unaffected.
+    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
+    const localSupabase = /^http:\/\/(127\.0\.0\.1|localhost)/.test(supabaseUrl)
+      ? ` ${supabaseUrl} ${supabaseUrl.replace(/^http/, 'ws')}`
+      : ''
+
     const csp = [
       "default-src 'self'",
       "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
       "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
       "font-src 'self' data: https://fonts.gstatic.com",
       "img-src 'self' data: blob: https:",
-      "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+      `connect-src 'self' https://*.supabase.co wss://*.supabase.co${localSupabase}`,
       "frame-ancestors 'none'",
       "base-uri 'self'",
       "form-action 'self'",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,13 +9,23 @@ if (!process.env.CI && existsSync('.env.e2e')) {
 
 const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000'
 
+// Optional browser channel (e.g. 'msedge') for machines where Playwright's
+// bundled Chromium download stalls. Set PLAYWRIGHT_CHANNEL in .env.e2e to use
+// a system-installed browser instead. Unset => Playwright's bundled Chromium.
+const channel = process.env.PLAYWRIGHT_CHANNEL || undefined
+
 export default defineConfig({
   testDir: './e2e',
   globalTeardown: './e2e/global.teardown.ts',
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // Always run serially: the whole suite shares a single authenticated test user
+  // (one storageState), so parallel workers race on per-user rows — e.g. two
+  // specs inserting the same (user_id, month, year) monthly_plan collide on its
+  // unique constraint. CI already used 1 worker; E2E now runs locally too, so
+  // keep it serial everywhere rather than relying on the CI default.
+  workers: 1,
   reporter: process.env.CI
     ? [['github'], ['html', { open: 'never' }]]
     : [['list'], ['html', { open: 'on-failure' }]],
@@ -24,18 +34,21 @@ export default defineConfig({
     baseURL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    // Video capture is unreliable with the msedge channel — disable it there.
+    video: channel ? 'off' : 'retain-on-failure',
   },
 
   projects: [
     {
       name: 'setup',
       testMatch: /global\.setup\.ts/,
+      use: { channel },
     },
     {
       name: 'chromium',
       use: {
         ...devices['Desktop Chrome'],
+        channel,
         storageState: 'e2e/.auth/session.json',
       },
       testIgnore: ['**/funds.spec.ts'],
@@ -44,6 +57,7 @@ export default defineConfig({
     {
       name: 'mobile',
       use: {
+        channel,
         viewport: { width: 390, height: 844 },
         storageState: 'e2e/.auth/session.json',
       },

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,414 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "allocate"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files that describe your database.
+# Supports glob patterns relative to supabase directory: "./schemas/*.sql"
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+# Disabled for local E2E — the app doesn't use Realtime. Saves memory.
+enabled = false
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+# Disabled for local E2E — not needed to run tests. Saves memory.
+enabled = false
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+# Disabled for local E2E — email confirmations are off, so no mail testing needed.
+enabled = false
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+# Disabled for local E2E — the app doesn't use Supabase Storage. Saves memory.
+enabled = false
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+# This feature is only available on the hosted platform.
+[storage.vector]
+enabled = false
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:3000"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["https://127.0.0.1:3000"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = false
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ .Code }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ .Code }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+# Disabled for local E2E — no Supabase Edge Functions in this app. Saves memory.
+enabled = false
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+# Disabled for local E2E — Logflare/Vector are the heaviest containers. Saves memory.
+enabled = false
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# [experimental.pgdelta]
+# When enabled, pg-delta becomes the active engine for supported schema flows.
+# enabled = false
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260609000001_add_investment_transactions_fund_fk.sql
+++ b/supabase/migrations/20260609000001_add_investment_transactions_fund_fk.sql
@@ -1,0 +1,26 @@
+-- investment_transactions.fund_id links a fund transaction to its fund, but the
+-- foreign key was originally added out-of-band on the live database and never
+-- captured in a migration (see 20260321000001_unify_investments.sql, which only
+-- adds the bare column). As a result, a database built purely from migrations
+-- (e.g. a local `supabase start` stack for E2E) has no FK, so PostgREST cannot
+-- resolve the `funds(...)` embed in the dashboard overview query and returns a
+-- 500 ("Could not find a relationship between 'investment_transactions' and
+-- 'funds'").
+--
+-- Add the FK here so the migrated schema matches production. Guarded so it is a
+-- no-op on any database that already has a FK from investment_transactions to
+-- funds (i.e. production), avoiding a duplicate-constraint error on deploy.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'investment_transactions'::regclass
+      AND confrelid = 'funds'::regclass
+      AND contype = 'f'
+  ) THEN
+    ALTER TABLE investment_transactions
+      ADD CONSTRAINT investment_transactions_fund_id_fkey
+      FOREIGN KEY (fund_id) REFERENCES funds(id) ON DELETE SET NULL;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Makes the Playwright E2E suite runnable **locally** against a `supabase start` stack (E2E was removed from CI in #313), and fixes two issues that block any from-scratch schema/build — not just one machine.

## Changes
- **`next.config.ts`** — CSP `connect-src` now allows the local Supabase origin when `NEXT_PUBLIC_SUPABASE_URL` is `localhost`/`127.0.0.1`. Production CSP (`https://*.supabase.co` only) is byte-for-byte unchanged. Without this, the browser silently blocks all auth/data calls to the local stack (`Failed to fetch`).
- **`supabase/migrations/20260609000001_add_investment_transactions_fund_fk.sql`** — adds the `investment_transactions.fund_id → funds(id)` foreign key. It existed only on prod (added out-of-band; see the comment in `20260321000001_unify_investments.sql`), so the dashboard overview's `funds(...)` PostgREST embed 500'd on a freshly migrated DB. **Guarded** to be a no-op where the FK already exists (prod), so it won't error on deploy.
- **`playwright.config.ts`** — adds `PLAYWRIGHT_CHANNEL` support (run against system-installed Edge when Playwright's bundled Chromium download stalls) and forces `workers: 1`. The suite shares a single auth user, so parallel workers race on per-user rows (e.g. the `(user_id, month, year)` monthly_plan unique constraint).
- **`supabase/config.toml`** (+ `supabase/.gitignore`) — scaffolds the local stack, trimmed to `db`/`auth`/`rest`/`api` (the app uses no realtime/storage/edge functions) to keep it light.
- **`README.md` / `CLAUDE.md`** — document the WSL2/Windows setup and what to run before opening a PR.

## Testing
Full suite against the local stack: **263 passed, 1 skipped, 0 failed** (chromium + mobile).

## Notes
- `.env.e2e` (gitignored) holds the local keys + `PLAYWRIGHT_CHANNEL=msedge` and is not committed.
- The only prod-affecting change is the FK migration, which is a guarded no-op there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)