### PR TITLE
fix(plan): round override sheet top corners on iOS (#319)

### DIFF
--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -105,6 +105,10 @@ function Sheet({ open, onClose, title, children }: { open: boolean; onClose: () 
       <div
         style={{
           width: '100%', background: 'var(--c-card)', borderRadius: '16px 16px 0 0',
+          // overflow:hidden forces iOS WebKit to clip the rounded top corners —
+          // without it the slide-up transform composites the layer and the
+          // corners render square (issue #319).
+          overflow: 'hidden',
           paddingBottom: 'env(safe-area-inset-bottom,0)',
           animation: open ? 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' : 'slide-down 180ms ease forwards',
         }}

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -272,6 +272,26 @@ describe('MobilePlanningView — iOS zoom guard (issue #265)', () => {
   })
 })
 
+describe('MobilePlanningView — override sheet rounded corners (issue #319)', () => {
+  // The override bottom-sheet animates up with a `transform` (slide-up). On iOS
+  // WebKit that composites the layer, and the rounded top corners are only
+  // clipped when the card also sets `overflow: hidden` — otherwise the corners
+  // render square (issue #319). Assert both the radius and the clip.
+  it('gives the override sheet card rounded, clipped top corners', async () => {
+    const user = userEvent.setup()
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={baseFixedExpenses} />)
+
+    await user.click(screen.getAllByLabelText('More options')[0])
+    await user.click(screen.getByText('Override amount'))
+
+    const title = await screen.findByText('Override amount', { selector: 'p' })
+    const card = title.closest('div')!.parentElement as HTMLElement
+
+    expect(card.style.borderRadius).toBe('16px 16px 0 0')
+    expect(card.style.overflow).toBe('hidden')
+  })
+})
+
 describe('MobilePlanningView — by goal section', () => {
   it('shows investments grouped by goal', () => {
     render(<MobilePlanningView {...defaultProps} plan={basePlan} investments={baseInvestments} savings={baseSavings} />)


### PR DESCRIPTION
Closes #319

## Problem
On mobile, the Plan → **Override amount** bottom-sheet renders with **square top corners** on iOS, even though the sheet's container sets `borderRadius: 16px 16px 0 0`.

![reported](https://github.com/user-attachments/assets/d7018573-3331-4dfe-9b70-b97fa1b90795)

## Cause
The planning `Sheet` animates up with a `transform` (`slide-up`). iOS WebKit composites that layer and **does not clip the rounded corners unless the element also sets `overflow: hidden`** — so the corners render square. The working `AddTransactionSheet` bottom-sheet already pairs its top radius with `overflow: hidden`; the planning `Sheet` was missing it.

## Fix
Add `overflow: 'hidden'` to the planning `Sheet` card. Safe for the other sheets that share this component (salary, delete, add-item, override) — they're simple forms, and the only escaping UI (kebab dropdowns) uses `position: fixed` outside the sheet.

## Tests
- New unit test opens the override sheet and asserts the card carries **both** the `16px 16px 0 0` radius and `overflow: hidden` (red before the fix, green after).
- Full `MobilePlanningView` suite passes (44 tests).

> Note: the bug is iOS-WebKit-specific (chromium/jsdom clip fine regardless), so the unit test guards the style contract rather than a cross-browser render. Please verify visually on the iPhone preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)