### PR TITLE
feat(deposits): group an accumulating book into one Unallocated row

### DIFF
--- a/app/api/v1/investment-transactions/[id]/assign/route.ts
+++ b/app/api/v1/investment-transactions/[id]/assign/route.ts
@@ -33,6 +33,37 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
   }
 
+  // An accumulating book shares one goal across all tranches. Assigning a book
+  // (its anchor) must move the WHOLE group, or it splits across goals — so route a
+  // book through the atomic cascade RPC (goal_id only; no tranche-level changes).
+  // Non-book holdings take the plain single-row update below.
+  const { data: existing } = await supabase
+    .from('investment_transactions')
+    .select('deposit_group_id')
+    .eq('transaction_id', txId)
+    .eq('user_id', user.id)
+    .single()
+  if (!existing) return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
+
+  if (existing.deposit_group_id) {
+    const { data: row, error: bookErr } = await supabase
+      .rpc('update_deposit_book', {
+        p_tx_id: txId,
+        p_set_goal: true, p_goal_id: cleanGoalId,
+        p_set_expiry: false, p_expiry_date: null,
+        p_set_amount: false, p_amount_vnd: null,
+        p_set_rate: false, p_interest_rate: null,
+        p_set_investment: false, p_investment_date: null,
+        p_set_notes: false, p_notes: null,
+      })
+      .single()
+    if (bookErr || !row) {
+      console.error('assign: book cascade failed', bookErr?.message)
+      return NextResponse.json({ error: 'Failed to assign deposit book' }, { status: 500 })
+    }
+    return NextResponse.json(row)
+  }
+
   const { data: transaction, error } = await supabase
     .from('investment_transactions')
     .update({ goal_id: cleanGoalId, updated_at: new Date().toISOString() })

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -22,6 +22,7 @@ import MaturityActionCard from './components/MaturityActionCard'
 import { MaturityResolveSheet, MaturityResolveModal } from './components/MaturityResolveSheet'
 import { isActionableTermDeposit, MATURING_COUNT_EVENT } from '@/lib/maturity'
 import { actionableBooks } from './maturityCardItems'
+import { collapseUnallocatedBooks } from './unallocatedBooks'
 import type { InvRow } from './components/goalDetailShared'
 import { loadOverview, overviewErrorText, getCachedOverview, setCachedOverview } from './overviewData'
 
