### PR TITLE
feat(loading): button mutation states use the Cairn loader (#235)

### DIFF
--- a/app/(app)/planning/components/DirectSavingsSection.tsx
+++ b/app/(app)/planning/components/DirectSavingsSection.tsx
@@ -7,6 +7,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
+import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import type { MonthlyPlan, DirectSaving, Goal } from '../PlanningClient'
 import { fmt } from '@/lib/formatters'
@@ -204,7 +205,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
             <div className="flex gap-3">
               <Button type="button" variant="outline" className="flex-1" onClick={() => setShowForm(false)}>{tc('cancel')}</Button>
               <Button type="submit" className="flex-1 bg-emerald-600 hover:bg-emerald-700" disabled={saving}>
-                {saving && <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />}
+                {saving && <CairnLoader size={14} variant="on-dark" />}
                 {saving ? tc('saving') : tc('save')}
               </Button>
             </div>

--- a/app/(app)/planning/components/DirectSavingsSection.tsx
+++ b/app/(app)/planning/components/DirectSavingsSection.tsx
@@ -32,6 +32,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
   const [formError, setFormError] = useState('')
   const [saving, setSaving] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState<DirectSaving | null>(null)
+  const [deleting, setDeleting] = useState(false)
 
   const minDate = new Date(plan.year, plan.month - 1, 1).toISOString().split('T')[0]
   const maxDate = new Date(plan.year, plan.month, 0).toISOString().split('T')[0]
@@ -104,11 +105,16 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
   }
 
   async function handleDelete(item: DirectSaving) {
-    const res = await fetch(`/api/v1/investment-transactions/${item.transaction_id}`, { method: 'DELETE' })
-    if (res.ok) {
-      setConfirmDelete(null)
-      onToast(t('savingsDeleted'))
-      onRefresh()
+    setDeleting(true)
+    try {
+      const res = await fetch(`/api/v1/investment-transactions/${item.transaction_id}`, { method: 'DELETE' })
+      if (res.ok) {
+        setConfirmDelete(null)
+        onToast(t('savingsDeleted'))
+        onRefresh()
+      }
+    } finally {
+      setDeleting(false)
     }
   }
 
@@ -153,7 +159,7 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
                     <button onClick={() => openEdit(item)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                       <Edit className="h-4 w-4 text-blue-600 dark:text-blue-400" />
                     </button>
-                    <button onClick={() => setConfirmDelete(item)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+                    <button aria-label={tc('delete')} onClick={() => setConfirmDelete(item)} className="h-8 w-8 inline-flex items-center justify-center rounded-md hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                       <Trash2 className="h-4 w-4 text-red-600 dark:text-red-400" />
                     </button>
                   </div>
@@ -226,8 +232,11 @@ export default function DirectSavingsSection({ plan, savings, goals, onRefresh, 
             <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">{t('deleteSavingsMessage')}</p>
           </div>
           <div className="flex gap-3">
-            <Button variant="outline" className="flex-1" onClick={() => setConfirmDelete(null)}>{tc('cancel')}</Button>
-            <Button className="flex-1 bg-red-600 hover:bg-red-700" onClick={() => confirmDelete && handleDelete(confirmDelete)}>{tc('delete')}</Button>
+            <Button variant="outline" className="flex-1" onClick={() => setConfirmDelete(null)} disabled={deleting}>{tc('cancel')}</Button>
+            <Button data-testid="savings-delete-confirm" className="flex-1 bg-red-600 hover:bg-red-700" onClick={() => confirmDelete && handleDelete(confirmDelete)} disabled={deleting}>
+              {deleting && <CairnLoader size={14} variant="on-dark" />}
+              {deleting ? tc('deleting') : tc('delete')}
+            </Button>
           </div>
         </DialogContent>
       </Dialog>

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -34,6 +34,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
   const [formError, setFormError] = useState('')
   const [saving, setSaving] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState<FundInvestment | null>(null)
+  const [deleting, setDeleting] = useState(false)
 
   const minDate = new Date(plan.year, plan.month - 1, 1).toISOString().split('T')[0]
   const maxDate = new Date(plan.year, plan.month, 0).toISOString().split('T')[0]
@@ -113,11 +114,16 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
   }
 
   async function handleDelete(inv: FundInvestment) {
-    const res = await fetch(`/api/v1/investment-transactions/${inv.transaction_id}`, { method: 'DELETE' })
-    if (res.ok) {
-      setConfirmDelete(null)
-      onToast(t('fundDeleted'))
-      onRefresh()
+    setDeleting(true)
+    try {
+      const res = await fetch(`/api/v1/investment-transactions/${inv.transaction_id}`, { method: 'DELETE' })
+      if (res.ok) {
+        setConfirmDelete(null)
+        onToast(t('fundDeleted'))
+        onRefresh()
+      }
+    } finally {
+      setDeleting(false)
     }
   }
 
@@ -257,8 +263,11 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
             <p className="text-sm text-gray-600 dark:text-gray-400 leading-relaxed">{t('deleteFundMessage')}</p>
           </div>
           <div className="flex gap-3">
-            <Button variant="outline" className="flex-1" onClick={() => setConfirmDelete(null)}>{tc('cancel')}</Button>
-            <Button className="flex-1 bg-red-600 hover:bg-red-700" onClick={() => confirmDelete && handleDelete(confirmDelete)}>{tc('delete')}</Button>
+            <Button variant="outline" className="flex-1" onClick={() => setConfirmDelete(null)} disabled={deleting}>{tc('cancel')}</Button>
+            <Button data-testid="fund-delete-confirm" className="flex-1 bg-red-600 hover:bg-red-700" onClick={() => confirmDelete && handleDelete(confirmDelete)} disabled={deleting}>
+              {deleting && <CairnLoader size={14} variant="on-dark" />}
+              {deleting ? tc('deleting') : tc('delete')}
+            </Button>
           </div>
         </DialogContent>
       </Dialog>

--- a/app/(app)/planning/components/FundInvestmentsSection.tsx
+++ b/app/(app)/planning/components/FundInvestmentsSection.tsx
@@ -9,6 +9,7 @@ import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import DecimalInput from '@/app/components/ui/DecimalInput'
+import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import type { MonthlyPlan, FundInvestment, Fund, Goal } from '../PlanningClient'
 import { fmt } from '@/lib/formatters'
 
@@ -235,7 +236,7 @@ export default function FundInvestmentsSection({ plan, investments, funds, goals
             <div className="flex gap-3">
               <Button type="button" variant="outline" className="flex-1" onClick={() => setShowForm(false)}>{tc('cancel')}</Button>
               <Button type="submit" className="flex-1 bg-emerald-600 hover:bg-emerald-700" disabled={saving}>
-                {saving && <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />}
+                {saving && <CairnLoader size={14} variant="on-dark" />}
                 {saving ? tc('saving') : tc('save')}
               </Button>
             </div>

--- a/app/(app)/planning/components/InsuranceSection.tsx
+++ b/app/(app)/planning/components/InsuranceSection.tsx
@@ -26,6 +26,7 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
   const [formError, setFormError] = useState('')
   const [saving, setSaving] = useState(false)
   const [confirmSkip, setConfirmSkip] = useState<InsuranceMember | null>(null)
+  const [skipping, setSkipping] = useState(false)
 
   function openEdit(member: InsuranceMember) {
     setEditItem(member)
@@ -65,14 +66,19 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
   }
 
   async function handleSkip(member: InsuranceMember) {
-    await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ member_id: member.member_id }),
-    })
-    setConfirmSkip(null)
-    onToast(t('insuranceSkipped', { name: member.member_name }))
-    onRefresh()
+    setSkipping(true)
+    try {
+      await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ member_id: member.member_id }),
+      })
+      setConfirmSkip(null)
+      onToast(t('insuranceSkipped', { name: member.member_name }))
+      onRefresh()
+    } finally {
+      setSkipping(false)
+    }
   }
 
   async function handleRestore(member: InsuranceMember) {
@@ -215,8 +221,11 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
             )}
           </div>
           <div className="flex gap-3">
