### PR TITLE
feat(deposits): dashboard "Needs attention" card + nav maturity badge (PR2)

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -18,6 +18,10 @@ import AssignGoalSheet from './components/AssignGoalSheet'
 import DownloadReportSheet from './components/DownloadReportSheet'
 import AddTransactionSheet from './components/AddTransactionSheet'
 import RecentActivityCard from './components/RecentActivityCard'
+import MaturityActionCard from './components/MaturityActionCard'
+import { MaturityResolveSheet, MaturityResolveModal } from './components/MaturityResolveSheet'
+import { isActionableTermDeposit } from '@/lib/maturity'
+import type { InvRow } from './components/goalDetailShared'
 import { loadOverview, overviewErrorText, getCachedOverview, setCachedOverview } from './overviewData'
 
 import TransactionHistorySheet from './components/TransactionHistorySheet'
@@ -180,6 +184,28 @@ function fmtTimeAgo(isoString: string, locale: string): string {
   return isVi ? `${mins} phút trước` : `${mins}m ago`
 }
 
+// Map a dashboard overview non-fund holding to the InvRow shape the maturity
+// resolve flow expects.
+function nonFundToInvRow(it: NonFundUnallocatedItem, isVi: boolean): InvRow {
+  return {
+    id: it.transactionId,
+    name: it.notes ?? (it.type === 'bank' ? (isVi ? 'Tiền gửi' : 'Bank deposit') : it.type),
+    type: it.type,
+    value: it.currentValue,
+    gainPct: it.amount > 0 ? ((it.currentValue - it.amount) / it.amount) * 100 : null,
+    units: it.units,
+    principal: it.amount,
+    interestRate: it.interestRate,
+    expiryDate: it.expiryDate,
+    investmentDate: it.investmentDate,
+    fund: null,
+  }
+}
+
+// A maturing deposit plus the context needed to act on it: the goal it belongs
+// to (null when unassigned) and the raw item for the unallocated withdraw flow.
+interface MaturingDep { inv: InvRow; goalId: string | null; raw: NonFundUnallocatedItem }
+
 function useIsDesktop(): boolean {
   const [isDesktop, setIsDesktop] = useState(false)
   useEffect(() => {
@@ -224,6 +250,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
   // page reload.
   const [selectedGoalId, setSelectedGoalId] = useState<string | null>(null)
   const [goalDetailOpen, setGoalDetailOpen] = useState(false)
+  const [resolveDep, setResolveDep] = useState<MaturingDep | null>(null)
   const [showReportSheet, setShowReportSheet] = useState(false)
   const [selectedInsuranceId, setSelectedInsuranceId] = useState<string | null>(null)
   const [desktopAddTxOpen, setDesktopAddTxOpen] = useState(false)
@@ -447,6 +474,32 @@ export default function DashboardClient({ userId }: { userId: string }) {
   const allFunds = data ? [...data.unallocated.funds, ...data.goals.flatMap((g) => g.funds)] : []
   const detailFund = fundDetailId ? allFunds.find((f) => f.fundId === fundDetailId) : null
 
+  const isVi = locale === 'vi'
+
+  // Term deposits (assigned + unassigned) that need a renew/withdraw decision,
+  // carrying the context needed to act on each.
+  const maturingDeposits: MaturingDep[] = data ? [
+    ...data.goals.flatMap((g) => (g.nonFunds ?? []).filter(isActionableTermDeposit)
+      .map((it) => ({ inv: nonFundToInvRow(it, isVi), goalId: g.goalId, raw: it }))),
+    ...data.unallocated.nonFunds.filter(isActionableTermDeposit)
+      .map((it) => ({ inv: nonFundToInvRow(it, isVi), goalId: null, raw: it })),
+  ] : []
+
+  // Withdraw from the maturity card: route to the correct existing flow. A
+  // goal-assigned deposit must withdraw in its goal context (so the withdrawal
+  // links to the goal — issue #261); an unassigned one uses the unallocated
+  // sell sheet directly. Takes the dep explicitly because the resolve sheet
+  // clears `resolveDep` before invoking onWithdraw.
+  function withdrawMaturingDeposit(dep: MaturingDep | null) {
+    if (!dep) return
+    if (dep.goalId) {
+      setSelectedGoalId(dep.goalId)
+      if (!isDesktop) setGoalDetailOpen(true)
+    } else {
+      openSellNonFund(dep.raw)
+    }
+  }
+
   return (
     <div className="space-y-4 md:space-y-0 md:flex md:flex-col md:flex-1 md:min-h-0">
         {/* Pull-to-refresh indicator (mobile PWA only) */}
@@ -582,6 +635,13 @@ export default function DashboardClient({ userId }: { userId: string }) {
               <div style={{ display: 'flex', flex: 1, minHeight: 0, overflow: 'hidden' }}>
               {/* Left column: goals, unallocated, insurance */}
               <div style={{ flex: 1, minWidth: 0, overflowY: 'auto', padding: '20px 20px 40px 28px' }}>
+                {/* Term deposits needing a maturity decision */}
+                <MaturityActionCard
+                  items={maturingDeposits.map((d) => d.inv)}
+                  isVi={isVi}
+                  onResolve={(inv) => setResolveDep(maturingDeposits.find((d) => d.inv.id === inv.id) ?? null)}
+                  style={{ marginBottom: 24 }}
+                />
                 {/* Goals */}
                 {sortedGoals.length > 0 && (
                   <section style={{ marginBottom: 24 }}>
@@ -744,6 +804,13 @@ export default function DashboardClient({ userId }: { userId: string }) {
                   } : undefined}
                 />
               </div>
+
+              {/* Term deposits needing a maturity decision */}
+              <MaturityActionCard
+                items={maturingDeposits.map((d) => d.inv)}
+                isVi={isVi}
+                onResolve={(inv) => setResolveDep(maturingDeposits.find((d) => d.inv.id === inv.id) ?? null)}
+              />
 
               {/* Goals */}
               {sortedGoals.length > 0 && (
@@ -948,6 +1015,27 @@ export default function DashboardClient({ userId }: { userId: string }) {
         onClose={() => setSellSheetOpen(false)}
         onSuccess={() => fetchData({ force: true })}
       />
+
+      {/* Maturity resolve — mobile sheet / desktop modal */}
+      {!isDesktop && (
+        <MaturityResolveSheet
+          open={!!resolveDep}
+          inv={resolveDep?.inv ?? null}
+          isVi={isVi}
+          onClose={() => setResolveDep(null)}
+          onRenewed={() => { setResolveDep(null); fetchData({ force: true }) }}
+          onWithdraw={() => withdrawMaturingDeposit(resolveDep)}
+        />
+      )}
+      {isDesktop && resolveDep && (
+        <MaturityResolveModal
+          inv={resolveDep.inv}
+          isVi={isVi}
+          onClose={() => setResolveDep(null)}
+          onRenewed={() => { setResolveDep(null); fetchData({ force: true }) }}
+          onWithdraw={() => withdrawMaturingDeposit(resolveDep)}
+        />
+      )}
 
       {/* Goal Detail Sheet */}
       <GoalDetailSheet

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -203,8 +203,22 @@ function nonFundToInvRow(it: NonFundUnallocatedItem, isVi: boolean): InvRow {
 }
 
 // A maturing deposit plus the context needed to act on it: the goal it belongs
-// to (null when unassigned) and the raw item for the unallocated withdraw flow.
+// to (null when unassigned) and the raw item for the withdraw flow.
 interface MaturingDep { inv: InvRow; goalId: string | null; raw: NonFundUnallocatedItem }
+
+// Build the SellWithdrawSheet payload for a non-fund holding (bank/gold/stock).
+function nonFundToSellItem(item: NonFundUnallocatedItem): SellItem {
+  return {
+    type: item.type as 'bank' | 'gold' | 'stock',
+    name: item.notes ?? (item.type === 'bank' ? 'Bank deposit' : item.type === 'gold' ? 'Gold' : item.type),
+    currentValue: item.currentValue,
+    units: item.units ?? undefined,
+    navPerUnit: item.units && item.units > 0 ? item.currentValue / item.units : undefined,
+    interestRate: item.interestRate ?? undefined,
+    transactionId: item.transactionId,
+    purchasePrice: item.amount,
+  }
+}
 
 function useIsDesktop(): boolean {
   const [isDesktop, setIsDesktop] = useState(false)
@@ -251,6 +265,12 @@ export default function DashboardClient({ userId }: { userId: string }) {
   const [selectedGoalId, setSelectedGoalId] = useState<string | null>(null)
   const [goalDetailOpen, setGoalDetailOpen] = useState(false)
   const [resolveDep, setResolveDep] = useState<MaturingDep | null>(null)
+  // Goal-context withdraw triggered from the maturity flow — a dedicated
+  // SellWithdrawSheet so a goal-assigned deposit withdraws in one tap (linked to
+  // its goal, issue #261) instead of bouncing through the goal detail panel.
+  const [maturityWithdraw, setMaturityWithdraw] = useState<
+    { item: SellItem; goalId: string; goalCurrentValue: number; goalTargetAmount: number | null } | null
+  >(null)
   const [showReportSheet, setShowReportSheet] = useState(false)
   const [selectedInsuranceId, setSelectedInsuranceId] = useState<string | null>(null)
   const [desktopAddTxOpen, setDesktopAddTxOpen] = useState(false)
@@ -446,17 +466,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
   }
 
   function openSellNonFund(item: NonFundUnallocatedItem) {
-    const navPerUnit = item.units && item.units > 0 ? item.currentValue / item.units : undefined
-    setSellItem({
-      type: item.type as 'bank' | 'gold' | 'stock',
-      name: item.notes ?? (item.type === 'bank' ? 'Bank deposit' : item.type === 'gold' ? 'Gold' : item.type),
-      currentValue: item.currentValue,
-      units: item.units ?? undefined,
-      navPerUnit,
-      interestRate: item.interestRate ?? undefined,
-      transactionId: item.transactionId,
-      purchasePrice: item.amount,
-    })
+    setSellItem(nonFundToSellItem(item))
     setSellSheetOpen(true)
   }
 
@@ -496,16 +506,21 @@ export default function DashboardClient({ userId }: { userId: string }) {
       .map((it) => ({ inv: nonFundToInvRow(it, isVi), goalId: null, raw: it })),
   ] : []
 
-  // Withdraw from the maturity card: route to the correct existing flow. A
-  // goal-assigned deposit must withdraw in its goal context (so the withdrawal
-  // links to the goal — issue #261); an unassigned one uses the unallocated
-  // sell sheet directly. Takes the dep explicitly because the resolve sheet
+  // Withdraw from the maturity card: open the withdraw sheet pre-targeted at the
+  // deposit in one tap. A goal-assigned deposit withdraws in its goal context so
+  // the withdrawal links to the goal (issue #261); an unassigned one uses the
+  // unallocated sell flow. Takes the dep explicitly because the resolve sheet
   // clears `resolveDep` before invoking onWithdraw.
   function withdrawMaturingDeposit(dep: MaturingDep | null) {
     if (!dep) return
     if (dep.goalId) {
-      setSelectedGoalId(dep.goalId)
-      if (!isDesktop) setGoalDetailOpen(true)
+      const goal = data?.goals.find((g) => g.goalId === dep.goalId)
+      setMaturityWithdraw({
+        item: nonFundToSellItem(dep.raw),
+        goalId: dep.goalId,
+        goalCurrentValue: goal?.currentValue ?? dep.raw.currentValue,
+        goalTargetAmount: goal?.targetAmount ?? null,
+      })
     } else {
       openSellNonFund(dep.raw)
     }
@@ -1026,6 +1041,21 @@ export default function DashboardClient({ userId }: { userId: string }) {
         onClose={() => setSellSheetOpen(false)}
         onSuccess={() => fetchData({ force: true })}
       />
+
+      {/* Goal-context withdraw deep-linked from the maturity flow */}
+      {maturityWithdraw && (
+        <SellWithdrawSheet
+          item={maturityWithdraw.item}
+          open
+          context="goal"
+          goalId={maturityWithdraw.goalId}
+          goalCurrentValue={maturityWithdraw.goalCurrentValue}
+          goalTargetAmount={maturityWithdraw.goalTargetAmount}
+          desktop={isDesktop}
+          onClose={() => setMaturityWithdraw(null)}
+          onSuccess={() => { setMaturityWithdraw(null); fetchData({ force: true }) }}
+        />
+      )}
 
       {/* Maturity resolve — mobile sheet / desktop modal */}
       {!isDesktop && (

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -20,7 +20,7 @@ import AddTransactionSheet from './components/AddTransactionSheet'
 import RecentActivityCard from './components/RecentActivityCard'
 import MaturityActionCard from './components/MaturityActionCard'
 import { MaturityResolveSheet, MaturityResolveModal } from './components/MaturityResolveSheet'
-import { isActionableTermDeposit } from '@/lib/maturity'
+import { isActionableTermDeposit, MATURING_COUNT_EVENT } from '@/lib/maturity'
 import type { InvRow } from './components/goalDetailShared'
 import { loadOverview, overviewErrorText, getCachedOverview, setCachedOverview } from './overviewData'
 
@@ -419,6 +419,17 @@ export default function DashboardClient({ userId }: { userId: string }) {
     return () => setMobileTopBar({ title: '' })
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [userName, data, isDesktop])
+
+  // Publish the live count of maturing deposits so the nav badge stays in sync
+  // with this view — e.g. after renewing on the dashboard, the card drops the
+  // item and the badge must drop with it (not wait for its own cache TTL).
+  // Same filter as the card and the badge hook, so they can't disagree.
+  useEffect(() => {
+    if (!data) return
+    const items = [...data.goals.flatMap((g) => g.nonFunds ?? []), ...data.unallocated.nonFunds]
+    const count = items.filter(isActionableTermDeposit).length
+    window.dispatchEvent(new CustomEvent(MATURING_COUNT_EVENT, { detail: count }))
+  }, [data])
 
   function openSellFund(fund: FundBreakdownItem) {
     setSellItem({

--- a/app/assets/components/MaturityActionCard.tsx
+++ b/app/assets/components/MaturityActionCard.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+// Dashboard "Needs attention" card: lists bank term deposits that are matured
+// or maturing within the reminder window, each with a one-tap "Handle" action
+// that opens the renew/withdraw flow. Renders nothing when there's nothing to
+// act on. Purely presentational — the parent supplies the already-filtered rows
+// (see isActionableTermDeposit) and handles the resolve flow.
+
+import { AlertTriangle, Building2, RefreshCw } from 'lucide-react'
+import { fmtCompact } from '@/lib/formatters'
+import { daysUntil } from '@/lib/maturity'
+import type { InvRow } from './goalDetailShared'
+
+function pillFor(inv: InvRow, isVi: boolean): { text: string; color: string; bg: string } {
+  const diff = daysUntil(inv.expiryDate ?? '')
+  if (diff < 0) {
+    const n = Math.abs(diff)
+    return {
+      text: isVi ? (n === 0 ? 'Đã đáo hạn' : `Quá hạn ${n} ngày`) : (n === 0 ? 'Matured' : `${n}d overdue`),
+      color: 'var(--c-neg)', bg: 'var(--c-neg-tint)',
+    }
+  }
+  return {
+    text: isVi ? (diff === 0 ? 'Đáo hạn hôm nay' : 'Đáo hạn ngày mai') : (diff === 0 ? 'Matures today' : 'Matures tomorrow'),
+    color: 'var(--c-warn)', bg: 'var(--c-warn-tint)',
+  }
+}
+
+export default function MaturityActionCard({
+  items, isVi, onResolve, style,
+}: {
+  items: InvRow[]
+  isVi: boolean
+  onResolve: (inv: InvRow) => void
+  style?: React.CSSProperties
+}) {
+  if (!items.length) return null
+
+  return (
+    <div data-testid="maturity-action-card" className="cn-card" style={{ overflow: 'hidden', ...style }}>
+      <div style={{ padding: '11px 16px', display: 'flex', alignItems: 'center', gap: 8, background: 'var(--c-warn-tint)', color: 'var(--c-warn)', borderBottom: '1px solid rgba(180,83,9,0.12)' }}>
+        <AlertTriangle size={14} strokeWidth={2.2} />
+        <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.02em', flex: 1 }}>
+          {isVi ? 'Cần xử lý' : 'Needs attention'}
+        </span>
+        <span data-testid="maturity-action-count" style={{ fontSize: 11, fontWeight: 700, padding: '2px 9px', borderRadius: 999, background: 'rgba(180,83,9,0.14)', color: 'var(--c-warn)' }}>
+          {items.length}
+        </span>
+      </div>
+      <div style={{ padding: '4px 16px 6px' }}>
+        {items.map((inv, i) => {
+          const pill = pillFor(inv, isVi)
+          return (
+            <div key={inv.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 0', borderBottom: i === items.length - 1 ? 'none' : '1px solid var(--c-line)' }}>
+              <div style={{ width: 34, height: 34, borderRadius: 9, background: 'var(--c-card-2)', color: '#047857', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                <Building2 size={16} />
+              </div>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{inv.name}</div>
+                <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1, display: 'flex', alignItems: 'center', gap: 6, fontVariantNumeric: 'tabular-nums' }}>
+                  <span>{fmtCompact(inv.principal ?? inv.value)}</span>
+                  <span style={{ fontSize: 10, fontWeight: 600, padding: '1px 7px', borderRadius: 999, background: pill.bg, color: pill.color }}>{pill.text}</span>
+                </div>
+              </div>
+              <button
+                onClick={() => onResolve(inv)}
+                className="cn-btn primary"
+                style={{ padding: '7px 13px', fontSize: 12.5, gap: 5, flexShrink: 0, display: 'flex', alignItems: 'center' }}
+              >
+                <RefreshCw size={13} strokeWidth={2.2} />
+                {isVi ? 'Xử lý' : 'Handle'}
+              </button>
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/app/assets/components/MaturityActionCard.tsx
+++ b/app/assets/components/MaturityActionCard.tsx
@@ -9,10 +9,11 @@
 import { AlertTriangle, Building2, RefreshCw } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
 import { daysUntil } from '@/lib/maturity'
-import type { InvRow } from './goalDetailShared'
+import { GD_COLORS, type InvRow } from './goalDetailShared'
 
-function pillFor(inv: InvRow, isVi: boolean): { text: string; color: string; bg: string } {
+function pillFor(inv: InvRow, isVi: boolean): { text: string; color: string; bg: string } | null {
   const diff = daysUntil(inv.expiryDate ?? '')
+  if (Number.isNaN(diff)) return null // no maturity date → no status pill
   if (diff < 0) {
     const n = Math.abs(diff)
     return {
@@ -39,8 +40,8 @@ export default function MaturityActionCard({
   return (
     <div data-testid="maturity-action-card" className="cn-card" style={{ overflow: 'hidden', ...style }}>
       <div style={{ padding: '11px 16px', display: 'flex', alignItems: 'center', gap: 8, background: 'var(--c-warn-tint)', color: 'var(--c-warn)', borderBottom: '1px solid rgba(180,83,9,0.12)' }}>
-        <AlertTriangle size={14} strokeWidth={2.2} />
-        <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.02em', flex: 1 }}>
+        <AlertTriangle size={15} strokeWidth={2.2} />
+        <span style={{ fontSize: 13, fontWeight: 700, letterSpacing: '0.02em', flex: 1 }}>
           {isVi ? 'Cần xử lý' : 'Needs attention'}
         </span>
         <span data-testid="maturity-action-count" style={{ fontSize: 11, fontWeight: 700, padding: '2px 9px', borderRadius: 999, background: 'rgba(180,83,9,0.14)', color: 'var(--c-warn)' }}>
@@ -52,20 +53,20 @@ export default function MaturityActionCard({
           const pill = pillFor(inv, isVi)
           return (
             <div key={inv.id} style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '12px 0', borderBottom: i === items.length - 1 ? 'none' : '1px solid var(--c-line)' }}>
-              <div style={{ width: 34, height: 34, borderRadius: 9, background: 'var(--c-card-2)', color: '#047857', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+              <div style={{ width: 34, height: 34, borderRadius: 9, background: 'var(--c-card-2)', color: GD_COLORS.bank, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
                 <Building2 size={16} />
               </div>
               <div style={{ flex: 1, minWidth: 0 }}>
                 <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{inv.name}</div>
                 <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1, display: 'flex', alignItems: 'center', gap: 6, fontVariantNumeric: 'tabular-nums' }}>
                   <span>{fmtCompact(inv.principal ?? inv.value)}</span>
-                  <span style={{ fontSize: 10, fontWeight: 600, padding: '1px 7px', borderRadius: 999, background: pill.bg, color: pill.color }}>{pill.text}</span>
+                  {pill && <span style={{ fontSize: 10, fontWeight: 600, padding: '1px 7px', borderRadius: 999, background: pill.bg, color: pill.color }}>{pill.text}</span>}
                 </div>
               </div>
               <button
                 onClick={() => onResolve(inv)}
                 className="cn-btn primary"
-                style={{ padding: '7px 13px', fontSize: 12.5, gap: 5, flexShrink: 0, display: 'flex', alignItems: 'center' }}
+                style={{ padding: '7px 13px', minHeight: 44, fontSize: 12.5, gap: 5, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
               >
                 <RefreshCw size={13} strokeWidth={2.2} />
                 {isVi ? 'Xử lý' : 'Handle'}

--- a/app/assets/components/__tests__/MaturityActionCard.test.tsx
+++ b/app/assets/components/__tests__/MaturityActionCard.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MaturityActionCard from '../MaturityActionCard'
+import type { InvRow } from '../goalDetailShared'
+
+function daysFromNow(n: number): string {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  d.setDate(d.getDate() + n)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+const mk = (over: Partial<InvRow>): InvRow => ({
+  id: 'tx', name: 'Deposit', type: 'bank', value: 10_500_000, gainPct: 5,
+  units: null, principal: 10_000_000, interestRate: 6,
+  expiryDate: daysFromNow(-2), investmentDate: daysFromNow(-360), fund: null,
+  ...over,
+})
+
+describe('MaturityActionCard', () => {
+  it('renders nothing when there are no actionable deposits', () => {
+    const { container } = render(<MaturityActionCard items={[]} isVi={false} onResolve={() => {}} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('lists each deposit with the count and fires onResolve with the row', async () => {
+    const user = userEvent.setup()
+    const onResolve = vi.fn()
+    const items = [
+      mk({ id: 'a', name: 'TCB Term' }),
+      mk({ id: 'b', name: 'VCB Savings', expiryDate: daysFromNow(0) }),
+    ]
+    render(<MaturityActionCard items={items} isVi={false} onResolve={onResolve} />)
+
+    expect(screen.getByTestId('maturity-action-count').textContent).toBe('2')
+    expect(screen.getByText('TCB Term')).toBeInTheDocument()
+    expect(screen.getByText('VCB Savings')).toBeInTheDocument()
+
+    await user.click(screen.getAllByRole('button', { name: /Handle/i })[0])
+    expect(onResolve).toHaveBeenCalledTimes(1)
+    expect(onResolve).toHaveBeenCalledWith(expect.objectContaining({ id: 'a' }))
+  })
+})

--- a/app/assets/components/__tests__/MaturityActionCard.test.tsx
+++ b/app/assets/components/__tests__/MaturityActionCard.test.tsx
@@ -41,4 +41,12 @@ describe('MaturityActionCard', () => {
     expect(onResolve).toHaveBeenCalledTimes(1)
     expect(onResolve).toHaveBeenCalledWith(expect.objectContaining({ id: 'a' }))
   })
+
+  it('renders a row without a status pill (no crash) when the expiry date is missing', () => {
+    render(<MaturityActionCard items={[mk({ name: 'No Expiry', expiryDate: null })]} isVi={false} onResolve={() => {}} />)
+    // The row still renders (name + Handle), just with no maturity pill.
+    expect(screen.getByText('No Expiry')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Handle/i })).toBeInTheDocument()
+    expect(screen.queryByText(/overdue|Matured|Matures/i)).not.toBeInTheDocument()
+  })
 })

--- a/app/components/navigation/MobileBottomTabs.tsx
+++ b/app/components/navigation/MobileBottomTabs.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Calendar, TrendingUp, Settings } from 'lucide-react'
 import { useTranslations } from 'next-intl'
+import { useMaturingDepositsCount } from './useMaturingDepositsCount'
 
 function MountainsIcon({ size = 22, strokeWidth = 1.75 }: { size?: number; strokeWidth?: number }) {
   return (
@@ -48,6 +49,7 @@ const TABS: TabDef[] = [
 export default function MobileBottomTabs() {
   const pathname = usePathname()
   const t = useTranslations('nav')
+  const maturingCount = useMaturingDepositsCount()
 
   return (
     <nav
@@ -63,13 +65,28 @@ export default function MobileBottomTabs() {
       <div className="grid grid-cols-4 px-1 py-1.5">
         {TABS.map(({ href, key, renderIcon }) => {
           const isActive = pathname.startsWith(href)
+          const badge = key === 'dashboard' && maturingCount > 0 ? maturingCount : 0
           return (
             <Link
               key={href}
               href={href}
-              className="flex flex-col items-center gap-0.5 py-2 rounded-xl transition-colors"
+              className="relative flex flex-col items-center gap-0.5 py-2 rounded-xl transition-colors"
               style={{ color: isActive ? 'var(--c-navy)' : 'var(--c-muted)' }}
             >
+              {badge > 0 && (
+                <span
+                  data-testid="nav-maturity-badge"
+                  aria-label={`${badge} ${t('dashboard')}`}
+                  style={{
+                    position: 'absolute', top: 2, right: '50%', marginRight: -18,
+                    minWidth: 16, height: 16, padding: '0 4px', borderRadius: 999,
+                    background: 'var(--c-warn)', color: '#fff', fontSize: 9.5, fontWeight: 700,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center', lineHeight: 1,
+                  }}
+                >
+                  {badge}
+                </span>
+              )}
               {renderIcon(isActive)}
               <span style={{ fontSize: '10.5px', fontWeight: isActive ? 600 : 500, letterSpacing: '0.01em', lineHeight: 1 }}>
                 {t(key)}

--- a/app/components/navigation/Sidebar.tsx
+++ b/app/components/navigation/Sidebar.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Calendar, TrendingUp, Settings } from 'lucide-react'
 import { useNavigation } from './NavigationContext'
+import { useMaturingDepositsCount } from './useMaturingDepositsCount'
 import { useTranslations } from 'next-intl'
 
 // Real Cairn logo from cairn-icon-transparent.svg (stacked rounded rectangles)
@@ -61,6 +62,7 @@ export default function Sidebar({ email, initials, onNavClick, hideLogo = false 
   const pathname = usePathname()
   const { sidebarCollapsed, setSidebarCollapsed, userName } = useNavigation()
   const t = useTranslations('nav')
+  const maturingCount = useMaturingDepositsCount()
 
   const displayInitials = userName
     .split(/\s+/)
@@ -118,6 +120,7 @@ export default function Sidebar({ email, initials, onNavClick, hideLogo = false 
       }}>
         {NAV_ITEMS.map(({ label, href, renderIcon }) => {
           const active = pathname === href
+          const badge = href === '/dashboard' && maturingCount > 0 ? maturingCount : 0
           return (
             <Link
               key={href}
@@ -162,6 +165,23 @@ export default function Sidebar({ email, initials, onNavClick, hideLogo = false 
               )}
               {renderIcon(active)}
               {!sidebarCollapsed && <span>{label}</span>}
+              {badge > 0 && (
+                <span
+                  data-testid="nav-maturity-badge"
+                  aria-label={`${badge} ${label}`}
+                  style={{
+                    position: 'absolute',
+                    ...(sidebarCollapsed
+                      ? { top: 6, right: 14 }
+                      : { right: 10, top: '50%', transform: 'translateY(-50%)' }),
+                    minWidth: 16, height: 16, padding: '0 4px', borderRadius: 999,
+                    background: 'var(--c-warn)', color: '#fff', fontSize: 9.5, fontWeight: 700,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center', lineHeight: 1,
+                  }}
+                >
+                  {badge}
+                </span>
+              )}
             </Link>
           )
         })}

--- a/app/components/navigation/__tests__/useMaturingDepositsCount.test.tsx
+++ b/app/components/navigation/__tests__/useMaturingDepositsCount.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen, act, waitFor } from '@testing-library/react'
+import { useMaturingDepositsCount } from '../useMaturingDepositsCount'
+import { MATURING_COUNT_EVENT } from '@/lib/maturity'
+
+function daysFromNow(n: number): string {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  d.setDate(d.getDate() + n)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+function Probe() {
+  return <span data-testid="count">{useMaturingDepositsCount()}</span>
+}
+
+afterEach(() => vi.restoreAllMocks())
+
+describe('useMaturingDepositsCount', () => {
+  it('tracks the dashboard live-count event so it never desyncs from the card', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({ goals: [], unallocated: { nonFunds: [] } }) }))
+    render(<Probe />)
+    expect(screen.getByTestId('count').textContent).toBe('0')
+
+    // Dashboard publishes a live count (e.g. 3 deposits need attention).
+    act(() => { window.dispatchEvent(new CustomEvent(MATURING_COUNT_EVENT, { detail: 3 })) })
+    expect(screen.getByTestId('count').textContent).toBe('3')
+
+    // After a renewal the dashboard republishes — badge drops in lockstep.
+    act(() => { window.dispatchEvent(new CustomEvent(MATURING_COUNT_EVENT, { detail: 2 })) })
+    expect(screen.getByTestId('count').textContent).toBe('2')
+  })
+
+  it('falls back to the overview fetch on pages where the dashboard is not mounted', async () => {
+    const data = {
+      goals: [{ nonFunds: [{ type: 'bank', interestRate: 6, expiryDate: daysFromNow(-1) }] }],
+      unallocated: { nonFunds: [{ type: 'bank', interestRate: 6, expiryDate: daysFromNow(0) }] },
+    }
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => data }))
+    render(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('count').textContent).toBe('2'))
+  })
+
+  it('does not let a slow fallback fetch overwrite a live count', async () => {
+    let resolveFetch: (v: unknown) => void = () => {}
+    vi.stubGlobal('fetch', vi.fn().mockReturnValue(new Promise((res) => { resolveFetch = res })))
+    render(<Probe />)
+
+    // Live event arrives first.
+    act(() => { window.dispatchEvent(new CustomEvent(MATURING_COUNT_EVENT, { detail: 5 })) })
+    expect(screen.getByTestId('count').textContent).toBe('5')
+
+    // The fetch resolves later with a staler (empty) snapshot — must be ignored.
+    await act(async () => {
+      resolveFetch({ ok: true, json: async () => ({ goals: [], unallocated: { nonFunds: [] } }) })
+    })
+    expect(screen.getByTestId('count').textContent).toBe('5')
+  })
+})

--- a/app/components/navigation/useMaturingDepositsCount.ts
+++ b/app/components/navigation/useMaturingDepositsCount.ts
@@ -1,23 +1,34 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { isActionableTermDeposit } from '@/lib/maturity'
+import { useEffect, useRef, useState } from 'react'
+import { isActionableTermDeposit, MATURING_COUNT_EVENT } from '@/lib/maturity'
 import type { DashboardData } from '@/app/assets/DashboardClient'
 
 // Count of bank term deposits that currently need a renew/withdraw decision —
-// drives the nav badge so the user sees it from any page. Fetches the dashboard
-// overview once on mount (the same endpoint the dashboard uses, served from the
-// SW/HTTP cache when warm). Fails silent → 0, so the badge simply hides on error
-// rather than blocking navigation. Uses the same isActionableTermDeposit filter
-// as the dashboard "Needs attention" card, so the two never disagree.
+// drives the nav badge so the user sees it from any page. Two sources, no
+// disagreement: the dashboard's live event is authoritative when mounted, and a
+// one-time overview fetch is the fallback for pages where the dashboard isn't
+// mounted. Both use the same isActionableTermDeposit filter as the card. Fails
+// silent → 0 so the badge simply hides on error.
 export function useMaturingDepositsCount(): number {
-  const [count, setCount] = useState(0)
+  const [count, setCount] = useState<number | null>(null)
+  // Once a live dashboard event arrives it is the source of truth; don't let a
+  // slower fallback fetch overwrite it with a staler number.
+  const liveRef = useRef(false)
+
   useEffect(() => {
     let cancelled = false
+
+    const onLiveCount = (e: Event) => {
+      liveRef.current = true
+      setCount((e as CustomEvent<number>).detail)
+    }
+    window.addEventListener(MATURING_COUNT_EVENT, onLiveCount)
+
     fetch('/api/v1/dashboard/overview', { cache: 'no-store' })
       .then((r) => (r.ok ? r.json() : null))
       .then((data: DashboardData | null) => {
-        if (cancelled || !data) return
+        if (cancelled || liveRef.current || !data) return
         const items = [
           ...data.goals.flatMap((g) => g.nonFunds ?? []),
           ...data.unallocated.nonFunds,
@@ -25,7 +36,12 @@ export function useMaturingDepositsCount(): number {
         setCount(items.filter(isActionableTermDeposit).length)
       })
       .catch(() => {})
-    return () => { cancelled = true }
+
+    return () => {
+      cancelled = true
+      window.removeEventListener(MATURING_COUNT_EVENT, onLiveCount)
+    }
   }, [])
-  return count
+
+  return count ?? 0
 }

--- a/app/components/navigation/useMaturingDepositsCount.ts
+++ b/app/components/navigation/useMaturingDepositsCount.ts
@@ -1,0 +1,31 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { isActionableTermDeposit } from '@/lib/maturity'
+import type { DashboardData } from '@/app/assets/DashboardClient'
+
+// Count of bank term deposits that currently need a renew/withdraw decision —
+// drives the nav badge so the user sees it from any page. Fetches the dashboard
+// overview once on mount (the same endpoint the dashboard uses, served from the
+// SW/HTTP cache when warm). Fails silent → 0, so the badge simply hides on error
+// rather than blocking navigation. Uses the same isActionableTermDeposit filter
+// as the dashboard "Needs attention" card, so the two never disagree.
+export function useMaturingDepositsCount(): number {
+  const [count, setCount] = useState(0)
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/v1/dashboard/overview', { cache: 'no-store' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data: DashboardData | null) => {
+        if (cancelled || !data) return
+        const items = [
+          ...data.goals.flatMap((g) => g.nonFunds ?? []),
+          ...data.unallocated.nonFunds,
+        ]
+        setCount(items.filter(isActionableTermDeposit).length)
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [])
+  return count
+}

--- a/e2e/dashboard-desktop.spec.ts
+++ b/e2e/dashboard-desktop.spec.ts
@@ -138,6 +138,42 @@ test.describe('Desktop overview layout', () => {
     await row.click()
     await expect(page.getByTestId('insurance-remove-btn')).toBeVisible({ timeout: 5_000 })
   })
+
+  // PR2: a matured term deposit surfaces the dashboard "Needs attention" card
+  // and the sidebar nav badge; renewing it from the card rolls it forward so it
+  // leaves the card (closing the UI loop).
+  test('matured deposit shows the Needs attention card + nav badge, and renewing clears it', async ({ page }) => {
+    test.slow()
+    const iso = (d: number) => new Date(Date.now() + d * 86_400_000).toISOString().slice(0, 10)
+    const tx = await api.createTransaction({
+      asset_type: 'bank',
+      amount_vnd: 12_000_000,
+      investment_date: iso(-400),
+      interest_rate: 6,
+      expiry_date: iso(-20), // matured
+      notes: 'E2E Maturing Deposit',
+    })
+    try {
+      await page.goto('/dashboard')
+      await page.waitForLoadState('networkidle')
+
+      const card = page.getByTestId('maturity-action-card')
+      await expect(card).toBeVisible({ timeout: 10_000 })
+      await expect(card.getByText('E2E Maturing Deposit')).toBeVisible({ timeout: 10_000 })
+      // Sidebar badge (scope to the sidebar — the hidden mobile tabs also render one).
+      await expect(page.getByTestId('desktop-sidebar').getByTestId('nav-maturity-badge')).toBeVisible({ timeout: 10_000 })
+
+      // Renew via the card → desktop resolve modal → confirm the default renewal.
+      await card.getByRole('button', { name: /Handle|Xử lý/i }).first().click()
+      await page.getByRole('button', { name: /Confirm renewal|Xác nhận tái tục/i }).click()
+      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+
+      // After it rolls forward (future maturity), the deposit leaves the card.
+      await expect(card.getByText('E2E Maturing Deposit')).toHaveCount(0, { timeout: 30_000 })
+    } finally {
+      await api.deleteTransactionCascade(tx.transaction_id)
+    }
+  })
 })
 
 test.describe('Desktop insurance — mark as paid (issue #227)', () => {

--- a/lib/__tests__/maturity.test.ts
+++ b/lib/__tests__/maturity.test.ts
@@ -7,7 +7,17 @@ import {
   addMonths,
   monthsBetween,
   renewalPrincipal,
+  daysUntil,
+  isActionableTermDeposit,
 } from '../maturity'
+
+// A YYYY-MM-DD string `n` days from today (deterministic regardless of run date).
+function daysFromNow(n: number): string {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  d.setDate(d.getDate() + n)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
 
 describe('isTermDeposit', () => {
   it('is true for a bank holding with a rate and an expiry date', () => {
@@ -70,6 +80,28 @@ describe('monthsBetween', () => {
   })
   it('does not count an incomplete final month', () => {
     expect(monthsBetween('2026-01-20', '2026-04-10')).toBe(2) // not yet 3 full months
+  })
+})
+
+describe('daysUntil', () => {
+  it('is 0 today, positive in the future, negative in the past', () => {
+    expect(daysUntil(daysFromNow(0))).toBe(0)
+    expect(daysUntil(daysFromNow(5))).toBe(5)
+    expect(daysUntil(daysFromNow(-3))).toBe(-3)
+  })
+})
+
+describe('isActionableTermDeposit', () => {
+  it('is true for a matured or soon-maturing bank term deposit', () => {
+    expect(isActionableTermDeposit({ type: 'bank', interestRate: 6, expiryDate: daysFromNow(-1) })).toBe(true)
+    expect(isActionableTermDeposit({ type: 'bank', interestRate: 6, expiryDate: daysFromNow(1) })).toBe(true)
+  })
+  it('is false for a deposit maturing well in the future', () => {
+    expect(isActionableTermDeposit({ type: 'bank', interestRate: 6, expiryDate: daysFromNow(30) })).toBe(false)
+  })
+  it('is false for non-term and non-bank holdings', () => {
+    expect(isActionableTermDeposit({ type: 'bank', interestRate: null, expiryDate: daysFromNow(-1) })).toBe(false)
+    expect(isActionableTermDeposit({ type: 'gold', interestRate: null, expiryDate: null })).toBe(false)
   })
 })
 

--- a/lib/maturity.ts
+++ b/lib/maturity.ts
@@ -12,6 +12,11 @@
 // maturity (in addition to already-matured ones).
 export const MATURITY_REMINDER_DAYS = 1
 
+// Window event the dashboard dispatches (detail = number) with the live count of
+// maturing deposits, so the nav badge updates the instant the dashboard's data
+// changes — e.g. right after a renewal — instead of waiting for its own fetch.
+export const MATURING_COUNT_EVENT = 'cairn:maturing-count'
+
 export type MaturityState = 'active' | 'maturing' | 'matured'
 
 export type RenewMode = 'principal_interest' | 'principal_only' | 'change'

--- a/lib/maturity.ts
+++ b/lib/maturity.ts
@@ -41,6 +41,27 @@ export function isMaturityActionable(state: MaturityState): boolean {
   return state === 'matured' || state === 'maturing'
 }
 
+// Whole days from today until the given YYYY-MM-DD date (negative once past).
+// Mirrors the diffDays computation in fmtMaturity so the two never diverge.
+export function daysUntil(isoDate: string): number {
+  const d = new Date(isoDate + 'T00:00:00')
+  if (isNaN(d.getTime())) return NaN
+  const today = new Date()
+  today.setHours(0, 0, 0, 0)
+  return Math.round((d.getTime() - today.getTime()) / 86_400_000)
+}
+
+// Whether a non-fund holding is a term deposit that needs a decision right now
+// (matured, or within the reminder window). Generic over the minimal shape so
+// both dashboard overview items and InvRows qualify — the single source of
+// truth for the "needs attention" card and the nav badge count.
+export function isActionableTermDeposit(
+  it: { type: string; interestRate: number | null; expiryDate: string | null },
+): boolean {
+  if (!isTermDeposit(it)) return false
+  return isMaturityActionable(depositMaturityState(daysUntil(it.expiryDate!)))
+}
+
 const pad = (n: number) => String(n).padStart(2, '0')
 
 // Add `n` whole months to a YYYY-MM-DD date, keeping the day of month but


### PR DESCRIPTION
## What & why

**PR2 of the term-deposit maturity feature** (PR1 #328 shipped the renew/withdraw resolve flow). This surfaces deposits that need a decision so the user sees them without opening each goal:

- A dashboard **"Needs attention" card** listing every term deposit that's matured or maturing today/tomorrow, each with a one-tap **Handle** action.
- A **nav badge** (count) on the Dashboard tab — mobile bottom tabs + desktop sidebar — so it's visible from any page.

## How it works

- **`lib/maturity.ts`** — adds `daysUntil` + `isActionableTermDeposit`, the single filter shared by the card and the badge so they never disagree.
- **`MaturityActionCard`** — purely presentational; the parent passes already-filtered rows and handles the resolve flow. Renders nothing when empty.
- **`DashboardClient`** — derives the actionable list from the **overview data already in memory** (`goals[].nonFunds` + `unallocated.nonFunds`), so the card needs **no extra fetch**. Renders it on mobile + desktop and opens the PR1 resolve sheet/modal.
  - **Renew** → reload overview (the deposit's maturity moves to the future, so it drops out).
  - **Withdraw** → routes to the correct existing flow: a **goal-assigned** deposit withdraws in its goal context (so the withdrawal links to the goal — issue #261), an **unassigned** one uses the unallocated sell sheet. No duplicated withdraw logic.
- **`useMaturingDepositsCount`** — one cached overview fetch on mount, drives the badge in `MobileBottomTabs` + `Sidebar`.

## Tests
- Unit: `daysUntil`, `isActionableTermDeposit` (boundaries + non-term/non-bank).
- Component: `MaturityActionCard` renders rows + count, fires `onResolve` with the row, renders nothing when empty.
- Desktop E2E: seed a matured deposit → assert the card + sidebar badge appear → Handle → renew → assert it leaves the card.
- Full unit suite **594 passing**; `tsc --noEmit` clean; changed files lint-clean.

## Verify on preview
With a matured term deposit present, the dashboard shows a "Needs attention" card at the top and a count badge on the Dashboard nav. Tap **Handle** → renew (clears it) or withdraw (routes to the right withdraw flow).

> E2E runs locally only (not CI); authored to the existing `dashboard-desktop.spec.ts` pattern, not run here (local WSL2 Supabase stack wasn't up this session).

## Follow-up (separate, not in this PR)
Multi-cycle renewal lineage (new renewal row + close old, instead of in-place overwrite) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)