### PR TITLE
feat(loading): number-refresh, sync pill, pull-to-refresh Cairn (#235)

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -6,6 +6,7 @@ import { useTranslations } from 'next-intl'
 import { Plus, RefreshCw, Search, X } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
 import { Skeleton } from '@/app/components/ui/Skeleton'
+import { SyncPill } from '@/app/components/ui/SyncPill'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -562,6 +563,9 @@ export default function DesktopFundLibraryView() {
 
   return (
     <div className="hidden md:flex" style={{ flex: 1, minHeight: 0, overflow: 'hidden', flexDirection: 'column' }}>
+      {/* Background-sync pill while NAV prices refresh */}
+      <SyncPill label={t('syncingPrices')} show={refreshing} />
+
       {/* Toast notifications */}
       <div style={{ position: 'fixed', top: 16, right: 16, zIndex: 300, display: 'flex', flexDirection: 'column', gap: 8 }}>
         {toasts.map(t => (
@@ -635,7 +639,7 @@ export default function DesktopFundLibraryView() {
               className="cn-btn ghost"
               style={{ padding: '7px 10px', gap: 5, fontSize: 12, display: 'flex', alignItems: 'center' }}
             >
-              <RefreshCw size={15} className={refreshing ? 'animate-spin' : ''} />
+              <RefreshCw size={15} />
               Refresh
             </button>
             <button

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from 'next-intl'
 import { Plus, RefreshCw, Search, X, ChevronDown, Check } from 'lucide-react'
 import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import { Skeleton } from '@/app/components/ui/Skeleton'
+import { SyncPill } from '@/app/components/ui/SyncPill'
 
 function fmtCompactDca(n: number): string {
   const abs = Math.abs(n)
@@ -569,7 +570,7 @@ export default function MobileFundLibraryView() {
             aria-label="Refresh NAV"
             style={{ padding: 8, background: 'transparent', border: '1px solid var(--c-line)', borderRadius: 10, cursor: 'pointer', display: 'flex', alignItems: 'center', opacity: refreshing || !funds.some((f) => f.nav_source_url) ? 0.4 : 1 }}
           >
-            <RefreshCw size={16} color="var(--c-ink)" style={{ animation: refreshing ? 'spin 1s linear infinite' : 'none' }} />
+            <RefreshCw size={16} color="var(--c-ink)" />
           </button>
           <button
             onClick={() => { setFormError(null); setAddOpen(true) }}
@@ -725,6 +726,9 @@ export default function MobileFundLibraryView() {
 
   return (
     <div data-testid="mobile-funds" className="md:hidden" style={{ minHeight: '100dvh', background: 'var(--c-canvas)' }}>
+      {/* Background-sync pill while NAV prices refresh */}
+      <SyncPill label={t('syncingPrices')} show={refreshing} />
+
       {/* Toasts */}
       <div style={{ position: 'fixed', top: 16, right: 16, zIndex: 300, display: 'flex', flexDirection: 'column', gap: 8, pointerEvents: 'none' }}>
         {toasts.map((toast) => (

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -6,6 +6,7 @@ import { useTranslations, useLocale } from 'next-intl'
 import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import { CreateGoalSheet } from './components/CreateGoalSheet'
 import { DashboardSkeleton, DesktopDashboardSkeleton } from './components/Skeletons'
+import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import NetWorthCard from './components/NetWorthCard'
 import GoalCard from './components/GoalCard'
 import UnallocatedSection from './components/UnallocatedSection'
@@ -198,6 +199,9 @@ export default function DashboardClient({ userId }: { userId: string }) {
   const isDesktop = useIsDesktop()
   const [data, setData] = useState<DashboardData | null>(null)
   const [loading, setLoading] = useState(true)
+  // Re-fetch while data is already on screen → number-refresh state (pulse + XS
+  // Cairn), as opposed to `loading` which drives the first-paint skeleton.
+  const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState('')
   const [fundDetailId, setFundDetailId] = useState<string | null>(null)
   const [goalPickerFundId, setGoalPickerFundId] = useState<string | null>(null)
@@ -243,8 +247,10 @@ export default function DashboardClient({ userId }: { userId: string }) {
       setLoading(false)
       return
     }
-    // Only show skeleton on initial load — if data is already visible, refresh silently
+    // Only show skeleton on initial load — if data is already visible, refresh
+    // silently with the number-refresh pulse instead.
     if (!hasDataRef.current) setLoading(true)
+    else setRefreshing(true)
     setError('')
 
     // Resilient load: retries once on a transient failure (e.g. the service
@@ -267,6 +273,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
     }
     setError(overviewErrorText(result, tc('error')) ?? '')
     setLoading(false)
+    setRefreshing(false)
   }, [userId, tc])
 
   useEffect(() => { fetchDataRef.current = fetchData }, [fetchData])
@@ -447,7 +454,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
           className="md:hidden -mx-4 -mt-4 overflow-hidden flex items-center justify-center"
           style={{ height: `${pullY}px`, transition: pullY === 0 ? 'height 0.25s ease' : 'none' }}
         >
-          <div className={`w-6 h-6 rounded-full border-2 border-emerald-500 border-t-transparent ${pullY >= PULL_THRESHOLD ? 'animate-spin' : ''}`} />
+          <CairnLoader size={20} variant="pos" />
         </div>
 
         {/* Error state */}
@@ -711,6 +718,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                     goldUnits={data.goldUnits}
                     locale={locale}
                     refreshKey={historyKey}
+                    refreshing={refreshing}
                     navUpdatedAt={data.netWorth.navUpdatedAt}
                     onDownloadReport={() => setShowReportSheet(true)}
                   />
@@ -726,6 +734,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                 <NetWorthCard
                   {...data.netWorth}
                   refreshKey={historyKey}
+                  refreshing={refreshing}
                   allocationBar={allocationTotals ? {
                     fund: allocationTotals.equityTotal + allocationTotals.bondTotal + allocationTotals.balancedTotal,
                     bank: allocationTotals.bankTotal,

--- a/app/assets/components/DesktopNetWorthPanel.tsx
+++ b/app/assets/components/DesktopNetWorthPanel.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { ArrowDownToLine } from 'lucide-react'
 import { fmtCompact, fmtPct } from '@/lib/formatters'
+import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import type { DashboardData } from '../DashboardClient'
 
 const TIME_RANGES = ['1M', '3M', '6M', '1Y', 'All'] as const
@@ -74,11 +75,12 @@ interface Props {
   goldUnits?: number
   locale: string
   refreshKey?: number
+  refreshing?: boolean
   navUpdatedAt?: string | null
   onDownloadReport: () => void
 }
 
-export default function DesktopNetWorthPanel({ data, allocationTotals, goldUnits, locale, refreshKey, navUpdatedAt, onDownloadReport }: Props) {
+export default function DesktopNetWorthPanel({ data, allocationTotals, goldUnits, locale, refreshKey, refreshing, navUpdatedAt, onDownloadReport }: Props) {
   const { netWorth } = data
   const isPos = netWorth.overallProfitLoss >= 0
   const isVi = locale === 'vi'
@@ -127,9 +129,10 @@ export default function DesktopNetWorthPanel({ data, allocationTotals, goldUnits
           {isVi ? 'Tài sản ròng' : 'Net worth'}
         </div>
 
-        {/* Value */}
-        <div style={{ fontSize: 30, fontWeight: 700, letterSpacing: '-0.03em', lineHeight: 1, color: 'var(--c-ink)' }}>
-          {fmtCompact(netWorth.netWorth)}
+        {/* Value — pulses + shows an XS Cairn while re-fetching (value stays visible) */}
+        <div style={{ fontSize: 30, fontWeight: 700, letterSpacing: '-0.03em', lineHeight: 1, color: 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span className={refreshing ? 'num' : undefined}>{fmtCompact(netWorth.netWorth)}</span>
+          {refreshing && <CairnLoader size={14} variant="muted" />}
         </div>
 
         {/* P&L chip */}

--- a/app/assets/components/DesktopNetWorthPanel.tsx
+++ b/app/assets/components/DesktopNetWorthPanel.tsx
@@ -129,8 +129,9 @@ export default function DesktopNetWorthPanel({ data, allocationTotals, goldUnits
           {isVi ? 'Tài sản ròng' : 'Net worth'}
         </div>
 
-        {/* Value — pulses + shows an XS Cairn while re-fetching (value stays visible) */}
-        <div style={{ fontSize: 30, fontWeight: 700, letterSpacing: '-0.03em', lineHeight: 1, color: 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8 }}>
+        {/* Value — pulses + shows an XS Cairn while re-fetching (value stays visible).
+            The `num-refresh` wrapper is what scopes the `.num` pulse animation. */}
+        <div className={refreshing ? 'num-refresh' : undefined} style={{ fontSize: 30, fontWeight: 700, letterSpacing: '-0.03em', lineHeight: 1, color: 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8 }}>
           <span className={refreshing ? 'num' : undefined}>{fmtCompact(netWorth.netWorth)}</span>
           {refreshing && <CairnLoader size={14} variant="muted" />}
         </div>

--- a/app/assets/components/NetWorthCard.tsx
+++ b/app/assets/components/NetWorthCard.tsx
@@ -170,8 +170,9 @@ export default function NetWorthCard({
         {t('netWorth')}
       </div>
 
-      {/* Hero number — pulses + shows an XS Cairn while re-fetching (value stays visible) */}
-      <div style={{
+      {/* Hero number — pulses + shows an XS Cairn while re-fetching (value stays visible).
+          The `num-refresh` wrapper is what scopes the `.num` pulse animation. */}
+      <div className={refreshing ? 'num-refresh' : undefined} style={{
         fontSize: 32, fontWeight: 600, letterSpacing: '-0.025em',
         fontVariantNumeric: 'tabular-nums', color: 'var(--c-ink)',
         lineHeight: 1.1, display: 'flex', alignItems: 'center', gap: 8,

--- a/app/assets/components/NetWorthCard.tsx
+++ b/app/assets/components/NetWorthCard.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { useLocale, useTranslations } from 'next-intl'
 import { TrendingUp, TrendingDown } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
+import { CairnLoader } from '@/app/components/ui/CairnLoader'
 
 const TIME_RANGES = ['1M', '3M', '6M', '1Y', 'All'] as const
 type TimeRange = typeof TIME_RANGES[number]
@@ -126,11 +127,12 @@ interface Props {
   overallProfitLossPercentage: number
   allocationBar?: { fund: number; bank: number; gold: number; stock: number; goldUnits?: number }
   refreshKey?: number
+  refreshing?: boolean
 }
 
 export default function NetWorthCard({
   totalAssets, totalLiabilities, netWorth, totalInvested, currentValue,
-  overallProfitLoss, overallProfitLossPercentage, allocationBar, refreshKey,
+  overallProfitLoss, overallProfitLossPercentage, allocationBar, refreshKey, refreshing,
 }: Props) {
   const locale = useLocale()
   const t = useTranslations('dashboard')
@@ -168,13 +170,19 @@ export default function NetWorthCard({
         {t('netWorth')}
       </div>
 
-      {/* Hero number */}
+      {/* Hero number — pulses + shows an XS Cairn while re-fetching (value stays visible) */}
       <div style={{
         fontSize: 32, fontWeight: 600, letterSpacing: '-0.025em',
         fontVariantNumeric: 'tabular-nums', color: 'var(--c-ink)',
-        lineHeight: 1.1, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        lineHeight: 1.1, display: 'flex', alignItems: 'center', gap: 8,
       }}>
-        {fmt(netWorth)}
+        <span
+          className={refreshing ? 'num' : undefined}
+          style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0 }}
+        >
+          {fmt(netWorth)}
+        </span>
+        {refreshing && <CairnLoader size={14} variant="muted" />}
       </div>
 
       {/* P&L row */}

--- a/app/assets/components/__tests__/NetWorthCardRefresh.test.tsx
+++ b/app/assets/components/__tests__/NetWorthCardRefresh.test.tsx
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render } from '@testing-library/react'
+import NetWorthCard from '../NetWorthCard'
+
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
+  useTranslations: () => (key: string) => key,
+}))
+vi.mock('@/lib/formatters', () => ({
+  fmt: (n: number) => `₫${n}`,
+  fmtCompact: (n: number) => `₫${n}`,
+  fmtPct: (n: number) => `${n}%`,
+}))
+
+const base = {
+  totalAssets: 1, totalLiabilities: 0, netWorth: 100, totalInvested: 1,
+  currentValue: 1, overallProfitLoss: 1, overallProfitLossPercentage: 1,
+}
+
+afterEach(() => vi.unstubAllGlobals())
+
+// §03 "Re-fetching a value": the figure pulses + an XS Cairn sits beside it
+// while the value is being recomputed — no skeleton (the value is still shown).
+describe('NetWorthCard number-refresh', () => {
+  it('pulses the value and shows an XS Cairn while refreshing', () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) })))
+    const { container } = render(<NetWorthCard {...base} refreshing />)
+    expect(container.querySelector('.num')).toBeInTheDocument()
+    expect(container.querySelector('.cairn-loader')).toBeInTheDocument()
+  })
+
+  it('shows no loader or pulse when not refreshing', () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) })))
+    const { container } = render(<NetWorthCard {...base} />)
+    expect(container.querySelector('.cairn-loader')).toBeNull()
+    expect(container.querySelector('.num')).toBeNull()
+  })
+})

--- a/app/assets/components/__tests__/NetWorthCardRefresh.test.tsx
+++ b/app/assets/components/__tests__/NetWorthCardRefresh.test.tsx
@@ -25,7 +25,9 @@ describe('NetWorthCard number-refresh', () => {
   it('pulses the value and shows an XS Cairn while refreshing', () => {
     vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) })))
     const { container } = render(<NetWorthCard {...base} refreshing />)
-    expect(container.querySelector('.num')).toBeInTheDocument()
+    // The pulse CSS is `.num-refresh .num` — the `.num` must have a `.num-refresh`
+    // ancestor or the animation never fires (descendant-selector mismatch bug).
+    expect(container.querySelector('.num-refresh .num')).toBeInTheDocument()
     expect(container.querySelector('.cairn-loader')).toBeInTheDocument()
   })
 

--- a/app/components/ui/SyncPill.tsx
+++ b/app/components/ui/SyncPill.tsx
@@ -1,0 +1,28 @@
+import { CairnLoader } from './CairnLoader'
+
+interface SyncPillProps {
+  /** Label, e.g. "Syncing fund prices…". */
+  label: string
+  /** When false, render nothing. */
+  show: boolean
+}
+
+/**
+ * Background-sync pill — a floating, non-blocking banner near the top of the
+ * screen with an XS Cairn, shown while a background refresh runs (loading
+ * design §03 · "Background sync", issue #235).
+ */
+export function SyncPill({ label, show }: SyncPillProps) {
+  if (!show) return null
+  return (
+    <div className="sync-bar sync-bar-float" role="status" aria-live="polite">
+      {/* Loader is decorative here — the pill itself is the live region. */}
+      <span aria-hidden="true" style={{ display: 'inline-flex' }}>
+        <CairnLoader size={14} />
+      </span>
+      {label}
+    </div>
+  )
+}
+
+export default SyncPill

--- a/app/components/ui/__tests__/SyncPill.test.tsx
+++ b/app/components/ui/__tests__/SyncPill.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import { SyncPill } from '../SyncPill'
+
+describe('SyncPill', () => {
+  it('renders the floating pill with an XS Cairn and label when shown', () => {
+    const { container, getByText, getByRole } = render(<SyncPill label="Syncing fund prices…" show />)
+    expect(container.querySelector('.sync-bar')).toBeInTheDocument()
+    expect(getByRole('status')).toBeInTheDocument()
+    expect(container.querySelector('.cairn-loader')).toBeInTheDocument()
+    expect(getByText('Syncing fund prices…')).toBeInTheDocument()
+  })
+
+  it('renders nothing when not shown', () => {
+    const { container } = render(<SyncPill label="Syncing fund prices…" show={false} />)
+    expect(container.querySelector('.sync-bar')).toBeNull()
+  })
+})

--- a/app/globals.css
+++ b/app/globals.css
@@ -396,9 +396,43 @@
   100% { stroke-dashoffset: -300; }
 }
 
+/* Number refresh — subtle opacity pulse on a tabular figure as it re-fetches. */
+.num-refresh { display: inline-flex; align-items: center; gap: 8px; }
+.num-refresh .num { animation: num-fade 1.6s ease-in-out infinite; }
+@keyframes num-fade {
+  0%, 100% { opacity: 0.45; }
+  50%      { opacity: 1; }
+}
+
+/* Background-sync pill — floating banner while a non-blocking refresh runs. */
+.sync-bar {
+  display: inline-flex; align-items: center; gap: 10px;
+  padding: 8px 14px;
+  background: var(--c-navy-tint);
+  color: var(--c-navy);
+  border-radius: 999px;
+  font-size: 12px; font-weight: 500;
+  border: 1px solid rgba(15, 42, 74, 0.08);
+  box-shadow: var(--shadow-pop);
+}
+/* Centered, floats just below the top edge; slides in. */
+.sync-bar-float {
+  position: fixed;
+  top: 14px; left: 50%;
+  transform: translateX(-50%);
+  z-index: 50;
+  animation: sync-slide-in 220ms ease;
+}
+@keyframes sync-slide-in {
+  from { opacity: 0; transform: translate(-50%, -8px); }
+  to   { opacity: 1; transform: translate(-50%, 0); }
+}
+
 /* Respect reduced-motion: hold steady instead of pulsing/shimmering/drawing. */
 @media (prefers-reduced-motion: reduce) {
   .cairn-loader .stone { animation: none; opacity: 0.55; }
   .sk { animation: none; }
   .spark-draw path { animation: none; stroke-dashoffset: 0; }
+  .num-refresh .num { animation: none; opacity: 1; }
+  .sync-bar-float { animation: none; }
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -568,7 +568,8 @@
     "searchPlaceholder": "Search by fund name or code...",
     "fundsCount": "{count, plural, one {# fund} other {# funds}}",
     "dcaGoalLabel": "Allocate to",
-    "dcaGoalUnallocated": "Unallocated"
+    "dcaGoalUnallocated": "Unallocated",
+    "syncingPrices": "Syncing fund prices…"
   },
   "planning": {
     "title": "Monthly Plan",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -568,7 +568,8 @@
     "searchPlaceholder": "Tìm theo tên hoặc mã quỹ...",
     "fundsCount": "{count} quỹ",
     "dcaGoalLabel": "Phân bổ vào",
-    "dcaGoalUnallocated": "Chưa phân bổ"
+    "dcaGoalUnallocated": "Chưa phân bổ",
+    "syncingPrices": "Đang đồng bộ giá quỹ…"
   },
   "planning": {
     "title": "Kế hoạch Tháng",


### PR DESCRIPTION
## What

PR 3 (final) of issue #235 — the remaining §03 inline / action states, scoped to what actually applies in this app.

### Number-refresh (§03 "Re-fetching a value")
The dashboard net-worth value now **pulses + shows an XS Cairn** beside it while a refetch runs with data already on screen (pull-to-refresh, post-transaction) — the value stays trustable, no skeleton. Adds a `refreshing` signal to `DashboardClient`, threaded to `NetWorthCard` (mobile) and `DesktopNetWorthPanel` (desktop). Previously a silent refetch showed *no* indication.

### Background sync (§03 "Background sync")
The funds NAV refresh shows the design's floating **"Syncing fund prices…" pill** (`SyncPill` / `.sync-bar`) with an XS Cairn near the top, replacing the ad-hoc `RefreshCw` spin (which is now a static icon).

### Pull-to-refresh
Swapped the dashboard pull-to-refresh spinner circle for the **Cairn loader** (`pos` variant) — one vocabulary.

### Omitted: infinite-scroll "Loading more…"
Intentionally **not** built — no list in the app paginates / infinite-scrolls (they load all rows at once), so there's no place to attach it. Flagged rather than inventing pagination.

### Supporting
- `globals.css`: `.num-refresh`/`.num` + `num-fade`, `.sync-bar` (+ floating slide-in), all with `prefers-reduced-motion` fallbacks.
- New `funds.syncingPrices` string (en + vi).

## Testing
- TDD: `NetWorthCard` refresh test (pulse + Cairn while refreshing, nothing otherwise) and `SyncPill` test (pill + Cairn + label when shown, nothing when hidden).
- `npm test -- --run` → **561 passed**.
- `npx tsc --noEmit` → clean. Changed files add **zero** new lint problems (verified vs `main` baseline).

## Try on preview
- **Dashboard**: pull-to-refresh (mobile PWA) shows the Cairn; after adding a transaction / refetch, the net-worth figure pulses with an XS Cairn while it recomputes.
- **Funds**: tap Refresh → the "Syncing fund prices…" pill floats in at the top until prices land.

This completes the §04 loading vocabulary across the app (first-app skeletons → button mutations → re-fetch / sync states).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
