### PR TITLE
feat(deposits): renewal-history summary (renewed N× · total interest)

### DIFF
--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -19,13 +19,14 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const body = await request.json()
-  const { amount_vnd, interest_rate, expiry_date, investment_date } = body
+  const { amount_vnd, interest_rate, expiry_date, investment_date, interest_earned_vnd } = body
 
   let txId: string
   let cleanAmount: number
   let cleanRate: number | null = null
   let cleanExpiry: string | null = null
   let cleanInvestmentDate: string
+  let cleanInterestEarned: number | null = null
   try {
     txId = validateUUID(id, 'transaction_id')
     cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
@@ -33,6 +34,14 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     if (interest_rate != null && interest_rate !== '') cleanRate = validateRate(interest_rate, 'interest_rate')
     if (expiry_date) cleanExpiry = validateDate(expiry_date, 'expiry_date')
     cleanInvestmentDate = validateDate(investment_date, 'investment_date')
+    // Realized interest is user-entered money recorded permanently — keep it
+    // sane: non-negative and not absurd relative to the new principal.
+    if (interest_earned_vnd != null && interest_earned_vnd !== '') {
+      const n = Number(interest_earned_vnd)
+      if (!Number.isFinite(n) || n < 0) throw new ValidationError('interest_earned_vnd must be a non-negative number')
+      if (n > cleanAmount * 10) throw new ValidationError('interest_earned_vnd is unreasonably large')
+      cleanInterestEarned = Math.round(n)
+    }
   } catch (e) {
     if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
     throw e
@@ -86,6 +95,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       interest_rate: old.interest_rate,
       notes: old.notes,
       renewed_from_transaction_id: txId,
+      interest_earned_vnd: cleanInterestEarned,
       affects_progress: false,
     })
   if (snapshotErr) console.error('renew: failed to write history snapshot', snapshotErr.message)

--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -34,12 +34,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     if (interest_rate != null && interest_rate !== '') cleanRate = validateRate(interest_rate, 'interest_rate')
     if (expiry_date) cleanExpiry = validateDate(expiry_date, 'expiry_date')
     cleanInvestmentDate = validateDate(investment_date, 'investment_date')
-    // Realized interest is user-entered money recorded permanently — keep it
-    // sane: non-negative and not absurd relative to the new principal.
+    // Realized interest is user-entered money recorded permanently — must be a
+    // non-negative finite number. The upper bound is checked after the old row
+    // is read (interest accrued on the OLD principal, not the new cycle's).
     if (interest_earned_vnd != null && interest_earned_vnd !== '') {
       const n = Number(interest_earned_vnd)
       if (!Number.isFinite(n) || n < 0) throw new ValidationError('interest_earned_vnd must be a non-negative number')
-      if (n > cleanAmount * 10) throw new ValidationError('interest_earned_vnd is unreasonably large')
       cleanInterestEarned = Math.round(n)
     }
   } catch (e) {
@@ -61,6 +61,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   if (fetchErr || !old) return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
   if (old.asset_type !== 'bank') {
     return NextResponse.json({ error: 'Only bank term deposits can be renewed.' }, { status: 400 })
+  }
+
+  // Sanity-bound the realized interest against the OLD principal it accrued on
+  // (not the new cycle's principal, which a "change amount" renewal may shrink).
+  if (cleanInterestEarned != null && cleanInterestEarned > old.amount_vnd * 10) {
+    return NextResponse.json({ error: 'interest_earned_vnd is unreasonably large' }, { status: 400 })
   }
 
   // Roll the active row forward to the new cycle (in place — valuation unchanged).

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -26,7 +26,7 @@ export async function GET(request: NextRequest) {
 
   let query = supabase
     .from('investment_transactions')
-    .select('transaction_id, goal_id, asset_type, transaction_type, parent_transaction_id, renewed_from_transaction_id, investment_date, amount_vnd, unit_price, units, interest_rate, expiry_date, notes, fund_id, principal_withdrawn, units_withdrawn, affects_progress, savings_goals(goal_name), funds(id, name, nav)', { count: 'exact' })
+    .select('transaction_id, goal_id, asset_type, transaction_type, parent_transaction_id, renewed_from_transaction_id, interest_earned_vnd, investment_date, amount_vnd, unit_price, units, interest_rate, expiry_date, notes, fund_id, principal_withdrawn, units_withdrawn, affects_progress, savings_goals(goal_name), funds(id, name, nav)', { count: 'exact' })
     .eq('user_id', user.id)
     .order('investment_date', { ascending: false })
     .range(offset, offset + limit - 1)

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield, RefreshCw } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, AffectsProgressControl, BankInfoStrip, needsMaturityAction, type InvRow } from './goalDetailShared'
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, AffectsProgressControl, BankInfoStrip, RenewalSummaryLine, needsMaturityAction, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { MaturityResolveModal } from './MaturityResolveSheet'
 import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
