### PR TITLE
fix(progress): honest affects-progress OFF copy (no within-goal transfer promise)

### DIFF
--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -259,7 +259,10 @@ export async function GET() {
       const valued = valueNonFundHolding(tx, parentWdMapAll, goldPricePerChi)
       const progValued = valueNonFundHolding(tx, parentWdMap, goldPricePerChi)
       // The bar holds the value any affects_progress=false withdrawal removed,
-      // even after the holding is fully gone from net worth.
+      // even after the holding is fully gone from net worth. Known limitation:
+      // if those proceeds are re-bought into the SAME goal, the bar double-counts
+      // (this add-back + the re-buy's own progress). Needs a withdrawal→destination
+      // link to fix — tracked in issue #342.
       const progressContribution = progValued?.currentValue ?? 0
       if (tx.goal_id && goalMap.has(tx.goal_id)) {
         goalMap.get(tx.goal_id)!.progressValue += progressContribution

--- a/app/assets/components/__tests__/AffectsProgressControl.test.tsx
+++ b/app/assets/components/__tests__/AffectsProgressControl.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AffectsProgressControl } from '../goalDetailShared'
+
+// The OFF copy used to read "for rebalancing or moving money within the goal",
+// which advertises a within-goal transfer the flow never performs: proceeds
+// route to Unallocated, and re-buying into the same goal double-counts the bar
+// (issue #342). The honest framing keeps it to what the toggle actually does —
+// hold the bar steady for a withdrawal that doesn't reduce your commitment —
+// without implying a transfer.
+describe('AffectsProgressControl — OFF copy does not promise a within-goal transfer', () => {
+  function renderOff(isVi: boolean) {
+    render(
+      <AffectsProgressControl
+        checked={false}
+        onChange={() => {}}
+        isVi={isVi}
+        currentValue={20_000_000}
+        targetAmount={50_000_000}
+        withdrawnValue={4_000_000}
+      />,
+    )
+    return screen.getByTestId('affects-progress-control').textContent ?? ''
+  }
+
+  it('drops the misleading "moving money / rebalancing" framing (en)', () => {
+    const text = renderOff(false)
+    expect(text).not.toMatch(/moving money/i)
+    expect(text).not.toMatch(/rebalanc/i)
+    expect(text).not.toMatch(/within the goal/i)
+    // States the real semantics instead: it's about commitment, not a transfer.
+    expect(text).toMatch(/commitment/i)
+  })
+
+  it('drops the misleading "luân chuyển / cân đối" framing (vi)', () => {
+    const text = renderOff(true)
+    expect(text).not.toMatch(/luân chuyển/i)
+    expect(text).not.toMatch(/cân đối/i)
+    expect(text).toMatch(/cam kết/i)
+  })
+})

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -70,10 +70,18 @@ function Switch({ checked, onChange }: { checked: boolean; onChange: (v: boolean
 
 // "Count toward goal progress" toggle + a live progress-impact preview, shown
 // only when withdrawing from within a goal. Default ON: the withdrawal lowers
-// the goal's tracked progress. OFF (affects_progress=false) is for rebalancing
-// or moving money within the goal — the holding still leaves, but progress is
-// held steady. The preview animates current% → resulting% so the consequence
-// is visible before confirming.
+// the goal's tracked progress. OFF (affects_progress=false) holds the bar steady
+// for a withdrawal that doesn't reduce your commitment to the goal — the holding
+// still leaves (net worth falls), the bar just doesn't move.
+//
+// NB: this is NOT a within-goal transfer. Proceeds route to Unallocated; the
+// flow does not move money between holdings in the goal. If you withdraw OFF and
+// then re-buy into the same goal, the bar double-counts (the source is still
+// credited via add-back AND the re-buy adds its own progress) — see issue #342.
+// The OFF copy below deliberately avoids promising a transfer.
+//
+// The preview animates current% → resulting% so the consequence is visible
+// before confirming.
 export function AffectsProgressControl({
   checked, onChange, isVi, currentValue, targetAmount, withdrawnValue = 0,
 }: {
@@ -87,12 +95,12 @@ export function AffectsProgressControl({
   const t = isVi ? {
     label: 'Tính vào tiến độ mục tiêu',
     on: 'Khoản rút này sẽ làm giảm tiến độ của mục tiêu.',
-    off: 'Tiến độ giữ nguyên — dùng khi cân đối lại hoặc luân chuyển trong mục tiêu.',
+    off: 'Tiến độ giữ nguyên — dùng cho khoản rút không làm giảm cam kết với mục tiêu này.',
     title: 'Tiến độ mục tiêu', unchanged: 'Giữ nguyên', offGoalValue: 'khỏi giá trị mục tiêu',
   } : {
     label: 'Count toward goal progress',
     on: 'This withdrawal lowers your tracked progress for this goal.',
-    off: 'Progress stays the same — for rebalancing or moving money within the goal.',
+    off: 'Progress stays the same — for a withdrawal that doesn’t reduce your commitment to this goal.',
     title: 'Goal progress', unchanged: 'Unchanged', offGoalValue: 'off goal value',
   }
 

--- a/lib/withdrawalProgress.ts
+++ b/lib/withdrawalProgress.ts
@@ -16,7 +16,8 @@ export type FundWdMap = Map<string, { units: number; cost: number }>
 // conflated:
 //   • parentWdMap / fundWdMap   — PROGRESS accounting. Drop affects_progress=false
 //     rows so a "doesn't count toward progress" withdrawal leaves the goal bar
-//     steady (the rebalance-within-a-goal case).
+//     steady. (This holds the bar; it is not a within-goal transfer — re-buying
+//     the proceeds back into the same goal double-counts the bar, see issue #342.)
 //   • parentWdMapAll / fundWdMapAll — VALUATION. Count every withdrawal: the money
 //     actually left the holding, so book value / net worth must fall regardless of
 //     the progress flag. Sharing the progress maps for valuation overstated net


### PR DESCRIPTION
## What

Reframes the "Count toward goal progress" toggle's **OFF** copy so it no longer promises a within-goal transfer the app doesn't perform. This is the **cheap half of #342** (chosen direction: *honest reframe + document*) — no bar math, no schema change.

## Why

OFF copy today:
> "Progress stays the same — for rebalancing or **moving money within the goal**."

But the flow never moves money within the goal: withdrawal proceeds route to **Unallocated** (`SellWithdrawSheet.tsx:275-277`). A user who follows that suggestion — withdraw OFF, then manually re-buy into the same goal — **double-counts the bar**: the source holding is still credited via add-back (`overview/route.ts:263`) *and* the re-buy adds its own progress. Net worth is correct (after #341); only the bar overstates.

The misleading copy is what invites the bad path, so making it honest removes the trap at near-zero cost.

## Changes

- **`goalDetailShared.tsx`** — honest EN/VI OFF copy + corrected component doc comment:
  - EN: *"Progress stays the same — for a withdrawal that doesn't reduce your commitment to this goal."*
  - VI: *"Tiến độ giữ nguyên — dùng cho khoản rút không làm giảm cam kết với mục tiêu này."*
- **`lib/withdrawalProgress.ts` / `overview/route.ts`** — comments at the progress-map and add-back seams cross-referencing #342 (known double-count limitation, fix = withdrawal→destination link).
- **`AffectsProgressControl.test.tsx`** (new) — asserts the OFF copy drops the `moving money / rebalanc / within the goal / luân chuyển / cân đối` framing and states the real semantics (commitment). Written red → green (TDD).

## Not in scope

A true within-goal transfer (link a withdrawal to its destination holding so re-deployed money isn't re-counted) remains a separate feature tracked on **#342**, with its regression test to ship alongside that fix.

## Verification

- `npx vitest run` — **625 passed** (+2 new), `tsc --noEmit` clean, eslint clean on touched files.
- No E2E run: copy-only change, no DOM/selector/i18n-key impact — grep of `e2e/` finds no reference to the old or new strings.

Closes the "document/reframe" portion of #342 (issue stays open for the transfer feature).
