### PR TITLE
fix(deposits): surface goal-assigned matured deposits in the Needs attention card

### DIFF
--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -136,6 +136,8 @@ export async function GET() {
       amount: number
       currentValue: number
       interestRate: number | null
+      expiryDate: string | null
+      investmentDate: string
       units: number | null
       notes: string | null
     }>
@@ -253,6 +255,11 @@ export async function GET() {
           amount: effectiveAmount,
           currentValue,
           interestRate: tx.interest_rate ?? null,
+          // expiryDate + investmentDate are required for the dashboard maturity
+          // card / nav badge to recognise a goal-assigned term deposit (without
+          // expiryDate, isTermDeposit returns false and it never surfaces).
+          expiryDate: tx.expiry_date ?? null,
+          investmentDate: tx.investment_date,
           units: effectiveUnits,
           notes: tx.notes ?? null,
         })

--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -6,6 +6,41 @@ import { shouldWriteSnapshot } from '@/lib/snapshots'
 
 export const dynamic = 'force-dynamic'
 
+// A non-fund holding (bank / gold / stock) as the dashboard exposes it, for both
+// goal-assigned and unallocated buckets. Built only via `buildNonFund` so the two
+// buckets can never drift — omitting a field in one branch (e.g. expiryDate,
+// which the maturity card needs) is exactly the bug this factory prevents.
+type NonFundEntry = {
+  transactionId: string
+  type: string
+  amount: number
+  currentValue: number
+  interestRate: number | null
+  expiryDate: string | null
+  investmentDate: string
+  units: number | null
+  notes: string | null
+}
+
+function buildNonFund(
+  tx: { transaction_id: string; asset_type: string; interest_rate: number | null; expiry_date: string | null; investment_date: string; notes: string | null },
+  amount: number,
+  currentValue: number,
+  units: number | null,
+): NonFundEntry {
+  return {
+    transactionId: tx.transaction_id,
+    type: tx.asset_type,
+    amount,
+    currentValue,
+    interestRate: tx.interest_rate ?? null,
+    expiryDate: tx.expiry_date ?? null,
+    investmentDate: tx.investment_date,
+    units,
+    notes: tx.notes ?? null,
+  }
+}
+
 export async function GET() {
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
@@ -130,17 +165,7 @@ export async function GET() {
       profitLossPercentage: number
       goalId: string
     }>
-    nonFunds: Array<{
-      transactionId: string
-      type: string
-      amount: number
-      currentValue: number
-      interestRate: number | null
-      expiryDate: string | null
-      investmentDate: string
-      units: number | null
-      notes: string | null
-    }>
+    nonFunds: NonFundEntry[]
   }>()
 
   for (const goal of goals) {
@@ -178,9 +203,7 @@ export async function GET() {
   const nonFundByType: Record<string, number> = { bank: 0, gold: 0, stock: 0 }
   let goldUnits = 0  // total gold holdings in chỉ (after withdrawals)
 
-  const unallocatedNonFunds: {
-    transactionId: string; type: string; amount: number; currentValue: number; interestRate: number | null; expiryDate: string | null; investmentDate: string; notes: string | null; units: number | null
-  }[] = []
+  const unallocatedNonFunds: NonFundEntry[] = []
 
   for (const tx of investments) {
     if (tx.asset_type === 'fund' && tx.units) {
@@ -249,33 +272,10 @@ export async function GET() {
         goalEntry.totalInvested += effectiveAmount
         goalEntry.currentValue += currentValue
         goalEntry.transactionCount += 1
-        goalEntry.nonFunds.push({
-          transactionId: tx.transaction_id,
-          type: tx.asset_type,
-          amount: effectiveAmount,
-          currentValue,
-          interestRate: tx.interest_rate ?? null,
-          // expiryDate + investmentDate are required for the dashboard maturity
-          // card / nav badge to recognise a goal-assigned term deposit (without
-          // expiryDate, isTermDeposit returns false and it never surfaces).
-          expiryDate: tx.expiry_date ?? null,
-          investmentDate: tx.investment_date,
-          units: effectiveUnits,
-          notes: tx.notes ?? null,
-        })
+        goalEntry.nonFunds.push(buildNonFund(tx, effectiveAmount, currentValue, effectiveUnits))
       } else {
         unallocatedNonFundValue += currentValue
-        unallocatedNonFunds.push({
-          transactionId: tx.transaction_id,
-          type: tx.asset_type,
-          amount: effectiveAmount,
-          currentValue,
-          interestRate: tx.interest_rate ?? null,
-          expiryDate: tx.expiry_date ?? null,
-          investmentDate: tx.investment_date,
-          notes: tx.notes ?? null,
-          units: effectiveUnits,
-        })
+        unallocatedNonFunds.push(buildNonFund(tx, effectiveAmount, currentValue, effectiveUnits))
       }
     }
   }

--- a/e2e/dashboard-desktop.spec.ts
+++ b/e2e/dashboard-desktop.spec.ts
@@ -142,15 +142,22 @@ test.describe('Desktop overview layout', () => {
   // PR2: a matured term deposit surfaces the dashboard "Needs attention" card
   // and the sidebar nav badge; renewing it from the card rolls it forward so it
   // leaves the card (closing the UI loop).
+  //
+  // Uses a GOAL-ASSIGNED deposit on purpose — the overview API built goal-assigned
+  // nonFunds without expiryDate, so isTermDeposit returned false and the card
+  // never showed for a deposit attached to a goal (the common case). Regression
+  // guard for that fix.
   test('matured deposit shows the Needs attention card + nav badge, and renewing clears it', async ({ page }) => {
     test.slow()
     const iso = (d: number) => new Date(Date.now() + d * 86_400_000).toISOString().slice(0, 10)
+    const goal = await api.createGoal({ goal_name: 'E2E Maturity Goal', target_amount: 50_000_000 })
     const tx = await api.createTransaction({
       asset_type: 'bank',
       amount_vnd: 12_000_000,
       investment_date: iso(-400),
       interest_rate: 6,
       expiry_date: iso(-20), // matured
+      goal_id: goal.goal_id, // assigned to a goal — the case the card used to miss
       notes: 'E2E Maturing Deposit',
     })
     try {
@@ -172,6 +179,7 @@ test.describe('Desktop overview layout', () => {
       await expect(card.getByText('E2E Maturing Deposit')).toHaveCount(0, { timeout: 30_000 })
     } finally {
       await api.deleteTransactionCascade(tx.transaction_id)
+      await api.deleteGoal(goal.goal_id)
     }
   })
 })


### PR DESCRIPTION
## The bug (reported)

> "My account has one matured bank term deposit, but there's no Needs attention section on the Overview page."

The dashboard **"Needs attention" card** and the **nav badge** decide a deposit is actionable via `isTermDeposit`, which requires a non-null **`expiryDate`**. The overview API builds its per-deposit `nonFunds` in two places:

- **Unassigned** deposits → push **includes** `expiryDate` + `investmentDate` ✅
- **Goal-assigned** deposits → push at `dashboard/overview/route.ts:250` **omitted** them ❌

…and the local `goalMap` `nonFunds` type didn't require those fields, so `tsc` never flagged it. So a matured term deposit **attached to a goal** (the common case) reached the client with `expiryDate: undefined` → `isTermDeposit` false → it never showed in the card or the nav badge.

It still worked *inside* the goal detail (that path fetches transactions directly with the expiry), which is why it looked half-working.

Pre-existing since **PR #329** — missed because that feature's E2E used an *unassigned* deposit.

## Fix
- Add `expiryDate` + `investmentDate` to the goal-assigned `nonFunds` push **and** to the local type (so it can't silently drop again).
- **E2E regression guard:** the dashboard card test now **assigns the matured deposit to a goal** — the exact case that was broken — and still asserts the card + sidebar badge appear and clear on renewal.

## Tests
- Full unit suite **604 passing**; `tsc` + lint clean; E2E parses.
- E2E runs locally only (WSL2 stack not up this session); verified by code + the assertion now covering the goal-assigned path.

## Verify on preview
With your matured deposit assigned to a goal, the Overview page should now show the "Needs attention" card listing it, plus the count badge on the Dashboard nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)