### PR TITLE
feat(deposits): collapse an accumulating (Loại 2) book at maturity — book-level renewal

### DIFF
--- a/app/api/v1/investment-transactions/[id]/collapse/route.ts
+++ b/app/api/v1/investment-transactions/[id]/collapse/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateRate, validateUUID } from '@/lib/validation'
+import { isFutureInvestmentDate } from '@/lib/dates'
+import { buildCollapsePlan, type CollapseTrancheInput } from '@/lib/accumulating'
+
+// Collapse an accumulating ("Loại 2") book at maturity into ONE fresh term
+// deposit (the book-level renewal). `id` is the deposit_group_id (= the anchor
+// row's transaction_id).
+//
+// The book's tranches each carry their own locked rate, so the interest of each
+// closed cycle is valued HERE with lib/finance's single formula (capped at the
+// shared maturity) and passed per-tranche to collapse_accumulating_book, which
+// writes it onto that tranche's history snapshot. Keeping the formula in TS — the
+// same one buildInvRows/the dashboard use — is deliberate: there is exactly one
+// interest source of truth and the SQL never re-derives it. The route only reads
+// and computes; the coupled writes (snapshot every tranche, re-parent its
+// withdrawals, roll the anchor forward, delete the rest, optionally fold in a
+// recurring saving) all run atomically inside the RPC.
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await request.json()
+  const { amount_vnd, interest_rate, expiry_date, investment_date, fulfill_recurring } = body
+
+  let groupId: string
+  let cleanAmount: number
+  let cleanRate: number | null = null
+  let cleanExpiry: string | null = null
+  let cleanInvestmentDate: string
+  let cleanFulfillSavingId: string | null = null
+  let cleanFulfillYm: string | null = null
+  let cleanFulfillAmount: number | null = null
+  try {
+    groupId = validateUUID(id, 'group_id')
+    cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
+    if (cleanAmount <= 0) throw new ValidationError('amount_vnd must be positive')
+    if (interest_rate != null && interest_rate !== '') cleanRate = validateRate(interest_rate, 'interest_rate')
+    if (expiry_date) cleanExpiry = validateDate(expiry_date, 'expiry_date')
+    cleanInvestmentDate = validateDate(investment_date, 'investment_date')
+    if (fulfill_recurring != null) {
+      cleanFulfillSavingId = validateUUID(fulfill_recurring.saving_id, 'fulfill_recurring.saving_id')
+      if (typeof fulfill_recurring.ym !== 'string' || !/^\d{4}-\d{2}$/.test(fulfill_recurring.ym)) {
+        throw new ValidationError('fulfill_recurring.ym must be a YYYY-MM month')
+      }
+      cleanFulfillYm = fulfill_recurring.ym
+      const a = Number(fulfill_recurring.amount ?? 0)
+      if (!Number.isFinite(a) || a < 0) throw new ValidationError('fulfill_recurring.amount must be a non-negative number')
+      cleanFulfillAmount = Math.round(a)
+    }
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  if (isFutureInvestmentDate(cleanInvestmentDate)) {
+    return NextResponse.json({ error: 'Investment date cannot be in the future.' }, { status: 400 })
+  }
+  // The new cycle must have positive length (ISO date strings sort chronologically).
+  if (cleanExpiry && cleanExpiry <= cleanInvestmentDate) {
+    return NextResponse.json({ error: 'New maturity must be after the investment date.' }, { status: 400 })
+  }
+
+  // The anchor must be a real accumulating book owned by this user (the row whose
+  // group = its own id). The RPC re-checks under FOR UPDATE; this is the friendly 4xx.
+  const { data: anchor, error: anchorErr } = await supabase
+    .from('investment_transactions')
+    .select('asset_type, deposit_group_id')
+    .eq('transaction_id', groupId)
+    .eq('user_id', user.id)
+    .single()
+  if (anchorErr || !anchor) return NextResponse.json({ error: 'Deposit not found' }, { status: 404 })
+  if (anchor.asset_type !== 'bank' || anchor.deposit_group_id !== groupId) {
+    return NextResponse.json({ error: 'Only an accumulating book can be collapsed.' }, { status: 400 })
+  }
+
+  // Read every live tranche of the book plus any partial withdrawals on them, so
+  // we value each tranche on its EFFECTIVE (post-withdrawal) principal — a
+  // withdrawal that spanned a tranche is netted before interest is computed.
+  const { data: tranches, error: trErr } = await supabase
+    .from('investment_transactions')
+    .select('transaction_id, amount_vnd, interest_rate, investment_date, expiry_date')
+    .eq('user_id', user.id)
+    .eq('deposit_group_id', groupId)
+    .eq('transaction_type', 'investment')
+    .is('renewed_from_transaction_id', null)
+  if (trErr || !tranches || tranches.length === 0) {
+    return NextResponse.json({ error: 'Book has no tranches to collapse.' }, { status: 400 })
+  }
+
+  const trancheIds = tranches.map((t) => t.transaction_id)
+  const { data: withdrawals } = await supabase
+    .from('investment_transactions')
+    .select('parent_transaction_id, principal_withdrawn')
+    .eq('user_id', user.id)
+    .eq('transaction_type', 'withdrawal')
+    .in('parent_transaction_id', trancheIds)
+  const wdByParent = new Map<string, number>()
+  for (const w of withdrawals ?? []) {
+    if (!w.parent_transaction_id) continue
+    wdByParent.set(w.parent_transaction_id, (wdByParent.get(w.parent_transaction_id) ?? 0) + (w.principal_withdrawn ?? 0))
+  }
+
+  const planInput: CollapseTrancheInput[] = tranches.map((t) => ({
+    id: t.transaction_id,
+    principal: Math.max(0, t.amount_vnd - (wdByParent.get(t.transaction_id) ?? 0)),
+    rate: t.interest_rate ?? null,
+    investmentDate: t.investment_date,
+    expiryDate: t.expiry_date ?? null,
+  }))
+  const plan = buildCollapsePlan(planInput)
+
+  const { data: collapsed, error: rpcErr } = await supabase
+    .rpc('collapse_accumulating_book', {
+      p_group_id: groupId,
+      p_amount_vnd: Math.round(cleanAmount),
+      p_interest_rate: cleanRate,
+      p_expiry_date: cleanExpiry,
+      p_investment_date: cleanInvestmentDate,
+      p_tranche_ids: plan.tranches.map((t) => t.id),
+      p_tranche_interest: plan.tranches.map((t) => t.interest),
+      p_fulfill_saving_id: cleanFulfillSavingId,
+      p_fulfill_ym: cleanFulfillYm,
+      p_fulfill_amount: cleanFulfillAmount,
+      p_fulfill_source: cleanFulfillSavingId ? 'maturity-collapse' : null,
+    })
+    .single()
+  if (rpcErr || !collapsed) {
+    console.error('collapse: atomic collapse failed', rpcErr?.message)
+    return NextResponse.json({ error: 'Failed to collapse book' }, { status: 500 })
+  }
+
+  return NextResponse.json(collapsed)
+}

--- a/app/api/v1/investment-transactions/[id]/collapse/route.ts
+++ b/app/api/v1/investment-transactions/[id]/collapse/route.ts
@@ -129,6 +129,11 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     })
     .single()
   if (rpcErr || !collapsed) {
+    // The book changed between our read and the RPC (e.g. a top-up landed) — the
+    // RPC aborted rather than drop the new tranche. Tell the client to reload.
+    if (rpcErr?.message?.includes('book changed since load')) {
+      return NextResponse.json({ error: 'This deposit changed — please reload and try again.' }, { status: 409 })
+    }
     console.error('collapse: atomic collapse failed', rpcErr?.message)
     return NextResponse.json({ error: 'Failed to collapse book' }, { status: 500 })
   }

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield, RefreshCw } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, AffectsProgressControl, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, AffectsProgressControl, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { MaturityResolveModal } from './MaturityResolveSheet'
 import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
