### PR TITLE
fix(goals): reconcile the progress bar with net worth on goal cards

### DIFF
--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -403,6 +403,10 @@ export async function GET() {
       targetAmount: g.targetAmount,
       targetDate: g.targetDate,
       currentValue: g.currentValue,
+      // Surfaced so the goal card/hero can reconcile the bar (progress) against
+      // net worth (currentValue) when an affects_progress=false withdrawal makes
+      // them diverge — see ProgressCreditNote.
+      progressValue: g.progressValue,
       totalInvested: g.totalInvested,
       profitLoss,
       profitLossPercentage,

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -52,6 +52,10 @@ export interface GoalData {
   targetAmount: number | null
   targetDate: string | null
   currentValue: number
+  // Progress-bar numerator: equals currentValue except that affects_progress=false
+  // withdrawals are added back, so the bar holds steady while net worth (currentValue)
+  // falls. Optional for back-compat with cached overview payloads predating the field.
+  progressValue?: number
   totalInvested: number
   profitLoss: number
   profitLossPercentage: number
@@ -881,6 +885,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                       <GoalCard
                         key={goal.goalId}
                         {...goal}
+                        locale={locale}
                         onClick={() => { setSelectedGoalId(goal.goalId); setGoalDetailOpen(true) }}
                       />
                     ))}

--- a/app/assets/components/DesktopGoalCard.tsx
+++ b/app/assets/components/DesktopGoalCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
+import { ProgressCreditNote, progressCredit } from './goalDetailShared'
 import type { GoalData } from '../DashboardClient'
 
 interface Props {
@@ -14,6 +15,7 @@ export default function DesktopGoalCard({ goal, locale, onClick }: Props) {
   const progress = goal.progressPercentage ?? 0
   const isComplete = progress >= 100
   const isVi = locale === 'vi'
+  const creditedWithdrawn = progressCredit(goal.currentValue, goal.progressValue)
 
   return (
     <button
@@ -69,6 +71,10 @@ export default function DesktopGoalCard({ goal, locale, onClick }: Props) {
             transition: 'width 400ms ease',
           }} />
         </div>
+      )}
+
+      {goal.progressPercentage !== null && creditedWithdrawn > 0 && (
+        <ProgressCreditNote amount={creditedWithdrawn} isVi={isVi} style={{ marginTop: 6 }} />
       )}
 
       {/* P&L row + transaction count */}

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield, RefreshCw } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, AffectsProgressControl, BankInfoStrip, RenewalSummaryLine, needsMaturityAction, type InvRow, type GoalDetailTx } from './goalDetailShared'
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, AffectsProgressControl, BankInfoStrip, RenewalSummaryLine, needsMaturityAction, ProgressCreditNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { MaturityResolveModal } from './MaturityResolveSheet'
 import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
@@ -153,6 +153,9 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
   const isPos = goal.profitLoss >= 0
   const isComplete = (goal.progressPercentage ?? 0) >= 100
   const progress = Math.min(goal.progressPercentage ?? 0, 100)
+  // Bar (progress) vs the big value (net worth) diverge by any affects_progress=false
+  // withdrawal added back to progress — surfaced as a reconciling caption.
+  const creditedWithdrawn = progressCredit(goal.currentValue, goal.progressValue)
 
   // Build investment rows (shared with the mobile sheet's valuation logic).
   const invRows: InvRow[] = buildInvRows(transactions, goal.funds, goldPricePerChi, isVi)
@@ -240,6 +243,10 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                 transition: 'width 400ms ease',
               }} />
             </div>
+          )}
+
+          {goal.progressPercentage !== null && creditedWithdrawn > 0 && (
+            <ProgressCreditNote amount={creditedWithdrawn} isVi={isVi} style={{ marginTop: 8 }} />
           )}
 
           {/* P/L grid */}

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield, RefreshCw } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, AffectsProgressControl, BankInfoStrip, RenewalSummaryLine, needsMaturityAction, ProgressCreditNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, AffectsProgressControl, BankInfoStrip, RenewalSummaryLine, needsMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { MaturityResolveModal } from './MaturityResolveSheet'
 import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
@@ -440,6 +440,10 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                     </div>
                   ))}
                 </div>
