### PR TITLE
fix(dates): unify plain-date handling on the local calendar day

### DIFF
--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateRate, validateUUID } from '@/lib/validation'
+import { isFutureInvestmentDate } from '@/lib/dates'
 
 // Renew a bank term deposit.
 //
@@ -48,7 +49,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     throw e
   }
 
-  if (new Date(cleanInvestmentDate) > new Date()) {
+  if (isFutureInvestmentDate(cleanInvestmentDate)) {
     return NextResponse.json({ error: 'Investment date cannot be in the future.' }, { status: 400 })
   }
 

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateEnum, validateNotes, validateRate, validateUUID } from '@/lib/validation'
+import { isFutureInvestmentDate } from '@/lib/dates'
 
 const ASSET_TYPES = ['fund', 'bank', 'stock', 'gold'] as const
 
@@ -106,7 +107,7 @@ export async function POST(request: NextRequest) {
   }
 
   // Allow future dates within the plan month (plan_id provided); otherwise reject future dates
-  if (!cleanPlanId && new Date(cleanInvestmentDate) > new Date()) {
+  if (!cleanPlanId && isFutureInvestmentDate(cleanInvestmentDate)) {
     return NextResponse.json({ error: 'Investment date cannot be in the future.' }, { status: 400 })
   }
 

--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { X, TrendingUp, Building2, Coins, ArrowUpRight, ArrowDownRight, ArrowDownToLine, Wallet, Shield } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
+import { todayIso } from '@/lib/dates'
 
 interface Fund { id: string; name: string; nav: number; code: string | null; fund_type?: string }
 interface Goal { goal_id: string; goal_name: string }
@@ -152,7 +153,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
   const [assetType, setAssetType] = useState<AssetType>('fund')
   const [dir, setDir] = useState<'buy' | 'sell'>('buy')
   const [goalId, setGoalId] = useState('')
-  const [date, setDate] = useState(new Date().toISOString().slice(0, 10))
+  const [date, setDate] = useState(todayIso())
   const [note, setNote] = useState('')
 
   // fund fields
@@ -223,7 +224,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
     setAssetType(at)
     setDir('buy')
     setGoalId(existing.goal_id || '')
-    setDate(existing.investment_date || new Date().toISOString().slice(0, 10))
+    setDate(existing.investment_date || todayIso())
     if (at === 'fund') {
       setFundId(existing.fund_id || '')
       setAmount(existing.amount_vnd != null ? String(existing.amount_vnd) : '')
@@ -283,7 +284,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
     setAssetType('fund')
     setDir('buy')
     setGoalId('')
-    setDate(new Date().toISOString().slice(0, 10))
+    setDate(todayIso())
     setNote('')
     setFundId('')
     setAmount('')

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -8,6 +8,7 @@ import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, build
 import { MaturityResolveModal } from './MaturityResolveSheet'
 import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
+import { todayIso } from '@/lib/dates'
 
 interface InvestmentTx {
   transaction_id: string
@@ -819,7 +820,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
     if (!isValid) return
     setSaving(true); setError('')
     try {
-      const today = new Date().toISOString().slice(0, 10)
+      const today = todayIso()
       if (isFund && inv.fund) {
         const unitsWithdrawn = navPerUnit ? numAmount / navPerUnit : (inv.units ?? 0)
         const principalWithdrawn = inv.fund.purchasePrice

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -23,10 +23,9 @@ import {
   renewalPrincipal,
   type RenewMode,
 } from '@/lib/maturity'
+import { todayIso } from '@/lib/dates'
 
 type Mode = RenewMode | 'withdraw'
-
-const todayIso = () => new Date().toISOString().slice(0, 10)
 
 const fieldLabel: React.CSSProperties = {
   fontSize: 11, fontWeight: 600, letterSpacing: '0.05em',

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { useLocale, useTranslations } from 'next-intl'
 import { ArrowDownRight, ArrowDownToLine, Building, Check, Coins, Shield, TrendingUp, Wallet, X } from 'lucide-react'
 import { fmt } from '@/lib/formatters'
+import { todayIso } from '@/lib/dates'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { AffectsProgressControl } from './goalDetailShared'
 const fmtVND = (n: number, _locale?: string) => fmt(n)
@@ -184,7 +185,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
     setSaving(true)
     setError('')
     try {
-      const today = new Date().toISOString().slice(0, 10)
+      const today = todayIso()
       // Withdrawals from a goal carry that goal's id so the goal-detail view
       // (which fetches by goal_id) sees them; from the unallocated list there
       // is no goal to link to (issue #261).

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -13,10 +13,13 @@ function daysFromNow(n: number): string {
   d.setDate(d.getDate() + n)
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
-// Match the component's todayIso() (UTC) so the assertion is timezone-robust —
-// a local-date `today` flakes near the UTC midnight boundary on dev machines
-// behind/ahead of UTC (CI runners are UTC, so it only bit locally).
-const today = () => new Date().toISOString().slice(0, 10)
+// Match the component's todayIso() (lib/dates), which is the LOCAL calendar day
+// — same parse style as `daysFromNow` above and as daysUntil/fmtMaturity, so the
+// predicted investment_date / new maturity stays in lock-step with the component.
+const today = () => {
+  const d = new Date()
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
 
 // A matured term deposit: value (compounded) > principal, expiry in the past.
 const maturedDeposit: InvRow = {

--- a/lib/__tests__/dates.test.ts
+++ b/lib/__tests__/dates.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest'
+import { todayIso, isFutureInvestmentDate } from '../dates'
+import { daysUntil } from '../maturity'
+
+describe('todayIso', () => {
+  // The contract that ties todayIso to the maturity code: "today" must be 0 days
+  // until today. daysUntil/fmtMaturity parse plain dates at LOCAL midnight, so a
+  // UTC-derived today (new Date().toISOString()) would read as -1 in the first
+  // hours of the day in a timezone ahead of UTC (e.g. VN, UTC+7) — the drift
+  // this helper exists to remove.
+  it('is the local calendar day (daysUntil(todayIso()) === 0)', () => {
+    expect(daysUntil(todayIso())).toBe(0)
+  })
+
+  it('formats from local date parts', () => {
+    const now = new Date()
+    const p = (n: number) => String(n).padStart(2, '0')
+    expect(todayIso()).toBe(`${now.getFullYear()}-${p(now.getMonth() + 1)}-${p(now.getDate())}`)
+  })
+})
+
+describe('isFutureInvestmentDate', () => {
+  // The server runs in UTC but clients send their LOCAL "today". A client ahead
+  // of UTC (VN) can legitimately send the server's "tomorrow", so the guard
+  // allows one day of skew and only rejects dates clearly in the future.
+  const asOf = new Date('2026-06-14T00:00:00Z')
+
+  it('accepts today', () => {
+    expect(isFutureInvestmentDate('2026-06-14', asOf)).toBe(false)
+  })
+
+  it('accepts a past date', () => {
+    expect(isFutureInvestmentDate('2026-01-01', asOf)).toBe(false)
+  })
+
+  it('tolerates one day of client/server timezone skew', () => {
+    expect(isFutureInvestmentDate('2026-06-15', asOf)).toBe(false)
+  })
+
+  it('rejects a date clearly in the future', () => {
+    expect(isFutureInvestmentDate('2026-06-16', asOf)).toBe(true)
+    expect(isFutureInvestmentDate('2027-01-01', asOf)).toBe(true)
+  })
+
+  it('ignores any time portion on the input', () => {
+    expect(isFutureInvestmentDate('2026-06-15T23:59:59Z', asOf)).toBe(false)
+    expect(isFutureInvestmentDate('2026-06-16T00:00:00Z', asOf)).toBe(true)
+  })
+})

--- a/lib/__tests__/dates.test.ts
+++ b/lib/__tests__/dates.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { todayIso, isFutureInvestmentDate } from '../dates'
 import { daysUntil } from '../maturity'
+
+afterEach(() => vi.useRealTimers())
 
 describe('todayIso', () => {
   // The contract that ties todayIso to the maturity code: "today" must be 0 days
@@ -13,6 +15,9 @@ describe('todayIso', () => {
   })
 
   it('formats from local date parts', () => {
+    // Pin the clock so both new Date() reads see the same instant (no midnight-
+    // rollover flake between todayIso()'s read and the expectation's).
+    vi.setSystemTime(new Date('2026-06-14T08:30:00'))
     const now = new Date()
     const p = (n: number) => String(n).padStart(2, '0')
     expect(todayIso()).toBe(`${now.getFullYear()}-${p(now.getMonth() + 1)}-${p(now.getDate())}`)

--- a/lib/dates.ts
+++ b/lib/dates.ts
@@ -1,0 +1,27 @@
+// Plain-date ("YYYY-MM-DD") helpers that treat a date as a LOCAL calendar day,
+// matching how daysUntil/fmtMaturity parse maturity dates (`new Date(d + 'T00:00:00')`).
+//
+// Why this exists: `new Date().toISOString().slice(0, 10)` yields the UTC date,
+// which in a timezone ahead of UTC (e.g. Vietnam, UTC+7) is yesterday during the
+// first hours of the local day. Mixing that with the local-parsing maturity code
+// drifted "today" — and a recorded investment_date — by up to a day. Use these so
+// every plain-date "today"/comparison agrees on the user's local calendar.
+
+const pad = (n: number) => String(n).padStart(2, '0')
+
+// Today in the local timezone as YYYY-MM-DD (not the UTC date).
+export function todayIso(): string {
+  const d = new Date()
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+}
+
+// Whether a plain investment date is clearly in the future. The server runs in
+// UTC but clients send their LOCAL "today", so a client ahead of UTC can send
+// the server's "tomorrow" for a perfectly valid same-day entry. Allow one day of
+// skew and reject only dates beyond it. Compared as plain dates (ISO strings sort
+// chronologically), so any time portion on the input is ignored.
+export function isFutureInvestmentDate(isoDate: string, asOf: Date = new Date()): boolean {
+  const max = new Date(asOf)
+  max.setUTCDate(max.getUTCDate() + 1)
+  return isoDate.slice(0, 10) > max.toISOString().slice(0, 10)
+}


### PR DESCRIPTION
## Problem

Review feedback (point 1): `daysUntil`/`fmtMaturity` parse maturity dates at **local** midnight (`new Date(d + 'T00:00:00')`), but the renewal flow (`MaturityResolveSheet.todayIso()`) and the transaction forms derived "today" from `new Date().toISOString().slice(0, 10)` — the **UTC** date. In a timezone ahead of UTC (Vietnam, UTC+7), the two disagree during the first 7h of the day, drifting "today" — and a recorded `investment_date` / new maturity — by up to a day.

No money impact: `calcProjectedInterest` keeps its UTC-absolute day-count (its tests pin a UTC `asOf`, and changing it would flake on non-UTC machines). The divergence was on **date milestones** only.

## Decision

Standardize the milestone/renewal path on the **local calendar day** (chosen direction) — the most intuitive for users ("Matures today" is correct in VN) and consistent with the already-local `daysUntil`/`fmtMaturity`.

## Changes

- **`lib/dates.ts`** (new):
  - `todayIso()` — today as `YYYY-MM-DD` in the **local** tz (not UTC).
  - `isFutureInvestmentDate(iso, asOf?)` — rejects future dates but allows **one day of client/server tz skew**. This is required: the server runs in UTC, so a client ahead of UTC legitimately sends the server's "tomorrow" for a same-day entry. The old `new Date(date) > new Date()` guard only worked *because* the client also sent a UTC "today"; switching the client to local would otherwise have made it wrongly reject valid early-morning-VN entries.
- **Server guards** (`/renew`, `investment-transactions` POST) now use `isFutureInvestmentDate`.
- **Client "today"** in `MaturityResolveSheet`, `AddTransactionSheet`, `SellWithdrawSheet`, `DesktopGoalDetail` now comes from the shared local `todayIso()`.
- Updated `MaturityResolveSheet.test.tsx`'s `today()` helper to local (matches the component + the existing `daysFromNow` helper).

Out of scope: planning/insurance/report/scrape date code (separate features; server-side report/scrape are genuinely UTC contexts).

## Tests (TDD)

- New `lib/__tests__/dates.test.ts` (7 cases): `todayIso()` ⇒ `daysUntil(todayIso()) === 0` invariant + local-parts format; `isFutureInvestmentDate` today/past/+1-day-grace/clearly-future/time-portion. Written failing (module absent), then implemented.

## Verification

- `npm test -- --run` — 611 passed (was 604; +7)
- `npx tsc --noEmit` — clean; `eslint` on changed files adds no new errors (pre-existing `set-state-in-effect` warnings in untouched effect bodies remain)
- Targeted E2E against local Supabase: `add-transaction`, `goal-detail-desktop`, `dashboard` — **42 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)