### PR TITLE
fix(overview): stop affects_progress from distorting net-worth valuation

### DIFF
--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -118,7 +118,13 @@ export async function GET() {
   )
   const withdrawals = allTxsRaw.filter((tx) => tx.transaction_type === 'withdrawal')
 
-  const { parentWdMap, fundWdMap } = buildWithdrawalMaps(withdrawals)
+  // Two axes (see lib/withdrawalProgress): the …All maps drive VALUATION /
+  // net worth (every withdrawal counts — the money left the holding); the
+  // progress-filtered maps drive the goal bar (affects_progress=false held
+  // steady). currentValue and progressValue below are computed independently
+  // so a "doesn't count toward progress" withdrawal lowers net worth without
+  // moving the bar — and the dashboard agrees with the goal-detail tab.
+  const { parentWdMap, fundWdMap, parentWdMapAll, fundWdMapAll } = buildWithdrawalMaps(withdrawals)
 
   const insuranceMembers = insuranceRes.data ?? []
   const goldPricePerChi: number | null = goldPriceRes.data?.price_per_chi ?? null
@@ -152,6 +158,9 @@ export async function GET() {
     targetAmount: number | null
     targetDate: string | null
     currentValue: number
+    // Progress numerator — equals currentValue except that affects_progress=false
+    // withdrawals are added back, so the bar holds steady while net worth falls.
+    progressValue: number
     totalInvested: number
     transactionCount: number
     funds: Array<{
@@ -176,6 +185,7 @@ export async function GET() {
       targetAmount: goal.target_amount ?? null,
       targetDate: goal.target_date ?? null,
       currentValue: 0,
+      progressValue: 0,
       totalInvested: 0,
       transactionCount: 0,
       funds: [],
@@ -242,8 +252,20 @@ export async function GET() {
     } else {
       // bank / stock / gold — apply any partial withdrawals. Shared, unit-tested
       // valuation so renewal re-parenting can't double-count a withdrawal here.
-      const valued = valueNonFundHolding(tx, parentWdMap, goldPricePerChi)
-      if (!valued) continue // fully withdrawn / sold
+      // Value twice: parentWdMapAll (every withdrawal → net worth) and parentWdMap
+      // (progress-affecting only → goal bar). They differ only when the holding
+      // has an affects_progress=false withdrawal, which net worth must subtract
+      // but the bar must not.
+      const valued = valueNonFundHolding(tx, parentWdMapAll, goldPricePerChi)
+      const progValued = valueNonFundHolding(tx, parentWdMap, goldPricePerChi)
+      // The bar holds the value any affects_progress=false withdrawal removed,
+      // even after the holding is fully gone from net worth.
+      const progressContribution = progValued?.currentValue ?? 0
+      if (tx.goal_id && goalMap.has(tx.goal_id)) {
+        goalMap.get(tx.goal_id)!.progressValue += progressContribution
+      }
+
+      if (!valued) continue // fully withdrawn / sold (net worth)
       const { effectiveAmount, currentValue, effectiveUnits } = valued
 
       totalAssets += currentValue
@@ -266,8 +288,19 @@ export async function GET() {
     }
   }
 
-  // Subtract fund sell withdrawals from fund accumulators
-  for (const [key, wd] of fundWdMap) {
+  // Fund progress contribution (goal bar): value the units left after only the
+  // progress-affecting sells. Computed from the gross accumulators BEFORE the
+  // net-worth subtraction below, and added even when the fund is fully sold for
+  // net worth — an affects_progress=false sell holds the bar steady.
+  for (const [key, acc] of fundAccumMap) {
+    if (!acc.goalId || !goalMap.has(acc.goalId)) continue
+    const progUnits = acc.totalUnits - (fundWdMap.get(key)?.units ?? 0)
+    if (progUnits > 0) goalMap.get(acc.goalId)!.progressValue += acc.currentNAV * progUnits
+  }
+
+  // Subtract ALL fund sell withdrawals from fund accumulators for valuation /
+  // net worth — the units are gone regardless of affects_progress.
+  for (const [key, wd] of fundWdMapAll) {
     const acc = fundAccumMap.get(key)
     if (!acc || wd.units <= 0) continue
     const totalUnitsBefore = acc.totalUnits
@@ -348,6 +381,7 @@ export async function GET() {
     if (c.goalId && goalMap.has(c.goalId)) {
       const g = goalMap.get(c.goalId)!
       g.currentValue += c.amount
+      g.progressValue += c.amount // no withdrawals involved — counts toward the bar too
       g.totalInvested += c.amount
       g.transactionCount += 1
     }
@@ -356,8 +390,11 @@ export async function GET() {
   const goalsOutput = Array.from(goalMap.values()).map((g) => {
     const profitLoss = g.currentValue - g.totalInvested
     const profitLossPercentage = g.totalInvested > 0 ? (profitLoss / g.totalInvested) * 100 : 0
+    // Progress runs off progressValue, not currentValue: affects_progress=false
+    // withdrawals lower net worth (currentValue) but are added back here so the
+    // bar holds steady (see the withdrawal-map split above).
     const progressPercentage = g.targetAmount && g.targetAmount > 0
-      ? Math.min((g.currentValue / g.targetAmount) * 100, 100)
+      ? Math.min((g.progressValue / g.targetAmount) * 100, 100)
       : null
 
     return {

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -202,7 +202,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
             </div>
             <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
               {goal.progressPercentage !== null && (
-                <span style={{
+                <span data-testid="desktop-goal-detail-progress" style={{
                   fontSize: 11, fontWeight: 700, padding: '3px 9px', borderRadius: 999,
                   background: isComplete ? 'var(--c-pos-tint)' : 'var(--c-navy-tint)',
                   color: isComplete ? 'var(--c-pos)' : 'var(--c-navy)',

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -123,11 +123,15 @@ test.describe('Desktop goal detail panel', () => {
     }
   })
 
-  // Withdrawing from the goal detail can opt out of affecting goal progress
-  // via the "Count toward goal progress" toggle (ported from the legacy
-  // Settings view). Toggling it off must persist affects_progress=false.
-  test('withdraw with progress toggle off stores affects_progress=false', async ({ page }) => {
-    // Heavy flow (two dashboard loads + a withdrawal round-trip). Tolerate a
+  // Withdrawing from the goal detail can opt out of affecting goal progress via
+  // the "Count toward goal progress" toggle. affects_progress is a PROGRESS axis,
+  // not a valuation one: the money still leaves, so net worth / the goal's
+  // current value must fall, while the progress bar holds steady. This closes the
+  // loop on both — the stored flag AND the two rendered numbers (a regression
+  // here once overstated net worth by reusing the progress-filtered withdrawal
+  // map for valuation; only the bar-steady half was ever visible).
+  test('withdraw with progress toggle off stores affects_progress=false and lowers value while holding the bar', async ({ page }) => {
+    // Heavy flow (multiple dashboard loads + a withdrawal round-trip). Tolerate a
     // slow / IO-throttled backend rather than racing the default 30s cap.
     test.slow()
     const tx = await api.createTransaction({
@@ -138,14 +142,21 @@ test.describe('Desktop goal detail panel', () => {
       goal_id: goalId,
       notes: 'E2E Progress Toggle Deposit',
     })
+    const digits = (s: string | null) => Number((s ?? '').replace(/\D/g, ''))
     try {
-      await page.goto('/dashboard')
-      await page.waitForLoadState('networkidle')
+      // Fresh load so the header value (from the overview API) reflects the
+      // just-created deposit, not a stale cached overview.
+      await gotoFreshDashboard(page)
 
       await page.getByText('E2E Desktop Goal').first().click()
       const panel = page.getByTestId('desktop-goal-detail')
       await expect(panel).toBeVisible({ timeout: 10_000 })
       await expect(panel.getByText('E2E Progress Toggle Deposit')).toBeVisible({ timeout: 10_000 })
+
+      // Capture the rendered value + progress BEFORE the withdrawal.
+      const valueBefore = digits(await panel.getByTestId('desktop-goal-detail-value').textContent())
+      const progressBefore = (await panel.getByTestId('desktop-goal-detail-progress').textContent())?.trim()
+      expect(valueBefore).toBeGreaterThan(0)
 
       await panel.getByRole('button', { name: 'Options', exact: true }).first().click()
       await page.getByText(/^(Withdraw|Rút tiền)$/).click()
@@ -170,6 +181,17 @@ test.describe('Desktop goal detail panel', () => {
         .eq('transaction_type', 'withdrawal')
       expect(withdrawals).toHaveLength(1)
       expect(withdrawals![0].affects_progress).toBe(false)
+
+      // Rendered outcome (the regression guard). Reload past the overview cache,
+      // reopen the goal, and assert the two numbers moved on independent axes:
+      // current value fell (the money left) but the progress bar is unchanged.
+      await gotoFreshDashboard(page)
+      await page.getByText('E2E Desktop Goal').first().click()
+      await expect(panel).toBeVisible({ timeout: 10_000 })
+      await expect
+        .poll(async () => digits(await panel.getByTestId('desktop-goal-detail-value').textContent()), { timeout: 15_000 })
+        .toBeLessThan(valueBefore)
+      await expect(panel.getByTestId('desktop-goal-detail-progress')).toHaveText(progressBefore!, { timeout: 10_000 })
     } finally {
       await api.deleteTransactionCascade(tx.transaction_id)
     }

--- a/lib/__tests__/depositValuation.test.ts
+++ b/lib/__tests__/depositValuation.test.ts
@@ -64,6 +64,25 @@ describe('valueNonFundHolding', () => {
     expect(valueNonFundHolding(bank({ amount_vnd: 10_000_000 }), parentWdMap, null, ASOF)).toBeNull()
   })
 
+  // Valuation must NOT bend to affects_progress — the money left the holding, so
+  // its book value falls whether or not the withdrawal counts toward the goal
+  // bar. The overview feeds the VALUATION map (parentWdMapAll) here; it used to
+  // (wrongly) feed the progress-filtered map, overstating net worth and making
+  // the same deposit show two different values vs the goal-detail tab (which
+  // always counts every withdrawal). See lib/withdrawalProgress + the decoupled
+  // currentValue/progressValue split in the overview route.
+  it('subtracts an affects_progress=false withdrawal when valued (uses the …All map)', () => {
+    const maps = buildWithdrawalMaps([
+      withdrawal({ principal_withdrawn: 4_000_000, affects_progress: false }),
+    ])
+    // Progress map drops it (bar held steady) → would keep full principal.
+    const progress = valueNonFundHolding(bank({ amount_vnd: 10_000_000 }), maps.parentWdMap, null, ASOF)!
+    expect(progress.effectiveAmount).toBe(10_000_000)
+    // Valuation map counts it (net worth falls) → principal net of the withdrawal.
+    const valuation = valueNonFundHolding(bank({ amount_vnd: 10_000_000 }), maps.parentWdMapAll, null, ASOF)!
+    expect(valuation.effectiveAmount).toBe(6_000_000)
+  })
+
   // Regression (review point 3 / E2E goal-detail-desktop.spec.ts:276): after a
   // renewal the closed cycle's withdrawal is re-parented onto the history
   // snapshot, so parentWdMap is keyed by the SNAPSHOT id — not the active row.

--- a/lib/__tests__/withdrawalProgress.test.ts
+++ b/lib/__tests__/withdrawalProgress.test.ts
@@ -89,8 +89,46 @@ describe('buildWithdrawalMaps', () => {
   })
 
   it('returns empty maps for empty input', () => {
-    const { parentWdMap, fundWdMap } = buildWithdrawalMaps([])
+    const { parentWdMap, fundWdMap, parentWdMapAll, fundWdMapAll } = buildWithdrawalMaps([])
     expect(parentWdMap.size).toBe(0)
     expect(fundWdMap.size).toBe(0)
+    expect(parentWdMapAll.size).toBe(0)
+    expect(fundWdMapAll.size).toBe(0)
+  })
+
+  // affects_progress is a PROGRESS-accounting axis, not a valuation one. The
+  // progress maps (parentWdMap/fundWdMap) drop affects_progress=false rows so a
+  // "doesn't count toward progress" withdrawal leaves the bar steady; the
+  // valuation maps (…All) must still count it, because the money actually left
+  // the holding and net worth has to fall. Reusing the progress maps for
+  // valuation overstated net worth by the withdrawn amount (the bug this guards).
+  describe('valuation maps (…All) count every withdrawal regardless of affects_progress', () => {
+    it('includes an affects_progress=false bank/gold withdrawal in parentWdMapAll', () => {
+      const wd = makeWithdrawal({ affects_progress: false, principal_withdrawn: 300_000 })
+      const { parentWdMap, parentWdMapAll } = buildWithdrawalMaps([wd])
+      expect(parentWdMap.has('parent-1')).toBe(false)              // progress: held steady
+      expect(parentWdMapAll.get('parent-1')).toEqual({ principal: 300_000, units: 0 }) // valuation: counted
+    })
+
+    it('includes an affects_progress=false fund withdrawal in fundWdMapAll', () => {
+      const wd = makeWithdrawal({
+        asset_type: 'fund', fund_id: 'fund-1', parent_transaction_id: null,
+        units_withdrawn: 100, principal_withdrawn: 2_000_000, affects_progress: false,
+      })
+      const { fundWdMap, fundWdMapAll } = buildWithdrawalMaps([wd])
+      expect(fundWdMap.has('goal-1::fund-1')).toBe(false)          // progress: held steady
+      expect(fundWdMapAll.get('goal-1::fund-1')).toEqual({ units: 100, cost: 2_000_000 }) // valuation: counted
+    })
+
+    it('accumulates ALL withdrawals in the valuation map while progress filters', () => {
+      const wds = [
+        makeWithdrawal({ transaction_id: 'tx-1', affects_progress: true, principal_withdrawn: 500_000 }),
+        makeWithdrawal({ transaction_id: 'tx-2', affects_progress: false, principal_withdrawn: 300_000 }),
+        makeWithdrawal({ transaction_id: 'tx-3', affects_progress: null, principal_withdrawn: 200_000 }),
+      ]
+      const { parentWdMap, parentWdMapAll } = buildWithdrawalMaps(wds)
+      expect(parentWdMap.get('parent-1')).toEqual({ principal: 700_000, units: 0 })    // true + null only
+      expect(parentWdMapAll.get('parent-1')).toEqual({ principal: 1_000_000, units: 0 }) // all three
+    })
   })
 })

--- a/lib/withdrawalProgress.ts
+++ b/lib/withdrawalProgress.ts
@@ -12,29 +12,52 @@ export type WithdrawalRow = {
 export type ParentWdMap = Map<string, { principal: number; units: number }>
 export type FundWdMap = Map<string, { units: number; cost: number }>
 
+// Aggregates withdrawals onto their holding along TWO axes that must not be
+// conflated:
+//   • parentWdMap / fundWdMap   — PROGRESS accounting. Drop affects_progress=false
+//     rows so a "doesn't count toward progress" withdrawal leaves the goal bar
+//     steady (the rebalance-within-a-goal case).
+//   • parentWdMapAll / fundWdMapAll — VALUATION. Count every withdrawal: the money
+//     actually left the holding, so book value / net worth must fall regardless of
+//     the progress flag. Sharing the progress maps for valuation overstated net
+//     worth by the withdrawn amount and made the same deposit show two different
+//     values across the dashboard vs the goal-detail tab.
 export function buildWithdrawalMaps(withdrawals: WithdrawalRow[]): {
   parentWdMap: ParentWdMap
   fundWdMap: FundWdMap
+  parentWdMapAll: ParentWdMap
+  fundWdMapAll: FundWdMap
 } {
   const parentWdMap: ParentWdMap = new Map()
   const fundWdMap: FundWdMap = new Map()
+  const parentWdMapAll: ParentWdMap = new Map()
+  const fundWdMapAll: FundWdMap = new Map()
+
+  const addFund = (map: FundWdMap, key: string, wd: WithdrawalRow) => {
+    const e = map.get(key) ?? { units: 0, cost: 0 }
+    e.units += wd.units_withdrawn ?? 0
+    e.cost += wd.principal_withdrawn ?? 0
+    map.set(key, e)
+  }
+  const addParent = (map: ParentWdMap, key: string, wd: WithdrawalRow) => {
+    const e = map.get(key) ?? { principal: 0, units: 0 }
+    e.principal += wd.principal_withdrawn ?? 0
+    e.units += wd.units_withdrawn ?? 0
+    map.set(key, e)
+  }
 
   for (const wd of withdrawals) {
-    if (wd.affects_progress === false) continue
+    const affectsProgress = wd.affects_progress !== false
 
     if (wd.asset_type === 'fund' && wd.fund_id) {
       const key = `${wd.goal_id ?? 'unallocated'}::${wd.fund_id}`
-      const e = fundWdMap.get(key) ?? { units: 0, cost: 0 }
-      e.units += wd.units_withdrawn ?? 0
-      e.cost += wd.principal_withdrawn ?? 0
-      fundWdMap.set(key, e)
+      addFund(fundWdMapAll, key, wd)
+      if (affectsProgress) addFund(fundWdMap, key, wd)
     } else if (wd.parent_transaction_id) {
-      const e = parentWdMap.get(wd.parent_transaction_id) ?? { principal: 0, units: 0 }
-      e.principal += wd.principal_withdrawn ?? 0
-      e.units += wd.units_withdrawn ?? 0
-      parentWdMap.set(wd.parent_transaction_id, e)
+      addParent(parentWdMapAll, wd.parent_transaction_id, wd)
+      if (affectsProgress) addParent(parentWdMap, wd.parent_transaction_id, wd)
     }
   }
 
-  return { parentWdMap, fundWdMap }
+  return { parentWdMap, fundWdMap, parentWdMapAll, fundWdMapAll }
 }


### PR DESCRIPTION
## The bug

A withdrawal flagged **`affects_progress = false`** (the "don't count toward the goal bar" toggle, meant for rebalancing *within* a goal) was being excluded from the overview's **valuation**, not just its progress accounting.

- `buildWithdrawalMaps` skips `affects_progress === false` rows. That's right for *progress*, but the overview's **only** use of its maps is *valuation* (`valueNonFundHolding` + the fund subtraction).
- So a bank/gold/fund holding partially withdrawn with `affects_progress=false` was valued at **full principal** in net worth and `goal.currentValue`, while the goal-detail tab (`buildInvRows`, which counts every withdrawal) showed it **net of the withdrawal**.
- → Same holding, two different numbers across the dashboard vs goal-detail; net worth overstated by the withdrawn amount.

## New, not pre-existing

Traced to **PR #167** ("affects-progress checkbox"). Before it, the overview built its withdrawal maps inline, **counting every withdrawal** for valuation. #167 extracted that loop into `buildWithdrawalMaps` and added the `affects_progress === false` skip — silently importing a progress-only filter into the valuation path. The new `depositValuation.test.ts` missed it because the `withdrawal()` factory defaults `affects_progress: true`.

## The fix — decouple valuation from progress

`affects_progress` is a **progress** axis, not a valuation one: the money left the holding, so book value / net worth must fall regardless of the flag.

- `buildWithdrawalMaps` now returns `parentWdMapAll` / `fundWdMapAll` (every withdrawal, for valuation) alongside the existing progress-filtered maps.
- The overview computes **`currentValue`** (net worth) from the `…All` maps, and a separate **`progressValue`** that adds back `affects_progress=false` amounts so the goal bar **still holds steady** (preserves #167's intent) while net worth and the two screens now agree.

```
currentValue  = principal − ALL withdrawals                     // net worth, matches buildInvRows
progressValue = currentValue + Σ(affects_progress=false withdrawn) // bar held steady
progressPct   = progressValue / target
```

## Tests (TDD)

- **Unit (red→green):** `withdrawalProgress.test.ts` — the `…All` maps count `affects_progress=false` while the progress maps don't; `depositValuation.test.ts` — the valuation seam subtracts an `affects_progress=false` withdrawal (the case the divergence slipped through).
- **E2E (rendered outcome):** the goal-detail `affects_progress=false` test now asserts the **current value falls while the progress badge is unchanged**. The old code held *both* steady — which is exactly what hid the bug, so this is the real regression guard. Added a `desktop-goal-detail-progress` testid for an unambiguous locator.

## Verification

- `npm test -- --run` → 623 passed
- `npx tsc --noEmit` → clean
- Targeted E2E (local): `goal-detail-desktop` (12), `dashboard` + `dashboard-desktop` + `investments` + `goals` (44) → all passed, incl. the renewal double-count valuation test
- Lint: the 27 errors present are pre-existing on `main` (`ThemeProvider.tsx` et al.), none in touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)