### PR TITLE
fix(deposits): re-parent withdrawals on renewal so they aren't double-counted

### DIFF
--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -4,14 +4,15 @@ import { ValidationError, validateAmount, validateDate, validateRate, validateUU
 
 // Renew a bank term deposit.
 //
-// The active deposit row is updated in place to the new cycle (new principal /
-// rate / maturity, accrual date reset to today) — its valuation is unchanged
-// from a plain edit. To preserve the history the overwrite would erase, we then
-// append a history-only "snapshot" of the cycle that just closed, linked via
-// `renewed_from_transaction_id`. The snapshot is never counted anywhere it is
-// excluded by that link, so the two writes don't need to be atomic: the
-// snapshot is best-effort and a failure there only drops a history row, never
-// double-counts.
+// The renewal performs three coupled writes — roll the active row forward to
+// the new cycle (in place), append a history snapshot of the cycle that just
+// closed, and re-parent that cycle's partial-withdrawal rows onto the snapshot.
+// The re-parent is correctness-critical: leaving a withdrawal attached to the
+// now-renewed active row subtracts it from net worth a second time (the exact
+// double-count this guards against). So all three run inside the
+// `renew_term_deposit` Postgres function as a single transaction — they commit
+// together or roll back together, leaving no intermediate double-count state and
+// never returning 200 on a partial write.
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const supabase = await createSupabaseServerClient()
@@ -51,10 +52,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     return NextResponse.json({ error: 'Investment date cannot be in the future.' }, { status: 400 })
   }
 
-  // Read the current cycle (owned by this user) before overwriting it.
+  // Validate against the current cycle (owned by this user) for friendly 4xx
+  // messages. The renewal itself re-reads and locks the row inside
+  // renew_term_deposit, which builds the snapshot from that authoritative read.
   const { data: old, error: fetchErr } = await supabase
     .from('investment_transactions')
-    .select('transaction_id, user_id, goal_id, asset_type, amount_vnd, investment_date, expiry_date, interest_rate, notes')
+    .select('asset_type, amount_vnd')
     .eq('transaction_id', txId)
     .eq('user_id', user.id)
     .single()
@@ -69,62 +72,24 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     return NextResponse.json({ error: 'interest_earned_vnd is unreasonably large' }, { status: 400 })
   }
 