-            <Button variant="outline" className="flex-1" onClick={() => setConfirmSkip(null)}>{tc('cancel')}</Button>
-            <Button className="flex-1 bg-red-600 hover:bg-red-700" onClick={() => confirmSkip && handleSkip(confirmSkip)}>{t('skipConfirm')}</Button>
+            <Button variant="outline" className="flex-1" onClick={() => setConfirmSkip(null)} disabled={skipping}>{tc('cancel')}</Button>
+            <Button data-testid="insurance-skip-confirm" className="flex-1 bg-red-600 hover:bg-red-700" onClick={() => confirmSkip && handleSkip(confirmSkip)} disabled={skipping}>
+              {skipping && <CairnLoader size={14} variant="on-dark" />}
+              {skipping ? t('skipping') : t('skipConfirm')}
+            </Button>
           </div>
         </DialogContent>
       </Dialog>

--- a/app/(app)/planning/components/InsuranceSection.tsx
+++ b/app/(app)/planning/components/InsuranceSection.tsx
@@ -7,6 +7,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
+import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import type { MonthlyPlan, InsuranceMember } from '../PlanningClient'
 import { fmt } from '@/lib/formatters'
 
@@ -189,7 +190,7 @@ export default function InsuranceSection({ plan, insuranceMembers, onRefresh, on
             <div className="flex gap-3">
               <Button type="button" variant="outline" className="flex-1" onClick={() => setEditItem(null)}>{tc('cancel')}</Button>
               <Button type="submit" className="flex-1 bg-emerald-600 hover:bg-emerald-700" disabled={saving}>
-                {saving && <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />}
+                {saving && <CairnLoader size={14} variant="on-dark" />}
                 {saving ? tc('saving') : tc('save')}
               </Button>
             </div>

--- a/app/(app)/planning/components/OtherExpensesSection.tsx
+++ b/app/(app)/planning/components/OtherExpensesSection.tsx
@@ -7,6 +7,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Button } from '@/components/ui/button'
+import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import type { MonthlyPlan, OtherExpense } from '../PlanningClient'
 import { fmt } from '@/lib/formatters'
 
@@ -163,7 +164,7 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
             <div className="flex gap-3">
               <Button type="button" variant="outline" className="flex-1" onClick={() => setShowForm(false)}>{tc('cancel')}</Button>
               <Button type="submit" className="flex-1 bg-emerald-600 hover:bg-emerald-700" disabled={saving}>
-                {saving && <span className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />}
+                {saving && <CairnLoader size={14} variant="on-dark" />}
                 {saving ? tc('saving') : tc('save')}
               </Button>
             </div>

--- a/app/(app)/planning/components/OtherExpensesSection.tsx
+++ b/app/(app)/planning/components/OtherExpensesSection.tsx
@@ -187,7 +187,8 @@ export default function OtherExpensesSection({ plan, otherExpenses, onRefresh, o
           </div>
           <div className="flex gap-3">
             <Button variant="outline" className="flex-1" onClick={() => setConfirmDelete(null)} disabled={deleting}>{tc('cancel')}</Button>
-            <Button className="flex-1 bg-red-600 hover:bg-red-700" onClick={() => confirmDelete && handleDelete(confirmDelete)} disabled={deleting}>
+            <Button data-testid="other-delete-confirm" className="flex-1 bg-red-600 hover:bg-red-700" onClick={() => confirmDelete && handleDelete(confirmDelete)} disabled={deleting}>
+              {deleting && <CairnLoader size={14} variant="on-dark" />}
               {deleting ? tc('deleting') : tc('delete')}
             </Button>
           </div>

--- a/app/(app)/planning/components/SalaryInput.tsx
+++ b/app/(app)/planning/components/SalaryInput.tsx
@@ -6,6 +6,7 @@ import { AlertTriangle } from 'lucide-react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import AmountInput from '@/app/components/ui/AmountInput'
 import { Button } from '@/components/ui/button'
+import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import type { MonthlyPlan } from '../PlanningClient'
 
 interface Props {
@@ -108,7 +109,7 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
               className="px-3 h-9 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
             >
               {deleting ? (
-                <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />
+                <CairnLoader size={14} variant="on-dark" />
               ) : (
                 tc('delete')
               )}
@@ -127,9 +128,7 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
             placeholder={t('salaryPlaceholder')}
             className="flex-1 px-3 py-2 border border-gray-200 dark:border-gray-600 rounded-md text-lg font-medium bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-60"
           />
-          {saving && (
-            <div className="w-5 h-5 border-2 border-emerald-600 border-t-transparent rounded-full animate-spin" />
-          )}
+          {saving && <CairnLoader size={16} variant="muted" />}
         </div>
       </div>
 

--- a/app/(app)/planning/components/SalaryInput.tsx
+++ b/app/(app)/planning/components/SalaryInput.tsx
@@ -106,13 +106,10 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
             <button
               onClick={() => setShowConfirm(true)}
               disabled={deleting || saving}
-              className="px-3 h-9 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
+              className="px-3 h-9 inline-flex items-center justify-center gap-2 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 disabled:opacity-60 disabled:cursor-not-allowed transition-colors"
             >
-              {deleting ? (
-                <CairnLoader size={14} variant="on-dark" />
-              ) : (
-                tc('delete')
-              )}
+              {deleting && <CairnLoader size={14} variant="on-dark" />}
+              {deleting ? tc('deleting') : tc('delete')}
             </button>
           )}
         </div>
@@ -128,7 +125,7 @@ export default function SalaryInput({ plan, month, year, onPlanCreated, onPlanDe
             placeholder={t('salaryPlaceholder')}
             className="flex-1 px-3 py-2 border border-gray-200 dark:border-gray-600 rounded-md text-lg font-medium bg-gray-50 dark:bg-gray-800 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-emerald-500 disabled:opacity-60"
           />
-          {saving && <CairnLoader size={16} variant="muted" />}
+          {saving && <CairnLoader size={14} variant="muted" />}
         </div>
       </div>
 

--- a/app/(app)/planning/components/__tests__/DirectSavingsSectionDelete.test.tsx
+++ b/app/(app)/planning/components/__tests__/DirectSavingsSectionDelete.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import DirectSavingsSection from '../DirectSavingsSection'
+import type { MonthlyPlan, DirectSaving, Goal } from '../../PlanningClient'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+vi.mock('@/lib/formatters', () => ({ fmt: (n: number) => `₫${n}` }))
+
+const plan: MonthlyPlan = { id: 'p1', month: 6, year: 2026, salary_vnd: 45_000_000 }
+const saving: DirectSaving = {
+  transaction_id: 't1', plan_id: 'p1', goal_id: null, amount_vnd: 5_000_000,
+  interest_rate: null, expiry_date: null, investment_date: '2026-06-01', savings_goals: null,
+}
+const goals: Goal[] = []
+
+afterEach(() => vi.unstubAllGlobals())
+
+// §04: destructive mutations (delete) get the same in-button Cairn + disabled +
+// tense as other mutations, and must not be double-submittable.
+describe('DirectSavingsSection delete loading state', () => {
+  it('shows the Cairn loader and disables the confirm button while deleting', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {}))) // never resolves → stays deleting
+    render(
+      <DirectSavingsSection plan={plan} savings={[saving]} goals={goals} onRefresh={() => {}} onToast={() => {}} />,
+    )
+
+    // Open the delete confirmation, then confirm. (Dialog renders in a portal,
+    // so query at document level, not within the render container.)
+    fireEvent.click(screen.getByLabelText('delete'))
+    const confirm = screen.getByTestId('savings-delete-confirm')
+    expect(confirm).not.toBeDisabled()
+    fireEvent.click(confirm)
+
+    await waitFor(() => {
+      expect(document.querySelector('.cairn-loader')).toBeInTheDocument()
+    })
+    expect(screen.getByTestId('savings-delete-confirm')).toBeDisabled()
+  })
+})

