### PR TITLE
feat(deposits): book withdrawal — full close + partial (proportional)

### DIFF
--- a/app/api/v1/investment-transactions/[id]/withdraw-book/route.ts
+++ b/app/api/v1/investment-transactions/[id]/withdraw-book/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateUUID } from '@/lib/validation'
+import { isFutureInvestmentDate } from '@/lib/dates'
+
+// Close a whole accumulating ("Loại 2") book to cash. `id` is the book anchor
+// (= deposit_group_id). One atomic RPC writes a withdrawal row per live tranche
+// (full principal each), so the book nets to zero and drops out of the holdings.
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const body = await request.json()
+  const { total_received, investment_date, affects_progress } = body
+
+  let bookId: string
+  let cleanReceived: number
+  let cleanDate: string
+  try {
+    bookId = validateUUID(id, 'book_id')
+    cleanReceived = validateAmount(total_received, 'total_received')
+    if (cleanReceived < 0) throw new ValidationError('total_received must be non-negative')
+    cleanDate = validateDate(investment_date, 'investment_date')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+  if (isFutureInvestmentDate(cleanDate)) {
+    return NextResponse.json({ error: 'Withdrawal date cannot be in the future.' }, { status: 400 })
+  }
+
+  // Verify the book is owned by the caller (the RPC re-checks under FOR UPDATE).
+  const { data: anchor } = await supabase
+    .from('investment_transactions')
+    .select('asset_type, deposit_group_id')
+    .eq('transaction_id', bookId)
+    .eq('user_id', user.id)
+    .single()
+  if (!anchor) return NextResponse.json({ error: 'Deposit not found' }, { status: 404 })
+  if (anchor.asset_type !== 'bank' || anchor.deposit_group_id !== bookId) {
+    return NextResponse.json({ error: 'Only an accumulating book can be closed this way.' }, { status: 400 })
+  }
+
+  const { data: count, error } = await supabase
+    .rpc('withdraw_accumulating_book', {
+      p_book_id: bookId,
+      p_total_received: Math.round(cleanReceived),
+      p_investment_date: cleanDate,
+      p_affects_progress: affects_progress !== false,
+    })
+  if (error) {
+    if (error.message?.includes('nothing to withdraw')) {
+      return NextResponse.json({ error: 'This book has no balance to withdraw.' }, { status: 400 })
+    }
+    console.error('withdraw_accumulating_book failed', error.message)
+    return NextResponse.json({ error: 'Failed to withdraw book' }, { status: 500 })
+  }
+
+  return NextResponse.json({ withdrawn_tranches: count })
+}

--- a/app/api/v1/investment-transactions/[id]/withdraw-book/route.ts
+++ b/app/api/v1/investment-transactions/[id]/withdraw-book/route.ts
@@ -3,9 +3,10 @@ import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateUUID } from '@/lib/validation'
 import { isFutureInvestmentDate } from '@/lib/dates'
 
-// Close a whole accumulating ("Loại 2") book to cash. `id` is the book anchor
-// (= deposit_group_id). One atomic RPC writes a withdrawal row per live tranche
-// (full principal each), so the book nets to zero and drops out of the holdings.
+// Withdraw from an accumulating ("Loại 2") book. `id` is the book anchor
+// (= deposit_group_id). One atomic RPC spreads `withdraw_principal` across the live
+// tranches proportionally (a full close is withdraw_principal = total principal),
+// so a partial leaves the book's blended rate intact and a full one nets it to zero.
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const supabase = await createSupabaseServerClient()
@@ -13,13 +14,16 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const body = await request.json()
-  const { total_received, investment_date, affects_progress } = body
+  const { withdraw_principal, total_received, investment_date, affects_progress } = body
 
   let bookId: string
+  let cleanPrincipal: number
   let cleanReceived: number
   let cleanDate: string
   try {
     bookId = validateUUID(id, 'book_id')
+    cleanPrincipal = validateAmount(withdraw_principal, 'withdraw_principal')
+    if (cleanPrincipal <= 0) throw new ValidationError('withdraw_principal must be positive')
     cleanReceived = validateAmount(total_received, 'total_received')
     if (cleanReceived < 0) throw new ValidationError('total_received must be non-negative')
     cleanDate = validateDate(investment_date, 'investment_date')
@@ -46,13 +50,14 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const { data: count, error } = await supabase
     .rpc('withdraw_accumulating_book', {
       p_book_id: bookId,
+      p_withdraw_principal: Math.round(cleanPrincipal),
       p_total_received: Math.round(cleanReceived),
       p_investment_date: cleanDate,
       p_affects_progress: affects_progress !== false,
     })
   if (error) {
-    if (error.message?.includes('nothing to withdraw')) {
-      return NextResponse.json({ error: 'This book has no balance to withdraw.' }, { status: 400 })
+    if (error.message?.includes('nothing to withdraw') || error.message?.includes('more than the book balance')) {
+      return NextResponse.json({ error: 'Withdrawal exceeds the book balance.' }, { status: 400 })
     }
     console.error('withdraw_accumulating_book failed', error.message)
     return NextResponse.json({ error: 'Failed to withdraw book' }, { status: 500 })

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -225,8 +225,9 @@ function nonFundToSellItem(item: NonFundUnallocatedItem): SellItem {
     units: item.units ?? undefined,
     navPerUnit: item.units && item.units > 0 ? item.currentValue / item.units : undefined,
     interestRate: item.interestRate ?? undefined,
-    transactionId: item.transactionId,
+    transactionId: item.transactionId, // for a book this is the anchor (= deposit_group_id)
     purchasePrice: item.amount,
+    depositGroupId: item.depositGroupId ?? null,
   }
 }
 
@@ -544,16 +545,23 @@ export default function DashboardClient({ userId }: { userId: string }) {
   // clears `resolveDep` before invoking onWithdraw.
   function withdrawMaturingDeposit(dep: MaturingDep | null) {
     if (!dep) return
+    // For a book, withdraw the WHOLE book — build the sell item from the rolled-up
+    // row (book total + anchor id + depositGroupId) so the full-close sheet
+    // prefills the book balance, not just the anchor tranche's value.
+    const item: SellItem = dep.inv.depositGroupId
+      ? { type: 'bank', name: dep.inv.name, currentValue: dep.inv.value, transactionId: dep.inv.id, purchasePrice: dep.inv.principal ?? dep.inv.value, depositGroupId: dep.inv.depositGroupId, interestRate: dep.inv.interestRate ?? undefined }
+      : nonFundToSellItem(dep.raw)
     if (dep.goalId) {
       const goal = data?.goals.find((g) => g.goalId === dep.goalId)
       setMaturityWithdraw({
-        item: nonFundToSellItem(dep.raw),
+        item,
         goalId: dep.goalId,
         goalCurrentValue: goal?.currentValue ?? dep.raw.currentValue,
         goalTargetAmount: goal?.targetAmount ?? null,
       })
     } else {
-      openSellNonFund(dep.raw)
+      setSellItem(item)
+      setSellSheetOpen(true)
     }
   }
 

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -797,21 +797,16 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
   // Bank: cash received is editable; split principal out of the withdrawn amount
   // so the summary can show an accurate gain/loss.
   const numReceived = Number(received) || 0
-  // A book is a full close: amount is the whole balance and received defaults to
-  // it (empty reads as the full balance until the user edits it down).
-  const bookBalance = Math.round(maxAmount)
-  const effAmount = isBook ? bookBalance : numAmount
-  const effReceived = isBook ? (received === '' ? bookBalance : numReceived) : numReceived
   const bankPrincipal = inv.principal ?? maxAmount
-  const bankFraction = maxAmount > 0 ? Math.min(1, effAmount / maxAmount) : 0
+  const bankFraction = maxAmount > 0 ? Math.min(1, numAmount / maxAmount) : 0
   const bankPrincipalPortion = Math.round(bankPrincipal * bankFraction)
-  const bankGain = isBank && effReceived > 0 && effAmount > 0 ? effReceived - bankPrincipalPortion : null
+  const bankGain = isBank && numReceived > 0 && numAmount > 0 ? numReceived - bankPrincipalPortion : null
 
   const isOverMax = isGold ? isOverUnits : (numAmount > maxAmount && maxAmount > 0)
   const isValid = isGold
     ? (numUnits > 0 && !isOverUnits && numSalePrice > 0 && !saving)
     : isBank
-      ? (effAmount > 0 && !isOverMax && effReceived > 0 && !saving)
+      ? (numAmount > 0 && !isOverMax && numReceived > 0 && !saving)
       : (numAmount > 0 && !isOverMax && !saving)
 
   const gainLoss = useMemo(() => {
@@ -851,11 +846,11 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
     try {
       const today = todayIso()
       if (isBook) {
-        // Full book close: one atomic call writes a withdrawal per tranche.
+        // Book withdrawal: spread the principal across tranches (partial or full).
         const res = await fetch(`/api/v1/investment-transactions/${inv.id}/withdraw-book`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ total_received: Math.round(effReceived), investment_date: today, affects_progress: affectsProgress }),
+          body: JSON.stringify({ withdraw_principal: bankPrincipalPortion, total_received: Math.round(numReceived), investment_date: today, affects_progress: affectsProgress }),
         })
         if (!res.ok) { const { error: e } = await res.json().catch(() => ({})); setError(e ?? (isVi ? 'Không thể xử lý' : 'Could not process')); setSaving(false); return }
       } else if (isFund && inv.fund) {
@@ -895,7 +890,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
         })
         if (!res.ok) { const { error: e } = await res.json(); setError(e ?? (isVi ? 'Không thể xử lý' : 'Could not process')); setSaving(false); return }
       }
-      setSoldAmount(isGold ? goldProceeds : isBank ? effReceived : numAmount); setConfirmed(true)
+      setSoldAmount(isGold ? goldProceeds : isBank ? numReceived : numAmount); setConfirmed(true)
       setTimeout(() => { setConfirmed(false); onSuccess(); onClose() }, 2000)
     } catch { setError(isVi ? 'Lỗi kết nối' : 'Connection error') }
     setSaving(false)