-  // Roll the active row forward to the new cycle (in place — valuation unchanged).
-  const { data: renewed, error: updateErr } = await supabase
-    .from('investment_transactions')
-    .update({
-      amount_vnd: Math.round(cleanAmount),
-      interest_rate: cleanRate,
-      expiry_date: cleanExpiry,
-      investment_date: cleanInvestmentDate,
-      updated_at: new Date().toISOString(),
+  // Perform the three coupled writes (roll forward, snapshot, re-parent
+  // withdrawals) atomically. The re-parent is correctness-critical — a partial
+  // success that skipped it would silently double-count the withdrawn amount —
+  // so a failure here aborts the whole renewal rather than returning 200.
+  const { data: renewed, error: renewErr } = await supabase
+    .rpc('renew_term_deposit', {
+      p_tx_id: txId,
+      p_amount_vnd: Math.round(cleanAmount),
+      p_interest_rate: cleanRate,
+      p_expiry_date: cleanExpiry,
+      p_investment_date: cleanInvestmentDate,
+      p_interest_earned_vnd: cleanInterestEarned,
     })
-    .eq('transaction_id', txId)
-    .eq('user_id', user.id)
-    .select()
     .single()
-  if (updateErr || !renewed) return NextResponse.json({ error: 'Failed to renew deposit' }, { status: 500 })
-
-  // Best-effort: append a history snapshot of the cycle that just closed. A
-  // failure here doesn't undo the renewal — it only loses a history row, never
-  // affects totals (the snapshot is excluded from valuation by its link).
-  const { data: snapshot, error: snapshotErr } = await supabase
-    .from('investment_transactions')
-    .insert({
-      user_id: user.id,
-      goal_id: old.goal_id,
-      asset_type: 'bank',
-      transaction_type: 'investment',
-      amount_vnd: old.amount_vnd,
-      investment_date: old.investment_date,
-      expiry_date: old.expiry_date,
-      interest_rate: old.interest_rate,
-      notes: old.notes,
-      renewed_from_transaction_id: txId,
-      interest_earned_vnd: cleanInterestEarned,
-      affects_progress: false,
-    })
-    .select('transaction_id')
-    .single()
-  if (snapshotErr) console.error('renew: failed to write history snapshot', snapshotErr.message)
-
-  // Re-home any partial-withdrawal rows of the cycle that just closed. They link
-  // to this deposit via parent_transaction_id, and the new cycle's principal was
-  // chosen to ALREADY exclude them (the renewal form defaults to the net, post-
-  // withdrawal balance). Leaving them attached would make every later overview
-  // load subtract the withdrawn amount a SECOND time from the new principal,
-  // shorting net worth and goal value by exactly what was withdrawn. Move them
-  // onto the closed-cycle snapshot (excluded from all totals) so the active row
-  // starts clean and the withdrawals stay in history. If the snapshot write
-  // failed, orphan them (null parent) instead — losing the history link is the
-  // accepted best-effort failure mode; double-counting net worth is not.
-  const { error: reparentErr } = await supabase
-    .from('investment_transactions')
-    .update({ parent_transaction_id: snapshot?.transaction_id ?? null })
-    .eq('parent_transaction_id', txId)
-    .eq('transaction_type', 'withdrawal')
-    .eq('user_id', user.id)
-  if (reparentErr) console.error('renew: failed to re-parent withdrawal rows', reparentErr.message)
+  if (renewErr || !renewed) {
+    console.error('renew: atomic renewal failed', renewErr?.message)
+    return NextResponse.json({ error: 'Failed to renew deposit' }, { status: 500 })
+  }
 
   return NextResponse.json(renewed)
 }

--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -88,7 +88,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   // Best-effort: append a history snapshot of the cycle that just closed. A
   // failure here doesn't undo the renewal — it only loses a history row, never
   // affects totals (the snapshot is excluded from valuation by its link).
-  const { error: snapshotErr } = await supabase
+  const { data: snapshot, error: snapshotErr } = await supabase
     .from('investment_transactions')
     .insert({
       user_id: user.id,
@@ -104,7 +104,27 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       interest_earned_vnd: cleanInterestEarned,
       affects_progress: false,
     })
+    .select('transaction_id')
+    .single()
   if (snapshotErr) console.error('renew: failed to write history snapshot', snapshotErr.message)
+
+  // Re-home any partial-withdrawal rows of the cycle that just closed. They link
+  // to this deposit via parent_transaction_id, and the new cycle's principal was
+  // chosen to ALREADY exclude them (the renewal form defaults to the net, post-
+  // withdrawal balance). Leaving them attached would make every later overview
+  // load subtract the withdrawn amount a SECOND time from the new principal,
+  // shorting net worth and goal value by exactly what was withdrawn. Move them
+  // onto the closed-cycle snapshot (excluded from all totals) so the active row
+  // starts clean and the withdrawals stay in history. If the snapshot write
+  // failed, orphan them (null parent) instead — losing the history link is the
+  // accepted best-effort failure mode; double-counting net worth is not.
+  const { error: reparentErr } = await supabase
+    .from('investment_transactions')
+    .update({ parent_transaction_id: snapshot?.transaction_id ?? null })
+    .eq('parent_transaction_id', txId)
+    .eq('transaction_type', 'withdrawal')
+    .eq('user_id', user.id)
+  if (reparentErr) console.error('renew: failed to re-parent withdrawal rows', reparentErr.message)
 
   return NextResponse.json(renewed)
 }

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -1,7 +1,20 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 import * as api from './helpers/api'
 
 // Desktop viewport (Desktop Chrome default) — all tests run in 1280×800+