+              )}
+
+              {calcInput > 0 && goal.targetAmount && creditedWithdrawn > 0 && remaining > 0 && (
+                <ProgressGatherNote amount={creditedWithdrawn} isVi={isVi} />
               )}
 
               {calcInput <= 0 && (

--- a/app/assets/components/GoalCard.tsx
+++ b/app/assets/components/GoalCard.tsx
@@ -2,11 +2,14 @@
 
 import { useTranslations } from 'next-intl'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
+import { ProgressCreditNote, progressCredit } from './goalDetailShared'
 
 interface Props {
   goalName: string
   targetAmount: number | null
   currentValue: number
+  progressValue?: number
+  locale: string
   profitLoss: number
   profitLossPercentage: number
   progressPercentage: number | null
@@ -15,11 +18,12 @@ interface Props {
 }
 
 export default function GoalCard({
-  goalName, targetAmount, currentValue,
+  goalName, targetAmount, currentValue, progressValue, locale,
   profitLoss, profitLossPercentage, progressPercentage, transactionCount,
   onClick,
 }: Props) {
   const t = useTranslations('dashboard')
+  const creditedWithdrawn = progressCredit(currentValue, progressValue)
   const plPositive = profitLoss >= 0
   const progress = Math.min(progressPercentage ?? 0, 100)
   const isComplete = progressPercentage !== null && progressPercentage >= 100
@@ -94,6 +98,9 @@ export default function GoalCard({
               transition: 'width 400ms ease',
             }} />
           </div>
+          {targetAmount != null && creditedWithdrawn > 0 && (
+            <ProgressCreditNote amount={creditedWithdrawn} isVi={locale === 'vi'} style={{ marginTop: 6 }} />
+          )}
         </div>
       )}
 

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -11,7 +11,7 @@ import type { GoalData, FundBreakdownItem } from '../DashboardClient'
 import TransactionHistorySheet, { type PurchaseHistoryRow } from './TransactionHistorySheet'
 import { SellWithdrawSheet, type SellItem } from './SellWithdrawSheet'
 import { MaturityResolveSheet } from './MaturityResolveSheet'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, RenewalSummaryLine, needsMaturityAction, type InvRow, type GoalDetailTx } from './goalDetailShared'
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, RenewalSummaryLine, needsMaturityAction, ProgressCreditNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 
@@ -790,6 +790,11 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   const progress = Math.min(goal.progressPercentage ?? 0, 100)
   const exceededTarget = goal.progressPercentage !== null && goal.progressPercentage >= 100
   const isPositive = goal.profitLoss >= 0
+  // The bar runs off progressValue (affects_progress=false withdrawals added
+  // back), so the fraction beside it uses the same numerator to stay coherent;
+  // the big "current value" above stays net worth. creditedWithdrawn is the gap.
+  const progValue = goal.progressValue ?? goal.currentValue
+  const creditedWithdrawn = progressCredit(goal.currentValue, goal.progressValue)
 
   const fundMap = new Map(goal.funds.map((f) => [f.fundId, f]))
 
@@ -875,7 +880,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
             </p>
             {goal.targetAmount && (
               <p style={{ fontSize: 12, color: 'var(--c-muted)', marginBottom: 12, fontVariantNumeric: 'tabular-nums' }}>
-                {fmtCompact(goal.currentValue)} / {fmtCompact(goal.targetAmount)} {isVI ? 'mục tiêu' : 'target'}
+                {fmtCompact(progValue)} / {fmtCompact(goal.targetAmount)} {isVI ? 'mục tiêu' : 'target'}
               </p>
             )}
             {goal.targetAmount && (
@@ -896,6 +901,10 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
                   </span>
                 </div>
               </>
+            )}
+
+            {goal.targetAmount && creditedWithdrawn > 0 && (
+              <ProgressCreditNote amount={creditedWithdrawn} isVi={isVI} style={{ marginTop: 8 }} />
             )}
 
             {/* P/L strip — grid with separator lines */}

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -11,7 +11,7 @@ import type { GoalData, FundBreakdownItem } from '../DashboardClient'
 import TransactionHistorySheet, { type PurchaseHistoryRow } from './TransactionHistorySheet'
 import { SellWithdrawSheet, type SellItem } from './SellWithdrawSheet'
 import { MaturityResolveSheet } from './MaturityResolveSheet'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, RenewalSummaryLine, needsMaturityAction, ProgressCreditNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, RenewalSummaryLine, needsMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 
@@ -1160,6 +1160,10 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
                     </div>
                   ))}
                 </div>