--- a/app/(app)/planning/components/__tests__/SalaryInput.test.tsx
+++ b/app/(app)/planning/components/__tests__/SalaryInput.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import SalaryInput from '../SalaryInput'
+import type { MonthlyPlan } from '../../PlanningClient'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => {
+    const t = (key: string) => key
+    ;(t as unknown as { rich: (k: string) => string }).rich = (key: string) => key
+    return t
+  },
+}))
+
+const plan: MonthlyPlan = { id: 'p1', month: 6, year: 2026, salary_vnd: 45_000_000 }
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('SalaryInput loading state (§03 button/inline mutation)', () => {
+  it('shows the brand Cairn loader while saving, not a CSS border-spinner', async () => {
+    // fetch never resolves → component stays in the saving state
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+    const { container } = render(
+      <SalaryInput plan={plan} month={6} year={2026} onPlanCreated={() => {}} onPlanDeleted={() => {}} />,
+    )
+
+    // Blur the salary field → triggers saveSalary() with the preset value.
+    fireEvent.blur(screen.getByTestId('salary-input'))
+
+    await waitFor(() => {
+      expect(container.querySelector('.cairn-loader')).toBeInTheDocument()
+    })
+    // The old ad-hoc CSS spinner must be gone.
+    expect(container.querySelector('.animate-spin')).toBeNull()
+  })
+})

