### PR TITLE
feat(deposits): term-deposit maturity renew/withdraw flow (PR1)

### DIFF
--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -1,10 +1,11 @@
 'use client'
 
 import { useState, useEffect, useMemo } from 'react'
-import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield } from 'lucide-react'
+import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield, RefreshCw } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, AffectsProgressControl, BankInfoStrip, type InvRow } from './goalDetailShared'
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, AffectsProgressControl, BankInfoStrip, needsMaturityAction, type InvRow } from './goalDetailShared'
+import { MaturityResolveModal } from './MaturityResolveSheet'
 import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 
@@ -55,6 +56,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
   // Investment options state
   const [actionInv, setActionInv] = useState<InvRow | null>(null)
   const [showInvOptions, setShowInvOptions] = useState(false)
+  const [showResolve, setShowResolve] = useState(false)
   const [showSell, setShowSell] = useState(false)
   const [showUnassignConfirm, setShowUnassignConfirm] = useState(false)
   const [unassigning, setUnassigning] = useState(false)
@@ -519,8 +521,20 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
           isVi={isVi}
           onClose={() => { setShowInvOptions(false) }}
           onHistory={() => { setShowInvOptions(false); setTab('history') }}
+          onResolve={() => { setShowInvOptions(false); setTimeout(() => setShowResolve(true), 80) }}
           onSell={() => { setShowInvOptions(false); setTimeout(() => setShowSell(true), 80) }}
           onUnassign={() => { setShowInvOptions(false); setTimeout(() => setShowUnassignConfirm(true), 80) }}
+        />
+      )}
+
+      {/* Maturity resolve modal */}
+      {showResolve && actionInv && (
+        <MaturityResolveModal
+          inv={actionInv}
+          isVi={isVi}
+          onClose={() => setShowResolve(false)}
+          onRenewed={() => { setShowResolve(false); onDataChanged() }}
+          onWithdraw={() => { setShowResolve(false); setTimeout(() => setShowSell(true), 80) }}
         />
       )}
 
@@ -556,14 +570,22 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
 }
 
 // ─── Investment options modal ──────────────────────────────────────────────
