### PR TITLE
fix(progress): honest affects-progress OFF copy (no transfer promise)

### DIFF
--- a/app/assets/components/__tests__/AffectsProgressControl.test.tsx
+++ b/app/assets/components/__tests__/AffectsProgressControl.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AffectsProgressControl } from '../goalDetailShared'
+
+// The OFF copy used to read "for rebalancing or moving money within the goal",
+// which advertises a within-goal transfer the flow never performs: proceeds
+// route to Unallocated, and re-buying into the same goal double-counts the bar
+// (issue #342). The honest framing states what actually happens — the money
+// still leaves, but it keeps counting toward the goal — without implying a
+// transfer between holdings.
+describe('AffectsProgressControl — OFF copy does not promise a within-goal transfer', () => {
+  function renderOff(isVi: boolean) {
+    render(
+      <AffectsProgressControl
+        checked={false}
+        onChange={() => {}}
+        isVi={isVi}
+        currentValue={20_000_000}
+        targetAmount={50_000_000}
+        withdrawnValue={4_000_000}
+      />,
+    )
+    return screen.getByTestId('affects-progress-control').textContent ?? ''
+  }
+
+  it('drops the misleading "moving money within the goal" framing (en)', () => {
+    const text = renderOff(false)
+    expect(text).not.toMatch(/moving money/i)
+    expect(text).not.toMatch(/within the goal/i)
+    // States the real semantics instead: the money leaves but still counts.
+    expect(text).toMatch(/still leaves/i)
+    expect(text).toMatch(/counting toward/i)
+  })
+
+  it('drops the misleading "luân chuyển trong mục tiêu" framing (vi)', () => {
+    const text = renderOff(true)
+    expect(text).not.toMatch(/luân chuyển/i)
+    expect(text).toMatch(/vẫn rời mục tiêu/i)
+    expect(text).toMatch(/vẫn được tính vào tiến độ/i)
+  })
+})

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -71,10 +71,11 @@ function Switch({ checked, onChange }: { checked: boolean; onChange: (v: boolean
 
 // "Count toward goal progress" toggle + a live progress-impact preview, shown
 // only when withdrawing from within a goal. Default ON: the withdrawal lowers
-// the goal's tracked progress. OFF (affects_progress=false) is for rebalancing
-// or moving money within the goal — the holding still leaves, but progress is
-// held steady. The preview animates current% → resulting% so the consequence
-// is visible before confirming.
+// the goal's tracked progress. OFF (affects_progress=false) is for rebalancing —
+// the holding still leaves (net worth falls), but progress is held steady. It is
+// NOT a within-goal transfer: proceeds route to Unallocated, so re-buying them
+// into the same goal double-counts the bar (issue #342). The preview animates
+// current% → resulting% so the consequence is visible before confirming.
 export function AffectsProgressControl({
   checked, onChange, isVi, currentValue, targetAmount, withdrawnValue = 0,
 }: {
@@ -88,12 +89,12 @@ export function AffectsProgressControl({
   const t = isVi ? {
     label: 'Tính vào tiến độ mục tiêu',
     on: 'Khoản rút này sẽ làm giảm tiến độ của mục tiêu.',
-    off: 'Tiến độ giữ nguyên — dùng khi cân đối lại hoặc luân chuyển trong mục tiêu.',
+    off: 'Tiến độ giữ nguyên — khoản tiền vẫn rời mục tiêu nhưng vẫn được tính vào tiến độ.',
     title: 'Tiến độ mục tiêu', unchanged: 'Giữ nguyên', offGoalValue: 'khỏi giá trị mục tiêu',
   } : {
     label: 'Count toward goal progress',
     on: 'This withdrawal lowers your tracked progress for this goal.',
-    off: 'Progress stays the same — for rebalancing or moving money within the goal.',
+    off: 'Progress stays the same — the money still leaves, but it keeps counting toward this goal.',
     title: 'Goal progress', unchanged: 'Unchanged', offGoalValue: 'off goal value',
   }
 


### PR DESCRIPTION
Supersedes #343 (closed) — re-applied as a minimal copy-only change off current `main` (post #344), so there's zero overlap with #341/#344 logic.

## Change (copy + comment only)
The OFF toggle copy read *"for rebalancing or moving money within the goal"*, which advertises a within-goal transfer the flow never performs — proceeds route to Unallocated, and re-buying into the same goal double-counts the bar (#342).

```diff
- off: 'Progress stays the same — for rebalancing or moving money within the goal.'
+ off: 'Progress stays the same — the money still leaves, but it keeps counting toward this goal.'

- off: 'Tiến độ giữ nguyên — dùng khi cân đối lại hoặc luân chuyển trong mục tiêu.'
+ off: 'Tiến độ giữ nguyên — khoản tiền vẫn rời mục tiêu nhưng vẫn được tính vào tiến độ.'
```

Also drops "moving money within the goal" from the component comment (keeps the rebalancing use-case, minus the transfer implication; notes the #342 double-count).

## Tests
Added `AffectsProgressControl.test.tsx` asserting the OFF copy (EN + VI) no longer implies a transfer. No logic touched; full unit suite + lint + typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)