### PR TITLE
fix(renew): anchor renewed deposit to old maturity, allow date edit

### DIFF
--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -54,6 +54,14 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     return NextResponse.json({ error: 'Investment date cannot be in the future.' }, { status: 400 })
   }
 
+  // The new cycle must have positive length: its maturity has to fall strictly
+  // after its start (investment) date. The client anchors the start to the old
+  // maturity, so a hand-edited new maturity on or before it would mint a
+  // zero/negative-length cycle. ISO date strings sort chronologically.
+  if (cleanExpiry && cleanExpiry <= cleanInvestmentDate) {
+    return NextResponse.json({ error: 'New maturity must be after the investment date.' }, { status: 400 })
+  }
+
   // Validate against the current cycle (owned by this user) for friendly 4xx
   // messages. The renewal itself re-reads and locks the row inside
   // renew_term_deposit, which builds the snapshot from that authoritative read.

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -5,12 +5,16 @@
 // interest, principal only, or change amount/term) or withdraw. This is the
 // shared form plus a mobile bottom-sheet and a desktop modal wrapper.
 //
-// Renewal is a single PUT to the existing transaction: it updates the deposit
-// in place (new principal / rate / maturity) and resets `investment_date` to
-// today so the compound-interest valuation in buildInvRows restarts from the
-// new principal — and so the PUT's future-date guard never trips when maturity
-// is tomorrow. Withdrawal hands off to the existing Sell/Withdraw flow rather
-// than re-implementing the payout (the parent wires `onWithdraw`).
+// Renewal is a single POST to the renew route: it rolls the deposit forward in
+// place (new principal / rate / maturity) and sets `investment_date` to the OLD
+// maturity date, so the new cycle's compound-interest valuation in buildInvRows
+// picks up exactly where the closed cycle ended — an overdue book does not lose
+// the days it sat past maturity, nor does its next maturity skip forward by them.
+// (An actionable deposit's old maturity is at most "tomorrow", so this never
+// trips the route's future-date guard.) The new maturity defaults to old-maturity
+// + term and follows the term until the user edits it by hand. Withdrawal hands
+// off to the existing Sell/Withdraw flow rather than re-implementing the payout
+// (the parent wires `onWithdraw`).
 
 import { useState, useEffect } from 'react'
 import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X } from 'lucide-react'