+              )}
+
+              {monthly > 0 && goal.targetAmount && creditedWithdrawn > 0 && remaining > 0 && (
+                <ProgressGatherNote amount={creditedWithdrawn} isVi={isVI} />
               )}
 
               {/* Empty state */}

--- a/app/assets/components/__tests__/DesktopGoalCard.test.tsx
+++ b/app/assets/components/__tests__/DesktopGoalCard.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import DesktopGoalCard from '../DesktopGoalCard'
+import type { GoalData } from '../../DashboardClient'
+
+const mockGoal: GoalData = {
+  goalId: 'goal-1',
+  goalName: 'Emergency Fund',
+  targetAmount: 120_000_000,
+  targetDate: null,
+  currentValue: 60_000_000,
+  progressValue: 60_000_000,
+  totalInvested: 55_000_000,
+  profitLoss: 5_000_000,
+  profitLossPercentage: 9.09,
+  progressPercentage: 50,
+  transactionCount: 3,
+  funds: [],
+}
+
+const baseProps = { goal: mockGoal, locale: 'en', onClick: vi.fn() }
+
+describe('DesktopGoalCard — progress credit note', () => {
+  it('shows a reconciling caption when progressValue exceeds the net-worth currentValue', () => {
+    const goal = { ...mockGoal, currentValue: 90_900_000, progressValue: 121_900_000, progressPercentage: 100 }
+    render(<DesktopGoalCard {...baseProps} goal={goal} />)
+    expect(screen.getByTestId('progress-credit-note')).toHaveTextContent('31.0M ₫')
+  })
+
+  it('omits the caption when progressValue equals currentValue', () => {
+    render(<DesktopGoalCard {...baseProps} />)
+    expect(screen.queryByTestId('progress-credit-note')).not.toBeInTheDocument()
+  })
+})

--- a/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
@@ -266,6 +266,39 @@ describe('DesktopGoalDetail — progress credit note (decoupled progress vs net 
   })
 })
 
+describe('DesktopGoalDetail — calculator reconciles its shortfall against net worth', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({ ok: true, json: async () => ({ transactions: [] }) }),
+    )
+  })
+
+  // Bar reads complete (progressValue ≥ target) but the calculator runs off net
+  // worth, so "Still needed" stays > 0. A note explains the gap.
+  const creditedGoal: GoalData = {
+    ...mockGoal,
+    currentValue: 90_900_000,
+    progressValue: 121_900_000,
+    targetAmount: 120_000_000,
+    progressPercentage: 100,
+  }
+
+  it('explains why the calculator shows a shortfall while the bar reads complete', async () => {
+    render(<DesktopGoalDetail {...baseProps} goal={creditedGoal} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Calculator' }))
+    await userEvent.type(screen.getByPlaceholderText('0'), '1000000')
+    await waitFor(() => expect(screen.getByTestId('progress-gather-note')).toHaveTextContent('31.0M ₫'))
+  })
+
+  it('omits the gather note when progress equals net worth', async () => {
+    render(<DesktopGoalDetail {...baseProps} goal={{ ...creditedGoal, progressValue: 90_900_000, progressPercentage: 76 }} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Calculator' }))
+    await userEvent.type(screen.getByPlaceholderText('0'), '1000000')
+    await waitFor(() => expect(screen.getByText('Still needed')).toBeInTheDocument())
+    expect(screen.queryByTestId('progress-gather-note')).not.toBeInTheDocument()
+  })
+})
+
 describe('DesktopGoalDetail — singular month wording (issue #262)', () => {
   // 1,000,000₫ left to reach the target.
   const nearGoal: GoalData = { ...mockGoal, targetAmount: 10_000_000, currentValue: 9_000_000, targetDate: null }

--- a/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
@@ -240,6 +240,32 @@ describe('DesktopGoalDetail — bank maturity in Options modal (issue #263)', ()
   })
 })
 
