### PR TITLE
fix(deposits): reject renewing a flex (non-term) bank deposit

### DIFF
--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateRate, validateUUID } from '@/lib/validation'
+import { isTermDeposit } from '@/lib/maturity'
 
 // Renew a bank term deposit.
 //
@@ -57,12 +58,18 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   // renew_term_deposit, which builds the snapshot from that authoritative read.
   const { data: old, error: fetchErr } = await supabase
     .from('investment_transactions')
-    .select('asset_type, amount_vnd')
+    .select('asset_type, amount_vnd, interest_rate, expiry_date')
     .eq('transaction_id', txId)
     .eq('user_id', user.id)
     .single()
   if (fetchErr || !old) return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
-  if (old.asset_type !== 'bank') {
+  // Only a bank TERM deposit can be renewed: it must carry both an interest rate
+  // and a maturity date. A flexible bank deposit (rate/expiry null) has no cycle
+  // to roll forward — renewing it would invent a maturity and interest it never
+  // had. The asset_type==='bank' check alone let flex deposits through, so guard
+  // on the full term-deposit shape (mirrored in renew_term_deposit for callers
+  // hitting the RPC directly).
+  if (!isTermDeposit({ type: old.asset_type, interestRate: old.interest_rate, expiryDate: old.expiry_date })) {
     return NextResponse.json({ error: 'Only bank term deposits can be renewed.' }, { status: 400 })
   }
 

--- a/e2e/api-validation.spec.ts
+++ b/e2e/api-validation.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test'
+import * as api from './helpers/api'
 
 // API-level validator rejection tests. These hit the route handlers directly
 // using Playwright's authenticated request context (storageState from setup).
@@ -76,5 +77,35 @@ test.describe('API input validation', () => {
       },
     })
     expect(res.status()).toBe(400)
+  })
+
+  // Only bank TERM deposits (interest rate + maturity date) can be renewed. A
+  // flexible bank deposit — asset_type='bank' but no rate and no expiry — has no
+  // cycle to roll forward; renewing it would mint a maturity/interest it never
+  // had. The route's asset_type==='bank' check alone passed it through, so guard
+  // on the term-deposit shape too. (Body is otherwise valid: the 400 is the
+  // flex-deposit guard, not payload validation.)
+  test('POST /api/v1/investment-transactions/<id>/renew rejects a flex bank deposit (400)', async ({ request }) => {
+    const today = new Date().toISOString().slice(0, 10)
+    // A flexible deposit: bank, but no interest_rate and no expiry_date.
+    const flex = await api.createTransaction({
+      asset_type: 'bank',
+      amount_vnd: 5_000_000,
+      investment_date: today,
+      notes: 'E2E flex renew guard',
+    })
+    try {
+      const res = await request.post(`/api/v1/investment-transactions/${flex.transaction_id}/renew`, {
+        data: {
+          amount_vnd: 5_000_000,
+          interest_rate: 6,
+          expiry_date: new Date(Date.now() + 90 * 86_400_000).toISOString().slice(0, 10),
+          investment_date: today,
+        },
+      })
+      expect(res.status()).toBe(400)
+    } finally {
+      await api.deleteTransaction(flex.transaction_id)
+    }
   })
 })