@@ -511,6 +512,10 @@ export default function DashboardClient({ userId }: { userId: string }) {
   const allFunds = data ? [...data.unallocated.funds, ...data.goals.flatMap((g) => g.funds)] : []
   const detailFund = fundDetailId ? allFunds.find((f) => f.fundId === fundDetailId) : null
 
+  // Roll an unallocated accumulating book's tranches into one row (the assign/sell
+  // actions then act on the whole book — /assign cascades a book's goal atomically).
+  const unallocatedNonFunds = data ? collapseUnallocatedBooks(data.unallocated.nonFunds) : []
+
   const isVi = locale === 'vi'
 
   // Term deposits (assigned + unassigned) that need a renew/withdraw decision,
@@ -736,7 +741,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                     <UnallocatedSection
                       unallocatedAmount={data.unallocated.totalValue}
                       funds={data.unallocated.funds}
-                      nonFunds={data.unallocated.nonFunds}
+                      nonFunds={unallocatedNonFunds}
                       onFundClick={handleFundClick}
                       onAssignToGoal={(fundId, name, value, type) => { setGoalPickerFundId(fundId); setGoalPickerFundItem({ name, value, type }) }}
                       onSellFund={openSellFund}
@@ -920,7 +925,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                 <UnallocatedSection
                   unallocatedAmount={data.unallocated.totalValue}
                   funds={data.unallocated.funds}
-                  nonFunds={data.unallocated.nonFunds}
+                  nonFunds={unallocatedNonFunds}
                   onFundClick={handleFundClick}
                   onAssignToGoal={(fundId, name, value, type) => { setGoalPickerFundId(fundId); setGoalPickerFundItem({ name, value, type }) }}
                   onSellFund={openSellFund}

--- a/app/assets/__tests__/unallocatedBooks.test.ts
+++ b/app/assets/__tests__/unallocatedBooks.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { collapseUnallocatedBooks, type UnallocatedNonFund } from '../unallocatedBooks'
+
+const item = (over: Partial<UnallocatedNonFund>): UnallocatedNonFund => ({
+  transactionId: 't', type: 'bank', amount: 1_000_000, currentValue: 1_010_000,
+  interestRate: 3, expiryDate: '2027-01-01', investmentDate: '2025-01-01',
+  notes: null, units: null, depositGroupId: null, ...over,
+})
+
+describe('collapseUnallocatedBooks', () => {
+  it('rolls a book\'s tranches into one anchor row (summed amount/value, blended rate)', () => {
+    const out = collapseUnallocatedBooks([
+      item({ transactionId: 'grp', amount: 50_000_000, currentValue: 51_000_000, interestRate: 3.0, notes: 'My book', depositGroupId: 'grp' }),
+      item({ transactionId: 't2', amount: 10_000_000, currentValue: 10_100_000, interestRate: 3.6, depositGroupId: 'grp' }),
+    ])
+    expect(out).toHaveLength(1)
+    const book = out[0]
+    expect(book.transactionId).toBe('grp')
+    expect(book.amount).toBe(60_000_000)
+    expect(book.currentValue).toBe(61_100_000)
+    expect(book.notes).toBe('My book')
+    // (50·3.0 + 10·3.6)/60 = 3.1, rounded to 1dp for display
+    expect(book.interestRate).toBe(3.1)
+  })
+
+  it('leaves ungrouped (term / one-off) items untouched', () => {
+    const out = collapseUnallocatedBooks([
+      item({ transactionId: 'a', depositGroupId: null }),
+      item({ transactionId: 'b', type: 'gold', depositGroupId: null }),
+    ])
+    expect(out.map((x) => x.transactionId).sort()).toEqual(['a', 'b'])
+    expect(out).toHaveLength(2)
+  })
+
+  it('keeps singles and books together; one row per book', () => {
+    const out = collapseUnallocatedBooks([
+      item({ transactionId: 'single', depositGroupId: null }),
+      item({ transactionId: 'gA', depositGroupId: 'gA' }),
+      item({ transactionId: 'gA2', depositGroupId: 'gA' }),
+      item({ transactionId: 'gB', depositGroupId: 'gB' }),
+    ])
+    expect(out.map((x) => x.transactionId).sort()).toEqual(['gA', 'gB', 'single'])
+  })
+
+  it('falls back to the first tranche when the anchor row is absent (a split book)', () => {
+    const out = collapseUnallocatedBooks([
+      item({ transactionId: 't2', amount: 10_000_000, currentValue: 10_100_000, depositGroupId: 'grp' }),
+    ])
+    expect(out).toHaveLength(1)
+    expect(out[0].amount).toBe(10_000_000)
+  })
+})

--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -231,6 +231,9 @@ export default function UnallocatedSection({
 
   const canSell = actionTarget?.kind === 'fund' || (
     actionTarget?.kind === 'nonFund' && (actionTarget.item.type === 'bank' || actionTarget.item.type === 'gold')
+    // An accumulating book can't be withdrawn tranche-by-tranche yet — same guard
+    // as goal-detail. It can still be assigned to a goal (cascades to the group).
+    && !actionTarget.item.depositGroupId
   )
 
   const actionName = actionTarget?.kind === 'fund'

--- a/app/assets/unallocatedBooks.ts
+++ b/app/assets/unallocatedBooks.ts
@@ -1,0 +1,58 @@
+// Collapse an accumulating ("Loại 2") book's tranches into ONE row in the
+// Unallocated list. The overview returns a book as several flat per-tranche
+// nonFund items; goal-detail and the needs-attention card already roll these up,
+// so this brings the last surface in line. Books are goal-assigned by design, so
+// an unallocated book is uncommon — but when one exists (created without a goal)
+// it should read as a single deposit, and assigning it moves the whole group
+// (the /assign route cascades a book's goal atomically).
+
+import { blendedRate } from '@/lib/accumulating'
+
+// The minimal per-tranche shape this needs — structurally a NonFundUnallocatedItem.
+export interface UnallocatedNonFund {
+  transactionId: string
+  type: string
+  amount: number
+  currentValue: number
+  interestRate: number | null
+  expiryDate: string | null
+  investmentDate: string
+  notes: string | null
+  units: number | null
+  depositGroupId?: string | null
+}
+
+// Roll each book's tranches up into one anchor-based row (summed principal +
+// value, amount-weighted blended rate rounded for display); non-book items pass
+// through untouched. The book row keeps the anchor's transactionId (= the
+// deposit_group_id), so the assign/sell actions act on the book as a whole.
+export function collapseUnallocatedBooks<T extends UnallocatedNonFund>(items: T[]): T[] {
+  const groups = new Map<string, T[]>()
+  const singles: T[] = []
+  for (const it of items) {
+    if (it.depositGroupId) {
+      const arr = groups.get(it.depositGroupId) ?? []
+      arr.push(it)
+      groups.set(it.depositGroupId, arr)
+    } else {
+      singles.push(it)
+    }
+  }
+
+  const books: T[] = []
+  for (const [groupId, rows] of groups) {
+    const anchor = rows.find((r) => r.transactionId === groupId) ?? rows[0]
+    const amount = rows.reduce((s, r) => s + r.amount, 0)
+    const currentValue = rows.reduce((s, r) => s + r.currentValue, 0)
+    const rate = blendedRate(rows.map((r) => ({ amount: r.amount, rate: r.interestRate })))
+    books.push({
+      ...anchor,
+      amount,
+      currentValue,
+      interestRate: Math.round(rate * 10) / 10,
+      units: null,
+    })
+  }
+
+  return [...singles, ...books]
+}

--- a/e2e/unallocated-book.spec.ts
+++ b/e2e/unallocated-book.spec.ts
@@ -1,0 +1,70 @@
+import { test, expect, type Page } from '@playwright/test'
+import * as api from './helpers/api'
+
+// Accumulating ("Loại 2") books in the Unallocated list. A book is normally goal-
+// assigned, but an unallocated one (created without a goal) must read as ONE row
+// (its tranches rolled up), and assigning it must move the WHOLE book to the goal
+// — the /assign route cascades a book's goal atomically, never splitting it.
+
+const iso = (d: number) => new Date(Date.now() + d * 86_400_000).toISOString().slice(0, 10)
+
+async function gotoFreshDashboard(page: Page) {
+  await page.goto('/settings')
+  await page.evaluate(() => {
+    Object.keys(localStorage).filter((k) => k.startsWith('dashboardOverviewCache')).forEach((k) => localStorage.removeItem(k))
+  })
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/v1/dashboard/overview') && r.status() === 200, { timeout: 20_000 }),
+    page.goto('/dashboard'),
+  ])
+}
+
+test.describe('Accumulating book in the Unallocated list', () => {
+  test('an unallocated book rolls its tranches into one row with the combined value', async ({ page }) => {
+    test.slow()
+    // A goal-less book: anchor 30M + a 20M top-up = 50M across two tranches.
+    const anchor = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { asset_type: 'bank', accumulating: true, notes: 'E2E Unalloc Book', amount_vnd: 30_000_000, interest_rate: 3.0, investment_date: iso(-30), expiry_date: iso(60) },
+    })).json()
+    expect(anchor.deposit_group_id).toBe(anchor.transaction_id)
+    expect(anchor.goal_id).toBeNull()
+    await page.request.post('/api/v1/investment-transactions', {
+      data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 20_000_000, interest_rate: 3.6, investment_date: iso(-10) },
+    })
+    try {
+      await gotoFreshDashboard(page)
+      // Exactly one Unallocated row for the book, showing the SUMMED value (~50M) —
+      // not two rows, and not just the anchor's 30M.
+      const row = page.getByTestId('unallocated-row').filter({ hasText: 'E2E Unalloc Book' })
+      await expect(row).toHaveCount(1)
+      await expect(row).toContainText(/5\d\.\dM/) // 50–59M (anchor-only would be 30.xM)
+    } finally {
+      await api.deleteDepositGroup(anchor.transaction_id)
+    }
+  })
+
+  test('assigning an unallocated book moves the whole book to the goal (cascade, no split)', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Unalloc Assign Goal', target_amount: 100_000_000 })
+    const anchor = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { asset_type: 'bank', accumulating: true, notes: 'E2E Unalloc Assign', amount_vnd: 30_000_000, interest_rate: 3.0, investment_date: iso(-30), expiry_date: iso(60) },
+    })).json()
+    const tranche = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 20_000_000, interest_rate: 3.6, investment_date: iso(-10) },
+    })).json()
+    try {
+      // Assign the book (its anchor) to the goal — what the Unallocated "Assign" action POSTs.
+      const res = await page.request.put(`/api/v1/investment-transactions/${anchor.transaction_id}/assign`, {
+        data: { goal_id: goal.goal_id },
+      })
+      expect(res.ok()).toBeTruthy()
+      // Both tranches followed — the book moved as a whole, not split across goals.
+      const anchorNow = await (await page.request.get(`/api/v1/investment-transactions/${anchor.transaction_id}`)).json()
+      const trancheNow = await (await page.request.get(`/api/v1/investment-transactions/${tranche.transaction_id}`)).json()
+      expect(anchorNow.goal_id).toBe(goal.goal_id)
+      expect(trancheNow.goal_id).toBe(goal.goal_id)
+    } finally {
+      await api.deleteDepositGroup(anchor.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+})


