### PR TITLE
test(finance): pin clock in calcProjectedInterest deposit test

### DIFF
--- a/lib/__tests__/finance.test.ts
+++ b/lib/__tests__/finance.test.ts
@@ -22,10 +22,18 @@ describe('calcProjectedInterest', () => {
     expect(withExpiry).toBeGreaterThan(0)
   })
   it('produces positive interest for a bank deposit', () => {
-    // 10M VND at 8%/year for ~1 year should yield ~800k
-    const result = calcProjectedInterest(10_000_000, 8, '2025-04-29')
-    expect(result).toBeGreaterThan(700_000)
-    expect(result).toBeLessThan(900_000)
+    // 10M VND at 8%/year for exactly 1 year should yield ~800k. Pin "now" so the
+    // result doesn't drift as the calendar moves past the investment date (the
+    // function accrues interest up to Date.now()).
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-29'))
+    try {
+      const result = calcProjectedInterest(10_000_000, 8, '2025-04-29')
+      expect(result).toBeGreaterThan(700_000)
+      expect(result).toBeLessThan(900_000)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })
 


### PR DESCRIPTION
## Problem

The Unit Tests CI check is failing on **every** PR (it's a required check, so nothing can merge). The cause is unrelated to any feature work:

`calcProjectedInterest > produces positive interest for a bank deposit` passes a hardcoded investment date (`'2025-04-29'`) and asserts the result is `< 900_000`. The function accrues interest up to `Date.now()`, so as the calendar advances the projected 8%/year interest creeps past 900k — `expected 903784 to be less than 900000` as of 2026-06-13.

## Fix

Pin "now" to exactly one year after the investment date with `vi.useFakeTimers()` / `vi.setSystemTime(...)` (the same pattern already used in this file's `isNavStale` tests), so the test deterministically asserts ~800k and never drifts again.

## Test

- `npm test -- --run lib/__tests__/finance.test.ts` → 41/41 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)