### PR TITLE
fix(deposits): unify bank-deposit valuation on one shared formula

### DIFF
--- a/app/api/v1/savings-goals/route.ts
+++ b/app/api/v1/savings-goals/route.ts
@@ -1,14 +1,9 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateEnum, validateText, validateYearMonth } from '@/lib/validation'
-
-function calcProjectedInterest(amount: number, rate: number | null, investmentDate: string): number {
-  if (!rate) return 0
-  const months = Math.max(0, Math.floor(
-    (Date.now() - new Date(investmentDate).getTime()) / (1000 * 60 * 60 * 24 * 30.44)
-  ))
-  return amount * Math.pow(1 + rate / 100 / 12, months) - amount
-}
+// Shared bank-deposit valuation (simple interest, capped at maturity) so the
+// goals list matches the dashboard and goal detail.
+import { calcProjectedInterest } from '@/lib/finance'
 
 export async function GET(request: NextRequest) {
   const supabase = await createSupabaseServerClient()
@@ -31,7 +26,7 @@ export async function GET(request: NextRequest) {
   // Fetch transactions with fund NAV in parallel with goals already done
   const { data: transactions, error: txError } = await supabase
     .from('investment_transactions')
-    .select('transaction_id, goal_id, asset_type, transaction_type, amount_vnd, units, unit_price, interest_rate, investment_date, funds(id, name, nav)')
+    .select('transaction_id, goal_id, asset_type, transaction_type, amount_vnd, units, unit_price, interest_rate, investment_date, expiry_date, funds(id, name, nav)')
     .eq('user_id', user.id)
     .not('goal_id', 'is', null)
     .is('renewed_from_transaction_id', null) // exclude renewal history snapshots from goal stats
@@ -48,6 +43,7 @@ export async function GET(request: NextRequest) {
     unit_price: number | null
     interest_rate: number | null
     investment_date: string
+    expiry_date: string | null
     funds?: { id: string; name: string; nav: number } | { id: string; name: string; nav: number }[] | null
   }
 
@@ -65,7 +61,7 @@ export async function GET(request: NextRequest) {
       const currentNav = fund?.nav ?? tx.unit_price ?? 0
       gain = tx.units * currentNav - tx.amount_vnd
     } else {
-      gain = calcProjectedInterest(tx.amount_vnd, tx.interest_rate, tx.investment_date)
+      gain = calcProjectedInterest(tx.amount_vnd, tx.interest_rate, tx.investment_date, tx.expiry_date)
     }
     statsMap.set(tx.goal_id, { count: existing.count + 1, invested: existing.invested + tx.amount_vnd, interest: existing.interest + gain })
   })

--- a/app/assets/components/__tests__/goalDetailShared.test.tsx
+++ b/app/assets/components/__tests__/goalDetailShared.test.tsx
@@ -44,7 +44,7 @@ describe('buildInvRows', () => {
     expect(rows[0].value).toBe(9_000_000)
   })
 
