### PR TITLE
fix(plan): honor recurring_saving_fulfillments when marking a line recorded

### DIFF
--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -80,6 +80,13 @@ export interface RecurringSavingOverride {
   monthly_amount_override_vnd: number
 }
 
+// A recurring recorded this month via maturity-combine / book top-up (no
+// plan-scoped deposit). amount_vnd is what was actually fulfilled.
+export interface RecurringFulfillment {
+  recurring_saving_id: string
+  amount_vnd: number
+}
+
 export interface Fund {
   id: string; name: string; nav: number
   is_dca?: boolean
@@ -135,7 +142,7 @@ export default function PlanningClient() {
   const [recurringSavings, setRecurringSavings] = useState<RecurringSaving[]>(initialCache?.recurringSavings ?? [])
   const [recurringSavingOverrides, setRecurringSavingOverrides] = useState<RecurringSavingOverride[]>(initialCache?.recurringSavingOverrides ?? [])
   const [dcaSkips, setDcaSkips] = useState<DcaSkip[]>(initialCache?.dcaSkips ?? [])
-  const [recurringFulfilledIds, setRecurringFulfilledIds] = useState<string[]>(initialCache?.recurringFulfilledIds ?? [])
+  const [recurringFulfillments, setRecurringFulfillments] = useState<RecurringFulfillment[]>(initialCache?.recurringFulfillments ?? [])
   const [funds, setFunds] = useState<Fund[]>(initialCache?.funds ?? [])
   const [goals, setGoals] = useState<Goal[]>(initialCache?.goals ?? [])
   const [loading, setLoading] = useState(!initialCache)
@@ -188,9 +195,7 @@ export default function PlanningClient() {
         recurringSavings: p.recurring_savings ?? [],
         recurringSavingOverrides: p.recurring_saving_overrides ?? [],
         dcaSkips: p.dca_skips ?? [],
-        recurringFulfilledIds: (p.recurring_fulfillments ?? []).map(
-          (f: { recurring_saving_id: string }) => f.recurring_saving_id,
-        ),
+        recurringFulfillments: p.recurring_fulfillments ?? [],
       }
       setPlanCache(month, year, fresh)
       setPlan(fresh.plan)
@@ -204,7 +209,7 @@ export default function PlanningClient() {
       setRecurringSavings(fresh.recurringSavings)
       setRecurringSavingOverrides(fresh.recurringSavingOverrides)
       setDcaSkips(fresh.dcaSkips)
-      setRecurringFulfilledIds(fresh.recurringFulfilledIds)
+      setRecurringFulfillments(fresh.recurringFulfillments)
     } else {
       bustPlanCache(month, year)
       setPlan(null)
@@ -216,7 +221,7 @@ export default function PlanningClient() {
       setRecurringSavings([])
       setRecurringSavingOverrides([])
       setDcaSkips([])
-      setRecurringFulfilledIds([])
+      setRecurringFulfillments([])
       // Still load fixed expenses and insurance even without a plan
       const [expRes, insRes] = await Promise.all([
         fetch('/api/v1/fixed-expenses'),
@@ -297,7 +302,7 @@ export default function PlanningClient() {
         otherExpenses={otherExpenses}
         recurringSavings={recurringSavings}
         recurringSavingOverrides={recurringSavingOverrides}
-        recurringFulfilledIds={recurringFulfilledIds}
+        recurringFulfillments={recurringFulfillments}
         dcaSkips={dcaSkips}
         funds={funds}
         goals={goals}
@@ -327,7 +332,7 @@ export default function PlanningClient() {
         otherExpenses={otherExpenses}
         recurringSavings={recurringSavings}
         recurringSavingOverrides={recurringSavingOverrides}
-        recurringFulfilledIds={recurringFulfilledIds}
+        recurringFulfillments={recurringFulfillments}
         dcaSkips={dcaSkips}
         funds={funds}
         goals={goals}

--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -135,6 +135,7 @@ export default function PlanningClient() {
   const [recurringSavings, setRecurringSavings] = useState<RecurringSaving[]>(initialCache?.recurringSavings ?? [])
   const [recurringSavingOverrides, setRecurringSavingOverrides] = useState<RecurringSavingOverride[]>(initialCache?.recurringSavingOverrides ?? [])
   const [dcaSkips, setDcaSkips] = useState<DcaSkip[]>(initialCache?.dcaSkips ?? [])
+  const [recurringFulfilledIds, setRecurringFulfilledIds] = useState<string[]>(initialCache?.recurringFulfilledIds ?? [])
   const [funds, setFunds] = useState<Fund[]>(initialCache?.funds ?? [])
   const [goals, setGoals] = useState<Goal[]>(initialCache?.goals ?? [])
   const [loading, setLoading] = useState(!initialCache)
@@ -187,6 +188,9 @@ export default function PlanningClient() {
         recurringSavings: p.recurring_savings ?? [],
         recurringSavingOverrides: p.recurring_saving_overrides ?? [],
         dcaSkips: p.dca_skips ?? [],
+        recurringFulfilledIds: (p.recurring_fulfillments ?? []).map(
+          (f: { recurring_saving_id: string }) => f.recurring_saving_id,
+        ),
       }
       setPlanCache(month, year, fresh)
       setPlan(fresh.plan)
@@ -200,6 +204,7 @@ export default function PlanningClient() {
       setRecurringSavings(fresh.recurringSavings)
       setRecurringSavingOverrides(fresh.recurringSavingOverrides)
       setDcaSkips(fresh.dcaSkips)
+      setRecurringFulfilledIds(fresh.recurringFulfilledIds)
     } else {
       bustPlanCache(month, year)
       setPlan(null)
@@ -211,6 +216,7 @@ export default function PlanningClient() {
       setRecurringSavings([])
       setRecurringSavingOverrides([])
       setDcaSkips([])
+      setRecurringFulfilledIds([])
       // Still load fixed expenses and insurance even without a plan
       const [expRes, insRes] = await Promise.all([
         fetch('/api/v1/fixed-expenses'),
@@ -291,6 +297,7 @@ export default function PlanningClient() {
         otherExpenses={otherExpenses}
         recurringSavings={recurringSavings}
         recurringSavingOverrides={recurringSavingOverrides}
+        recurringFulfilledIds={recurringFulfilledIds}
         dcaSkips={dcaSkips}
         funds={funds}
         goals={goals}
@@ -320,6 +327,7 @@ export default function PlanningClient() {
         otherExpenses={otherExpenses}
         recurringSavings={recurringSavings}
         recurringSavingOverrides={recurringSavingOverrides}
+        recurringFulfilledIds={recurringFulfilledIds}
         dcaSkips={dcaSkips}
         funds={funds}
         goals={goals}

--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -80,11 +80,13 @@ export interface RecurringSavingOverride {
   monthly_amount_override_vnd: number
 }
 
-// A recurring recorded this month via maturity-combine / book top-up (no
-// plan-scoped deposit). amount_vnd is what was actually fulfilled.
+// A recurring recorded this month via maturity-combine / book top-up. amount_vnd
+// is what was fulfilled; source distinguishes whether a plan-scoped deposit was
+// also logged (book top-up) so contributed isn't double-counted.
 export interface RecurringFulfillment {
   recurring_saving_id: string
   amount_vnd: number
+  source: string
 }
 
 export interface Fund {

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -16,7 +16,7 @@ import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/comp
 import { buildByGoal, resolveRecurringSavings, type GoalItem } from '@/lib/planning'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
-  InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, DcaSkip, Fund, Goal,
+  InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, RecurringFulfillment, DcaSkip, Fund, Goal,
 } from '../PlanningClient'
 
 // ─── Pure helpers ─────────────────────────────────────────────────────────────
@@ -410,7 +410,7 @@ interface Props {
   otherExpenses: OtherExpense[]
   recurringSavings: RecurringSaving[]
   recurringSavingOverrides: RecurringSavingOverride[]
-  recurringFulfilledIds: string[]
+  recurringFulfillments: RecurringFulfillment[]
   dcaSkips: DcaSkip[]
   funds: Fund[]
   goals: Goal[]
@@ -428,7 +428,7 @@ interface Props {
 
 export default function DesktopPlanningView({
   month, year, plan, investments, savings, fixedExpenses, insuranceMembers,
-  otherExpenses, recurringSavings, recurringSavingOverrides, recurringFulfilledIds, dcaSkips, funds, goals, loading,
+  otherExpenses, recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, loading,
   onPrev, onNext, onToday, onPlanCreated, onPlanDeleted, onRefresh, onToast,
 }: Props) {
   const locale = useLocale()
@@ -476,12 +476,15 @@ export default function DesktopPlanningView({
         funds: { name: f.name },
       }))
   }, [funds, dcaSkips])
-  const fulfilledSet = useMemo(() => new Set(recurringFulfilledIds), [recurringFulfilledIds])
+  const fulfilledAmounts = useMemo(
+    () => new Map(recurringFulfillments.map(f => [f.recurring_saving_id, f.amount_vnd])),
+    [recurringFulfillments],
+  )
   const byGoal = useMemo(
     () => buildByGoal([...investments, ...skippedDcaInvestments], savings, resolvedRecurring, goalsById, {
       unallocated: isVI ? 'Chưa phân bổ' : 'Unallocated',
-    }, fulfilledSet),
-    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI, fulfilledSet],
+    }, fulfilledAmounts),
+    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI, fulfilledAmounts],
   )
   const totalGoalAmount = byGoal.reduce((s, g) => s + g.totalAllocated, 0)
   const contributedTotal = byGoal.reduce((s, g) => s + g.contributed, 0)

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -13,7 +13,7 @@ import FixedExpenseManager from './FixedExpenseManager'
 import RecurringSavingManager from './RecurringSavingManager'
 import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
-import { buildByGoal, resolveRecurringSavings, type GoalItem } from '@/lib/planning'
+import { buildByGoal, resolveRecurringSavings, DEPOSIT_BACKED_FULFILLMENT_SOURCES, type GoalItem } from '@/lib/planning'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
   InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, RecurringFulfillment, DcaSkip, Fund, Goal,
@@ -476,15 +476,18 @@ export default function DesktopPlanningView({
         funds: { name: f.name },
       }))
   }, [funds, dcaSkips])
-  const fulfilledAmounts = useMemo(
-    () => new Map(recurringFulfillments.map(f => [f.recurring_saving_id, f.amount_vnd])),
+  const fulfillments = useMemo(
+    () => new Map(recurringFulfillments.map(f => [f.recurring_saving_id, {
+      amount: f.amount_vnd,
+      countedAsDeposit: DEPOSIT_BACKED_FULFILLMENT_SOURCES.has(f.source),
+    }])),
     [recurringFulfillments],
   )
   const byGoal = useMemo(
     () => buildByGoal([...investments, ...skippedDcaInvestments], savings, resolvedRecurring, goalsById, {
       unallocated: isVI ? 'Chưa phân bổ' : 'Unallocated',
-    }, fulfilledAmounts),
-    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI, fulfilledAmounts],
+    }, fulfillments),
+    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI, fulfillments],
   )
   const totalGoalAmount = byGoal.reduce((s, g) => s + g.totalAllocated, 0)
   const contributedTotal = byGoal.reduce((s, g) => s + g.contributed, 0)

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -410,6 +410,7 @@ interface Props {
   otherExpenses: OtherExpense[]
   recurringSavings: RecurringSaving[]
   recurringSavingOverrides: RecurringSavingOverride[]
+  recurringFulfilledIds: string[]
   dcaSkips: DcaSkip[]
   funds: Fund[]
   goals: Goal[]
@@ -427,7 +428,7 @@ interface Props {
 
 export default function DesktopPlanningView({
   month, year, plan, investments, savings, fixedExpenses, insuranceMembers,
-  otherExpenses, recurringSavings, recurringSavingOverrides, dcaSkips, funds, goals, loading,
+  otherExpenses, recurringSavings, recurringSavingOverrides, recurringFulfilledIds, dcaSkips, funds, goals, loading,
   onPrev, onNext, onToday, onPlanCreated, onPlanDeleted, onRefresh, onToast,
 }: Props) {
   const locale = useLocale()
@@ -475,11 +476,12 @@ export default function DesktopPlanningView({
         funds: { name: f.name },
       }))
   }, [funds, dcaSkips])
+  const fulfilledSet = useMemo(() => new Set(recurringFulfilledIds), [recurringFulfilledIds])
   const byGoal = useMemo(
     () => buildByGoal([...investments, ...skippedDcaInvestments], savings, resolvedRecurring, goalsById, {
       unallocated: isVI ? 'Chưa phân bổ' : 'Unallocated',
-    }),
-    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI],
+    }, fulfilledSet),
+    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI, fulfilledSet],
   )
   const totalGoalAmount = byGoal.reduce((s, g) => s + g.totalAllocated, 0)
   const contributedTotal = byGoal.reduce((s, g) => s + g.contributed, 0)

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -16,7 +16,7 @@ import { buildByGoal, resolveRecurringSavings, type GoalRow, type GoalItem } fro
 import { MobilePlanningSkeleton } from './PlanningSkeleton'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
-  InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, DcaSkip, Fund, Goal,
+  InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, RecurringFulfillment, DcaSkip, Fund, Goal,
 } from '../PlanningClient'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -32,7 +32,7 @@ interface Props {
   otherExpenses: OtherExpense[]
   recurringSavings: RecurringSaving[]
   recurringSavingOverrides: RecurringSavingOverride[]
-  recurringFulfilledIds: string[]
+  recurringFulfillments: RecurringFulfillment[]
   dcaSkips: DcaSkip[]
   funds: Fund[]
   goals: Goal[]
@@ -996,7 +996,7 @@ function MenuItem({ icon, label, onClick, danger, noBorder }: {
 
 export default function MobilePlanningView({
   month, year, plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,
-  recurringSavings, recurringSavingOverrides, recurringFulfilledIds, dcaSkips, funds, goals, loading,
+  recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, loading,
   onPlanCreated, onPlanDeleted, onRefresh, onToast,
 }: Props) {
   const locale = useLocale()
@@ -1033,12 +1033,15 @@ export default function MobilePlanningView({
         funds: { name: f.name },
       }))
   }, [funds, dcaSkips])
-  const fulfilledSet = useMemo(() => new Set(recurringFulfilledIds), [recurringFulfilledIds])
+  const fulfilledAmounts = useMemo(
+    () => new Map(recurringFulfillments.map(f => [f.recurring_saving_id, f.amount_vnd])),
+    [recurringFulfillments],
+  )
   const byGoal = useMemo(
     () => buildByGoal([...investments, ...skippedDcaInvestments], savings, resolvedRecurring, goalsById, {
       unallocated: isVI ? 'Chưa phân bổ' : 'Unallocated',
-    }, fulfilledSet),
-    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI, fulfilledSet],
+    }, fulfilledAmounts),
+    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI, fulfilledAmounts],
   )
   const totalGoals = useMemo(() => byGoal.reduce((s, g) => s + g.totalAllocated, 0), [byGoal])
   const contributedTotal = useMemo(() => byGoal.reduce((s, g) => s + g.contributed, 0), [byGoal])

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -32,6 +32,7 @@ interface Props {
   otherExpenses: OtherExpense[]
   recurringSavings: RecurringSaving[]
   recurringSavingOverrides: RecurringSavingOverride[]
+  recurringFulfilledIds: string[]
   dcaSkips: DcaSkip[]
   funds: Fund[]
   goals: Goal[]
@@ -995,7 +996,7 @@ function MenuItem({ icon, label, onClick, danger, noBorder }: {
 
 export default function MobilePlanningView({
   month, year, plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,
-  recurringSavings, recurringSavingOverrides, dcaSkips, funds, goals, loading,
+  recurringSavings, recurringSavingOverrides, recurringFulfilledIds, dcaSkips, funds, goals, loading,
   onPlanCreated, onPlanDeleted, onRefresh, onToast,
 }: Props) {
   const locale = useLocale()
@@ -1032,11 +1033,12 @@ export default function MobilePlanningView({
         funds: { name: f.name },
       }))
   }, [funds, dcaSkips])
+  const fulfilledSet = useMemo(() => new Set(recurringFulfilledIds), [recurringFulfilledIds])
   const byGoal = useMemo(
     () => buildByGoal([...investments, ...skippedDcaInvestments], savings, resolvedRecurring, goalsById, {
       unallocated: isVI ? 'Chưa phân bổ' : 'Unallocated',
-    }),
-    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI],
+    }, fulfilledSet),
+    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI, fulfilledSet],
   )
   const totalGoals = useMemo(() => byGoal.reduce((s, g) => s + g.totalAllocated, 0), [byGoal])
   const contributedTotal = useMemo(() => byGoal.reduce((s, g) => s + g.contributed, 0), [byGoal])

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -12,7 +12,7 @@ import FixedExpenseManager from './FixedExpenseManager'
 import RecurringSavingManager from './RecurringSavingManager'
 import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