-function InvOptionsModal({ inv, isVi, onClose, onHistory, onSell, onUnassign }: {
+function InvOptionsModal({ inv, isVi, onClose, onHistory, onResolve, onSell, onUnassign }: {
   inv: InvRow; isVi: boolean
-  onClose: () => void; onHistory: () => void; onSell: () => void; onUnassign: () => void
+  onClose: () => void; onHistory: () => void; onResolve: () => void; onSell: () => void; onUnassign: () => void
 }) {
   const isBank = inv.type === 'bank'
   const typeColor = GD_COLORS[inv.type] ?? 'var(--c-muted)'
+  const needsMaturity = needsMaturityAction(inv, isVi)
 
   const actions = [
+    ...(needsMaturity ? [{
+      icon: <RefreshCw size={18} color="var(--c-warn,#b45309)" />,
+      bg: 'var(--c-warn-tint,#fef3c7)',
+      label: isVi ? 'Xử lý đáo hạn' : 'Handle maturity',
+      sub: isVi ? 'Tái tục hoặc chuyển sang chờ rút' : 'Renew or mark for withdrawal',
+      onClick: onResolve,
+    }] : []),
     {
       icon: <CalendarDays size={18} color="var(--c-muted)" />,
       bg: 'var(--c-card-2)',

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -3,14 +3,15 @@
 import { useState, useEffect } from 'react'
 import {
   ChevronLeft, ChevronRight, MoreHorizontal,
-  Edit2, Trash2, Calendar, Download, ArrowDownRight, ArrowUpRight, Target,
+  Edit2, Trash2, Calendar, Download, ArrowDownRight, ArrowUpRight, Target, RefreshCw,
 } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData, FundBreakdownItem } from '../DashboardClient'
 import TransactionHistorySheet, { type PurchaseHistoryRow } from './TransactionHistorySheet'
 import { SellWithdrawSheet, type SellItem } from './SellWithdrawSheet'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, BankInfoStrip, type InvRow } from './goalDetailShared'
+import { MaturityResolveSheet } from './MaturityResolveSheet'
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, BankInfoStrip, needsMaturityAction, type InvRow } from './goalDetailShared'
 import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 
@@ -342,6 +343,7 @@ function InvestmentActionSheet({
   onViewHistory,
   onSell,
   onUnassign,
+  onResolve,
 }: {
   open: boolean
   onClose: () => void
@@ -349,6 +351,7 @@ function InvestmentActionSheet({
   onViewHistory: () => void
   onSell: () => void
   onUnassign: () => void
+  onResolve: () => void
 }) {
   const isVI = useLocale() === 'vi'
   const [mounted, setMounted] = useState(false)
@@ -361,9 +364,12 @@ function InvestmentActionSheet({
   const typeColor = GD_COLORS[inv.type] ?? 'var(--c-muted)'
   const isBank = inv.type === 'bank'
   const isPos = (inv.gainPct ?? 0) >= 0
+  const needsMaturity = needsMaturityAction(inv, isVI)
 
   const t = isVI ? {
     title: 'Tùy chọn',
+    handle: 'Xử lý đáo hạn',
+    handleSub: 'Tái tục hoặc chuyển sang chờ rút',
     history: 'Lịch sử giao dịch',
     historySub: 'Xem các lần mua / bán trước đây',
     sell: isBank ? 'Rút tiền' : 'Bán',
@@ -372,6 +378,8 @@ function InvestmentActionSheet({
     unassignSub: 'Chuyển khoản đầu tư này sang trạng thái chưa gán',
   } : {
     title: 'Options',
+    handle: 'Handle maturity',
+    handleSub: 'Renew or mark for withdrawal',
     history: 'Transaction history',
     historySub: 'View past buys & sells',
     sell: isBank ? 'Withdraw' : 'Sell',
@@ -433,6 +441,29 @@ function InvestmentActionSheet({
 
           {/* Bank info strip — interest rate + maturity + time left (issue #263) */}
           <BankInfoStrip inv={inv} isVi={isVI} />
+
+          {/* Handle maturity — only for a term deposit at/near its maturity date */}
+          {needsMaturity && (
+            <button
+              data-testid="handle-maturity-btn"
+              onClick={() => { onClose(); setTimeout(onResolve, 60) }}
+              style={{
+                width: '100%', textAlign: 'left', padding: '14px 16px',
+                background: 'var(--c-warn-tint)', border: '1px solid rgba(180,83,9,0.18)',
+                borderRadius: 14, cursor: 'pointer', fontFamily: 'inherit',
+                display: 'flex', alignItems: 'center', gap: 14,
+              }}
+            >
+              <div style={{ width: 42, height: 42, borderRadius: 12, background: 'var(--c-card)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                <RefreshCw size={20} color="var(--c-warn)" />
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 14, fontWeight: 600, color: 'var(--c-warn)' }}>{t.handle}</div>
+                <div style={{ fontSize: 12, color: 'var(--c-muted)', marginTop: 2 }}>{t.handleSub}</div>
+              </div>
+              <ChevronRight size={16} color="var(--c-warn)" />
+            </button>
+          )}
 
           {/* View history */}
           <button
@@ -629,6 +660,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   const [isDeleting, setIsDeleting] = useState(false)
   const [actionInv, setActionInv] = useState<InvRow | null>(null)
   const [investActionOpen, setInvestActionOpen] = useState(false)
+  const [resolveOpen, setResolveOpen] = useState(false)
   const [sellOpen, setSellOpen] = useState(false)
   const [unassignConfirmOpen, setUnassignConfirmOpen] = useState(false)
   const [unassigning, setUnassigning] = useState(false)
@@ -1210,6 +1242,16 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
         }}
         onSell={() => setSellOpen(true)}
         onUnassign={() => setUnassignConfirmOpen(true)}
+        onResolve={() => setResolveOpen(true)}
+      />
+
+      <MaturityResolveSheet
+        open={resolveOpen}
+        inv={actionInv}
+        isVi={isVI}
+        onClose={() => setResolveOpen(false)}
+        onRenewed={() => { setResolveOpen(false); onDataChanged() }}
+        onWithdraw={() => { setResolveOpen(false); setSellOpen(true) }}
       />
 
       <SellWithdrawSheet

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -1,0 +1,397 @@
+'use client'
+
+// Term-deposit maturity decision flow. When a bank term deposit reaches (or
+// nears) its maturity date the user must decide: renew (roll principal +
+// interest, principal only, or change amount/term) or withdraw. This is the
+// shared form plus a mobile bottom-sheet and a desktop modal wrapper.
+//
+// Renewal is a single PUT to the existing transaction: it updates the deposit
+// in place (new principal / rate / maturity) and resets `investment_date` to
+// today so the compound-interest valuation in buildInvRows restarts from the
+// new principal — and so the PUT's future-date guard never trips when maturity
+// is tomorrow. Withdrawal hands off to the existing Sell/Withdraw flow rather
+// than re-implementing the payout (the parent wires `onWithdraw`).
+
+import { useState } from 'react'
+import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X } from 'lucide-react'
+import { fmt, fmtCompact } from '@/lib/formatters'
+import { fmtMaturity, type InvRow } from './goalDetailShared'
+import {
+  depositMaturityState,
+  addMonths,
+  renewalPrincipal,
+  type RenewMode,
+} from '@/lib/maturity'
+
+type Mode = RenewMode | 'withdraw'
+
+const todayIso = () => new Date().toISOString().slice(0, 10)
+
+const fieldLabel: React.CSSProperties = {
+  fontSize: 11, fontWeight: 600, letterSpacing: '0.05em',
+  textTransform: 'uppercase', color: 'var(--c-muted)', marginBottom: 6,
+}
+const moneyInput: React.CSSProperties = {
+  display: 'block', width: '100%', boxSizing: 'border-box',
+  padding: '10px 12px', fontFamily: 'inherit', fontSize: 15,
+  fontVariantNumeric: 'tabular-nums', fontWeight: 600,
+  background: 'var(--c-canvas,#faf9f7)', border: '1.5px solid var(--c-line)',
+  borderRadius: 10, color: 'var(--c-ink)', outline: 'none',
+}
+
+function MoneyField({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+  return (
+    <div>
+      <div style={fieldLabel}>{label}</div>
+      <div style={{ position: 'relative' }}>
+        <input type="number" value={value} onChange={(e) => onChange(e.target.value)} style={moneyInput} />
+        <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * The shared decision form. Rendered inside the mobile sheet or desktop modal.
+ * `onRenewed` fires after a successful PUT; `onWithdraw` hands control to the
+ * parent's existing Sell/Withdraw flow.
+ */
+export function MaturityResolveBody({
+  inv, isVi, onClose, onRenewed, onWithdraw,
+}: {
+  inv: InvRow
+  isVi: boolean
+  onClose: () => void
+  onRenewed: () => void
+  onWithdraw: () => void
+}) {
+  const principal = inv.principal ?? inv.value ?? 0
+  // Best real-data estimate of interest earned this cycle: current (compounded)
+  // value minus the principal still held.
+  const estInterest = Math.max(0, Math.round((inv.value ?? 0) - principal))
+  const m = fmtMaturity(inv.expiryDate, isVi)
+  const state = depositMaturityState(m?.diffDays ?? 0)
+  const matured = state === 'matured'
+
+  const [mode, setMode] = useState<Mode>('principal_interest')
+  const [interest, setInterest] = useState(String(estInterest))
+  const [term, setTerm] = useState('12')
+  const [rate, setRate] = useState(inv.interestRate != null ? String(inv.interestRate) : '')
+  const [newAmount, setNewAmount] = useState(String(principal))
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+  const [done, setDone] = useState<null | { newPrincipal: number; newMaturity: string }>(null)
+
+  const iNum = Number(interest) || 0
+  const tNum = Number(term) || 12
+  const newPrincipal = mode === 'withdraw'
+    ? principal
+    : renewalPrincipal(mode, principal, iNum, Number(newAmount) || 0)
+  // Extend from today for an already-matured deposit (so the new maturity is
+  // always in the future), otherwise from the existing maturity date.
+  const baseDate = matured || !inv.expiryDate ? todayIso() : inv.expiryDate
+  const newMaturity = addMonths(baseDate, tNum)
+  const newMaturityFmt = fmtMaturity(newMaturity, isVi)?.formatted ?? newMaturity
+  const payout = principal + iNum
+
+  const t = isVi ? {
+    summarySuffix: 'năm', perYr: 'năm', mo: 'tháng',
+    why: matured
+      ? 'Sổ đã đáo hạn. Nếu không xử lý, ngân hàng thường tự tái tục theo kỳ hạn cũ. Hãy ghi nhận quyết định của bạn.'
+      : 'Sổ sắp đáo hạn. Chọn cách xử lý cho kỳ tiếp theo.',
+    prompt: 'Bạn muốn làm gì?',
+    newAmount: 'Số tiền kỳ mới', interestReceived: 'Lãi thực nhận',
+    interestPaidOut: 'Lãi thực nhận (rút ra)',
+    newTerm: 'Kỳ hạn mới', newRate: 'Lãi suất kỳ mới',
+    newCycle: 'Kỳ mới', newMaturityLabel: 'Ngày đáo hạn mới',
+    interestIn: 'Lãi nhập gốc', interestOut: 'Lãi rút ra',
+    totalPayout: 'Tổng nhận về',
+    cancel: 'Hủy', confirmRenew: 'Xác nhận tái tục', confirmWithdraw: 'Đánh dấu chờ rút',
+    renewed: 'Đã tái tục', renewedSub: (p: string, d: string) => `Kỳ mới ${p} · đáo hạn ${d}`,
+  } : {
+    summarySuffix: 'yr', perYr: 'yr', mo: 'mo',
+    why: matured
+      ? 'This deposit has matured. Banks usually auto-renew at the same term — record what you decided.'
+      : 'This deposit is about to mature. Choose how to handle the next cycle.',
+    prompt: 'What do you want to do?',
+    newAmount: 'New amount', interestReceived: 'Interest received',
+    interestPaidOut: 'Interest received (paid out)',
+    newTerm: 'New term', newRate: 'New interest rate',
+    newCycle: 'New cycle', newMaturityLabel: 'New maturity',
+    interestIn: 'Interest added', interestOut: 'Interest out',
+    totalPayout: 'Total payout',
+    cancel: 'Cancel', confirmRenew: 'Confirm renewal', confirmWithdraw: 'Mark for withdrawal',
+    renewed: 'Deposit renewed', renewedSub: (p: string, d: string) => `New term ${p} · matures ${d}`,
+  }
+
+  const POLICIES: { id: Mode; icon: React.ReactNode; label: string; sub: string; danger?: boolean }[] = [
+    { id: 'principal_interest', icon: <RefreshCw size={16} />, label: isVi ? 'Tái tục gốc + lãi' : 'Renew principal + interest', sub: isVi ? 'Cộng lãi vào gốc cho kỳ mới' : 'Roll interest into the new principal' },
+    { id: 'principal_only', icon: <RefreshCw size={16} />, label: isVi ? 'Tái tục chỉ gốc' : 'Renew principal only', sub: isVi ? 'Lãi chuyển ra ngoài (về ví)' : 'Interest paid out to your wallet' },
+    { id: 'change', icon: <Pencil size={16} />, label: isVi ? 'Đổi số tiền / kỳ hạn' : 'Change amount / term', sub: isVi ? 'Điều chỉnh gốc hoặc kỳ hạn kỳ mới' : 'Adjust principal or term for the new cycle' },
+    { id: 'withdraw', icon: <ArrowDownToLine size={16} />, label: isVi ? 'Không tái tục — rút' : 'Don’t renew — withdraw', sub: isVi ? 'Rút toàn bộ số dư' : 'Withdraw the full balance', danger: true },
+  ]
+
+  async function handleConfirm() {
+    if (mode === 'withdraw') { onClose(); setTimeout(onWithdraw, 60); return }
+    setSaving(true); setError('')
+    try {
+      const res = await fetch(`/api/v1/investment-transactions/${inv.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          amount_vnd: Math.round(newPrincipal),
+          interest_rate: rate === '' ? null : Number(rate),
+          expiry_date: newMaturity,
+          // Reset the accrual base so the value calc restarts from the new
+          // principal and the future-date guard never trips.
+          investment_date: todayIso(),
+        }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setError(body.error ?? (isVi ? 'Không thể tái tục' : 'Could not renew'))
+        setSaving(false)
+        return
+      }
+      setDone({ newPrincipal: Math.round(newPrincipal), newMaturity })
+      setTimeout(() => { onRenewed(); onClose() }, 1700)
+    } catch {
+      setError(isVi ? 'Lỗi kết nối' : 'Connection error')
+      setSaving(false)
+    }
+  }
+
+  // ─── Success state ───
+  if (done) {
+    return (
+      <div data-testid="maturity-renewed" style={{ padding: '24px 4px 8px', textAlign: 'center' }}>
+        <div style={{ width: 56, height: 56, borderRadius: 28, background: 'var(--c-pos-tint)', color: 'var(--c-pos)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 14px' }}>
+          <Check size={26} strokeWidth={2.4} />
+        </div>
+        <div style={{ fontSize: 15, fontWeight: 700 }}>{t.renewed}</div>
+        <div style={{ fontSize: 13, color: 'var(--c-muted)', marginTop: 6, lineHeight: 1.5 }}>
+          {t.renewedSub(fmtCompact(done.newPrincipal), newMaturityFmt)}
+        </div>
+      </div>
+    )
+  }
+
+  const pill = (() => {
+    if (state === 'matured') {
+      const n = Math.abs(m?.diffDays ?? 0)
+      return { text: isVi ? (n === 0 ? 'Đã đáo hạn' : `Quá hạn ${n} ngày`) : (n === 0 ? 'Matured' : `${n}d overdue`), color: 'var(--c-neg)', bg: 'var(--c-neg-tint)' }
+    }
+    const n = m?.diffDays ?? 0
+    return { text: isVi ? (n === 0 ? 'Đáo hạn hôm nay' : 'Đáo hạn ngày mai') : (n === 0 ? 'Matures today' : 'Matures tomorrow'), color: 'var(--c-warn)', bg: 'var(--c-warn-tint)' }
+  })()
+
+  return (
+    <div style={{ display: 'grid', gap: 16 }}>
+      {/* Deposit summary */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 14px', background: 'var(--c-card-2)', borderRadius: 12 }}>
+        <div style={{ width: 40, height: 40, borderRadius: 10, background: 'var(--c-card)', color: '#047857', display: 'flex', alignItems: 'center', justifyContent: 'center', border: '1px solid var(--c-line)', flexShrink: 0 }}>
+          <Building2 size={18} />
+        </div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{ fontSize: 14, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{inv.name}</div>
+          <div style={{ fontSize: 12, color: 'var(--c-muted)', marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>
+            {fmtCompact(principal)}{inv.interestRate != null ? ` · ${inv.interestRate}%/${t.perYr}` : ''}
+          </div>
+        </div>
+        <span style={{ flexShrink: 0, fontSize: 11, fontWeight: 600, padding: '3px 9px', borderRadius: 999, background: pill.bg, color: pill.color }}>{pill.text}</span>
+      </div>
+
+      {/* Why this needs a decision */}
+      <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '11px 13px', background: 'var(--c-warn-tint)', borderRadius: 10 }}>
+        <AlertTriangle size={15} color="var(--c-warn)" strokeWidth={2.2} style={{ flexShrink: 0, marginTop: 1 }} />
+        <p style={{ margin: 0, fontSize: 12.5, color: 'var(--c-warn)', lineHeight: 1.5 }}>{t.why}</p>
+      </div>
+
+      {/* Decision picker */}
+      <div>
+        <div style={fieldLabel}>{t.prompt}</div>
+        <div style={{ display: 'grid', gap: 8 }}>
+          {POLICIES.map((p) => {
+            const active = mode === p.id
+            const accent = p.danger ? 'var(--c-neg)' : 'var(--c-navy)'
+            const tint = p.danger ? 'var(--c-neg-tint)' : 'var(--c-navy-tint)'
+            return (
+              <button key={p.id} type="button" onClick={() => setMode(p.id)} style={{
+                width: '100%', textAlign: 'left', padding: '11px 12px',
+                background: active ? tint : 'var(--c-card)',
+                border: `1.5px solid ${active ? accent : 'var(--c-line)'}`,
+                borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit',
+                display: 'flex', alignItems: 'center', gap: 11, transition: 'all 120ms',
+              }}>
+                <div style={{ width: 34, height: 34, borderRadius: 9, background: active ? 'var(--c-card)' : 'var(--c-card-2)', color: accent, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                  {p.icon}
+                </div>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontSize: 13.5, fontWeight: 600, color: active ? accent : 'var(--c-ink)' }}>{p.label}</div>
+                  <div style={{ fontSize: 11.5, color: 'var(--c-muted)', marginTop: 1, lineHeight: 1.4 }}>{p.sub}</div>
+                </div>
+                <div style={{ width: 18, height: 18, borderRadius: 9, border: `1.5px solid ${active ? accent : 'var(--c-line-strong)'}`, background: active ? accent : 'transparent', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                  {active && <Check size={11} strokeWidth={3} color="#fff" />}
+                </div>
+              </button>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Inputs per mode */}
+      {mode !== 'withdraw' && (
+        <div style={{ display: 'grid', gap: 12 }}>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+            {mode === 'change'
+              ? <MoneyField label={t.newAmount} value={newAmount} onChange={setNewAmount} />
+              : <MoneyField label={t.interestReceived} value={interest} onChange={setInterest} />}
+            <div>
+              <div style={fieldLabel}>{t.newTerm}</div>
+              <div style={{ position: 'relative' }}>
+                <input type="number" value={term} onChange={(e) => setTerm(e.target.value)} style={moneyInput} />
+                <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>{t.mo}</span>
+              </div>
+            </div>
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: mode === 'change' ? '1fr 1fr' : '1fr', gap: 10 }}>
+            <div>
+              <div style={fieldLabel}>{t.newRate}</div>
+              <div style={{ position: 'relative' }}>
+                <input type="number" step="0.1" value={rate} onChange={(e) => setRate(e.target.value)} style={moneyInput} />
+                <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>%/{t.perYr}</span>
+              </div>
+            </div>
+            {mode === 'change' && <MoneyField label={t.interestPaidOut} value={interest} onChange={setInterest} />}
+          </div>
+
+          {/* Preview */}
+          <div style={{ border: '1px solid var(--c-line)', borderRadius: 12, overflow: 'hidden' }}>
+            <div style={{ padding: '10px 14px', background: 'var(--c-navy-tint)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--c-navy)' }}>{t.newCycle}</span>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span data-testid="maturity-new-principal" style={{ fontSize: 16, fontWeight: 700, color: 'var(--c-navy)', fontVariantNumeric: 'tabular-nums' }}>{fmt(newPrincipal)}</span>
+                {rate !== '' && <span style={{ fontSize: 11, fontWeight: 600, padding: '2px 8px', borderRadius: 999, background: 'var(--c-card)', color: 'var(--c-navy)' }}>{rate}%/{t.perYr}</span>}
+              </span>
+            </div>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 1, background: 'var(--c-line)' }}>
+              <div style={{ background: 'var(--c-card)', padding: '9px 12px' }}>
+                <div style={{ fontSize: 10, color: 'var(--c-muted)' }}>{t.newMaturityLabel}</div>
+                <div data-testid="maturity-new-date" style={{ fontSize: 13, fontWeight: 600, marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>{newMaturityFmt}</div>
+              </div>
+              <div style={{ background: 'var(--c-card)', padding: '9px 12px' }}>
+                <div style={{ fontSize: 10, color: 'var(--c-muted)' }}>{mode === 'principal_interest' ? t.interestIn : t.interestOut}</div>
+                <div style={{ fontSize: 13, fontWeight: 600, marginTop: 2, color: 'var(--c-pos)', fontVariantNumeric: 'tabular-nums' }}>+{fmtCompact(iNum)}</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {mode === 'withdraw' && (
+        <div style={{ border: '1px solid var(--c-line)', borderRadius: 12, padding: '12px 14px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: 'var(--c-card-2)' }}>
+          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-muted)' }}>{t.totalPayout}</span>
+          <span style={{ fontSize: 16, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>{fmt(payout)}</span>
+        </div>
+      )}
+
+      {error && <p style={{ margin: 0, fontSize: 13, color: 'var(--c-neg)' }}>{error}</p>}
+
+      {/* Actions */}
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button type="button" onClick={onClose} className="cn-btn ghost" style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}>{t.cancel}</button>
+        <button type="button" onClick={handleConfirm} disabled={saving} style={{
+          flex: 2, justifyContent: 'center', gap: 7, padding: '10px 14px', borderRadius: 10, border: 'none',
+          fontSize: 14, fontWeight: 600, fontFamily: 'inherit', cursor: saving ? 'default' : 'pointer',
+          opacity: saving ? 0.6 : 1, color: '#fff',
+          background: mode === 'withdraw' ? 'var(--c-neg)' : 'var(--c-btn-primary)',
+          display: 'flex', alignItems: 'center',
+        }}>
+          {mode === 'withdraw' ? <ArrowDownToLine size={14} strokeWidth={2.2} /> : <RefreshCw size={14} strokeWidth={2.2} />}
+          {mode === 'withdraw' ? t.confirmWithdraw : t.confirmRenew}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ─── Mobile bottom-sheet wrapper ───────────────────────────────────────────
+export function MaturityResolveSheet({
+  open, inv, isVi, onClose, onRenewed, onWithdraw,
+}: {
+  open: boolean
+  inv: InvRow | null
+  isVi: boolean
+  onClose: () => void
+  onRenewed: () => void
+  onWithdraw: () => void
+}) {
+  if (!open || !inv) return null
+  return (
+    <div
+      style={{ position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.2)', zIndex: 170 }}
+      onClick={onClose}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          position: 'absolute', bottom: 0, left: 0, right: 0,
+          background: 'var(--c-card)', borderRadius: '16px 16px 0 0',
+          padding: '0 0 env(safe-area-inset-bottom,0)', maxHeight: '92vh', overflowY: 'auto',
+          animation: 'slide-up 220ms cubic-bezier(0.2, 0.8, 0.2, 1)',
+        }}
+      >
+        <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '6px auto 14px' }} />
+        <div style={{ padding: '0 16px 20px' }}>
+          <h2 style={{ margin: '0 0 14px', fontSize: 17, fontWeight: 700, letterSpacing: '-0.01em' }}>
+            {isVi ? 'Xử lý đáo hạn' : 'Handle maturity'}
+          </h2>
+          <MaturityResolveBody inv={inv} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─── Desktop modal wrapper ─────────────────────────────────────────────────
+export function MaturityResolveModal({
+  inv, isVi, onClose, onRenewed, onWithdraw,
+}: {
+  inv: InvRow
+  isVi: boolean
+  onClose: () => void
+  onRenewed: () => void
+  onWithdraw: () => void
+}) {
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)', zIndex: 200,
+        display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24,
+        animation: 'fade-in 150ms ease', backdropFilter: 'blur(2px)',
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: '100%', maxWidth: 460, maxHeight: 'calc(100vh - 48px)',
+          background: 'var(--c-card)', borderRadius: 16,
+          boxShadow: '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)',
+          display: 'flex', flexDirection: 'column',
+          animation: 'modal-in 200ms cubic-bezier(0.2,0.8,0.2,1)', overflow: 'hidden',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0 }}>
+          <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{isVi ? 'Xử lý đáo hạn' : 'Handle maturity'}</h3>
+          <button onClick={onClose} className="cn-btn ghost" style={{ padding: 6 }} aria-label="Close"><X size={18} /></button>
+        </div>
+        <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto' }}>
+          <MaturityResolveBody inv={inv} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -12,13 +12,14 @@
 // is tomorrow. Withdrawal hands off to the existing Sell/Withdraw flow rather
 // than re-implementing the payout (the parent wires `onWithdraw`).
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import { fmtMaturity, type InvRow } from './goalDetailShared'
 import {
   depositMaturityState,
   addMonths,
+  monthsBetween,
   renewalPrincipal,
   type RenewMode,
 } from '@/lib/maturity'
@@ -39,12 +40,12 @@ const moneyInput: React.CSSProperties = {
   borderRadius: 10, color: 'var(--c-ink)', outline: 'none',
 }
 
-function MoneyField({ label, value, onChange }: { label: string; value: string; onChange: (v: string) => void }) {
+function MoneyField({ label, value, onChange, testId }: { label: string; value: string; onChange: (v: string) => void; testId?: string }) {
   return (
     <div>
       <div style={fieldLabel}>{label}</div>
       <div style={{ position: 'relative' }}>
-        <input type="number" value={value} onChange={(e) => onChange(e.target.value)} style={moneyInput} />
+        <input data-testid={testId} type="number" value={value} onChange={(e) => onChange(e.target.value)} style={moneyInput} />
         <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
       </div>
     </div>
@@ -73,9 +74,12 @@ export function MaturityResolveBody({
   const state = depositMaturityState(m?.diffDays ?? 0)
   const matured = state === 'matured'
 
+  // Suggest the original term length (open date → maturity), falling back to 12
+  // months when we can't derive it (no stored open date).
+  const derivedTerm = inv.investmentDate && inv.expiryDate ? monthsBetween(inv.investmentDate, inv.expiryDate) : 0
   const [mode, setMode] = useState<Mode>('principal_interest')
   const [interest, setInterest] = useState(String(estInterest))
-  const [term, setTerm] = useState('12')
+  const [term, setTerm] = useState(String(derivedTerm > 0 ? derivedTerm : 12))
   const [rate, setRate] = useState(inv.interestRate != null ? String(inv.interestRate) : '')
   const [newAmount, setNewAmount] = useState(String(principal))
   const [saving, setSaving] = useState(false)
@@ -83,16 +87,25 @@ export function MaturityResolveBody({
   const [done, setDone] = useState<null | { newPrincipal: number; newMaturity: string }>(null)
 
   const iNum = Number(interest) || 0
-  const tNum = Number(term) || 12
+  const tNum = Number(term) || 0
+  // Pass null (not 0) for an empty "new amount" so renewalPrincipal can fall
+  // back to the current principal rather than writing 0₫ to the deposit.
+  const newAmountNum = newAmount.trim() === '' ? null : Number(newAmount)
   const newPrincipal = mode === 'withdraw'
     ? principal
-    : renewalPrincipal(mode, principal, iNum, Number(newAmount) || 0)
+    : renewalPrincipal(mode, principal, iNum, newAmountNum)
   // Extend from today for an already-matured deposit (so the new maturity is
   // always in the future), otherwise from the existing maturity date.
   const baseDate = matured || !inv.expiryDate ? todayIso() : inv.expiryDate
-  const newMaturity = addMonths(baseDate, tNum)
+  const newMaturity = addMonths(baseDate, tNum > 0 ? tNum : 0)
   const newMaturityFmt = fmtMaturity(newMaturity, isVi)?.formatted ?? newMaturity
   const payout = principal + iNum
+
+  // Guard against writing a zero/empty principal, a non-positive term, or
+  // clearing the rate (which would drop the deposit out of maturity tracking).
+  const rateValid = rate.trim() !== '' && Number(rate) > 0
+  const amountValid = mode !== 'change' || (newAmount.trim() !== '' && Number(newAmount) > 0)
+  const canRenew = tNum > 0 && rateValid && amountValid && newPrincipal > 0
 
   const t = isVi ? {
     summarySuffix: 'năm', perYr: 'năm', mo: 'tháng',
@@ -133,6 +146,7 @@ export function MaturityResolveBody({
 
   async function handleConfirm() {
     if (mode === 'withdraw') { onClose(); setTimeout(onWithdraw, 60); return }
+    if (!canRenew) return
     setSaving(true); setError('')
     try {
       const res = await fetch(`/api/v1/investment-transactions/${inv.id}`, {
@@ -140,7 +154,7 @@ export function MaturityResolveBody({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           amount_vnd: Math.round(newPrincipal),
-          interest_rate: rate === '' ? null : Number(rate),
+          interest_rate: Number(rate),
           expiry_date: newMaturity,
           // Reset the accrual base so the value calc restarts from the new
           // principal and the future-date guard never trips.
@@ -244,12 +258,12 @@ export function MaturityResolveBody({
         <div style={{ display: 'grid', gap: 12 }}>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
             {mode === 'change'
-              ? <MoneyField label={t.newAmount} value={newAmount} onChange={setNewAmount} />
+              ? <MoneyField label={t.newAmount} value={newAmount} onChange={setNewAmount} testId="maturity-new-amount" />
               : <MoneyField label={t.interestReceived} value={interest} onChange={setInterest} />}
             <div>
               <div style={fieldLabel}>{t.newTerm}</div>
               <div style={{ position: 'relative' }}>
-                <input type="number" value={term} onChange={(e) => setTerm(e.target.value)} style={moneyInput} />
+                <input data-testid="maturity-term-input" type="number" value={term} onChange={(e) => setTerm(e.target.value)} style={moneyInput} />
                 <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>{t.mo}</span>
               </div>
             </div>
@@ -300,10 +314,11 @@ export function MaturityResolveBody({
       {/* Actions */}
       <div style={{ display: 'flex', gap: 8 }}>
         <button type="button" onClick={onClose} className="cn-btn ghost" style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}>{t.cancel}</button>
-        <button type="button" onClick={handleConfirm} disabled={saving} style={{
+        <button type="button" onClick={handleConfirm} disabled={saving || (mode !== 'withdraw' && !canRenew)} style={{
           flex: 2, justifyContent: 'center', gap: 7, padding: '10px 14px', borderRadius: 10, border: 'none',
-          fontSize: 14, fontWeight: 600, fontFamily: 'inherit', cursor: saving ? 'default' : 'pointer',
-          opacity: saving ? 0.6 : 1, color: '#fff',
+          fontSize: 14, fontWeight: 600, fontFamily: 'inherit',
+          cursor: saving || (mode !== 'withdraw' && !canRenew) ? 'default' : 'pointer',
+          opacity: saving || (mode !== 'withdraw' && !canRenew) ? 0.6 : 1, color: '#fff',
           background: mode === 'withdraw' ? 'var(--c-neg)' : 'var(--c-btn-primary)',
           display: 'flex', alignItems: 'center',
         }}>
@@ -326,6 +341,13 @@ export function MaturityResolveSheet({
   onRenewed: () => void
   onWithdraw: () => void
 }) {
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
   if (!open || !inv) return null
   return (
     <div

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MaturityResolveBody } from '../MaturityResolveSheet'
-import { addMonths } from '@/lib/maturity'
+import { addMonths, monthsBetween } from '@/lib/maturity'
 import { fmt } from '@/lib/formatters'
 import type { InvRow } from '../goalDetailShared'
 
@@ -26,6 +26,7 @@ const maturedDeposit: InvRow = {
   principal: 35_000_000,
   interestRate: 5.8,
   expiryDate: daysFromNow(-12), // already matured
+  investmentDate: null,         // no stored open date → term falls back to 12
   fund: null,
 }
 
@@ -63,6 +64,32 @@ describe('MaturityResolveBody', () => {
       expiry_date: addMonths(today(), 12), // new maturity from today (matured)
       investment_date: today(),            // accrual reset, never future-dated
     })
+  })
+
+  it('suggests the original term length derived from the open + maturity dates', () => {
+    const deposit: InvRow = { ...maturedDeposit, investmentDate: daysFromNow(-190), expiryDate: daysFromNow(-7) }
+    const expectedTerm = monthsBetween(deposit.investmentDate!, deposit.expiryDate!)
+    render(
+      <MaturityResolveBody inv={deposit} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+    expect((screen.getByTestId('maturity-term-input') as HTMLInputElement).value).toBe(String(expectedTerm))
+  })
+
+  it('disables Confirm and never writes 0₫ when the change-amount field is cleared', async () => {
+    const user = userEvent.setup()
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <MaturityResolveBody inv={maturedDeposit} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+    await user.click(screen.getByRole('button', { name: /Change amount/i }))
+    await user.clear(screen.getByTestId('maturity-new-amount'))
+
+    const confirm = screen.getByRole('button', { name: /Confirm renewal/i })
+    expect(confirm).toBeDisabled()
+    await user.click(confirm)
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('hands off to the existing withdraw flow instead of renewing', async () => {

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MaturityResolveBody } from '../MaturityResolveSheet'
+import { addMonths } from '@/lib/maturity'
+import { fmt } from '@/lib/formatters'
+import type { InvRow } from '../goalDetailShared'
+
+// A YYYY-MM-DD string `n` days from today (deterministic regardless of run date).
+function daysFromNow(n: number): string {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  d.setDate(d.getDate() + n)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+const today = () => daysFromNow(0)
+
+// A matured term deposit: value (compounded) > principal, expiry in the past.
+const maturedDeposit: InvRow = {
+  id: 'tx-bank-1',
+  name: 'TCB Term Deposit',
+  type: 'bank',
+  value: 37_030_000,
+  gainPct: 5.8,
+  units: null,
+  principal: 35_000_000,
+  interestRate: 5.8,
+  expiryDate: daysFromNow(-12), // already matured
+  fund: null,
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('MaturityResolveBody', () => {
+  it('previews the rolled-up principal and a future maturity for principal + interest', () => {
+    render(
+      <MaturityResolveBody inv={maturedDeposit} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+    // Default mode is principal + interest: 35,000,000 + (37,030,000 − 35,000,000) = 37,030,000
+    expect(screen.getByTestId('maturity-new-principal').textContent).toContain(fmt(37_030_000))
+    // Matured → new term extends from today (12 months default), always in the future.
+    const expectedMaturity = addMonths(today(), 12)
+    expect(screen.getByTestId('maturity-new-date').textContent).toContain(expectedMaturity.slice(0, 4))
+  })
+
+  it('renews via a single PUT that resets the accrual date and sets the new maturity', async () => {
+    const user = userEvent.setup()
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <MaturityResolveBody inv={maturedDeposit} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+    await user.click(screen.getByRole('button', { name: /Confirm renewal/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(url).toBe('/api/v1/investment-transactions/tx-bank-1')
+    expect(opts.method).toBe('PUT')
+    expect(JSON.parse(opts.body)).toMatchObject({
+      amount_vnd: 37_030_000,
+      interest_rate: 5.8,
+      expiry_date: addMonths(today(), 12), // new maturity from today (matured)
+      investment_date: today(),            // accrual reset, never future-dated
+    })
+  })
+
+  it('hands off to the existing withdraw flow instead of renewing', async () => {
+    const user = userEvent.setup()
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    vi.stubGlobal('fetch', fetchMock)
+    const onWithdraw = vi.fn()
+    const onClose = vi.fn()
+
+    render(
+      <MaturityResolveBody inv={maturedDeposit} isVi={false} onClose={onClose} onRenewed={() => {}} onWithdraw={onWithdraw} />,
+    )
+    await user.click(screen.getByRole('button', { name: /Don.t renew/i }))
+    await user.click(screen.getByRole('button', { name: /Mark for withdrawal/i }))
+
+    expect(onClose).toHaveBeenCalled()
+    await waitFor(() => expect(onWithdraw).toHaveBeenCalled())
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+})

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -6,6 +6,7 @@
 import { TrendingUp, Building, Coins, BarChart2, Target } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
 import { fmtTxDate } from './transactionUtils'
+import { isTermDeposit, depositMaturityState, isMaturityActionable } from '@/lib/maturity'
 import type { FundBreakdownItem } from '../DashboardClient'
 
 export const GD_COLORS: Record<string, string> = {
@@ -274,6 +275,16 @@ export interface Maturity {
   diffDays: number
   relative: string
   tone: 'neutral' | 'warn' | 'pos'
+}
+
+// Whether a holding is a term deposit at (or within the reminder window of) its
+// maturity date — i.e. it needs a renew/withdraw decision. Shared so the mobile
+// sheet and desktop panel surface the "Handle maturity" action identically.
+export function needsMaturityAction(inv: InvRow, isVi: boolean): boolean {
+  if (!isTermDeposit({ type: inv.type, interestRate: inv.interestRate, expiryDate: inv.expiryDate })) return false
+  const m = fmtMaturity(inv.expiryDate, isVi)
+  if (!m) return false
+  return isMaturityActionable(depositMaturityState(m.diffDays))
 }
 
 export function fmtMaturity(dateStr: string | null | undefined, isVi: boolean): Maturity | null {

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -158,6 +158,9 @@ export interface InvRow {
   interestRate: number | null
   // Bank deposit maturity (YYYY-MM-DD); null for non-bank holdings or no term.
   expiryDate: string | null
+  // When the (current) cycle was opened — used to derive the original term
+  // length on renewal. null for fund holdings.
+  investmentDate: string | null
   fund: FundBreakdownItem | null
 }
 
@@ -262,7 +265,7 @@ export function buildInvRows(
       }
     }
 
-    return { id: tx.transaction_id, name, type: tx.asset_type, value, gainPct, units, principal, interestRate: tx.interest_rate ?? null, expiryDate: tx.expiry_date ?? null, fund: fund ?? null }
+    return { id: tx.transaction_id, name, type: tx.asset_type, value, gainPct, units, principal, interestRate: tx.interest_rate ?? null, expiryDate: tx.expiry_date ?? null, investmentDate: fund ? null : (tx.investment_date ?? null), fund: fund ?? null }
   }).filter((row): row is InvRow => row !== null)
 }
 

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -162,6 +162,67 @@ test.describe('Desktop goal detail panel', () => {
     }
   })
 
+  // Term-deposit maturity: a deposit past its maturity date surfaces a
+  // "Handle maturity" action; renewing it rolls the principal forward, sets a
+  // future maturity and resets the accrual date — closing the UI→DB loop.
+  test('renewing a matured term deposit rolls it forward in the DB', async ({ page }) => {
+    test.slow()
+    const iso = (offsetDays: number) => new Date(Date.now() + offsetDays * 86_400_000).toISOString().slice(0, 10)
+    const today = iso(0)
+    // Invested ~13 months ago, matured ~30 days ago → there is accrued interest
+    // to roll in, and the deposit reads as "matured".
+    const tx = await api.createTransaction({
+      asset_type: 'bank',
+      amount_vnd: 10_000_000,
+      investment_date: iso(-400),
+      interest_rate: 6,
+      expiry_date: iso(-30),
+      goal_id: goalId,
+      notes: 'E2E Maturity Deposit',
+    })
+    try {
+      await page.goto('/dashboard')
+      await page.waitForLoadState('networkidle')
+
+      await page.getByText('E2E Desktop Goal').first().click()
+      const panel = page.getByTestId('desktop-goal-detail')
+      await expect(panel).toBeVisible({ timeout: 10_000 })
+      await expect(panel.getByText('E2E Maturity Deposit')).toBeVisible({ timeout: 10_000 })
+
+      // Open the holding options → Handle maturity → confirm the default renewal
+      // (principal + interest).
+      await panel.getByRole('button', { name: 'Options', exact: true }).first().click()
+      await page.getByText(/^(Handle maturity|Xử lý đáo hạn)$/).click()
+      await page.getByRole('button', { name: /Confirm renewal|Xác nhận tái tục/i }).click()
+
+      // Success confirmation proves the PUT landed.
+      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+
+      // Close the loop: the stored deposit must now have a future maturity, a
+      // larger principal (interest rolled in) and today's accrual date.
+      const { createClient } = await import('@supabase/supabase-js')
+      const supabase = createClient(process.env.E2E_SUPABASE_URL!, process.env.E2E_SUPABASE_SERVICE_ROLE_KEY!)
+      await expect.poll(async () => {
+        const { data } = await supabase
+          .from('investment_transactions')
+          .select('amount_vnd, expiry_date, investment_date')
+          .eq('transaction_id', tx.transaction_id)
+          .single()
+        return data
+      }, { timeout: 15_000 }).toMatchObject({ investment_date: today })
+
+      const { data: renewed } = await supabase
+        .from('investment_transactions')
+        .select('amount_vnd, expiry_date, investment_date')
+        .eq('transaction_id', tx.transaction_id)
+        .single()
+      expect(renewed!.amount_vnd).toBeGreaterThan(10_000_000) // interest rolled into principal
+      expect(renewed!.expiry_date > today).toBe(true)         // maturity moved into the future
+    } finally {
+      await api.deleteTransactionCascade(tx.transaction_id)
+    }
+  })
+
   test('clicking an insurance row while goal detail is open switches to insurance detail', async ({ page }) => {
     // Bug #226: with goal detail open in the right panel, clicking an insurance
     // member did nothing because the panel prioritised the still-selected goal.

--- a/lib/__tests__/maturity.test.ts
+++ b/lib/__tests__/maturity.test.ts
@@ -5,6 +5,7 @@ import {
   depositMaturityState,
   isMaturityActionable,
   addMonths,
+  monthsBetween,
   renewalPrincipal,
 } from '../maturity'
 
@@ -58,6 +59,17 @@ describe('addMonths', () => {
   })
   it('handles a zero-month term as a no-op', () => {
     expect(addMonths('2026-06-13', 0)).toBe('2026-06-13')
+  })
+})
+
+describe('monthsBetween', () => {
+  it('counts whole months for a standard term', () => {
+    expect(monthsBetween('2025-08-15', '2026-08-15')).toBe(12)
+    expect(monthsBetween('2026-03-01', '2026-06-01')).toBe(3)
+    expect(monthsBetween('2026-06-14', '2026-12-14')).toBe(6)
+  })
+  it('does not count an incomplete final month', () => {
+    expect(monthsBetween('2026-01-20', '2026-04-10')).toBe(2) // not yet 3 full months
   })
 })
 

--- a/lib/__tests__/maturity.test.ts
+++ b/lib/__tests__/maturity.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest'
+import {
+  MATURITY_REMINDER_DAYS,
+  isTermDeposit,
+  depositMaturityState,
+  isMaturityActionable,
+  addMonths,
+  renewalPrincipal,
+} from '../maturity'
+
+describe('isTermDeposit', () => {
+  it('is true for a bank holding with a rate and an expiry date', () => {
+    expect(isTermDeposit({ type: 'bank', interestRate: 5.5, expiryDate: '2026-08-15' })).toBe(true)
+  })
+  it('is false for a flexible bank deposit (no rate / no expiry)', () => {
+    expect(isTermDeposit({ type: 'bank', interestRate: null, expiryDate: '2026-08-15' })).toBe(false)
+    expect(isTermDeposit({ type: 'bank', interestRate: 5.5, expiryDate: null })).toBe(false)
+  })
+  it('is false for non-bank holdings', () => {
+    expect(isTermDeposit({ type: 'fund', interestRate: 5.5, expiryDate: '2026-08-15' })).toBe(false)
+    expect(isTermDeposit({ type: 'gold', interestRate: null, expiryDate: null })).toBe(false)
+  })
+})
+
+describe('depositMaturityState', () => {
+  it('classifies a passed maturity as matured', () => {
+    expect(depositMaturityState(-1)).toBe('matured')
+    expect(depositMaturityState(-30)).toBe('matured')
+  })
+  it('classifies today and tomorrow as maturing (REMINDER_DAYS = 1)', () => {
+    expect(MATURITY_REMINDER_DAYS).toBe(1)
+    expect(depositMaturityState(0)).toBe('maturing')
+    expect(depositMaturityState(1)).toBe('maturing')
+  })
+  it('classifies the day after tomorrow onward as active', () => {
+    expect(depositMaturityState(2)).toBe('active')
+    expect(depositMaturityState(30)).toBe('active')
+  })
+})
+
+describe('isMaturityActionable', () => {
+  it('is true for matured and maturing, false for active', () => {
+    expect(isMaturityActionable('matured')).toBe(true)
+    expect(isMaturityActionable('maturing')).toBe(true)
+    expect(isMaturityActionable('active')).toBe(false)
+  })
+})
+
+describe('addMonths', () => {
+  it('adds whole months keeping the day of month', () => {
+    expect(addMonths('2026-08-15', 12)).toBe('2027-08-15')
+    expect(addMonths('2026-06-14', 6)).toBe('2026-12-14')
+    expect(addMonths('2026-11-20', 3)).toBe('2027-02-20')
+  })
+  it('clamps to the last day when the target month is shorter', () => {
+    expect(addMonths('2026-01-31', 1)).toBe('2026-02-28') // Feb 2026 has 28 days
+    expect(addMonths('2026-08-31', 1)).toBe('2026-09-30') // Sep has 30 days
+  })
+  it('handles a zero-month term as a no-op', () => {
+    expect(addMonths('2026-06-13', 0)).toBe('2026-06-13')
+  })
+})
+
+describe('renewalPrincipal', () => {
+  it('rolls interest into principal for principal_interest', () => {
+    expect(renewalPrincipal('principal_interest', 35_000_000, 2_030_000, null)).toBe(37_030_000)
+  })
+  it('keeps the principal unchanged for principal_only', () => {
+    expect(renewalPrincipal('principal_only', 35_000_000, 2_030_000, null)).toBe(35_000_000)
+  })
+  it('uses the new amount for change', () => {
+    expect(renewalPrincipal('change', 35_000_000, 2_030_000, 40_000_000)).toBe(40_000_000)
+  })
+})

--- a/lib/maturity.ts
+++ b/lib/maturity.ts
@@ -1,0 +1,69 @@
+// Bank term-deposit maturity helpers.
+//
+// A "term deposit" is a bank investment that carries an interest rate and a
+// maturity (expiry) date. Once it passes that date the user must decide what to
+// do — renew (roll principal + interest, principal only, or change amount/term)
+// or withdraw — so the app surfaces the ones that need a decision. These are the
+// pure, framework-free pieces of that flow; the UI lives in
+// app/assets/components/MaturityResolveSheet.tsx. See also `fmtMaturity` in
+// goalDetailShared.tsx for the display formatting.
+
+// Surface a deposit as "needs attention" once it is within this many days of
+// maturity (in addition to already-matured ones).
+export const MATURITY_REMINDER_DAYS = 1
+
+export type MaturityState = 'active' | 'maturing' | 'matured'
+
+export type RenewMode = 'principal_interest' | 'principal_only' | 'change'
+
+export interface MaturityDeposit {
+  type: string
+  interestRate: number | null
+  expiryDate: string | null
+}
+
+// A bank holding counts as a term deposit only when it has both an interest
+// rate and a maturity date — that is what the add-transaction form records for
+// `depositType: 'term'` (a flexible deposit leaves the rate null).
+export function isTermDeposit(inv: MaturityDeposit): boolean {
+  return inv.type === 'bank' && inv.interestRate != null && !!inv.expiryDate
+}
+
+// Classify a deposit from the number of days until its maturity (negative =
+// already passed). `diffDays` comes from `fmtMaturity(...).diffDays`.
+export function depositMaturityState(diffDays: number): MaturityState {
+  if (diffDays < 0) return 'matured'
+  if (diffDays <= MATURITY_REMINDER_DAYS) return 'maturing'
+  return 'active'
+}
+
+export function isMaturityActionable(state: MaturityState): boolean {
+  return state === 'matured' || state === 'maturing'
+}
+
+const pad = (n: number) => String(n).padStart(2, '0')
+
+// Add `n` whole months to a YYYY-MM-DD date, keeping the day of month but
+// clamping to the last valid day when the target month is shorter (so
+// 31 Jan + 1 month → 28 Feb rather than rolling into March). Computed in UTC
+// from the date parts to stay timezone-independent.
+export function addMonths(isoDate: string, n: number): string {
+  const [y, m, d] = isoDate.split('-').map(Number)
+  const target = new Date(Date.UTC(y, m - 1 + n, 1))
+  const year = target.getUTCFullYear()
+  const month = target.getUTCMonth()
+  const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate()
+  return `${year}-${pad(month + 1)}-${pad(Math.min(d, lastDay))}`
+}
+
+// The principal that the next cycle starts with, per the chosen renewal mode.
+export function renewalPrincipal(
+  mode: RenewMode,
+  principal: number,
+  interest: number,
+  newAmount: number | null,
+): number {
+  if (mode === 'principal_interest') return principal + interest
+  if (mode === 'change') return newAmount ?? principal
+  return principal // principal_only
+}

--- a/lib/maturity.ts
+++ b/lib/maturity.ts
@@ -56,6 +56,17 @@ export function addMonths(isoDate: string, n: number): string {
   return `${year}-${pad(month + 1)}-${pad(Math.min(d, lastDay))}`
 }
 
+// Whole months between two YYYY-MM-DD dates (the count of complete months from
+// `fromIso` to `toIso`). Used to derive a deposit's original term length from
+// its open date and maturity date when suggesting the renewal term.
+export function monthsBetween(fromIso: string, toIso: string): number {
+  const [fy, fm, fd] = fromIso.split('-').map(Number)
+  const [ty, tm, td] = toIso.split('-').map(Number)
+  let months = (ty - fy) * 12 + (tm - fm)
+  if (td < fd) months -= 1 // the final month hasn't fully elapsed
+  return months
+}
+
 // The principal that the next cycle starts with, per the chosen renewal mode.
 export function renewalPrincipal(
   mode: RenewMode,


### PR DESCRIPTION
## What & why

Bank **term deposits** that pass their maturity date used to just sit there showing a static "Matured" label while their value kept compounding forever. In reality the bank usually auto-renews at the old term unless you act — so the user must **decide**: renew or withdraw. This PR adds that decision flow to the goal-detail holding menu (mobile sheet + desktop panel).

This is **PR1 of 2** (core flow). PR2 will add the dashboard "Needs attention" card + nav badge.

## How it works

- **`lib/maturity.ts`** — pure, unit-tested helpers: `isTermDeposit`, `depositMaturityState` (matured / maturing within `REMINDER_DAYS=1` / active), `addMonths` (month-end clamped), `renewalPrincipal`.
- **`MaturityResolveSheet.tsx`** — shared decision form with a mobile bottom-sheet and desktop modal wrapper. Four choices: renew principal+interest / principal only / change amount-term / don't renew → withdraw.
- **Renewal = one PUT** to the existing `/investment-transactions/[id]` endpoint (no API change). It updates principal/rate/maturity and **resets `investment_date` to today** so the compound-interest valuation in `buildInvRows` restarts from the new principal — and so the endpoint's future-date guard never trips when maturity is tomorrow.
- **Withdrawal** hands off to the existing Sell/Withdraw flow (no re-implementation).
- **"Handle maturity"** action added to the mobile `InvestmentActionSheet` and desktop `InvOptionsModal`, gated on a shared `needsMaturityAction` helper.

## Decisions (confirmed)
- Renewal **updates the deposit only** — no separate "dividend" ledger row.
- Surfacing window: **matured + maturing today/tomorrow**.

## Detection model
A "term deposit" = a `bank` holding with both an `interest_rate` and an `expiry_date` (what the add-transaction form already records for `depositType: 'term'`). No schema change.

## Tests
- `lib/__tests__/maturity.test.ts` — 13 cases (state boundaries, addMonths clamp, renewal math).
- `MaturityResolveSheet.test.tsx` — preview math, the renewal PUT body (incl. accrual reset), and withdraw hand-off.
- Targeted desktop E2E — renew a matured deposit and assert the **DB row** rolled forward (future maturity, larger principal, today's accrual date), closing the UI→outcome loop.
- Full unit suite: **584 passing**; `tsc --noEmit` clean; no new lint errors.

## Verify on preview
Create a bank term deposit with a past maturity date (interest rate + maturity set) → open the goal → tap the holding's ⋯ → **Handle maturity** → try each renewal mode and confirm the new principal/maturity render correctly; the withdraw option opens the existing Withdraw sheet.

> Note: E2E runs locally only (not in CI) and wasn't run here because the local WSL2 Supabase stack wasn't up this session — it's authored to the existing `goal-detail-desktop.spec.ts` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)