### PR TITLE
feat(deposits): surface a matured accumulating book in the Needs-attention card

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -21,7 +21,7 @@ import RecentActivityCard from './components/RecentActivityCard'
 import MaturityActionCard from './components/MaturityActionCard'
 import { MaturityResolveSheet, MaturityResolveModal } from './components/MaturityResolveSheet'
 import { isActionableTermDeposit, MATURING_COUNT_EVENT } from '@/lib/maturity'
-import { actionableBookRows } from './maturityCardItems'
+import { actionableBooks } from './maturityCardItems'
 import type { InvRow } from './components/goalDetailShared'
 import { loadOverview, overviewErrorText, getCachedOverview, setCachedOverview } from './overviewData'
 
@@ -455,10 +455,15 @@ export default function DashboardClient({ userId }: { userId: string }) {
   // Same filter as the card and the badge hook, so they can't disagree.
   useEffect(() => {
     if (!data) return
-    const items = [...data.goals.flatMap((g) => g.nonFunds ?? []), ...data.unallocated.nonFunds]
-    // Term deposits count one each; an accumulating book counts as ONE (grouped),
-    // not per-tranche. isVi is irrelevant to the count, so pass false.
-    const count = items.filter(isActionableTermDeposit).length + actionableBookRows(items, false).length
+    // Tag each tranche with its goal bucket, then group books GLOBALLY — same as
+    // the card below — so the badge and the card can't disagree even if a book is
+    // momentarily split across goals. Term deposits count one each; a book counts
+    // as ONE. isVi is irrelevant to the count, so pass false.
+    const tagged = [
+      ...data.goals.flatMap((g) => (g.nonFunds ?? []).map((it) => ({ it, goalId: g.goalId }))),
+      ...data.unallocated.nonFunds.map((it) => ({ it, goalId: null as string | null })),
+    ]
+    const count = tagged.filter(({ it }) => isActionableTermDeposit(it)).length + actionableBooks(tagged, false).length
     window.dispatchEvent(new CustomEvent(MATURING_COUNT_EVENT, { detail: count }))
   }, [data])
 
@@ -511,21 +516,21 @@ export default function DashboardClient({ userId }: { userId: string }) {
   // Term deposits (assigned + unassigned) that need a renew/withdraw decision,
   // carrying the context needed to act on each.
   // Single term deposits surface one row each; an accumulating book surfaces as
-  // ONE grouped row (its tranches rolled up via actionableBookRows) that opens the
-  // collapse flow. The book's `raw` is its anchor tranche — carried only for the
-  // resolve sheet's context; withdraw isn't offered for a book.
-  const maturingDeposits: MaturingDep[] = data ? [
-    ...data.goals.flatMap((g) => [
-      ...(g.nonFunds ?? []).filter(isActionableTermDeposit)
-        .map((it) => ({ inv: nonFundToInvRow(it, isVi), goalId: g.goalId, raw: it })),
-      ...actionableBookRows(g.nonFunds ?? [], isVi)
-        .map((b) => ({ inv: b.inv, goalId: g.goalId, raw: b.anchor })),
-    ]),
-    ...data.unallocated.nonFunds.filter(isActionableTermDeposit)
-      .map((it) => ({ inv: nonFundToInvRow(it, isVi), goalId: null, raw: it })),
-    ...actionableBookRows(data.unallocated.nonFunds, isVi)
-      .map((b) => ({ inv: b.inv, goalId: null, raw: b.anchor })),
+  // ONE grouped row (its tranches rolled up via actionableBooks) that opens the
+  // collapse flow. We tag every tranche with its goal bucket, then group books
+  // GLOBALLY across buckets so a momentarily goal-split book still shows one row
+  // (full principal, anchor's goal) — and matches the badge count above. A book's
+  // `raw` is its anchor tranche — context only; withdraw isn't offered for a book.
+  const taggedNonFunds = data ? [
+    ...data.goals.flatMap((g) => (g.nonFunds ?? []).map((it) => ({ it, goalId: g.goalId as string | null }))),
+    ...data.unallocated.nonFunds.map((it) => ({ it, goalId: null as string | null })),
   ] : []
+  const maturingDeposits: MaturingDep[] = [
+    ...taggedNonFunds.filter(({ it }) => isActionableTermDeposit(it))
+      .map(({ it, goalId }) => ({ inv: nonFundToInvRow(it, isVi), goalId, raw: it })),
+    ...actionableBooks(taggedNonFunds, isVi)
+      .map((b) => ({ inv: b.inv, goalId: b.goalId, raw: b.anchor })),
+  ]
 
   // Withdraw from the maturity card: open the withdraw sheet pre-targeted at the
   // deposit in one tap. A goal-assigned deposit withdraws in its goal context so

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -21,6 +21,7 @@ import RecentActivityCard from './components/RecentActivityCard'
 import MaturityActionCard from './components/MaturityActionCard'
 import { MaturityResolveSheet, MaturityResolveModal } from './components/MaturityResolveSheet'
 import { isActionableTermDeposit, MATURING_COUNT_EVENT } from '@/lib/maturity'
+import { actionableBookRows } from './maturityCardItems'
 import type { InvRow } from './components/goalDetailShared'
 import { loadOverview, overviewErrorText, getCachedOverview, setCachedOverview } from './overviewData'
 
@@ -455,7 +456,9 @@ export default function DashboardClient({ userId }: { userId: string }) {
   useEffect(() => {
     if (!data) return
     const items = [...data.goals.flatMap((g) => g.nonFunds ?? []), ...data.unallocated.nonFunds]
-    const count = items.filter(isActionableTermDeposit).length
+    // Term deposits count one each; an accumulating book counts as ONE (grouped),
+    // not per-tranche. isVi is irrelevant to the count, so pass false.
+    const count = items.filter(isActionableTermDeposit).length + actionableBookRows(items, false).length
     window.dispatchEvent(new CustomEvent(MATURING_COUNT_EVENT, { detail: count }))
   }, [data])
 
@@ -507,11 +510,21 @@ export default function DashboardClient({ userId }: { userId: string }) {
 
   // Term deposits (assigned + unassigned) that need a renew/withdraw decision,
   // carrying the context needed to act on each.
+  // Single term deposits surface one row each; an accumulating book surfaces as
+  // ONE grouped row (its tranches rolled up via actionableBookRows) that opens the
+  // collapse flow. The book's `raw` is its anchor tranche — carried only for the
+  // resolve sheet's context; withdraw isn't offered for a book.
   const maturingDeposits: MaturingDep[] = data ? [
-    ...data.goals.flatMap((g) => (g.nonFunds ?? []).filter(isActionableTermDeposit)
-      .map((it) => ({ inv: nonFundToInvRow(it, isVi), goalId: g.goalId, raw: it }))),
+    ...data.goals.flatMap((g) => [
+      ...(g.nonFunds ?? []).filter(isActionableTermDeposit)
+        .map((it) => ({ inv: nonFundToInvRow(it, isVi), goalId: g.goalId, raw: it })),
+      ...actionableBookRows(g.nonFunds ?? [], isVi)
+        .map((b) => ({ inv: b.inv, goalId: g.goalId, raw: b.anchor })),
+    ]),
     ...data.unallocated.nonFunds.filter(isActionableTermDeposit)
       .map((it) => ({ inv: nonFundToInvRow(it, isVi), goalId: null, raw: it })),
+    ...actionableBookRows(data.unallocated.nonFunds, isVi)
+      .map((b) => ({ inv: b.inv, goalId: null, raw: b.anchor })),
   ] : []
 
   // Withdraw from the maturity card: open the withdraw sheet pre-targeted at the

--- a/app/assets/__tests__/maturityCardItems.test.ts
+++ b/app/assets/__tests__/maturityCardItems.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest'
+import { actionableBookRows, type MaturityNonFund } from '../maturityCardItems'
+
+// A YYYY-MM-DD string `n` days from today (deterministic regardless of run date).
+function daysFromNow(n: number): string {
+  const d = new Date()
+  d.setHours(0, 0, 0, 0)
+  d.setDate(d.getDate() + n)
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+}
+
+const tranche = (over: Partial<MaturityNonFund>): MaturityNonFund => ({
+  transactionId: 't', type: 'bank', amount: 1_000_000, currentValue: 1_010_000,
+  interestRate: 3, expiryDate: daysFromNow(-2), investmentDate: '2025-01-01',
+  notes: null, units: null, depositGroupId: 'grp', ...over,
+})
+
+describe('actionableBookRows — group accumulating tranches into one card row', () => {
+  it('rolls a matured book\'s tranches into ONE row (summed value/principal, blended rate, book maturity)', () => {
+    const rows = actionableBookRows([
+      tranche({ transactionId: 'grp', amount: 50_000_000, currentValue: 51_000_000, interestRate: 3.0, notes: 'My book', investmentDate: '2025-01-01' }),
+      tranche({ transactionId: 't2', amount: 10_000_000, currentValue: 10_100_000, interestRate: 3.6, investmentDate: '2025-06-01' }),
+    ], false)
+    expect(rows).toHaveLength(1)
+    const { inv, anchor } = rows[0]
+    expect(inv.id).toBe('grp')
+    expect(inv.depositGroupId).toBe('grp')
+    expect(inv.principal).toBe(60_000_000)
+    expect(inv.value).toBe(61_100_000)
+    expect(inv.name).toBe('My book')
+    expect(inv.interestRate).toBeCloseTo((50 * 3.0 + 10 * 3.6) / 60, 6)
+    expect(inv.investmentDate).toBe('2025-01-01') // earliest tranche opened the book
+    expect(anchor.transactionId).toBe('grp') // the self-grouped row, for context
+  })
+
+  it('excludes a book whose shared maturity is still well in the future', () => {
+    expect(actionableBookRows([
+      tranche({ transactionId: 'grp', expiryDate: daysFromNow(40) }),
+      tranche({ transactionId: 't2', expiryDate: daysFromNow(40) }),
+    ], false)).toHaveLength(0)
+  })
+
+  it('includes a book maturing within the reminder window (tomorrow)', () => {
+    expect(actionableBookRows([
+      tranche({ transactionId: 'grp', expiryDate: daysFromNow(1) }),
+    ], false)).toHaveLength(1)
+  })
+
+  it('ignores ungrouped term deposits — it returns books only', () => {
+    expect(actionableBookRows([
+      tranche({ transactionId: 'x', depositGroupId: null, expiryDate: daysFromNow(-1) }),
+    ], false)).toHaveLength(0)
+  })
+
+  it('keeps two separate books separate', () => {
+    const rows = actionableBookRows([
+      tranche({ transactionId: 'a', depositGroupId: 'a' }),
+      tranche({ transactionId: 'b', depositGroupId: 'b' }),
+    ], false)
+    expect(rows.map((r) => r.inv.id).sort()).toEqual(['a', 'b'])
+  })
+})

--- a/app/assets/__tests__/maturityCardItems.test.ts
+++ b/app/assets/__tests__/maturityCardItems.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { actionableBookRows, type MaturityNonFund } from '../maturityCardItems'
+import { actionableBooks, type MaturityNonFund, type TaggedTranche } from '../maturityCardItems'
 
 // A YYYY-MM-DD string `n` days from today (deterministic regardless of run date).
 function daysFromNow(n: number): string {
@@ -14,15 +14,16 @@ const tranche = (over: Partial<MaturityNonFund>): MaturityNonFund => ({
   interestRate: 3, expiryDate: daysFromNow(-2), investmentDate: '2025-01-01',
   notes: null, units: null, depositGroupId: 'grp', ...over,
 })
+const tag = (it: MaturityNonFund, goalId: string | null = 'g1'): TaggedTranche<MaturityNonFund> => ({ it, goalId })
 
-describe('actionableBookRows — group accumulating tranches into one card row', () => {
-  it('rolls a matured book\'s tranches into ONE row (summed value/principal, blended rate, book maturity)', () => {
-    const rows = actionableBookRows([
-      tranche({ transactionId: 'grp', amount: 50_000_000, currentValue: 51_000_000, interestRate: 3.0, notes: 'My book', investmentDate: '2025-01-01' }),
-      tranche({ transactionId: 't2', amount: 10_000_000, currentValue: 10_100_000, interestRate: 3.6, investmentDate: '2025-06-01' }),
+describe('actionableBooks — group accumulating tranches into one card row', () => {
+  it('rolls a matured book\'s tranches into ONE row (summed value/principal, blended rate, book maturity, anchor goal)', () => {
+    const rows = actionableBooks([
+      tag(tranche({ transactionId: 'grp', amount: 50_000_000, currentValue: 51_000_000, interestRate: 3.0, notes: 'My book', investmentDate: '2025-01-01' }), 'g1'),
+      tag(tranche({ transactionId: 't2', amount: 10_000_000, currentValue: 10_100_000, interestRate: 3.6, investmentDate: '2025-06-01' }), 'g1'),
     ], false)
     expect(rows).toHaveLength(1)
-    const { inv, anchor } = rows[0]
+    const { inv, anchor, goalId } = rows[0]
     expect(inv.id).toBe('grp')
     expect(inv.depositGroupId).toBe('grp')
     expect(inv.principal).toBe(60_000_000)
@@ -30,32 +31,46 @@ describe('actionableBookRows — group accumulating tranches into one card row',
     expect(inv.name).toBe('My book')
     expect(inv.interestRate).toBeCloseTo((50 * 3.0 + 10 * 3.6) / 60, 6)
     expect(inv.investmentDate).toBe('2025-01-01') // earliest tranche opened the book
-    expect(anchor.transactionId).toBe('grp') // the self-grouped row, for context
+    expect(anchor.transactionId).toBe('grp')
+    expect(goalId).toBe('g1')
+  })
+
+  it('groups a book to ONE row even if its tranches are split across goal buckets, using the anchor\'s goal', () => {
+    // Mid-way through #349's non-atomic goal cascade a book can momentarily span
+    // goals. Global grouping must still yield one row with the FULL principal and
+    // the anchor's goal — so the card and the badge never disagree.
+    const rows = actionableBooks([
+      tag(tranche({ transactionId: 'grp', amount: 50_000_000, currentValue: 51_000_000 }), 'gAnchor'),
+      tag(tranche({ transactionId: 't2', amount: 10_000_000, currentValue: 10_100_000 }), 'gOther'),
+    ], false)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].inv.principal).toBe(60_000_000) // full, not a partial bucket sum
+    expect(rows[0].goalId).toBe('gAnchor')
   })
 
   it('excludes a book whose shared maturity is still well in the future', () => {
-    expect(actionableBookRows([
-      tranche({ transactionId: 'grp', expiryDate: daysFromNow(40) }),
-      tranche({ transactionId: 't2', expiryDate: daysFromNow(40) }),
+    expect(actionableBooks([
+      tag(tranche({ transactionId: 'grp', expiryDate: daysFromNow(40) })),
+      tag(tranche({ transactionId: 't2', expiryDate: daysFromNow(40) })),
     ], false)).toHaveLength(0)
   })
 
   it('includes a book maturing within the reminder window (tomorrow)', () => {
-    expect(actionableBookRows([
-      tranche({ transactionId: 'grp', expiryDate: daysFromNow(1) }),
+    expect(actionableBooks([
+      tag(tranche({ transactionId: 'grp', expiryDate: daysFromNow(1) })),
     ], false)).toHaveLength(1)
   })
 
   it('ignores ungrouped term deposits — it returns books only', () => {
-    expect(actionableBookRows([
-      tranche({ transactionId: 'x', depositGroupId: null, expiryDate: daysFromNow(-1) }),
+    expect(actionableBooks([
+      tag(tranche({ transactionId: 'x', depositGroupId: null, expiryDate: daysFromNow(-1) })),
     ], false)).toHaveLength(0)
   })
 
   it('keeps two separate books separate', () => {
-    const rows = actionableBookRows([
-      tranche({ transactionId: 'a', depositGroupId: 'a' }),
-      tranche({ transactionId: 'b', depositGroupId: 'b' }),
+    const rows = actionableBooks([
+      tag(tranche({ transactionId: 'a', depositGroupId: 'a' })),
+      tag(tranche({ transactionId: 'b', depositGroupId: 'b' })),
     ], false)
     expect(rows.map((r) => r.inv.id).sort()).toEqual(['a', 'b'])
   })

--- a/app/assets/maturityCardItems.ts
+++ b/app/assets/maturityCardItems.ts
@@ -1,12 +1,16 @@
 // Group an accumulating ("Loại 2") book's tranches into ONE actionable row for
 // the dashboard "Needs attention" card + nav badge. The overview returns a book
-// as several flat per-tranche nonFund items (sharing a deposit_group_id); the
-// single-row term path excludes them (isActionableTermDeposit), so without this a
-// matured book would either show N rows or — as shipped in #349 — none at all,
-// leaving the user no prompt to collapse it. This rolls the tranches up the same
-// way buildInvRows does for goal-detail, and is the single source of truth the
-// card, the dashboard count, and the nav badge hook all share so they can't
-// disagree.
+// as several flat per-tranche nonFund items (sharing a deposit_group_id), split
+// across goal buckets; the single-row term path excludes them
+// (isActionableTermDeposit), so without this a matured book would either show N
+// rows or — as shipped in #349 — none at all, leaving the user no prompt to
+// collapse it.
+//
+// Grouping is GLOBAL (across every goal bucket + unallocated), not per-bucket, so
+// the card and the nav badge can't disagree even if a book is momentarily split
+// across goals — e.g. mid-way through #349's non-atomic goal cascade. A book's
+// goal context comes from its anchor tranche (the self-grouped row), the
+// authoritative owner. This is the single source of truth both consumers share.
 
 import { blendedRate } from '@/lib/accumulating'
 import { isActionableAccumulatingBook } from '@/lib/maturity'
@@ -27,48 +31,65 @@ export interface MaturityNonFund {
   depositGroupId?: string | null
 }
 
-// One actionable book: the rolled-up InvRow plus its anchor tranche (the self-
-// grouped row, carried for the resolve flow's context — withdraw isn't offered
-// for a book, so it's never used to subtract).
+// A tranche tagged with the goal bucket it came from (null = unallocated). The
+// overview splits nonFunds by goal without a goal_id on each item, so callers tag
+// them when flattening — letting us group across buckets yet recover each book's
+// goal context.
+export interface TaggedTranche<T extends MaturityNonFund> {
+  it: T
+  goalId: string | null
+}
+
+// One actionable book: the rolled-up InvRow, its anchor tranche (the self-grouped
+// row — context for the resolve flow; withdraw isn't offered for a book so it's
+// never used to subtract), and the book's goal (from the anchor).
 export interface ActionableBook<T extends MaturityNonFund> {
   inv: InvRow
   anchor: T
+  goalId: string | null
 }
 
-// The accumulating books in `nonFunds` that are at/near their shared maturity,
-// one InvRow each. Ungrouped term deposits are ignored here (the caller keeps
-// handling those via isActionableTermDeposit).
-export function actionableBookRows<T extends MaturityNonFund>(nonFunds: T[], isVi: boolean): ActionableBook<T>[] {
-  const groups = new Map<string, T[]>()
-  for (const it of nonFunds) {
-    if (!it.depositGroupId) continue
-    const arr = groups.get(it.depositGroupId) ?? []
-    arr.push(it)
-    groups.set(it.depositGroupId, arr)
+// The accumulating books among `tagged` that are at/near their shared maturity,
+// one InvRow each, grouped globally by deposit_group_id. Ungrouped term deposits
+// are ignored here (the caller keeps handling those via isActionableTermDeposit).
+export function actionableBooks<T extends MaturityNonFund>(
+  tagged: TaggedTranche<T>[],
+  isVi: boolean,
+): ActionableBook<T>[] {
+  const groups = new Map<string, TaggedTranche<T>[]>()
+  for (const t of tagged) {
+    const gid = t.it.depositGroupId
+    if (!gid) continue
+    const arr = groups.get(gid) ?? []
+    arr.push(t)
+    groups.set(gid, arr)
   }
 
   const out: ActionableBook<T>[] = []
-  for (const [groupId, rows] of groups) {
+  for (const [groupId, members] of groups) {
+    const rows = members.map((m) => m.it)
     const value = rows.reduce((s, r) => s + r.currentValue, 0)
     const principal = rows.reduce((s, r) => s + r.amount, 0)
-    const anchor = rows.find((r) => r.transactionId === groupId) ?? rows[0]
+    // The anchor (deposit_group_id = its own id) carries the book's true goal +
+    // maturity; fall back to the first tranche only if it isn't in the set.
+    const anchorTag = members.find((m) => m.it.transactionId === groupId) ?? members[0]
     const earliest = rows.reduce((d, r) => (r.investmentDate < d ? r.investmentDate : d), rows[0].investmentDate)
     const inv: InvRow = {
       id: groupId,
-      name: anchor.notes ?? (isVi ? 'Tiền gửi' : 'Bank deposit'),
+      name: anchorTag.it.notes ?? (isVi ? 'Tiền gửi' : 'Bank deposit'),
       type: 'bank',
       value,
       gainPct: principal > 0 ? ((value - principal) / principal) * 100 : null,
       units: null,
       principal,
       interestRate: blendedRate(rows.map((r) => ({ amount: r.amount, rate: r.interestRate }))),
-      expiryDate: anchor.expiryDate,
+      expiryDate: anchorTag.it.expiryDate,
       investmentDate: earliest,
       fund: null,
       depositGroupId: groupId,
     }
     if (isActionableAccumulatingBook({ type: inv.type, expiryDate: inv.expiryDate, depositGroupId: inv.depositGroupId })) {
-      out.push({ inv, anchor })
+      out.push({ inv, anchor: anchorTag.it, goalId: anchorTag.goalId })
     }
   }
   return out

--- a/app/assets/maturityCardItems.ts
+++ b/app/assets/maturityCardItems.ts
@@ -1,0 +1,75 @@
+// Group an accumulating ("Loại 2") book's tranches into ONE actionable row for
+// the dashboard "Needs attention" card + nav badge. The overview returns a book
+// as several flat per-tranche nonFund items (sharing a deposit_group_id); the
+// single-row term path excludes them (isActionableTermDeposit), so without this a
+// matured book would either show N rows or — as shipped in #349 — none at all,
+// leaving the user no prompt to collapse it. This rolls the tranches up the same
+// way buildInvRows does for goal-detail, and is the single source of truth the
+// card, the dashboard count, and the nav badge hook all share so they can't
+// disagree.
+
+import { blendedRate } from '@/lib/accumulating'
+import { isActionableAccumulatingBook } from '@/lib/maturity'
+import type { InvRow } from './components/goalDetailShared'
+
+// The minimal per-tranche shape this needs — structurally a NonFundUnallocatedItem
+// (so callers pass their overview items directly).
+export interface MaturityNonFund {
+  transactionId: string
+  type: string
+  amount: number
+  currentValue: number
+  interestRate: number | null
+  expiryDate: string | null
+  investmentDate: string
+  notes: string | null
+  units: number | null
+  depositGroupId?: string | null
+}
+
+// One actionable book: the rolled-up InvRow plus its anchor tranche (the self-
+// grouped row, carried for the resolve flow's context — withdraw isn't offered
+// for a book, so it's never used to subtract).
+export interface ActionableBook<T extends MaturityNonFund> {
+  inv: InvRow
+  anchor: T
+}
+
+// The accumulating books in `nonFunds` that are at/near their shared maturity,
+// one InvRow each. Ungrouped term deposits are ignored here (the caller keeps
+// handling those via isActionableTermDeposit).
+export function actionableBookRows<T extends MaturityNonFund>(nonFunds: T[], isVi: boolean): ActionableBook<T>[] {
+  const groups = new Map<string, T[]>()
+  for (const it of nonFunds) {
+    if (!it.depositGroupId) continue
+    const arr = groups.get(it.depositGroupId) ?? []
+    arr.push(it)
+    groups.set(it.depositGroupId, arr)
+  }
+
+  const out: ActionableBook<T>[] = []
+  for (const [groupId, rows] of groups) {
+    const value = rows.reduce((s, r) => s + r.currentValue, 0)
+    const principal = rows.reduce((s, r) => s + r.amount, 0)
+    const anchor = rows.find((r) => r.transactionId === groupId) ?? rows[0]
+    const earliest = rows.reduce((d, r) => (r.investmentDate < d ? r.investmentDate : d), rows[0].investmentDate)
+    const inv: InvRow = {
+      id: groupId,
+      name: anchor.notes ?? (isVi ? 'Tiền gửi' : 'Bank deposit'),
+      type: 'bank',
+      value,
+      gainPct: principal > 0 ? ((value - principal) / principal) * 100 : null,
+      units: null,
+      principal,
+      interestRate: blendedRate(rows.map((r) => ({ amount: r.amount, rate: r.interestRate }))),
+      expiryDate: anchor.expiryDate,
+      investmentDate: earliest,
+      fund: null,
+      depositGroupId: groupId,
+    }
+    if (isActionableAccumulatingBook({ type: inv.type, expiryDate: inv.expiryDate, depositGroupId: inv.depositGroupId })) {
+      out.push({ inv, anchor })
+    }
+  }
+  return out
+}

--- a/app/components/navigation/useMaturingDepositsCount.ts
+++ b/app/components/navigation/useMaturingDepositsCount.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { isActionableTermDeposit, MATURING_COUNT_EVENT } from '@/lib/maturity'
+import { actionableBookRows } from '@/app/assets/maturityCardItems'
 import type { DashboardData } from '@/app/assets/DashboardClient'
 
 // Count of bank term deposits that currently need a renew/withdraw decision —
@@ -33,7 +34,9 @@ export function useMaturingDepositsCount(): number {
           ...data.goals.flatMap((g) => g.nonFunds ?? []),
           ...data.unallocated.nonFunds,
         ]
-        setCount(items.filter(isActionableTermDeposit).length)
+        // Same tally as the dashboard: term deposits one each + each accumulating
+        // book counted ONCE (grouped). isVi doesn't affect the count.
+        setCount(items.filter(isActionableTermDeposit).length + actionableBookRows(items, false).length)
       })
       .catch(() => {})
 

--- a/app/components/navigation/useMaturingDepositsCount.ts
+++ b/app/components/navigation/useMaturingDepositsCount.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { isActionableTermDeposit, MATURING_COUNT_EVENT } from '@/lib/maturity'
-import { actionableBookRows } from '@/app/assets/maturityCardItems'
+import { actionableBooks } from '@/app/assets/maturityCardItems'
 import type { DashboardData } from '@/app/assets/DashboardClient'
 
 // Count of bank term deposits that currently need a renew/withdraw decision —
@@ -30,13 +30,15 @@ export function useMaturingDepositsCount(): number {
       .then((r) => (r.ok ? r.json() : null))
       .then((data: DashboardData | null) => {
         if (cancelled || liveRef.current || !data) return
-        const items = [
-          ...data.goals.flatMap((g) => g.nonFunds ?? []),
-          ...data.unallocated.nonFunds,
+        // Same tally as the dashboard: tag each tranche with its goal bucket, then
+        // term deposits one each + each accumulating book counted ONCE (grouped
+        // globally so a goal-split book can't be double-/under-counted). isVi
+        // doesn't affect the count.
+        const tagged = [
+          ...data.goals.flatMap((g) => (g.nonFunds ?? []).map((it) => ({ it, goalId: g.goalId }))),
+          ...data.unallocated.nonFunds.map((it) => ({ it, goalId: null as string | null })),
         ]
-        // Same tally as the dashboard: term deposits one each + each accumulating
-        // book counted ONCE (grouped). isVi doesn't affect the count.
-        setCount(items.filter(isActionableTermDeposit).length + actionableBookRows(items, false).length)
+        setCount(tagged.filter(({ it }) => isActionableTermDeposit(it)).length + actionableBooks(tagged, false).length)
       })
       .catch(() => {})
 

--- a/e2e/accumulating-collapse.spec.ts
+++ b/e2e/accumulating-collapse.spec.ts
@@ -117,6 +117,52 @@ test.describe('Accumulating book collapse (Loại 2 book-level renewal)', () => 
     }
   })
 
+  test('a matured book collapses straight from the dashboard Needs-attention card', async ({ page }) => {
+    test.slow()
+    const goal = await api.createGoal({ goal_name: 'E2E Card Collapse Goal', target_amount: 200_000_000 })
+    const anchor = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Card Collapse Book', amount_vnd: 40_000_000, interest_rate: 3.0, investment_date: iso(-150), expiry_date: iso(30) },
+    })).json()
+    await page.request.post('/api/v1/investment-transactions', {
+      data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 8_000_000, interest_rate: 3.6, investment_date: iso(-20) },
+    })
+    await page.request.put(`/api/v1/investment-transactions/${anchor.transaction_id}`, { data: { expiry_date: iso(-2) } })
+
+    try {
+      await gotoFreshDashboard(page)
+      // The book shows as ONE grouped row in the card — open its collapse flow.
+      const card = page.getByTestId('maturity-action-card')
+      await expect(card).toBeVisible({ timeout: 10_000 })
+      await expect(card).toContainText('E2E Card Collapse Book')
+      await card.locator('div').filter({ hasText: 'E2E Card Collapse Book' })
+        .getByRole('button', { name: /Handle|Xử lý/i }).first().click()
+
+      await page.getByTestId('maturity-term-input').fill('12')
+      const [resp] = await Promise.all([
+        page.waitForResponse((r) => r.url().includes('/collapse') && r.request().method() === 'POST'),
+        page.getByRole('button', { name: /Confirm renewal|Xác nhận tái tục/i }).click(),
+      ])
+      expect(resp.status()).toBe(200)
+      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+
+      // Collapsed → a plain term deposit with a future maturity, so it drops off
+      // the card. (No deposit_group_id; sibling tranche folded in.)
+      const all = await (await page.request.get('/api/v1/investment-transactions?include_history=true&limit=1000')).json()
+      const anchorNow = (all.transactions as Array<{ transaction_id: string; deposit_group_id: string | null }>)
+        .find((r) => r.transaction_id === anchor.transaction_id)
+      expect(anchorNow!.deposit_group_id).toBeNull()
+      await gotoFreshDashboard(page)
+      const cardAfter = page.getByTestId('maturity-action-card')
+      if (await cardAfter.isVisible().catch(() => false)) {
+        await expect(cardAfter).not.toContainText('E2E Card Collapse Book')
+      }
+    } finally {
+      await api.deleteDepositGroup(anchor.transaction_id)
+      await api.deleteTransactionCascade(anchor.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
   test('a book that changed since load (a top-up landed mid-flight) aborts the collapse, losing nothing', async ({ page }) => {
     const goal = await api.createGoal({ goal_name: 'E2E Collapse Race Goal', target_amount: 200_000_000 })
     const anchor = await (await page.request.post('/api/v1/investment-transactions', {

--- a/e2e/accumulating-deposit.spec.ts
+++ b/e2e/accumulating-deposit.spec.ts
@@ -112,18 +112,18 @@ test.describe('Accumulating bank deposits (Loại 2)', () => {
     }
   })
 
-  test('a matured book is kept out of the maturity card and cannot be topped up', async ({ page }) => {
+  test('a matured book surfaces in the maturity card as one grouped row and still can\'t be topped up', async ({ page }) => {
     const goal = await api.createGoal({ goal_name: 'E2E Matured Book', target_amount: 100_000_000 })
-    // Matured anchor — a term deposit would surface in the "needs attention" card.
+    // Matured anchor — now surfaces in the "needs attention" card (book-level
+    // renewal exists), grouped to one row that opens the collapse flow.
     const anchor = await (await page.request.post('/api/v1/investment-transactions', {
       data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Matured Flex', amount_vnd: 20_000_000, interest_rate: 3.0, investment_date: iso(-200), expiry_date: iso(-5) },
     })).json()
     try {
       await gotoFreshDashboard(page)
       const card = page.getByTestId('maturity-action-card')
-      if (await card.isVisible().catch(() => false)) {
-        await expect(card).not.toContainText('E2E Matured Flex')
-      }
+      await expect(card).toBeVisible({ timeout: 10_000 })
+      await expect(card).toContainText('E2E Matured Flex')
       // Topping up a matured book is rejected (a tranche dated today would accrue 0).
       const late = await page.request.post('/api/v1/investment-transactions', {
         data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 1_000_000, interest_rate: 3.0, investment_date: iso(0) },


### PR DESCRIPTION
## What
Closes the discoverability gap left by the book-level renewal work (#350). #349 deliberately kept an accumulating ("Loại 2") book **out** of the dashboard **"Needs attention"** card and nav badge (the overview returns a book as N flat per-tranche rows, and the single-row term filter excludes grouped rows). Now that a book *can* be collapsed at maturity, a matured book was only findable inside goal-detail — the user got no prompt to act.

This surfaces a matured/maturing book as **ONE grouped row** in the card (and counts it once in the nav badge), whose **Handle** action opens the collapse flow.

## How
- **New shared helper `actionableBookRows`** (`app/assets/maturityCardItems.ts`): groups a book's flat overview tranches (by `deposit_group_id`) into one actionable `InvRow` — Σ value / Σ principal, amount-weighted blended rate, shared book maturity — gated by `isActionableAccumulatingBook`. This is the **single source of truth** shared by the card items, the dashboard's live count event, and the nav badge hook, so they can't drift (the same no-divergence rule the existing count comment calls out). Unit-tested.
- **`DashboardClient`**: `maturingDeposits` and the `MATURING_COUNT` event now include grouped books (one each); a book row's `raw` is its anchor tranche (context only — withdraw isn't offered for a book).
- **`useMaturingDepositsCount`**: same tally, so the nav badge from any page matches.
- **Combine-into-collapse comes for free here**: the dashboard already passes `goalId` to the resolve sheet, so a due recurring saving can be folded into the lump (the collapse route already supports `fulfill_recurring`).

## Tests / checks
- ✅ Unit `actionableBookRows` (grouping, blended rate, actionability window, books-only) — **676 pass**, `tsc` clean, changed files lint-clean.
- ✅ E2E: the existing "matured book kept out of card" test **flips** to assert it now shows as one grouped row; new test **collapses a book straight from the card** and asserts it then drops off (it's become a future-dated plain term deposit). Re-ran dashboard-desktop + maturity-combine + accumulating suites — all green.

## Notes
- **No migration** — pure client/overview-consumer change. Works against current prod.

## Deferred (remaining #349 follow-ups)
- **Recurring auto-top-up** into a book (reusing #348's link).
- **Unallocated grouping** (group a book's tranches into one row there too).
- **Whole-book withdrawal** at maturity (depends on per-tranche withdrawal support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)