-import { buildByGoal, resolveRecurringSavings, type GoalRow, type GoalItem } from '@/lib/planning'
+import { buildByGoal, resolveRecurringSavings, DEPOSIT_BACKED_FULFILLMENT_SOURCES, type GoalRow, type GoalItem } from '@/lib/planning'
 import { MobilePlanningSkeleton } from './PlanningSkeleton'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
@@ -1033,15 +1033,18 @@ export default function MobilePlanningView({
         funds: { name: f.name },
       }))
   }, [funds, dcaSkips])
-  const fulfilledAmounts = useMemo(
-    () => new Map(recurringFulfillments.map(f => [f.recurring_saving_id, f.amount_vnd])),
+  const fulfillments = useMemo(
+    () => new Map(recurringFulfillments.map(f => [f.recurring_saving_id, {
+      amount: f.amount_vnd,
+      countedAsDeposit: DEPOSIT_BACKED_FULFILLMENT_SOURCES.has(f.source),
+    }])),
     [recurringFulfillments],
   )
   const byGoal = useMemo(
     () => buildByGoal([...investments, ...skippedDcaInvestments], savings, resolvedRecurring, goalsById, {
       unallocated: isVI ? 'Chưa phân bổ' : 'Unallocated',
-    }, fulfilledAmounts),
-    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI, fulfilledAmounts],
+    }, fulfillments),
+    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI, fulfillments],
   )
   const totalGoals = useMemo(() => byGoal.reduce((s, g) => s + g.totalAllocated, 0), [byGoal])
   const contributedTotal = useMemo(() => byGoal.reduce((s, g) => s + g.contributed, 0), [byGoal])

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DesktopPlanningView from '../DesktopPlanningView'
-import type { MonthlyPlan, FundInvestment, DirectSaving, RecurringSaving } from '../../PlanningClient'
+import type { MonthlyPlan, FundInvestment, DirectSaving, RecurringSaving, RecurringFulfillment } from '../../PlanningClient'
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
@@ -46,7 +46,7 @@ const defaultProps = {
   otherExpenses: [],
   recurringSavings: [] as RecurringSaving[],
   recurringSavingOverrides: [],
-  recurringFulfilledIds: [] as string[],
+  recurringFulfillments: [] as RecurringFulfillment[],
   dcaSkips: [],
   funds: [],
   goals: [],
@@ -119,21 +119,25 @@ describe('DesktopPlanningView — recurring bank "Saved" deposit', () => {
     expect(screen.getByText('100%')).toBeInTheDocument()
   })
 
-  it('shows the recurring as recorded from a fulfillment alone — no matching deposit (maturity-combine / book top-up)', () => {
+  it('records the line AND fills the goal progress from a fulfillment alone — no deposit (maturity-combine / book top-up)', () => {
     // Regression: recording via maturity-combine writes a recurring_saving_fulfillments
     // row, not a plan-scoped deposit. The Plan page used to ignore fulfillments and
-    // matched only on goal+amount, so the line stayed "Record deposit" forever.
+    // matched only on goal+amount, so the line stayed "Record deposit" AND the goal
+    // progress bar showed 0% / "Nothing yet" forever.
     render(
       <DesktopPlanningView
         {...defaultProps}
         plan={basePlan}
         recurringSavings={recurringSavings}
-        recurringFulfilledIds={['rs1']}
+        recurringFulfillments={[{ recurring_saving_id: 'rs1', amount_vnd: 2_000_000 }]}
       />,
     )
     // The line is recorded → the prominent Record deposit pill is gone, even with
     // zero logged deposits this month.
     expect(screen.queryByRole('button', { name: /Record deposit/i })).not.toBeInTheDocument()
+    // And the goal progress reflects the fulfilled 2M of 2M planned → 100%.
+    expect(screen.getByText('100%')).toBeInTheDocument()
+    expect(screen.queryByText(/Nothing yet/i)).not.toBeInTheDocument()
   })
 
   it('opens the Add-Transaction sheet when Saved is clicked', async () => {

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -46,6 +46,7 @@ const defaultProps = {
   otherExpenses: [],
   recurringSavings: [] as RecurringSaving[],
   recurringSavingOverrides: [],
+  recurringFulfilledIds: [] as string[],
   dcaSkips: [],
   funds: [],
   goals: [],
@@ -116,6 +117,23 @@ describe('DesktopPlanningView — recurring bank "Saved" deposit', () => {
     expect(screen.queryByRole('button', { name: /Record deposit/i })).not.toBeInTheDocument()
     // The goal progress reflects the logged contribution (2M of 2M planned).
     expect(screen.getByText('100%')).toBeInTheDocument()
+  })
+
+  it('shows the recurring as recorded from a fulfillment alone — no matching deposit (maturity-combine / book top-up)', () => {
+    // Regression: recording via maturity-combine writes a recurring_saving_fulfillments
+    // row, not a plan-scoped deposit. The Plan page used to ignore fulfillments and
+    // matched only on goal+amount, so the line stayed "Record deposit" forever.
+    render(
+      <DesktopPlanningView
+        {...defaultProps}
+        plan={basePlan}
+        recurringSavings={recurringSavings}
+        recurringFulfilledIds={['rs1']}
+      />,
+    )
+    // The line is recorded → the prominent Record deposit pill is gone, even with
+    // zero logged deposits this month.
+    expect(screen.queryByRole('button', { name: /Record deposit/i })).not.toBeInTheDocument()
   })
 
   it('opens the Add-Transaction sheet when Saved is clicked', async () => {

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -119,7 +119,7 @@ describe('DesktopPlanningView — recurring bank "Saved" deposit', () => {
     expect(screen.getByText('100%')).toBeInTheDocument()
   })
 
-  it('records the line AND fills the goal progress from a fulfillment alone — no deposit (maturity-combine / book top-up)', () => {
+  it('combine: records the line AND fills the goal progress from a fulfillment alone — no deposit', () => {
     // Regression: recording via maturity-combine writes a recurring_saving_fulfillments
     // row, not a plan-scoped deposit. The Plan page used to ignore fulfillments and
     // matched only on goal+amount, so the line stayed "Record deposit" AND the goal
@@ -129,7 +129,7 @@ describe('DesktopPlanningView — recurring bank "Saved" deposit', () => {
         {...defaultProps}
         plan={basePlan}
         recurringSavings={recurringSavings}
-        recurringFulfillments={[{ recurring_saving_id: 'rs1', amount_vnd: 2_000_000 }]}
+        recurringFulfillments={[{ recurring_saving_id: 'rs1', amount_vnd: 2_000_000, source: 'maturity-combine' }]}
       />,
     )
     // The line is recorded → the prominent Record deposit pill is gone, even with
@@ -138,6 +138,32 @@ describe('DesktopPlanningView — recurring bank "Saved" deposit', () => {
     // And the goal progress reflects the fulfilled 2M of 2M planned → 100%.
     expect(screen.getByText('100%')).toBeInTheDocument()
     expect(screen.queryByText(/Nothing yet/i)).not.toBeInTheDocument()
+  })
+
+  it('book top-up: records the line without double-counting the tranche in contributed', () => {
+    // The top-up RPC logs a plan-scoped bank tranche (in `savings`) AND a
+    // fulfillment (source 'recurring-topup'). contributed must count it once.
+    const savings: DirectSaving[] = [
+      {
+        transaction_id: 'd1', plan_id: 'plan-1', goal_id: 'g1', amount_vnd: 2_000_000,
+        interest_rate: null, expiry_date: null, investment_date: '2026-05-10',
+        savings_goals: { goal_name: 'Retirement' },
+      },
+    ]
+    render(
+      <DesktopPlanningView
+        {...defaultProps}
+        plan={basePlan}
+        recurringSavings={recurringSavings}
+        savings={savings}
+        recurringFulfillments={[{ recurring_saving_id: 'rs1', amount_vnd: 2_000_000, source: 'recurring-topup' }]}
+      />,
+    )
+    expect(screen.queryByRole('button', { name: /Record deposit/i })).not.toBeInTheDocument()
+    expect(screen.getByText('100%')).toBeInTheDocument()
+    // Counted once (₫ 2000000), not doubled to ₫ 4000000.
+    expect(screen.getByText(/₫ 2000000 in/)).toBeInTheDocument()
+    expect(screen.queryByText(/₫ 4000000/)).not.toBeInTheDocument()
   })
 
   it('opens the Add-Transaction sheet when Saved is clicked', async () => {

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -87,6 +87,7 @@ const defaultProps = {
   otherExpenses: [] as OtherExpense[],
   recurringSavings: [],
   recurringSavingOverrides: [],
+  recurringFulfilledIds: [] as string[],
   dcaSkips: [],
   funds: [],
   goals: [],

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MobilePlanningView from '../MobilePlanningView'
-import type { MonthlyPlan, FixedExpense, InsuranceMember, OtherExpense, FundInvestment, DirectSaving } from '../../PlanningClient'
+import type { MonthlyPlan, FixedExpense, InsuranceMember, OtherExpense, FundInvestment, DirectSaving, RecurringFulfillment } from '../../PlanningClient'
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
@@ -87,7 +87,7 @@ const defaultProps = {
   otherExpenses: [] as OtherExpense[],
   recurringSavings: [],
   recurringSavingOverrides: [],
-  recurringFulfilledIds: [] as string[],
+  recurringFulfillments: [] as RecurringFulfillment[],
   dcaSkips: [],
   funds: [],
   goals: [],

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -28,7 +28,8 @@ export async function GET(request: NextRequest) {
 
   if (searchParams.get('full') === 'true') {
     const planDateForActive = `${plan.year}-${String(plan.month).padStart(2, '0')}-01`
-    const [invRes, savRes, overridesRes, expRes, insRes, exclRes, insOverridesRes, goalsRes, fundsRes, otherExpRes, recSavRes, recSavOverridesRes, dcaSkipsRes] = await Promise.all([
+    const ym = `${plan.year}-${String(plan.month).padStart(2, '0')}`
+    const [invRes, savRes, overridesRes, expRes, insRes, exclRes, insOverridesRes, goalsRes, fundsRes, otherExpRes, recSavRes, recSavOverridesRes, dcaSkipsRes, recFulfillmentsRes] = await Promise.all([
       supabase
         .from('investment_transactions')
         .select('transaction_id, plan_id, fund_id, goal_id, amount_vnd, units, unit_price, investment_date, is_dca_seeded, funds(name, nav), savings_goals(goal_name)')
@@ -80,6 +81,12 @@ export async function GET(request: NextRequest) {
       supabase
         .from('plan_dca_skips')
         .select('fund_id').eq('plan_id', plan.id),
+      // A recurring recorded via maturity-combine / book top-up writes a
+      // fulfillment row instead of a plan-scoped deposit. The Plan page uses
+      // these to mark such lines recorded (keyed by saving id for the month).
+      supabase
+        .from('recurring_saving_fulfillments')
+        .select('recurring_saving_id').eq('user_id', user.id).eq('ym', ym),
     ])
     // Auto-seed DCA fund entries and keep pending rows in sync with current DCA amount
     const allFunds = fundsRes.data ?? []
@@ -152,6 +159,7 @@ export async function GET(request: NextRequest) {
       recurring_savings:           recSavRes.data ?? [],
       recurring_saving_overrides:  recSavOverridesRes.data ?? [],
       dca_skips:                   dcaSkipsRes.data ?? [],
+      recurring_fulfillments:      recFulfillmentsRes.data ?? [],
     })
   }
 

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -83,10 +83,11 @@ export async function GET(request: NextRequest) {
         .select('fund_id').eq('plan_id', plan.id),
       // A recurring recorded via maturity-combine / book top-up writes a
       // fulfillment row instead of a plan-scoped deposit. The Plan page uses
-      // these to mark such lines recorded (keyed by saving id for the month).
+      // these to mark such lines recorded and count them toward goal progress
+      // (keyed by saving id, with the amount actually fulfilled this month).
       supabase
         .from('recurring_saving_fulfillments')
-        .select('recurring_saving_id').eq('user_id', user.id).eq('ym', ym),
+        .select('recurring_saving_id, amount_vnd').eq('user_id', user.id).eq('ym', ym),
     ])
     // Auto-seed DCA fund entries and keep pending rows in sync with current DCA amount
     const allFunds = fundsRes.data ?? []

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -87,7 +87,7 @@ export async function GET(request: NextRequest) {
       // (keyed by saving id, with the amount actually fulfilled this month).
       supabase
         .from('recurring_saving_fulfillments')
-        .select('recurring_saving_id, amount_vnd').eq('user_id', user.id).eq('ym', ym),
+        .select('recurring_saving_id, amount_vnd, source').eq('user_id', user.id).eq('ym', ym),
     ])
     // Auto-seed DCA fund entries and keep pending rows in sync with current DCA amount
     const allFunds = fundsRes.data ?? []

--- a/lib/__tests__/planning.test.ts
+++ b/lib/__tests__/planning.test.ts
@@ -178,3 +178,58 @@ describe('buildByGoal — planned vs contributed', () => {
     expect(rows.map(r => r.isUnallocated)).toEqual([false, true])
   })
 })
+
+describe('buildByGoal — fulfillment-based recording', () => {
+  const goalsById = new Map([['g-1', 'Retirement']])
+
+  // A recurring can be recorded without a matching plan-scoped deposit — e.g.
+  // maturity-combine or a book top-up writes a recurring_saving_fulfillments row
+  // instead of a standalone deposit. The Plan page must honor that fulfillment.
+  it('marks a recurring recorded from a fulfillment even with no matching deposit', () => {
+    const recurring = resolveRecurringSavings([saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 1_800_000 })], [])
+    const [row] = buildByGoal([], [], recurring, goalsById, undefined, new Set(['s-1']))
+    expect(row.items[0].recorded).toBe(true)
+    expect(row.totalAllocated).toBe(1_800_000) // still planned
+    expect(row.contributed).toBe(0)            // no deposit logged → not double-counted
+  })
+
+  it('leaves a recurring unrecorded when its id is not in the fulfilled set', () => {
+    const recurring = resolveRecurringSavings([saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 1_800_000 })], [])
+    const [row] = buildByGoal([], [], recurring, goalsById, undefined, new Set(['other']))
+    expect(row.items[0].recorded).toBeFalsy()
+  })
+
+  it('does not consume a deposit when the line is already fulfilled, so a sibling line can still match it', () => {
+    // Two same-amount lines in one goal; one fulfilled, one deposit logged.
+    // The fulfilled line must NOT eat the deposit — the other line should match it.
+    const recurring = resolveRecurringSavings([
+      saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 2_000_000 }),
+      saving({ saving_id: 's-2', goal_id: 'g-1', amount_vnd: 2_000_000 }),
+    ], [])
+    const directSavings: GoalDirectSaving[] = [
+      { goal_id: 'g-1', amount_vnd: 2_000_000, savings_goals: { goal_name: 'Retirement' } },
+    ]
+    const [row] = buildByGoal([], directSavings, recurring, goalsById, undefined, new Set(['s-1']))
+    expect(row.items.find(i => i.recurringId === 's-1')!.recorded).toBe(true) // via fulfillment
+    expect(row.items.find(i => i.recurringId === 's-2')!.recorded).toBe(true) // via deposit
+  })
+
+  it('never marks a skipped recurring recorded even if a fulfillment exists', () => {
+    const recurring = resolveRecurringSavings(
+      [saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 2_000_000 })],
+      [{ recurring_saving_id: 's-1', monthly_amount_override_vnd: 0 }],
+    )
+    const [row] = buildByGoal([], [], recurring, goalsById, undefined, new Set(['s-1']))
+    expect(row.items[0].skipped).toBe(true)
+    expect(row.items[0].recorded).toBeFalsy()
+  })
+
+  it('still matches by deposit when no fulfilled set is passed (back-compat)', () => {
+    const recurring = resolveRecurringSavings([saving({ goal_id: 'g-1', amount_vnd: 2_000_000 })], [])
+    const directSavings: GoalDirectSaving[] = [
+      { goal_id: 'g-1', amount_vnd: 2_000_000, savings_goals: { goal_name: 'Retirement' } },
+    ]
+    const [row] = buildByGoal([], directSavings, recurring, goalsById)
+    expect(row.items[0].recorded).toBe(true)
+  })
+})

--- a/lib/__tests__/planning.test.ts
+++ b/lib/__tests__/planning.test.ts
@@ -182,35 +182,53 @@ describe('buildByGoal — planned vs contributed', () => {
 describe('buildByGoal — fulfillment-based recording', () => {
   const goalsById = new Map([['g-1', 'Retirement']])
 
-  // A recurring can be recorded without a matching plan-scoped deposit — e.g.
-  // maturity-combine or a book top-up writes a recurring_saving_fulfillments row
-  // instead of a standalone deposit. The Plan page must honor that fulfillment:
-  // mark the line recorded AND count its amount toward the goal's contributed
-  // (so the progress bar fills), without double-counting.
-  it('records the line AND counts the fulfillment toward contributed (progress fills)', () => {
+  // A recurring can be recorded without a *matchable* plan-scoped deposit — e.g.
+  // maturity-combine (its re-deposit isn't plan-scoped) or a book top-up (its
+  // tranche IS plan-scoped). The Plan page honors the fulfillment to mark the
+  // line recorded; for contributed it must NOT double-count a top-up tranche that
+  // already lands in directSavings — only inject the amount for fulfillments with
+  // no plan-scoped deposit (countedAsDeposit:false → maturity-combine).
+  it('combine: records the line AND injects contributed (no plan-scoped deposit)', () => {
     const recurring = resolveRecurringSavings([saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 1_800_000 })], [])
-    const [row] = buildByGoal([], [], recurring, goalsById, undefined, new Map([['s-1', 1_800_000]]))
+    const [row] = buildByGoal([], [], recurring, goalsById, undefined,
+      new Map([['s-1', { amount: 1_800_000, countedAsDeposit: false }]]))
     expect(row.items[0].recorded).toBe(true)
     expect(row.totalAllocated).toBe(1_800_000) // planned
     expect(row.contributed).toBe(1_800_000)    // fulfilled → 100%, drives the progress bar
   })
 
-  it('counts the fulfillment\'s actual amount, not the planned line amount', () => {
+  it('combine: injects the fulfillment\'s actual amount, not the planned line amount', () => {
     // A partial maturity-combine: planned 2M, only 1.5M actually folded in.
     const recurring = resolveRecurringSavings([saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 2_000_000 })], [])
-    const [row] = buildByGoal([], [], recurring, goalsById, undefined, new Map([['s-1', 1_500_000]]))
+    const [row] = buildByGoal([], [], recurring, goalsById, undefined,
+      new Map([['s-1', { amount: 1_500_000, countedAsDeposit: false }]]))
     expect(row.contributed).toBe(1_500_000)
+  })
+
+  it('book top-up: records the line but does NOT double-count (tranche already in contributed)', () => {
+    // The top-up RPC logs a plan-scoped bank tranche (in directSavings) AND a
+    // fulfillment. contributed must count the amount exactly once — via the
+    // tranche — so the fulfillment marks recorded only (countedAsDeposit:true).
+    const recurring = resolveRecurringSavings([saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 1_800_000 })], [])
+    const directSavings: GoalDirectSaving[] = [
+      { goal_id: 'g-1', amount_vnd: 1_800_000, savings_goals: { goal_name: 'Retirement' } },
+    ]
+    const [row] = buildByGoal([], directSavings, recurring, goalsById, undefined,
+      new Map([['s-1', { amount: 1_800_000, countedAsDeposit: true }]]))
+    expect(row.items[0].recorded).toBe(true)
+    expect(row.contributed).toBe(1_800_000) // counted once, not 3.6M
   })
 
   it('leaves a recurring unrecorded when its id is not fulfilled', () => {
     const recurring = resolveRecurringSavings([saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 1_800_000 })], [])
-    const [row] = buildByGoal([], [], recurring, goalsById, undefined, new Map([['other', 1_000_000]]))
+    const [row] = buildByGoal([], [], recurring, goalsById, undefined,
+      new Map([['other', { amount: 1_000_000, countedAsDeposit: false }]]))
     expect(row.items[0].recorded).toBeFalsy()
     expect(row.contributed).toBe(0)
   })
 
   it('does not consume a deposit when the line is already fulfilled, so a sibling line can still match it', () => {
-    // Two same-amount lines in one goal; one fulfilled, one deposit logged.
+    // Two same-amount lines in one goal; one fulfilled via combine, one deposit logged.
     // The fulfilled line must NOT eat the deposit — the other line should match it.
     const recurring = resolveRecurringSavings([
       saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 2_000_000 }),
@@ -219,10 +237,11 @@ describe('buildByGoal — fulfillment-based recording', () => {
     const directSavings: GoalDirectSaving[] = [
       { goal_id: 'g-1', amount_vnd: 2_000_000, savings_goals: { goal_name: 'Retirement' } },
     ]
-    const [row] = buildByGoal([], directSavings, recurring, goalsById, undefined, new Map([['s-1', 2_000_000]]))
+    const [row] = buildByGoal([], directSavings, recurring, goalsById, undefined,
+      new Map([['s-1', { amount: 2_000_000, countedAsDeposit: false }]]))
     expect(row.items.find(i => i.recurringId === 's-1')!.recorded).toBe(true) // via fulfillment
     expect(row.items.find(i => i.recurringId === 's-2')!.recorded).toBe(true) // via deposit
-    expect(row.contributed).toBe(4_000_000) // fulfillment 2M + deposit 2M, no double-count
+    expect(row.contributed).toBe(4_000_000) // combine fulfillment 2M + deposit 2M
   })
 
   it('never marks a skipped recurring recorded even if a fulfillment exists', () => {
@@ -230,7 +249,8 @@ describe('buildByGoal — fulfillment-based recording', () => {
       [saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 2_000_000 })],
       [{ recurring_saving_id: 's-1', monthly_amount_override_vnd: 0 }],
     )
-    const [row] = buildByGoal([], [], recurring, goalsById, undefined, new Map([['s-1', 2_000_000]]))
+    const [row] = buildByGoal([], [], recurring, goalsById, undefined,
+      new Map([['s-1', { amount: 2_000_000, countedAsDeposit: false }]]))
     expect(row.items[0].skipped).toBe(true)
     expect(row.items[0].recorded).toBeFalsy()
     expect(row.contributed).toBe(0)

--- a/lib/__tests__/planning.test.ts
+++ b/lib/__tests__/planning.test.ts
@@ -184,19 +184,29 @@ describe('buildByGoal — fulfillment-based recording', () => {
 
   // A recurring can be recorded without a matching plan-scoped deposit — e.g.
   // maturity-combine or a book top-up writes a recurring_saving_fulfillments row
-  // instead of a standalone deposit. The Plan page must honor that fulfillment.
-  it('marks a recurring recorded from a fulfillment even with no matching deposit', () => {
+  // instead of a standalone deposit. The Plan page must honor that fulfillment:
+  // mark the line recorded AND count its amount toward the goal's contributed
+  // (so the progress bar fills), without double-counting.
+  it('records the line AND counts the fulfillment toward contributed (progress fills)', () => {
     const recurring = resolveRecurringSavings([saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 1_800_000 })], [])
-    const [row] = buildByGoal([], [], recurring, goalsById, undefined, new Set(['s-1']))
+    const [row] = buildByGoal([], [], recurring, goalsById, undefined, new Map([['s-1', 1_800_000]]))
     expect(row.items[0].recorded).toBe(true)
-    expect(row.totalAllocated).toBe(1_800_000) // still planned
-    expect(row.contributed).toBe(0)            // no deposit logged → not double-counted
+    expect(row.totalAllocated).toBe(1_800_000) // planned
+    expect(row.contributed).toBe(1_800_000)    // fulfilled → 100%, drives the progress bar
   })
 
-  it('leaves a recurring unrecorded when its id is not in the fulfilled set', () => {
+  it('counts the fulfillment\'s actual amount, not the planned line amount', () => {
+    // A partial maturity-combine: planned 2M, only 1.5M actually folded in.
+    const recurring = resolveRecurringSavings([saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 2_000_000 })], [])
+    const [row] = buildByGoal([], [], recurring, goalsById, undefined, new Map([['s-1', 1_500_000]]))
+    expect(row.contributed).toBe(1_500_000)
+  })
+
+  it('leaves a recurring unrecorded when its id is not fulfilled', () => {
     const recurring = resolveRecurringSavings([saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 1_800_000 })], [])
-    const [row] = buildByGoal([], [], recurring, goalsById, undefined, new Set(['other']))
+    const [row] = buildByGoal([], [], recurring, goalsById, undefined, new Map([['other', 1_000_000]]))
     expect(row.items[0].recorded).toBeFalsy()
+    expect(row.contributed).toBe(0)
   })
 
   it('does not consume a deposit when the line is already fulfilled, so a sibling line can still match it', () => {
@@ -209,9 +219,10 @@ describe('buildByGoal — fulfillment-based recording', () => {
     const directSavings: GoalDirectSaving[] = [
       { goal_id: 'g-1', amount_vnd: 2_000_000, savings_goals: { goal_name: 'Retirement' } },
     ]
-    const [row] = buildByGoal([], directSavings, recurring, goalsById, undefined, new Set(['s-1']))
+    const [row] = buildByGoal([], directSavings, recurring, goalsById, undefined, new Map([['s-1', 2_000_000]]))
     expect(row.items.find(i => i.recurringId === 's-1')!.recorded).toBe(true) // via fulfillment
     expect(row.items.find(i => i.recurringId === 's-2')!.recorded).toBe(true) // via deposit
+    expect(row.contributed).toBe(4_000_000) // fulfillment 2M + deposit 2M, no double-count
   })
 
   it('never marks a skipped recurring recorded even if a fulfillment exists', () => {
@@ -219,12 +230,13 @@ describe('buildByGoal — fulfillment-based recording', () => {
       [saving({ saving_id: 's-1', goal_id: 'g-1', amount_vnd: 2_000_000 })],
       [{ recurring_saving_id: 's-1', monthly_amount_override_vnd: 0 }],
     )
-    const [row] = buildByGoal([], [], recurring, goalsById, undefined, new Set(['s-1']))
+    const [row] = buildByGoal([], [], recurring, goalsById, undefined, new Map([['s-1', 2_000_000]]))
     expect(row.items[0].skipped).toBe(true)
     expect(row.items[0].recorded).toBeFalsy()
+    expect(row.contributed).toBe(0)
   })
 
-  it('still matches by deposit when no fulfilled set is passed (back-compat)', () => {
+  it('still matches by deposit when no fulfillments are passed (back-compat)', () => {
     const recurring = resolveRecurringSavings([saving({ goal_id: 'g-1', amount_vnd: 2_000_000 })], [])
     const directSavings: GoalDirectSaving[] = [
       { goal_id: 'g-1', amount_vnd: 2_000_000, savings_goals: { goal_name: 'Retirement' } },

--- a/lib/planning.ts
+++ b/lib/planning.ts
@@ -125,10 +125,11 @@ export function buildByGoal(
   recurring: ResolvedSaving[],
   goalsById: Map<string, string>,
   labels?: { unallocated?: string },
-  // Recurring-saving ids with a fulfillment row for this month. These were
-  // recorded via a path that doesn't log a plan-scoped deposit (maturity-combine,
-  // book top-up), so the goal+amount deposit match below can't see them.
-  fulfilledSavingIds?: Set<string>,
+  // Recurring-saving ids → amount fulfilled this month. These were recorded via a
+  // path that doesn't log a plan-scoped deposit (maturity-combine, book top-up),
+  // so the goal+amount deposit match below can't see them; we mark the line
+  // recorded and count the fulfilled amount toward the goal's contributed.
+  fulfilledAmounts?: Map<string, number>,
 ): GoalRow[] {
   const unallocatedLabel = labels?.unallocated ?? 'Unallocated'
   const map = new Map<string, GoalRow>()
@@ -198,11 +199,15 @@ export function buildByGoal(
     // the month (maturity-combine / book top-up), or — failing that — once a
     // deposit of the same amount toward the same goal has been logged. We check
     // the fulfillment first and don't touch the pool when it hits, so a fulfilled
-    // line never eats a deposit that a sibling line should match.
+    // line never eats a deposit that a sibling line should match. A fulfillment
+    // also counts toward contributed (it isn't a logged deposit, so it's the only
+    // place its money lands) — that drives the goal progress bar.
     let recorded = false
     if (!r.skipped) {
-      if (fulfilledSavingIds?.has(r.id)) {
+      const fulfilled = fulfilledAmounts?.get(r.id)
+      if (fulfilled !== undefined) {
         recorded = true
+        row.contributed += fulfilled
       } else {
         const pool = depositPool.get(r.goalId ?? UNALLOCATED)
         const i = pool ? pool.indexOf(r.amount) : -1

--- a/lib/planning.ts
+++ b/lib/planning.ts
@@ -125,6 +125,10 @@ export function buildByGoal(
   recurring: ResolvedSaving[],
   goalsById: Map<string, string>,
   labels?: { unallocated?: string },
+  // Recurring-saving ids with a fulfillment row for this month. These were
+  // recorded via a path that doesn't log a plan-scoped deposit (maturity-combine,
+  // book top-up), so the goal+amount deposit match below can't see them.
+  fulfilledSavingIds?: Set<string>,
 ): GoalRow[] {
   const unallocatedLabel = labels?.unallocated ?? 'Unallocated'
   const map = new Map<string, GoalRow>()
@@ -190,13 +194,20 @@ export function buildByGoal(
   for (const r of recurring) {
     const row = ensure(r.goalId, r.goalName)
     row.totalAllocated += r.amount
-    // A non-skipped recurring line is "recorded" once a deposit of the same
-    // amount toward the same goal has been logged this month.
+    // A non-skipped recurring line is "recorded" if it has a fulfillment row for
+    // the month (maturity-combine / book top-up), or — failing that — once a
+    // deposit of the same amount toward the same goal has been logged. We check
+    // the fulfillment first and don't touch the pool when it hits, so a fulfilled
+    // line never eats a deposit that a sibling line should match.
     let recorded = false
     if (!r.skipped) {
-      const pool = depositPool.get(r.goalId ?? UNALLOCATED)
-      const i = pool ? pool.indexOf(r.amount) : -1
-      if (pool && i !== -1) { pool.splice(i, 1); recorded = true }
+      if (fulfilledSavingIds?.has(r.id)) {
+        recorded = true
+      } else {
+        const pool = depositPool.get(r.goalId ?? UNALLOCATED)
+        const i = pool ? pool.indexOf(r.amount) : -1
+        if (pool && i !== -1) { pool.splice(i, 1); recorded = true }
+      }
     }
     row.items.push({
       name: r.name,

--- a/lib/planning.ts
+++ b/lib/planning.ts
@@ -9,6 +9,19 @@
 
 const UNALLOCATED = '__unallocated__'
 
+// A recurring recorded this month via a fulfillment row, and whether that path
+// ALSO logged a plan-scoped bank deposit. Book top-up writes a tranche with a
+// plan_id (so it's already in directSavings → contributed counts it); maturity-
+// combine's re-deposit isn't plan-scoped, so its fulfillment is the only record.
+export interface MonthFulfillment {
+  amount: number
+  countedAsDeposit: boolean
+}
+
+// Fulfillment `source` values whose path also logs a plan-scoped deposit — used
+// to set MonthFulfillment.countedAsDeposit so contributed isn't double-counted.
+export const DEPOSIT_BACKED_FULFILLMENT_SOURCES = new Set(['recurring-topup'])
+
 // ─── Recurring savings ─────────────────────────────────────────────────────────
 
 export interface RecurringSaving {
@@ -125,11 +138,12 @@ export function buildByGoal(
   recurring: ResolvedSaving[],
   goalsById: Map<string, string>,
   labels?: { unallocated?: string },
-  // Recurring-saving ids → amount fulfilled this month. These were recorded via a
-  // path that doesn't log a plan-scoped deposit (maturity-combine, book top-up),
-  // so the goal+amount deposit match below can't see them; we mark the line
-  // recorded and count the fulfilled amount toward the goal's contributed.
-  fulfilledAmounts?: Map<string, number>,
+  // Recurring-saving ids → this month's fulfillment. These were recorded via a
+  // path the goal+amount deposit match can't see (maturity-combine, book top-up),
+  // so we mark the line recorded. We add the amount to contributed ONLY when the
+  // path didn't also log a plan-scoped deposit (countedAsDeposit=false) — else
+  // the deposit already counts it in the directSavings loop and we'd double-count.
+  fulfillments?: Map<string, MonthFulfillment>,
 ): GoalRow[] {
   const unallocatedLabel = labels?.unallocated ?? 'Unallocated'
   const map = new Map<string, GoalRow>()
@@ -199,15 +213,16 @@ export function buildByGoal(
     // the month (maturity-combine / book top-up), or — failing that — once a
     // deposit of the same amount toward the same goal has been logged. We check
     // the fulfillment first and don't touch the pool when it hits, so a fulfilled
-    // line never eats a deposit that a sibling line should match. A fulfillment
-    // also counts toward contributed (it isn't a logged deposit, so it's the only
-    // place its money lands) — that drives the goal progress bar.
+    // line never eats a deposit that a sibling line should match. A combine
+    // fulfillment also counts toward contributed (its re-deposit isn't plan-scoped,
+    // so this is the only place its money lands → drives the progress bar); a
+    // top-up fulfillment does NOT, since its tranche already counts in directSavings.
     let recorded = false
     if (!r.skipped) {
-      const fulfilled = fulfilledAmounts?.get(r.id)
-      if (fulfilled !== undefined) {
+      const fulfilled = fulfillments?.get(r.id)
+      if (fulfilled) {
         recorded = true
-        row.contributed += fulfilled
+        if (!fulfilled.countedAsDeposit) row.contributed += fulfilled.amount
       } else {
         const pool = depositPool.get(r.goalId ?? UNALLOCATED)
         const i = pool ? pool.indexOf(r.amount) : -1


### PR DESCRIPTION
## Problem

The Plan page derived a recurring savings line's **"đã gửi" / recorded** state purely by matching a plan-scoped bank deposit on `goal_id` + **exact** `amount_vnd`, and **ignored the `recurring_saving_fulfillments` table** (only the dashboard reads it).

So a recurring recorded via a fulfillment-writing path showed correctly on the dashboard but on the Plan page (a) the line stayed on "Record deposit", and (b) the **goal progress bar stayed at 0% / "Chưa góp"**.

**Confirmed live** (`mphuongth@gmail.com`, June 2026): "PVCombank" 1.8M recorded via maturity-combine — fulfillment row written, but no 1.8M plan-scoped deposit, so the line never flipped.

## Fix

`buildByGoal` takes optional `fulfillments: Map<savingId, {amount, countedAsDeposit}>`:
- **recorded**: a non-skipped line is recorded if fulfilled, else falls back to the goal+amount deposit match. Checked first; does **not** consume a pooled deposit, so a fulfilled line never eats a deposit a sibling should match.
- **contributed** (drives the progress bar): the two fulfillment paths differ, so we discriminate by `source` to avoid both under- and over-counting:
  - **maturity-combine** — its re-deposit isn't plan-scoped (no `plan_id`) → not in `direct_savings` → the fulfillment is the only record → **inject** its amount (`countedAsDeposit:false`).
  - **book top-up** (`record_recurring_book_topup`) — logs a plan-scoped tranche that already counts in `direct_savings` → fulfillment marks recorded **only**, no contributed injection (`countedAsDeposit:true`), else it double-counts.

  Discriminated via exported `DEPOSIT_BACKED_FULFILLMENT_SOURCES = {'recurring-topup'}`.

Files: `lib/planning.ts` (logic + source set), `app/api/v1/monthly-plans/route.ts` (selects `source`, returns `recurring_fulfillments`), `PlanningClient.tsx` → both views (thread `RecurringFulfillment[]`).

## Tests (TDD)

- `lib/__tests__/planning.test.ts` — combine injects contributed (incl. partial amount); **book top-up records but counts once, not 2×**; not fulfilled → 0%; fulfilled line doesn't consume a sibling's deposit; skipped never recorded; back-compat with no fulfillments.
- `DesktopPlanningView.test.tsx` — **closes the loop on the rendered UI**: combine fulfillment alone → pill gone + bar shows 100% (not "Nothing yet"); book top-up → recorded + contributed shows ₫2M once, **not ₫4M**.

`npm test -- --run` → 691 passed. `tsc --noEmit` clean. Lint baseline unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)