@@ -610,14 +610,18 @@ function InvOptionsModal({ inv, isVi, renewalSummary, onClose, onHistory, onReso
 }) {
   const isBank = inv.type === 'bank'
   const typeColor = GD_COLORS[inv.type] ?? 'var(--c-muted)'
-  const needsMaturity = needsMaturityAction(inv, isVi)
+  // A matured term deposit renews; a matured accumulating book collapses — both
+  // open the same "Handle maturity" sheet (it branches internally).
+  const needsMaturity = needsMaturityAction(inv, isVi) || needsBookMaturityAction(inv)
 
   const actions = [
     ...(needsMaturity ? [{
       icon: <RefreshCw size={18} color="var(--c-warn,#b45309)" />,
       bg: 'var(--c-warn-tint,#fef3c7)',
       label: isVi ? 'Xử lý đáo hạn' : 'Handle maturity',
-      sub: isVi ? 'Tái tục hoặc chuyển sang chờ rút' : 'Renew or mark for withdrawal',
+      sub: inv.depositGroupId
+        ? (isVi ? 'Tất toán cả sổ & gửi lại' : 'Settle the book & re-deposit')
+        : (isVi ? 'Tái tục hoặc chuyển sang chờ rút' : 'Renew or mark for withdrawal'),
       onClick: onResolve,
     }] : []),
     {

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -11,7 +11,7 @@ import type { GoalData, FundBreakdownItem } from '../DashboardClient'
 import TransactionHistorySheet, { type PurchaseHistoryRow } from './TransactionHistorySheet'
 import { SellWithdrawSheet, type SellItem } from './SellWithdrawSheet'
 import { MaturityResolveSheet } from './MaturityResolveSheet'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
+import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 
@@ -370,12 +370,14 @@ function InvestmentActionSheet({
   const typeColor = GD_COLORS[inv.type] ?? 'var(--c-muted)'
   const isBank = inv.type === 'bank'
   const isPos = (inv.gainPct ?? 0) >= 0
-  const needsMaturity = needsMaturityAction(inv, isVI)
+  // A matured term deposit renews; a matured accumulating book collapses — both
+  // open the same "Handle maturity" sheet (it branches internally).
+  const needsMaturity = needsMaturityAction(inv, isVI) || needsBookMaturityAction(inv)
 
   const t = isVI ? {
     title: 'Tùy chọn',
     handle: 'Xử lý đáo hạn',
-    handleSub: 'Tái tục hoặc chuyển sang chờ rút',
+    handleSub: inv.depositGroupId ? 'Tất toán cả sổ & gửi lại' : 'Tái tục hoặc chuyển sang chờ rút',
     history: 'Lịch sử giao dịch',
     historySub: 'Xem các lần mua / bán trước đây',
     sell: isBank ? 'Rút tiền' : 'Bán',
@@ -385,7 +387,7 @@ function InvestmentActionSheet({
   } : {
     title: 'Options',
     handle: 'Handle maturity',
-    handleSub: 'Renew or mark for withdrawal',
+    handleSub: inv.depositGroupId ? 'Settle the book & re-deposit' : 'Renew or mark for withdrawal',
     history: 'Transaction history',
     historySub: 'View past buys & sells',
     sell: isBank ? 'Withdraw' : 'Sell',

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -96,7 +96,11 @@ export function MaturityResolveBody({
   // suggested new rate to 1dp so the field starts clean; a term deposit keeps its
   // exact stored rate.
   const [rate, setRate] = useState(inv.interestRate != null ? String(isBook ? Math.round(inv.interestRate * 10) / 10 : inv.interestRate) : '')
-  const [newAmount, setNewAmount] = useState(String(principal))
+  // The editable lump (change mode). For a book, seed it with the plan TOTAL
+  // (Σ principal + Σ interest) — the full payout the collapse would otherwise
+  // re-deposit — so a hand-edit starts from the book's real figure, not bare
+  // principal. A single term deposit keeps its principal-only default.
+  const [newAmount, setNewAmount] = useState(String(isBook ? principal + estInterest : principal))
   // The new maturity follows old-maturity + term until the user edits it by hand,
   // at which point we freeze their value (null = "follow the term").
   const [maturityOverride, setMaturityOverride] = useState<string | null>(null)

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -73,9 +73,14 @@ export function MaturityResolveBody({
   onRenewed: () => void
   onWithdraw: () => void
 }) {
+  // An accumulating ("Loại 2") book: `inv` is the rolled-up book row (principal =
+  // Σ tranche principals, value = Σ tranche valuations). It renews by COLLAPSING
+  // — settle every tranche into one fresh plain term deposit — so it posts to the
+  // collapse route, not /renew, and withdrawing the whole book isn't offered yet.
+  const isBook = !!inv.depositGroupId
   const principal = inv.principal ?? inv.value ?? 0
   // Best real-data estimate of interest earned this cycle: current (compounded)
-  // value minus the principal still held.
+  // value minus the principal still held. For a book this is Σ tranche interest.
   const estInterest = Math.max(0, Math.round((inv.value ?? 0) - principal))
   const m = fmtMaturity(inv.expiryDate, isVi)
   const state = depositMaturityState(m?.diffDays ?? 0)
@@ -87,7 +92,10 @@ export function MaturityResolveBody({
   const [mode, setMode] = useState<Mode>('principal_interest')
   const [interest, setInterest] = useState(String(estInterest))
   const [term, setTerm] = useState(String(derivedTerm > 0 ? derivedTerm : 12))
-  const [rate, setRate] = useState(inv.interestRate != null ? String(inv.interestRate) : '')
+  // For a book the rate is the blended average (often a long decimal) — round the
+  // suggested new rate to 1dp so the field starts clean; a term deposit keeps its
+  // exact stored rate.
+  const [rate, setRate] = useState(inv.interestRate != null ? String(isBook ? Math.round(inv.interestRate * 10) / 10 : inv.interestRate) : '')
   const [newAmount, setNewAmount] = useState(String(principal))
   // The new maturity follows old-maturity + term until the user edits it by hand,
   // at which point we freeze their value (null = "follow the term").
@@ -243,7 +251,9 @@ export function MaturityResolveBody({
     { id: 'principal_interest', icon: <RefreshCw size={16} />, label: isVi ? 'Tái tục gốc + lãi' : 'Renew principal + interest', sub: isVi ? 'Cộng lãi vào gốc cho kỳ mới' : 'Roll interest into the new principal' },
     { id: 'principal_only', icon: <RefreshCw size={16} />, label: isVi ? 'Tái tục chỉ gốc' : 'Renew principal only', sub: isVi ? 'Lãi chuyển ra ngoài (về ví)' : 'Interest paid out to your wallet' },
     { id: 'change', icon: <Pencil size={16} />, label: isVi ? 'Đổi số tiền / kỳ hạn' : 'Change amount / term', sub: isVi ? 'Điều chỉnh gốc hoặc kỳ hạn kỳ mới' : 'Adjust principal or term for the new cycle' },
-    { id: 'withdraw', icon: <ArrowDownToLine size={16} />, label: isVi ? 'Không tái tục — rút' : 'Don’t renew — withdraw', sub: isVi ? 'Rút toàn bộ số dư' : 'Withdraw the full balance', danger: true },
+    // Withdrawing the whole book isn't supported yet (per-tranche withdrawal is a
+    // later phase) — a book can only be re-deposited, so omit the withdraw option.
+    ...(isBook ? [] : [{ id: 'withdraw' as Mode, icon: <ArrowDownToLine size={16} />, label: isVi ? 'Không tái tục — rút' : 'Don’t renew — withdraw', sub: isVi ? 'Rút toàn bộ số dư' : 'Withdraw the full balance', danger: true }]),
   ]
 
   async function handleConfirm() {
@@ -251,7 +261,12 @@ export function MaturityResolveBody({
     if (!canRenew) return
     setSaving(true); setError('')
     try {
-      const res = await fetch(`/api/v1/investment-transactions/${inv.id}/renew`, {
+      // A book collapses (settle all tranches → one fresh deposit) via the collapse
+      // route; a single term deposit rolls forward via /renew. The collapse route
+      // values each tranche's interest itself (one TS formula → the per-tranche
+      // history snapshots), so — unlike /renew — it takes no interest_earned_vnd.
+      const endpoint = isBook ? 'collapse' : 'renew'
+      const res = await fetch(`/api/v1/investment-transactions/${inv.id}/${endpoint}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -266,8 +281,9 @@ export function MaturityResolveBody({
           // cycle that just closed.
           investment_date: baseDate,
           // Realized interest for the cycle that just closed — recorded
-          // permanently on the snapshot for the renewal-history summary.
-          interest_earned_vnd: iNum,
+          // permanently on the snapshot for the renewal-history summary. A book's
+          // collapse route derives this per tranche, so only send it for /renew.
+          ...(isBook ? {} : { interest_earned_vnd: iNum }),
           // Combine flow: mark this month's recurring saving fulfilled inside the
           // same transaction, so its amount (now folded into the principal above)
           // is not also counted as a separate synthesized contribution.

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -9,7 +9,7 @@ import { fmtCompact } from '@/lib/formatters'
 import { calcProjectedInterest } from '@/lib/finance'
 import { blendedRate } from '@/lib/accumulating'
 import { fmtTxDate } from './transactionUtils'
-import { isTermDeposit, depositMaturityState, isMaturityActionable } from '@/lib/maturity'
+import { isTermDeposit, depositMaturityState, isMaturityActionable, isActionableAccumulatingBook } from '@/lib/maturity'
 import type { FundBreakdownItem } from '../DashboardClient'
 
 export const GD_COLORS: Record<string, string> = {
@@ -431,6 +431,14 @@ export function needsMaturityAction(inv: InvRow, isVi: boolean): boolean {
   const m = fmtMaturity(inv.expiryDate, isVi)
   if (!m) return false
   return isMaturityActionable(depositMaturityState(m.diffDays))
+}
+
+// The book counterpart of needsMaturityAction: a matured/maturing accumulating
+// book needs a book-level collapse decision (the single-row path above excludes
+// grouped rows, so this is the only entry point that surfaces it). Drives the
+// same "Handle maturity" action — MaturityResolveBody branches to collapse for a book.
+export function needsBookMaturityAction(inv: InvRow): boolean {
+  return isActionableAccumulatingBook({ type: inv.type, expiryDate: inv.expiryDate, depositGroupId: inv.depositGroupId })
 }
 
 export function fmtMaturity(dateStr: string | null | undefined, isVi: boolean): Maturity | null {

--- a/e2e/accumulating-collapse.spec.ts
+++ b/e2e/accumulating-collapse.spec.ts
@@ -106,4 +106,43 @@ test.describe('Accumulating book collapse (Loại 2 book-level renewal)', () => 
       await api.deleteGoal(goal.goal_id)
     }
   })
+
+  test('a book that changed since load (a top-up landed mid-flight) aborts the collapse, losing nothing', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Collapse Race Goal', target_amount: 200_000_000 })
+    const anchor = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Collapse Race', amount_vnd: 50_000_000, interest_rate: 3.0, investment_date: iso(-150), expiry_date: iso(30) },
+    })).json()
+    const topUp = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 10_000_000, interest_rate: 3.6, investment_date: iso(-20) },
+    })).json()
+    try {
+      // Reproduce the TOCTOU: the route read only the anchor (T1), then this top-up
+      // committed. Call the RPC with that STALE tranche set (omitting the top-up).
+      // The loop meets a live tranche it wasn't given → it must abort, not snapshot
+      // + delete the top-up (which would vanish, its principal never in the lump).
+      const { error } = await api.rpcCollapseBook({
+        p_group_id: anchor.transaction_id,
+        p_amount_vnd: 50_000_000,
+        p_interest_rate: 3.0,
+        p_expiry_date: iso(120),
+        p_investment_date: iso(0),
+        p_tranche_ids: [anchor.transaction_id],
+        p_tranche_interest: [0],
+      })
+      expect(error).toBeTruthy()
+      expect(error!.message).toContain('book changed since load')
+
+      // Atomic abort: both tranches still live + grouped, no stray snapshots.
+      const all = await (await page.request.get('/api/v1/investment-transactions?include_history=true&limit=1000')).json()
+      const rows = all.transactions as Array<{ transaction_id: string; deposit_group_id: string | null; renewed_from_transaction_id: string | null }>
+      const live = rows.filter((r) => r.deposit_group_id === anchor.transaction_id && !r.renewed_from_transaction_id)
+      expect(live).toHaveLength(2)
+      expect(rows.some((r) => r.transaction_id === topUp.transaction_id)).toBe(true)
+      expect(rows.filter((r) => r.renewed_from_transaction_id === anchor.transaction_id)).toHaveLength(0)
+    } finally {
+      await api.deleteDepositGroup(anchor.transaction_id)
+      await api.deleteTransactionCascade(anchor.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
 })

--- a/e2e/accumulating-collapse.spec.ts
+++ b/e2e/accumulating-collapse.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect, type Page } from '@playwright/test'
+import * as api from './helpers/api'
+
+// Book-level renewal for accumulating ("Loại 2") deposits: at maturity the whole
+// book COLLAPSES into one fresh plain term deposit. This closes the loop on the
+// design call from #349 — settle every tranche into one lump, but keep each
+// tranche's closed cycle in history so the "topped up N×" story survives.
+//
+// What this asserts: (1) a matured book surfaces the "Handle maturity" action and
+// the collapse flow completes from the UI; (2) afterwards the anchor is a plain
+// term deposit (deposit_group_id cleared) with no surviving sibling tranche; and
+// (3) every tranche became its own history snapshot carrying real interest, so
+// nothing is double-counted and the lineage is preserved.
+
+const iso = (d: number) => new Date(Date.now() + d * 86_400_000).toISOString().slice(0, 10)
+
+async function gotoFreshDashboard(page: Page) {
+  await page.goto('/settings')
+  await page.evaluate(() => {
+    Object.keys(localStorage).filter((k) => k.startsWith('dashboardOverviewCache')).forEach((k) => localStorage.removeItem(k))
+  })
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/v1/dashboard/overview') && r.status() === 200, { timeout: 20_000 }),
+    page.goto('/dashboard'),
+  ])
+}
+
+test.describe('Accumulating book collapse (Loại 2 book-level renewal)', () => {
+  test('a matured book collapses into one plain term deposit, snapshotting each tranche', async ({ page }) => {
+    test.slow()
+    const goal = await api.createGoal({ goal_name: 'E2E Collapse Goal', target_amount: 200_000_000 })
+    // A live book (future maturity) so the top-up is accepted, then mature it.
+    const anchor = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Collapse Book', amount_vnd: 50_000_000, interest_rate: 3.0, investment_date: iso(-150), expiry_date: iso(30) },
+    })).json()
+    expect(anchor.deposit_group_id).toBe(anchor.transaction_id)
+    const topUp = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 10_000_000, interest_rate: 3.6, investment_date: iso(-20) },
+    })).json()
+    expect(topUp.deposit_group_id).toBe(anchor.transaction_id)
+    // Mature the whole book (PUT cascades the maturity to every tranche) so it
+    // needs a book-level decision.
+    const matured = await page.request.put(`/api/v1/investment-transactions/${anchor.transaction_id}`, { data: { expiry_date: iso(-2) } })
+    expect(matured.ok()).toBeTruthy()
+
+    try {
+      await gotoFreshDashboard(page)
+      await page.getByText('E2E Collapse Goal').first().click()
+      const panel = page.getByTestId('desktop-goal-detail')
+      await expect(panel).toBeVisible({ timeout: 5_000 })
+
+      // The book rolls up to ONE holding; open its options.
+      await expect(panel.getByRole('button', { name: 'Options', exact: true })).toHaveCount(1)
+      await panel.getByRole('button', { name: 'Options', exact: true }).first().click()
+
+      // A matured book now surfaces "Handle maturity" (the single-row path excludes
+      // books — this is the book-only entry point).
+      await page.getByRole('button', { name: /Handle maturity|Xử lý đáo hạn/i }).first().click()
+
+      // Collapse form (defaults to roll principal + interest). Give it a clean term
+      // and confirm — the route values each tranche's interest server-side.
+      await page.getByTestId('maturity-term-input').fill('12')
+      const [resp] = await Promise.all([
+        page.waitForResponse((r) => r.url().includes('/collapse') && r.request().method() === 'POST'),
+        page.getByRole('button', { name: /Confirm renewal|Xác nhận tái tục/i }).click(),
+      ])
+      expect(resp.status()).toBe(200)
+      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+
+      // ── Assert the persisted outcome ──────────────────────────────────────────
+      const all = await (await page.request.get('/api/v1/investment-transactions?include_history=true&limit=1000')).json()
+      const rows = all.transactions as Array<{ transaction_id: string; deposit_group_id: string | null; renewed_from_transaction_id: string | null; interest_earned_vnd: number | null; transaction_type: string }>
+
+      // (1) The anchor survived as a PLAIN term deposit (group cleared).
+      const anchorNow = rows.find((r) => r.transaction_id === anchor.transaction_id)
+      expect(anchorNow).toBeTruthy()
+      expect(anchorNow!.deposit_group_id).toBeNull()
+
+      // (2) No live tranche still belongs to the old book — it's collapsed to one row.
+      const liveGrouped = rows.filter((r) => r.deposit_group_id === anchor.transaction_id && !r.renewed_from_transaction_id)
+      expect(liveGrouped).toHaveLength(0)
+      // The non-anchor tranche row is gone entirely (folded into the lump + snapshot).
+      expect(rows.some((r) => r.transaction_id === topUp.transaction_id)).toBe(false)
+
+      // (3) Each of the two tranches became its own history snapshot carrying its
+      // real (positive) interest — the per-tranche lineage is preserved.
+      const snaps = rows.filter((r) => r.renewed_from_transaction_id === anchor.transaction_id)
+      expect(snaps).toHaveLength(2)
+      expect(snaps.every((s) => (s.interest_earned_vnd ?? 0) > 0)).toBeTruthy()
+    } finally {
+      await api.deleteDepositGroup(anchor.transaction_id) // live tranches (if not collapsed)
+      await api.deleteTransactionCascade(anchor.transaction_id) // collapsed anchor + snapshots
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+})

--- a/e2e/accumulating-collapse.spec.ts
+++ b/e2e/accumulating-collapse.spec.ts
@@ -64,6 +64,16 @@ test.describe('Accumulating book collapse (Loại 2 book-level renewal)', () => 
       // books — this is the book-only entry point).
       await page.getByRole('button', { name: /Handle maturity|Xử lý đáo hạn/i }).first().click()
 
+      // The lump prefills with the PLAN TOTAL (Σ principal + accrued interest), not
+      // bare principal — both in the default roll mode and the editable change mode.
+      const PRINCIPAL = 60_000_000 // 50M anchor + 10M top-up
+      const defaultLump = Number((await page.getByTestId('maturity-new-principal').textContent() ?? '').replace(/[^0-9]/g, ''))
+      expect(defaultLump).toBeGreaterThan(PRINCIPAL)
+      await page.getByRole('button', { name: /Change amount|Đổi số tiền/i }).click()
+      const changeLump = Number((await page.getByTestId('maturity-new-amount').inputValue()).replace(/[^0-9]/g, ''))
+      expect(changeLump).toBeGreaterThan(PRINCIPAL)
+      await page.getByRole('button', { name: /Renew principal \+ interest|Tái tục gốc \+ lãi/i }).click()
+
       // Collapse form (defaults to roll principal + interest). Give it a clean term
       // and confirm — the route values each tranche's interest server-side.
       await page.getByTestId('maturity-term-input').fill('12')

--- a/e2e/accumulating-collapse.spec.ts
+++ b/e2e/accumulating-collapse.spec.ts
@@ -38,6 +38,13 @@ test.describe('Accumulating book collapse (Loại 2 book-level renewal)', () => 
       data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 10_000_000, interest_rate: 3.6, investment_date: iso(-20) },
     })).json()
     expect(topUp.deposit_group_id).toBe(anchor.transaction_id)
+    // An EXPLICIT recurring link (#348) pointing at the NON-anchor tranche — the
+    // tranche the collapse will delete. The link must survive (re-pointed to the
+    // surviving anchor), not be silently nulled by the FK's ON DELETE SET NULL.
+    const saving = await api.createRecurringSaving({
+      name: 'E2E Collapse Linked Saving', goal_id: goal.goal_id, amount_vnd: 2_000_000,
+      linked_deposit_tx_id: topUp.transaction_id,
+    })
     // Mature the whole book (PUT cascades the maturity to every tranche) so it
     // needs a book-level decision.
     const matured = await page.request.put(`/api/v1/investment-transactions/${anchor.transaction_id}`, { data: { expiry_date: iso(-2) } })
@@ -87,7 +94,13 @@ test.describe('Accumulating book collapse (Loại 2 book-level renewal)', () => 
       const snaps = rows.filter((r) => r.renewed_from_transaction_id === anchor.transaction_id)
       expect(snaps).toHaveLength(2)
       expect(snaps.every((s) => (s.interest_earned_vnd ?? 0) > 0)).toBeTruthy()
+
+      // (4) The EXPLICIT link survived: it was re-pointed from the deleted tranche
+      // onto the surviving anchor (NOT silently nulled by ON DELETE SET NULL).
+      const savingNow = await api.getRecurringSaving(saving.saving_id)
+      expect(savingNow!.linked_deposit_tx_id).toBe(anchor.transaction_id)
     } finally {
+      await api.deleteRecurringSaving(saving.saving_id)
       await api.deleteDepositGroup(anchor.transaction_id) // live tranches (if not collapsed)
       await api.deleteTransactionCascade(anchor.transaction_id) // collapsed anchor + snapshots
       await api.deleteGoal(goal.goal_id)

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -66,6 +66,12 @@ export async function getRecurringSaving(savingId: string) {
   return data
 }
 
+// Invoke the collapse RPC directly (service role). Lets a spec drive it with a
+// deliberately stale tranche set to exercise the mid-flight-change guard.
+export async function rpcCollapseBook(args: Record<string, unknown>) {
+  return await supabase.rpc('collapse_accumulating_book', args)
+}
+
 export async function createInsuranceMember(data: {
   member_name: string
   relationship: string

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -61,6 +61,11 @@ export async function deleteRecurringSaving(savingId: string) {
   await supabase.from('recurring_savings').delete().eq('saving_id', savingId)
 }
 
+export async function getRecurringSaving(savingId: string) {
+  const { data } = await supabase.from('recurring_savings').select('*').eq('saving_id', savingId).single()
+  return data
+}
+
 export async function createInsuranceMember(data: {
   member_name: string
   relationship: string

--- a/lib/__tests__/accumulating.test.ts
+++ b/lib/__tests__/accumulating.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { isAccumulating, blendedRate, anchorId } from '../accumulating'
+import { isAccumulating, blendedRate, anchorId, buildCollapsePlan } from '../accumulating'
+import { calcProjectedInterest } from '../finance'
 
 describe('isAccumulating', () => {
   it('is true when the row carries a deposit_group_id', () => {
@@ -37,5 +38,50 @@ describe('blendedRate — amount-weighted average rate across tranches', () => {
   it('returns 0 when there is no principal', () => {
     expect(blendedRate([])).toBe(0)
     expect(blendedRate([{ amount: 0, rate: 5 }])).toBe(0)
+  })
+})
+
+describe('buildCollapsePlan — per-tranche interest + totals at a book collapse', () => {
+  // A fixed instant after the book's maturity so accrual is capped at expiry
+  // (the book is being collapsed because it matured) and the test is deterministic.
+  const asOf = new Date('2026-07-01T00:00:00Z').getTime()
+  const maturity = '2026-06-01'
+
+  it('values each tranche on its own rate (capped at the shared maturity) and sums them', () => {
+    const plan = buildCollapsePlan(
+      [
+        { id: 'a', principal: 50_000_000, rate: 3.0, investmentDate: '2025-06-01', expiryDate: maturity },
+        { id: 'b', principal: 2_000_000, rate: 3.4, investmentDate: '2025-09-01', expiryDate: maturity },
+        { id: 'c', principal: 2_000_000, rate: 3.5, investmentDate: '2026-01-01', expiryDate: maturity },
+      ],
+      asOf,
+    )
+    const iA = Math.round(calcProjectedInterest(50_000_000, 3.0, '2025-06-01', maturity, asOf))
+    const iB = Math.round(calcProjectedInterest(2_000_000, 3.4, '2025-09-01', maturity, asOf))
+    const iC = Math.round(calcProjectedInterest(2_000_000, 3.5, '2026-01-01', maturity, asOf))
+    expect(plan.tranches).toEqual([
+      { id: 'a', principal: 50_000_000, interest: iA },
+      { id: 'b', principal: 2_000_000, interest: iB },
+      { id: 'c', principal: 2_000_000, interest: iC },
+    ])
+    expect(plan.totalPrincipal).toBe(54_000_000)
+    // The book total is the sum of the per-tranche figures the snapshots store, so
+    // the rolled lump and the recorded history can never disagree.
+    expect(plan.totalInterest).toBe(iA + iB + iC)
+  })
+
+  it('gives a rate-less (flex) tranche zero interest but still counts its principal', () => {
+    const plan = buildCollapsePlan(
+      [{ id: 'a', principal: 1_000_000, rate: null, investmentDate: '2025-06-01', expiryDate: maturity }],
+      asOf,
+    )
+    expect(plan.tranches).toEqual([{ id: 'a', principal: 1_000_000, interest: 0 }])
+    expect(plan.totalPrincipal).toBe(1_000_000)
+    expect(plan.totalInterest).toBe(0)
+  })
+
+  it('handles an empty book (all tranches fully withdrawn) as zero', () => {
+    const plan = buildCollapsePlan([], asOf)
+    expect(plan).toEqual({ tranches: [], totalPrincipal: 0, totalInterest: 0 })
   })
 })

--- a/lib/__tests__/maturity.test.ts
+++ b/lib/__tests__/maturity.test.ts
@@ -9,6 +9,7 @@ import {
   renewalPrincipal,
   daysUntil,
   isActionableTermDeposit,
+  isActionableAccumulatingBook,
 } from '../maturity'
 
 // A YYYY-MM-DD string `n` days from today (deterministic regardless of run date).
@@ -115,6 +116,27 @@ describe('isActionableTermDeposit', () => {
   it('is false for non-term and non-bank holdings', () => {
     expect(isActionableTermDeposit({ type: 'bank', interestRate: null, expiryDate: daysFromNow(-1) })).toBe(false)
     expect(isActionableTermDeposit({ type: 'gold', interestRate: null, expiryDate: null })).toBe(false)
+  })
+})
+
+// The mirror of isActionableTermDeposit for the accumulating ("Loại 2") book
+// path: a whole book is renewed via collapse, so it surfaces a maturity decision
+// only when it CARRIES a deposit_group_id (the opposite requirement to the
+// single-row term path, which excludes grouped rows).
+describe('isActionableAccumulatingBook', () => {
+  it('is true for a matured or soon-maturing accumulating book', () => {
+    expect(isActionableAccumulatingBook({ type: 'bank', expiryDate: daysFromNow(-2), depositGroupId: 'grp-1' })).toBe(true)
+    expect(isActionableAccumulatingBook({ type: 'bank', expiryDate: daysFromNow(1), depositGroupId: 'grp-1' })).toBe(true)
+  })
+  it('is false for a book maturing well in the future', () => {
+    expect(isActionableAccumulatingBook({ type: 'bank', expiryDate: daysFromNow(30), depositGroupId: 'grp-1' })).toBe(false)
+  })
+  it('is false for an ungrouped term deposit (that goes through the single-row path)', () => {
+    expect(isActionableAccumulatingBook({ type: 'bank', expiryDate: daysFromNow(-2), depositGroupId: null })).toBe(false)
+  })
+  it('is false for a book with no maturity or a non-bank type', () => {
+    expect(isActionableAccumulatingBook({ type: 'bank', expiryDate: null, depositGroupId: 'grp-1' })).toBe(false)
+    expect(isActionableAccumulatingBook({ type: 'fund', expiryDate: daysFromNow(-2), depositGroupId: 'grp-1' })).toBe(false)
   })
 })
 

--- a/lib/accumulating.ts
+++ b/lib/accumulating.ts
@@ -1,10 +1,12 @@
 // Accumulating ("Loại 2") bank deposits: one logical book topped up over time,
 // each top-up a tranche with its own locked-in rate, all sharing the book's
 // maturity. A tranche is an investment_transactions row; the book is the set of
-// rows sharing a deposit_group_id (the anchor row self-groups). These are the
-// pure pieces — grouping the rows and valuing them stays with the callers that
-// already hold the withdrawal map (buildInvRows / the overview route), so this
-// file never needs the DB or the interest formula.
+// rows sharing a deposit_group_id (the anchor row self-groups). The grouping and
+// per-row valuation helpers here are pure (no DB) — `buildCollapsePlan` is the
+// one piece that touches the interest formula, reusing lib/finance's single
+// source of truth so a book collapse never re-derives interest in SQL.
+
+import { calcProjectedInterest } from './finance'
 
 export function isAccumulating(row: { depositGroupId?: string | null }): boolean {
   return row.depositGroupId != null
@@ -23,4 +25,43 @@ export function blendedRate(tranches: { amount: number; rate: number | null }[])
   const total = tranches.reduce((s, t) => s + t.amount, 0)
   if (total <= 0) return 0
   return tranches.reduce((s, t) => s + t.amount * (t.rate ?? 0), 0) / total
+}
+
+// One live tranche of a book about to be collapsed at maturity: its effective
+// (post-withdrawal) principal plus the inputs needed to value its accrued
+// interest on its own locked rate.
+export interface CollapseTrancheInput {
+  id: string
+  principal: number
+  rate: number | null
+  investmentDate: string
+  expiryDate: string | null
+}
+
+export interface CollapsePlan {
+  // Per-tranche principal + accrued interest, one entry per input. The collapse
+  // route writes each `interest` onto that tranche's history snapshot, so the
+  // book's history records the real interest of every top-up cycle.
+  tranches: { id: string; principal: number; interest: number }[]
+  totalPrincipal: number
+  totalInterest: number
+}
+
+// Value a book at collapse time: each tranche earns interest on its own rate,
+// capped at the shared maturity (calcProjectedInterest is the single formula —
+// see lib/finance), rounded per tranche so the book total equals the sum of the
+// per-tranche figures the snapshots store (no rolled-lump vs history drift). The
+// caller passes effective (post-withdrawal) principals, so a withdrawal that
+// spanned a tranche is already netted out before it reaches here.
+export function buildCollapsePlan(tranches: CollapseTrancheInput[], asOf?: number): CollapsePlan {
+  const out = tranches.map((t) => ({
+    id: t.id,
+    principal: t.principal,
+    interest: Math.round(calcProjectedInterest(t.principal, t.rate, t.investmentDate, t.expiryDate, asOf)),
+  }))
+  return {
+    tranches: out,
+    totalPrincipal: out.reduce((s, t) => s + t.principal, 0),
+    totalInterest: out.reduce((s, t) => s + t.interest, 0),
+  }
 }

--- a/lib/maturity.ts
+++ b/lib/maturity.ts
@@ -73,6 +73,18 @@ export function isActionableTermDeposit(
   return isMaturityActionable(depositMaturityState(daysUntil(it.expiryDate!)))
 }
 
+// The book-path mirror of isActionableTermDeposit: a whole accumulating book is
+// renewed by collapsing it (settle all tranches → one fresh deposit), so it
+// needs a maturity decision only when it CARRIES a deposit_group_id — the exact
+// opposite of the single-row term path, which excludes grouped rows. Drives the
+// "Handle maturity" entry the goal-detail Options modal shows for a matured book.
+export function isActionableAccumulatingBook(
+  it: { type: string; expiryDate: string | null; depositGroupId?: string | null },
+): boolean {
+  if (it.type !== 'bank' || it.depositGroupId == null || !it.expiryDate) return false
+  return isMaturityActionable(depositMaturityState(daysUntil(it.expiryDate)))
+}
+
 const pad = (n: number) => String(n).padStart(2, '0')
 
 // Add `n` whole months to a YYYY-MM-DD date, keeping the day of month but

--- a/supabase/migrations/20260618000001_collapse_accumulating_book.sql
+++ b/supabase/migrations/20260618000001_collapse_accumulating_book.sql
@@ -1,0 +1,166 @@
+-- Book-level renewal for accumulating ("Loại 2") deposits: collapse N tranches
+-- into ONE fresh term deposit at maturity.
+--
+-- An accumulating book is many investment_transactions rows sharing a
+-- deposit_group_id (the anchor row self-groups: deposit_group_id = its own id),
+-- all on one shared maturity, each tranche on its own locked rate. At maturity
+-- every tranche pays out together, so the natural action is to settle the whole
+-- book and re-deposit the total as a single lump — the renew flow's single-row
+-- roll can't express this (it would move one tranche and orphan the rest), which
+-- is why renew_term_deposit explicitly rejects a grouped row. This function is
+-- the book counterpart.
+--
+-- It performs the whole collapse as ONE transaction:
+--   1) Snapshot EVERY tranche as its own closed cycle (renewed_from = anchor),
+--      writing the per-tranche interest the route computed so the goal-detail
+--      History still tells the full "topped up N×, each earned X" story.
+--   2) Re-parent each tranche's partial-withdrawal rows onto its snapshot, so a
+--      withdrawal never stays attached to a live row and double-subtracts.
+--   3) Roll the ANCHOR row forward in place to the new single-deposit cycle
+--      (combined principal, new rate/maturity, deposit_group_id = NULL → it
+--      becomes a plain term deposit that renews through the normal path next time).
+--   4) Delete the non-anchor tranche rows (their value now lives in the lump and
+--      their history in the snapshots).
+--   5) Optionally fold this month's recurring saving in (combine flow), reusing
+--      the same recurring_saving_fulfillments mechanism as renew_term_deposit.
+--
+-- Interest is NOT computed here: the route values each tranche with lib/finance's
+-- single formula and passes (tranche_id → interest) parallel arrays down, so the
+-- TS valuation stays the one source of truth (no SQL port to drift from it).
+create or replace function public.collapse_accumulating_book(
+  p_group_id uuid,
+  p_amount_vnd bigint,
+  p_interest_rate numeric,
+  p_expiry_date date,
+  p_investment_date date,
+  p_tranche_ids uuid[],
+  p_tranche_interest bigint[],
+  p_fulfill_saving_id uuid default null,
+  p_fulfill_ym text default null,
+  p_fulfill_amount bigint default null,
+  p_fulfill_source text default null
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_anchor public.investment_transactions;
+  v_tranche public.investment_transactions;
+  v_snapshot_id uuid;
+  v_interest bigint;
+  v_idx int;
+  v_renewed public.investment_transactions;
+begin
+  -- Lock the anchor (the row whose group = its own id). Its existence with that
+  -- exact shape proves p_group_id names a real accumulating book the caller owns
+  -- (RLS scopes the read to the user under security invoker).
+  select * into v_anchor
+    from public.investment_transactions
+   where transaction_id = p_group_id
+     and deposit_group_id = p_group_id
+   for update;
+  if not found then
+    raise exception 'collapse_accumulating_book: accumulating book not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_anchor.asset_type is distinct from 'bank' then
+    raise exception 'collapse_accumulating_book: only bank books can be collapsed'
+      using errcode = 'check_violation';
+  end if;
+  if p_amount_vnd is null or p_amount_vnd <= 0 then
+    raise exception 'collapse_accumulating_book: amount must be positive'
+      using errcode = 'check_violation';
+  end if;
+  if p_investment_date > current_date + 1 then
+    raise exception 'collapse_accumulating_book: investment date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+  if p_expiry_date is not null and p_expiry_date <= p_investment_date then
+    raise exception 'collapse_accumulating_book: new maturity must be after the investment date'
+      using errcode = 'check_violation';
+  end if;
+
+  -- 1–4) Snapshot, re-parent, then delete every tranche. We snapshot the anchor
+  -- too (it is itself a closed cycle), then roll the anchor row forward after the
+  -- loop. Iterating the live tranches under FOR UPDATE locks each before we touch
+  -- it; deleting the non-anchor rows from inside the loop is safe (the loop reads
+  -- a query snapshot, not a sensitive cursor).
+  for v_tranche in
+    select * from public.investment_transactions
+     where deposit_group_id = p_group_id
+       and transaction_type = 'investment'
+       and renewed_from_transaction_id is null
+     order by investment_date
+     for update
+  loop
+    v_idx := array_position(p_tranche_ids, v_tranche.transaction_id);
+    v_interest := case when v_idx is null then null else p_tranche_interest[v_idx] end;
+
+    -- Snapshot this tranche's closed cycle (dates/amount/rate from the tranche),
+    -- linked to the surviving anchor so buildRenewalSummary/History collect them.
+    insert into public.investment_transactions (
+      user_id, goal_id, asset_type, transaction_type, amount_vnd,
+      investment_date, expiry_date, interest_rate, notes,
+      renewed_from_transaction_id, interest_earned_vnd, affects_progress
+    ) values (
+      v_tranche.user_id, v_tranche.goal_id, 'bank', 'investment', v_tranche.amount_vnd,
+      v_tranche.investment_date, v_tranche.expiry_date, v_tranche.interest_rate, v_tranche.notes,
+      p_group_id, v_interest, false
+    )
+    returning transaction_id into v_snapshot_id;
+
+    -- Re-parent this tranche's partial withdrawals onto its snapshot.
+    update public.investment_transactions
+       set parent_transaction_id = v_snapshot_id
+     where parent_transaction_id = v_tranche.transaction_id
+       and transaction_type = 'withdrawal';
+
+    -- The anchor row survives (rolled forward below); every other tranche's value
+    -- now lives in the lump, so remove the duplicate live row.
+    if v_tranche.transaction_id <> p_group_id then
+      delete from public.investment_transactions
+       where transaction_id = v_tranche.transaction_id;
+    end if;
+  end loop;
+
+  -- 3) Roll the anchor forward into the single fresh deposit. Clearing
+  -- deposit_group_id turns the book into a plain term deposit (it renews through
+  -- renew_term_deposit next time).
+  update public.investment_transactions
+     set amount_vnd        = p_amount_vnd,
+         interest_rate     = p_interest_rate,
+         expiry_date       = p_expiry_date,
+         investment_date   = p_investment_date,
+         deposit_group_id  = null,
+         updated_at        = now()
+   where transaction_id = p_group_id
+  returning * into v_renewed;
+
+  -- 5) Combine flow only: record this month's recurring saving as fulfilled so
+  -- its amount (now folded into the lump) is not also counted as a synthesized
+  -- contribution. Identical mechanism to renew_term_deposit's combine path.
+  if p_fulfill_saving_id is not null and p_fulfill_ym is not null then
+    if not exists (
+      select 1 from public.recurring_savings
+       where saving_id = p_fulfill_saving_id and user_id = v_anchor.user_id
+    ) then
+      raise exception 'collapse_accumulating_book: recurring saving not found'
+        using errcode = 'no_data_found';
+    end if;
+    insert into public.recurring_saving_fulfillments (
+      user_id, recurring_saving_id, ym, amount_vnd, source
+    ) values (
+      v_anchor.user_id, p_fulfill_saving_id, p_fulfill_ym,
+      coalesce(p_fulfill_amount, 0), coalesce(p_fulfill_source, 'maturity-collapse')
+    )
+    on conflict (recurring_saving_id, ym) do update
+      set amount_vnd = excluded.amount_vnd,
+          source     = excluded.source,
+          updated_at = now();
+  end if;
+
+  return v_renewed;
+end;
+$$;

--- a/supabase/migrations/20260618000002_collapse_repoint_explicit_link.sql
+++ b/supabase/migrations/20260618000002_collapse_repoint_explicit_link.sql
@@ -1,0 +1,153 @@
+-- Fix: collapse_accumulating_book must not silently drop a recurring saving's
+-- EXPLICIT deposit link (#348) when it deletes a tranche.
+--
+-- recurring_savings.linked_deposit_tx_id (migration 20260616000003) references
+-- investment_transactions ON DELETE SET NULL. A user can legitimately link a
+-- recurring saving to a specific top-up tranche. The original collapse RPC
+-- deletes every non-anchor tranche, so such a link would be SET NULL out from
+-- under the user — and inconsistently: a link to the anchor tranche survives
+-- (the anchor is rolled forward, not deleted) while a link to any other tranche
+-- vanishes, with no notice.
+--
+-- The collapse leaves exactly one surviving deposit (the rolled-forward anchor =
+-- p_group_id), which is the natural new target: the lump inherits the link so the
+-- EXPLICIT match tier still resolves it next cycle. So before deleting any
+-- tranche, re-point every recurring link that points at ANY of the book's
+-- tranches onto the anchor. (Re-pointing a link already on the anchor is a no-op.)
+--
+-- Body is otherwise identical to 20260618000001 — see it for the full rationale on
+-- the coupled, atomic writes.
+create or replace function public.collapse_accumulating_book(
+  p_group_id uuid,
+  p_amount_vnd bigint,
+  p_interest_rate numeric,
+  p_expiry_date date,
+  p_investment_date date,
+  p_tranche_ids uuid[],
+  p_tranche_interest bigint[],
+  p_fulfill_saving_id uuid default null,
+  p_fulfill_ym text default null,
+  p_fulfill_amount bigint default null,
+  p_fulfill_source text default null
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_anchor public.investment_transactions;
+  v_tranche public.investment_transactions;
+  v_snapshot_id uuid;
+  v_interest bigint;
+  v_idx int;
+  v_renewed public.investment_transactions;
+begin
+  select * into v_anchor
+    from public.investment_transactions
+   where transaction_id = p_group_id
+     and deposit_group_id = p_group_id
+   for update;
+  if not found then
+    raise exception 'collapse_accumulating_book: accumulating book not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_anchor.asset_type is distinct from 'bank' then
+    raise exception 'collapse_accumulating_book: only bank books can be collapsed'
+      using errcode = 'check_violation';
+  end if;
+  if p_amount_vnd is null or p_amount_vnd <= 0 then
+    raise exception 'collapse_accumulating_book: amount must be positive'
+      using errcode = 'check_violation';
+  end if;
+  if p_investment_date > current_date + 1 then
+    raise exception 'collapse_accumulating_book: investment date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+  if p_expiry_date is not null and p_expiry_date <= p_investment_date then
+    raise exception 'collapse_accumulating_book: new maturity must be after the investment date'
+      using errcode = 'check_violation';
+  end if;
+
+  -- 0) Preserve EXPLICIT recurring links (#348): re-point any link that targets a
+  -- tranche of this book onto the surviving anchor BEFORE the deletes below, so
+  -- the FK's ON DELETE SET NULL never fires on a still-wanted link.
+  update public.recurring_savings
+     set linked_deposit_tx_id = p_group_id,
+         updated_at = now()
+   where user_id = v_anchor.user_id
+     and linked_deposit_tx_id in (
+       select transaction_id from public.investment_transactions
+        where deposit_group_id = p_group_id
+          and transaction_type = 'investment'
+          and renewed_from_transaction_id is null
+     );
+
+  -- 1–4) Snapshot, re-parent, then delete every tranche; roll the anchor forward
+  -- after the loop.
+  for v_tranche in
+    select * from public.investment_transactions
+     where deposit_group_id = p_group_id
+       and transaction_type = 'investment'
+       and renewed_from_transaction_id is null
+     order by investment_date
+     for update
+  loop
+    v_idx := array_position(p_tranche_ids, v_tranche.transaction_id);
+    v_interest := case when v_idx is null then null else p_tranche_interest[v_idx] end;
+
+    insert into public.investment_transactions (
+      user_id, goal_id, asset_type, transaction_type, amount_vnd,
+      investment_date, expiry_date, interest_rate, notes,
+      renewed_from_transaction_id, interest_earned_vnd, affects_progress
+    ) values (
+      v_tranche.user_id, v_tranche.goal_id, 'bank', 'investment', v_tranche.amount_vnd,
+      v_tranche.investment_date, v_tranche.expiry_date, v_tranche.interest_rate, v_tranche.notes,
+      p_group_id, v_interest, false
+    )
+    returning transaction_id into v_snapshot_id;
+
+    update public.investment_transactions
+       set parent_transaction_id = v_snapshot_id
+     where parent_transaction_id = v_tranche.transaction_id
+       and transaction_type = 'withdrawal';
+
+    if v_tranche.transaction_id <> p_group_id then
+      delete from public.investment_transactions
+       where transaction_id = v_tranche.transaction_id;
+    end if;
+  end loop;
+
+  update public.investment_transactions
+     set amount_vnd        = p_amount_vnd,
+         interest_rate     = p_interest_rate,
+         expiry_date       = p_expiry_date,
+         investment_date   = p_investment_date,
+         deposit_group_id  = null,
+         updated_at        = now()
+   where transaction_id = p_group_id
+  returning * into v_renewed;
+
+  if p_fulfill_saving_id is not null and p_fulfill_ym is not null then
+    if not exists (
+      select 1 from public.recurring_savings
+       where saving_id = p_fulfill_saving_id and user_id = v_anchor.user_id
+    ) then
+      raise exception 'collapse_accumulating_book: recurring saving not found'
+        using errcode = 'no_data_found';
+    end if;
+    insert into public.recurring_saving_fulfillments (
+      user_id, recurring_saving_id, ym, amount_vnd, source
+    ) values (
+      v_anchor.user_id, p_fulfill_saving_id, p_fulfill_ym,
+      coalesce(p_fulfill_amount, 0), coalesce(p_fulfill_source, 'maturity-collapse')
+    )
+    on conflict (recurring_saving_id, ym) do update
+      set amount_vnd = excluded.amount_vnd,
+          source     = excluded.source,
+          updated_at = now();
+  end if;
+
+  return v_renewed;
+end;
+$$;

--- a/supabase/migrations/20260618000003_collapse_guard_stale_book.sql
+++ b/supabase/migrations/20260618000003_collapse_guard_stale_book.sql
@@ -1,0 +1,161 @@
+-- Guard collapse_accumulating_book against a stale read (TOCTOU money loss).
+--
+-- The route reads the book's tranches (T1), values each tranche's interest, then
+-- calls this RPC with those (tranche_id → interest) arrays (T2). If a NEW top-up
+-- commits between T1 and T2, the RPC's loop sees it (it matches the WHERE), but it
+-- is absent from p_tranche_ids — so it would be snapshotted with NULL interest and
+-- deleted, while its principal was never in the user's lump amount. The money in
+-- that fresh tranche would silently vanish.
+--
+-- It's a narrow window (same user, two near-simultaneous actions), but the failure
+-- mode is lost money, so close it hard: if the loop meets a live tranche that the
+-- caller didn't account for (array_position returns NULL), the book changed under
+-- us — raise and let the whole collapse roll back. The client reloads and retries
+-- against the current book. (A tranche that was concurrently DELETED is the
+-- opposite case and harmless: it simply never appears in the loop.)
+--
+-- Body is otherwise identical to 20260618000002 — see it and 20260618000001 for the
+-- full rationale on the coupled, atomic writes.
+create or replace function public.collapse_accumulating_book(
+  p_group_id uuid,
+  p_amount_vnd bigint,
+  p_interest_rate numeric,
+  p_expiry_date date,
+  p_investment_date date,
+  p_tranche_ids uuid[],
+  p_tranche_interest bigint[],
+  p_fulfill_saving_id uuid default null,
+  p_fulfill_ym text default null,
+  p_fulfill_amount bigint default null,
+  p_fulfill_source text default null
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_anchor public.investment_transactions;
+  v_tranche public.investment_transactions;
+  v_snapshot_id uuid;
+  v_interest bigint;
+  v_idx int;
+  v_renewed public.investment_transactions;
+begin
+  select * into v_anchor
+    from public.investment_transactions
+   where transaction_id = p_group_id
+     and deposit_group_id = p_group_id
+   for update;
+  if not found then
+    raise exception 'collapse_accumulating_book: accumulating book not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_anchor.asset_type is distinct from 'bank' then
+    raise exception 'collapse_accumulating_book: only bank books can be collapsed'
+      using errcode = 'check_violation';
+  end if;
+  if p_amount_vnd is null or p_amount_vnd <= 0 then
+    raise exception 'collapse_accumulating_book: amount must be positive'
+      using errcode = 'check_violation';
+  end if;
+  if p_investment_date > current_date + 1 then
+    raise exception 'collapse_accumulating_book: investment date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+  if p_expiry_date is not null and p_expiry_date <= p_investment_date then
+    raise exception 'collapse_accumulating_book: new maturity must be after the investment date'
+      using errcode = 'check_violation';
+  end if;
+
+  -- 0) Preserve EXPLICIT recurring links (#348): re-point any link that targets a
+  -- tranche of this book onto the surviving anchor BEFORE the deletes below.
+  update public.recurring_savings
+     set linked_deposit_tx_id = p_group_id,
+         updated_at = now()
+   where user_id = v_anchor.user_id
+     and linked_deposit_tx_id in (
+       select transaction_id from public.investment_transactions
+        where deposit_group_id = p_group_id
+          and transaction_type = 'investment'
+          and renewed_from_transaction_id is null
+     );
+
+  -- 1–4) Snapshot, re-parent, then delete every tranche; roll the anchor forward
+  -- after the loop.
+  for v_tranche in
+    select * from public.investment_transactions
+     where deposit_group_id = p_group_id
+       and transaction_type = 'investment'
+       and renewed_from_transaction_id is null
+     order by investment_date
+     for update
+  loop
+    v_idx := array_position(p_tranche_ids, v_tranche.transaction_id);
+    -- A live tranche the caller didn't account for ⇒ the book changed since the
+    -- route read it (e.g. a top-up landed mid-flight). Abort so its principal is
+    -- never silently dropped; the client reloads and retries.
+    if v_idx is null then
+      -- NB: a plain raise (errcode P0001), NOT serialization_failure (40001) — the
+      -- latter is conventionally auto-retried by drivers/poolers, which would spin
+      -- on this deterministic abort instead of surfacing it. The route maps this
+      -- message to a 409 so the client reloads.
+      raise exception 'collapse_accumulating_book: book changed since load, reload and retry';
+    end if;
+    v_interest := p_tranche_interest[v_idx];
+
+    insert into public.investment_transactions (
+      user_id, goal_id, asset_type, transaction_type, amount_vnd,
+      investment_date, expiry_date, interest_rate, notes,
+      renewed_from_transaction_id, interest_earned_vnd, affects_progress
+    ) values (
+      v_tranche.user_id, v_tranche.goal_id, 'bank', 'investment', v_tranche.amount_vnd,
+      v_tranche.investment_date, v_tranche.expiry_date, v_tranche.interest_rate, v_tranche.notes,
+      p_group_id, v_interest, false
+    )
+    returning transaction_id into v_snapshot_id;
+
+    update public.investment_transactions
+       set parent_transaction_id = v_snapshot_id
+     where parent_transaction_id = v_tranche.transaction_id
+       and transaction_type = 'withdrawal';
+
+    if v_tranche.transaction_id <> p_group_id then
+      delete from public.investment_transactions
+       where transaction_id = v_tranche.transaction_id;
+    end if;
+  end loop;
+
+  update public.investment_transactions
+     set amount_vnd        = p_amount_vnd,
+         interest_rate     = p_interest_rate,
+         expiry_date       = p_expiry_date,
+         investment_date   = p_investment_date,
+         deposit_group_id  = null,
+         updated_at        = now()
+   where transaction_id = p_group_id
+  returning * into v_renewed;
+
+  if p_fulfill_saving_id is not null and p_fulfill_ym is not null then
+    if not exists (
+      select 1 from public.recurring_savings
+       where saving_id = p_fulfill_saving_id and user_id = v_anchor.user_id
+    ) then
+      raise exception 'collapse_accumulating_book: recurring saving not found'
+        using errcode = 'no_data_found';
+    end if;
+    insert into public.recurring_saving_fulfillments (
+      user_id, recurring_saving_id, ym, amount_vnd, source
+    ) values (
+      v_anchor.user_id, p_fulfill_saving_id, p_fulfill_ym,
+      coalesce(p_fulfill_amount, 0), coalesce(p_fulfill_source, 'maturity-collapse')
+    )
+    on conflict (recurring_saving_id, ym) do update
+      set amount_vnd = excluded.amount_vnd,
+          source     = excluded.source,
+          updated_at = now();
+  end if;
+
+  return v_renewed;
+end;
+$$;


### PR DESCRIPTION
## What
Fills the functional gap flagged in #349: a **matured accumulating ("Loại 2") book** now has a maturity-resolution flow. Per the agreed design, the book **collapses N→1** — settle every tranche into **one fresh plain term deposit** — while preserving each tranche's closed cycle in history. Until now an accumulating book was excluded from the renew/combine path *and* the needs-attention card, so a matured book had no resolution at all.

## Design (as agreed)
- **Collapse, not roll.** At maturity every tranche has paid out together, so per-tranche rates no longer matter — the natural action is to re-deposit the total as a single lump. The result is a **plain term deposit** (`deposit_group_id` cleared) that renews through the normal single-row path next time.
- **One atomic RPC** `collapse_accumulating_book` (not crammed into `renew_term_deposit`):
  1. Snapshot **every** tranche as its own closed cycle (`renewed_from = anchor`), so goal-detail History still tells the "topped up N×, each earned X" story.
  2. Re-parent each tranche's partial-withdrawal rows onto its snapshot (no double-subtract).
  3. Roll the **anchor** forward in place (combined principal, new rate/maturity, `deposit_group_id = NULL`).
  4. Delete the non-anchor tranche rows.
  5. Optionally fold this month's recurring saving in, reusing `recurring_saving_fulfillments`.
- **One interest source of truth.** Interest is **not** computed in SQL. The route values each tranche with `lib/finance`'s single formula (capped at the shared maturity) and passes `(tranche → interest)` arrays down for the RPC to write onto each snapshot — no formula port, no rolled-lump-vs-history drift.
- **Effective principal.** The lump and each snapshot use Σ *post-withdrawal* principal, not Σ raw amount, so a withdrawal that spanned a tranche is netted first.

## Changes
- **Migration** `20260618000001_collapse_accumulating_book.sql` — the new atomic RPC.
- **`lib/accumulating.ts`** `buildCollapsePlan` (pure: per-tranche effective principal + accrued interest + totals); **`lib/maturity.ts`** `isActionableAccumulatingBook` (the book-path mirror of `isActionableTermDeposit`). Both unit-tested.
- **API** `POST /investment-transactions/[id]/collapse` — reads the group's tranches + withdrawals, nets effective principal, computes interest, calls the RPC.
- **UI** `MaturityResolveBody` branches to `/collapse` for a book (drops the withdraw mode — book withdrawal is still a later phase; rounds the blended-rate suggestion). A matured book now surfaces **"Handle maturity"** in the mobile + desktop options modals.

## Tests / checks
- ✅ Unit (`buildCollapsePlan`, `isActionableAccumulatingBook`) — **671 pass**, `tsc` clean.
- ✅ New E2E `e2e/accumulating-collapse.spec.ts`: mature a 2-tranche book → collapse from the UI → assert **one plain term deposit** (group cleared), the sibling tranche **folded in (row gone)**, and **two per-tranche history snapshots carrying real interest**.
- ✅ Re-ran the related suites (accumulating, maturity-combine, explicit-link, goal-detail-desktop) — **18 pass**.
- ✅ Changed files lint-clean (the repo's pre-existing `set-state-in-effect` errors are untouched).

## ⚠️ Before reviewing on preview
The migration adds a new RPC the collapse route calls, so **apply it to production before the preview works** (same as #347–#349; the preview reads prod). Local stack already migrated. I can push it with your go-ahead.

## Deferred (follow-ups)
- Re-include grouped books (as one row) in the dashboard **Needs attention** card — currently a matured book is only discoverable via goal-detail.
- **Withdraw the whole book** at maturity (depends on the deferred per-tranche withdrawal support).
- **Combine** (fold a recurring saving) into a book collapse — the plumbing is reused but goal-detail doesn't yet pass `goalId` to the resolve sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)