--- a/supabase/migrations/20260614000002_renew_term_deposit_guard_flex.sql
+++ b/supabase/migrations/20260614000002_renew_term_deposit_guard_flex.sql
@@ -1,0 +1,87 @@
+-- Guard renew_term_deposit against flexible (non-term) bank deposits.
+--
+-- The renewal rolls a deposit's cycle forward — it only makes sense for a bank
+-- TERM deposit, which carries both an interest rate and a maturity date. A
+-- flexible bank deposit has neither, so renewing it would mint a maturity and
+-- interest it never had. The API route now rejects this, but the RPC is also
+-- reachable directly by an authenticated caller, so harden the function too
+-- (defence-in-depth, mirroring the asset_type guard already here).
+--
+-- Function body is otherwise unchanged from 20260614000001 — see that migration
+-- for the full rationale on the three coupled, atomic writes.
+create or replace function public.renew_term_deposit(
+  p_tx_id uuid,
+  p_amount_vnd bigint,
+  p_interest_rate numeric,
+  p_expiry_date date,
+  p_investment_date date,
+  p_interest_earned_vnd bigint
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_old public.investment_transactions;
+  v_snapshot_id uuid;
+  v_renewed public.investment_transactions;
+begin
+  -- Lock + read the active row. RLS restricts this to the caller's own row, so
+  -- a missing row means "not yours / does not exist".
+  select * into v_old
+    from public.investment_transactions
+   where transaction_id = p_tx_id
+   for update;
+  if not found then
+    raise exception 'renew_term_deposit: transaction not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_old.asset_type is distinct from 'bank' then
+    raise exception 'renew_term_deposit: only bank term deposits can be renewed'
+      using errcode = 'check_violation';
+  end if;
+  -- A term deposit carries both a rate and a maturity; a flexible deposit has
+  -- neither and cannot be renewed.
+  if v_old.interest_rate is null or v_old.expiry_date is null then
+    raise exception 'renew_term_deposit: only bank term deposits can be renewed'
+      using errcode = 'check_violation';
+  end if;
+
+  -- 1) Roll the active row forward to the new cycle (valuation unchanged).
+  update public.investment_transactions
+     set amount_vnd      = p_amount_vnd,
+         interest_rate   = p_interest_rate,
+         expiry_date     = p_expiry_date,
+         investment_date = p_investment_date,
+         updated_at      = now()
+   where transaction_id = p_tx_id
+  returning * into v_renewed;
+
+  -- 2) Append the history snapshot of the cycle that just closed, linked to the
+  --    still-active row. Excluded from every total by renewed_from_transaction_id.
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, amount_vnd,
+    investment_date, expiry_date, interest_rate, notes,
+    renewed_from_transaction_id, interest_earned_vnd, affects_progress
+  ) values (
+    v_old.user_id, v_old.goal_id, 'bank', 'investment', v_old.amount_vnd,
+    v_old.investment_date, v_old.expiry_date, v_old.interest_rate, v_old.notes,
+    p_tx_id, p_interest_earned_vnd, false
+  )
+  returning transaction_id into v_snapshot_id;
+
+  -- 3) Re-parent the closed cycle's partial-withdrawal rows onto the snapshot so
+  --    they stop being subtracted from the renewed active row (its principal
+  --    already excludes them). The snapshot is excluded from all totals, so the
+  --    withdrawals are preserved in history without affecting valuation.
+  update public.investment_transactions
+     set parent_transaction_id = v_snapshot_id
+   where parent_transaction_id = p_tx_id
+     and transaction_type = 'withdrawal';
+
+  return v_renewed;
+end;
+$$;
+
+grant execute on function public.renew_term_deposit(uuid, bigint, numeric, date, date, bigint) to authenticated;


### PR DESCRIPTION
## Problem

Review feedback (point 2): the `/renew` route guards only `asset_type === 'bank'` — it never checks for a maturity date or interest rate. A **flexible** bank deposit (rate/expiry both null) is `asset_type='bank'`, so a direct API call could "renew" it, inventing a maturity and interest cycle it never had. The `renew_term_deposit` SQL function had the same gap.

## Fix

- **Route** (`renew/route.ts`): fetch `interest_rate`/`expiry_date` and reject anything that isn't a full term deposit via the existing `isTermDeposit()` predicate → `400 Only bank term deposits can be renewed.`
- **SQL** (`renew_term_deposit`): mirror the guard (raise on null rate/expiry) as defence-in-depth for callers hitting the RPC directly. New migration `20260614000002`, function body otherwise unchanged from `20260614000001`.

## Tests (TDD)

- New `e2e/api-validation.spec.ts` case: create a flex bank deposit → POST `/renew` with an otherwise-valid body → expect `400`. Confirmed red (got `200`) before the fix, green after.
- Existing renew specs still pass (`renewing a matured term deposit…`, `renewing a partially-withdrawn deposit does not double-count…`) — the function replacement is behaviour-preserving.

## Verification

- `npm test -- --run` — 604 passed
- `npx eslint` on changed files — clean (repo-wide pre-existing lint errors are in untouched files)
- Targeted E2E (`api-validation`, `goal-detail-desktop -g renew`) — all green against local Supabase stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)