--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { X, TrendingUp, Building2, Coins, ArrowUpRight, ArrowDownRight, ArrowDownToLine, Wallet, Shield } from 'lucide-react'
 import { useTranslations } from 'next-intl'
+import { CairnLoader } from '@/app/components/ui/CairnLoader'
 
 interface Fund { id: string; name: string; nav: number; code: string | null; fund_type?: string }
 interface Goal { goal_id: string; goal_name: string }
@@ -1253,8 +1254,10 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
                 color: '#fff', fontSize: 14, fontWeight: 600,
                 cursor: (saving || sellDisabled) ? 'not-allowed' : 'pointer',
                 fontFamily: 'inherit', opacity: (saving || sellDisabled) ? 0.7 : 1,
+                display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,
               }}
             >
+              {saving && <CairnLoader size={14} variant="on-dark" />}
               {saving
                 ? tc('saving')
                 : dir === 'sell'

--- a/app/assets/components/CreateGoalSheet.tsx
+++ b/app/assets/components/CreateGoalSheet.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
 import { X, Mountain, Home, Shield, ShoppingCart, Target } from 'lucide-react'
 import { fmt } from '@/lib/formatters'
+import { CairnLoader } from '@/app/components/ui/CairnLoader'
 
 interface Props {
   open: boolean
@@ -284,7 +285,7 @@ export function CreateGoalSheet({ open, onClose, onSuccess, desktop }: Props) {
                 opacity: saving ? 0.7 : 1,
               }}
             >
-              {saving && <span style={{ width: 14, height: 14, border: '2px solid rgba(255,255,255,0.4)', borderTopColor: '#fff', borderRadius: '50%', animation: 'spin 0.7s linear infinite', display: 'inline-block' }} />}
+              {saving && <CairnLoader size={14} variant="on-dark" />}
               {saving ? tc('saving') : tg('createBtn')}
             </button>
           </div>

--- a/app/assets/components/DownloadReportSheet.tsx
+++ b/app/assets/components/DownloadReportSheet.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { Check, Download, X } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmt } from '@/lib/formatters'
+import { CairnLoader } from '@/app/components/ui/CairnLoader'
 
 interface Props {
   open: boolean
@@ -197,7 +198,7 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
                   }}
                 >
                   {exporting ? (
-                    <span style={{ width: 14, height: 14, border: '2px solid #fff', borderTopColor: 'transparent', borderRadius: '50%', display: 'inline-block', animation: 'spin 0.6s linear infinite' }} />
+                    <CairnLoader size={14} variant="on-dark" />
                   ) : (
                     <Download size={14} strokeWidth={2.2} />
                   )}

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { useLocale, useTranslations } from 'next-intl'
 import { ArrowDownRight, ArrowDownToLine, Building, Check, Coins, Shield, TrendingUp, Wallet, X } from 'lucide-react'
 import { fmt } from '@/lib/formatters'