@@ -25,6 +25,7 @@ interface InvestmentTx {
   principal_withdrawn: number | null
   units_withdrawn: number | null
   renewed_from_transaction_id?: string | null
+  interest_earned_vnd?: number | null
   is_recurring?: boolean
 }
 
@@ -531,6 +532,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
         <InvOptionsModal
           inv={actionInv}
           isVi={isVi}
+          renewalSummary={buildRenewalSummary(transactions as GoalDetailTx[], actionInv.id)}
           onClose={() => { setShowInvOptions(false) }}
           onHistory={() => { setShowInvOptions(false); setTab('history') }}
           onResolve={() => { setShowInvOptions(false); setTimeout(() => setShowResolve(true), 80) }}
@@ -582,8 +584,8 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
 }
 
 // ─── Investment options modal ──────────────────────────────────────────────
-function InvOptionsModal({ inv, isVi, onClose, onHistory, onResolve, onSell, onUnassign }: {
-  inv: InvRow; isVi: boolean
+function InvOptionsModal({ inv, isVi, renewalSummary, onClose, onHistory, onResolve, onSell, onUnassign }: {
+  inv: InvRow; isVi: boolean; renewalSummary: ReturnType<typeof buildRenewalSummary>
   onClose: () => void; onHistory: () => void; onResolve: () => void; onSell: () => void; onUnassign: () => void
 }) {
   const isBank = inv.type === 'bank'
@@ -652,6 +654,9 @@ function InvOptionsModal({ inv, isVi, onClose, onHistory, onResolve, onSell, onU
 
         {/* Bank info strip — interest rate + maturity + time left (issue #263) */}
         <BankInfoStrip inv={inv} isVi={isVi} />
+
+        {/* Renewal history summary — only when this deposit has been renewed */}
+        <RenewalSummaryLine summary={renewalSummary} isVi={isVi} />
 
         {actions.map((a, i) => (
           <button key={i} onClick={a.onClick} style={{

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -11,7 +11,7 @@ import type { GoalData, FundBreakdownItem } from '../DashboardClient'
 import TransactionHistorySheet, { type PurchaseHistoryRow } from './TransactionHistorySheet'
 import { SellWithdrawSheet, type SellItem } from './SellWithdrawSheet'
 import { MaturityResolveSheet } from './MaturityResolveSheet'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, BankInfoStrip, needsMaturityAction, type InvRow } from './goalDetailShared'
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, RenewalSummaryLine, needsMaturityAction, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 
@@ -33,6 +33,7 @@ interface InvestmentTx {
   principal_withdrawn: number | null
   units_withdrawn: number | null
   renewed_from_transaction_id?: string | null
+  interest_earned_vnd?: number | null
   is_recurring?: boolean
 }
 
@@ -341,6 +342,7 @@ function InvestmentActionSheet({
   open,
   onClose,
   inv,
+  renewalSummary,
   onViewHistory,
   onSell,
   onUnassign,
@@ -349,6 +351,7 @@ function InvestmentActionSheet({
   open: boolean
   onClose: () => void
   inv: InvRow | null
+  renewalSummary: ReturnType<typeof buildRenewalSummary>
   onViewHistory: () => void
   onSell: () => void
   onUnassign: () => void
@@ -442,6 +445,9 @@ function InvestmentActionSheet({
 
           {/* Bank info strip — interest rate + maturity + time left (issue #263) */}
           <BankInfoStrip inv={inv} isVi={isVI} />
+
+          {/* Renewal history summary — only when this deposit has been renewed */}
+          <RenewalSummaryLine summary={renewalSummary} isVi={isVI} />
 
           {/* Handle maturity — only for a term deposit at/near its maturity date */}
           {needsMaturity && (
@@ -1249,6 +1255,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
         open={investActionOpen}
         onClose={() => setInvestActionOpen(false)}
         inv={actionInv}
+        renewalSummary={actionInv ? buildRenewalSummary(transactions as GoalDetailTx[], actionInv.id) : null}
         onViewHistory={() => {
           if (actionInv?.fund) openFundDetail(actionInv.fund)
           else setActiveTab('history')

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -115,6 +115,7 @@ export function MaturityResolveBody({
     prompt: 'Bạn muốn làm gì?',
     newAmount: 'Số tiền kỳ mới', interestReceived: 'Lãi thực nhận',
     interestPaidOut: 'Lãi thực nhận (rút ra)',
+    interestSavedHint: 'Số lãi này được lưu vĩnh viễn vào lịch sử tái tục.',
     newTerm: 'Kỳ hạn mới', newRate: 'Lãi suất kỳ mới',
     newCycle: 'Kỳ mới', newMaturityLabel: 'Ngày đáo hạn mới',
     interestIn: 'Lãi nhập gốc', interestOut: 'Lãi rút ra',
@@ -129,6 +130,7 @@ export function MaturityResolveBody({
     prompt: 'What do you want to do?',
     newAmount: 'New amount', interestReceived: 'Interest received',
     interestPaidOut: 'Interest received (paid out)',
+    interestSavedHint: 'This interest is saved permanently to the renewal history.',
     newTerm: 'New term', newRate: 'New interest rate',
     newCycle: 'New cycle', newMaturityLabel: 'New maturity',
     interestIn: 'Interest added', interestOut: 'Interest out',
@@ -161,6 +163,9 @@ export function MaturityResolveBody({
           // active row forward in place and appends a history snapshot of the
           // cycle that just closed.
           investment_date: todayIso(),
+          // Realized interest for the cycle that just closed — recorded
+          // permanently on the snapshot for the renewal-history summary.
+          interest_earned_vnd: iNum,
         }),
       })
       if (!res.ok) {
@@ -301,6 +306,8 @@ export function MaturityResolveBody({
               </div>
             </div>
           </div>
+
+          <p style={{ margin: 0, fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.4 }}>{t.interestSavedHint}</p>
         </div>
       )}
 

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -63,6 +63,7 @@ describe('MaturityResolveBody', () => {
       interest_rate: 5.8,
       expiry_date: addMonths(today(), 12), // new maturity from today (matured)
       investment_date: today(),            // accrual reset, never future-dated
+      interest_earned_vnd: 2_030_000,      // realized interest (value − principal) recorded permanently
     })
   })
 

--- a/app/assets/components/__tests__/goalDetailShared.test.tsx
+++ b/app/assets/components/__tests__/goalDetailShared.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { buildInvRows, calcDeadlineMonths, fmtMaturity, type GoalDetailTx } from '../goalDetailShared'
+import { buildInvRows, buildRenewalSummary, calcDeadlineMonths, fmtMaturity, type GoalDetailTx } from '../goalDetailShared'
 import type { FundBreakdownItem } from '../../DashboardClient'
 
 // A YYYY-MM-DD string `n` days from today (deterministic regardless of run date).
@@ -65,6 +65,29 @@ describe('buildInvRows', () => {
     expect(rows).toHaveLength(1)               // one row per fund
     expect(rows[0].value).toBe(2_500_000)      // fund.currentValue
     expect(rows[0].fund?.fundId).toBe('f1')
+  })
+
+  it('summarises a deposit\'s renewal history (count + total interest received)', () => {
+    const txs = [
+      baseTx({ transaction_id: 'active', asset_type: 'bank', amount_vnd: 12_000_000 }),
+      baseTx({ transaction_id: 's1', asset_type: 'bank', amount_vnd: 10_000_000, renewed_from_transaction_id: 'active', interest_earned_vnd: 600_000 }),
+      baseTx({ transaction_id: 's2', asset_type: 'bank', amount_vnd: 11_000_000, renewed_from_transaction_id: 'active', interest_earned_vnd: 660_000 }),
+    ]
+    const summary = buildRenewalSummary(txs, 'active')
+    expect(summary).toEqual({ count: 2, totalInterestVnd: 1_260_000, complete: true })
+  })
+
+  it('marks the renewal total incomplete when a cycle has no recorded interest (null != 0)', () => {
+    const txs = [
+      baseTx({ transaction_id: 's1', asset_type: 'bank', renewed_from_transaction_id: 'active', interest_earned_vnd: 600_000 }),
+      baseTx({ transaction_id: 's2', asset_type: 'bank', renewed_from_transaction_id: 'active', interest_earned_vnd: null }),
+    ]
+    const summary = buildRenewalSummary(txs, 'active')
+    expect(summary).toEqual({ count: 2, totalInterestVnd: 600_000, complete: false })
+  })
+
+  it('returns null when a deposit has never been renewed', () => {
+    expect(buildRenewalSummary([baseTx({ transaction_id: 'active', asset_type: 'bank' })], 'active')).toBeNull()
   })
 
   it('drops renewal history snapshots (renewed_from_transaction_id set) from active holdings', () => {

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -3,7 +3,7 @@
 // chrome, so the icons, colours, deadline math and — most importantly — the
 // investment-row valuation live here to stay in sync.
 
-import { TrendingUp, Building, Coins, BarChart2, Target } from 'lucide-react'
+import { TrendingUp, Building, Coins, BarChart2, Target, RefreshCw } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
 import { fmtTxDate } from './transactionUtils'
 import { isTermDeposit, depositMaturityState, isMaturityActionable } from '@/lib/maturity'
@@ -183,6 +183,26 @@ export interface GoalDetailTx {
   // Set on a renewal history snapshot (a closed past cycle) — excluded from
   // active holdings and every valuation. null/undefined for live rows.
   renewed_from_transaction_id?: string | null
+  // Realized interest the user recorded for a closed cycle (snapshot rows only).
+  // null = not recorded for that cycle (don't treat as 0).
+  interest_earned_vnd?: number | null
+}
+
+// Roll up a deposit's renewal history from the snapshot rows that point at it.
+// Returns null when it has never been renewed. `complete` is false when any
+// cycle's interest wasn't recorded (null), so callers can show a "≥" rather than
+// silently understating the total.
+export interface RenewalSummary { count: number; totalInterestVnd: number; complete: boolean }
+export function buildRenewalSummary(transactions: GoalDetailTx[], activeTxId: string): RenewalSummary | null {
+  const snaps = transactions.filter((tx) => tx.renewed_from_transaction_id === activeTxId)
+  if (!snaps.length) return null
+  let totalInterestVnd = 0
+  let complete = true
+  for (const s of snaps) {
+    if (s.interest_earned_vnd == null) complete = false
+    else totalInterestVnd += s.interest_earned_vnd
+  }
+  return { count: snaps.length, totalInterestVnd, complete }
 }
 
 // Dedup to one row per fund / per non-fund tx, then value each holding:
@@ -349,6 +369,26 @@ export function BankInfoStrip({ inv, isVi }: { inv: InvRow; isVi: boolean }) {
           </div>
         )
       })}
+    </div>
+  )
+}
+
+// "Renewed N× · total interest received X" line for a deposit that has renewal
+// history. Shown in the holding Options modal (mobile + desktop). When a cycle's
+// interest wasn't recorded the total is prefixed with ≥ rather than understated;
+// the interest clause is dropped entirely when nothing is recorded.
+export function RenewalSummaryLine({ summary, isVi }: { summary: RenewalSummary | null; isVi: boolean }) {
+  if (!summary) return null
+  const count = isVi ? `Đã tái tục ${summary.count} lần` : `Renewed ${summary.count}×`
+  let interest = ''
+  if (summary.totalInterestVnd > 0) {
+    const v = `${summary.complete ? '' : '≥ '}${fmtCompact(summary.totalInterestVnd)}`
+    interest = isVi ? ` · tổng lãi đã nhận ${v}` : ` · total interest ${v}`
+  }
+  return (
+    <div data-testid="renewal-summary" style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', background: 'var(--c-card-2)', borderRadius: 10, fontSize: 12, color: 'var(--c-muted)', marginBottom: 4 }}>
+      <RefreshCw size={13} style={{ flexShrink: 0 }} />
+      <span style={{ fontVariantNumeric: 'tabular-nums' }}>{count}{interest}</span>
     </div>
   )
 }

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -192,6 +192,12 @@ export interface GoalDetailTx {
 // Returns null when it has never been renewed. `complete` is false when any
 // cycle's interest wasn't recorded (null), so callers can show a "≥" rather than
 // silently understating the total.
+//
+// COUPLING: this matches snapshots by `renewed_from_transaction_id === activeTxId`,
+// which is correct only because renewal overwrites the deposit IN PLACE (the
+// active row keeps its id across cycles — see the /renew route). If renewal ever
+// switches to a new-row-per-cycle model, the snapshots would point at differing
+// ids and this lookup would silently miss earlier cycles — revisit it then.
 export interface RenewalSummary { count: number; totalInterestVnd: number; complete: boolean }
 export function buildRenewalSummary(transactions: GoalDetailTx[], activeTxId: string): RenewalSummary | null {
   const snaps = transactions.filter((tx) => tx.renewed_from_transaction_id === activeTxId)

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -231,12 +231,22 @@ test.describe('Desktop goal detail panel', () => {
 
       const { data: snapshot } = await supabase
         .from('investment_transactions')
-        .select('amount_vnd, investment_date, affects_progress')
+        .select('amount_vnd, investment_date, affects_progress, interest_earned_vnd')
         .eq('renewed_from_transaction_id', tx.transaction_id)
         .single()
       expect(snapshot!.investment_date).toBe(iso(-400)) // original open date preserved
       expect(snapshot!.amount_vnd).toBe(10_000_000)     // original principal preserved
       expect(snapshot!.affects_progress).toBe(false)    // never counts toward progress/net worth
+      expect(snapshot!.interest_earned_vnd).toBeGreaterThan(0) // realized interest captured
+
+      // UI loop: reopening the (still-active) deposit's options now shows the
+      // renewal-history summary. The panel stays open and refetches after the
+      // renewal, so the holding's Options button is the still-active deposit.
+      await expect(panel.getByText('E2E Maturity Deposit')).toBeVisible({ timeout: 15_000 })
+      await panel.getByRole('button', { name: 'Options', exact: true }).first().click()
+      const summary = page.getByTestId('renewal-summary')
+      await expect(summary).toBeVisible({ timeout: 10_000 })
+      await expect(summary).toContainText(/Renewed 1|Đã tái tục 1/)
     } finally {
       await api.deleteTransactionCascade(tx.transaction_id)
     }

--- a/supabase/migrations/20260613000002_add_renewal_interest_earned.sql
+++ b/supabase/migrations/20260613000002_add_renewal_interest_earned.sql
@@ -1,0 +1,12 @@
+-- Realized interest captured per term-deposit renewal.
+--
+-- When a deposit is renewed, the user enters the interest actually received for
+-- the cycle that just closed. We store that amount on the history snapshot row
+-- (the one carrying renewed_from_transaction_id) so the goal-detail view can
+-- show a truthful "renewed N times · total interest received X" summary.
+--
+-- Nullable on purpose: a null means "not recorded for this cycle" (e.g. an older
+-- snapshot), which the summary surfaces as a ≥ / — rather than counting it as 0,
+-- so the total is never silently understated.
+ALTER TABLE investment_transactions
+  ADD COLUMN IF NOT EXISTS interest_earned_vnd BIGINT;


### PR DESCRIPTION
## What & why

Final follow-up of the term-deposit maturity feature (#328 / #329 / #330). Surfaces a deposit's renewal lineage on the holding: **"Đã tái tục N lần · tổng lãi đã nhận X"** ("Renewed N× · total interest X"), using the snapshot rows shipped in #330.

## How it works

- **Migration** — adds nullable `interest_earned_vnd` to `investment_transactions`. It holds the **realized interest the user recorded** for a closed cycle (on the snapshot row). **Null = "not recorded"**, surfaced as a `≥` / omitted — never counted as 0, so the total is never silently understated. (No backfill needed — #330 left no snapshots in prod yet.)
- **`/renew` route** — now captures `interest_earned_vnd` from the resolve form and stores it on the snapshot, **validated server-side** (non-negative + sane upper bound, since it's permanent user money input).
- **Resolve form** — sends the realized interest and adds a hint that the amount is **saved permanently** to the renewal history (it's no longer a use-once estimate).
- **`buildRenewalSummary(transactions, activeId)`** — rolls up count + total interest from the snapshots already fetched client-side (no new endpoint), flagging `complete: false` when any cycle's interest is null so the UI shows `≥`. `RenewalSummaryLine` renders it in the holding Options modal (mobile + desktop), only when the deposit has been renewed.

## Per the agreed handling of nulls
`null` interest is treated as **unknown**, not zero: the total carries a `≥` prefix when any cycle is unrecorded, and the interest clause is dropped entirely when nothing is recorded. Count is always exact.

## Tests
- Unit: `buildRenewalSummary` (count + sum; `null` → incomplete with `≥`; never-renewed → null); resolve flow sends `interest_earned_vnd`.
- E2E: after renewing, the snapshot stored a **positive** realized interest, and reopening the holding shows the **renewal-summary** line ("Renewed 1×").
- Full unit suite **602 passing**; `tsc --noEmit` clean; changed files lint-clean.

## Verify on preview
Renew a matured deposit (enter/accept the interest), then reopen the holding's options → it shows "Renewed 1× · total interest …". Renew again → "Renewed 2× · …" with the summed interest.

> Migration applies via the "Apply DB migrations (production)" CI job on merge. E2E runs locally only and wasn't run here (local WSL2 Supabase stack wasn't up this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)