### PR DESCRIPTION
## What
The last #349 follow-up that still showed an accumulating ("Loại 2") book as N per-tranche rows: the **Unallocated** list. A book is normally goal-assigned, but an unallocated one (created without a goal) now reads as **one row** — its tranches rolled up (anchor-based: summed principal + value, amount-weighted blended rate), the same grouping goal-detail and the needs-attention card already use.

## Critical correctness — assign cascade
Grouping the row means the **Assign** action now targets the book's anchor. But `/assign` updated only the single row, so assigning a book would **split it across goals**. Fixed: `/assign` routes a book through the atomic `update_deposit_book` RPC (goal_id only), moving the **whole group** together; non-book holdings keep the plain single-row update. **Withdraw/sell is hidden** for a book row (per-tranche book withdrawal isn't supported yet — same guard as goal-detail); a book can still be assigned.

## Changes
- **`collapseUnallocatedBooks`** — pure grouping helper (unit-tested).
- **`DashboardClient`** feeds the collapsed list to `UnallocatedSection` (mobile + desktop); the section count reflects the grouped total.
- **`UnallocatedSection`** hides sell/withdraw for a book row.
- **`/assign` route** cascades a book's goal atomically (reuses `update_deposit_book`).

## Tests / checks
- ✅ New E2E `unallocated-book.spec.ts`: an unallocated book shows as **one row with the summed value** (~50M, not the anchor's 30M); **assigning** it cascades the goal to **every tranche** (no split).
- ✅ Unit **682 pass**, `tsc` clean, changed files lint-clean. Re-ran assign-goal + dashboard-desktop E2E (30) — green.
- ✅ **No migration** — reuses the existing `update_deposit_book` RPC, so it works against current prod.

## Remaining #349 follow-up
- **Whole-book withdrawal** at maturity — depends on per-tranche withdrawal support (a book withdrawal currently under-subtracts). The larger one, needs the withdrawal model extended first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)