### PR TITLE
chore(ci): bump action versions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -42,9 +42,9 @@ jobs:
     needs: test
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: supabase/setup-cli@v1
+      - uses: supabase/setup-cli@v2
         with:
           version: latest
 


### PR DESCRIPTION
## Why

The `Apply DB migrations (production)` job logged a deprecation warning on recent merges:

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 ... `actions/checkout@v4`, `supabase/setup-cli@v1`. Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.

This is about the **actions' own JS runtime**, not the Node used to run our tests.

## Change

Bump to the current majors (all run on Node 24):

| Action | Before | After |
|--------|--------|-------|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `supabase/setup-cli` | v1 | v2 |

`node-version: 20` (the project's test runtime in the `Unit Tests` job) is intentionally left unchanged — the deprecation does not concern it.

## Verification

The workflow itself is the test: on this PR the `Unit Tests` job runs with the bumped `checkout`/`setup-node`, and the warning should be gone. The `migrate` job stays `skipping` on PRs (it's gated to `push` on `main`); the upgraded `checkout`/`setup-cli` will exercise on the next merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)