-  it('compounds bank interest monthly and reports principal', () => {
+  it('values a bank deposit at principal + accrued interest and reports principal', () => {
     const rows = buildInvRows(
       [baseTx({ transaction_id: 'b1', asset_type: 'bank', amount_vnd: 5_000_000, interest_rate: 6 })],
       [], null, false,
@@ -52,6 +52,18 @@ describe('buildInvRows', () => {
     expect(rows[0].value).toBeGreaterThanOrEqual(5_000_000)
     expect(rows[0].principal).toBe(5_000_000)
     expect(rows[0].units).toBeNull()
+  })
+
+  it('caps a matured deposit at its term interest (frozen, simple interest)', () => {
+    // Term 2025-01-01 → 2025-07-01 (181 days). Interest is capped at maturity, so
+    // the value is deterministic regardless of when the test runs (today is past
+    // the expiry): 10M + 10M × 6% × 181/365.
+    const rows = buildInvRows(
+      [baseTx({ transaction_id: 'm1', asset_type: 'bank', amount_vnd: 10_000_000, interest_rate: 6, investment_date: '2025-01-01', expiry_date: '2025-07-01' })],
+      [], null, false,
+    )
+    const expected = Math.round(10_000_000 + 10_000_000 * 0.06 * (181 / 365))
+    expect(rows[0].value).toBe(expected)
   })
 
   it('uses the fund current value and dedups multiple txs of the same fund', () => {

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -5,6 +5,7 @@
 
 import { TrendingUp, Building, Coins, BarChart2, Target, RefreshCw } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
+import { calcProjectedInterest } from '@/lib/finance'
 import { fmtTxDate } from './transactionUtils'
 import { isTermDeposit, depositMaturityState, isMaturityActionable } from '@/lib/maturity'
 import type { FundBreakdownItem } from '../DashboardClient'
@@ -280,10 +281,8 @@ export function buildInvRows(
       } else {
         if (effectivePrincipal <= 0) return null // fully withdrawn
         if (tx.asset_type === 'bank' && tx.interest_rate) {
-          const months = Math.max(0, Math.floor(
-            (Date.now() - new Date(tx.investment_date).getTime()) / (1000 * 60 * 60 * 24 * 30.44)
-          ))
-          value = Math.round(effectivePrincipal * Math.pow(1 + tx.interest_rate / 100 / 12, months))
+          // Shared valuation: simple interest, capped at maturity (see lib/finance).
+          value = Math.round(effectivePrincipal + calcProjectedInterest(effectivePrincipal, tx.interest_rate, tx.investment_date, tx.expiry_date))
           gainPct = ((value - effectivePrincipal) / effectivePrincipal) * 100
           units = null
           principal = effectivePrincipal

--- a/lib/__tests__/finance.test.ts
+++ b/lib/__tests__/finance.test.ts
@@ -15,25 +15,22 @@ describe('calcProjectedInterest', () => {
     expect(calcProjectedInterest(-1000, 8, '2026-01-01')).toBe(0)
   })
   it('caps at expiry date when expiry is in the past', () => {
-    const noExpiry = calcProjectedInterest(10_000_000, 8, '2025-01-01')
-    const withExpiry = calcProjectedInterest(10_000_000, 8, '2025-01-01', '2025-06-01')
+    const asOf = new Date('2026-01-01').getTime()
+    const noExpiry = calcProjectedInterest(10_000_000, 8, '2025-01-01', null, asOf)
+    const withExpiry = calcProjectedInterest(10_000_000, 8, '2025-01-01', '2025-06-01', asOf)
     // with a past expiry, interest should be less than without expiry
     expect(withExpiry).toBeLessThan(noExpiry)
     expect(withExpiry).toBeGreaterThan(0)
   })
-  it('produces positive interest for a bank deposit', () => {
-    // 10M VND at 8%/year for exactly 1 year should yield ~800k. Pin "now" so the
-    // result doesn't drift as the calendar moves past the investment date (the
-    // function accrues interest up to Date.now()).
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-04-29'))
-    try {
-      const result = calcProjectedInterest(10_000_000, 8, '2025-04-29')
-      expect(result).toBeGreaterThan(700_000)
-      expect(result).toBeLessThan(900_000)
-    } finally {
-      vi.useRealTimers()
-    }
+  it('accrues simple (linear) interest pro-rated over the year', () => {
+    // 10M at 8%/yr for exactly 365 days = 10M × 0.08 × 1 = 800,000 (no compounding).
+    const asOf = new Date('2026-04-29').getTime()
+    expect(calcProjectedInterest(10_000_000, 8, '2025-04-29', null, asOf)).toBeCloseTo(800_000, 0)
+  })
+  it('freezes accrual at maturity — an overdue deposit earns no more after expiry', () => {
+    const atMaturity = calcProjectedInterest(10_000_000, 8, '2025-01-01', '2025-07-01', new Date('2025-07-01').getTime())
+    const longOverdue = calcProjectedInterest(10_000_000, 8, '2025-01-01', '2025-07-01', new Date('2026-06-01').getTime())
+    expect(longOverdue).toBe(atMaturity) // capped — no extra interest past maturity
   })
 })
 

--- a/lib/finance.ts
+++ b/lib/finance.ts
@@ -1,15 +1,25 @@
+// The single source of truth for a bank term deposit's accrued interest, used by
+// the dashboard/net-worth, the goals list and the goal-detail holding rows so
+// the same deposit never shows a different value across screens.
+//
+// Simple (linear) interest pro-rated over the year — `principal × rate × days/365`
+// — matching how a held-to-maturity Vietnamese term deposit pays and the
+// add-transaction preview. Accrual is capped at maturity (`min(asOf, expiry)`),
+// so an unrenewed overdue deposit stops earning at its maturity date rather than
+// running forever. Flex deposits (no rate) earn nothing here — callers keep them
+// on the `value = principal` branch. `asOf` defaults to now; pass it to value a
+// deposit as of a fixed instant (and for deterministic tests).
 export function calcProjectedInterest(
   amount: number,
   rate: number | null,
   investmentDate: string,
-  expiryDate?: string | null
+  expiryDate?: string | null,
+  asOf: number = Date.now()
 ): number {
   if (!rate || amount <= 0) return 0
-  const endMs = expiryDate
-    ? Math.min(Date.now(), new Date(expiryDate).getTime())
-    : Date.now()
+  const endMs = expiryDate ? Math.min(asOf, new Date(expiryDate).getTime()) : asOf
   const days = Math.max(0, (endMs - new Date(investmentDate).getTime()) / (1000 * 60 * 60 * 24))
-  return amount * Math.pow(1 + rate / 100, days / 365) - amount
+  return amount * (rate / 100) * (days / 365)
 }
 
 export function isNavStale(updatedAt: string): boolean {


### PR DESCRIPTION
## What & why

A bank term deposit could show **different current values** across screens, because three places valued it with two formulas — and two of them never stopped accruing past maturity:

| Where | Formula | Cap at maturity? |
|---|---|---|
| Dashboard / net worth (`calcProjectedInterest`) | annual compound | ✅ |
| Goal-detail holding rows (`buildInvRows`) | monthly compound | ❌ |
| Goals list (`savings-goals` — its own duplicate) | monthly compound | ❌ |

So the same deposit diverged between screens, and an overdue-unrenewed deposit kept "earning" forever in two of them.

## How it works

Consolidate all three onto **`lib/finance.calcProjectedInterest`** as the single source of truth, now: **simple (linear) interest** — `principal × rate × days/365` — **capped at maturity** (`min(asOf, expiry)`). This matches the Vietnamese held-to-maturity convention and the existing add-transaction preview, so every surface agrees and overdue deposits freeze at their maturity date.

- **`lib/finance`** — switch to simple interest; add an `asOf` param (default now) for as-of valuation + deterministic tests.
- **`buildInvRows`** — drop the inline monthly-compound/uncapped calc for the shared helper. Flex / no-rate deposits stay on the `value = principal` branch (per the agreed note).
- **`savings-goals` route** — delete its duplicate `calcProjectedInterest`, import the shared one, and pass `expiry_date` so the goals list caps too.
- **Overview / net worth** already used the shared helper — inherits the change automatically.

## Note on impact
Because net worth already used the (capped) shared helper, the dashboard shift is only annual→simple compounding — tiny for normal rates/terms. The visible correction is the goal-detail + goals-list now **capping at maturity** and matching the dashboard. No schema change.

## Tests
- `finance`: exact simple-interest accrual + **freeze-at-maturity** (via `asOf`, deterministic).
- `buildInvRows`: a matured deposit is valued at exactly principal + term interest (capped), deterministic regardless of run date.
- Full unit suite **604 passing**; `tsc` + lint clean.
- A grep confirms no monthly-compound bank calc remains anywhere.

## Verify on preview
Open a bank deposit with a **past maturity** — its value on the goal-detail holding row, the goal card, and the dashboard should now agree, and it should have stopped accruing at the maturity date (not kept climbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)