@@ -81,6 +85,9 @@ export function MaturityResolveBody({
   const [term, setTerm] = useState(String(derivedTerm > 0 ? derivedTerm : 12))
   const [rate, setRate] = useState(inv.interestRate != null ? String(inv.interestRate) : '')
   const [newAmount, setNewAmount] = useState(String(principal))
+  // The new maturity follows old-maturity + term until the user edits it by hand,
+  // at which point we freeze their value (null = "follow the term").
+  const [maturityOverride, setMaturityOverride] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const [done, setDone] = useState<null | { newPrincipal: number; newMaturity: string }>(null)
@@ -93,18 +100,25 @@ export function MaturityResolveBody({
   const newPrincipal = mode === 'withdraw'
     ? principal
     : renewalPrincipal(mode, principal, iNum, newAmountNum)
-  // Extend from today for an already-matured deposit (so the new maturity is
-  // always in the future), otherwise from the existing maturity date.
-  const baseDate = matured || !inv.expiryDate ? todayIso() : inv.expiryDate
-  const newMaturity = addMonths(baseDate, tNum > 0 ? tNum : 0)
+  // The new cycle is anchored to the OLD maturity date (the closed cycle's end),
+  // not today — so an overdue book's next maturity is old-maturity + term, and
+  // its accrual restarts from old maturity without skipping the overdue days.
+  const baseDate = inv.expiryDate || todayIso()
+  // New maturity defaults to old-maturity + term and tracks the term, until the
+  // user edits the date field by hand (then we honour their pick).
+  const derivedMaturity = addMonths(baseDate, tNum > 0 ? tNum : 0)
+  const dateTouched = maturityOverride !== null
+  const newMaturity = dateTouched ? maturityOverride : derivedMaturity
   const newMaturityFmt = fmtMaturity(newMaturity, isVi)?.formatted ?? newMaturity
   const payout = principal + iNum
 
-  // Guard against writing a zero/empty principal, a non-positive term, or
-  // clearing the rate (which would drop the deposit out of maturity tracking).
+  // Guard against writing a zero/empty principal, a non-positive term, clearing
+  // the rate (which would drop the deposit out of maturity tracking), or a new
+  // maturity that isn't strictly after the old one (a zero/negative-length cycle).
   const rateValid = rate.trim() !== '' && Number(rate) > 0
   const amountValid = mode !== 'change' || (newAmount.trim() !== '' && Number(newAmount) > 0)
-  const canRenew = tNum > 0 && rateValid && amountValid && newPrincipal > 0
+  const maturityValid = newMaturity > baseDate
+  const canRenew = tNum > 0 && rateValid && amountValid && newPrincipal > 0 && maturityValid
 
   const t = isVi ? {
     summarySuffix: 'năm', perYr: 'năm', mo: 'tháng',
@@ -117,6 +131,8 @@ export function MaturityResolveBody({
     interestSavedHint: 'Số lãi này được lưu vĩnh viễn vào lịch sử tái tục.',
     newTerm: 'Kỳ hạn mới', newRate: 'Lãi suất kỳ mới',
     newCycle: 'Kỳ mới', newMaturityLabel: 'Ngày đáo hạn mới',
+    maturityHint: 'Tự tính theo kỳ hạn, tính từ ngày đáo hạn cũ. Sửa nếu ngân hàng chốt ngày khác.',
+    resetDate: 'Đặt lại', maturityTooEarly: 'Ngày đáo hạn mới phải sau ngày đáo hạn cũ.',
     interestIn: 'Lãi nhập gốc', interestOut: 'Lãi rút ra',
     totalPayout: 'Tổng nhận về',
     cancel: 'Hủy', confirmRenew: 'Xác nhận tái tục', confirmWithdraw: 'Đánh dấu chờ rút',
@@ -132,6 +148,8 @@ export function MaturityResolveBody({
     interestSavedHint: 'This interest is saved permanently to the renewal history.',
     newTerm: 'New term', newRate: 'New interest rate',
     newCycle: 'New cycle', newMaturityLabel: 'New maturity',
+    maturityHint: 'Auto-calculated from the term, starting at the old maturity date. Edit if your bank set a different date.',
+    resetDate: 'Reset', maturityTooEarly: 'New maturity must be after the old maturity date.',
     interestIn: 'Interest added', interestOut: 'Interest out',
     totalPayout: 'Total payout',
     cancel: 'Cancel', confirmRenew: 'Confirm renewal', confirmWithdraw: 'Mark for withdrawal',
@@ -157,11 +175,13 @@ export function MaturityResolveBody({
           amount_vnd: Math.round(newPrincipal),
           interest_rate: Number(rate),
           expiry_date: newMaturity,
-          // Reset the accrual base so the value calc restarts from the new
-          // principal and the future-date guard never trips. The route rolls the
-          // active row forward in place and appends a history snapshot of the
+          // Anchor the new cycle's accrual to the OLD maturity date (baseDate) so
+          // the value calc restarts where the closed cycle ended — overdue days
+          // are not lost. An actionable deposit's old maturity is ≤ tomorrow, so
+          // this stays within the route's future-date tolerance. The route rolls
+          // the active row forward in place and appends a history snapshot of the
           // cycle that just closed.
-          investment_date: todayIso(),
+          investment_date: baseDate,
           // Realized interest for the cycle that just closed — recorded
           // permanently on the snapshot for the renewal-history summary.
           interest_earned_vnd: iNum,
@@ -283,6 +303,35 @@ export function MaturityResolveBody({
               </div>
             </div>
             {mode === 'change' && <MoneyField label={t.interestPaidOut} value={interest} onChange={setInterest} />}
+          </div>
+
+          {/* New maturity date — defaults to old-maturity + term, follows the term
+              until the user edits it, with a reset back to the auto value. */}
+          <div>
+            <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 6 }}>
+              <span style={{ ...fieldLabel, marginBottom: 0 }}>{t.newMaturityLabel}</span>
+              {dateTouched && (
+                <button
+                  type="button"
+                  data-testid="maturity-date-reset"
+                  onClick={() => setMaturityOverride(null)}
+                  style={{ fontSize: 11, fontWeight: 600, color: 'var(--c-navy)', background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'inherit', padding: 0 }}
+                >
+                  {t.resetDate}
+                </button>
+              )}
+            </div>
+            <input
+              data-testid="maturity-date-input"
+              type="date"
+              value={newMaturity}
+              min={baseDate}
+              onChange={(e) => setMaturityOverride(e.target.value)}
+              style={moneyInput}
+            />
+            {maturityValid
+              ? <p style={{ margin: '6px 0 0', fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.4 }}>{t.maturityHint}</p>
+              : <p style={{ margin: '6px 0 0', fontSize: 11, color: 'var(--c-neg)', lineHeight: 1.4 }}>{t.maturityTooEarly}</p>}
           </div>
 
           {/* Preview */}

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MaturityResolveBody } from '../MaturityResolveSheet'
 import { addMonths, monthsBetween } from '@/lib/maturity'
@@ -13,14 +13,6 @@ function daysFromNow(n: number): string {
   d.setDate(d.getDate() + n)
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
 }
-// Match the component's todayIso() (lib/dates), which is the LOCAL calendar day
-// — same parse style as `daysFromNow` above and as daysUntil/fmtMaturity, so the
-// predicted investment_date / new maturity stays in lock-step with the component.
-const today = () => {
-  const d = new Date()
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-}
-
 // A matured term deposit: value (compounded) > principal, expiry in the past.
 const maturedDeposit: InvRow = {
   id: 'tx-bank-1',
@@ -39,18 +31,20 @@ const maturedDeposit: InvRow = {
 afterEach(() => vi.restoreAllMocks())
 
 describe('MaturityResolveBody', () => {
-  it('previews the rolled-up principal and a future maturity for principal + interest', () => {
+  it('previews the rolled-up principal and a maturity measured from the OLD maturity date', () => {
     render(
       <MaturityResolveBody inv={maturedDeposit} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
     )
     // Default mode is principal + interest: 35,000,000 + (37,030,000 − 35,000,000) = 37,030,000
     expect(screen.getByTestId('maturity-new-principal').textContent).toContain(fmt(37_030_000))
-    // Matured → new term extends from today (12 months default), always in the future.
-    const expectedMaturity = addMonths(today(), 12)
+    // New term extends from the OLD maturity date (not today), even when overdue,
+    // so an overdue book's next cycle lands at old-maturity + term — not today + term.
+    const expectedMaturity = addMonths(maturedDeposit.expiryDate!, 12)
+    expect((screen.getByTestId('maturity-date-input') as HTMLInputElement).value).toBe(expectedMaturity)
     expect(screen.getByTestId('maturity-new-date').textContent).toContain(expectedMaturity.slice(0, 4))
   })
 
-  it('renews via the renew route that rolls the deposit forward from today', async () => {
+  it('renews via the renew route, anchoring the new cycle to the old maturity date', async () => {
     const user = userEvent.setup()
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
     vi.stubGlobal('fetch', fetchMock)
@@ -67,10 +61,68 @@ describe('MaturityResolveBody', () => {
     expect(JSON.parse(opts.body)).toMatchObject({
       amount_vnd: 37_030_000,
       interest_rate: 5.8,
-      expiry_date: addMonths(today(), 12), // new maturity from today (matured)
-      investment_date: today(),            // accrual reset, never future-dated
-      interest_earned_vnd: 2_030_000,      // realized interest (value − principal) recorded permanently
+      // New maturity = old maturity + term (overdue days are NOT skipped forward).
+      expiry_date: addMonths(maturedDeposit.expiryDate!, 12),
+      // Accrual base = the OLD maturity date, so the new cycle's interest does not
+      // lose the days the book sat overdue. (≤ tomorrow, so never future-rejected.)
+      investment_date: maturedDeposit.expiryDate,
+      interest_earned_vnd: 2_030_000, // realized interest (value − principal) recorded permanently
     })
+  })
+
+  it('lets the user override the new maturity date and freezes it from the term', async () => {
+    const user = userEvent.setup()
+    render(
+      <MaturityResolveBody inv={maturedDeposit} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+    const dateInput = screen.getByTestId('maturity-date-input') as HTMLInputElement
+    // Defaults to old maturity + the (12-month fallback) term.
+    expect(dateInput.value).toBe(addMonths(maturedDeposit.expiryDate!, 12))
+
+    // Manual edit freezes the date — changing the term no longer moves it.
+    fireEvent.change(dateInput, { target: { value: '2027-03-15' } })
+    expect(dateInput.value).toBe('2027-03-15')
+    fireEvent.change(screen.getByTestId('maturity-term-input'), { target: { value: '6' } })
+    expect(dateInput.value).toBe('2027-03-15')
+
+    // Reset re-couples the date to the term (now 6 months from the old maturity).
+    await user.click(screen.getByRole('button', { name: /Reset|Đặt lại/i }))
+    expect(dateInput.value).toBe(addMonths(maturedDeposit.expiryDate!, 6))
+  })
+
+  it('sends the manually edited maturity date through to the renew route', async () => {
+    const user = userEvent.setup()
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <MaturityResolveBody inv={maturedDeposit} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+    fireEvent.change(screen.getByTestId('maturity-date-input'), { target: { value: '2027-03-15' } })
+    await user.click(screen.getByRole('button', { name: /Confirm renewal/i }))
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({
+      expiry_date: '2027-03-15',
+      investment_date: maturedDeposit.expiryDate, // still anchored to the old maturity
+    })
+  })
+
+  it('blocks confirm when the new maturity is not after the old maturity date', async () => {
+    const user = userEvent.setup()
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(
+      <MaturityResolveBody inv={maturedDeposit} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+    // Equal to the old maturity → zero-length cycle, must be rejected.
+    fireEvent.change(screen.getByTestId('maturity-date-input'), { target: { value: maturedDeposit.expiryDate! } })
+
+    const confirm = screen.getByRole('button', { name: /Confirm renewal/i })
+    expect(confirm).toBeDisabled()
+    await user.click(confirm)
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('suggests the original term length derived from the open + maturity dates', () => {

--- a/e2e/api-validation.spec.ts
+++ b/e2e/api-validation.spec.ts
@@ -108,4 +108,35 @@ test.describe('API input validation', () => {
       await api.deleteTransaction(flex.transaction_id)
     }
   })
+
+  // The renewed cycle must have positive length: its new maturity has to fall
+  // strictly after its start (investment) date. The client anchors the start to
+  // the old maturity, so a hand-edited maturity on or before it must be rejected.
+  test('POST /api/v1/investment-transactions/<id>/renew rejects a non-positive cycle length (400)', async ({ request }) => {
+    const opened = '2026-03-04'
+    const maturity = '2026-06-04'
+    // A real bank TERM deposit: carries both an interest rate and a maturity.
+    const term = await api.createTransaction({
+      asset_type: 'bank',
+      amount_vnd: 20_000_000,
+      investment_date: opened,
+      interest_rate: 5.5,
+      expiry_date: maturity,
+      notes: 'E2E renew date-order guard',
+    })
+    try {
+      const res = await request.post(`/api/v1/investment-transactions/${term.transaction_id}/renew`, {
+        data: {
+          amount_vnd: 20_000_000,
+          interest_rate: 5.5,
+          // New maturity equals the investment date → zero-length cycle.
+          expiry_date: maturity,
+          investment_date: maturity,
+        },
+      })
+      expect(res.status()).toBe(400)
+    } finally {
+      await api.deleteTransactionCascade(term.transaction_id)
+    }
+  })
 })

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -202,7 +202,8 @@ test.describe('Desktop goal detail panel', () => {
 
   // Term-deposit maturity: a deposit past its maturity date surfaces a
   // "Handle maturity" action; renewing it rolls the principal forward, sets a
-  // future maturity and resets the accrual date — closing the UI→DB loop.
+  // future maturity and anchors the accrual date to the OLD maturity (so an
+  // overdue book's next cycle doesn't lose the overdue days) — closing the loop.
   test('renewing a matured term deposit rolls it forward in the DB', async ({ page }) => {
     test.slow()
     const iso = (offsetDays: number) => new Date(Date.now() + offsetDays * 86_400_000).toISOString().slice(0, 10)
@@ -237,7 +238,8 @@ test.describe('Desktop goal detail panel', () => {
       await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
 
       // Close the loop: the stored deposit must now have a future maturity, a
-      // larger principal (interest rolled in) and today's accrual date.
+      // larger principal (interest rolled in) and an accrual date anchored to the
+      // OLD maturity (iso(-30)) — NOT today — so the new cycle keeps the overdue days.
       const { createClient } = await import('@supabase/supabase-js')
       const supabase = createClient(process.env.E2E_SUPABASE_URL!, process.env.E2E_SUPABASE_SERVICE_ROLE_KEY!)
       await expect.poll(async () => {
@@ -247,7 +249,7 @@ test.describe('Desktop goal detail panel', () => {
           .eq('transaction_id', tx.transaction_id)
           .single()
         return data
-      }, { timeout: 15_000 }).toMatchObject({ investment_date: today })
+      }, { timeout: 15_000 }).toMatchObject({ investment_date: iso(-30) })
 
       const { data: renewed } = await supabase
         .from('investment_transactions')
@@ -350,7 +352,7 @@ test.describe('Desktop goal detail panel', () => {
           .eq('transaction_id', tx.transaction_id)
           .single()
         return data?.investment_date
-      }, { timeout: 15_000 }).toBe(today)
+      }, { timeout: 15_000 }).toBe(iso(-30)) // accrual anchored to the old maturity, not today
       const { data: renewed } = await supabase
         .from('investment_transactions')
         .select('amount_vnd')

--- a/supabase/migrations/20260614000003_renew_term_deposit_date_validation.sql
+++ b/supabase/migrations/20260614000003_renew_term_deposit_date_validation.sql
@@ -1,0 +1,112 @@
+-- Validate the renewal dates inside renew_term_deposit, and lock in that the
+-- history snapshot keeps the CLOSED cycle's own dates.
+--
+-- Two changes vs 20260614000002 (the flex guard); the three coupled, atomic
+-- writes are otherwise identical — see 20260614000001 for their full rationale.
+--
+-- 1. Date validation (defence-in-depth; the API route checks these too, but the
+--    RPC is reachable directly by an authenticated caller):
+--      * the new maturity must fall strictly AFTER the new cycle's start
+--        (investment) date — otherwise the cycle has zero/negative length;
+--      * the investment date may not be in the future. The client now anchors it
+--        to the OLD maturity date (so an overdue book's new cycle does not lose
+--        the days it sat past maturity); an actionable deposit's old maturity is
+--        at most "tomorrow", so allow one day of client/server timezone skew
+--        (mirroring lib/dates.isFutureInvestmentDate) and reject only beyond it.
+--
+-- 2. Snapshot lineage: step 2 builds the history snapshot from `v_old`, captured
+--    by the `select ... for update` BEFORE the step-1 roll-forward. That is the
+--    point of reading into v_old first — the snapshot records the closed cycle's
+--    real open date and maturity (v_old.investment_date / v_old.expiry_date), and
+--    is unaffected by the active row's investment_date now becoming the old
+--    maturity. The snapshot must NEVER take p_investment_date / p_expiry_date,
+--    which describe the NEW cycle.
+create or replace function public.renew_term_deposit(
+  p_tx_id uuid,
+  p_amount_vnd bigint,
+  p_interest_rate numeric,
+  p_expiry_date date,
+  p_investment_date date,
+  p_interest_earned_vnd bigint
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_old public.investment_transactions;
+  v_snapshot_id uuid;
+  v_renewed public.investment_transactions;
+begin
+  -- Lock + read the active row. RLS restricts this to the caller's own row, so
+  -- a missing row means "not yours / does not exist".
+  select * into v_old
+    from public.investment_transactions
+   where transaction_id = p_tx_id
+   for update;
+  if not found then
+    raise exception 'renew_term_deposit: transaction not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_old.asset_type is distinct from 'bank' then
+    raise exception 'renew_term_deposit: only bank term deposits can be renewed'
+      using errcode = 'check_violation';
+  end if;
+  -- A term deposit carries both a rate and a maturity; a flexible deposit has
+  -- neither and cannot be renewed.
+  if v_old.interest_rate is null or v_old.expiry_date is null then
+    raise exception 'renew_term_deposit: only bank term deposits can be renewed'
+      using errcode = 'check_violation';
+  end if;
+  -- The investment date may not be in the future (allow one day of timezone
+  -- skew, matching the route's lenient client-vs-server "today" tolerance).
+  if p_investment_date > current_date + 1 then
+    raise exception 'renew_term_deposit: investment date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+  -- The new cycle must have positive length: maturity strictly after the start.
+  if p_expiry_date is not null and p_expiry_date <= p_investment_date then
+    raise exception 'renew_term_deposit: new maturity must be after the investment date'
+      using errcode = 'check_violation';
+  end if;
+
+  -- 1) Roll the active row forward to the new cycle (valuation unchanged).
+  update public.investment_transactions
+     set amount_vnd      = p_amount_vnd,
+         interest_rate   = p_interest_rate,
+         expiry_date     = p_expiry_date,
+         investment_date = p_investment_date,
+         updated_at      = now()
+   where transaction_id = p_tx_id
+  returning * into v_renewed;
+
+  -- 2) Append the history snapshot of the cycle that just closed, linked to the
+  --    still-active row. Excluded from every total by renewed_from_transaction_id.
+  --    Dates come from v_old (pre-roll-forward) so the snapshot keeps the CLOSED
+  --    cycle's real open + maturity dates — never the new p_* dates.
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, amount_vnd,
+    investment_date, expiry_date, interest_rate, notes,
+    renewed_from_transaction_id, interest_earned_vnd, affects_progress
+  ) values (
+    v_old.user_id, v_old.goal_id, 'bank', 'investment', v_old.amount_vnd,
+    v_old.investment_date, v_old.expiry_date, v_old.interest_rate, v_old.notes,
+    p_tx_id, p_interest_earned_vnd, false
+  )
+  returning transaction_id into v_snapshot_id;
+
+  -- 3) Re-parent the closed cycle's partial-withdrawal rows onto the snapshot so
+  --    they stop being subtracted from the renewed active row (its principal
+  --    already excludes them). The snapshot is excluded from all totals, so the
+  --    withdrawals are preserved in history without affecting valuation.
+  update public.investment_transactions
+     set parent_transaction_id = v_snapshot_id
+   where parent_transaction_id = p_tx_id
+     and transaction_type = 'withdrawal';
+
+  return v_renewed;
+end;
+$$;
+
+grant execute on function public.renew_term_deposit(uuid, bigint, numeric, date, date, bigint) to authenticated;


### PR DESCRIPTION
## Problem

Term-deposit renewal measured the new cycle from **today**, not the old maturity date:
- New maturity = `today + term`
- `investment_date` reset to `today`

For an **overdue** book this was wrong in two ways. If a deposit was 10 days overdue with old maturity **4 Jun** and a 3-month term, it renewed to **14 Sep** instead of **4 Sep**, and the new cycle's interest under-accrued by the ~10 overdue days (accrual restarted from today, skipping them).

## Changes

1. **`MaturityResolveSheet` — maturity base**: drop `baseDate = matured ? today : expiry`; always anchor the new cycle to the **old maturity date**. Overdue 10 days, old maturity 4 Jun → new maturity 4 Sep.
2. **`MaturityResolveSheet` — editable date**: add an `<input type="date">` for the new maturity, defaulting to `addMonths(old_expiry, term)` and **following the term until the user edits it by hand** (`dateTouched`), with a **Reset** button + an explanatory hint. Confirm is blocked when the new maturity isn't strictly after the old one.
3. **`/renew` route + `renew_term_deposit` RPC**: client now sends `investment_date = old expiry` (≤ tomorrow for any actionable deposit, so within the existing future-date tolerance) so the new cycle keeps the overdue days. Both layers validate `new_maturity > investment_date` and `investment_date <= today` (defence-in-depth; the RPC is reachable directly).
4. **Snapshot lineage**: unchanged on purpose — the RPC builds the history snapshot from `v_old`, captured *before* the roll-forward, so the closed cycle keeps its real open + maturity dates. New migration adds a comment locking that invariant in.

## Testing

TDD throughout (tests written first).

- **Unit** (`MaturityResolveSheet.test.tsx`): 8/8 — new maturity measured from old expiry; POST sends `investment_date = old expiry` + `expiry_date = old + term`; manual date edit freezes from the term; Reset re-couples; confirm blocked when maturity ≤ old maturity. Full suite: **641/641**.
- **E2E** (local stack, migration applied):
  - `api-validation.spec.ts` — renew rejects a non-positive cycle length (400). ✓
  - `goal-detail-desktop.spec.ts` — happy-path renewal now stores `investment_date = old maturity` (updated assertion); snapshot still preserves the original open date; partial-withdrawal double-count regression still holds. ✓
- `npm run lint` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)