### PR TITLE
feat(loading): detail panels & sheets first-load skeleton (#235)

### DIFF
--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -6,6 +6,7 @@ import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
 import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, AffectsProgressControl, BankInfoStrip, type InvRow } from './goalDetailShared'
 import { fmtTxDate } from './transactionUtils'
+import { TxRowsSkeleton } from './Skeletons'
 
 interface InvestmentTx {
   transaction_id: string
@@ -290,11 +291,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
           {/* Investments tab */}
           {tab === 'investments' && (
             <>
-              {txLoading && (
-                <p style={{ color: 'var(--c-muted)', fontSize: 13, textAlign: 'center', padding: '20px 0' }}>
-                  {isVi ? 'Đang tải…' : 'Loading…'}
-                </p>
-              )}
+              {txLoading && <TxRowsSkeleton />}
               {!txLoading && visibleInvRows.length === 0 && (
                 <p style={{ color: 'var(--c-muted)', fontSize: 13, textAlign: 'center', padding: '20px 0' }}>
                   {isVi ? 'Chưa có khoản đầu tư nào' : 'No investments yet'}
@@ -440,11 +437,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
           {/* History tab */}
           {tab === 'history' && (
             <>
-              {txLoading && (
-                <p style={{ color: 'var(--c-muted)', fontSize: 13, textAlign: 'center', padding: '20px 0' }}>
-                  {isVi ? 'Đang tải…' : 'Loading…'}
-                </p>
-              )}
+              {txLoading && <TxRowsSkeleton />}
               {!txLoading && transactions.length === 0 && (
                 <p style={{ color: 'var(--c-muted)', fontSize: 13, textAlign: 'center', padding: '20px 0' }}>
                   {isVi ? 'Chưa có giao dịch nào' : 'No transactions yet'}

--- a/app/assets/components/DesktopInsuranceDetail.tsx
+++ b/app/assets/components/DesktopInsuranceDetail.tsx
@@ -6,6 +6,7 @@ import { fmt, fmtCompact } from '@/lib/formatters'
 import { STATUS_COLOR, BAR_COLOR_DETAIL, COVERAGE_OPTIONS, insurancePaidState, insuranceStatusLabel } from './insuranceShared'
 import type { InsuranceData } from '../DashboardClient'
 import LogInsurancePaymentModal from './LogInsurancePaymentModal'
+import { TxRowsSkeleton } from './Skeletons'
 
 interface Props {
   ins: InsuranceData
@@ -362,7 +363,7 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
               {isVi ? 'Lịch sử thanh toán' : 'Payment history'}
             </div>
             {historyLoading && history === null ? (
-              <div style={{ padding: '14px 16px', fontSize: 12, color: 'var(--c-muted)' }}>…</div>
+              <TxRowsSkeleton rows={3} />
             ) : !history || history.length === 0 ? (
               <div style={{ padding: '14px 16px', fontSize: 12, color: 'var(--c-muted)' }}>
                 {isVi ? 'Chưa có giao dịch' : 'No payments yet'}

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -12,6 +12,7 @@ import TransactionHistorySheet, { type PurchaseHistoryRow } from './TransactionH
 import { SellWithdrawSheet, type SellItem } from './SellWithdrawSheet'
 import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, BankInfoStrip, type InvRow } from './goalDetailShared'
 import { fmtTxDate } from './transactionUtils'
+import { TxRowsSkeleton } from './Skeletons'
 
 interface InvestmentTx {
   transaction_id: string
@@ -940,11 +941,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
           {/* Investments tab */}
           {activeTab === 'investments' && (
             <div style={{ background: 'var(--c-card)', borderRadius: 16, padding: '0 14px', boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }}>
-              {txLoading && (
-                <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0' }}>
-                  {isVI ? 'Đang tải…' : 'Loading…'}
-                </p>
-              )}
+              {txLoading && <TxRowsSkeleton />}
               {!txLoading && invRows.length === 0 && (
                 <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0' }}>
                   {isVI ? 'Chưa có khoản đầu tư nào' : 'No investments yet'}
@@ -1139,11 +1136,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
           {/* History tab */}
           {activeTab === 'history' && (
             <div style={{ background: 'var(--c-card)', borderRadius: 16, padding: '0 14px', boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }}>
-              {txLoading && (
-                <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0' }}>
-                  {isVI ? 'Đang tải…' : 'Loading…'}
-                </p>
-              )}
+              {txLoading && <TxRowsSkeleton />}
               {!txLoading && transactions.length === 0 && (
                 <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0' }}>
                   {isVI ? 'Chưa có giao dịch nào' : 'No transactions yet'}

--- a/app/assets/components/RecentActivityCard.tsx
+++ b/app/assets/components/RecentActivityCard.tsx
@@ -12,6 +12,7 @@ import {
   txPrimaryName,
   fmtTxDate,
 } from './transactionUtils'
+import { TxRowsSkeleton } from './Skeletons'
 
 // Asset-type badge colors for investment rows. Withdrawals use the negative
 // color regardless of asset.
@@ -37,6 +38,7 @@ export default function RecentActivityCard({ locale, desktop, refreshKey, onChan
   const tt = useTranslations('transactions')
   const [txs, setTxs] = useState<LedgerTransaction[]>([])
   const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
   const [showLedger, setShowLedger] = useState(false)
   const [localKey, setLocalKey] = useState(0)
 
@@ -56,6 +58,7 @@ export default function RecentActivityCard({ locale, desktop, refreshKey, onChan
         setTotal(data.total ?? 0)
       })
       .catch(() => { if (!cancelled) { setTxs([]); setTotal(0) } })
+      .finally(() => { if (!cancelled) setLoading(false) })
     return () => { cancelled = true }
   }, [refreshKey, localKey])
 
@@ -71,7 +74,9 @@ export default function RecentActivityCard({ locale, desktop, refreshKey, onChan
     </button>
   )
 
-  const rows = total === 0 ? (
+  const rows = loading ? (
+    <TxRowsSkeleton rows={3} />
+  ) : total === 0 ? (
     <div style={{ padding: '20px 16px', fontSize: 13, color: 'var(--c-muted)', textAlign: 'center' }}>
       {t('recentActivityEmpty')}
     </div>
@@ -148,7 +153,7 @@ export default function RecentActivityCard({ locale, desktop, refreshKey, onChan
       boxShadow: 'var(--shadow-card)',
       overflow: 'hidden',
     }}>
-      <div style={{ padding: '13px 16px', borderBottom: total > 0 ? '1px solid var(--c-line)' : 'none', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+      <div style={{ padding: '13px 16px', borderBottom: (loading || total > 0) ? '1px solid var(--c-line)' : 'none', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
         <div style={{ display: 'flex', alignItems: 'center', gap: 10, minWidth: 0 }}>
           <div style={{ width: 32, height: 32, borderRadius: 8, background: 'var(--c-card-2)', color: 'var(--c-muted)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
             <Calendar size={15} />

--- a/app/assets/components/Skeletons.tsx
+++ b/app/assets/components/Skeletons.tsx
@@ -63,6 +63,35 @@ export function DashboardSkeleton() {
   )
 }
 
+/**
+ * Row-list first-load shimmer — the shared placeholder for the detail panels and
+ * sheets that fetch a list on open (transaction history, goal-detail investments
+ * / history tabs, insurance payment history, the dashboard's Recent activity).
+ * Mirrors a transaction row: leading icon chip, two stacked text lines, a
+ * trailing amount. Replaces the legacy "Loading…" text / bare "…" so every
+ * first-load speaks the same Cairn vocabulary (issue #235 · §04).
+ */
+export function TxRowsSkeleton({ rows = 4 }: { rows?: number }) {
+  return (
+    <div data-testid="skeleton-tx-rows" aria-hidden="true">
+      {Array.from({ length: rows }, (_, i) => (
+        <div
+          key={i}
+          data-testid="skeleton-tx-row"
+          style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '11px 14px', borderBottom: i < rows - 1 ? '1px solid var(--c-line)' : 'none' }}
+        >
+          <Skeleton width={30} height={30} style={{ borderRadius: 8 }} />
+          <div style={{ flex: 1, display: 'grid', gap: 6 }}>
+            <Skeleton width="44%" height={11} />
+            <Skeleton width="26%" height={9} />
+          </div>
+          <Skeleton width={56} height={12} />
+        </div>
+      ))}
+    </div>
+  )
+}
+
 /** A single goal-card placeholder in the desktop goals grid. */
 function DeskGoalCardSk() {
   return (

--- a/app/assets/components/TransactionHistorySheet.tsx
+++ b/app/assets/components/TransactionHistorySheet.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { ChevronLeft, ArrowUpRight, ArrowDownRight, Plus } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmtCompact, fmtNav, fmtPct, fmtUnits } from '@/lib/formatters'
+import { TxRowsSkeleton } from './Skeletons'
 
 export interface PurchaseHistoryRow {
   purchase_date: string
@@ -169,11 +170,7 @@ export default function TransactionHistorySheet({
             </button>
           </div>
           <div style={{ background: 'var(--c-card)', borderRadius: 16, padding: '0 14px', boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }}>
-            {loading && (
-              <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0' }}>
-                {isVI ? 'Đang tải…' : 'Loading…'}
-              </p>
-            )}
+            {loading && <TxRowsSkeleton />}
             {!loading && purchaseHistory.length === 0 && (
               <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0' }}>
                 {isVI ? 'Chưa có lịch sử giao dịch' : 'No transaction history'}

--- a/app/assets/components/__tests__/RecentActivityCard.test.tsx
+++ b/app/assets/components/__tests__/RecentActivityCard.test.tsx
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import RecentActivityCard from '../RecentActivityCard'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (k: string) => k,
+}))
+// The ledger sheet fetches on its own; stub it so this test only exercises the card.
+vi.mock('../TransactionLedgerSheet', () => ({ default: () => null }))
+
+const mockTx = {
+  transaction_id: 'tx-1',
+  transaction_type: 'buy',
+  asset_type: 'fund',
+  fund_name: 'VNINDEX ETF',
+  investment_date: '2024-01-15',
+  amount_vnd: 2_200_000,
+  savings_goals: { goal_name: 'House' },
+}
+
+// Issue #235 · §04 ("PR 4"): the dashboard's Recent activity used to pop in with
+// no loading indicator. It must now show the shared row skeleton on first load,
+// the same vocabulary as the detail panels/sheets.
+describe('RecentActivityCard — first-load skeleton', () => {
+  it('shows the row skeleton while loading, then the real rows', async () => {
+    let resolveFetch: () => void = () => {}
+    global.fetch = vi.fn().mockImplementation(
+      () =>
+        new Promise((r) => {
+          resolveFetch = () => r({ ok: true, json: async () => ({ transactions: [mockTx], total: 1 }) })
+        }),
+    )
+
+    render(<RecentActivityCard locale="en" />)
+
+    // First paint: skeleton, not an empty card that pops in later.
+    expect(screen.getByTestId('skeleton-tx-rows')).toBeInTheDocument()
+    expect(screen.queryByTestId('recent-activity-row')).toBeNull()
+
+    resolveFetch()
+    await waitFor(() => expect(screen.getByTestId('recent-activity-row')).toBeInTheDocument())
+    expect(screen.queryByTestId('skeleton-tx-rows')).toBeNull()
+  })
+
+  it('replaces the skeleton with the empty state when there are no transactions', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ transactions: [], total: 0 }) })
+
+    render(<RecentActivityCard locale="en" />)
+
+    await waitFor(() => expect(screen.queryByTestId('skeleton-tx-rows')).toBeNull())
+    expect(screen.getByText('recentActivityEmpty')).toBeInTheDocument()
+  })
+})

--- a/app/assets/components/__tests__/Skeletons.test.tsx
+++ b/app/assets/components/__tests__/Skeletons.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { render } from '@testing-library/react'
-import { DashboardSkeleton, DesktopDashboardSkeleton } from '../Skeletons'
+import { DashboardSkeleton, DesktopDashboardSkeleton, TxRowsSkeleton } from '../Skeletons'
 
 // The dashboard first-load skeleton must match the design (§02 · Skeleton
 // screens → "Overview — mobile first load"): net-worth card with a drawing-in
@@ -47,5 +47,32 @@ describe('DesktopDashboardSkeleton', () => {
   it('renders a two-column goal grid (4 cards)', () => {
     const { getAllByTestId } = render(<DesktopDashboardSkeleton />)
     expect(getAllByTestId('skeleton-desktop-goal-card')).toHaveLength(4)
+  })
+})
+
+// The detail panels / sheets (transaction history, goal-detail tabs, insurance
+// payment history, recent activity) are lists, so their first-load uses a shared
+// row-shimmer instead of "Loading…" text or a bare "…". Issue #235 · §04 / "PR 4".
+describe('TxRowsSkeleton', () => {
+  it('renders branded shimmer rows, not the old animate-pulse blocks', () => {
+    const { container, getByTestId } = render(<TxRowsSkeleton />)
+    expect(getByTestId('skeleton-tx-rows')).toBeInTheDocument()
+    expect(container.querySelectorAll('.sk').length).toBeGreaterThan(0)
+    expect(container.querySelector('.animate-pulse')).toBeNull()
+  })
+
+  it('is hidden from assistive tech (decorative)', () => {
+    const { getByTestId } = render(<TxRowsSkeleton />)
+    expect(getByTestId('skeleton-tx-rows')).toHaveAttribute('aria-hidden', 'true')
+  })
+
+  it('defaults to a handful of rows', () => {
+    const { getAllByTestId } = render(<TxRowsSkeleton />)
+    expect(getAllByTestId('skeleton-tx-row')).toHaveLength(4)
+  })
+
+  it('honours the rows count', () => {
+    const { getAllByTestId } = render(<TxRowsSkeleton rows={6} />)
+    expect(getAllByTestId('skeleton-tx-row')).toHaveLength(6)
   })
 })

--- a/app/assets/components/__tests__/TransactionHistorySheet.test.tsx
+++ b/app/assets/components/__tests__/TransactionHistorySheet.test.tsx
@@ -72,9 +72,9 @@ describe('TransactionHistorySheet', () => {
     expect(screen.getByText(/Jun.*2024.*40/i)).toBeInTheDocument()
   })
 
-  it('shows loading state when loading=true', () => {
+  it('shows the row skeleton when loading=true', () => {
     render(<TransactionHistorySheet {...baseProps} purchaseHistory={[]} loading={true} />)
-    expect(screen.getByText('Loading…')).toBeInTheDocument()
+    expect(screen.getByTestId('skeleton-tx-rows')).toBeInTheDocument()
   })
 
   it('shows empty state when no history and not loading', () => {


### PR DESCRIPTION
@
## What & why

The brand Cairn loading vocabulary from PRs #320/#322/#323 never reached the **detail panels and sheets** that fetch a list on open. They still spoke the legacy dialect:

| Surface | Before | After |
|---|---|---|
| Transaction history sheet | `Loading…` text | row skeleton |
| Goal detail — investments + history (desktop + mobile) | `Loading…` text | row skeleton |
| Insurance detail — payment history | bare `…` ellipsis | row skeleton |
| Dashboard Recent activity | nothing (pops in) | row skeleton |

This contradicted issue #235 ("loading state for all pages, all states") and §04. Framed as **PR 4** of #235.

## How

- New shared **`TxRowsSkeleton`** in `Skeletons.tsx` — a row-list shimmer built on the existing `Skeleton` primitive (mirrors the recent-activity row: icon chip + two text lines + trailing amount). `aria-hidden`, configurable `rows`.
- Wired into all five list first-loads, replacing the `Loading…` / `…` / pop-in.
- **Recent activity** now tracks a `loading` state (true until the first fetch resolves) so it shows the skeleton instead of silently popping in.

No new i18n strings — skeletons are decorative (`aria-hidden`, no text).

## Tests (TDD)

- `Skeletons.test.tsx` — new `TxRowsSkeleton` cases (shimmer rows, `aria-hidden`, default + custom row count).
- `RecentActivityCard.test.tsx` (new) — skeleton on first load → rows after fetch; skeleton → empty state when no transactions.
- Updated `TransactionHistorySheet.test.tsx` to assert the skeleton instead of the removed `Loading…` text.
- Full unit suite green: **567 passed**.

## Verification notes

- No E2E spec depends on the removed `Loading…` / `…` text. The one relevant hook (`recent-activity-row`) is unchanged and the skeleton uses distinct testids, so existing specs are unaffected.
- I did **not** run the full WSL2/Edge E2E stack locally for this change — it is a transient loading visual with strong unit coverage and no selector dependencies. Best confirmed on the Vercel preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@