### PR TITLE
feat(goal-detail): show bank deposit maturity in Options modal (#263)

### DIFF
--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, AffectsProgressControl, type InvRow } from './goalDetailShared'
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, AffectsProgressControl, BankInfoStrip, type InvRow } from './goalDetailShared'
 import { fmtTxDate } from './transactionUtils'
 
 interface InvestmentTx {
@@ -18,6 +18,7 @@ interface InvestmentTx {
   amount_vnd: number
   units: number | null
   interest_rate: number | null
+  expiry_date: string | null
   notes: string | null
   principal_withdrawn: number | null
   units_withdrawn: number | null
@@ -621,6 +622,9 @@ function InvOptionsModal({ inv, isVi, onClose, onHistory, onSell, onUnassign }: 
             </div>
           </div>
         </div>
+
+        {/* Bank info strip — interest rate + maturity + time left (issue #263) */}
+        <BankInfoStrip inv={inv} isVi={isVi} />
 
         {actions.map((a, i) => (
           <button key={i} onClick={a.onClick} style={{

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -10,7 +10,7 @@ import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData, FundBreakdownItem } from '../DashboardClient'
 import TransactionHistorySheet, { type PurchaseHistoryRow } from './TransactionHistorySheet'
 import { SellWithdrawSheet, type SellItem } from './SellWithdrawSheet'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, type InvRow } from './goalDetailShared'
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, BankInfoStrip, type InvRow } from './goalDetailShared'
 import { fmtTxDate } from './transactionUtils'
 
 interface InvestmentTx {
@@ -429,6 +429,9 @@ function InvestmentActionSheet({
               </div>
             </div>
           </div>
+
+          {/* Bank info strip — interest rate + maturity + time left (issue #263) */}
+          <BankInfoStrip inv={inv} isVi={isVI} />
 
           {/* View history */}
           <button

--- a/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
@@ -182,6 +182,64 @@ describe('DesktopGoalDetail — History date matches Recent activity (issue #300
   })
 })
 
+describe('DesktopGoalDetail — bank maturity in Options modal (issue #263)', () => {
+  const mockBankTx = {
+    transaction_id: 'tx-bank-1',
+    transaction_type: 'investment',
+    asset_type: 'bank',
+    fund_id: null,
+    fund_name: null,
+    parent_transaction_id: null,
+    investment_date: '2026-01-01',
+    amount_vnd: 10_000_000,
+    units: null,
+    interest_rate: 6,
+    expiry_date: '2030-08-15',
+    notes: 'Techcombank',
+    principal_withdrawn: null,
+    units_withdrawn: null,
+  }
+
+  beforeEach(() => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [mockBankTx] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+  })
+
+  it('shows the maturity date and time-left for a bank deposit', async () => {
+    render(<DesktopGoalDetail {...baseProps} />)
+    await waitFor(() => screen.getByText('Techcombank'))
+
+    await userEvent.click(screen.getByRole('button', { name: 'Options' }))
+
+    // Bank info strip: interest rate + maturity date + time left.
+    await waitFor(() => expect(screen.getByText('Maturity')).toBeInTheDocument())
+    expect(screen.getByText('15 Aug 2030')).toBeInTheDocument()
+    expect(screen.getByText('Time left')).toBeInTheDocument()
+    expect(screen.getByText(/days left/)).toBeInTheDocument()
+    expect(screen.getByText('6%/yr')).toBeInTheDocument()
+  })
+
+  it('does not show a maturity row when the deposit has no expiry', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [{ ...mockBankTx, expiry_date: null }] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    render(<DesktopGoalDetail {...baseProps} />)
+    await waitFor(() => screen.getByText('Techcombank'))
+    await userEvent.click(screen.getByRole('button', { name: 'Options' }))
+
+    await waitFor(() => expect(screen.getByText('6%/yr')).toBeInTheDocument())
+    expect(screen.queryByText('Maturity')).not.toBeInTheDocument()
+  })
+})
+
 describe('DesktopGoalDetail — singular month wording (issue #262)', () => {
   // 1,000,000₫ left to reach the target.
   const nearGoal: GoalData = { ...mockGoal, targetAmount: 10_000_000, currentValue: 9_000_000, targetDate: null }

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -334,6 +334,45 @@ describe('GoalDetailSheet — investment options Sell / history (issue #224)', (
   })
 })
 
+describe('GoalDetailSheet — bank maturity in Options sheet (issue #263)', () => {
+  const mockBankTx = {
+    transaction_id: 'tx-bank-1',
+    transaction_type: 'investment',
+    asset_type: 'bank',
+    fund_id: null,
+    fund_name: null,
+    fund_code: null,
+    investment_date: '2026-01-01',
+    amount_vnd: 5_000_000,
+    units: null,
+    unit_price: null,
+    interest_rate: 6,
+    expiry_date: '2030-08-15',
+    notes: 'Techcombank',
+    principal_withdrawn: null,
+    units_withdrawn: null,
+  }
+  const bankGoal: GoalData = { ...mockGoal, funds: [] }
+
+  it('shows the maturity date and time-left for a bank deposit', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [mockBankTx] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+    render(<GoalDetailSheet {...baseProps} goal={bankGoal} />)
+    await waitFor(() => screen.getByText('Techcombank'))
+    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+
+    await waitFor(() => expect(screen.getByText('Maturity')).toBeInTheDocument())
+    expect(screen.getByText('15 Aug 2030')).toBeInTheDocument()
+    expect(screen.getByText('Time left')).toBeInTheDocument()
+    expect(screen.getByText(/days left/)).toBeInTheDocument()
+    expect(screen.getByText('6%/yr')).toBeInTheDocument()
+  })
+})
+
 describe('GoalDetailSheet — gold sell uses current price (issue #251)', () => {
   // Bought 1 chỉ at 9,000,000. Current market price is 9,200,000.
   const mockGoldTx = {

--- a/app/assets/components/__tests__/goalDetailShared.test.tsx
+++ b/app/assets/components/__tests__/goalDetailShared.test.tsx
@@ -1,6 +1,14 @@
 import { describe, it, expect } from 'vitest'
-import { buildInvRows, calcDeadlineMonths, type GoalDetailTx } from '../goalDetailShared'
+import { buildInvRows, calcDeadlineMonths, fmtMaturity, type GoalDetailTx } from '../goalDetailShared'
 import type { FundBreakdownItem } from '../../DashboardClient'
+
+// A YYYY-MM-DD string `n` days from today (deterministic regardless of run date).
+function daysFromNow(n: number): string {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  d.setDate(d.getDate() + n)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
 
 const baseTx = (over: Partial<GoalDetailTx>): GoalDetailTx => ({
   transaction_id: 't', transaction_type: 'investment', asset_type: 'gold',
@@ -127,6 +135,68 @@ describe('buildInvRows', () => {
       [], 9_200_000, true,
     )
     expect(rows[0].name).toBe('Vàng')
+  })
+
+  it('carries the bank deposit maturity (expiry_date) through to the row (issue #263)', () => {
+    const rows = buildInvRows(
+      [baseTx({ transaction_id: 'b1', asset_type: 'bank', amount_vnd: 5_000_000, interest_rate: 6, expiry_date: '2026-08-15' })],
+      [], null, false,
+    )
+    expect(rows[0].expiryDate).toBe('2026-08-15')
+  })
+
+  it('leaves expiryDate null when the deposit has no maturity', () => {
+    const rows = buildInvRows(
+      [baseTx({ transaction_id: 'b1', asset_type: 'bank', amount_vnd: 5_000_000, interest_rate: 6 })],
+      [], null, false,
+    )
+    expect(rows[0].expiryDate).toBeNull()
+  })
+})
+
+describe('fmtMaturity (issue #263)', () => {
+  it('returns null for a missing date', () => {
+    expect(fmtMaturity(null, false)).toBeNull()
+    expect(fmtMaturity('', false)).toBeNull()
+  })
+
+  it('formats the maturity date as "DD Mon YYYY"', () => {
+    expect(fmtMaturity('2026-08-15', false)?.formatted).toBe('15 Aug 2026')
+  })
+
+  it('counts down the days left and stays neutral when far out', () => {
+    const m = fmtMaturity(daysFromNow(200), false)!
+    expect(m.diffDays).toBe(200)
+    expect(m.relative).toBe('200 days left')
+    expect(m.tone).toBe('neutral')
+  })
+
+  it('warns when maturity is within 30 days', () => {
+    const m = fmtMaturity(daysFromNow(10), false)!
+    expect(m.relative).toBe('10 days left')
+    expect(m.tone).toBe('warn')
+  })
+
+  it('uses the singular "1 day left"', () => {
+    expect(fmtMaturity(daysFromNow(1), false)!.relative).toBe('1 day left')
+  })
+
+  it('says "Matures today" on the maturity day', () => {
+    const m = fmtMaturity(daysFromNow(0), false)!
+    expect(m.relative).toBe('Matures today')
+    expect(m.tone).toBe('warn')
+  })
+
+  it('says "Matured" once the date has passed', () => {
+    const m = fmtMaturity(daysFromNow(-5), false)!
+    expect(m.relative).toBe('Matured')
+    expect(m.tone).toBe('pos')
+  })
+
+  it('localises the relative text in Vietnamese', () => {
+    expect(fmtMaturity(daysFromNow(10), true)!.relative).toBe('Còn 10 ngày')
+    expect(fmtMaturity(daysFromNow(-5), true)!.relative).toBe('Đã đáo hạn')
+    expect(fmtMaturity(daysFromNow(0), true)!.relative).toBe('Đáo hạn hôm nay')
   })
 })
 

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -5,6 +5,7 @@
 
 import { TrendingUp, Building, Coins, BarChart2, Target } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
+import { fmtTxDate } from './transactionUtils'
 import type { FundBreakdownItem } from '../DashboardClient'
 
 export const GD_COLORS: Record<string, string> = {
@@ -154,6 +155,8 @@ export interface InvRow {
   units: number | null
   principal: number | null
   interestRate: number | null
+  // Bank deposit maturity (YYYY-MM-DD); null for non-bank holdings or no term.
+  expiryDate: string | null
   fund: FundBreakdownItem | null
 }
 
@@ -169,6 +172,7 @@ export interface GoalDetailTx {
   amount_vnd: number
   units: number | null
   interest_rate: number | null
+  expiry_date?: string | null
   notes: string | null
   principal_withdrawn: number | null
   units_withdrawn: number | null
@@ -257,6 +261,74 @@ export function buildInvRows(
       }
     }
 
-    return { id: tx.transaction_id, name, type: tx.asset_type, value, gainPct, units, principal, interestRate: tx.interest_rate ?? null, fund: fund ?? null }
+    return { id: tx.transaction_id, name, type: tx.asset_type, value, gainPct, units, principal, interestRate: tx.interest_rate ?? null, expiryDate: tx.expiry_date ?? null, fund: fund ?? null }
   }).filter((row): row is InvRow => row !== null)
+}
+
+// A bank-deposit maturity date, formatted for display plus a relative
+// "time left" summary. Returns null when there's no date. `tone` drives the
+// colour: 'warn' when due within 30 days (or today), 'pos' once matured,
+// 'neutral' otherwise (issue #263).
+export interface Maturity {
+  formatted: string
+  diffDays: number
+  relative: string
+  tone: 'neutral' | 'warn' | 'pos'
+}
+
+export function fmtMaturity(dateStr: string | null | undefined, isVi: boolean): Maturity | null {
+  if (!dateStr) return null
+  const d = new Date(dateStr + 'T00:00:00')
+  if (isNaN(d.getTime())) return null
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  const diffDays = Math.round((d.getTime() - today.getTime()) / 86_400_000)
+  const formatted = fmtTxDate(dateStr, isVi ? 'vi' : 'en')
+
+  let relative: string
+  let tone: Maturity['tone'] = 'neutral'
+  if (diffDays < 0) {
+    relative = isVi ? 'Đã đáo hạn' : 'Matured'
+    tone = 'pos'
+  } else if (diffDays === 0) {
+    relative = isVi ? 'Đáo hạn hôm nay' : 'Matures today'
+    tone = 'warn'
+  } else if (diffDays <= 30) {
+    relative = isVi ? `Còn ${diffDays} ngày` : `${diffDays} day${diffDays === 1 ? '' : 's'} left`
+    tone = 'warn'
+  } else {
+    relative = isVi ? `Còn ${diffDays} ngày` : `${diffDays} days left`
+  }
+  return { formatted, diffDays, relative, tone }
+}
+
+// Bank-deposit info strip shown in the investment Options modal: interest rate,
+// maturity date and time-left. Renders nothing for non-bank holdings or when
+// there's no info to show (issue #263). Shared so desktop + mobile stay in sync.
+export function BankInfoStrip({ inv, isVi }: { inv: InvRow; isVi: boolean }) {
+  if (inv.type !== 'bank') return null
+  const m = fmtMaturity(inv.expiryDate, isVi)
+  const cells: { l: string; v: string; tone?: Maturity['tone'] }[] = []
+  if (inv.interestRate != null) {
+    cells.push({ l: isVi ? 'Lãi suất' : 'Interest rate', v: `${inv.interestRate}%/${isVi ? 'năm' : 'yr'}` })
+  }
+  if (m) {
+    cells.push({ l: isVi ? 'Ngày đáo hạn' : 'Maturity', v: m.formatted })
+    cells.push({ l: isVi ? 'Còn lại' : 'Time left', v: m.relative, tone: m.tone })
+  }
+  if (!cells.length) return null
+
+  return (
+    <div data-testid="bank-info-strip" style={{ display: 'grid', gridTemplateColumns: `repeat(${cells.length}, 1fr)`, gap: 1, background: 'var(--c-line)', borderRadius: 10, overflow: 'hidden', marginBottom: 4 }}>
+      {cells.map((c, i) => {
+        const color = c.tone === 'warn' ? 'var(--c-warn)' : c.tone === 'pos' ? 'var(--c-pos)' : 'var(--c-ink)'
+        return (
+          <div key={i} style={{ background: 'var(--c-card)', padding: '8px 10px' }}>
+            <div style={{ fontSize: 10, color: 'var(--c-muted)' }}>{c.l}</div>
+            <div style={{ fontSize: 12, fontWeight: 600, marginTop: 2, color, fontVariantNumeric: 'tabular-nums' }}>{c.v}</div>
+          </div>
+        )
+      })}
+    </div>
+  )
 }


### PR DESCRIPTION
## What

Closes #263 — show the maturity (expiry) date for a bank deposit when opening the investment **Options** modal.

Previously the Options modal showed only the holding name, value and gain — nothing about a deposit's term. This adds a **bank info strip** below the item summary with three cells, matching the design:

- **Interest rate** (e.g. `6%/yr`)
- **Maturity** date (e.g. `15 Aug 2026`)
- **Time left** — a relative countdown that turns **amber** within 30 days / on the maturity day and **green** once matured

It renders only for bank holdings, and skips the maturity/time-left cells when the deposit has no term.

## How

- `goalDetailShared.tsx`
  - carry `expiry_date` through `buildInvRows` onto `InvRow.expiryDate`
  - add `fmtMaturity()` (formatted date + relative text + tone)
  - add a shared `BankInfoStrip` component so desktop + mobile stay in sync
- `DesktopGoalDetail.tsx` / `GoalDetailSheet.tsx` — render `<BankInfoStrip>` in the Options modal/sheet; add `expiry_date` to the desktop tx type

The `/api/v1/investment-transactions` GET already returns `expiry_date`, so no API change was needed.

## Tests (TDD)

- `goalDetailShared.test.tsx` — `expiryDate` passthrough + full `fmtMaturity` coverage (far-out / within-30-days / today / matured, singular day, VI localisation)
- `DesktopGoalDetail.test.tsx` / `GoalDetailSheet.test.tsx` — opening Options on a bank deposit renders the maturity date, time-left and rate; no maturity row when there's no expiry

`npm test -- --run` → 527 passed. `tsc --noEmit` clean. No new lint errors (pre-existing `set-state-in-effect` only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