+
+// Force a fresh dashboard load that bypasses the localStorage overview cache, so
+// data created via the API since the last navigation is guaranteed to render.
+async function gotoFreshDashboard(page: Page) {
+  await page.goto('/settings') // unmount DashboardClient
+  await page.evaluate(() => {
+    Object.keys(localStorage).filter((k) => k.startsWith('dashboardOverviewCache')).forEach((k) => localStorage.removeItem(k))
+  })
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/v1/dashboard/overview') && r.status() === 200, { timeout: 20_000 }),
+    page.goto('/dashboard'),
+  ])
+}
 
 test.describe('Desktop goal detail panel', () => {
   let goalId: string
@@ -287,8 +300,11 @@ test.describe('Desktop goal detail panel', () => {
       investment_date: today,
     })
     try {
-      await page.goto('/dashboard')
-      await page.waitForLoadState('networkidle')
+      // The dashboard caches its overview in localStorage (2-min TTL), and the
+      // beforeEach navigation cached the snapshot from BEFORE this goal existed.
+      // Bust that cache so the fresh mount fetches the new goal — otherwise the
+      // goal card never renders and there is nothing to click.
+      await gotoFreshDashboard(page)
 
       await page.getByText('E2E Renew Withdraw Goal').first().click()
       const panel = page.getByTestId('desktop-goal-detail')

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -252,6 +252,106 @@ test.describe('Desktop goal detail panel', () => {
     }
   })
 
+  // Regression: renewing a deposit that was PARTIALLY withdrawn must not
+  // subtract the withdrawn amount a second time. The withdrawal row links to the
+  // deposit via parent_transaction_id; the renewal rolls the row forward in
+  // place (txId unchanged) to a new principal that already excludes the
+  // withdrawal. If the withdrawal stays parented to the active row, the next
+  // overview load subtracts it again → net worth / goal value short by the
+  // withdrawn amount. The fix re-parents the closed cycle's withdrawals onto the
+  // history snapshot so the active row starts clean.
+  test('renewing a partially-withdrawn deposit does not double-count the withdrawal', async ({ page }) => {
+    test.slow()
+    const iso = (offsetDays: number) => new Date(Date.now() + offsetDays * 86_400_000).toISOString().slice(0, 10)
+    const today = iso(0)
+    const { createClient } = await import('@supabase/supabase-js')
+    const supabase = createClient(process.env.E2E_SUPABASE_URL!, process.env.E2E_SUPABASE_SERVICE_ROLE_KEY!)
+
+    // Dedicated goal so its totalInvested reflects only this one deposit.
+    const goal = await api.createGoal({ goal_name: 'E2E Renew Withdraw Goal', target_amount: 100_000_000 })
+    // Matured deposit (so it renews) with a 4M partial withdrawal already taken.
+    const tx = await api.createTransaction({
+      asset_type: 'bank',
+      amount_vnd: 10_000_000,
+      investment_date: iso(-400),
+      interest_rate: 6,
+      expiry_date: iso(-30),
+      goal_id: goal.goal_id,
+      notes: 'E2E Renew Withdraw Deposit',
+    })
+    const wd = await api.createWithdrawal({
+      parent_transaction_id: tx.transaction_id,
+      amount_vnd: 4_000_000,
+      principal_withdrawn: 4_000_000,
+      goal_id: goal.goal_id,
+      investment_date: today,
+    })
+    try {
+      await page.goto('/dashboard')
+      await page.waitForLoadState('networkidle')
+
+      await page.getByText('E2E Renew Withdraw Goal').first().click()
+      const panel = page.getByTestId('desktop-goal-detail')
+      await expect(panel).toBeVisible({ timeout: 10_000 })
+      await expect(panel.getByText('E2E Renew Withdraw Deposit')).toBeVisible({ timeout: 10_000 })
+
+      // Renew through the UI (principal + interest — the default).
+      await panel.getByRole('button', { name: 'Options', exact: true }).first().click()
+      await page.getByText(/^(Handle maturity|Xử lý đáo hạn)$/).click()
+      await page.getByRole('button', { name: /Confirm renewal|Xác nhận tái tục/i }).click()
+      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+
+      // The active row rolled forward to a fresh principal (net + interest).
+      await expect.poll(async () => {
+        const { data } = await supabase
+          .from('investment_transactions')
+          .select('amount_vnd, investment_date')
+          .eq('transaction_id', tx.transaction_id)
+          .single()
+        return data?.investment_date
+      }, { timeout: 15_000 }).toBe(today)
+      const { data: renewed } = await supabase
+        .from('investment_transactions')
+        .select('amount_vnd')
+        .eq('transaction_id', tx.transaction_id)
+        .single()
+      const renewedAmount = renewed!.amount_vnd
+
+      // The closed cycle's withdrawal must no longer parent the active row — it
+      // was re-parented onto the history snapshot.
+      await expect.poll(async () => {
+        const { count } = await supabase
+          .from('investment_transactions')
+          .select('transaction_id', { count: 'exact', head: true })
+          .eq('parent_transaction_id', tx.transaction_id)
+          .eq('transaction_type', 'withdrawal')
+        return count
+      }, { timeout: 15_000 }).toBe(0)
+      const { data: snapshot } = await supabase
+        .from('investment_transactions')
+        .select('transaction_id')
+        .eq('renewed_from_transaction_id', tx.transaction_id)
+        .single()
+      const { data: movedWd } = await supabase
+        .from('investment_transactions')
+        .select('parent_transaction_id')
+        .eq('transaction_id', wd.transaction_id)
+        .single()
+      expect(movedWd!.parent_transaction_id).toBe(snapshot!.transaction_id)
+
+      // Close the loop on the render-feeding computation: the overview values
+      // the active deposit at its full renewed principal — the 4M withdrawal is
+      // NOT subtracted again. (totalInvested = effectiveAmount = amount_vnd.)
+      const overview = await (await page.request.get('/api/v1/dashboard/overview')).json()
+      const goalOut = overview.goals.find((g: { goalId: string }) => g.goalId === goal.goal_id)
+      expect(goalOut.totalInvested).toBe(renewedAmount)
+    } finally {
+      await supabase.from('investment_transactions').delete().eq('transaction_id', wd.transaction_id)
+      await api.deleteTransactionCascade(tx.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
   test('clicking an insurance row while goal detail is open switches to insurance detail', async ({ page }) => {
     // Bug #226: with goal detail open in the right panel, clicking an insurance
     // member did nothing because the panel prioritised the still-selected goal.

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -127,6 +127,33 @@ export async function deleteTransaction(txId: string) {
   await supabase.from('investment_transactions').delete().eq('transaction_id', txId)
 }
 
+// Insert a withdrawal row against an existing deposit, mirroring what the
+// SellWithdraw flow POSTs (transaction_type='withdrawal', linked by
+// parent_transaction_id, asset_type null). Returns the created row.
+export async function createWithdrawal(data: {
+  parent_transaction_id: string
+  amount_vnd: number
+  principal_withdrawn: number
+  goal_id?: string | null
+  investment_date: string
+  affects_progress?: boolean
+}) {
+  const userId = await getTestUserId()
+  const { data: wd, error } = await supabase
+    .from('investment_transactions')
+    .insert({
+      user_id: userId,
+      transaction_type: 'withdrawal',
+      asset_type: null,
+      affects_progress: data.affects_progress ?? true,
+      ...data,
+    })
+    .select()
+    .single()
+  if (error) throw error
+  return wd
+}
+
 // Delete a transaction together with any withdrawal rows that reference it.
 // The parent_transaction_id FK is ON DELETE SET NULL, so withdrawals would
 // otherwise be orphaned (and stay attached to their goal) after the parent

--- a/supabase/migrations/20260614000001_renew_term_deposit_atomic.sql
+++ b/supabase/migrations/20260614000001_renew_term_deposit_atomic.sql
@@ -1,0 +1,91 @@
+-- Atomic term-deposit renewal.
+--
+-- A renewal performs three coupled writes:
+--   1. roll the active deposit row forward to the new cycle (in place),
+--   2. append a history-only snapshot of the cycle that just closed,
+--   3. re-parent that cycle's partial-withdrawal rows onto the snapshot.
+--
+-- Step 3 is correctness-critical, NOT best-effort: if it is skipped, the
+-- withdrawal stays attached to the now-renewed active row via
+-- parent_transaction_id and is subtracted from net worth a SECOND time (the
+-- exact double-count this whole flow exists to prevent). Running the three as
+-- separate statements from the API route left a window where the roll-forward +
+-- snapshot could commit but the re-parent fail — the route would log and still
+-- return 200, silently re-introducing the bug. This function runs all three in
+-- one transaction, so they commit together or roll back together. A re-parent
+-- failure now aborts the whole renewal and surfaces as an error.
+--
+-- SECURITY INVOKER (the default): every statement inside still runs under the
+-- caller's row-level security, so a caller can only ever read/roll/re-parent
+-- their OWN rows. search_path is pinned empty and all objects are schema-
+-- qualified, per Supabase function-hardening guidance.
+create or replace function public.renew_term_deposit(
+  p_tx_id uuid,
+  p_amount_vnd bigint,
+  p_interest_rate numeric,
+  p_expiry_date date,
+  p_investment_date date,
+  p_interest_earned_vnd bigint
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_old public.investment_transactions;
+  v_snapshot_id uuid;
+  v_renewed public.investment_transactions;
+begin
+  -- Lock + read the active row. RLS restricts this to the caller's own row, so
+  -- a missing row means "not yours / does not exist".
+  select * into v_old
+    from public.investment_transactions
+   where transaction_id = p_tx_id
+   for update;
+  if not found then
+    raise exception 'renew_term_deposit: transaction not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_old.asset_type is distinct from 'bank' then
+    raise exception 'renew_term_deposit: only bank term deposits can be renewed'
+      using errcode = 'check_violation';
+  end if;
+
+  -- 1) Roll the active row forward to the new cycle (valuation unchanged).
+  update public.investment_transactions
+     set amount_vnd      = p_amount_vnd,
+         interest_rate   = p_interest_rate,
+         expiry_date     = p_expiry_date,
+         investment_date = p_investment_date,
+         updated_at      = now()
+   where transaction_id = p_tx_id
+  returning * into v_renewed;
+
+  -- 2) Append the history snapshot of the cycle that just closed, linked to the
+  --    still-active row. Excluded from every total by renewed_from_transaction_id.
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, amount_vnd,
+    investment_date, expiry_date, interest_rate, notes,
+    renewed_from_transaction_id, interest_earned_vnd, affects_progress
+  ) values (
+    v_old.user_id, v_old.goal_id, 'bank', 'investment', v_old.amount_vnd,
+    v_old.investment_date, v_old.expiry_date, v_old.interest_rate, v_old.notes,
+    p_tx_id, p_interest_earned_vnd, false
+  )
+  returning transaction_id into v_snapshot_id;
+
+  -- 3) Re-parent the closed cycle's partial-withdrawal rows onto the snapshot so
+  --    they stop being subtracted from the renewed active row (its principal
+  --    already excludes them). The snapshot is excluded from all totals, so the
+  --    withdrawals are preserved in history without affecting valuation.
+  update public.investment_transactions
+     set parent_transaction_id = v_snapshot_id
+   where parent_transaction_id = p_tx_id
+     and transaction_type = 'withdrawal';
+
+  return v_renewed;
+end;
+$$;
+
+grant execute on function public.renew_term_deposit(uuid, bigint, numeric, date, date, bigint) to authenticated;


### PR DESCRIPTION
## The bug

Renewing a term deposit that had a **partial withdrawal** subtracts the withdrawn amount a **second time** — net worth and goal value end up short by exactly what was withdrawn. Data-correctness, traceable end-to-end:

1. Partial withdrawal (issue #261) creates a `withdrawal` row linked via `parent_transaction_id = txId`.
2. Overview values the deposit at the **net**: `effectiveAmount = amount_vnd − withdrawnPrincipal`, and returns that as `amount`.
3. The renewal form defaults the new principal to that net; confirming writes `amount_vnd = net + interest`.
4. `/renew` rolls the active row forward **in place** (`txId` unchanged) but never touches the old withdrawal rows — they still point at `txId`.
5. Next overview load: `effectiveAmount = (net + interest) − withdrawnPrincipal` → the withdrawal is subtracted **again** from the new principal.

(Full withdrawals drop the deposit from the actionable list, so it can't be renewed — only partial-withdraw-then-renew hits this.)

## The fix

When renewing, re-home the closed cycle's withdrawal rows onto the history **snapshot** (which is excluded from every total) so the active row starts clean and the withdrawals stay in history — correct semantics, since the snapshot *is* the closed cycle. If the best-effort snapshot write failed, orphan the withdrawals (`null` parent) instead: losing a history link is the accepted failure mode; double-counting net worth is not.

Verified consistent across readers — `goalDetailShared` excludes snapshots from `investmentRows`, so the re-parented withdrawal is never re-applied to the active holding either.

## Test

E2E regression in `e2e/goal-detail-desktop.spec.ts`: create a matured deposit with a 4M partial withdrawal → renew through the UI → assert (a) the withdrawal was re-parented off the active row onto the snapshot, and (b) the **overview** values the deposit at its full renewed principal (closing the loop on the render-feeding computation, not just storage).

## Checks

- `npm test -- --run` — 604 passed
- `npm run lint` — changed files clean (pre-existing repo-wide `react-hooks` errors on untouched files remain)
- ⚠️ **E2E not run here** — the WSL2 Supabase stack + dev server weren't up. Please run the targeted spec on your stack before merging:
  `npx playwright test e2e/goal-detail-desktop.spec.ts --project=chromium` (Edge channel per your setup). Worth confirming it goes red without the route fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