+import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { AffectsProgressControl } from './goalDetailShared'
 const fmtVND = (n: number, _locale?: string) => fmt(n)
 
@@ -628,15 +629,19 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
                 disabled={!isValid}
                 style={{
                   flex: 2, padding: '11px 14px',
-                  background: isValid ? 'var(--c-neg, #dc2626)' : 'var(--c-line)',
-                  color: isValid ? '#fff' : 'var(--c-muted)',
+                  // Keep the active (red) look while saving so the loader stays
+                  // legible and the button reads as "processing", not disabled.
+                  background: (isValid || saving) ? 'var(--c-neg, #dc2626)' : 'var(--c-line)',
+                  color: (isValid || saving) ? '#fff' : 'var(--c-muted)',
                   border: 'none', borderRadius: 10, fontSize: 13, fontWeight: 600,
                   cursor: isValid ? 'pointer' : 'default',
                   display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
                   transition: 'background 120ms, color 120ms',
                 }}
               >
-                {isBank ? <ArrowDownToLine size={15} strokeWidth={2.2} /> : <ArrowDownRight size={15} strokeWidth={2.2} />}
+                {saving
+                  ? <CairnLoader size={14} variant="on-dark" />
+                  : isBank ? <ArrowDownToLine size={15} strokeWidth={2.2} /> : <ArrowDownRight size={15} strokeWidth={2.2} />}
                 {(isGold ? numUnits <= 0 : numAmount <= 0)
                   ? (isVI
                       ? (isBank ? 'Nhập số tiền rút' : isGold ? 'Nhập số lượng bán' : 'Nhập số tiền bán')

--- a/messages/en.json
+++ b/messages/en.json
@@ -685,7 +685,8 @@
     "descLabel": "Description",
     "descPlaceholder": "e.g., Buy laptop, Car repair...",
     "descRequired": "Description is required",
-    "cannotSave": "Unable to save. Please check your connection and try again."
+    "cannotSave": "Unable to save. Please check your connection and try again.",
+    "skipping": "Skipping…"
   },
   "auth": {
     "loginTitle": "Welcome back",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -685,7 +685,8 @@
     "descLabel": "Mô tả",
     "descPlaceholder": "VD: Mua laptop, Sửa xe...",
     "descRequired": "Mô tả là bắt buộc",
-    "cannotSave": "Không thể lưu. Vui lòng kiểm tra kết nối và thử lại."
+    "cannotSave": "Không thể lưu. Vui lòng kiểm tra kết nối và thử lại.",
+    "skipping": "Đang bỏ qua…"
   },
   "auth": {
     "loginTitle": "Chào mừng trở lại",


### PR DESCRIPTION
## What

PR 2 of issue #235 (loading rollout). Implements the **button mutation** state from the design's §03 (Inline & action states) and §04 decision matrix:

> **Mutation (Save / Sell)** → Button spinner inside the button; lock width, disable, change verb tense.
> *"Replace the leading icon with an XS Cairn — the same indicator used everywhere else, one vocabulary across the app."*

Every ad-hoc CSS border-spinner on a mutation button is replaced with the brand `CairnLoader` (size 14). Existing disable + verb-tense change + locked width are kept.

### Swapped to `<CairnLoader size={14}>`
- **Planning section saves** — Direct savings, Other expenses, Insurance, Fund investments (`on-dark`).
- **Create goal**, **Download report**, **Salary delete** (`on-dark`); the **inline salary save** indicator (`muted`).
- **Sell / Withdraw confirm** — leading arrow icon → Cairn while saving. Also keeps the button's active (red) style during save so the loader stays legible instead of greying out.
- **Add-transaction submit** — leading Cairn added while saving.

### Destructive path — unified (review follow-up)
The DELETE / skip confirm buttons were inconsistent (one had the full loader, one only tense+disable, three had nothing — and the bare three could double-submit on a double-tap). All five now get the same treatment:
- **Direct savings / Fund investments delete** — added a `deleting` state → Cairn + `disabled` + "Deleting…" (previously bare, double-submittable).
- **Insurance skip** — added a `skipping` state + `planning.skipping` string → Cairn + `disabled` + "Skipping…".
- **Other expenses delete** — added the missing Cairn (already had tense+disable).
- **Salary delete** — added the "Deleting…" tense next to the Cairn; shrank the inline save indicator 16 → 14 for XS parity.
- A11y: the savings row delete trigger gains an `aria-label`.

### Deliberately left as-is (→ PR3)
These are re-fetch / gesture affordances, not mutations:
- Funds `RefreshCw` refresh-icon spin (re-fetch / background sync).
- Dashboard pull-to-refresh indicator (gesture, rotation tied to pull distance).

## Testing
- TDD: `SalaryInput` test drives the saving state and asserts the brand `.cairn-loader` renders (old `.animate-spin` gone); `DirectSavingsSection` delete test drives the confirm and asserts the Cairn shows + the button is `disabled` while deleting.
- `npm test -- --run` → **557 passed**.
- `npx tsc --noEmit` → clean. Changed files add **zero** new lint problems (verified vs `main` baseline; the pre-existing `set-state-in-effect` errors are untouched).

## Notes
- Variant choice: `on-dark` (white stones) on dark/colored buttons, `muted` for the inline indicator on the light surface — per §01 ("inverts on dark backgrounds, mutes on inline placeholders").
- Remaining rollout: **PR3** — number-refresh pulse, background-sync pill banner, infinite-scroll "Loading more…" row (and the refresh/pull spinners above fold in there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
