### PR TITLE
fix(funds): bump DCA goal select to 16px to stop iOS zoom (#321)

### DIFF
--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -444,7 +444,9 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
               aria-label={goalLabel}
               onChange={(e) => onGoalChange(e.target.value || null)}
               style={{
-                fontSize: 13, fontWeight: 500, padding: '3px 6px', maxWidth: 130,
+                // 16px (not 13) so iOS Safari doesn't zoom the viewport on focus
+                // and persist that zoom across reloads (#321).
+                fontSize: 16, fontWeight: 500, padding: '3px 6px', maxWidth: 130,
                 border: '1px solid var(--c-line)', borderRadius: 6,
                 background: 'var(--c-card)', color: 'var(--c-muted)',
                 fontFamily: 'inherit', cursor: 'pointer', appearance: 'none', outline: 'none',

--- a/e2e/input-zoom.spec.ts
+++ b/e2e/input-zoom.spec.ts
@@ -1,4 +1,9 @@
 import { test, expect, type Page } from '@playwright/test'
+import * as api from './helpers/api'
+import { makeCleanupStack } from './helpers/cleanup'
+
+const cleanup = makeCleanupStack()
+test.afterEach(() => cleanup.run())
 
 // ─── iOS auto-zoom on text fields (issue #265) ───────────────────────────────
 // iOS Safari zooms the viewport when a focused native field has font-size < 16px
@@ -71,5 +76,26 @@ test.describe('Fund library — no field triggers iOS zoom', () => {
     // The name field's placeholder confirms the form is open.
     await expect(page.getByPlaceholder(/Vanguard|S&P/i)).toBeVisible({ timeout: 5_000 })
     await expectNoZoomFields(page)
+  })
+
+  // Regression for #321: the DCA goal <select> only renders for DCA-enabled funds,
+  // so the loads-a-fresh-page tests above never exercise it. iOS persists the
+  // focus-zoom across reloads, so a <16px select left the whole Fund page zoomed
+  // on subsequent first loads.
+  test('DCA goal select renders at >=16px', async ({ page }) => {
+    const fund = await api.createFund({
+      name: 'E2E Zoom DCA Fund', code: 'E2EZM', fund_type: 'equity', nav: 45000,
+      is_dca: true, dca_monthly_amount_vnd: 1_000_000,
+    })
+    cleanup.add(() => api.deleteFund(fund.id))
+
+    await useEnglish(page)
+    await page.goto('/funds')
+    await page.waitForLoadState('networkidle')
+
+    const select = page.getByTestId('mobile-funds').getByTestId(`dca-goal-${fund.id}`)
+    await expect(select).toBeVisible({ timeout: 10_000 })
+    const fontSize = await select.evaluate((el) => parseFloat(getComputedStyle(el).fontSize))
+    expect(fontSize).toBeGreaterThanOrEqual(16)
   })
 })


### PR DESCRIPTION
## Problem

Fixes #321 — on mobile, the Fund page would *sometimes auto-zoom in and stay zoomed* on first load.

The DCA goal `<select>` (`MobileFundLibraryView.tsx`) rendered at `fontSize: 13`. iOS Safari zooms the viewport whenever a native field smaller than 16px is focused **and persists that zoom across reloads** — so once the user touched that select, the Fund page would reopen already zoomed in.

This was the last sub-16px native field on the page. Issue #265 bumped every text input to 16px, but that select was missed because it only renders for **DCA-enabled** funds, and #265's `input-zoom` test loads a fresh funds page with no DCA fund.

## Fix

- Bump the DCA goal `<select>` to `fontSize: 16` to match every other native field.

## Test (TDD)

- Added a regression test to `e2e/input-zoom.spec.ts` that creates a DCA-enabled fund, loads the funds page, and asserts the rendered `font-size` of the `dca-goal-*` select is ≥ 16px (the user-visible outcome, not the markup).

## Verification

- `npm run lint` — no new errors on changed files (pre-existing baseline unchanged).
- `npm test -- --run` — passes (the one failing `calcProjectedInterest` test is a pre-existing date-drift fixture, unrelated to this change).
- Targeted E2E not run locally (local Supabase/WSL stack was down this session). Please confirm on the Vercel preview: on an iPhone, enable DCA on a fund, tap the goal dropdown — the page should no longer zoom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
