### PR TITLE
chore(deposits): DB-level net so renewal snapshots can't be summed

### DIFF
--- a/app/api/v1/dashboard/history/route.ts
+++ b/app/api/v1/dashboard/history/route.ts
@@ -41,7 +41,10 @@ export async function GET(request: Request) {
   // Withdrawals are intentionally excluded: they are recorded at market value which can exceed
   // original cost, driving the cumulative negative and causing a visual cliff.
   const { data: txData } = await supabase
-    .from('investment_transactions')
+    // Snapshot-free view: a renewal history row is an `investment` carrying the
+    // OLD principal, so summing it here would double-count it into the cumulative
+    // invested chart. The view keeps it out.
+    .from('active_investment_transactions')
     .select('investment_date, amount_vnd')
     .eq('user_id', user.id)
     .eq('transaction_type', 'investment')

--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -22,7 +22,9 @@ export async function GET() {
       .select('goal_id, goal_name, target_amount, target_date')
       .eq('user_id', user.id),
     supabase
-      .from('investment_transactions')
+      // Snapshot-free view — renewal history rows can't reach the net-worth /
+      // goal / allocation totals (defence on top of the app-side filter below).
+      .from('active_investment_transactions')
       .select('transaction_id, goal_id, amount_vnd, interest_rate, investment_date, asset_type, transaction_type, units, unit_price, units_withdrawn, principal_withdrawn, fund_id, parent_transaction_id, renewed_from_transaction_id, expiry_date, notes, affects_progress, funds(id, name, nav, updated_at, fund_type)')
       .eq('user_id', user.id),
     supabase
@@ -75,7 +77,7 @@ export async function GET() {
   // Separate investment vs withdrawal rows
   const investments = allTxsRaw.filter((tx) =>
     tx.transaction_type !== 'withdrawal' &&
-    !tx.renewed_from_transaction_id && // exclude renewal history snapshots (never counted)
+    !tx.renewed_from_transaction_id && // exclude renewal snapshots (defence; the active_* view already does)
     !(tx.asset_type === 'fund' && tx.units == null) // exclude pending DCA-seeded fund rows
   )
   const withdrawals = allTxsRaw.filter((tx) => tx.transaction_type === 'withdrawal')

--- a/app/api/v1/savings-goals/route.ts
+++ b/app/api/v1/savings-goals/route.ts
@@ -25,11 +25,12 @@ export async function GET(request: NextRequest) {
 
   // Fetch transactions with fund NAV in parallel with goals already done
   const { data: transactions, error: txError } = await supabase
-    .from('investment_transactions')
+    // Snapshot-free view so renewal history rows can't reach per-goal stats.
+    .from('active_investment_transactions')
     .select('transaction_id, goal_id, asset_type, transaction_type, amount_vnd, units, unit_price, interest_rate, investment_date, expiry_date, funds(id, name, nav)')
     .eq('user_id', user.id)
     .not('goal_id', 'is', null)
-    .is('renewed_from_transaction_id', null) // exclude renewal history snapshots from goal stats
+    .is('renewed_from_transaction_id', null) // defence; the active_* view already excludes snapshots
 
   if (txError) return NextResponse.json({ error: 'Failed to fetch transactions' }, { status: 500 })
 

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -13,7 +13,10 @@ function daysFromNow(n: number): string {
   d.setDate(d.getDate() + n)
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
-const today = () => daysFromNow(0)
+// Match the component's todayIso() (UTC) so the assertion is timezone-robust —
+// a local-date `today` flakes near the UTC midnight boundary on dev machines
+// behind/ahead of UTC (CI runners are UTC, so it only bit locally).
+const today = () => new Date().toISOString().slice(0, 10)
 
 // A matured term deposit: value (compounded) > principal, expiry in the past.
 const maturedDeposit: InvRow = {

--- a/supabase/migrations/20260613000003_active_investment_transactions_view.sql
+++ b/supabase/migrations/20260613000003_active_investment_transactions_view.sql
@@ -1,0 +1,22 @@
+-- DB-level safety net for renewal history snapshots.
+--
+-- Renewal "snapshot" rows (renewed_from_transaction_id IS NOT NULL) are a record
+-- of a closed past cycle and must never be summed into any total. Every
+-- aggregating reader already filters them out in app code, but that relies on
+-- each query remembering to. This view is the structural backstop: the
+-- aggregating reads query it instead of the base table, so a snapshot can't be
+-- counted even if a future query forgets the filter.
+--
+-- security_invoker = true is REQUIRED: without it the view would run as its
+-- owner and bypass the base table's row-level security, exposing other users'
+-- rows. With it, the caller's `user_id = auth.uid()` policy on
+-- investment_transactions applies as normal.
+--
+-- Writes and the goal-detail History tab (which intentionally shows snapshots
+-- via ?include_history=true) keep using the base table directly.
+CREATE OR REPLACE VIEW active_investment_transactions
+  WITH (security_invoker = true) AS
+  SELECT * FROM investment_transactions
+  WHERE renewed_from_transaction_id IS NULL;
+
+GRANT SELECT ON active_investment_transactions TO authenticated;


### PR DESCRIPTION
## What & why

The 🟢 final hardening item from the #330 review. Renewal history **snapshots** (`renewed_from_transaction_id IS NOT NULL`) must never be summed into a total. Every aggregating reader already filters them app-side — but that relies on each query *remembering* to, and one didn't:

- **`dashboard/history`** summed snapshot `amount_vnd` (the OLD principal of a renewed cycle, stored as an `investment` row) into the cumulative-invested chart → **double-counted** a renewed deposit. A real latent bug, not just future-proofing.

Add a structural backstop: a Postgres **view** that excludes snapshots, used by the aggregating reads.

## How it works

- **Migration** — `CREATE VIEW active_investment_transactions WITH (security_invoker = true) AS SELECT * FROM investment_transactions WHERE renewed_from_transaction_id IS NULL` + `GRANT SELECT ... TO authenticated`.
  - **`security_invoker = true` is mandatory** — otherwise the view runs as its owner and bypasses the base table's RLS (`user_id = auth.uid()`), leaking other users' rows. With it, per-caller RLS still applies.
- **Three aggregating reads switch to the view** (one-line relation swap): `dashboard/overview` (net worth / goal & global totals / allocation), `savings-goals` (per-goal stats), and `dashboard/history` (the latent over-count fix). The existing app-side snapshot filters are **kept as defence-in-depth**.
- **Everything else stays on the base table**: all writes, the `GET /investment-transactions?include_history=true` path (the goal-detail History tab intentionally shows snapshots), and single-row / list reads.

## Scope checked
Inventoried every `.from('investment_transactions')` across `app/api/**`: only the three aggregating reads adopt the view; the ~12 write sites and the conditional/history/single-row reads are unaffected. Withdrawals (always `renewed_from` null) remain visible in the view, so the overview's parent-matching is unchanged. The Supabase client is untyped, so querying the view needs no cast.

## Also in this PR
Fixed a pre-existing **timezone flake** in `MaturityResolveSheet.test` — the renew-body assertion compared against a *local* `today` while the component sends UTC `todayIso()`. Only bit on dev machines near the UTC date boundary (CI runners are UTC, so it always passed there); now timezone-robust.

## Tests / Verify
- Full unit suite **604 passing**; `tsc` + lint clean. (No API-route unit-test harness exists, so the view itself is verified by the migration + preview.)
- Migration applies via the "Apply DB migrations (production)" CI job on merge.
- **Preview:** after renewing a deposit, net worth + goal totals + the **dashboard history chart** exclude the snapshot (no double-count), while the goal-detail **History tab still shows the muted "Renewed" row** (base table via `include_history`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)