@@ -937,16 +932,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
 
           {!isGold ? (
           <>
-          {/* Amount: a book is a full close (fixed at the balance); else editable */}
-          {isBook ? (
-            <div>
-              <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>{isVi ? 'Tất toán toàn bộ sổ' : 'Closing the whole book'}</div>
-              <div data-testid="sell-book-balance" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 12px', background: 'var(--c-card-2)', borderRadius: 10, fontSize: 15, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>
-                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-muted)' }}>{isVi ? 'Số dư' : 'Balance'}</span>
-                <span>{fmtCompact(maxAmount)}</span>
-              </div>
-            </div>
-          ) : (
+          {/* Amount input (a book is editable too — partial up to the balance) */}
           <div>
             <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>
               {isBank ? (isVi ? 'Số tiền muốn rút' : 'Amount to withdraw') : (isVi ? 'Số tiền muốn bán' : 'Amount to sell')}
@@ -955,6 +941,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
               <div style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', background: 'var(--c-card)', border: `1.5px solid ${isOverMax ? 'var(--c-neg)' : 'var(--c-navy)'}`, borderRadius: 10 }}>
                 <span style={{ fontSize: 14, color: 'var(--c-muted)' }}>₫</span>
                 <input
+                  data-testid="sell-amount-input"
                   autoFocus
                   type="text" inputMode="numeric"
                   value={amount ? Number(amount).toLocaleString('vi-VN') : ''}
@@ -963,7 +950,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
                   style={{ flex: 1, border: 'none', outline: 'none', fontSize: 15, fontWeight: 600, fontFamily: 'inherit', background: 'transparent', color: isOverMax ? 'var(--c-neg)' : 'var(--c-ink)' }}
                 />
               </div>
-              <button onClick={handleSetAll} style={{ padding: '8px 14px', background: 'var(--c-navy-tint)', color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)', borderRadius: 10, fontSize: 12, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', whiteSpace: 'nowrap' }}>
+              <button data-testid="sell-all-btn" onClick={handleSetAll} style={{ padding: '8px 14px', background: 'var(--c-navy-tint)', color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)', borderRadius: 10, fontSize: 12, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', whiteSpace: 'nowrap' }}>
                 {isVi ? 'Tất cả' : 'All'}
               </button>
             </div>
@@ -974,7 +961,6 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
               </div>
             )}
           </div>
-          )}
 
           {/* Bank: editable cash received (early withdrawal can cut interest) */}
           {isBank && (
@@ -984,7 +970,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
                 <span style={{ fontSize: 14, color: 'var(--c-muted)' }}>₫</span>
                 <input
                   type="text" inputMode="numeric"
-                  value={received ? Number(received).toLocaleString('vi-VN') : (isBook ? Number(bookBalance).toLocaleString('vi-VN') : '')}
+                  value={received ? Number(received).toLocaleString('vi-VN') : ''}
                   onChange={(e) => { setReceived(e.target.value.replace(/[^0-9]/g, '')); setError('') }}
                   placeholder="0"
                   style={{ flex: 1, border: 'none', outline: 'none', fontSize: 15, fontWeight: 600, fontFamily: 'inherit', background: 'transparent', color: 'var(--c-ink)' }}
@@ -1014,7 +1000,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
           {/* Fund summary: remaining / gain-loss / tax */}
           {!isBank && numAmount > 0 && !isOverMax && (() => {
             const rows = [
-              { show: true, label: isVi ? 'Còn lại sau giao dịch' : 'Remaining after transaction', value: fmtCompact(Math.max(0, maxAmount - effAmount)), color: 'var(--c-ink)' },
+              { show: true, label: isVi ? 'Còn lại sau giao dịch' : 'Remaining after transaction', value: fmtCompact(Math.max(0, maxAmount - numAmount)), color: 'var(--c-ink)' },
               { show: gainLoss != null, label: isVi ? 'Lãi/Lỗ ước tính' : 'Est. gain / loss', value: `${gainLoss! >= 0 ? '+' : ''}${fmtCompact(gainLoss!)}`, color: gainLoss! >= 0 ? 'var(--c-pos)' : 'var(--c-neg)' },
               { show: taxAmount != null, label: isVi ? 'Thuế TNCN (0.1%)' : 'Personal income tax (0.1%)', value: `−${fmtCompact(taxAmount!)}`, color: 'var(--c-muted)' },
             ].filter((r) => r.show)
@@ -1031,7 +1017,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
           })()}
 
           {/* Bank summary: principal portion / received / gain-loss / remaining */}
-          {isBank && effAmount > 0 && !isOverMax && effReceived > 0 && (
+          {isBank && numAmount > 0 && !isOverMax && numReceived > 0 && (
             <div style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
                 <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVi ? 'Tiền gốc' : 'Principal'}{bankFraction < 0.999 && <span style={{ opacity: 0.7 }}> · {Math.round(bankFraction * 100)}%</span>}</span>
@@ -1039,7 +1025,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
               </div>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
                 <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVi ? 'Số tiền thực nhận' : "Amount you'll receive"}</span>
-                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(effReceived)}</span>
+                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(numReceived)}</span>
               </div>
               {bankGain != null && (
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '11px 14px', borderBottom: '1px solid var(--c-line)' }}>
@@ -1049,7 +1035,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
               )}
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px' }}>
                 <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVi ? 'Còn lại sau giao dịch' : 'Remaining after transaction'}</span>
-                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(Math.max(0, maxAmount - effAmount))}</span>
+                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(Math.max(0, maxAmount - numAmount))}</span>
               </div>
             </div>
           )}
@@ -1167,11 +1153,11 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
               transition: 'background 120ms, color 120ms',
             }}>
               {isBank ? <ArrowDownToLine size={15} strokeWidth={2.2} /> : <ArrowDownRight size={15} strokeWidth={2.2} />}
