### PR TITLE
feat(maturity): combine — settle & re-deposit, merging a due recurring saving

### DIFF
--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -91,7 +91,7 @@ export async function GET() {
   const plans = (plansRes.data ?? []) as { id: string; month: number; year: number }[]
   const planIds = plans.map((p) => p.id)
 
-  const [insExclusionsRes, insOverridesRes, recOverridesRes] = await Promise.all([
+  const [insExclusionsRes, insOverridesRes, recOverridesRes, recFulfillmentsRes] = await Promise.all([
     planIds.length > 0
       ? supabase.from('plan_excluded_insurance_members').select('plan_id, member_id').in('plan_id', planIds)
       : Promise.resolve({ data: [], error: null }),
@@ -101,6 +101,9 @@ export async function GET() {
     planIds.length > 0
       ? supabase.from('recurring_saving_overrides').select('plan_id, recurring_saving_id, monthly_amount_override_vnd').in('plan_id', planIds)
       : Promise.resolve({ data: [], error: null }),
+    // Months a recurring saving was settled by a maturity-combine renewal — used
+    // to suppress its synthesized contribution (the amount lives in the deposit).
+    supabase.from('recurring_saving_fulfillments').select('recurring_saving_id, ym').eq('user_id', user.id),
   ])
 
   if (goalsRes.error || txRes.error || insuranceRes.error) {
@@ -373,6 +376,7 @@ export async function GET() {
     plans,
     recOverridesRes.data ?? [],
     loggedRecurringDeposits,
+    recFulfillmentsRes.data ?? [],
   )
   for (const c of recContributions) {
     totalAssets += c.amount

--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const body = await request.json()
-  const { amount_vnd, interest_rate, expiry_date, investment_date, interest_earned_vnd } = body
+  const { amount_vnd, interest_rate, expiry_date, investment_date, interest_earned_vnd, fulfill_recurring } = body
 
   let txId: string
   let cleanAmount: number
@@ -30,6 +30,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   let cleanExpiry: string | null = null
   let cleanInvestmentDate: string
   let cleanInterestEarned: number | null = null
+  // Combine flow only: the recurring saving folded into this re-deposit, marked
+  // fulfilled for its month inside the same atomic renewal so it isn't also
+  // counted as a separate synthesized contribution.
+  let cleanFulfillSavingId: string | null = null
+  let cleanFulfillYm: string | null = null
+  let cleanFulfillAmount: number | null = null
   try {
     txId = validateUUID(id, 'transaction_id')
     cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
@@ -44,6 +50,16 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       const n = Number(interest_earned_vnd)
       if (!Number.isFinite(n) || n < 0) throw new ValidationError('interest_earned_vnd must be a non-negative number')
       cleanInterestEarned = Math.round(n)
+    }
+    if (fulfill_recurring != null) {
+      cleanFulfillSavingId = validateUUID(fulfill_recurring.saving_id, 'fulfill_recurring.saving_id')
+      if (typeof fulfill_recurring.ym !== 'string' || !/^\d{4}-\d{2}$/.test(fulfill_recurring.ym)) {
+        throw new ValidationError('fulfill_recurring.ym must be a YYYY-MM month')
+      }
+      cleanFulfillYm = fulfill_recurring.ym
+      const a = Number(fulfill_recurring.amount ?? 0)
+      if (!Number.isFinite(a) || a < 0) throw new ValidationError('fulfill_recurring.amount must be a non-negative number')
+      cleanFulfillAmount = Math.round(a)
     }
   } catch (e) {
     if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
@@ -100,6 +116,12 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       p_expiry_date: cleanExpiry,
       p_investment_date: cleanInvestmentDate,
       p_interest_earned_vnd: cleanInterestEarned,
+      // Combine flow: fold this month's recurring saving in atomically (NULL for
+      // a plain renewal — the RPC's params default to NULL).
+      p_fulfill_saving_id: cleanFulfillSavingId,
+      p_fulfill_ym: cleanFulfillYm,
+      p_fulfill_amount: cleanFulfillAmount,
+      p_fulfill_source: cleanFulfillSavingId ? 'maturity-combine' : null,
     })
     .single()
   if (renewErr || !renewed) {

--- a/app/api/v1/recurring-savings/route.ts
+++ b/app/api/v1/recurring-savings/route.ts
@@ -31,6 +31,23 @@ export async function GET(request: NextRequest) {
 
   const { data: savings, error } = await query
   if (error) return NextResponse.json({ error: 'Failed to fetch recurring savings' }, { status: 500 })
+
+  // When a specific month is requested, flag the ones already settled for it via
+  // a maturity-combine renewal — the maturity "combine" picker uses this to avoid
+  // offering (and double-folding) a recurring that's already been folded in.
+  if (month && year && savings && savings.length > 0) {
+    const ym = `${year}-${String(month).padStart(2, '0')}`
+    const { data: fulfilled } = await supabase
+      .from('recurring_saving_fulfillments')
+      .select('recurring_saving_id')
+      .eq('user_id', user.id)
+      .eq('ym', ym)
+    const fulfilledSet = new Set((fulfilled ?? []).map((f) => f.recurring_saving_id))
+    return NextResponse.json({
+      savings: savings.map((s) => ({ ...s, fulfilled: fulfilledSet.has(s.saving_id) })),
+    })
+  }
+
   return NextResponse.json({ savings })
 }
 

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -1070,6 +1070,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
         <MaturityResolveSheet
           open={!!resolveDep}
           inv={resolveDep?.inv ?? null}
+          goalId={resolveDep?.goalId ?? null}
           isVi={isVi}
           onClose={() => setResolveDep(null)}
           onRenewed={() => { setResolveDep(null); fetchData({ force: true }) }}
@@ -1079,6 +1080,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
       {isDesktop && resolveDep && (
         <MaturityResolveModal
           inv={resolveDep.inv}
+          goalId={resolveDep.goalId ?? null}
           isVi={isVi}
           onClose={() => setResolveDep(null)}
           onRenewed={() => { setResolveDep(null); fetchData({ force: true }) }}

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -369,8 +369,10 @@ export function MaturityResolveBody({
       {/* Combine — settle & re-deposit, folding in this month's recurring saving */}
       {mode === 'combine' && (
         <div data-testid="maturity-combine" style={{ display: 'grid', gap: 12 }}>
-          {/* Which recurring to merge — shown when more than one is foldable */}
-          {combineLink && combineLink.candidates.length > 1 && (
+          {/* Which recurring to merge — shown when more than one is foldable, or
+              when the match is ambiguous (so a loose single match stays opt-in,
+              never auto-folded). */}
+          {combineLink && (combineLink.candidates.length > 1 || combineLink.ambiguous) && (
             <div>
               <div style={fieldLabel}>{t.whichRecurring}</div>
               <div style={{ display: 'grid', gap: 7 }}>

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -17,7 +17,7 @@
 // (the parent wires `onWithdraw`).
 
 import { useState, useEffect } from 'react'
-import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X } from 'lucide-react'
+import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X, Plus, Wallet } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import { fmtMaturity, type InvRow } from './goalDetailShared'
 import {
@@ -27,9 +27,10 @@ import {
   renewalPrincipal,
   type RenewMode,
 } from '@/lib/maturity'
+import { linkedSavingFor, type RecurringLinkCandidate, type RecurringLinkResult } from '@/lib/recurringLink'
 import { todayIso } from '@/lib/dates'
 
-type Mode = RenewMode | 'withdraw'
+type Mode = RenewMode | 'withdraw' | 'combine'
 
 const fieldLabel: React.CSSProperties = {
   fontSize: 11, fontWeight: 600, letterSpacing: '0.05em',
@@ -61,9 +62,12 @@ function MoneyField({ label, value, onChange, testId }: { label: string; value: 
  * parent's existing Sell/Withdraw flow.
  */
 export function MaturityResolveBody({
-  inv, isVi, onClose, onRenewed, onWithdraw,
+  inv, goalId, isVi, onClose, onRenewed, onWithdraw,
 }: {
   inv: InvRow
+  // The goal this deposit is assigned to (null = unallocated). Used to find the
+  // recurring saving that can be folded into the re-deposit (combine flow).
+  goalId?: string | null
   isVi: boolean
   onClose: () => void
   onRenewed: () => void
@@ -92,14 +96,65 @@ export function MaturityResolveBody({
   const [error, setError] = useState('')
   const [done, setDone] = useState<null | { newPrincipal: number; newMaturity: string }>(null)
 
+  // ── Combine ("settle & re-deposit", merge recurring) ────────────────────────
+  // A recurring bank saving due for this goal this month can be folded into the
+  // re-deposit. We fetch the goal's active recurring savings on open and match
+  // one (linkedSavingFor); if found, the combine option appears (pre-selected).
+  const fulfillYm = todayIso().slice(0, 7)
+  const [combineLink, setCombineLink] = useState<RecurringLinkResult | null>(null)
+  const [pickedSavingId, setPickedSavingId] = useState<string | null>(null)
+  const [redeposit, setRedeposit] = useState(String(principal))
+  const [redepositTouched, setRedepositTouched] = useState(false)
+  const [markFulfilled, setMarkFulfilled] = useState(true)
+
+  useEffect(() => {
+    // Combine needs the deposit's goal scope. When the caller doesn't wire it
+    // (goalId omitted), stay in plain renew-only mode and skip the lookup.
+    if (goalId === undefined) return
+    let cancelled = false
+    const [y, mo] = fulfillYm.split('-')
+    fetch(`/api/v1/recurring-savings?month=${Number(mo)}&year=${y}`)
+      .then((r) => (r.ok ? r.json() : { savings: [] }))
+      .then((data: { savings?: Array<{ saving_id: string; name: string; goal_id: string | null; amount_vnd: number; fulfilled?: boolean }> }) => {
+        if (cancelled) return
+        const candidates: RecurringLinkCandidate[] = (data.savings ?? [])
+          .filter((s) => (s.goal_id ?? null) === (goalId ?? null))
+          .map((s) => ({ saving_id: s.saving_id, name: s.name, amount_vnd: s.amount_vnd, fulfilled: !!s.fulfilled }))
+        const link = linkedSavingFor(inv.name, candidates)
+        if (!link) return
+        setCombineLink(link)
+        setPickedSavingId(link.match?.saving_id ?? null)
+        setMode('combine')
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  // The candidate currently chosen to fold in (explicit pick, else the match).
+  const pickedCand: RecurringLinkCandidate | null = combineLink
+    ? (pickedSavingId ? combineLink.candidates.find((c) => c.saving_id === pickedSavingId) ?? null : combineLink.match)
+    : null
+  const linkedAmt = pickedCand ? pickedCand.amount_vnd : 0
+  const canCombine = !!combineLink
+
   const iNum = Number(interest) || 0
   const tNum = Number(term) || 0
   // Pass null (not 0) for an empty "new amount" so renewalPrincipal can fall
   // back to the current principal rather than writing 0₫ to the deposit.
   const newAmountNum = newAmount.trim() === '' ? null : Number(newAmount)
+  const redepositNum = redeposit.trim() === '' ? 0 : Number(redeposit)
   const newPrincipal = mode === 'withdraw'
     ? principal
-    : renewalPrincipal(mode, principal, iNum, newAmountNum)
+    : mode === 'combine'
+      ? redepositNum
+      : renewalPrincipal(mode, principal, iNum, newAmountNum)
+
+  // Suggested re-deposit = principal + interest + this month's recurring, until
+  // the user edits it (their bank's actual figure may differ).
+  useEffect(() => {
+    if (!redepositTouched) setRedeposit(String(principal + iNum + linkedAmt))
+  }, [principal, iNum, linkedAmt, redepositTouched])
   // The new cycle is anchored to the OLD maturity date (the closed cycle's end),
   // not today — so an overdue book's next maturity is old-maturity + term, and
   // its accrual restarts from old maturity without skipping the overdue days.
@@ -137,6 +192,17 @@ export function MaturityResolveBody({
     totalPayout: 'Tổng nhận về',
     cancel: 'Hủy', confirmRenew: 'Xác nhận tái tục', confirmWithdraw: 'Đánh dấu chờ rút',
     renewed: 'Đã tái tục', renewedSub: (p: string, d: string) => `Kỳ mới ${p} · đáo hạn ${d}`,
+    combineLabel: 'Tất toán & gửi lại (gộp định kỳ)',
+    combineSubPick: 'Chọn khoản định kỳ để gộp',
+    combineSub: (amt: string) => `Cộng ${amt} định kỳ tháng này rồi gửi lại`,
+    whichRecurring: 'Gộp kèm khoản định kỳ nào?',
+    pickHint: 'Chọn một khoản để gộp, hoặc bỏ trống để chỉ tái tục gốc + lãi.',
+    toAccount: 'Về tài khoản thường', principalOut: 'Gốc tất toán',
+    recurringThisMonth: 'Gửi định kỳ tháng này',
+    redepositAmount: 'Số tiền gửi lại',
+    redepositHint: (amt: string) => `Gợi ý ${amt} (gốc + lãi + định kỳ) — sửa nếu thực tế khác.`,
+    markDeposited: (amt: string) => `Đánh dấu đã gửi định kỳ tháng này (${amt})`,
+    confirmCombine: 'Lưu sổ mới',
   } : {
     summarySuffix: 'yr', perYr: 'yr', mo: 'mo',
     why: matured
@@ -154,9 +220,24 @@ export function MaturityResolveBody({
     totalPayout: 'Total payout',
     cancel: 'Cancel', confirmRenew: 'Confirm renewal', confirmWithdraw: 'Mark for withdrawal',
     renewed: 'Deposit renewed', renewedSub: (p: string, d: string) => `New term ${p} · matures ${d}`,
+    combineLabel: 'Settle & re-deposit (merge recurring)',
+    combineSubPick: 'Pick a recurring to merge',
+    combineSub: (amt: string) => `Add ${amt} recurring, then re-deposit`,
+    whichRecurring: 'Which recurring to merge?',
+    pickHint: 'Pick one to merge, or leave none to renew principal + interest only.',
+    toAccount: 'To your account', principalOut: 'Principal out',
+    recurringThisMonth: 'Recurring this month',
+    redepositAmount: 'Re-deposit amount',
+    redepositHint: (amt: string) => `Suggested ${amt} (principal + interest + recurring) — edit if reality differs.`,
+    markDeposited: (amt: string) => `Mark this month's recurring as deposited (${amt})`,
+    confirmCombine: 'Save new deposit',
   }
 
   const POLICIES: { id: Mode; icon: React.ReactNode; label: string; sub: string; danger?: boolean }[] = [
+    ...(canCombine ? [{
+      id: 'combine' as Mode, icon: <Plus size={16} />, label: t.combineLabel,
+      sub: combineLink?.ambiguous && !pickedCand ? t.combineSubPick : t.combineSub(fmtCompact(linkedAmt)),
+    }] : []),
     { id: 'principal_interest', icon: <RefreshCw size={16} />, label: isVi ? 'Tái tục gốc + lãi' : 'Renew principal + interest', sub: isVi ? 'Cộng lãi vào gốc cho kỳ mới' : 'Roll interest into the new principal' },
     { id: 'principal_only', icon: <RefreshCw size={16} />, label: isVi ? 'Tái tục chỉ gốc' : 'Renew principal only', sub: isVi ? 'Lãi chuyển ra ngoài (về ví)' : 'Interest paid out to your wallet' },
     { id: 'change', icon: <Pencil size={16} />, label: isVi ? 'Đổi số tiền / kỳ hạn' : 'Change amount / term', sub: isVi ? 'Điều chỉnh gốc hoặc kỳ hạn kỳ mới' : 'Adjust principal or term for the new cycle' },
@@ -185,6 +266,12 @@ export function MaturityResolveBody({
           // Realized interest for the cycle that just closed — recorded
           // permanently on the snapshot for the renewal-history summary.
           interest_earned_vnd: iNum,
+          // Combine flow: mark this month's recurring saving fulfilled inside the
+          // same transaction, so its amount (now folded into the principal above)
+          // is not also counted as a separate synthesized contribution.
+          fulfill_recurring: mode === 'combine' && pickedCand && markFulfilled
+            ? { saving_id: pickedCand.saving_id, ym: fulfillYm, amount: linkedAmt }
+            : undefined,
         }),
       })
       if (!res.ok) {
@@ -279,8 +366,128 @@ export function MaturityResolveBody({
         </div>
       </div>
 
+      {/* Combine — settle & re-deposit, folding in this month's recurring saving */}
+      {mode === 'combine' && (
+        <div data-testid="maturity-combine" style={{ display: 'grid', gap: 12 }}>
+          {/* Which recurring to merge — shown when more than one is foldable */}
+          {combineLink && combineLink.candidates.length > 1 && (
+            <div>
+              <div style={fieldLabel}>{t.whichRecurring}</div>
+              <div style={{ display: 'grid', gap: 7 }}>
+                {combineLink.candidates.map((c) => {
+                  const sel = pickedCand?.saving_id === c.saving_id
+                  return (
+                    <button key={c.saving_id} type="button" onClick={() => setPickedSavingId(sel ? null : c.saving_id)}
+                      style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '10px 12px', borderRadius: 10, cursor: 'pointer', textAlign: 'left',
+                        border: `1.5px solid ${sel ? 'var(--c-navy)' : 'var(--c-line)'}`, background: sel ? 'var(--c-navy-tint)' : 'var(--c-card)', fontFamily: 'inherit' }}>
+                      {/* --c-btn-primary (not --c-navy) so the white check stays legible in dark mode — issue #264 */}
+                      <span style={{ width: 18, height: 18, borderRadius: 9, flexShrink: 0, border: `1.5px solid ${sel ? 'var(--c-btn-primary)' : 'var(--c-line-strong)'}`, background: sel ? 'var(--c-btn-primary)' : 'transparent', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                        {sel && <Check size={11} color="#fff" strokeWidth={3} />}
+                      </span>
+                      <span style={{ flex: 1, minWidth: 0, fontSize: 13, fontWeight: 600 }}>{c.name}</span>
+                      <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(c.amount_vnd)}</span>
+                    </button>
+                  )
+                })}
+              </div>
+              {!pickedCand && <p style={{ margin: '7px 2px 0', fontSize: 11, color: 'var(--c-warn)', lineHeight: 1.45 }}>{t.pickHint}</p>}
+            </div>
+          )}
+
+          <MoneyField label={t.interestReceived} value={interest} onChange={setInterest} />
+
+          {/* Cash-flow recap — what lands in the account before re-depositing */}
+          <div style={{ border: '1px solid var(--c-line)', borderRadius: 12, overflow: 'hidden' }}>
+            <div style={{ padding: '8px 13px', background: 'var(--c-card-2)', display: 'flex', alignItems: 'center', gap: 7 }}>
+              <Wallet size={14} color="var(--c-muted)" />
+              <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--c-muted)' }}>{t.toAccount}</span>
+            </div>
+            <div style={{ padding: '10px 13px', display: 'grid', gap: 7 }}>
+              {[
+                { l: t.principalOut, v: principal, plus: false },
+                { l: t.interestReceived, v: iNum, plus: true },
+                { l: t.recurringThisMonth, v: linkedAmt, plus: true },
+              ].map((r, i) => (
+                <div key={i} style={{ display: 'flex', justifyContent: 'space-between', fontSize: 12.5 }}>
+                  <span style={{ color: 'var(--c-muted)' }}>{r.l}</span>
+                  <span style={{ fontWeight: 600, color: r.plus ? 'var(--c-pos)' : 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{r.plus ? '+' : ''}{fmt(r.v)}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Re-deposit amount (suggested = principal + interest + recurring) */}
+          <div>
+            <div style={fieldLabel}>{t.redepositAmount}</div>
+            <div style={{ position: 'relative' }}>
+              <input data-testid="maturity-redeposit" type="number" value={redeposit}
+                onChange={(e) => { setRedeposit(e.target.value); setRedepositTouched(true) }}
+                style={{ ...moneyInput, borderColor: 'var(--c-navy)' }} />
+              <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
+            </div>
+            <p style={{ margin: '7px 2px 0', fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.45 }}>{t.redepositHint(fmtCompact(principal + iNum + linkedAmt))}</p>
+          </div>
+
+          {/* New term + rate */}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+            <div>
+              <div style={fieldLabel}>{t.newTerm}</div>
+              <div style={{ position: 'relative' }}>
+                <input type="number" value={term} onChange={(e) => setTerm(e.target.value)} style={moneyInput} />
+                <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>{t.mo}</span>
+              </div>
+            </div>
+            <div>
+              <div style={fieldLabel}>{t.newRate}</div>
+              <div style={{ position: 'relative' }}>
+                <input type="number" step="0.1" value={rate} onChange={(e) => setRate(e.target.value)} style={moneyInput} />
+                <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>%/{t.perYr}</span>
+              </div>
+            </div>
+          </div>
+
+          {/* New maturity date — same anchor (old maturity + term) as a renewal */}
+          <div>
+            <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 6 }}>
+              <span style={{ ...fieldLabel, marginBottom: 0 }}>{t.newMaturityLabel}</span>
+              {dateTouched && (
+                <button type="button" onClick={() => setMaturityOverride(null)}
+                  style={{ fontSize: 11, fontWeight: 600, color: 'var(--c-navy)', background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'inherit', padding: 0 }}>
+                  {t.resetDate}
+                </button>
+              )}
+            </div>
+            <input type="date" value={newMaturity} min={baseDate} onChange={(e) => setMaturityOverride(e.target.value)} style={moneyInput} />
+            {!maturityValid && <p style={{ margin: '6px 0 0', fontSize: 11, color: 'var(--c-neg)', lineHeight: 1.4 }}>{t.maturityTooEarly}</p>}
+          </div>
+
+          {/* Mark this month's recurring as deposited (prevents double-count) */}
+          {linkedAmt > 0 && pickedCand && (
+            <label style={{ display: 'flex', alignItems: 'center', gap: 9, padding: '10px 12px', background: 'var(--c-pos-tint)', borderRadius: 10, fontSize: 12.5, color: 'var(--c-ink)', lineHeight: 1.4, cursor: 'pointer' }}>
+              <input data-testid="maturity-mark-fulfilled" type="checkbox" checked={markFulfilled} onChange={(e) => setMarkFulfilled(e.target.checked)} style={{ accentColor: 'var(--c-pos)', width: 16, height: 16, flexShrink: 0 }} />
+              <span>{t.markDeposited(fmtCompact(linkedAmt))}</span>
+            </label>
+          )}
+
+          {/* Preview */}
+          <div style={{ border: '1px solid var(--c-line)', borderRadius: 12, overflow: 'hidden' }}>
+            <div style={{ padding: '10px 14px', background: 'var(--c-navy-tint)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--c-navy)' }}>{t.newCycle}</span>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span data-testid="maturity-new-principal" style={{ fontSize: 16, fontWeight: 700, color: 'var(--c-navy)', fontVariantNumeric: 'tabular-nums' }}>{fmt(newPrincipal)}</span>
+                {rate !== '' && <span style={{ fontSize: 11, fontWeight: 600, padding: '2px 8px', borderRadius: 999, background: 'var(--c-card)', color: 'var(--c-navy)' }}>{rate}%/{t.perYr}</span>}
+              </span>
+            </div>
+            <div style={{ background: 'var(--c-card)', padding: '9px 12px' }}>
+              <div style={{ fontSize: 10, color: 'var(--c-muted)' }}>{t.newMaturityLabel}</div>
+              <div data-testid="maturity-new-date" style={{ fontSize: 13, fontWeight: 600, marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>{newMaturityFmt}</div>
+            </div>
+          </div>
+        </div>
+      )}
+
       {/* Inputs per mode */}
-      {mode !== 'withdraw' && (
+      {mode !== 'withdraw' && mode !== 'combine' && (
         <div style={{ display: 'grid', gap: 12 }}>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
             {mode === 'change'
@@ -379,8 +586,8 @@ export function MaturityResolveBody({
           background: mode === 'withdraw' ? 'var(--c-neg)' : 'var(--c-btn-primary)',
           display: 'flex', alignItems: 'center',
         }}>
-          {mode === 'withdraw' ? <ArrowDownToLine size={14} strokeWidth={2.2} /> : <RefreshCw size={14} strokeWidth={2.2} />}
-          {mode === 'withdraw' ? t.confirmWithdraw : t.confirmRenew}
+          {mode === 'withdraw' ? <ArrowDownToLine size={14} strokeWidth={2.2} /> : mode === 'combine' ? <Plus size={14} strokeWidth={2.2} /> : <RefreshCw size={14} strokeWidth={2.2} />}
+          {mode === 'withdraw' ? t.confirmWithdraw : mode === 'combine' ? t.confirmCombine : t.confirmRenew}
         </button>
       </div>
     </div>
@@ -389,10 +596,11 @@ export function MaturityResolveBody({
 
 // ─── Mobile bottom-sheet wrapper ───────────────────────────────────────────
 export function MaturityResolveSheet({
-  open, inv, isVi, onClose, onRenewed, onWithdraw,
+  open, inv, goalId, isVi, onClose, onRenewed, onWithdraw,
 }: {
   open: boolean
   inv: InvRow | null
+  goalId?: string | null
   isVi: boolean
   onClose: () => void
   onRenewed: () => void
@@ -425,7 +633,7 @@ export function MaturityResolveSheet({
           <h2 style={{ margin: '0 0 14px', fontSize: 17, fontWeight: 700, letterSpacing: '-0.01em' }}>
             {isVi ? 'Xử lý đáo hạn' : 'Handle maturity'}
           </h2>
-          <MaturityResolveBody inv={inv} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />
+          <MaturityResolveBody inv={inv} goalId={goalId} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />
         </div>
       </div>
     </div>
@@ -434,9 +642,10 @@ export function MaturityResolveSheet({
 
 // ─── Desktop modal wrapper ─────────────────────────────────────────────────
 export function MaturityResolveModal({
-  inv, isVi, onClose, onRenewed, onWithdraw,
+  inv, goalId, isVi, onClose, onRenewed, onWithdraw,
 }: {
   inv: InvRow
+  goalId?: string | null
   isVi: boolean
   onClose: () => void
   onRenewed: () => void
@@ -468,7 +677,7 @@ export function MaturityResolveModal({
           <button onClick={onClose} className="cn-btn ghost" style={{ padding: 6 }} aria-label="Close"><X size={18} /></button>
         </div>
         <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto' }}>
-          <MaturityResolveBody inv={inv} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />
+          <MaturityResolveBody inv={inv} goalId={goalId} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />
         </div>
       </div>
     </div>

--- a/e2e/maturity-combine.spec.ts
+++ b/e2e/maturity-combine.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect, type Page } from '@playwright/test'
+import * as api from './helpers/api'
+
+// Term-deposit maturity "combine" flow (Tất toán & gửi lại / settle & re-deposit,
+// merging this month's recurring saving). The correctness risk is a DOUBLE-COUNT:
+// the recurring amount gets folded into the (larger) re-deposit principal, so if
+// the synthesized recurring contribution isn't also suppressed it is counted
+// twice — once in the deposit, once on its own. This closes the loop: combine
+// from the UI, then assert the goal's progress value (what the bar renders) moved
+// by ~interest only, NOT by the extra recurring amount.
+
+const iso = (d: number) => new Date(Date.now() + d * 86_400_000).toISOString().slice(0, 10)
+
+async function gotoFreshDashboard(page: Page) {
+  await page.goto('/settings') // unmount DashboardClient
+  await page.evaluate(() => {
+    Object.keys(localStorage).filter((k) => k.startsWith('dashboardOverviewCache')).forEach((k) => localStorage.removeItem(k))
+  })
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/v1/dashboard/overview') && r.status() === 200, { timeout: 20_000 }),
+    page.goto('/dashboard'),
+  ])
+}
+
+// Read the goal's progress value straight from the overview API (no client cache).
+async function goalProgressValue(page: Page, goalId: string): Promise<number> {
+  const res = await page.request.get('/api/v1/dashboard/overview')
+  expect(res.ok()).toBeTruthy()
+  const json = await res.json()
+  const g = (json.goals ?? []).find((x: { goalId: string }) => x.goalId === goalId)
+  return g?.progressValue ?? 0
+}
+
+test.describe('Term-deposit maturity — combine (merge recurring into re-deposit)', () => {
+  test('folding this month\'s recurring into the re-deposit does not double-count it', async ({ page }) => {
+    test.slow()
+    const now = new Date()
+    const RECURRING = 2_000_000
+    const goal = await api.createGoal({ goal_name: 'E2E Combine Goal', target_amount: 100_000_000 })
+    // A realized plan for the current month makes the recurring saving count.
+    const plan = await api.createMonthlyPlan({ month: now.getMonth() + 1, year: now.getFullYear(), salary_vnd: 30_000_000 })
+    const deposit = await api.createTransaction({
+      asset_type: 'bank',
+      amount_vnd: 12_000_000,
+      investment_date: iso(-400),
+      interest_rate: 6,
+      expiry_date: iso(-10), // matured
+      goal_id: goal.goal_id,
+      notes: 'E2E Combine Deposit',
+    })
+    // Same name as the deposit → linkedSavingFor resolves it confidently.
+    const saving = await api.createRecurringSaving({
+      name: 'E2E Combine Deposit',
+      goal_id: goal.goal_id,
+      amount_vnd: RECURRING,
+    })
+    try {
+      await gotoFreshDashboard(page)
+      // Before: deposit (≈12.7M w/ interest) + the synthesized recurring (2M).
+      const before = await goalProgressValue(page, goal.goal_id)
+
+      // Open the resolve modal from the Needs attention card.
+      const card = page.getByTestId('maturity-action-card')
+      await expect(card).toBeVisible({ timeout: 10_000 })
+      await card.getByRole('button', { name: /Handle|Xử lý/i }).first().click()
+
+      // Combine is offered (a recurring is due this month) and pre-selected; its
+      // inputs (cash-flow recap + re-deposit) are visible.
+      await expect(page.getByTestId('maturity-combine')).toBeVisible({ timeout: 10_000 })
+
+      // Confirm with defaults: interest pre-filled, re-deposit = principal +
+      // interest + recurring, recurring marked deposited.
+      await page.getByRole('button', { name: /Save new deposit|Lưu sổ mới/i }).click()
+      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+
+      // After: the recurring now lives inside the deposit principal and is
+      // suppressed as a standalone contribution — progress must NOT have jumped by
+      // the full recurring amount on top of the folded-in deposit.
+      const after = await goalProgressValue(page, goal.goal_id)
+      expect(after).toBeLessThan(before + RECURRING / 2)
+    } finally {
+      await api.deleteRecurringSaving(saving.saving_id) // cascades the fulfillment row
+      await api.deleteTransactionCascade(deposit.transaction_id)
+      await api.deleteMonthlyPlan(plan.id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+})

--- a/lib/__tests__/recurringLink.test.ts
+++ b/lib/__tests__/recurringLink.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest'
+import { linkedSavingFor, type RecurringLinkCandidate } from '../recurringLink'
+
+const cand = (over: Partial<RecurringLinkCandidate> = {}): RecurringLinkCandidate => ({
+  saving_id: 's1',
+  name: 'MB Term 6M',
+  amount_vnd: 2_000_000,
+  fulfilled: false,
+  linkedDepositKey: null,
+  ...over,
+})
+
+describe('linkedSavingFor', () => {
+  it('returns null when there are no candidates', () => {
+    expect(linkedSavingFor('MB Term 6M', [], null)).toBeNull()
+  })
+
+  it('returns null when every candidate is already fulfilled this month', () => {
+    expect(linkedSavingFor('MB Term 6M', [cand({ fulfilled: true })], null)).toBeNull()
+  })
+
+  it('1. explicit link wins outright even amid other candidates', () => {
+    const res = linkedSavingFor(
+      'Whatever',
+      [
+        cand({ saving_id: 's1', name: 'ACB' }),
+        cand({ saving_id: 's2', name: 'MB', linkedDepositKey: 'dep-key' }),
+      ],
+      'dep-key',
+    )
+    expect(res?.reason).toBe('explicit')
+    expect(res?.ambiguous).toBe(false)
+    expect(res?.match?.saving_id).toBe('s2')
+  })
+
+  it('2. a single normalized name match wins', () => {
+    const res = linkedSavingFor(
+      'MB Term 6M',
+      [cand({ saving_id: 's1', name: 'mb term 6m' }), cand({ saving_id: 's2', name: 'ACB Savings' })],
+      null,
+    )
+    expect(res?.reason).toBe('name')
+    expect(res?.match?.saving_id).toBe('s1')
+  })
+
+  it('3. a sole candidate is matched when no name signal conflicts', () => {
+    const res = linkedSavingFor('Totally different', [cand({ saving_id: 's1', name: 'VCB' })], null)
+    expect(res?.reason).toBe('sole')
+    expect(res?.match?.saving_id).toBe('s1')
+  })
+
+  it('is ambiguous with two non-matching candidates and no link', () => {
+    const res = linkedSavingFor(
+      'Nope',
+      [cand({ saving_id: 's1', name: 'VCB' }), cand({ saving_id: 's2', name: 'ACB' })],
+      null,
+    )
+    expect(res?.ambiguous).toBe(true)
+    expect(res?.match).toBeNull()
+    expect(res?.candidates.map((c) => c.saving_id)).toEqual(['s1', 's2'])
+  })
+
+  it('is ambiguous when two candidates both name-match — shortlist is the matches', () => {
+    const res = linkedSavingFor(
+      'MB Term',
+      [
+        cand({ saving_id: 's1', name: 'MB Term 6M' }),
+        cand({ saving_id: 's2', name: 'MB Term 12M' }),
+        cand({ saving_id: 's3', name: 'ACB Savings' }),
+      ],
+      null,
+    )
+    expect(res?.ambiguous).toBe(true)
+    expect(res?.candidates.map((c) => c.saving_id)).toEqual(['s1', 's2'])
+  })
+
+  it('ignores fulfilled candidates when forming the pool', () => {
+    const res = linkedSavingFor(
+      'Anything',
+      [cand({ saving_id: 's1', name: 'VCB', fulfilled: true }), cand({ saving_id: 's2', name: 'ACB' })],
+      null,
+    )
+    // s1 drops out → s2 becomes the sole candidate.
+    expect(res?.reason).toBe('sole')
+    expect(res?.match?.saving_id).toBe('s2')
+  })
+})

--- a/lib/__tests__/recurringLink.test.ts
+++ b/lib/__tests__/recurringLink.test.ts
@@ -33,7 +33,7 @@ describe('linkedSavingFor', () => {
     expect(res?.match?.saving_id).toBe('s2')
   })
 
-  it('2. a single normalized name match wins', () => {
+  it('2. a single EXACT normalized name match wins', () => {
     const res = linkedSavingFor(
       'MB Term 6M',
       [cand({ saving_id: 's1', name: 'mb term 6m' }), cand({ saving_id: 's2', name: 'ACB Savings' })],
@@ -41,6 +41,30 @@ describe('linkedSavingFor', () => {
     )
     expect(res?.reason).toBe('name')
     expect(res?.match?.saving_id).toBe('s1')
+  })
+
+  it('does NOT auto-fold on a loose substring match — a short name stays ambiguous', () => {
+    // "So" must not silently grab "Social Fund" when another candidate exists.
+    const res = linkedSavingFor(
+      'So',
+      [cand({ saving_id: 's1', name: 'Social Fund' }), cand({ saving_id: 's2', name: 'ACB' })],
+      null,
+    )
+    expect(res?.ambiguous).toBe(true)
+    expect(res?.match).toBeNull()
+  })
+
+  it('a single substring (non-exact) match among several is ambiguous, not auto-folded', () => {
+    // "MB Term 6M" recurring substring-matches the deposit, but it is not the
+    // sole candidate, so the user must confirm rather than have it auto-folded.
+    const res = linkedSavingFor(
+      'MB Term 6M Special',
+      [cand({ saving_id: 's1', name: 'MB Term 6M' }), cand({ saving_id: 's2', name: 'ACB' })],
+      null,
+    )
+    expect(res?.ambiguous).toBe(true)
+    expect(res?.match).toBeNull()
+    expect(res?.candidates.map((c) => c.saving_id)).toEqual(['s1']) // shortlist = the substring match
   })
 
   it('3. a sole candidate is matched when no name signal conflicts', () => {

--- a/lib/__tests__/recurringSavings.test.ts
+++ b/lib/__tests__/recurringSavings.test.ts
@@ -101,4 +101,63 @@ describe('realizedRecurringContributions', () => {
     expect(rows[0].savingId).toBe('s1')
     expect(rows[0].planId).toBe('p-may')
   })
+
+  // ── Explicit fulfillments (maturity "combine" flow) ─────────────────────────
+  // When a maturing term deposit is renewed by folding in this month's recurring
+  // saving, the recurring amount becomes part of the (larger) deposit principal —
+  // so the synthesized contribution for that (saving, month) must be suppressed,
+  // exactly like a logged deposit does, but matched by id+month rather than amount
+  // (the combined re-deposit's amount no longer equals the recurring amount).
+  describe('explicit fulfillments', () => {
+    it('suppresses the contribution for a fulfilled (saving, month)', () => {
+      freezeJun2026()
+      const rows = realizedRecurringContributions(
+        [saving()],
+        [plan('p-may', 2026, 5), plan('p-jun', 2026, 6)],
+        [],
+        [],
+        [{ recurring_saving_id: 's1', ym: '2026-06' }],
+      )
+      expect(rows).toHaveLength(1)
+      expect(rows[0].date).toBe('2026-05-01')
+    })
+
+    it('only suppresses the exact month, not other months of the same saving', () => {
+      freezeJun2026()
+      const rows = realizedRecurringContributions(
+        [saving()],
+        [plan('p-may', 2026, 5), plan('p-jun', 2026, 6)],
+        [],
+        [],
+        [{ recurring_saving_id: 's1', ym: '2026-05' }],
+      )
+      expect(rows.map((r) => r.date)).toEqual(['2026-06-01'])
+    })
+
+    it('only suppresses the named saving, not a sibling saving in the same month', () => {
+      freezeJun2026()
+      const rows = realizedRecurringContributions(
+        [saving({ saving_id: 's1' }), saving({ saving_id: 's2', name: 'ACB Savings' })],
+        [plan('p-jun', 2026, 6)],
+        [],
+        [],
+        [{ recurring_saving_id: 's1', ym: '2026-06' }],
+      )
+      expect(rows.map((r) => r.savingId)).toEqual(['s2'])
+    })
+
+    it('does not double-spend a logged deposit when the month is also fulfilled', () => {
+      freezeJun2026()
+      // Fulfillment alone suppresses; the logged-deposit pool is left intact for
+      // any genuinely-separate deposit and not consumed by the fulfilled month.
+      const rows = realizedRecurringContributions(
+        [saving()],
+        [plan('p-jun', 2026, 6)],
+        [],
+        [{ month: '2026-06', goalId: 'g1', amount: 5_000_000 }],
+        [{ recurring_saving_id: 's1', ym: '2026-06' }],
+      )
+      expect(rows).toHaveLength(0)
+    })
+  })
 })

--- a/lib/finance.ts
+++ b/lib/finance.ts
@@ -150,12 +150,28 @@ export interface LoggedRecurringDeposit {
   amount: number
 }
 
+// A recurring saving explicitly marked as fulfilled for a given month — recorded
+// when a maturing term deposit is renewed by folding this month's recurring
+// saving into the (now larger) re-deposit. Unlike a logged deposit it is matched
+// by saving id + month, not amount, because the combined re-deposit's amount no
+// longer equals the recurring amount. Suppresses the synthesized contribution so
+// the folded-in amount is not counted twice (once in the deposit, once here).
+export interface RecurringFulfillmentRow {
+  recurring_saving_id: string
+  ym: string // 'YYYY-MM'
+}
+
 export function realizedRecurringContributions(
   savings: RecurringSavingDef[],
   plans: RecurringPlanMonth[],
   overrides: RecurringSavingOverrideRow[],
   loggedDeposits: LoggedRecurringDeposit[] = [],
+  fulfillments: RecurringFulfillmentRow[] = [],
 ): RealizedRecurringContribution[] {
+  // (saving, month) pairs already settled via a maturity-combine renewal.
+  const fulfilledSet = new Set<string>()
+  for (const f of fulfillments) fulfilledSet.add(`${f.recurring_saving_id}::${f.ym}`)
+
   const ovMap = new Map<string, number>()
   for (const o of overrides) {
     ovMap.set(`${o.plan_id}::${o.recurring_saving_id}`, o.monthly_amount_override_vnd)
@@ -181,6 +197,10 @@ export function realizedRecurringContributions(
       // override 0 = skip this month; any other positive override replaces the base.
       const amount = ov === 0 ? 0 : ov != null ? ov : s.amount_vnd
       if (amount <= 0) continue
+      // Explicitly fulfilled this month (folded into a renewed term deposit) —
+      // the amount already lives in that deposit's principal, so skip the
+      // synthesized duplicate without consuming a logged deposit.
+      if (fulfilledSet.has(`${s.saving_id}::${ym}`)) continue
       // A logged deposit for the same month + goal + amount already represents
       // this contribution — consume it and skip the synthesized duplicate.
       const k = `${ym}::${s.goal_id ?? ''}::${amount}`

--- a/lib/recurringLink.ts
+++ b/lib/recurringLink.ts
@@ -11,11 +11,15 @@
 //
 // Matching law (in priority order):
 //   1. EXPLICIT — a candidate whose linkedDepositKey === the deposit's key.
-//   2. NAME     — exactly one candidate whose name normalizes-equals / contains
-//                 (either direction) the deposit's name.
-//   3. SOLE     — exactly one candidate, with no conflicting name signal.
+//   2. NAME     — exactly one candidate whose name NORMALIZES-EQUALS the deposit's
+//                 name. Only an exact (whitespace/case-insensitive) match is
+//                 strong enough to auto-fold: a loose substring match would let a
+//                 short deposit name silently grab an unrelated longer recurring
+//                 (e.g. "So" → "Social Fund"). Substring is used only to order the
+//                 ambiguous shortlist below — it never auto-selects.
+//   3. SOLE     — exactly one candidate, with no exact-name tie.
 //   • Otherwise AMBIGUOUS — match is null; candidates is the shortlist to choose
-//     from (the name matches when there is more than one, else all candidates).
+//     from (exact ties, else substring matches, else all candidates).
 
 export interface RecurringLinkCandidate {
   saving_id: string
@@ -51,22 +55,27 @@ export function linkedSavingFor(
     if (linked) return { match: linked, candidates: pool, ambiguous: false, reason: 'explicit' }
   }
 
-  // 2. Name match within the goal (two-way, whitespace/case-insensitive).
+  // 2. Exact normalized name match — the only name signal strong enough to
+  //    auto-fold (a loose substring match must not silently pick the wrong one).
   const b = norm(depositName)
-  const nameMatches = b
-    ? pool.filter((c) => {
-        const a = norm(c.name)
-        return a === b || a.includes(b) || b.includes(a)
-      })
-    : []
-  if (nameMatches.length === 1) return { match: nameMatches[0], candidates: pool, ambiguous: false, reason: 'name' }
+  const exactMatches = b ? pool.filter((c) => norm(c.name) === b) : []
+  if (exactMatches.length === 1) return { match: exactMatches[0], candidates: pool, ambiguous: false, reason: 'name' }
 
-  // 3. Sole candidate, with no conflicting name signal.
-  if (pool.length === 1 && nameMatches.length !== 1) {
+  // 3. Sole candidate, with no exact-name tie.
+  if (pool.length === 1 && exactMatches.length === 0) {
     return { match: pool[0], candidates: pool, ambiguous: false, reason: 'sole' }
   }
 
-  // Ambiguous — let the user choose. Prefer the name matches as the shortlist.
-  const shortlist = nameMatches.length > 1 ? nameMatches : pool
+  // Ambiguous — let the user choose; never auto-fold. Shortlist order of
+  // preference: exact ties → substring matches (min length, so a tiny fragment
+  // like "So" doesn't drag in unrelated savings) → the whole pool.
+  const MIN_SUBSTRING = 4
+  const looseMatches = b.length >= MIN_SUBSTRING
+    ? pool.filter((c) => {
+        const a = norm(c.name)
+        return a !== b && a.length >= MIN_SUBSTRING && (a.includes(b) || b.includes(a))
+      })
+    : []
+  const shortlist = exactMatches.length > 1 ? exactMatches : looseMatches.length > 0 ? looseMatches : pool
   return { match: null, candidates: shortlist, ambiguous: true, reason: 'ambiguous' }
 }

--- a/lib/recurringLink.ts
+++ b/lib/recurringLink.ts
@@ -1,0 +1,72 @@
+// Match a maturing term deposit to the recurring bank saving that should be
+// folded into its "settle & re-deposit" (Tất toán & gửi lại) combine flow.
+//
+// The caller passes the candidates already scoped to the deposit's goal and
+// active in the deposit's maturity month (that scoping needs plan/effective
+// logic that lives elsewhere). This function drops any already-fulfilled
+// candidate, then applies the matching law below. It deliberately never guesses
+// when the choice is ambiguous — it hands the candidate list back so the UI can
+// ask the user which saving to fold in (or none), rather than silently folding
+// in the wrong one when a goal funds several recurring savings.
+//
+// Matching law (in priority order):
+//   1. EXPLICIT — a candidate whose linkedDepositKey === the deposit's key.
+//   2. NAME     — exactly one candidate whose name normalizes-equals / contains
+//                 (either direction) the deposit's name.
+//   3. SOLE     — exactly one candidate, with no conflicting name signal.
+//   • Otherwise AMBIGUOUS — match is null; candidates is the shortlist to choose
+//     from (the name matches when there is more than one, else all candidates).
+
+export interface RecurringLinkCandidate {
+  saving_id: string
+  name: string
+  amount_vnd: number
+  fulfilled?: boolean
+  linkedDepositKey?: string | null
+}
+
+export type RecurringLinkReason = 'explicit' | 'name' | 'sole' | 'ambiguous'
+
+export interface RecurringLinkResult {
+  match: RecurringLinkCandidate | null
+  candidates: RecurringLinkCandidate[]
+  ambiguous: boolean
+  reason: RecurringLinkReason
+}
+
+const norm = (s: string | null | undefined) => (s || '').toLowerCase().replace(/\s+/g, '')
+
+export function linkedSavingFor(
+  depositName: string,
+  candidates: RecurringLinkCandidate[],
+  depositKey?: string | null,
+): RecurringLinkResult | null {
+  // Only unfulfilled candidates can still be folded in this month.
+  const pool = candidates.filter((c) => !c.fulfilled)
+  if (pool.length === 0) return null
+
+  // 1. Explicit link wins outright.
+  if (depositKey) {
+    const linked = pool.find((c) => c.linkedDepositKey === depositKey)
+    if (linked) return { match: linked, candidates: pool, ambiguous: false, reason: 'explicit' }
+  }
+
+  // 2. Name match within the goal (two-way, whitespace/case-insensitive).
+  const b = norm(depositName)
+  const nameMatches = b
+    ? pool.filter((c) => {
+        const a = norm(c.name)
+        return a === b || a.includes(b) || b.includes(a)
+      })
+    : []
+  if (nameMatches.length === 1) return { match: nameMatches[0], candidates: pool, ambiguous: false, reason: 'name' }
+
+  // 3. Sole candidate, with no conflicting name signal.
+  if (pool.length === 1 && nameMatches.length !== 1) {
+    return { match: pool[0], candidates: pool, ambiguous: false, reason: 'sole' }
+  }
+
+  // Ambiguous — let the user choose. Prefer the name matches as the shortlist.
+  const shortlist = nameMatches.length > 1 ? nameMatches : pool
+  return { match: null, candidates: shortlist, ambiguous: true, reason: 'ambiguous' }
+}

--- a/supabase/migrations/20260616000001_create_recurring_saving_fulfillments.sql
+++ b/supabase/migrations/20260616000001_create_recurring_saving_fulfillments.sql
@@ -1,0 +1,37 @@
+-- Recurring-saving fulfillments — records that a recurring bank saving was
+-- settled for a specific month by folding it into a maturing term deposit's
+-- "settle & re-deposit" (Tất toán & gửi lại) combine renewal.
+--
+-- Why this exists: a recurring saving is a plan definition, not a logged row.
+-- The dashboard normally suppresses its synthesized contribution when it finds a
+-- logged bank deposit matching (month + goal + amount). But a combine renewal
+-- folds this month's recurring amount INTO the (larger) re-deposit principal, so
+-- the deposit's amount no longer equals the recurring amount and that
+-- amount-based match can't fire. This table is the explicit, id+month match that
+-- tells realizedRecurringContributions to skip the now-folded-in contribution —
+-- the guard against counting that amount twice (once in the deposit, once as a
+-- synthesized recurring row).
+
+CREATE TABLE IF NOT EXISTS recurring_saving_fulfillments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  recurring_saving_id UUID NOT NULL REFERENCES recurring_savings(saving_id) ON DELETE CASCADE,
+  ym TEXT NOT NULL CHECK (ym ~ '^\d{4}-\d{2}$'),
+  amount_vnd BIGINT NOT NULL DEFAULT 0 CHECK (amount_vnd >= 0),
+  source TEXT NOT NULL DEFAULT 'maturity-combine',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- One fulfillment per saving per month — re-combining the same month upserts.
+  UNIQUE (recurring_saving_id, ym)
+);
+
+ALTER TABLE recurring_saving_fulfillments ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "recurring_saving_fulfillments_select" ON recurring_saving_fulfillments
+  FOR SELECT TO authenticated USING (user_id = auth.uid());
+CREATE POLICY "recurring_saving_fulfillments_insert" ON recurring_saving_fulfillments
+  FOR INSERT TO authenticated WITH CHECK (user_id = auth.uid());
+CREATE POLICY "recurring_saving_fulfillments_update" ON recurring_saving_fulfillments
+  FOR UPDATE TO authenticated USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+CREATE POLICY "recurring_saving_fulfillments_delete" ON recurring_saving_fulfillments
+  FOR DELETE TO authenticated USING (user_id = auth.uid());

--- a/supabase/migrations/20260616000002_renew_term_deposit_with_fulfillment.sql
+++ b/supabase/migrations/20260616000002_renew_term_deposit_with_fulfillment.sql
@@ -1,0 +1,139 @@
+-- Extend renew_term_deposit to (optionally) record a recurring-saving
+-- fulfillment in the SAME transaction as the renewal.
+--
+-- The "settle & re-deposit (merge recurring)" combine flow folds this month's
+-- recurring bank saving into the renewed deposit's principal. Two writes must
+-- then happen together-or-not-at-all:
+--   • the deposit rolls forward with the larger (combined) principal, and
+--   • the recurring saving is marked fulfilled for that month.
+-- If only the first landed, the folded-in amount would be counted twice (once in
+-- the deposit principal, once as the still-synthesized recurring contribution) —
+-- the exact double-count this flow exists to prevent. So the fulfillment upsert
+-- joins the three existing coupled writes inside this one atomic function.
+--
+-- The four p_fulfill_* params default NULL, so plain (non-combine) renewals call
+-- this unchanged. CREATE OR REPLACE cannot change a function's signature, so the
+-- old 6-arg overload is dropped first — leaving both would make a 6-named-arg
+-- call ambiguous against this 10-arg version's defaults.
+drop function if exists public.renew_term_deposit(uuid, bigint, numeric, date, date, bigint);
+
+create or replace function public.renew_term_deposit(
+  p_tx_id uuid,
+  p_amount_vnd bigint,
+  p_interest_rate numeric,
+  p_expiry_date date,
+  p_investment_date date,
+  p_interest_earned_vnd bigint,
+  p_fulfill_saving_id uuid default null,
+  p_fulfill_ym text default null,
+  p_fulfill_amount bigint default null,
+  p_fulfill_source text default null
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_old public.investment_transactions;
+  v_snapshot_id uuid;
+  v_renewed public.investment_transactions;
+begin
+  -- Lock + read the active row. RLS restricts this to the caller's own row, so
+  -- a missing row means "not yours / does not exist".
+  select * into v_old
+    from public.investment_transactions
+   where transaction_id = p_tx_id
+   for update;
+  if not found then
+    raise exception 'renew_term_deposit: transaction not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_old.asset_type is distinct from 'bank' then
+    raise exception 'renew_term_deposit: only bank term deposits can be renewed'
+      using errcode = 'check_violation';
+  end if;
+  -- A term deposit carries both a rate and a maturity; a flexible deposit has
+  -- neither and cannot be renewed.
+  if v_old.interest_rate is null or v_old.expiry_date is null then
+    raise exception 'renew_term_deposit: only bank term deposits can be renewed'
+      using errcode = 'check_violation';
+  end if;
+  -- The investment date may not be in the future (allow one day of timezone
+  -- skew, matching the route's lenient client-vs-server "today" tolerance).
+  if p_investment_date > current_date + 1 then
+    raise exception 'renew_term_deposit: investment date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+  -- The new cycle must have positive length: maturity strictly after the start.
+  if p_expiry_date is not null and p_expiry_date <= p_investment_date then
+    raise exception 'renew_term_deposit: new maturity must be after the investment date'
+      using errcode = 'check_violation';
+  end if;
+
+  -- 1) Roll the active row forward to the new cycle (valuation unchanged).
+  update public.investment_transactions
+     set amount_vnd      = p_amount_vnd,
+         interest_rate   = p_interest_rate,
+         expiry_date     = p_expiry_date,
+         investment_date = p_investment_date,
+         updated_at      = now()
+   where transaction_id = p_tx_id
+  returning * into v_renewed;
+
+  -- 2) Append the history snapshot of the cycle that just closed, linked to the
+  --    still-active row. Excluded from every total by renewed_from_transaction_id.
+  --    Dates come from v_old (pre-roll-forward) so the snapshot keeps the CLOSED
+  --    cycle's real open + maturity dates — never the new p_* dates.
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, amount_vnd,
+    investment_date, expiry_date, interest_rate, notes,
+    renewed_from_transaction_id, interest_earned_vnd, affects_progress
+  ) values (
+    v_old.user_id, v_old.goal_id, 'bank', 'investment', v_old.amount_vnd,
+    v_old.investment_date, v_old.expiry_date, v_old.interest_rate, v_old.notes,
+    p_tx_id, p_interest_earned_vnd, false
+  )
+  returning transaction_id into v_snapshot_id;
+
+  -- 3) Re-parent the closed cycle's partial-withdrawal rows onto the snapshot so
+  --    they stop being subtracted from the renewed active row (its principal
+  --    already excludes them). The snapshot is excluded from all totals, so the
+  --    withdrawals are preserved in history without affecting valuation.
+  update public.investment_transactions
+     set parent_transaction_id = v_snapshot_id
+   where parent_transaction_id = p_tx_id
+     and transaction_type = 'withdrawal';
+
+  -- 4) Combine flow only: record that this month's recurring saving was folded
+  --    into the re-deposit, so the dashboard suppresses its synthesized
+  --    contribution instead of counting the amount a second time. Verify the
+  --    saving belongs to this user (the FK alone doesn't bind ownership), then
+  --    upsert — re-combining the same month is idempotent.
+  if p_fulfill_saving_id is not null and p_fulfill_ym is not null then
+    if not exists (
+      select 1 from public.recurring_savings
+       where saving_id = p_fulfill_saving_id and user_id = v_old.user_id
+    ) then
+      raise exception 'renew_term_deposit: recurring saving not found'
+        using errcode = 'no_data_found';
+    end if;
+    insert into public.recurring_saving_fulfillments (
+      user_id, recurring_saving_id, ym, amount_vnd, source
+    ) values (
+      v_old.user_id, p_fulfill_saving_id, p_fulfill_ym,
+      coalesce(p_fulfill_amount, 0), coalesce(p_fulfill_source, 'maturity-combine')
+    )
+    on conflict (recurring_saving_id, ym) do update
+      set amount_vnd = excluded.amount_vnd,
+          source     = excluded.source,
+          updated_at = now();
+  end if;
+
+  return v_renewed;
+end;
+$$;
+
+grant execute on function public.renew_term_deposit(
+  uuid, bigint, numeric, date, date, bigint, uuid, text, bigint, text
+) to authenticated;


### PR DESCRIPTION
## What

Implements the one part of the Cairn redesign's bank/maturity flow that wasn't already shipped: the **5th maturity decision** — **"Settle & re-deposit (merge recurring)"** (Tất toán & gửi lại / gộp định kỳ).

When a term deposit matures **and** a recurring bank saving for the same goal is due this month, the user can fold this month's recurring into the (larger) re-deposit in a single action, instead of tracking two rows.

> The other 95% of the design (matured/maturing detection, the Needs-attention card + nav badge, the resolve sheet/modal, principal+interest / principal-only / change / withdraw modes, old-maturity anchoring, lineage snapshots) was already delivered by #328/#330/#346.

## The correctness crux — no double-count

Recurring savings are synthesized contributions, normally suppressed when a logged deposit matches `(month, goal, amount)`. A **combined re-deposit's amount no longer equals the recurring amount**, so that guard can't fire — the folded-in amount would be counted twice (once in the deposit principal, once as the standalone recurring row).

Fix: an explicit per-month fulfillment record matched by `(saving_id, ym)`, written **in the same transaction as the renewal** so a partial failure can never leave a double-count.

## Changes
- **`lib/finance.ts`** — `realizedRecurringContributions` takes a fulfillments list; skips a fulfilled `(saving, month)` without consuming a logged deposit.
- **`lib/recurringLink.ts`** (new) — `linkedSavingFor` matching law: explicit → name → sole → ambiguous. Never silently folds in the wrong recurring; hands an ambiguous list to the picker.
- **Migrations** — `recurring_saving_fulfillments` (RLS, unique per saving+month); `renew_term_deposit` RPC gains optional fulfillment params (old 6-arg overload dropped) so renew + fulfill are atomic.
- **Renew route** accepts `fulfill_recurring`; **overview route** loads fulfillments and feeds the contribution expansion; **recurring-savings GET** flags per-month `fulfilled` for the picker.
- **`MaturityResolveSheet`** — combine policy (gated on a due recurring), cash-flow recap, "which recurring?" picker, editable re-deposit, "mark deposited" checkbox. Threaded `goalId` from the dashboard.

## Tests / checks
- ✅ `npm test -- --run` — **653 pass** (new unit coverage: fulfillment suppression in `recurringSavings.test.ts`, matching law in `recurringLink.test.ts`; existing maturity-sheet & dark-mode tests still green).
- ✅ `npx tsc --noEmit` clean · changed files lint clean (repo has pre-existing lint errors in `OfflineBanner`/`ThemeProvider`, untouched here).
- ⚠️ **E2E not run locally** — Docker/WSL2 stack isn't reachable from my shell. The spec `e2e/maturity-combine.spec.ts` is included (combine from the UI → goal progress moves by ~interest only, not the double-counted recurring). **Please run it** in the WSL2 stack before merge: `npx playwright test e2e/maturity-combine.spec.ts --project=chromium`. This PR also adds a migration + overview/renew route changes, so a **full E2E** pass is warranted.

## Notes / decisions
- "Mark this month's recurring as deposited" defaults **on** (confirmed) — this is what prevents the double-count; unchecking is only correct if the user excludes the recurring from the re-deposit amount.
- Explicit deposit↔recurring linking (`linkedDepositKey`) isn't in the schema yet, so matching relies on name + sole-candidate; the law degrades gracefully and the picker covers ambiguity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)