### PR TITLE
feat(deposits): recurring auto-top-up into an accumulating book

### DIFF
--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -71,6 +71,7 @@ export interface RecurringSaving {
   amount_vnd: number
   effective_from: string | null
   effective_to: string | null
+  linked_deposit_tx_id?: string | null
   savings_goals: { goal_name: string } | null
 }
 

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -12,6 +12,7 @@ import { DesktopPlanningSkeleton } from './PlanningSkeleton'
 import FixedExpenseManager from './FixedExpenseManager'
 import RecurringSavingManager from './RecurringSavingManager'
 import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
+import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
 import { buildByGoal, resolveRecurringSavings, type GoalItem } from '@/lib/planning'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
@@ -451,6 +452,7 @@ export default function DesktopPlanningView({
   // Logging a contribution from a goal header, or recording a recurring bank
   // deposit, opens the same sheet in create mode (POST) pre-filled with the goal.
   const [prefillTx, setPrefillTx] = useState<PrefillTransaction | null>(null)
+  const [bookTopUp, setBookTopUp] = useState<BookTopUpTarget | null>(null)
 
   // ── Derived values ──
   const goalsById = useMemo(() => new Map(goals.map(g => [g.goal_id, g.goal_name])), [goals])
@@ -640,6 +642,32 @@ export default function DesktopPlanningView({
       investment_date: new Date().toISOString().slice(0, 10),
       ...prefill,
     })
+  }
+
+  // The recurring "Saved" pill. If the recurring is linked to an accumulating
+  // book, open the prefilled top-up sheet (tranche + fulfillment); otherwise log a
+  // standalone contribution. A term-deposit link or a matured book falls through.
+  async function recordRecurring(g: { goalId: string; isUnallocated: boolean }, item: GoalItem) {
+    if (item.linkedDepositTxId && item.recurringId && plan) {
+      try {
+        const res = await fetch(`/api/v1/investment-transactions/${item.linkedDepositTxId}`)
+        if (res.ok) {
+          const dep = await res.json()
+          const isBookAnchor = dep.deposit_group_id && dep.deposit_group_id === dep.transaction_id
+          const matured = dep.expiry_date && dep.expiry_date < new Date().toISOString().slice(0, 10)
+          if (isBookAnchor && !matured) {
+            setBookTopUp({
+              savingId: item.recurringId, bookId: dep.transaction_id,
+              bookName: dep.notes || (isVI ? 'Sổ ngân hàng' : 'Bank deposit'),
+              ym: `${year}-${String(month).padStart(2, '0')}`, planId: plan.id,
+              amount: item.amount, rate: dep.interest_rate ?? null,
+            })
+            return
+          }
+        }
+      } catch { /* fall through to the standard contribution */ }
+    }
+    openContribution(g, { asset_type: 'bank', amount_vnd: item.amount })
   }
 
   async function handleSaveOverride() {
@@ -888,7 +916,7 @@ export default function DesktopPlanningView({
                             setOverrideVal(String(inv.baseAmount ?? inv.amount))
                           }}
                           onRecordBuy={() => openBuy(inv.transactionId)}
-                          onRecordDeposit={() => openContribution(g, { asset_type: 'bank', amount_vnd: inv.amount })}
+                          onRecordDeposit={() => recordRecurring(g, inv)}
                           onDcaSkip={() => handleDcaSkip(inv)}
                           onDcaRestore={() => handleDcaRestore(inv)}
                         />
@@ -1152,6 +1180,13 @@ export default function DesktopPlanningView({
           setBuyEdit(null); setPrefillTx(null); onRefresh()
           onToast(wasBuy ? (isVI ? 'Đã ghi nhận mua' : 'Buy recorded') : (isVI ? 'Đã ghi nhận đóng góp' : 'Contribution logged'))
         }}
+      />
+
+      <RecurringBookTopUpSheet
+        target={bookTopUp}
+        isVi={isVI}
+        onClose={() => setBookTopUp(null)}
+        onDone={() => { onRefresh(); onToast(isVI ? 'Đã nạp vào sổ' : 'Topped up book') }}
       />
     </div>
   )

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -645,8 +645,9 @@ export default function DesktopPlanningView({
   }
 
   // The recurring "Saved" pill. If the recurring is linked to an accumulating
-  // book, open the prefilled top-up sheet (tranche + fulfillment); otherwise log a
-  // standalone contribution. A term-deposit link or a matured book falls through.
+  // book, open the prefilled top-up sheet (tranche + fulfillment). A MATURED book
+  // can't be topped up — steer the user to handle its maturity rather than silently
+  // logging an unrelated standalone deposit. Otherwise log a standalone contribution.
   async function recordRecurring(g: { goalId: string; isUnallocated: boolean }, item: GoalItem) {
     if (item.linkedDepositTxId && item.recurringId && plan) {
       try {
@@ -654,8 +655,12 @@ export default function DesktopPlanningView({
         if (res.ok) {
           const dep = await res.json()
           const isBookAnchor = dep.deposit_group_id && dep.deposit_group_id === dep.transaction_id
-          const matured = dep.expiry_date && dep.expiry_date < new Date().toISOString().slice(0, 10)
-          if (isBookAnchor && !matured) {
+          if (isBookAnchor) {
+            const matured = dep.expiry_date && dep.expiry_date < new Date().toISOString().slice(0, 10)
+            if (matured) {
+              onToast(isVI ? 'Sổ đã đáo hạn — hãy xử lý đáo hạn trước.' : 'This book has matured — handle its maturity first.')
+              return
+            }
             setBookTopUp({
               savingId: item.recurringId, bookId: dep.transaction_id,
               bookName: dep.notes || (isVI ? 'Sổ ngân hàng' : 'Bank deposit'),

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -1149,10 +1149,10 @@ export default function MobilePlanningView({
   }
 
   // The recurring "Saved" pill. If the recurring is linked to an accumulating
-  // book, open the prefilled top-up sheet (adds a tranche to that book + marks the
-  // month fulfilled). Otherwise log a standalone contribution as before. A link to
-  // a single term deposit (combine target) or a matured book falls through to the
-  // normal path.
+  // book, open the prefilled top-up sheet (adds a tranche + marks the month
+  // fulfilled). A MATURED book can't be topped up — steer the user to handle its
+  // maturity rather than silently logging an unrelated standalone deposit.
+  // Otherwise (term-deposit link, or no link) log a standalone contribution.
   async function recordRecurring(entry: GoalRow, item: GoalItem) {
     if (item.linkedDepositTxId && item.recurringId && plan) {
       try {
@@ -1160,8 +1160,12 @@ export default function MobilePlanningView({
         if (res.ok) {
           const dep = await res.json()
           const isBookAnchor = dep.deposit_group_id && dep.deposit_group_id === dep.transaction_id
-          const matured = dep.expiry_date && dep.expiry_date < new Date().toISOString().slice(0, 10)
-          if (isBookAnchor && !matured) {
+          if (isBookAnchor) {
+            const matured = dep.expiry_date && dep.expiry_date < new Date().toISOString().slice(0, 10)
+            if (matured) {
+              onToast(isVI ? 'Sổ đã đáo hạn — hãy xử lý đáo hạn trước.' : 'This book has matured — handle its maturity first.')
+              return
+            }
             setBookTopUp({
               savingId: item.recurringId, bookId: dep.transaction_id,
               bookName: dep.notes || (isVI ? 'Sổ ngân hàng' : 'Bank deposit'),

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -11,6 +11,7 @@ import { fmt, fmtCompact } from '@/lib/formatters'
 import FixedExpenseManager from './FixedExpenseManager'
 import RecurringSavingManager from './RecurringSavingManager'
 import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
+import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
 import { buildByGoal, resolveRecurringSavings, type GoalRow, type GoalItem } from '@/lib/planning'
 import { MobilePlanningSkeleton } from './PlanningSkeleton'
 import type {
@@ -1005,6 +1006,7 @@ export default function MobilePlanningView({
   // planned row (PUT) rather than adding a duplicate contribution.
   const [buyEdit, setBuyEdit] = useState<EditableTransaction | null>(null)
   const [prefillTx, setPrefillTx] = useState<PrefillTransaction | null>(null)
+  const [bookTopUp, setBookTopUp] = useState<BookTopUpTarget | null>(null)
   const [overrideTarget, setOverrideTarget] = useState<{ type: 'fe' | 'ins' | 'rec'; id: string; name: string; defaultAmount: number } | null>(null)
 
   const monthLabel = getMonthLabel(month, year)
@@ -1144,6 +1146,34 @@ export default function MobilePlanningView({
       investment_date: new Date().toISOString().slice(0, 10),
       ...prefill,
     })
+  }
+
+  // The recurring "Saved" pill. If the recurring is linked to an accumulating
+  // book, open the prefilled top-up sheet (adds a tranche to that book + marks the
+  // month fulfilled). Otherwise log a standalone contribution as before. A link to
+  // a single term deposit (combine target) or a matured book falls through to the
+  // normal path.
+  async function recordRecurring(entry: GoalRow, item: GoalItem) {
+    if (item.linkedDepositTxId && item.recurringId && plan) {
+      try {
+        const res = await fetch(`/api/v1/investment-transactions/${item.linkedDepositTxId}`)
+        if (res.ok) {
+          const dep = await res.json()
+          const isBookAnchor = dep.deposit_group_id && dep.deposit_group_id === dep.transaction_id
+          const matured = dep.expiry_date && dep.expiry_date < new Date().toISOString().slice(0, 10)
+          if (isBookAnchor && !matured) {
+            setBookTopUp({
+              savingId: item.recurringId, bookId: dep.transaction_id,
+              bookName: dep.notes || (isVI ? 'Sổ ngân hàng' : 'Bank deposit'),
+              ym: `${year}-${String(month).padStart(2, '0')}`, planId: plan.id,
+              amount: item.amount, rate: dep.interest_rate ?? null,
+            })
+            return
+          }
+        }
+      } catch { /* fall through to the standard contribution */ }
+    }
+    openContribution(entry, { asset_type: 'bank', amount_vnd: item.amount })
   }
 
   function openBuy(item: GoalItem) {
@@ -1292,7 +1322,7 @@ export default function MobilePlanningView({
                     onRecOverride={openOverrideRec}
                     onRecEdit={() => setSheet({ type: 'manage-recurring' })}
                     onRecordBuy={openBuy}
-                    onRecordDeposit={(item) => openContribution(entry, { asset_type: 'bank', amount_vnd: item.amount })}
+                    onRecordDeposit={(item) => recordRecurring(entry, item)}
                     onLogContribution={() => openContribution(entry)}
                     onDcaSkip={handleDcaSkip}
                     onDcaRestore={handleDcaRestore}
@@ -1522,6 +1552,13 @@ export default function MobilePlanningView({
           onToast(wasBuy ? (isVI ? 'Đã ghi nhận mua' : 'Buy recorded') : (isVI ? 'Đã ghi nhận đóng góp' : 'Contribution logged'))
           onRefresh()
         }}
+      />
+
+      <RecurringBookTopUpSheet
+        target={bookTopUp}
+        isVi={isVI}
+        onClose={() => setBookTopUp(null)}
+        onDone={() => { onToast(isVI ? 'Đã nạp vào sổ' : 'Topped up book'); onRefresh() }}
       />
     </div>
   )

--- a/app/(app)/planning/components/RecurringSavingManager.tsx
+++ b/app/(app)/planning/components/RecurringSavingManager.tsx
@@ -17,13 +17,16 @@ interface Saving {
   savings_goals?: { goal_name: string } | null
 }
 
-// A term deposit the user can hard-link a recurring saving to (so it's the one
-// folded in when that deposit matures). Only bank rows with a rate + maturity.
-interface TermDeposit {
+// A deposit a recurring saving can be hard-linked to. Either a single TERM
+// deposit (folded in when it matures — the combine flow) or an accumulating BOOK
+// (topped up each month — auto top-up). For a book the target is its anchor row
+// (deposit_group_id = transaction_id); non-anchor tranches aren't link targets.
+interface LinkTarget {
   transaction_id: string
   goal_id: string | null
   notes: string | null
   expiry_date: string | null
+  kind: 'term' | 'book'
 }
 
 // "2026-04-01" → "2026-04" for <input type="month">
@@ -84,7 +87,7 @@ export default function RecurringSavingManager({ goals, onChange, onToast, varia
   const [saving, setSaving] = useState(false)
   const [confirmDelete, setConfirmDelete] = useState<Saving | null>(null)
   const [deleting, setDeleting] = useState(false)
-  const [deposits, setDeposits] = useState<TermDeposit[]>([])
+  const [deposits, setDeposits] = useState<LinkTarget[]>([])
 
   const unallocatedLabel = isVI ? 'Chưa phân bổ (đầu tư chung)' : 'Unallocated (general)'
 
@@ -97,15 +100,22 @@ export default function RecurringSavingManager({ goals, onChange, onToast, varia
 
   useEffect(() => { fetchList() }, [fetchList])
 
-  // Term deposits available to link to — bank holdings that carry a rate + a
-  // maturity (the only ones the combine flow can fold a recurring into).
+  // Deposits available to link to — bank holdings with a rate + maturity. A
+  // single term deposit (combine at maturity) or an accumulating book's ANCHOR
+  // (auto top-up). Non-anchor book tranches are excluded: link the book via its
+  // anchor (deposit_group_id = transaction_id).
   useEffect(() => {
     fetch('/api/v1/investment-transactions?asset_type=bank&limit=200')
       .then((r) => (r.ok ? r.json() : { transactions: [] }))
-      .then((data: { transactions?: Array<TermDeposit & { interest_rate: number | null; transaction_type: string }> }) => {
+      .then((data: { transactions?: Array<LinkTarget & { interest_rate: number | null; transaction_type: string; deposit_group_id: string | null }> }) => {
         setDeposits((data.transactions ?? [])
           .filter((t) => t.transaction_type === 'investment' && t.interest_rate != null && !!t.expiry_date)
-          .map((t) => ({ transaction_id: t.transaction_id, goal_id: t.goal_id, notes: t.notes, expiry_date: t.expiry_date })))
+          // Term deposit (ungrouped) or a book anchor (group = its own id); drop tranches.
+          .filter((t) => t.deposit_group_id == null || t.deposit_group_id === t.transaction_id)
+          .map((t) => ({
+            transaction_id: t.transaction_id, goal_id: t.goal_id, notes: t.notes, expiry_date: t.expiry_date,
+            kind: t.deposit_group_id != null ? 'book' as const : 'term' as const,
+          })))
       })
       .catch(() => {})
   }, [])
@@ -215,10 +225,18 @@ export default function RecurringSavingManager({ goals, onChange, onToast, varia
         </div>
 
         {(() => {
-          // Deposits in the same goal as this recurring — the only ones a combine
-          // renewal could fold it into. Hidden when there are none to link.
+          // Deposits in the same goal as this recurring — the only valid link
+          // targets. Hidden when there are none to link.
           const linkable = deposits.filter((d) => (d.goal_id ?? null) === (form.goal_id || null))
           if (linkable.length === 0) return null
+          const selected = linkable.find((d) => d.transaction_id === form.linked_deposit_tx_id)
+          // The link means different things per target: a term deposit folds this
+          // recurring in at maturity; a book gets topped up by it each month.
+          const hint = selected?.kind === 'book'
+            ? (isVI ? 'Mỗi tháng, nút “Đã gửi” sẽ nạp khoản này vào sổ tích luỹ đó.' : 'Each month, “Saved” tops this amount into that accumulating book.')
+            : selected?.kind === 'term'
+              ? (isVI ? 'Khi sổ này đáo hạn, khoản định kỳ sẽ được gộp đúng vào sổ đó.' : 'When that deposit matures, this recurring is the one folded into it.')
+              : (isVI ? 'Sổ kỳ hạn: gộp khi đáo hạn. Sổ tích luỹ: nạp thêm mỗi tháng.' : 'Term deposit: folded in at maturity. Accumulating book: topped up monthly.')
           return (
             <div>
               <label htmlFor="rs-deposit" style={labelStyle}>{isVI ? 'Gắn với sổ tiết kiệm (tuỳ chọn)' : 'Link to a deposit (optional)'}</label>
@@ -230,15 +248,16 @@ export default function RecurringSavingManager({ goals, onChange, onToast, varia
                 style={{ ...inputStyle, appearance: 'none', cursor: 'pointer' }}
               >
                 <option value="">{isVI ? 'Không gắn' : 'Not linked'}</option>
-                {linkable.map((d) => (
-                  <option key={d.transaction_id} value={d.transaction_id}>
-                    {(d.notes || (isVI ? 'Sổ ngân hàng' : 'Bank deposit')) + (d.expiry_date ? ` · ${d.expiry_date}` : '')}
-                  </option>
-                ))}
+                {linkable.map((d) => {
+                  const tag = d.kind === 'book' ? (isVI ? 'Tích luỹ' : 'Auto top-up') : (isVI ? 'Đáo hạn' : 'At maturity')
+                  return (
+                    <option key={d.transaction_id} value={d.transaction_id}>
+                      {(d.notes || (isVI ? 'Sổ ngân hàng' : 'Bank deposit')) + ` · ${tag}` + (d.expiry_date ? ` · ${d.expiry_date}` : '')}
+                    </option>
+                  )
+                })}
               </select>
-              <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 4 }}>
-                {isVI ? 'Khi sổ này đáo hạn, khoản định kỳ sẽ được gộp đúng vào sổ đó.' : 'When that deposit matures, this recurring is the one folded into it.'}
-              </div>
+              <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 4 }}>{hint}</div>
             </div>
           )
         })()}

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -70,7 +70,7 @@ export async function GET(request: NextRequest) {
         .select('id, description, amount_vnd, created_at').eq('plan_id', plan.id).order('created_at', { ascending: true }),
       supabase
         .from('recurring_savings')
-        .select('saving_id, name, goal_id, amount_vnd, effective_from, effective_to, savings_goals(goal_name)')
+        .select('saving_id, name, goal_id, amount_vnd, effective_from, effective_to, linked_deposit_tx_id, savings_goals(goal_name)')
         .eq('user_id', user.id)
         .or(`effective_from.is.null,effective_from.lte.${planDateForActive}`)
         .or(`effective_to.is.null,effective_to.gte.${planDateForActive}`),

--- a/app/api/v1/recurring-savings/[id]/topup/route.ts
+++ b/app/api/v1/recurring-savings/[id]/topup/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateRate, validateUUID, validateYearMonth } from '@/lib/validation'
+import { isFutureInvestmentDate } from '@/lib/dates'
+
+// Record this month's recurring saving as a top-up into its linked accumulating
+// book: add a real tranche AND mark the recurring fulfilled for the month, in one
+// atomic RPC (so the amount can't be double-counted — see
+// record_recurring_book_topup). The recurring must be linked to exactly this book
+// (its anchor); a tranche needs its own rate, which the client supplies (recurring
+// savings don't store one).
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await request.json()
+  const { book_id, amount_vnd, interest_rate, investment_date, ym, plan_id } = body
+
+  let savingId: string
+  let bookId: string
+  let cleanAmount: number
+  let cleanRate: number
+  let cleanDate: string
+  let cleanYm: string
+  let cleanPlanId: string | null = null
+  try {
+    savingId = validateUUID(id, 'saving_id')
+    bookId = validateUUID(book_id, 'book_id')
+    cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
+    if (cleanAmount <= 0) throw new ValidationError('amount_vnd must be positive')
+    // A tranche locks in its own rate — required (a book values each tranche on it).
+    if (interest_rate == null || interest_rate === '') throw new ValidationError('interest_rate is required')
+    cleanRate = validateRate(interest_rate, 'interest_rate')
+    cleanDate = validateDate(investment_date, 'investment_date')
+    cleanYm = validateYearMonth(ym, 'ym')
+    if (plan_id) cleanPlanId = validateUUID(plan_id, 'plan_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  if (isFutureInvestmentDate(cleanDate)) {
+    return NextResponse.json({ error: 'Investment date cannot be in the future.' }, { status: 400 })
+  }
+
+  // The recurring must exist, be owned by the caller, and be linked to exactly
+  // this book — this endpoint only materializes a recurring into its own linked book.
+  const { data: saving } = await supabase
+    .from('recurring_savings')
+    .select('linked_deposit_tx_id')
+    .eq('saving_id', savingId)
+    .eq('user_id', user.id)
+    .single()
+  if (!saving) return NextResponse.json({ error: 'Recurring saving not found' }, { status: 404 })
+  if (saving.linked_deposit_tx_id !== bookId) {
+    return NextResponse.json({ error: 'This recurring saving is not linked to that book.' }, { status: 400 })
+  }
+
+  const { data: tranche, error } = await supabase
+    .rpc('record_recurring_book_topup', {
+      p_book_id: bookId,
+      p_amount_vnd: Math.round(cleanAmount),
+      p_interest_rate: cleanRate,
+      p_investment_date: cleanDate,
+      p_saving_id: savingId,
+      p_ym: cleanYm,
+      p_plan_id: cleanPlanId,
+    })
+    .single()
+  if (error || !tranche) {
+    const msg = error?.message ?? ''
+    if (msg.includes('cannot top up a matured book')) {
+      return NextResponse.json({ error: 'Cannot top up a deposit that has already matured.' }, { status: 400 })
+    }
+    if (msg.includes('accumulating book not found')) {
+      return NextResponse.json({ error: 'Linked book not found.' }, { status: 404 })
+    }
+    console.error('record_recurring_book_topup failed', msg)
+    return NextResponse.json({ error: 'Failed to record top-up' }, { status: 500 })
+  }
+
+  return NextResponse.json(tranche, { status: 201 })
+}

--- a/app/api/v1/recurring-savings/[id]/topup/route.ts
+++ b/app/api/v1/recurring-savings/[id]/topup/route.ts
@@ -58,6 +58,19 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     return NextResponse.json({ error: 'This recurring saving is not linked to that book.' }, { status: 400 })
   }
 
+  // Verify plan ownership before tagging the tranche with it (the tranche's plan_id
+  // drives the By-goal "contributed" total). Reads are user-scoped, but reject a
+  // foreign/stale plan id at write time — same hygiene as the link-ownership checks.
+  if (cleanPlanId) {
+    const { data: plan } = await supabase
+      .from('monthly_plans')
+      .select('id')
+      .eq('id', cleanPlanId)
+      .eq('user_id', user.id)
+      .single()
+    if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
+  }
+
   const { data: tranche, error } = await supabase
     .rpc('record_recurring_book_topup', {
       p_book_id: bookId,

--- a/app/api/v1/recurring-savings/linkValidation.ts
+++ b/app/api/v1/recurring-savings/linkValidation.ts
@@ -18,7 +18,7 @@ export async function validateLinkedDeposit(
 ): Promise<string | null> {
   const { data, error } = await supabase
     .from('investment_transactions')
-    .select('asset_type, interest_rate, expiry_date, goal_id, transaction_type')
+    .select('asset_type, interest_rate, expiry_date, goal_id, transaction_type, deposit_group_id')
     .eq('transaction_id', txId)
     .eq('user_id', userId)
     .single()
@@ -30,6 +30,14 @@ export async function validateLinkedDeposit(
     !data.expiry_date
   ) {
     return 'Linked deposit must be a bank term deposit.'
+  }
+  // A link may target a single term deposit (combine at maturity) or an
+  // accumulating book (auto top-up each month). For a book, only its ANCHOR is a
+  // valid target — deposit_group_id = its own id — so the link points at the book
+  // as a whole and survives a collapse (the collapse re-points links to the
+  // surviving anchor). A non-anchor tranche is not a linkable target.
+  if (data.deposit_group_id != null && data.deposit_group_id !== txId) {
+    return 'Link an accumulating book via its anchor deposit.'
   }
   if ((data.goal_id ?? null) !== (recurringGoalId ?? null)) {
     return 'Linked deposit must belong to the same goal as the recurring saving.'

--- a/app/assets/components/RecurringBookTopUpSheet.tsx
+++ b/app/assets/components/RecurringBookTopUpSheet.tsx
@@ -1,0 +1,116 @@
+'use client'
+
+// Prefilled top-up sheet for a recurring saving that's linked to an accumulating
+// book. The Plan page's "Saved" pill opens this with amount = the planned monthly
+// amount, date = today, and rate = the book's suggested rate — a one-tap confirm
+// when nothing changed, or edit the rate when the bank's rate moved this month
+// (a recurring saving doesn't store a rate, and each tranche locks its own). On
+// confirm it POSTs to the recurring's topup endpoint, which atomically adds the
+// tranche AND marks the month fulfilled (no double-count).
+
+import { useEffect, useState, type CSSProperties } from 'react'
+import { fmtCompact } from '@/lib/formatters'
+
+export interface BookTopUpTarget {
+  savingId: string
+  bookId: string
+  bookName: string
+  ym: string
+  planId: string | null
+  amount: number
+  rate: number | null
+}
+
+const field: CSSProperties = {
+  width: '100%', boxSizing: 'border-box', padding: '10px 12px', fontSize: 15, fontWeight: 600,
+  background: 'var(--c-canvas,#faf9f7)', border: '1.5px solid var(--c-line)', borderRadius: 10,
+  color: 'var(--c-ink)', outline: 'none', fontVariantNumeric: 'tabular-nums',
+}
+const lbl: CSSProperties = { fontSize: 11, fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--c-muted)', marginBottom: 6, display: 'block' }
+
+export default function RecurringBookTopUpSheet({
+  target, isVi, onClose, onDone,
+}: {
+  target: BookTopUpTarget | null
+  isVi: boolean
+  onClose: () => void
+  onDone: () => void
+}) {
+  const [amount, setAmount] = useState('')
+  const [rate, setRate] = useState('')
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10))
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  // Re-seed the form whenever a new target opens.
+  useEffect(() => {
+    if (!target) return
+    setAmount(String(target.amount))
+    setRate(target.rate != null ? String(Math.round(target.rate * 10) / 10) : '')
+    setDate(new Date().toISOString().slice(0, 10))
+    setError('')
+  }, [target])
+
+  if (!target) return null
+  const amt = Number(amount)
+
+  async function submit() {
+    if (!target) return
+    if (!(amt > 0)) { setError(isVi ? 'Cần nhập số tiền' : 'Amount is required'); return }
+    if (!(Number(rate) > 0)) { setError(isVi ? 'Cần nhập lãi suất' : 'Rate is required'); return }
+    setSaving(true); setError('')
+    try {
+      const res = await fetch(`/api/v1/recurring-savings/${target.savingId}/topup`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          book_id: target.bookId,
+          amount_vnd: Math.round(amt),
+          interest_rate: Number(rate),
+          investment_date: date,
+          ym: target.ym,
+          plan_id: target.planId,
+        }),
+      })
+      if (!res.ok) { const d = await res.json().catch(() => ({})); setError(d.error ?? (isVi ? 'Lỗi' : 'Error')); setSaving(false); return }
+      onDone(); onClose()
+    } catch { setError(isVi ? 'Lỗi kết nối' : 'Connection error') } finally { setSaving(false) }
+  }
+
+  return (
+    <div onClick={() => !saving && onClose()} style={{ position: 'fixed', inset: 0, zIndex: 340, background: 'rgba(15,23,42,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+      <div onClick={(e) => e.stopPropagation()} data-testid="recurring-topup-modal" style={{ width: 380, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, display: 'grid', gap: 12, boxShadow: '0 20px 50px rgba(15,23,42,0.25)' }}>
+        <div>
+          <div style={{ fontSize: 15, fontWeight: 700 }}>{isVi ? 'Nạp vào sổ tích luỹ' : 'Top up accumulating book'}</div>
+          <div style={{ fontSize: 12, color: 'var(--c-muted)', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {target.bookName} · {isVi ? 'định kỳ tháng này' : "this month's recurring"}
+          </div>
+        </div>
+        <div>
+          <label style={lbl}>{isVi ? 'Số tiền nạp (₫)' : 'Top-up amount (₫)'}</label>
+          <input data-testid="recurring-topup-amount" type="text" inputMode="numeric"
+            value={amount ? Number(amount).toLocaleString('en-US') : ''}
+            onChange={(e) => setAmount(e.target.value.replace(/,/g, '').replace(/[^0-9]/g, ''))}
+            style={field} />
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <div>
+            <label style={lbl}>{isVi ? 'Lãi suất lần này' : 'Rate this top-up'}</label>
+            <input data-testid="recurring-topup-rate" type="number" step="0.1" value={rate} onChange={(e) => setRate(e.target.value)} placeholder="3.5" style={field} />
+          </div>
+          <div>
+            <label style={lbl}>{isVi ? 'Ngày nạp' : 'Date'}</label>
+            <input type="date" value={date} onChange={(e) => setDate(e.target.value)} style={field} />
+          </div>
+        </div>
+        <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: -2 }}>
+          {isVi ? `Gợi ý ${fmtCompact(target.amount)} theo kế hoạch — sửa lãi suất nếu kỳ này khác.` : `Suggested ${fmtCompact(target.amount)} from your plan — adjust the rate if it changed this cycle.`}
+        </div>
+        {error && <p style={{ margin: 0, fontSize: 13, color: 'var(--c-neg)' }}>{error}</p>}
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button type="button" onClick={onClose} style={{ flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)', background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit' }}>{isVi ? 'Huỷ' : 'Cancel'}</button>
+          <button type="button" data-testid="recurring-topup-submit" onClick={submit} disabled={saving || !(amt > 0)} style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit', opacity: saving || !(amt > 0) ? 0.6 : 1 }}>{isVi ? 'Nạp & ghi nhận' : 'Top up & record'}</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/e2e/recurring-book-topup.spec.ts
+++ b/e2e/recurring-book-topup.spec.ts
@@ -81,6 +81,28 @@ test.describe('Recurring auto-top-up into an accumulating book', () => {
     }
   })
 
+  test('topping up a matured book via the recurring is rejected', async ({ page }) => {
+    const now = new Date()
+    const ym = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+    const goal = await api.createGoal({ goal_name: 'E2E Topup Matured Goal', target_amount: 100_000_000 })
+    const anchor = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Topup Matured', amount_vnd: 10_000_000, interest_rate: 3.0, investment_date: iso(-100), expiry_date: iso(30) },
+    })).json()
+    const saving = await api.createRecurringSaving({ name: 'E2E Topup Matured Rec', goal_id: goal.goal_id, amount_vnd: 2_000_000, linked_deposit_tx_id: anchor.transaction_id })
+    // Mature the book.
+    await page.request.put(`/api/v1/investment-transactions/${anchor.transaction_id}`, { data: { expiry_date: iso(-2) } })
+    try {
+      const res = await page.request.post(`/api/v1/recurring-savings/${saving.saving_id}/topup`, {
+        data: { book_id: anchor.transaction_id, amount_vnd: 2_000_000, interest_rate: 3.0, investment_date: iso(0), ym },
+      })
+      expect(res.status()).toBe(400)
+    } finally {
+      await api.deleteRecurringSaving(saving.saving_id)
+      await api.deleteDepositGroup(anchor.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
   test('a recurring can be linked to a book anchor but not to a non-anchor tranche', async ({ page }) => {
     const goal = await api.createGoal({ goal_name: 'E2E Link Goal', target_amount: 100_000_000 })
     const anchor = await (await page.request.post('/api/v1/investment-transactions', {

--- a/e2e/recurring-book-topup.spec.ts
+++ b/e2e/recurring-book-topup.spec.ts
@@ -1,0 +1,109 @@
+import { test, expect, type Page } from '@playwright/test'
+import * as api from './helpers/api'
+
+// Recurring auto-top-up into an accumulating ("Loại 2") book. A recurring saving
+// is linked to a book's anchor; "recording" this month materializes it as a real
+// top-up tranche in the book AND marks the month fulfilled — atomically. The
+// correctness risk is a DOUBLE-COUNT: the tranche is a real bank row that also
+// lands in the overview's logged-deposit pool, so without the fulfillment ledger
+// (and consuming the backing deposit) the amount could be counted twice. This
+// drives the topup endpoint and asserts (1) the tranche joined the book and
+// (2) the goal's progress value did NOT jump by an extra recurring amount.
+
+const iso = (d: number) => new Date(Date.now() + d * 86_400_000).toISOString().slice(0, 10)
+
+async function gotoFreshDashboard(page: Page) {
+  await page.goto('/settings')
+  await page.evaluate(() => {
+    Object.keys(localStorage).filter((k) => k.startsWith('dashboardOverviewCache')).forEach((k) => localStorage.removeItem(k))
+  })
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/v1/dashboard/overview') && r.status() === 200, { timeout: 20_000 }),
+    page.goto('/dashboard'),
+  ])
+}
+
+async function goalProgressValue(page: Page, goalId: string): Promise<number> {
+  const res = await page.request.get('/api/v1/dashboard/overview')
+  expect(res.ok()).toBeTruthy()
+  const json = await res.json()
+  const g = (json.goals ?? []).find((x: { goalId: string }) => x.goalId === goalId)
+  return g?.progressValue ?? 0
+}
+
+test.describe('Recurring auto-top-up into an accumulating book', () => {
+  test('recording a book-linked recurring adds a tranche and is not double-counted', async ({ page }) => {
+    test.slow()
+    const now = new Date()
+    const RECURRING = 5_000_000
+    const ym = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`
+    const goal = await api.createGoal({ goal_name: 'E2E Topup Goal', target_amount: 200_000_000 })
+    const plan = await api.createMonthlyPlan({ month: now.getMonth() + 1, year: now.getFullYear(), salary_vnd: 40_000_000 })
+    // A live book (future maturity) so a top-up is accepted.
+    const anchor = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Topup Book', amount_vnd: 20_000_000, interest_rate: 3.0, investment_date: iso(-100), expiry_date: iso(60) },
+    })).json()
+    expect(anchor.deposit_group_id).toBe(anchor.transaction_id)
+    // Recurring linked to the book's anchor.
+    const saving = await api.createRecurringSaving({ name: 'E2E Topup Recurring', goal_id: goal.goal_id, amount_vnd: RECURRING, linked_deposit_tx_id: anchor.transaction_id })
+    try {
+      await gotoFreshDashboard(page)
+      // Before: the recurring is synthesized into the goal for this realized month.
+      const before = await goalProgressValue(page, goal.goal_id)
+
+      // Record the recurring as a book top-up (what the prefilled "Saved" sheet POSTs).
+      const res = await page.request.post(`/api/v1/recurring-savings/${saving.saving_id}/topup`, {
+        data: { book_id: anchor.transaction_id, amount_vnd: RECURRING, interest_rate: 3.5, investment_date: iso(0), ym, plan_id: plan.id },
+      })
+      expect(res.status()).toBe(201)
+
+      // (1) A new tranche joined the book (same group, the top-up amount, not the anchor).
+      const all = await (await page.request.get('/api/v1/investment-transactions?asset_type=bank&limit=1000')).json()
+      const tranches = (all.transactions as Array<{ transaction_id: string; deposit_group_id: string | null; amount_vnd: number; interest_rate: number | null }>)
+        .filter((t) => t.deposit_group_id === anchor.transaction_id)
+      expect(tranches.length).toBe(2) // anchor + the new top-up
+      const topup = tranches.find((t) => t.transaction_id !== anchor.transaction_id)
+      expect(topup?.amount_vnd).toBe(RECURRING)
+      expect(topup?.interest_rate).toBe(3.5)
+
+      // (2) No double-count: the synthesized recurring is now suppressed (fulfilled)
+      // and replaced by the real tranche — progress must NOT have jumped by an extra
+      // full recurring amount on top.
+      await gotoFreshDashboard(page)
+      const after = await goalProgressValue(page, goal.goal_id)
+      expect(after).toBeLessThan(before + RECURRING / 2)
+    } finally {
+      await api.deleteRecurringSaving(saving.saving_id) // cascades the fulfillment row
+      await api.deleteDepositGroup(anchor.transaction_id)
+      await api.deleteTransactionCascade(anchor.transaction_id)
+      await api.deleteMonthlyPlan(plan.id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
+  test('a recurring can be linked to a book anchor but not to a non-anchor tranche', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Link Goal', target_amount: 100_000_000 })
+    const anchor = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Link Book', amount_vnd: 10_000_000, interest_rate: 3.0, investment_date: iso(-50), expiry_date: iso(60) },
+    })).json()
+    const tranche = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 2_000_000, interest_rate: 3.4, investment_date: iso(-5) },
+    })).json()
+    try {
+      // Linking to a non-anchor tranche is rejected (link the book via its anchor).
+      const bad = await page.request.post('/api/v1/recurring-savings', {
+        data: { name: 'E2E Bad Link', goal_id: goal.goal_id, amount_vnd: 1_000_000, linked_deposit_tx_id: tranche.transaction_id },
+      })
+      expect(bad.status()).toBe(400)
+      // Linking to the anchor succeeds.
+      const good = await page.request.post('/api/v1/recurring-savings', {
+        data: { name: 'E2E Good Link', goal_id: goal.goal_id, amount_vnd: 1_000_000, linked_deposit_tx_id: anchor.transaction_id },
+      })
+      expect(good.status()).toBe(201)
+      await api.deleteRecurringSaving((await good.json()).saving_id)
+    } finally {
+      await api.deleteDepositGroup(anchor.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+})

--- a/lib/__tests__/recurringSavings.test.ts
+++ b/lib/__tests__/recurringSavings.test.ts
@@ -148,8 +148,9 @@ describe('realizedRecurringContributions', () => {
 
     it('does not double-spend a logged deposit when the month is also fulfilled', () => {
       freezeJun2026()
-      // Fulfillment alone suppresses; the logged-deposit pool is left intact for
-      // any genuinely-separate deposit and not consumed by the fulfilled month.
+      // Fulfillment suppresses the saving; its backing deposit is consumed (not
+      // left to suppress a different recurring). With no sibling here, the result
+      // is the same either way: nothing synthesized.
       const rows = realizedRecurringContributions(
         [saving()],
         [plan('p-jun', 2026, 6)],
@@ -158,6 +159,22 @@ describe('realizedRecurringContributions', () => {
         [{ recurring_saving_id: 's1', ym: '2026-06' }],
       )
       expect(rows).toHaveLength(0)
+    })
+
+    it('a fulfilled saving consumes its backing deposit, so it cannot also suppress a sibling', () => {
+      freezeJun2026()
+      // s1 is fulfilled this month and its book top-up logged a real 5M deposit
+      // (g1, Jun). s2 is a separate same-goal/same-amount recurring with NO deposit
+      // of its own. The top-up backs s1 (via the fulfillment) and must NOT also
+      // amount-suppress s2 — else s2 silently vanishes from the goal.
+      const rows = realizedRecurringContributions(
+        [saving({ saving_id: 's1' }), saving({ saving_id: 's2', name: 'ACB Savings' })],
+        [plan('p-jun', 2026, 6)],
+        [],
+        [{ month: '2026-06', goalId: 'g1', amount: 5_000_000 }], // the s1 top-up tranche
+        [{ recurring_saving_id: 's1', ym: '2026-06' }],
+      )
+      expect(rows.map((r) => r.savingId)).toEqual(['s2'])
     })
   })
 })

--- a/lib/finance.ts
+++ b/lib/finance.ts
@@ -197,10 +197,19 @@ export function realizedRecurringContributions(
       // override 0 = skip this month; any other positive override replaces the base.
       const amount = ov === 0 ? 0 : ov != null ? ov : s.amount_vnd
       if (amount <= 0) continue
-      // Explicitly fulfilled this month (folded into a renewed term deposit) —
-      // the amount already lives in that deposit's principal, so skip the
-      // synthesized duplicate without consuming a logged deposit.
-      if (fulfilledSet.has(`${s.saving_id}::${ym}`)) continue
+      // Explicitly fulfilled this month (folded into a renewed term deposit, or
+      // materialized as a book top-up) — the amount already lives in that
+      // deposit's principal, so skip the synthesized duplicate. If a logged
+      // deposit backs this fulfillment (a book top-up is a real bank row that also
+      // lands in the pool by month+goal+amount), consume it here so it can't ALSO
+      // amount-suppress a different recurring. Combine re-deposits don't match (a
+      // folded re-deposit's amount differs), so this is a no-op for them.
+      if (fulfilledSet.has(`${s.saving_id}::${ym}`)) {
+        const fk = `${ym}::${s.goal_id ?? ''}::${amount}`
+        const backing = depositPool.get(fk)
+        if (backing) depositPool.set(fk, backing - 1)
+        continue
+      }
       // A logged deposit for the same month + goal + amount already represents
       // this contribution — consume it and skip the synthesized duplicate.
       const k = `${ym}::${s.goal_id ?? ''}::${amount}`

--- a/lib/planning.ts
+++ b/lib/planning.ts
@@ -16,6 +16,7 @@ export interface RecurringSaving {
   name: string
   goal_id: string | null
   amount_vnd: number
+  linked_deposit_tx_id?: string | null
   savings_goals?: { goal_name: string } | null
 }
 
@@ -33,6 +34,7 @@ export interface ResolvedSaving {
   amount: number // effective amount this month (0 when skipped)
   skipped: boolean
   overridden: boolean
+  linkedDepositTxId: string | null // an explicitly linked deposit/book, if any
 }
 
 // Apply per-month overrides to the active recurring savings. An override of 0
@@ -55,6 +57,7 @@ export function resolveRecurringSavings(
       amount: skipped ? 0 : hasOv ? ov! : s.amount_vnd,
       skipped,
       overridden: hasOv && ov! > 0 && ov !== s.amount_vnd,
+      linkedDepositTxId: s.linked_deposit_tx_id ?? null,
     }
   })
 }
@@ -97,6 +100,9 @@ export interface GoalItem {
   recurringId?: string
   skipped?: boolean
   overridden?: boolean
+  // An accumulating book this recurring is linked to (its anchor id), if any —
+  // the "Saved" pill tops up that book instead of logging a standalone deposit.
+  linkedDepositTxId?: string | null
 }
 
 export interface GoalRow {
@@ -202,6 +208,7 @@ export function buildByGoal(
       skipped: r.skipped,
       overridden: r.overridden,
       recorded,
+      linkedDepositTxId: r.linkedDepositTxId,
     })
   }
 

--- a/supabase/migrations/20260618000006_record_recurring_book_topup.sql
+++ b/supabase/migrations/20260618000006_record_recurring_book_topup.sql
@@ -1,0 +1,96 @@
+-- Materialize a recurring saving as a top-up into its linked accumulating book,
+-- atomically.
+--
+-- A recurring saving can be linked (linked_deposit_tx_id) to a book's anchor.
+-- "Recording" this month's recurring then means adding a real top-up tranche to
+-- that book AND marking the recurring fulfilled for the month — both must happen
+-- together. The tranche is a real bank row, so it also lands in the overview's
+-- logged-deposit pool; the fulfillment row (saving_id, ym) is the reliable
+-- suppressor of the synthesized contribution (realizedRecurringContributions
+-- consumes the backing deposit on a fulfilled month, so it can't double-count).
+-- Creating the tranche but missing the fulfillment would double-count the amount
+-- — so they run in one transaction here, like the collapse / combine RPCs.
+create or replace function public.record_recurring_book_topup(
+  p_book_id uuid,
+  p_amount_vnd bigint,
+  p_interest_rate numeric,
+  p_investment_date date,
+  p_saving_id uuid,
+  p_ym text,
+  p_plan_id uuid default null
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_anchor public.investment_transactions;
+  v_tranche public.investment_transactions;
+begin
+  -- The book anchor (deposit_group_id = its own id) carries the book's goal +
+  -- maturity, copied down to the new tranche. Lock it for the insert.
+  select * into v_anchor
+    from public.investment_transactions
+   where transaction_id = p_book_id
+     and deposit_group_id = p_book_id
+   for update;
+  if not found then
+    raise exception 'record_recurring_book_topup: accumulating book not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_anchor.asset_type is distinct from 'bank' then
+    raise exception 'record_recurring_book_topup: not a bank book'
+      using errcode = 'check_violation';
+  end if;
+  if p_amount_vnd is null or p_amount_vnd <= 0 then
+    raise exception 'record_recurring_book_topup: amount must be positive'
+      using errcode = 'check_violation';
+  end if;
+  -- A matured book is closed: a tranche dated today would sit past the book's
+  -- maturity and accrue zero interest. Block it (mirrors the top-up route guard).
+  if v_anchor.expiry_date is not null and v_anchor.expiry_date < current_date then
+    raise exception 'record_recurring_book_topup: cannot top up a matured book'
+      using errcode = 'check_violation';
+  end if;
+  if p_investment_date > current_date + 1 then
+    raise exception 'record_recurring_book_topup: investment date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+  -- The recurring saving must belong to the caller (RLS scopes the read).
+  if not exists (
+    select 1 from public.recurring_savings
+     where saving_id = p_saving_id and user_id = v_anchor.user_id
+  ) then
+    raise exception 'record_recurring_book_topup: recurring saving not found'
+      using errcode = 'no_data_found';
+  end if;
+
+  -- 1) The top-up tranche — inherits the book's goal + maturity + name; carries
+  -- its own locked rate + the plan_id (so By-goal "contributed" counts it).
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, amount_vnd,
+    investment_date, expiry_date, interest_rate, notes,
+    deposit_group_id, plan_id, affects_progress
+  ) values (
+    v_anchor.user_id, v_anchor.goal_id, 'bank', 'investment', p_amount_vnd,
+    p_investment_date, v_anchor.expiry_date, p_interest_rate, v_anchor.notes,
+    p_book_id, p_plan_id, true
+  )
+  returning * into v_tranche;
+
+  -- 2) Mark the recurring fulfilled for the month so the synthesized contribution
+  -- is suppressed (and its backing deposit — this tranche — is reconciled).
+  insert into public.recurring_saving_fulfillments (
+    user_id, recurring_saving_id, ym, amount_vnd, source
+  ) values (
+    v_anchor.user_id, p_saving_id, p_ym, p_amount_vnd, 'recurring-topup'
+  )
+  on conflict (recurring_saving_id, ym) do update
+    set amount_vnd = excluded.amount_vnd,
+        source     = excluded.source,
+        updated_at = now();
+
+  return v_tranche;
+end;
+$$;


### PR DESCRIPTION
## What
The #349 follow-up: link a recurring saving to an accumulating ("Loại 2") **book**, and its Plan-page **"Saved"** pill tops up that book (adds a tranche) instead of logging a standalone deposit.

Because a tranche locks in its **own rate** (and `recurring_savings` doesn't store one), the pill opens a **prefilled** top-up sheet — amount = the planned monthly amount, date = today, rate = the book's suggested rate. One-tap confirm when nothing changed; edit the rate when the bank's rate moved this cycle.

## How
- **Atomic RPC `record_recurring_book_topup`** (migration `20260618000006`): adds the tranche **and** writes a `recurring_saving_fulfillments` row in one transaction. The tranche is a real bank row, so missing the fulfillment would double-count — both commit or neither does (same pattern as collapse/combine).
- **`POST /recurring-savings/[id]/topup`** calls it; requires the recurring be linked to exactly that book.
- **Double-count fix in `finance.ts`**: a fulfilled month now **consumes its backing logged deposit**, so a book top-up can't *also* amount-suppress a *different* same-amount recurring. No-op for the combine flow (its re-deposit amount differs). Unit-tested (red→green).
- **`linkValidation`** accepts a book **anchor** (links survive a collapse via the existing re-point) and rejects a non-anchor tranche. The **link dropdown** now lists books with per-target behavior ("Auto top-up" vs "At maturity").
- **`linked_deposit_tx_id`** threaded through `monthly-plans → planning → GoalItem` so the "Saved" pill can route to the book top-up. Wired in **both** mobile and desktop planning views via a shared `RecurringBookTopUpSheet`.

## Tests / checks
- ✅ New E2E `recurring-book-topup.spec.ts`: record a book-linked recurring → the tranche joins the book (right amount + rate) and the goal's progress value does **not** jump by an extra recurring (no double-count); linking rejects a non-anchor tranche and accepts the anchor.
- ✅ Unit **678 pass** (incl. the new consume-on-fulfillment case), `tsc` clean. Changed files add no new lint errors (pre-existing `set-state-in-effect` in unrelated inline sheets untouched).
- ✅ Re-ran planning + maturity-combine + explicit-link E2E — all green.

## ⚠️ Before reviewing on preview
The migration adds the RPC the endpoint calls, so **apply it to prod before the preview works** — already done (`supabase db push` → "Remote database is up to date").

## Deferred (remaining #349 follow-ups)
- **Unallocated grouping** (group a book's tranches into one row there too).
- **Whole-book withdrawal** at maturity (depends on per-tranche withdrawal support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)