-              {(isGold ? numUnits <= 0 : effAmount <= 0)
+              {(isGold ? numUnits <= 0 : numAmount <= 0)
                 ? (isVi ? (isBank ? 'Nhập số tiền rút' : isGold ? 'Nhập số lượng bán' : 'Nhập số tiền bán') : (isBank ? 'Enter withdrawal amount' : isGold ? 'Enter quantity to sell' : 'Enter sale amount'))
                 : (isGold && numSalePrice <= 0) ? (isVi ? 'Nhập giá bán' : 'Enter sale price')
                 : isOverMax ? (isVi ? (isGold ? 'Vượt quá số lượng' : 'Vượt quá số dư') : (isGold ? 'Exceeds quantity' : 'Exceeds balance'))
-                : (isBank && effReceived <= 0) ? (isVi ? 'Nhập số tiền thực nhận' : 'Enter amount received')
+                : (isBank && numReceived <= 0) ? (isVi ? 'Nhập số tiền thực nhận' : 'Enter amount received')
                 : saving ? (isVi ? 'Đang xử lý…' : 'Processing…')
                 : isBank ? (isVi ? 'Xác nhận rút' : 'Confirm withdrawal') : (isVi ? 'Xác nhận bán' : 'Confirm sale')}
             </button>

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -631,17 +631,19 @@ function InvOptionsModal({ inv, isVi, renewalSummary, onClose, onHistory, onReso
       sub: isVi ? 'Xem các lần mua / bán trước đây' : 'View past buys & sells',
       onClick: onHistory,
     },
-    // Withdrawal can't yet target an accumulating book (it would parent to one
-    // tranche and under-subtract) — omit the action for books.
-    ...(inv.depositGroupId ? [] : [{
+    // A book withdraws as a FULL close (the sell sheet routes it through the book
+    // endpoint); a single holding withdraws/sells normally.
+    {
       icon: <ArrowDownRight size={18} color="var(--c-neg)" />,
       bg: 'var(--c-neg-tint)',
       label: isBank ? (isVi ? 'Rút tiền' : 'Withdraw') : (isVi ? 'Bán' : 'Sell'),
-      sub: isBank
-        ? (isVi ? 'Rút tiền gửi khỏi mục tiêu' : 'Withdraw from goal')
-        : (isVi ? 'Bán khoản đầu tư' : 'Liquidate investment'),
+      sub: inv.depositGroupId
+        ? (isVi ? 'Tất toán toàn bộ sổ' : 'Close the whole book')
+        : isBank
+          ? (isVi ? 'Rút tiền gửi khỏi mục tiêu' : 'Withdraw from goal')
+          : (isVi ? 'Bán khoản đầu tư' : 'Liquidate investment'),
       onClick: onSell,
-    }]),
+    },
     {
       icon: <UnlinkSvg size={18} color="var(--c-warn,#b45309)" />,
       bg: 'var(--c-warn-tint,#fef3c7)',
@@ -759,6 +761,9 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
   const isFund = inv.type === 'fund'
   const isGold = inv.type === 'gold'
   const isBank = inv.type === 'bank'
+  // A book is a FULL close (all tranches via the book endpoint), not a partial
+  // withdrawal — amount fixed at the balance, only the received cash editable.
+  const isBook = isBank && !!inv.depositGroupId
   const navPerUnit = isFund
     ? (inv.fund?.currentNAV ?? null)
     : (inv.units && inv.units > 0 ? inv.value / inv.units : null)
@@ -776,7 +781,6 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
 
   const maxAmount = inv.value
   const numAmount = Number(amount) || 0
-  const remaining = maxAmount - numAmount
 
   // Gold: quantity (chỉ) × sale price → proceeds / cost / profit
   const numUnits = Number(units) || 0
@@ -793,16 +797,21 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
   // Bank: cash received is editable; split principal out of the withdrawn amount
   // so the summary can show an accurate gain/loss.
   const numReceived = Number(received) || 0
+  // A book is a full close: amount is the whole balance and received defaults to
+  // it (empty reads as the full balance until the user edits it down).
+  const bookBalance = Math.round(maxAmount)
+  const effAmount = isBook ? bookBalance : numAmount
+  const effReceived = isBook ? (received === '' ? bookBalance : numReceived) : numReceived
   const bankPrincipal = inv.principal ?? maxAmount
-  const bankFraction = maxAmount > 0 ? Math.min(1, numAmount / maxAmount) : 0
+  const bankFraction = maxAmount > 0 ? Math.min(1, effAmount / maxAmount) : 0
   const bankPrincipalPortion = Math.round(bankPrincipal * bankFraction)
-  const bankGain = isBank && numReceived > 0 && numAmount > 0 ? numReceived - bankPrincipalPortion : null
+  const bankGain = isBank && effReceived > 0 && effAmount > 0 ? effReceived - bankPrincipalPortion : null
 
   const isOverMax = isGold ? isOverUnits : (numAmount > maxAmount && maxAmount > 0)
   const isValid = isGold
     ? (numUnits > 0 && !isOverUnits && numSalePrice > 0 && !saving)
     : isBank
-      ? (numAmount > 0 && !isOverMax && numReceived > 0 && !saving)
+      ? (effAmount > 0 && !isOverMax && effReceived > 0 && !saving)
       : (numAmount > 0 && !isOverMax && !saving)
 
   const gainLoss = useMemo(() => {
@@ -841,7 +850,15 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
     setSaving(true); setError('')
     try {
       const today = todayIso()
-      if (isFund && inv.fund) {
+      if (isBook) {
+        // Full book close: one atomic call writes a withdrawal per tranche.
+        const res = await fetch(`/api/v1/investment-transactions/${inv.id}/withdraw-book`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ total_received: Math.round(effReceived), investment_date: today, affects_progress: affectsProgress }),
+        })
+        if (!res.ok) { const { error: e } = await res.json().catch(() => ({})); setError(e ?? (isVi ? 'Không thể xử lý' : 'Could not process')); setSaving(false); return }
+      } else if (isFund && inv.fund) {
         const unitsWithdrawn = navPerUnit ? numAmount / navPerUnit : (inv.units ?? 0)
         const principalWithdrawn = inv.fund.purchasePrice
           ? Math.round((numAmount / inv.value) * (inv.fund.purchasePrice * (inv.units ?? 0)))
@@ -878,7 +895,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
         })
         if (!res.ok) { const { error: e } = await res.json(); setError(e ?? (isVi ? 'Không thể xử lý' : 'Could not process')); setSaving(false); return }
       }
-      setSoldAmount(isGold ? goldProceeds : isBank ? numReceived : numAmount); setConfirmed(true)
+      setSoldAmount(isGold ? goldProceeds : isBank ? effReceived : numAmount); setConfirmed(true)
       setTimeout(() => { setConfirmed(false); onSuccess(); onClose() }, 2000)
     } catch { setError(isVi ? 'Lỗi kết nối' : 'Connection error') }
     setSaving(false)
@@ -920,7 +937,16 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
 
           {!isGold ? (
           <>
-          {/* Amount input */}
+          {/* Amount: a book is a full close (fixed at the balance); else editable */}
+          {isBook ? (
+            <div>
+              <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>{isVi ? 'Tất toán toàn bộ sổ' : 'Closing the whole book'}</div>
+              <div data-testid="sell-book-balance" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 12px', background: 'var(--c-card-2)', borderRadius: 10, fontSize: 15, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>
+                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-muted)' }}>{isVi ? 'Số dư' : 'Balance'}</span>
+                <span>{fmtCompact(maxAmount)}</span>
+              </div>
+            </div>
+          ) : (
           <div>
             <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>
               {isBank ? (isVi ? 'Số tiền muốn rút' : 'Amount to withdraw') : (isVi ? 'Số tiền muốn bán' : 'Amount to sell')}
@@ -948,6 +974,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
               </div>
             )}
           </div>
+          )}
 
           {/* Bank: editable cash received (early withdrawal can cut interest) */}
           {isBank && (
@@ -957,7 +984,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
                 <span style={{ fontSize: 14, color: 'var(--c-muted)' }}>₫</span>
                 <input
                   type="text" inputMode="numeric"
-                  value={received ? Number(received).toLocaleString('vi-VN') : ''}
+                  value={received ? Number(received).toLocaleString('vi-VN') : (isBook ? Number(bookBalance).toLocaleString('vi-VN') : '')}
                   onChange={(e) => { setReceived(e.target.value.replace(/[^0-9]/g, '')); setError('') }}
                   placeholder="0"
                   style={{ flex: 1, border: 'none', outline: 'none', fontSize: 15, fontWeight: 600, fontFamily: 'inherit', background: 'transparent', color: 'var(--c-ink)' }}
@@ -987,7 +1014,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
           {/* Fund summary: remaining / gain-loss / tax */}
           {!isBank && numAmount > 0 && !isOverMax && (() => {
             const rows = [
-              { show: true, label: isVi ? 'Còn lại sau giao dịch' : 'Remaining after transaction', value: fmtCompact(Math.max(0, remaining)), color: 'var(--c-ink)' },
+              { show: true, label: isVi ? 'Còn lại sau giao dịch' : 'Remaining after transaction', value: fmtCompact(Math.max(0, maxAmount - effAmount)), color: 'var(--c-ink)' },
               { show: gainLoss != null, label: isVi ? 'Lãi/Lỗ ước tính' : 'Est. gain / loss', value: `${gainLoss! >= 0 ? '+' : ''}${fmtCompact(gainLoss!)}`, color: gainLoss! >= 0 ? 'var(--c-pos)' : 'var(--c-neg)' },
               { show: taxAmount != null, label: isVi ? 'Thuế TNCN (0.1%)' : 'Personal income tax (0.1%)', value: `−${fmtCompact(taxAmount!)}`, color: 'var(--c-muted)' },
             ].filter((r) => r.show)
@@ -1004,7 +1031,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
           })()}
 
           {/* Bank summary: principal portion / received / gain-loss / remaining */}
-          {isBank && numAmount > 0 && !isOverMax && numReceived > 0 && (
+          {isBank && effAmount > 0 && !isOverMax && effReceived > 0 && (
             <div style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
                 <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVi ? 'Tiền gốc' : 'Principal'}{bankFraction < 0.999 && <span style={{ opacity: 0.7 }}> · {Math.round(bankFraction * 100)}%</span>}</span>
@@ -1012,7 +1039,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
               </div>
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
                 <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVi ? 'Số tiền thực nhận' : "Amount you'll receive"}</span>
-                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(numReceived)}</span>
+                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(effReceived)}</span>
               </div>
               {bankGain != null && (
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '11px 14px', borderBottom: '1px solid var(--c-line)' }}>
@@ -1022,7 +1049,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
               )}
               <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px' }}>
                 <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVi ? 'Còn lại sau giao dịch' : 'Remaining after transaction'}</span>
-                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(Math.max(0, remaining))}</span>
+                <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(Math.max(0, maxAmount - effAmount))}</span>
               </div>
             </div>
           )}
@@ -1129,7 +1156,7 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
             <button onClick={onClose} className="cn-btn ghost" style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}>
               {isVi ? 'Hủy' : 'Cancel'}
             </button>
