### PR TITLE
test(deposits): unit-test non-fund valuation against renewal double-counting

### DIFF
--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -1,7 +1,8 @@
 import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { calcProjectedInterest, isNavStale, insuranceStatus, isPlanMonthRealized, isInCurrentCycle, realizedRecurringContributions } from '@/lib/finance'
+import { isNavStale, insuranceStatus, isPlanMonthRealized, isInCurrentCycle, realizedRecurringContributions } from '@/lib/finance'
 import { buildWithdrawalMaps } from '@/lib/withdrawalProgress'
+import { valueNonFundHolding } from '@/lib/depositValuation'
 import { shouldWriteSnapshot } from '@/lib/snapshots'
 
 export const dynamic = 'force-dynamic'
@@ -239,26 +240,11 @@ export async function GET() {
         })
       }
     } else {
-      // bank / stock / gold — apply any partial withdrawals
-      const wd = parentWdMap.get(tx.transaction_id)
-      const withdrawnPrincipal = wd?.principal ?? 0
-      const withdrawnUnits = wd?.units ?? 0
-
-      let currentValue: number
-      let effectiveAmount: number
-      let effectiveUnits: number | null = tx.units ?? null
-
-      if (tx.asset_type === 'gold' && goldPricePerChi && tx.units) {
-        effectiveUnits = tx.units - withdrawnUnits
-        if (effectiveUnits <= 0) continue // fully sold
-        currentValue = effectiveUnits * goldPricePerChi
-        effectiveAmount = tx.amount_vnd - withdrawnPrincipal
-      } else {
-        effectiveAmount = tx.amount_vnd - withdrawnPrincipal
-        if (effectiveAmount <= 0) continue // fully withdrawn
-        const interest = calcProjectedInterest(effectiveAmount, tx.interest_rate, tx.investment_date, tx.expiry_date)
-        currentValue = effectiveAmount + interest
-      }
+      // bank / stock / gold — apply any partial withdrawals. Shared, unit-tested
+      // valuation so renewal re-parenting can't double-count a withdrawal here.
+      const valued = valueNonFundHolding(tx, parentWdMap, goldPricePerChi)
+      if (!valued) continue // fully withdrawn / sold
+      const { effectiveAmount, currentValue, effectiveUnits } = valued
 
       totalAssets += currentValue
       totalInvestedGlobal += effectiveAmount

--- a/lib/__tests__/depositValuation.test.ts
+++ b/lib/__tests__/depositValuation.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { valueNonFundHolding, type NonFundHoldingRow } from '../depositValuation'
+import { buildWithdrawalMaps, type WithdrawalRow } from '../withdrawalProgress'
+
+// A fixed instant so the pro-rated interest is deterministic regardless of the
+// run date. calcProjectedInterest caps accrual at maturity, so picking an asOf
+// inside the term keeps the maths simple.
+const ASOF = Date.UTC(2026, 6, 1) // 2026-07-01
+
+function bank(overrides: Partial<NonFundHoldingRow> = {}): NonFundHoldingRow {
+  return {
+    transaction_id: 'tx-1',
+    asset_type: 'bank',
+    amount_vnd: 10_000_000,
+    units: null,
+    interest_rate: null, // no rate → interest 0 → currentValue == effectiveAmount (clean principal asserts)
+    investment_date: '2026-01-01',
+    expiry_date: null,
+    ...overrides,
+  }
+}
+
+function withdrawal(overrides: Partial<WithdrawalRow> = {}): WithdrawalRow {
+  return {
+    transaction_id: 'wd-1',
+    goal_id: 'goal-1',
+    asset_type: null,
+    fund_id: null,
+    parent_transaction_id: 'tx-1',
+    units_withdrawn: null,
+    principal_withdrawn: 0,
+    affects_progress: true,
+    ...overrides,
+  }
+}
+
+describe('valueNonFundHolding', () => {
+  it('values a bank deposit with no withdrawals at its full principal', () => {
+    const { parentWdMap } = buildWithdrawalMaps([])
+    const v = valueNonFundHolding(bank({ amount_vnd: 10_000_000 }), parentWdMap, null, ASOF)
+    expect(v).toEqual({ effectiveAmount: 10_000_000, currentValue: 10_000_000, effectiveUnits: null })
+  })
+
+  it('adds pro-rated interest for a rate-bearing term deposit', () => {
+    const { parentWdMap } = buildWithdrawalMaps([])
+    // 6M × 6% × 181/365 (2026-01-01 → 2026-07-01), capped at maturity 2026-12-31.
+    const v = valueNonFundHolding(
+      bank({ amount_vnd: 6_000_000, interest_rate: 6, expiry_date: '2026-12-31' }),
+      parentWdMap, null, ASOF,
+    )!
+    const expectedInterest = 6_000_000 * 0.06 * (181 / 365)
+    expect(v.effectiveAmount).toBe(6_000_000)
+    expect(v.currentValue).toBeCloseTo(6_000_000 + expectedInterest, 5)
+  })
+
+  it('subtracts a partial withdrawal parented to the deposit', () => {
+    const { parentWdMap } = buildWithdrawalMaps([withdrawal({ principal_withdrawn: 4_000_000 })])
+    const v = valueNonFundHolding(bank({ amount_vnd: 10_000_000 }), parentWdMap, null, ASOF)!
+    expect(v.effectiveAmount).toBe(6_000_000)
+  })
+
+  it('returns null for a fully-withdrawn deposit (caller skips it)', () => {
+    const { parentWdMap } = buildWithdrawalMaps([withdrawal({ principal_withdrawn: 10_000_000 })])
+    expect(valueNonFundHolding(bank({ amount_vnd: 10_000_000 }), parentWdMap, null, ASOF)).toBeNull()
+  })
+
+  // Regression (review point 3 / E2E goal-detail-desktop.spec.ts:276): after a
+  // renewal the closed cycle's withdrawal is re-parented onto the history
+  // snapshot, so parentWdMap is keyed by the SNAPSHOT id — not the active row.
+  // The active row therefore finds no withdrawal and keeps its full rolled-
+  // forward principal; the 4M is NOT subtracted a second time.
+  it('does not double-count a re-parented withdrawal after renewal', () => {
+    // The renewed active row already rolled forward to net principal 6M.
+    const active = bank({ transaction_id: 'active', amount_vnd: 6_000_000 })
+    // The withdrawal was moved onto the snapshot (its parent is now the snapshot).
+    const { parentWdMap } = buildWithdrawalMaps([
+      withdrawal({ transaction_id: 'wd-1', parent_transaction_id: 'snapshot', principal_withdrawn: 4_000_000 }),
+    ])
+    const v = valueNonFundHolding(active, parentWdMap, null, ASOF)!
+    expect(v.effectiveAmount).toBe(6_000_000) // full renewed principal, no double-count
+
+    // Sanity: had the withdrawal stayed parented to the active row (the bug this
+    // guards against), the same code would have short-changed it by 4M.
+    const { parentWdMap: buggyMap } = buildWithdrawalMaps([
+      withdrawal({ transaction_id: 'wd-1', parent_transaction_id: 'active', principal_withdrawn: 4_000_000 }),
+    ])
+    expect(valueNonFundHolding(active, buggyMap, null, ASOF)!.effectiveAmount).toBe(2_000_000)
+  })
+
+  describe('gold', () => {
+    it('values remaining units at the gold price and reduces units by the sale', () => {
+      const { parentWdMap } = buildWithdrawalMaps([
+        withdrawal({ units_withdrawn: 2, principal_withdrawn: 3_000_000 }),
+      ])
+      const gold = bank({ asset_type: 'gold', amount_vnd: 15_000_000, units: 5, interest_rate: null })
+      const v = valueNonFundHolding(gold, parentWdMap, 4_000_000, ASOF)!
+      expect(v.effectiveUnits).toBe(3)               // 5 − 2 sold
+      expect(v.currentValue).toBe(3 * 4_000_000)     // remaining units × price
+      expect(v.effectiveAmount).toBe(12_000_000)     // 15M − 3M principal sold
+    })
+
+    it('returns null once all gold units are sold', () => {
+      const { parentWdMap } = buildWithdrawalMaps([
+        withdrawal({ units_withdrawn: 5, principal_withdrawn: 15_000_000 }),
+      ])
+      const gold = bank({ asset_type: 'gold', amount_vnd: 15_000_000, units: 5 })
+      expect(valueNonFundHolding(gold, parentWdMap, 4_000_000, ASOF)).toBeNull()
+    })
+
+    it('falls back to the principal branch when no gold price is available', () => {
+      const { parentWdMap } = buildWithdrawalMaps([])
+      const gold = bank({ asset_type: 'gold', amount_vnd: 15_000_000, units: 5, interest_rate: null })
+      const v = valueNonFundHolding(gold, parentWdMap, null, ASOF)!
+      expect(v.effectiveAmount).toBe(15_000_000)
+      expect(v.currentValue).toBe(15_000_000) // no rate, no price → principal only
+      expect(v.effectiveUnits).toBe(5)        // unchanged
+    })
+  })
+})

--- a/lib/depositValuation.ts
+++ b/lib/depositValuation.ts
@@ -1,0 +1,62 @@
+// Value a single non-fund holding (bank / stock / gold) the way the dashboard
+// overview does, after applying any partial withdrawals parented to it. This is
+// the money-critical core of the overview route's non-fund loop, lifted into a
+// pure function so it can be unit-tested in CI — the full route flow is only
+// covered by the local-only E2E suite.
+//
+// Renewal note: a renewed deposit's closed-cycle withdrawals are re-parented
+// onto the (excluded) history snapshot, so `parentWdMap` ends up keyed by the
+// snapshot's id, not the active row's. The active row therefore finds no
+// withdrawal here and keeps its full rolled-forward principal — the withdrawn
+// amount is NOT subtracted a second time (see lib/__tests__/depositValuation
+// and e2e/goal-detail-desktop.spec.ts).
+
+import { calcProjectedInterest } from './finance'
+import type { ParentWdMap } from './withdrawalProgress'
+
+export interface NonFundHoldingRow {
+  transaction_id: string
+  asset_type: string | null
+  amount_vnd: number
+  units: number | null
+  interest_rate: number | null
+  investment_date: string
+  expiry_date: string | null
+}
+
+export interface NonFundValuation {
+  effectiveAmount: number
+  currentValue: number
+  effectiveUnits: number | null
+}
+
+// Returns the holding's effective (post-withdrawal) principal, current value and
+// remaining units, or `null` when it is fully withdrawn/sold and the caller
+// should skip it. `asOf` defaults to now; pass it for deterministic tests.
+export function valueNonFundHolding(
+  tx: NonFundHoldingRow,
+  parentWdMap: ParentWdMap,
+  goldPricePerChi: number | null,
+  asOf: number = Date.now(),
+): NonFundValuation | null {
+  const wd = parentWdMap.get(tx.transaction_id)
+  const withdrawnPrincipal = wd?.principal ?? 0
+  const withdrawnUnits = wd?.units ?? 0
+
+  let effectiveUnits: number | null = tx.units ?? null
+
+  if (tx.asset_type === 'gold' && goldPricePerChi && tx.units) {
+    effectiveUnits = tx.units - withdrawnUnits
+    if (effectiveUnits <= 0) return null // fully sold
+    return {
+      effectiveAmount: tx.amount_vnd - withdrawnPrincipal,
+      currentValue: effectiveUnits * goldPricePerChi,
+      effectiveUnits,
+    }
+  }
+
+  const effectiveAmount = tx.amount_vnd - withdrawnPrincipal
+  if (effectiveAmount <= 0) return null // fully withdrawn
+  const interest = calcProjectedInterest(effectiveAmount, tx.interest_rate, tx.investment_date, tx.expiry_date, asOf)
+  return { effectiveAmount, currentValue: effectiveAmount + interest, effectiveUnits }
+}


### PR DESCRIPTION
## Why

Review feedback (point 3) asked for a regression test on "partial withdrawal → renew → not subtracted again." An **E2E** test for this already exists (`e2e/goal-detail-desktop.spec.ts:276`) and closes the loop on the rendered overview value — but E2E was removed from CI (PR #313) and runs **locally only**. This adds a fast, **CI-runnable** unit test for the same money-critical invariant, which is exactly the reviewer's fallback suggestion ("extract the effectiveAmount-after-renew+withdrawal logic into a pure function to test").

## What

- **Extract** the overview route's per-holding non-fund valuation (bank/stock/gold, post-withdrawal effective principal + current value) into a pure `valueNonFundHolding()` in `lib/depositValuation.ts`. The route now imports it instead of inlining the maths, so the test and the live computation can't drift.
- **Behaviour-preserving**: the lifted logic is the previous inline branch unchanged (added an optional `asOf` param, defaulting to `Date.now()`, for deterministic tests).
- **New unit tests** (`lib/__tests__/depositValuation.test.ts`, 8 cases): no-withdrawal full principal, pro-rated interest, partial withdrawal, fully-withdrawn → skip, gold partial/full sale, no-price fallback, and the **renewal double-count regression** — a withdrawal re-parented onto the snapshot leaves the active row at its full principal (6M), and a contrast assertion proves the buggy parent-on-active state would short it to 2M.

## Verification

- `npm test -- --run` — 612 passed (was 604; +8)
- `npx tsc --noEmit` — clean; `eslint` on changed files — clean
- Targeted E2E against local Supabase: `dashboard`, `dashboard-desktop`, `goals`, `goal-detail-desktop` — **53 passed** (overview API is the broad/risky surface this refactor touches, so ran its full consumer set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)