### PR TITLE
fix(goal-detail): History date format matches Recent activity (#300)

### DIFF
--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownR
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
 import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, AffectsProgressControl, type InvRow } from './goalDetailShared'
+import { fmtTxDate } from './transactionUtils'
 
 interface InvestmentTx {
   transaction_id: string
@@ -471,7 +472,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                     <div style={{ flex: 1, minWidth: 0 }}>
                       <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--c-ink)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{name}</div>
                       <div style={{ fontSize: 10, color: 'var(--c-muted)', marginTop: 1 }}>
-                        {new Date(tx.investment_date).toLocaleDateString(isVi ? 'vi-VN' : 'en-US')}
+                        {fmtTxDate(tx.investment_date, locale)}
                       </div>
                     </div>
                     <span style={{ fontSize: 12, fontWeight: 600, color: isWithdraw ? 'var(--c-neg)' : 'var(--c-pos)', fontVariantNumeric: 'tabular-nums', flexShrink: 0 }}>

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -11,6 +11,7 @@ import type { GoalData, FundBreakdownItem } from '../DashboardClient'
 import TransactionHistorySheet, { type PurchaseHistoryRow } from './TransactionHistorySheet'
 import { SellWithdrawSheet, type SellItem } from './SellWithdrawSheet'
 import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, type InvRow } from './goalDetailShared'
+import { fmtTxDate } from './transactionUtils'
 
 interface InvestmentTx {
   transaction_id: string
@@ -1171,7 +1172,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
                     <div style={{ flex: 1 }}>
                       <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--c-ink)' }}>{name}</div>
                       <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2 }}>
-                        {new Date(tx.investment_date).toLocaleDateString(isVI ? 'vi-VN' : 'en-US')}
+                        {fmtTxDate(tx.investment_date, isVI ? 'vi' : 'en')}
                       </div>
                     </div>
                     <span style={{ fontSize: 13, fontWeight: 600, color: isWithdraw ? 'var(--c-neg)' : 'var(--c-pos)', fontVariantNumeric: 'tabular-nums' }}>

--- a/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
@@ -139,6 +139,49 @@ describe('DesktopGoalDetail — bank withdrawal links to the goal (issue #261)',
   })
 })
 
+describe('DesktopGoalDetail — History date matches Recent activity (issue #300)', () => {
+  const mockTx = {
+    transaction_id: 'tx-1',
+    transaction_type: 'investment',
+    asset_type: 'gold',
+    fund_id: null,
+    fund_name: null,
+    investment_date: '2026-01-01',
+    amount_vnd: 9_000_000,
+    units: 1,
+    interest_rate: null,
+    notes: 'PNJ Gold',
+    principal_withdrawn: null,
+    units_withdrawn: null,
+  }
+
+  beforeEach(() => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [mockTx] }) })
+      }
+      if (url.includes('gold-price')) {
+        return Promise.resolve({ ok: true, json: async () => ({ price_per_chi: 9_200_000 }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+  })
+
+  it('renders the History row date in the same "01 Jan 2026" format as the Recent activity card', async () => {
+    render(<DesktopGoalDetail {...baseProps} />)
+    await waitFor(() => screen.getByText('PNJ Gold'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'History' }))
+
+    // Must match fmtTxDate (day: 2-digit, month: short, year: numeric — en-GB),
+    // not the browser-default "1/1/2026" the History tab used to print. The raw
+    // `new Date('2026-01-01')` also parsed as UTC midnight, shifting the day in
+    // negative-offset timezones — fmtTxDate pins it to local midnight.
+    await waitFor(() => expect(screen.getByText('01 Jan 2026')).toBeInTheDocument())
+    expect(screen.queryByText('1/1/2026')).not.toBeInTheDocument()
+  })
+})
+
 describe('DesktopGoalDetail — singular month wording (issue #262)', () => {
   // 1,000,000₫ left to reach the target.
   const nearGoal: GoalData = { ...mockGoal, targetAmount: 10_000_000, currentValue: 9_000_000, targetDate: null }

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -111,6 +111,20 @@ describe('GoalDetailSheet — DCA pending row filtering', () => {
   })
 })
 
+describe('GoalDetailSheet — History date matches Recent activity (issue #300)', () => {
+  it('renders the History row date in the same "15 Jan 2024" format as the Recent activity card', async () => {
+    render(<GoalDetailSheet {...baseProps} />)
+    await waitFor(() => expect(screen.getByText('VNINDEX ETF')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByRole('button', { name: 'History' }))
+
+    // Must match fmtTxDate (day: 2-digit, month: short, year: numeric — en-GB),
+    // not the browser-default "1/15/2024" the History tab used to print.
+    await waitFor(() => expect(screen.getByText('15 Jan 2024')).toBeInTheDocument())
+    expect(screen.queryByText('1/15/2024')).not.toBeInTheDocument()
+  })
+})
+
 describe('GoalDetailSheet — transaction history integration', () => {
   it('opens TransactionHistorySheet when "Transaction history" is tapped on a fund', async () => {
     render(<GoalDetailSheet {...baseProps} />)


### PR DESCRIPTION
Fixes #300 — *Goal detail · History tab · Date not consistent with Recent activity*.

## Problem
The Goal detail **History** tab rendered transaction dates with
`new Date(tx.investment_date).toLocaleDateString(...)`, producing a browser-default numeric format like `1/1/2026`. The **Recent activity** card uses the shared `fmtTxDate()` helper, which renders `01 Jan 2026` (`en-GB`, `day: 2-digit, month: short, year: numeric`). So the same transaction showed two different date strings depending on where you looked.

There was also a latent **off-by-one** bug: a date-only string (`2026-01-01`) parsed by the bare `Date` constructor is treated as **UTC midnight**, which shifts the day back one in negative-offset timezones. The test runner rendered `1/14/2024` for a `2024-01-15` transaction — confirming it. `fmtTxDate` appends `'T00:00:00'` so the date is pinned to **local** midnight.

## Fix
Both the desktop (`DesktopGoalDetail`) and mobile (`GoalDetailSheet`) History tabs now call the same `fmtTxDate()` helper Recent activity already uses. One source of truth → identical, timezone-safe dates everywhere.

## Tests (TDD)
Added a failing test to each component's suite asserting the History row renders the `fmtTxDate` format and not the old numeric one, then made them pass:
- `DesktopGoalDetail.test.tsx` — `01 Jan 2026`, not `1/1/2026`
- `GoalDetailSheet.test.tsx` — `15 Jan 2024`, not `1/15/2024`

## Verification
- `npm test -- --run` → **514 passed**
- `npm run lint` → no new errors on the changed files (only pre-existing `react-hooks/set-state-in-effect` warnings unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)