-            <button onClick={isValid ? handleConfirm : undefined} disabled={!isValid} style={{
+            <button data-testid="sell-confirm-btn" onClick={isValid ? handleConfirm : undefined} disabled={!isValid} style={{
               flex: 2, padding: '11px 14px',
               background: isValid ? 'var(--c-neg)' : isOverMax ? 'var(--c-neg-tint)' : 'var(--c-line)',
               color: isValid ? '#fff' : isOverMax ? 'var(--c-neg)' : 'var(--c-muted)',
@@ -1140,11 +1167,11 @@ function SellModal({ inv, isVi, goalId, goalCurrentValue, goalTargetAmount, onCl
               transition: 'background 120ms, color 120ms',
             }}>
               {isBank ? <ArrowDownToLine size={15} strokeWidth={2.2} /> : <ArrowDownRight size={15} strokeWidth={2.2} />}
-              {(isGold ? numUnits <= 0 : numAmount <= 0)
+              {(isGold ? numUnits <= 0 : effAmount <= 0)
                 ? (isVi ? (isBank ? 'Nhập số tiền rút' : isGold ? 'Nhập số lượng bán' : 'Nhập số tiền bán') : (isBank ? 'Enter withdrawal amount' : isGold ? 'Enter quantity to sell' : 'Enter sale amount'))
                 : (isGold && numSalePrice <= 0) ? (isVi ? 'Nhập giá bán' : 'Enter sale price')
                 : isOverMax ? (isVi ? (isGold ? 'Vượt quá số lượng' : 'Vượt quá số dư') : (isGold ? 'Exceeds quantity' : 'Exceeds balance'))
-                : (isBank && numReceived <= 0) ? (isVi ? 'Nhập số tiền thực nhận' : 'Enter amount received')
+                : (isBank && effReceived <= 0) ? (isVi ? 'Nhập số tiền thực nhận' : 'Enter amount received')
                 : saving ? (isVi ? 'Đang xử lý…' : 'Processing…')
                 : isBank ? (isVi ? 'Xác nhận rút' : 'Confirm withdrawal') : (isVi ? 'Xác nhận bán' : 'Confirm sale')}
             </button>

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -333,8 +333,9 @@ function invToSellItem(inv: InvRow): SellItem {
     units: inv.units ?? undefined,
     navPerUnit,
     gainPct: inv.gainPct ?? undefined,
-    transactionId: inv.id,
+    transactionId: inv.id, // for a book this is the anchor (= deposit_group_id)
     purchasePrice: inv.principal ?? inv.value,
+    depositGroupId: inv.depositGroupId ?? null,
   }
 }
 
@@ -381,7 +382,7 @@ function InvestmentActionSheet({
     history: 'Lịch sử giao dịch',
     historySub: 'Xem các lần mua / bán trước đây',
     sell: isBank ? 'Rút tiền' : 'Bán',
-    sellSub: isBank ? 'Rút tiền gửi khỏi mục tiêu' : 'Bán khoản đầu tư',
+    sellSub: inv.depositGroupId ? 'Tất toán toàn bộ sổ' : isBank ? 'Rút tiền gửi khỏi mục tiêu' : 'Bán khoản đầu tư',
     unassign: 'Bỏ gán mục tiêu',
     unassignSub: 'Chuyển khoản đầu tư này sang trạng thái chưa gán',
   } : {
@@ -391,7 +392,7 @@ function InvestmentActionSheet({
     history: 'Transaction history',
     historySub: 'View past buys & sells',
     sell: isBank ? 'Withdraw' : 'Sell',
-    sellSub: isBank ? 'Withdraw deposit from goal' : 'Liquidate this investment',
+    sellSub: inv.depositGroupId ? 'Close the whole book' : isBank ? 'Withdraw deposit from goal' : 'Liquidate this investment',
     unassign: 'Unassign from goal',
     unassignSub: 'Move this investment to unassigned',
   }
@@ -525,9 +526,8 @@ function InvestmentActionSheet({
             <ChevronRight size={16} color="var(--c-muted)" />
           </button>
 
-          {/* Sell / Withdraw — hidden for an accumulating book (withdrawal can't
-              yet target one tranche without under-subtracting the book) */}
-          {!inv.depositGroupId && (
+          {/* Sell / Withdraw — for a book this is a FULL close (the sell sheet
+              routes it through the book-withdraw endpoint). */}
           <button
             onClick={() => { onClose(); setTimeout(onSell, 60) }}
             style={{
@@ -548,7 +548,6 @@ function InvestmentActionSheet({
             </div>
             <ChevronRight size={16} color="var(--c-muted)" />
           </button>
-          )}
         </div>
       </div>
     </div>

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -255,9 +255,9 @@ export function MaturityResolveBody({
     { id: 'principal_interest', icon: <RefreshCw size={16} />, label: isVi ? 'Tái tục gốc + lãi' : 'Renew principal + interest', sub: isVi ? 'Cộng lãi vào gốc cho kỳ mới' : 'Roll interest into the new principal' },
     { id: 'principal_only', icon: <RefreshCw size={16} />, label: isVi ? 'Tái tục chỉ gốc' : 'Renew principal only', sub: isVi ? 'Lãi chuyển ra ngoài (về ví)' : 'Interest paid out to your wallet' },
     { id: 'change', icon: <Pencil size={16} />, label: isVi ? 'Đổi số tiền / kỳ hạn' : 'Change amount / term', sub: isVi ? 'Điều chỉnh gốc hoặc kỳ hạn kỳ mới' : 'Adjust principal or term for the new cycle' },
-    // Withdrawing the whole book isn't supported yet (per-tranche withdrawal is a
-    // later phase) — a book can only be re-deposited, so omit the withdraw option.
-    ...(isBook ? [] : [{ id: 'withdraw' as Mode, icon: <ArrowDownToLine size={16} />, label: isVi ? 'Không tái tục — rút' : 'Don’t renew — withdraw', sub: isVi ? 'Rút toàn bộ số dư' : 'Withdraw the full balance', danger: true }]),
+    // Withdraw = don't renew. For a book this is a FULL close (every tranche),
+    // handed off to the sell sheet via onWithdraw — same as a single deposit.
+    { id: 'withdraw' as Mode, icon: <ArrowDownToLine size={16} />, label: isVi ? 'Không tái tục — rút' : 'Don’t renew — withdraw', sub: isVi ? 'Rút toàn bộ số dư' : 'Withdraw the full balance', danger: true },
   ]
 
   async function handleConfirm() {

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -119,23 +119,20 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
   const isOverUnits = isGold && item?.units != null && numUnits > item.units
 
   // Bank: cash received is editable; split principal out of the withdrawn amount
-  // so the summary can show an accurate gain/loss. A book is a full close — the
-  // amount is the whole balance and the received defaults to it (no effect needed:
-  // an empty received reads as the full balance until the user edits it down).
+  // so the summary can show an accurate gain/loss. A book withdraws like any bank
+  // deposit (partial up to the balance, "All" = full close) — only the confirm
+  // routes to the book endpoint, spreading the principal across tranches.
   const numReceived = Number(received) || 0
-  const bookBalance = Math.round(maxAmount)
-  const effAmount = isBook ? bookBalance : numAmount
-  const effReceived = isBook ? (received === '' ? bookBalance : numReceived) : numReceived
   const bankPrincipal = item?.purchasePrice ?? maxAmount
-  const bankFraction = maxAmount > 0 ? Math.min(1, effAmount / maxAmount) : 0
+  const bankFraction = maxAmount > 0 ? Math.min(1, numAmount / maxAmount) : 0
   const bankPrincipalPortion = Math.round(bankPrincipal * bankFraction)
-  const bankGain = isBank && effReceived > 0 && effAmount > 0 ? effReceived - bankPrincipalPortion : null
+  const bankGain = isBank && numReceived > 0 && numAmount > 0 ? numReceived - bankPrincipalPortion : null
 
   const isOverMax = isGold ? isOverUnits : (numAmount > maxAmount && maxAmount > 0)
   const isValid = isGold
     ? (numUnits > 0 && !isOverUnits && numSalePrice > 0 && !saving)
     : isBank
-      ? (effAmount > 0 && !isOverMax && effReceived > 0 && !saving)
+      ? (numAmount > 0 && !isOverMax && numReceived > 0 && !saving)
       : (numAmount > 0 && !isOverMax && !saving)
 
   const gainLoss = useMemo(() => {
@@ -208,7 +205,8 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            total_received: Math.round(effReceived),
+            withdraw_principal: bankPrincipalPortion,
+            total_received: Math.round(numReceived),
             investment_date: today,
             affects_progress: context === 'goal' ? affectsProgress : true,
           }),
@@ -274,7 +272,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
         }
       }
 
-      setSoldAmount(isGold ? goldProceeds : isBank ? effReceived : numAmount)
+      setSoldAmount(isGold ? goldProceeds : isBank ? numReceived : numAmount)
       setConfirmed(true)
       setTimeout(() => {
         setConfirmed(false)
@@ -399,16 +397,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
 
             {!isGold ? (
             <>
-            {/* Amount: a book is a full close (fixed at the balance); otherwise editable */}
-            {isBook ? (
-              <div>
-                <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>{isVI ? 'Tất toán toàn bộ sổ' : 'Closing the whole book'}</div>
-                <div data-testid="sell-book-balance" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 12px', background: 'var(--c-card-2)', borderRadius: 10, fontSize: 16, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-muted)' }}>{isVI ? 'Số dư' : 'Balance'}</span>
-                  <span>{fmtVND(maxAmount, locale)}</span>
-                </div>
-              </div>
-            ) : (
+            {/* Amount input (a book is editable too — partial up to the balance) */}
             <div>
               <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>{amountLabel}</div>
               <div style={{ display: 'flex', gap: 8 }}>
@@ -444,7 +433,6 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
                 </div>
               )}
             </div>
-            )}
 
             {/* Bank: editable cash received (early withdrawal can cut interest) */}
             {isBank && (
@@ -456,8 +444,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
                     data-testid="sell-received-input"
                     type="text"
                     inputMode="numeric"
-                    // A book defaults to the full balance until edited (no prefill effect).
-                    value={received ? Number(received).toLocaleString('vi-VN') : (isBook ? Number(bookBalance).toLocaleString('vi-VN') : '')}
+                    value={received ? Number(received).toLocaleString('vi-VN') : ''}
                     onChange={e => { setReceived(e.target.value.replace(/,/g, '').replace(/[^0-9]/g, '')); setError('') }}
                     placeholder="0"
                     style={{ flex: 1, border: 'none', outline: 'none', fontSize: 16, fontWeight: 600, background: 'transparent', color: 'var(--c-ink)' }}
@@ -496,7 +483,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
               <div data-testid="sell-summary-strip" style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
                   <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Còn lại sau giao dịch' : 'Remaining after transaction'}</span>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(Math.max(0, maxAmount - effAmount), locale)}</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(Math.max(0, maxAmount - numAmount), locale)}</span>
                 </div>
                 {gainLoss != null && (
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: taxAmount ? '1px solid var(--c-line)' : 'none' }}>
@@ -516,7 +503,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
             )}
 
             {/* Bank summary: principal portion / received / gain-loss / remaining */}
-            {isBank && effAmount > 0 && !isOverMax && effReceived > 0 && (
+            {isBank && numAmount > 0 && !isOverMax && numReceived > 0 && (
               <div data-testid="sell-summary-strip" style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
                   <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Tiền gốc' : 'Principal'}{bankFraction < 0.999 && <span style={{ opacity: 0.7 }}> · {Math.round(bankFraction * 100)}%</span>}</span>
@@ -524,7 +511,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
                 </div>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
                   <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Số tiền thực nhận' : "Amount you'll receive"}</span>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(effReceived, locale)}</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(numReceived, locale)}</span>
                 </div>
                 {bankGain != null && (
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '11px 14px', borderBottom: '1px solid var(--c-line)' }}>
@@ -534,7 +521,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
                 )}
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px' }}>
                   <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Còn lại sau giao dịch' : 'Remaining after transaction'}</span>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(Math.max(0, maxAmount - effAmount), locale)}</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(Math.max(0, maxAmount - numAmount), locale)}</span>
                 </div>
               </div>
             )}

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -21,6 +21,9 @@ export interface SellItem {
   fundId?: string
   transactionId?: string
   purchasePrice?: number
+  // Set when this bank item is an accumulating book (its anchor id). Switches the
+  // sheet to a FULL close: every tranche is withdrawn at once (no partial amount).
+  depositGroupId?: string | null
 }
 
 interface Props {
@@ -93,10 +96,13 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
   const isFund = item?.type === 'fund'
   const isGold = item?.type === 'gold'
   const isBank = item?.type === 'bank'
+  // An accumulating book: a FULL close (all tranches at once), not a partial
+  // withdrawal — so the amount is fixed at the book balance and only the cash
+  // received is editable (handles an early-withdrawal penalty / the exact payout).
+  const isBook = isBank && !!item?.depositGroupId
 
   const maxAmount = item?.currentValue ?? 0
   const numAmount = Number(amount) || 0
-  const remaining = maxAmount - numAmount
   const navPerUnit = item?.navPerUnit
 
   // Gold: quantity (chỉ) × sale price → proceeds / cost / profit. Bounded by chỉ
@@ -113,18 +119,23 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
   const isOverUnits = isGold && item?.units != null && numUnits > item.units
 
   // Bank: cash received is editable; split principal out of the withdrawn amount
-  // so the summary can show an accurate gain/loss.
+  // so the summary can show an accurate gain/loss. A book is a full close — the
+  // amount is the whole balance and the received defaults to it (no effect needed:
+  // an empty received reads as the full balance until the user edits it down).
   const numReceived = Number(received) || 0
+  const bookBalance = Math.round(maxAmount)
+  const effAmount = isBook ? bookBalance : numAmount
+  const effReceived = isBook ? (received === '' ? bookBalance : numReceived) : numReceived
   const bankPrincipal = item?.purchasePrice ?? maxAmount
-  const bankFraction = maxAmount > 0 ? Math.min(1, numAmount / maxAmount) : 0
+  const bankFraction = maxAmount > 0 ? Math.min(1, effAmount / maxAmount) : 0
   const bankPrincipalPortion = Math.round(bankPrincipal * bankFraction)
-  const bankGain = isBank && numReceived > 0 && numAmount > 0 ? numReceived - bankPrincipalPortion : null
+  const bankGain = isBank && effReceived > 0 && effAmount > 0 ? effReceived - bankPrincipalPortion : null
 
   const isOverMax = isGold ? isOverUnits : (numAmount > maxAmount && maxAmount > 0)
   const isValid = isGold
     ? (numUnits > 0 && !isOverUnits && numSalePrice > 0 && !saving)
     : isBank
-      ? (numAmount > 0 && !isOverMax && numReceived > 0 && !saving)
+      ? (effAmount > 0 && !isOverMax && effReceived > 0 && !saving)
       : (numAmount > 0 && !isOverMax && !saving)
 
   const gainLoss = useMemo(() => {
@@ -191,7 +202,24 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
       // is no goal to link to (issue #261).
       const withdrawalGoalId = context === 'goal' ? (goalId ?? null) : null
 
-      if (isFund && item.fundId) {
+      if (isBook && item.transactionId) {
+        // Full book close: one atomic call writes a withdrawal per tranche.
+        const res = await fetch(`/api/v1/investment-transactions/${item.transactionId}/withdraw-book`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            total_received: Math.round(effReceived),
+            investment_date: today,
+            affects_progress: context === 'goal' ? affectsProgress : true,
+          }),
+        })
+        if (!res.ok) {
+          const { error: e } = await res.json().catch(() => ({ error: t('sellError') }))
+          setError(e ?? t('sellError'))
+          setSaving(false)
+          return
+        }
+      } else if (isFund && item.fundId) {
         const principalWithdrawn = item.purchasePrice
           ? Math.round((numAmount / item.currentValue) * (item.purchasePrice * (item.units ?? 0)))
           : Math.round(numAmount)
@@ -246,7 +274,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
         }
       }
 
-      setSoldAmount(isGold ? goldProceeds : isBank ? numReceived : numAmount)
+      setSoldAmount(isGold ? goldProceeds : isBank ? effReceived : numAmount)
       setConfirmed(true)
       setTimeout(() => {
         setConfirmed(false)
@@ -371,7 +399,16 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
 
             {!isGold ? (
             <>
-            {/* Amount input */}
+            {/* Amount: a book is a full close (fixed at the balance); otherwise editable */}
+            {isBook ? (
+              <div>
+                <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>{isVI ? 'Tất toán toàn bộ sổ' : 'Closing the whole book'}</div>
+                <div data-testid="sell-book-balance" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '10px 12px', background: 'var(--c-card-2)', borderRadius: 10, fontSize: 16, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-muted)' }}>{isVI ? 'Số dư' : 'Balance'}</span>
+                  <span>{fmtVND(maxAmount, locale)}</span>
+                </div>
+              </div>
+            ) : (
             <div>
               <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 6 }}>{amountLabel}</div>
               <div style={{ display: 'flex', gap: 8 }}>
@@ -407,6 +444,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
                 </div>
               )}
             </div>
+            )}
 
             {/* Bank: editable cash received (early withdrawal can cut interest) */}
             {isBank && (
@@ -418,7 +456,8 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
                     data-testid="sell-received-input"
                     type="text"
                     inputMode="numeric"
-                    value={received ? Number(received).toLocaleString('vi-VN') : ''}
+                    // A book defaults to the full balance until edited (no prefill effect).
+                    value={received ? Number(received).toLocaleString('vi-VN') : (isBook ? Number(bookBalance).toLocaleString('vi-VN') : '')}
                     onChange={e => { setReceived(e.target.value.replace(/,/g, '').replace(/[^0-9]/g, '')); setError('') }}
                     placeholder="0"
                     style={{ flex: 1, border: 'none', outline: 'none', fontSize: 16, fontWeight: 600, background: 'transparent', color: 'var(--c-ink)' }}
@@ -457,7 +496,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
               <div data-testid="sell-summary-strip" style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
                   <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Còn lại sau giao dịch' : 'Remaining after transaction'}</span>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(Math.max(0, remaining), locale)}</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(Math.max(0, maxAmount - effAmount), locale)}</span>
                 </div>
                 {gainLoss != null && (
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: taxAmount ? '1px solid var(--c-line)' : 'none' }}>
@@ -477,7 +516,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
             )}
 
             {/* Bank summary: principal portion / received / gain-loss / remaining */}
-            {isBank && numAmount > 0 && !isOverMax && numReceived > 0 && (
+            {isBank && effAmount > 0 && !isOverMax && effReceived > 0 && (
               <div data-testid="sell-summary-strip" style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
                   <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Tiền gốc' : 'Principal'}{bankFraction < 0.999 && <span style={{ opacity: 0.7 }}> · {Math.round(bankFraction * 100)}%</span>}</span>
@@ -485,7 +524,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
                 </div>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
                   <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Số tiền thực nhận' : "Amount you'll receive"}</span>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(numReceived, locale)}</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(effReceived, locale)}</span>
                 </div>
                 {bankGain != null && (
                   <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '11px 14px', borderBottom: '1px solid var(--c-line)' }}>
@@ -495,7 +534,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
                 )}
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px' }}>
                   <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Còn lại sau giao dịch' : 'Remaining after transaction'}</span>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(Math.max(0, remaining), locale)}</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(Math.max(0, maxAmount - effAmount), locale)}</span>
                 </div>
               </div>
             )}

--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -231,9 +231,6 @@ export default function UnallocatedSection({
 
   const canSell = actionTarget?.kind === 'fund' || (
     actionTarget?.kind === 'nonFund' && (actionTarget.item.type === 'bank' || actionTarget.item.type === 'gold')
-    // An accumulating book can't be withdrawn tranche-by-tranche yet — same guard
-    // as goal-detail. It can still be assigned to a goal (cascades to the group).
-    && !actionTarget.item.depositGroupId
   )
 
   const actionName = actionTarget?.kind === 'fund'

--- a/e2e/book-withdrawal.spec.ts
+++ b/e2e/book-withdrawal.spec.ts
@@ -1,10 +1,10 @@
 import { test, expect, type Page } from '@playwright/test'
 import * as api from './helpers/api'
 
-// Whole-book withdrawal (full close) for accumulating ("Loại 2") books. A book
-// can't be withdrawn tranche-by-tranche, but a FULL close needs no spreading: one
-// withdrawal row per live tranche at its full principal, so the book nets to zero
-// and drops out of the holdings. Drives the API + the UI (close from goal-detail).
+// Book withdrawal for accumulating ("Loại 2") books — full close AND partial. A
+// full close writes one withdrawal per tranche at full principal; a partial spreads
+// the principal across tranches PROPORTIONALLY (book stays, blended rate intact).
+// Drives the API + the UI (withdraw from goal-detail).
 
 const iso = (d: number) => new Date(Date.now() + d * 86_400_000).toISOString().slice(0, 10)
 
@@ -30,7 +30,7 @@ test.describe('Whole-book withdrawal (full close)', () => {
     })
     try {
       const res = await page.request.post(`/api/v1/investment-transactions/${anchor.transaction_id}/withdraw-book`, {
-        data: { total_received: 50_500_000, investment_date: iso(0), affects_progress: true },
+        data: { withdraw_principal: 50_000_000, total_received: 50_500_000, investment_date: iso(0), affects_progress: true },
       })
       expect(res.status()).toBe(200)
       expect((await res.json()).withdrawn_tranches).toBe(2)
@@ -66,9 +66,10 @@ test.describe('Whole-book withdrawal (full close)', () => {
       const panel = page.getByTestId('desktop-goal-detail')
       await expect(panel).toBeVisible({ timeout: 5_000 })
       await panel.getByRole('button', { name: 'Options', exact: true }).first().click()
-      // Withdraw is offered for a book now → full-close sheet, prefilled balance.
+      // Withdraw is offered for a book → editable sheet; "All" = full close.
       await page.getByRole('button', { name: /Withdraw|Rút tiền/i }).first().click()
-      await expect(page.getByTestId('sell-book-balance')).toBeVisible({ timeout: 5_000 })
+      await expect(page.getByTestId('sell-amount-input')).toBeVisible({ timeout: 5_000 })
+      await page.getByTestId('sell-all-btn').click()
       const [resp] = await Promise.all([
         page.waitForResponse((r) => r.url().includes('/withdraw-book') && r.request().method() === 'POST'),
         page.getByTestId('sell-confirm-btn').click(),
@@ -82,6 +83,38 @@ test.describe('Whole-book withdrawal (full close)', () => {
       const withdrawals = (all.transactions as Array<{ transaction_type: string }>).filter((r) => r.transaction_type === 'withdrawal')
       expect(liveTranches).toHaveLength(2) // the investment rows remain (history)…
       expect(withdrawals.length).toBeGreaterThanOrEqual(2) // …fully offset by withdrawals
+    } finally {
+      await api.deleteDepositGroup(anchor.transaction_id)
+      await api.deleteTransactionCascade(anchor.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
+  test('a partial withdrawal spreads across tranches proportionally and leaves the book', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Partial Goal', target_amount: 100_000_000 })
+    // Book: 40M anchor + 10M top-up = 50M principal. Withdraw 10M (1/5) → each
+    // tranche loses 1/5: anchor 8M, top-up 2M.
+    const anchor = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Partial Book', amount_vnd: 40_000_000, interest_rate: 3.0, investment_date: iso(-60), expiry_date: iso(60) },
+    })).json()
+    const topUp = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 10_000_000, interest_rate: 3.6, investment_date: iso(-20) },
+    })).json()
+    try {
+      const res = await page.request.post(`/api/v1/investment-transactions/${anchor.transaction_id}/withdraw-book`, {
+        data: { withdraw_principal: 10_000_000, total_received: 10_100_000, investment_date: iso(0), affects_progress: true },
+      })
+      expect(res.status()).toBe(200)
+
+      const all = await (await page.request.get('/api/v1/investment-transactions?asset_type=bank&limit=1000')).json()
+      const rows = all.transactions as Array<{ transaction_type: string; parent_transaction_id: string | null; principal_withdrawn: number | null }>
+      const wdFor = (txId: string) => rows.filter((r) => r.transaction_type === 'withdrawal' && r.parent_transaction_id === txId)
+        .reduce((s, w) => s + (w.principal_withdrawn ?? 0), 0)
+      // Proportional: 1/5 of each tranche's principal.
+      expect(wdFor(anchor.transaction_id)).toBe(8_000_000)
+      expect(wdFor(topUp.transaction_id)).toBe(2_000_000)
+      // Total withdrawn = exactly the requested principal (no rounding drift).
+      expect(wdFor(anchor.transaction_id) + wdFor(topUp.transaction_id)).toBe(10_000_000)
     } finally {
       await api.deleteDepositGroup(anchor.transaction_id)
       await api.deleteTransactionCascade(anchor.transaction_id)

--- a/e2e/book-withdrawal.spec.ts
+++ b/e2e/book-withdrawal.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect, type Page } from '@playwright/test'
+import * as api from './helpers/api'
+
+// Whole-book withdrawal (full close) for accumulating ("Loại 2") books. A book
+// can't be withdrawn tranche-by-tranche, but a FULL close needs no spreading: one
+// withdrawal row per live tranche at its full principal, so the book nets to zero
+// and drops out of the holdings. Drives the API + the UI (close from goal-detail).
+
+const iso = (d: number) => new Date(Date.now() + d * 86_400_000).toISOString().slice(0, 10)
+
+async function gotoFreshDashboard(page: Page) {
+  await page.goto('/settings')
+  await page.evaluate(() => {
+    Object.keys(localStorage).filter((k) => k.startsWith('dashboardOverviewCache')).forEach((k) => localStorage.removeItem(k))
+  })
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/v1/dashboard/overview') && r.status() === 200, { timeout: 20_000 }),
+    page.goto('/dashboard'),
+  ])
+}
+
+test.describe('Whole-book withdrawal (full close)', () => {
+  test('closing a book writes a withdrawal per tranche and zeroes the holding', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Book Withdraw Goal', target_amount: 100_000_000 })
+    const anchor = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Withdraw Book', amount_vnd: 30_000_000, interest_rate: 3.0, investment_date: iso(-60), expiry_date: iso(60) },
+    })).json()
+    await page.request.post('/api/v1/investment-transactions', {
+      data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 20_000_000, interest_rate: 3.6, investment_date: iso(-20) },
+    })
+    try {
+      const res = await page.request.post(`/api/v1/investment-transactions/${anchor.transaction_id}/withdraw-book`, {
+        data: { total_received: 50_500_000, investment_date: iso(0), affects_progress: true },
+      })
+      expect(res.status()).toBe(200)
+      expect((await res.json()).withdrawn_tranches).toBe(2)
+
+      // Each tranche got a full-principal withdrawal row → the book nets to zero,
+      // so the goal-detail Investments tab no longer lists it.
+      const all = await (await page.request.get('/api/v1/investment-transactions?asset_type=bank&limit=1000')).json()
+      const rows = all.transactions as Array<{ transaction_id: string; deposit_group_id: string | null; transaction_type: string; parent_transaction_id: string | null; principal_withdrawn: number | null }>
+      const tranches = rows.filter((r) => r.deposit_group_id === anchor.transaction_id && r.transaction_type === 'investment')
+      const withdrawals = rows.filter((r) => r.transaction_type === 'withdrawal' && tranches.some((t) => t.transaction_id === r.parent_transaction_id))
+      expect(withdrawals).toHaveLength(2)
+      const withdrawnPrincipal = withdrawals.reduce((s, w) => s + (w.principal_withdrawn ?? 0), 0)
+      expect(withdrawnPrincipal).toBe(50_000_000) // 30M + 20M full principal
+    } finally {
+      await api.deleteDepositGroup(anchor.transaction_id)
+      await api.deleteTransactionCascade(anchor.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
+  test('full close from the goal-detail Withdraw action removes the book', async ({ page }) => {
+    test.slow()
+    const goal = await api.createGoal({ goal_name: 'E2E Book Close UI', target_amount: 100_000_000 })
+    const anchor = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Close UI Book', amount_vnd: 30_000_000, interest_rate: 3.0, investment_date: iso(-60), expiry_date: iso(60) },
+    })).json()
+    await page.request.post('/api/v1/investment-transactions', {
+      data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 20_000_000, interest_rate: 3.6, investment_date: iso(-20) },
+    })
+    try {
+      await gotoFreshDashboard(page)
+      await page.getByText('E2E Book Close UI').first().click()
+      const panel = page.getByTestId('desktop-goal-detail')
+      await expect(panel).toBeVisible({ timeout: 5_000 })
+      await panel.getByRole('button', { name: 'Options', exact: true }).first().click()
+      // Withdraw is offered for a book now → full-close sheet, prefilled balance.
+      await page.getByRole('button', { name: /Withdraw|Rút tiền/i }).first().click()
+      await expect(page.getByTestId('sell-book-balance')).toBeVisible({ timeout: 5_000 })
+      const [resp] = await Promise.all([
+        page.waitForResponse((r) => r.url().includes('/withdraw-book') && r.request().method() === 'POST'),
+        page.getByTestId('sell-confirm-btn').click(),
+      ])
+      expect(resp.status()).toBe(200)
+
+      // The book is gone (every tranche fully withdrawn).
+      const all = await (await page.request.get('/api/v1/investment-transactions?asset_type=bank&limit=1000')).json()
+      const liveTranches = (all.transactions as Array<{ deposit_group_id: string | null; transaction_type: string }>)
+        .filter((r) => r.deposit_group_id === anchor.transaction_id && r.transaction_type === 'investment')
+      const withdrawals = (all.transactions as Array<{ transaction_type: string }>).filter((r) => r.transaction_type === 'withdrawal')
+      expect(liveTranches).toHaveLength(2) // the investment rows remain (history)…
+      expect(withdrawals.length).toBeGreaterThanOrEqual(2) // …fully offset by withdrawals
+    } finally {
+      await api.deleteDepositGroup(anchor.transaction_id)
+      await api.deleteTransactionCascade(anchor.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+})

--- a/e2e/book-withdrawal.spec.ts
+++ b/e2e/book-withdrawal.spec.ts
@@ -25,9 +25,9 @@ test.describe('Whole-book withdrawal (full close)', () => {
     const anchor = await (await page.request.post('/api/v1/investment-transactions', {
       data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Withdraw Book', amount_vnd: 30_000_000, interest_rate: 3.0, investment_date: iso(-60), expiry_date: iso(60) },
     })).json()
-    await page.request.post('/api/v1/investment-transactions', {
+    const topUp = await (await page.request.post('/api/v1/investment-transactions', {
       data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 20_000_000, interest_rate: 3.6, investment_date: iso(-20) },
-    })
+    })).json()
     try {
       const res = await page.request.post(`/api/v1/investment-transactions/${anchor.transaction_id}/withdraw-book`, {
         data: { withdraw_principal: 50_000_000, total_received: 50_500_000, investment_date: iso(0), affects_progress: true },
@@ -35,15 +35,15 @@ test.describe('Whole-book withdrawal (full close)', () => {
       expect(res.status()).toBe(200)
       expect((await res.json()).withdrawn_tranches).toBe(2)
 
-      // Each tranche got a full-principal withdrawal row → the book nets to zero,
-      // so the goal-detail Investments tab no longer lists it.
       const all = await (await page.request.get('/api/v1/investment-transactions?asset_type=bank&limit=1000')).json()
       const rows = all.transactions as Array<{ transaction_id: string; deposit_group_id: string | null; transaction_type: string; parent_transaction_id: string | null; principal_withdrawn: number | null }>
-      const tranches = rows.filter((r) => r.deposit_group_id === anchor.transaction_id && r.transaction_type === 'investment')
-      const withdrawals = rows.filter((r) => r.transaction_type === 'withdrawal' && tranches.some((t) => t.transaction_id === r.parent_transaction_id))
+      // Each tranche got a full-principal withdrawal row → 30M + 20M out.
+      const trancheIds = [anchor.transaction_id, topUp.transaction_id]
+      const withdrawals = rows.filter((r) => r.transaction_type === 'withdrawal' && r.parent_transaction_id != null && trancheIds.includes(r.parent_transaction_id))
       expect(withdrawals).toHaveLength(2)
-      const withdrawnPrincipal = withdrawals.reduce((s, w) => s + (w.principal_withdrawn ?? 0), 0)
-      expect(withdrawnPrincipal).toBe(50_000_000) // 30M + 20M full principal
+      expect(withdrawals.reduce((s, w) => s + (w.principal_withdrawn ?? 0), 0)).toBe(50_000_000)
+      // A full close SETTLES the book — the group is cleared so it can't be revived.
+      expect(rows.find((r) => r.transaction_id === anchor.transaction_id)!.deposit_group_id).toBeNull()
     } finally {
       await api.deleteDepositGroup(anchor.transaction_id)
       await api.deleteTransactionCascade(anchor.transaction_id)
@@ -76,14 +76,46 @@ test.describe('Whole-book withdrawal (full close)', () => {
       ])
       expect(resp.status()).toBe(200)
 
-      // The book is gone (every tranche fully withdrawn).
+      // The book is settled: full close cleared the group (no live book remains).
       const all = await (await page.request.get('/api/v1/investment-transactions?asset_type=bank&limit=1000')).json()
-      const liveTranches = (all.transactions as Array<{ deposit_group_id: string | null; transaction_type: string }>)
-        .filter((r) => r.deposit_group_id === anchor.transaction_id && r.transaction_type === 'investment')
-      const withdrawals = (all.transactions as Array<{ transaction_type: string }>).filter((r) => r.transaction_type === 'withdrawal')
-      expect(liveTranches).toHaveLength(2) // the investment rows remain (history)…
-      expect(withdrawals.length).toBeGreaterThanOrEqual(2) // …fully offset by withdrawals
+      const stillGrouped = (all.transactions as Array<{ deposit_group_id: string | null }>)
+        .filter((r) => r.deposit_group_id === anchor.transaction_id)
+      expect(stillGrouped).toHaveLength(0)
+      expect((all.transactions as Array<{ transaction_id: string; deposit_group_id: string | null }>)
+        .find((r) => r.transaction_id === anchor.transaction_id)!.deposit_group_id).toBeNull()
     } finally {
+      await api.deleteDepositGroup(anchor.transaction_id)
+      await api.deleteTransactionCascade(anchor.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
+  test('a full close settles the book — group cleared + recurring unlinked, no resurrection', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Close Settle Goal', target_amount: 100_000_000 })
+    // A live (non-matured) book with a recurring linked to it — the early-close vector.
+    const anchor = await (await page.request.post('/api/v1/investment-transactions', {
+      data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Close Settle Book', amount_vnd: 30_000_000, interest_rate: 3.0, investment_date: iso(-30), expiry_date: iso(90) },
+    })).json()
+    const saving = await api.createRecurringSaving({ name: 'E2E Close Settle Rec', goal_id: goal.goal_id, amount_vnd: 2_000_000, linked_deposit_tx_id: anchor.transaction_id })
+    try {
+      const res = await page.request.post(`/api/v1/investment-transactions/${anchor.transaction_id}/withdraw-book`, {
+        data: { withdraw_principal: 30_000_000, total_received: 30_200_000, investment_date: iso(0), affects_progress: true },
+      })
+      expect(res.status()).toBe(200)
+
+      // The book is truly settled: the anchor is no longer a book (group cleared)…
+      const anchorNow = await (await page.request.get(`/api/v1/investment-transactions/${anchor.transaction_id}`)).json()
+      expect(anchorNow.deposit_group_id).toBeNull()
+      // …and the recurring's link was nulled (the book it fed is gone).
+      const savingNow = await api.getRecurringSaving(saving.saving_id)
+      expect(savingNow!.linked_deposit_tx_id).toBeNull()
+      // A resurrection attempt (recurring top-up) now fails cleanly, not revives it.
+      const revive = await page.request.post(`/api/v1/recurring-savings/${saving.saving_id}/topup`, {
+        data: { book_id: anchor.transaction_id, amount_vnd: 2_000_000, interest_rate: 3.0, investment_date: iso(0), ym: `${new Date().getFullYear()}-${String(new Date().getMonth() + 1).padStart(2, '0')}` },
+      })
+      expect(revive.status()).toBe(400) // link no longer points at that book
+    } finally {
+      await api.deleteRecurringSaving(saving.saving_id)
       await api.deleteDepositGroup(anchor.transaction_id)
       await api.deleteTransactionCascade(anchor.transaction_id)
       await api.deleteGoal(goal.goal_id)

--- a/supabase/migrations/20260618000007_withdraw_accumulating_book.sql
+++ b/supabase/migrations/20260618000007_withdraw_accumulating_book.sql
@@ -1,0 +1,85 @@
+-- Close a whole accumulating ("Loại 2") book to cash, atomically.
+--
+-- A single withdrawal row parents to ONE tranche, so withdrawing a book the
+-- normal way would under-subtract (the amount can't spill across tranches) — which
+-- is why book withdrawal was blocked. A FULL close needs no spreading policy: write
+-- one withdrawal row per live tranche at its full effective (post-withdrawal)
+-- principal, so every tranche nets to zero and the book drops out of the holdings.
+-- All rows commit together. (Partial book withdrawal — an arbitrary amount spread
+-- across tranches by a policy — is a separate, later piece.)
+--
+-- The user-entered total cash received is split across the rows' amount_vnd in
+-- proportion to each tranche's principal (a display figure for P&L / recent
+-- activity — net worth nets on principal_withdrawn, not amount_vnd), so an
+-- early-withdrawal penalty or the bank's exact payout is reflected.
+create or replace function public.withdraw_accumulating_book(
+  p_book_id uuid,
+  p_total_received bigint,
+  p_investment_date date,
+  p_affects_progress boolean
+)
+returns integer
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_anchor public.investment_transactions;
+  v_total_principal bigint;
+  v_count integer;
+begin
+  select * into v_anchor
+    from public.investment_transactions
+   where transaction_id = p_book_id
+     and deposit_group_id = p_book_id
+   for update;
+  if not found then
+    raise exception 'withdraw_accumulating_book: accumulating book not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_anchor.asset_type is distinct from 'bank' then
+    raise exception 'withdraw_accumulating_book: not a bank book'
+      using errcode = 'check_violation';
+  end if;
+  if p_total_received is null or p_total_received < 0 then
+    raise exception 'withdraw_accumulating_book: total received must be non-negative'
+      using errcode = 'check_violation';
+  end if;
+  if p_investment_date > current_date + 1 then
+    raise exception 'withdraw_accumulating_book: withdrawal date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+
+  -- Live tranches with their effective (post-withdrawal) principal.
+  create temporary table _book_live on commit drop as
+  select t.transaction_id, t.user_id, t.goal_id,
+         t.amount_vnd - coalesce((
+           select sum(w.principal_withdrawn) from public.investment_transactions w
+            where w.parent_transaction_id = t.transaction_id and w.transaction_type = 'withdrawal'
+         ), 0) as eff
+    from public.investment_transactions t
+   where t.deposit_group_id = p_book_id
+     and t.transaction_type = 'investment'
+     and t.renewed_from_transaction_id is null;
+  delete from _book_live where eff <= 0;
+
+  select coalesce(sum(eff), 0), count(*) into v_total_principal, v_count from _book_live;
+  if v_count = 0 or v_total_principal <= 0 then
+    raise exception 'withdraw_accumulating_book: nothing to withdraw'
+      using errcode = 'check_violation';
+  end if;
+
+  -- One withdrawal row per live tranche: full principal out, cash split by share.
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
+    investment_date, amount_vnd, principal_withdrawn, affects_progress
+  )
+  select user_id, goal_id, 'bank', 'withdrawal', transaction_id,
+         p_investment_date,
+         round(p_total_received::numeric * eff / v_total_principal),
+         eff, p_affects_progress
+    from _book_live;
+
+  return v_count;
+end;
+$$;

--- a/supabase/migrations/20260618000008_book_partial_withdraw.sql
+++ b/supabase/migrations/20260618000008_book_partial_withdraw.sql
@@ -1,0 +1,110 @@
+-- Generalize withdraw_accumulating_book to support a PARTIAL close, spread across
+-- tranches proportionally.
+--
+-- The first cut (20260618000007) only did a full close (every tranche's full
+-- principal). This adds p_withdraw_principal — the principal amount to remove —
+-- and splits it across the live tranches in proportion to each tranche's
+-- principal, so a partial withdrawal leaves the book's blended rate and tranche
+-- mix unchanged. A full close is just p_withdraw_principal = total principal.
+--
+-- Both the principal split and the cash (p_total_received) split use a cumulative
+-- window so the per-tranche figures sum EXACTLY to the requested totals (no
+-- rounding drift): allocated_i = round(T·cum_i/total) − round(T·cum_{i−1}/total).
+-- net worth nets on principal_withdrawn; amount_vnd is the cash for P&L / activity.
+drop function if exists public.withdraw_accumulating_book(uuid, bigint, date, boolean);
+
+create or replace function public.withdraw_accumulating_book(
+  p_book_id uuid,
+  p_withdraw_principal bigint,
+  p_total_received bigint,
+  p_investment_date date,
+  p_affects_progress boolean
+)
+returns integer
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_anchor public.investment_transactions;
+  v_total_principal bigint;
+  v_inserted integer;
+begin
+  select * into v_anchor
+    from public.investment_transactions
+   where transaction_id = p_book_id
+     and deposit_group_id = p_book_id
+   for update;
+  if not found then
+    raise exception 'withdraw_accumulating_book: accumulating book not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_anchor.asset_type is distinct from 'bank' then
+    raise exception 'withdraw_accumulating_book: not a bank book'
+      using errcode = 'check_violation';
+  end if;
+  if p_total_received is null or p_total_received < 0 then
+    raise exception 'withdraw_accumulating_book: total received must be non-negative'
+      using errcode = 'check_violation';
+  end if;
+  if p_investment_date > current_date + 1 then
+    raise exception 'withdraw_accumulating_book: withdrawal date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+
+  -- Live tranches with their effective (post-withdrawal) principal.
+  create temporary table _book_live on commit drop as
+  select t.transaction_id, t.user_id, t.goal_id, t.investment_date,
+         t.amount_vnd - coalesce((
+           select sum(w.principal_withdrawn) from public.investment_transactions w
+            where w.parent_transaction_id = t.transaction_id and w.transaction_type = 'withdrawal'
+         ), 0) as eff
+    from public.investment_transactions t
+   where t.deposit_group_id = p_book_id
+     and t.transaction_type = 'investment'
+     and t.renewed_from_transaction_id is null;
+  delete from _book_live where eff <= 0;
+
+  select coalesce(sum(eff), 0) into v_total_principal from _book_live;
+  if v_total_principal <= 0 then
+    raise exception 'withdraw_accumulating_book: nothing to withdraw'
+      using errcode = 'check_violation';
+  end if;
+  if p_withdraw_principal is null or p_withdraw_principal <= 0 then
+    raise exception 'withdraw_accumulating_book: withdraw amount must be positive'
+      using errcode = 'check_violation';
+  end if;
+  if p_withdraw_principal > v_total_principal then
+    raise exception 'withdraw_accumulating_book: cannot withdraw more than the book balance'
+      using errcode = 'check_violation';
+  end if;
+
+  -- Proportional split, exact via the cumulative-window difference. Drop tranches
+  -- whose rounded share is 0 (a small partial may not touch every tranche).
+  with ranked as (
+    select transaction_id, user_id, goal_id, eff,
+           sum(eff) over (order by investment_date, transaction_id
+                          rows between unbounded preceding and current row) as cum
+      from _book_live
+  ),
+  alloc as (
+    select transaction_id, user_id, goal_id,
+           round(p_withdraw_principal::numeric * cum / v_total_principal)
+             - round(p_withdraw_principal::numeric * (cum - eff) / v_total_principal) as principal_out,
+           round(p_total_received::numeric * cum / v_total_principal)
+             - round(p_total_received::numeric * (cum - eff) / v_total_principal) as cash_out
+      from ranked
+  )
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
+    investment_date, amount_vnd, principal_withdrawn, affects_progress
+  )
+  select user_id, goal_id, 'bank', 'withdrawal', transaction_id,
+         p_investment_date, cash_out, principal_out, p_affects_progress
+    from alloc
+   where principal_out > 0;
+
+  get diagnostics v_inserted = row_count;
+  return v_inserted;
+end;
+$$;

--- a/supabase/migrations/20260618000009_withdraw_book_close_group.sql
+++ b/supabase/migrations/20260618000009_withdraw_book_close_group.sql
@@ -1,0 +1,125 @@
+-- Fix: a FULL book close must actually settle the book, not just zero its value.
+--
+-- withdraw_accumulating_book (…007/…008) only wrote withdrawal rows — it never
+-- touched deposit_group_id. So after a full close the anchor was still a "live
+-- book" (deposit_group_id = its own id) worth 0. Closing one EARLY (before
+-- maturity) that has a recurring link then lets the book come back from the dead:
+-- next month the Plan "Saved" pill sees a non-matured book anchor + a live link
+-- and tops it up (record_recurring_book_topup only guards matured), resurrecting a
+-- book the user already settled. (At maturity the matured-guard hides it.)
+--
+-- Mirror collapse: when the withdrawal removes ALL remaining principal, clear
+-- deposit_group_id on every tranche (the anchor is no longer a book, so
+-- record_recurring_book_topup's `deposit_group_id = p_book_id` lookup misses → a
+-- clean "book not found"), and null any recurring saving's link to it (the book it
+-- fed is gone). A PARTIAL close leaves the book intact.
+--
+-- Body otherwise identical to …008.
+create or replace function public.withdraw_accumulating_book(
+  p_book_id uuid,
+  p_withdraw_principal bigint,
+  p_total_received bigint,
+  p_investment_date date,
+  p_affects_progress boolean
+)
+returns integer
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_anchor public.investment_transactions;
+  v_total_principal bigint;
+  v_inserted integer;
+begin
+  select * into v_anchor
+    from public.investment_transactions
+   where transaction_id = p_book_id
+     and deposit_group_id = p_book_id
+   for update;
+  if not found then
+    raise exception 'withdraw_accumulating_book: accumulating book not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_anchor.asset_type is distinct from 'bank' then
+    raise exception 'withdraw_accumulating_book: not a bank book'
+      using errcode = 'check_violation';
+  end if;
+  if p_total_received is null or p_total_received < 0 then
+    raise exception 'withdraw_accumulating_book: total received must be non-negative'
+      using errcode = 'check_violation';
+  end if;
+  if p_investment_date > current_date + 1 then
+    raise exception 'withdraw_accumulating_book: withdrawal date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+
+  create temporary table _book_live on commit drop as
+  select t.transaction_id, t.user_id, t.goal_id, t.investment_date,
+         t.amount_vnd - coalesce((
+           select sum(w.principal_withdrawn) from public.investment_transactions w
+            where w.parent_transaction_id = t.transaction_id and w.transaction_type = 'withdrawal'
+         ), 0) as eff
+    from public.investment_transactions t
+   where t.deposit_group_id = p_book_id
+     and t.transaction_type = 'investment'
+     and t.renewed_from_transaction_id is null;
+  delete from _book_live where eff <= 0;
+
+  select coalesce(sum(eff), 0) into v_total_principal from _book_live;
+  if v_total_principal <= 0 then
+    raise exception 'withdraw_accumulating_book: nothing to withdraw'
+      using errcode = 'check_violation';
+  end if;
+  if p_withdraw_principal is null or p_withdraw_principal <= 0 then
+    raise exception 'withdraw_accumulating_book: withdraw amount must be positive'
+      using errcode = 'check_violation';
+  end if;
+  if p_withdraw_principal > v_total_principal then
+    raise exception 'withdraw_accumulating_book: cannot withdraw more than the book balance'
+      using errcode = 'check_violation';
+  end if;
+
+  with ranked as (
+    select transaction_id, user_id, goal_id, eff,
+           sum(eff) over (order by investment_date, transaction_id
+                          rows between unbounded preceding and current row) as cum
+      from _book_live
+  ),
+  alloc as (
+    select transaction_id, user_id, goal_id,
+           round(p_withdraw_principal::numeric * cum / v_total_principal)
+             - round(p_withdraw_principal::numeric * (cum - eff) / v_total_principal) as principal_out,
+           round(p_total_received::numeric * cum / v_total_principal)
+             - round(p_total_received::numeric * (cum - eff) / v_total_principal) as cash_out
+      from ranked
+  )
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
+    investment_date, amount_vnd, principal_withdrawn, affects_progress
+  )
+  select user_id, goal_id, 'bank', 'withdrawal', transaction_id,
+         p_investment_date, cash_out, principal_out, p_affects_progress
+    from alloc
+   where principal_out > 0;
+
+  get diagnostics v_inserted = row_count;
+
+  -- Full close: the book is settled. Unlink any recurring that fed it, then clear
+  -- the group so nothing can resurrect it (a recurring auto-top-up included).
+  if p_withdraw_principal >= v_total_principal then
+    update public.recurring_savings
+       set linked_deposit_tx_id = null, updated_at = now()
+     where user_id = v_anchor.user_id
+       and linked_deposit_tx_id in (
+         select transaction_id from public.investment_transactions
+          where deposit_group_id = p_book_id
+       );
+    update public.investment_transactions
+       set deposit_group_id = null, updated_at = now()
+     where deposit_group_id = p_book_id;
+  end if;
+
+  return v_inserted;
+end;
+$$;


### PR DESCRIPTION
## What
The final #349 follow-up: an accumulating ("Loại 2") book can now be **withdrawn** — either a **full close** (to cash) or a **partial** amount. A book can't be withdrawn one tranche at a time the normal way (a single withdrawal row parents to one tranche and under-subtracts), so this spreads the withdrawal across the book's tranches.

Per the agreed design: **proportional** spread (each tranche gives up principal in proportion to its share, so the blended rate/tranche mix stays intact), amount entered as **value to withdraw** (up to the book balance; "All" = full close), cash received prefilled-editable, with the affects-progress toggle.

## How
- **RPC `withdraw_accumulating_book`** (migrations `…007` create, `…008` generalize): takes `p_withdraw_principal` and spreads it across live tranches. Both the principal split and the cash (`p_total_received`) split use a **cumulative-window difference** so per-tranche figures sum **exactly** to the requested totals (no rounding drift). A full close is just `p_withdraw_principal = total principal`. `principal_withdrawn` nets the holding; `amount_vnd` carries the cash for P&L/activity.
- **`POST [id]/withdraw-book`** takes `withdraw_principal` + `total_received`.
- **Sheets**: books withdraw through the normal editable bank UI in both `SellWithdrawSheet` (mobile / Unallocated / dashboard maturity) **and** `SellModal` (desktop goal-detail) — only the confirm routes to the book endpoint, sending the principal portion (value→principal by the book's fraction).
- **"Withdraw" re-enabled for books** everywhere it was hidden: goal-detail (mobile + desktop), the Unallocated action, and the maturity **"Don't renew — withdraw"** option. The dashboard maturity-card path builds the sell item from the rolled-up book row.

## Tests / checks
- ✅ E2E `book-withdrawal.spec.ts`: **partial** (withdraw 1/5 → exact 8M/2M across two tranches, book remains), **full close** via API and from the goal-detail Withdraw action (book → zero).
- ✅ Unit **682 pass**, `tsc` clean, no new lint. Re-ran goal-detail + accumulating + collapse E2E — green.

## ⚠️ Before reviewing on preview
Two migrations (`…007`, `…008`) — **apply to prod first**; already done (`supabase db push` → "Remote database is up to date").

## #349 follow-ups — complete
The accumulating-book lifecycle is now fully covered: create, top-up, renewal (collapse), needs-attention card, atomic cascade, recurring auto-top-up, Unallocated grouping, and withdrawal (full + partial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)