+describe('DesktopGoalDetail — progress credit note (decoupled progress vs net worth)', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({ ok: true, json: async () => ({ transactions: [] }) }),
+    )
+  })
+
+  const creditedGoal: GoalData = {
+    ...mockGoal,
+    currentValue: 90_900_000,
+    progressValue: 121_900_000,
+    targetAmount: 120_000_000,
+    progressPercentage: 100,
+  }
+
+  it('shows a reconciling caption when the bar (progressValue) exceeds net worth', () => {
+    render(<DesktopGoalDetail {...baseProps} goal={creditedGoal} />)
+    expect(screen.getByTestId('progress-credit-note')).toHaveTextContent('31.0M ₫')
+  })
+
+  it('omits the caption when there is no off-progress withdrawal credited', () => {
+    render(<DesktopGoalDetail {...baseProps} goal={{ ...mockGoal, progressValue: mockGoal.currentValue }} />)
+    expect(screen.queryByTestId('progress-credit-note')).not.toBeInTheDocument()
+  })
+})
+
 describe('DesktopGoalDetail — singular month wording (issue #262)', () => {
   // 1,000,000₫ left to reach the target.
   const nearGoal: GoalData = { ...mockGoal, targetAmount: 10_000_000, currentValue: 9_000_000, targetDate: null }

--- a/app/assets/components/__tests__/GoalCard.test.tsx
+++ b/app/assets/components/__tests__/GoalCard.test.tsx
@@ -9,6 +9,8 @@ const baseProps = {
   goalName: 'Emergency Fund',
   targetAmount: 100_000_000,
   currentValue: 60_000_000,
+  progressValue: 60_000_000,
+  locale: 'en',
   profitLoss: 5_000_000,
   profitLossPercentage: 9.09,
   progressPercentage: 60,
@@ -70,5 +72,18 @@ describe('GoalCard', () => {
   it('passes plural transactionCount to the transactions label', () => {
     render(<GoalCard {...baseProps} transactionCount={5} />)
     expect(screen.getByText('transactions:{"count":5}')).toBeInTheDocument()
+  })
+
+  // When a withdrawal was taken with "count toward progress" OFF, the bar (which
+  // runs off progressValue) sits higher than the net-worth currentValue. A
+  // reconciling caption explains why the bar is fuller than the value held.
+  it('shows a reconciling caption when progressValue exceeds the net-worth currentValue', () => {
+    render(<GoalCard {...baseProps} currentValue={90_900_000} progressValue={121_900_000} />)
+    expect(screen.getByTestId('progress-credit-note')).toHaveTextContent('31.0M ₫')
+  })
+
+  it('omits the caption when progressValue equals currentValue (no off-progress withdrawal)', () => {
+    render(<GoalCard {...baseProps} currentValue={60_000_000} progressValue={60_000_000} />)
+    expect(screen.queryByTestId('progress-credit-note')).not.toBeInTheDocument()
   })
 })

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -472,6 +472,45 @@ describe('GoalDetailSheet — singular month wording (issue #262)', () => {
   })
 })
 
+describe('GoalDetailSheet — progress credit note (decoupled progress vs net worth)', () => {
+  // Net worth held = 90.9M (after a 31M off-progress withdrawal); the bar still
+  // counts the 31M, so progressValue = 121.9M against a 120M target → 100%.
+  const creditedGoal: GoalData = {
+    ...mockGoal,
+    funds: [],
+    currentValue: 90_900_000,
+    progressValue: 121_900_000,
+    targetAmount: 120_000_000,
+    progressPercentage: 100,
+  }
+
+  beforeEach(() => {
+    global.fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({ ok: true, json: async () => ({ transactions: [] }) }),
+    )
+  })
+
+  it('keeps net worth as the big number but runs the bar fraction off progressValue so it matches the bar', () => {
+    render(<GoalDetailSheet {...baseProps} goal={creditedGoal} />)
+    // Big "current value" stays net worth.
+    expect(screen.getByText('₫ 90.900.000')).toBeInTheDocument()
+    // Fraction next to the bar uses progressValue (matches the 100% bar), not net worth.
+    expect(screen.getByText(/121\.9M ₫ \/ 120\.0M ₫ target/)).toBeInTheDocument()
+    expect(screen.queryByText(/90\.9M ₫ \/ 120\.0M ₫ target/)).not.toBeInTheDocument()
+  })
+
+  it('explains the gap with a reconciling caption naming the credited amount', () => {
+    render(<GoalDetailSheet {...baseProps} goal={creditedGoal} />)
+    expect(screen.getByTestId('progress-credit-note')).toHaveTextContent('31.0M ₫')
+  })
+
+  it('omits the caption and keeps the fraction on net worth when progress equals net worth', () => {
+    render(<GoalDetailSheet {...baseProps} goal={{ ...creditedGoal, progressValue: 90_900_000, progressPercentage: 76 }} />)
+    expect(screen.queryByTestId('progress-credit-note')).not.toBeInTheDocument()
+    expect(screen.getByText(/90\.9M ₫ \/ 120\.0M ₫ target/)).toBeInTheDocument()
+  })
+})
+
 describe('GoalDetailSheet — refreshKey triggers refetch', () => {
   it('refetches /investment-transactions when refreshKey changes', async () => {
     const fetchMock = vi.fn().mockImplementation((url: string) => {

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -509,6 +509,21 @@ describe('GoalDetailSheet — progress credit note (decoupled progress vs net wo
     expect(screen.queryByTestId('progress-credit-note')).not.toBeInTheDocument()
     expect(screen.getByText(/90\.9M ₫ \/ 120\.0M ₫ target/)).toBeInTheDocument()
   })
+
+  it('explains the shortfall in the Calculator tab (net worth based) while the bar reads complete', async () => {
+    render(<GoalDetailSheet {...baseProps} goal={creditedGoal} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Calculator' }))
+    await userEvent.type(screen.getByPlaceholderText('0'), '1000000')
+    await waitFor(() => expect(screen.getByTestId('progress-gather-note')).toHaveTextContent('31.0M ₫'))
+  })
+
+  it('omits the calculator gather note when progress equals net worth', async () => {
+    render(<GoalDetailSheet {...baseProps} goal={{ ...creditedGoal, progressValue: 90_900_000, progressPercentage: 76 }} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Calculator' }))
+    await userEvent.type(screen.getByPlaceholderText('0'), '1000000')
+    await waitFor(() => expect(screen.getByText('Still needed')).toBeInTheDocument())
+    expect(screen.queryByTestId('progress-gather-note')).not.toBeInTheDocument()
+  })
 })
 
 describe('GoalDetailSheet — refreshKey triggers refetch', () => {

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -176,6 +176,24 @@ export function ProgressCreditNote({ amount, isVi, style }: { amount: number; is
   )
 }
 
+// Calculator counterpart to ProgressCreditNote. The savings calculator's "still
+// needed" runs off net worth (you have to gather money you actually hold), while
+// the bar runs off progressValue. So the bar can read "complete" while the
+// calculator still shows a shortfall — this note explains that the shortfall
+// reflects the already-withdrawn amount the progress bar still counts. Renders
+// nothing when the two axes agree.
+export function ProgressGatherNote({ amount, isVi, style }: { amount: number; isVi: boolean; style?: CSSProperties }) {
+  if (!(amount > 0)) return null
+  const text = isVi
+    ? `Tiến độ đã gồm ${fmtCompact(amount)} bạn đã rút; ước tính này tính trên tiền đang giữ nên vẫn còn thiếu.`
+    : `Progress counts ${fmtCompact(amount)} you withdrew; this estimate is based on what you still hold, so a gap remains.`
+  return (
+    <p data-testid="progress-gather-note" style={{ fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.4, margin: 0, ...style }}>
+      {text}
+    </p>
+  )
+}
+
 export interface InvRow {
   id: string
   name: string

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -3,6 +3,7 @@
 // chrome, so the icons, colours, deadline math and — most importantly — the
 // investment-row valuation live here to stay in sync.
 
+import type { CSSProperties } from 'react'
 import { TrendingUp, Building, Coins, BarChart2, Target, RefreshCw } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
 import { calcProjectedInterest } from '@/lib/finance'
@@ -145,6 +146,33 @@ export function AffectsProgressControl({
         </div>
       )}
     </div>
+  )
+}
+
+// Net worth (currentValue) and the goal bar (progressValue) decoupled once
+// affects_progress=false withdrawals were introduced: such a withdrawal lowers
+// net worth but is added back to progress, so the bar holds steady while the
+// value held drops. On a card that shows both, the bar then reads fuller than
+// the value — this caption reconciles them by naming the credited-but-withdrawn
+// amount (progressValue − currentValue). Renders nothing when they agree.
+//
+// Honest-copy note (mirrors AffectsProgressControl): the money was withdrawn and
+// is NOT still held — it just still counts toward the goal. The wording says so
+// rather than implying a transfer.
+export function progressCredit(currentValue: number, progressValue: number | undefined): number {
+  if (progressValue == null) return 0
+  return Math.max(0, Math.round(progressValue) - Math.round(currentValue))
+}
+
+export function ProgressCreditNote({ amount, isVi, style }: { amount: number; isVi: boolean; style?: CSSProperties }) {
+  if (!(amount > 0)) return null
+  const text = isVi
+    ? `Gồm ${fmtCompact(amount)} đã rút nhưng vẫn tính vào mục tiêu`
+    : `Includes ${fmtCompact(amount)} withdrawn that still counts toward this goal`
+  return (
+    <p data-testid="progress-credit-note" style={{ fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.4, margin: 0, ...style }}>
+      {text}
+    </p>
   )
 }
 

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -192,6 +192,9 @@ test.describe('Desktop goal detail panel', () => {
         .poll(async () => digits(await panel.getByTestId('desktop-goal-detail-value').textContent()), { timeout: 15_000 })
         .toBeLessThan(valueBefore)
       await expect(panel.getByTestId('desktop-goal-detail-progress')).toHaveText(progressBefore!, { timeout: 10_000 })
+      // The reconciling caption now appears, explaining why the bar held full
+      // while the value fell: the withdrawn money still counts toward progress.
+      await expect(panel.getByTestId('progress-credit-note')).toBeVisible({ timeout: 10_000 })
     } finally {
       await api.deleteTransactionCascade(tx.transaction_id)
     }


### PR DESCRIPTION
## Problem

After the `affects_progress` decouple (#341), three numbers on a goal card/hero stopped sharing a numerator:

- **Big "Giá trị hiện tại"** = `currentValue` → net worth (31M spent subtracted)
- **"X / Y mục tiêu" fraction** = `currentValue / target` → also net worth
- **Bar** = `progressPercentage` → runs off `progressValue` (31M added back)

For a goal with an `affects_progress=false` withdrawal, the bar reads **fuller than the fraction/value** — e.g. a ~100% bar next to "90.9M / 120M". Each number is right on its own axis (real net worth vs held-steady progress), but side by side on one card they look contradictory. This is a display-coherence issue, not a number bug.

## Fix (decided with the user: "Both")

- **Mobile goal-detail fraction → `progressValue`** so the fraction and the bar agree; the big "current value" number stays net worth.
- **Shared `ProgressCreditNote` caption** — shown only when `progressValue` exceeds net worth — names the credited-but-withdrawn gap (`progressValue − currentValue`), reconciling the full bar with the lower value. Applied to **all four surfaces**: mobile + desktop goal cards, mobile + desktop goal-detail heroes.
- **Expose `progressValue`** from the overview API (it was server-only); client defaults to `currentValue` for back-compat with cached payloads.

### Honest copy
The caption says the money was *withdrawn but still counts* — it does **not** imply the money is still held or was transferred (mirrors the `AffectsProgressControl` honesty direction).

## Tests (TDD — written first, red → green)
- Rendered-output assertions on all four surfaces: caption appears when progress exceeds net worth, absent when equal; mobile fraction uses `progressValue` while the big number stays net worth.
- E2E guard in `goal-detail-desktop.spec.ts`: the caption appears after an off-progress withdrawal.
- Full unit suite (634) + typecheck + lint (on changed files) green.

## Isolation
Branched off `main` — independent of the open #343 (honest-copy) PR; does not include its commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)