### PR TITLE
feat(deposits): fold sibling deposits into a renewing term deposit (merge-on-renew)

### DIFF
--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const body = await request.json()
-  const { amount_vnd, interest_rate, expiry_date, investment_date, interest_earned_vnd, fulfill_recurring } = body
+  const { amount_vnd, interest_rate, expiry_date, investment_date, interest_earned_vnd, fulfill_recurring, merge_sources } = body
 
   let txId: string
   let cleanAmount: number
@@ -36,6 +36,11 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   let cleanFulfillSavingId: string | null = null
   let cleanFulfillYm: string | null = null
   let cleanFulfillAmount: number | null = null
+  // Merge flow only: sibling bank deposits in the same goal settled early and
+  // folded into this re-deposit. Parsed into two parallel arrays the RPC takes.
+  // When non-empty, amount_vnd is the BASE and the RPC adds Σ(received).
+  const cleanMergeSourceIds: string[] = []
+  const cleanMergeReceived: number[] = []
   try {
     txId = validateUUID(id, 'transaction_id')
     cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
@@ -60,6 +65,17 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       const a = Number(fulfill_recurring.amount ?? 0)
       if (!Number.isFinite(a) || a < 0) throw new ValidationError('fulfill_recurring.amount must be a non-negative number')
       cleanFulfillAmount = Math.round(a)
+    }
+    if (merge_sources != null) {
+      if (!Array.isArray(merge_sources)) throw new ValidationError('merge_sources must be an array')
+      for (const s of merge_sources) {
+        const sid = validateUUID(s?.tx_id, 'merge_sources.tx_id')
+        if (sid === txId) throw new ValidationError('a deposit cannot merge into itself')
+        const r = Number(s?.received)
+        if (!Number.isFinite(r) || r < 0) throw new ValidationError('merge_sources.received must be a non-negative number')
+        cleanMergeSourceIds.push(sid)
+        cleanMergeReceived.push(Math.round(r))
+      }
     }
   } catch (e) {
     if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
@@ -109,22 +125,45 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   // withdrawals) atomically. The re-parent is correctness-critical — a partial
   // success that skipped it would silently double-count the withdrawn amount —
   // so a failure here aborts the whole renewal rather than returning 200.
-  const { data: renewed, error: renewErr } = await supabase
-    .rpc('renew_term_deposit', {
-      p_tx_id: txId,
-      p_amount_vnd: Math.round(cleanAmount),
-      p_interest_rate: cleanRate,
-      p_expiry_date: cleanExpiry,
-      p_investment_date: cleanInvestmentDate,
-      p_interest_earned_vnd: cleanInterestEarned,
-      // Combine flow: fold this month's recurring saving in atomically (NULL for
-      // a plain renewal — the RPC's params default to NULL).
-      p_fulfill_saving_id: cleanFulfillSavingId,
-      p_fulfill_ym: cleanFulfillYm,
-      p_fulfill_amount: cleanFulfillAmount,
-      p_fulfill_source: cleanFulfillSavingId ? 'maturity-combine' : null,
-    })
-    .single()
+  //
+  // When sibling deposits are being merged in, route to renew_term_deposit_with_merge:
+  // it ALSO closes each source and adds Σ(received) to the principal. amount_vnd
+  // is then the BASE (principal + interest + recurring) — the RPC, not the
+  // client, sums in the received cash, so the net-worth invariant can't diverge.
+  const hasMerge = cleanMergeSourceIds.length > 0
+  const { data: renewed, error: renewErr } = hasMerge
+    ? await supabase
+        .rpc('renew_term_deposit_with_merge', {
+          p_tx_id: txId,
+          p_amount_vnd: Math.round(cleanAmount), // BASE; the RPC adds Σ(received)
+          p_interest_rate: cleanRate,
+          p_expiry_date: cleanExpiry,
+          p_investment_date: cleanInvestmentDate,
+          p_interest_earned_vnd: cleanInterestEarned,
+          p_fulfill_saving_id: cleanFulfillSavingId,
+          p_fulfill_ym: cleanFulfillYm,
+          p_fulfill_amount: cleanFulfillAmount,
+          p_fulfill_source: cleanFulfillSavingId ? 'maturity-combine' : null,
+          p_merge_source_ids: cleanMergeSourceIds,
+          p_merge_received: cleanMergeReceived,
+        })
+        .single()
+    : await supabase
+        .rpc('renew_term_deposit', {
+          p_tx_id: txId,
+          p_amount_vnd: Math.round(cleanAmount),
+          p_interest_rate: cleanRate,
+          p_expiry_date: cleanExpiry,
+          p_investment_date: cleanInvestmentDate,
+          p_interest_earned_vnd: cleanInterestEarned,
+          // Combine flow: fold this month's recurring saving in atomically (NULL for
+          // a plain renewal — the RPC's params default to NULL).
+          p_fulfill_saving_id: cleanFulfillSavingId,
+          p_fulfill_ym: cleanFulfillYm,
+          p_fulfill_amount: cleanFulfillAmount,
+          p_fulfill_source: cleanFulfillSavingId ? 'maturity-combine' : null,
+        })
+        .single()
   if (renewErr || !renewed) {
     console.error('renew: atomic renewal failed', renewErr?.message)
     return NextResponse.json({ error: 'Failed to renew deposit' }, { status: 500 })

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -565,6 +565,8 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
       {showResolve && actionInv && (
         <MaturityResolveModal
           inv={actionInv}
+          goalId={goal.goalId}
+          siblingDeposits={invRows}
           isVi={isVi}
           onClose={() => setShowResolve(false)}
           onRenewed={() => { setShowResolve(false); (onRenewed ?? onDataChanged)() }}

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -1292,6 +1292,8 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
       <MaturityResolveSheet
         open={resolveOpen}
         inv={actionInv}
+        goalId={goal.goalId}
+        siblingDeposits={invRows}
         isVi={isVI}
         onClose={() => setResolveOpen(false)}
         onRenewed={() => { setResolveOpen(false); onDataChanged() }}

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -25,6 +25,7 @@ import {
   addMonths,
   monthsBetween,
   renewalPrincipal,
+  allocateCumulative,
   type RenewMode,
 } from '@/lib/maturity'
 import { linkedSavingFor, type RecurringLinkCandidate, type RecurringLinkResult } from '@/lib/recurringLink'
@@ -62,12 +63,17 @@ function MoneyField({ label, value, onChange, testId }: { label: string; value: 
  * parent's existing Sell/Withdraw flow.
  */
 export function MaturityResolveBody({
-  inv, goalId, isVi, onClose, onRenewed, onWithdraw,
+  inv, goalId, siblingDeposits, isVi, onClose, onRenewed, onWithdraw,
 }: {
   inv: InvRow
   // The goal this deposit is assigned to (null = unallocated). Used to find the
   // recurring saving that can be folded into the re-deposit (combine flow).
   goalId?: string | null
+  // The goal's other holdings. The combine flow can fold sibling bank deposits
+  // (settle each early, add the cash to this re-deposit) — an internal transfer
+  // that prevents the "inflate the principal but leave the sibling active"
+  // double-count. Omitted by callers that don't wire it (feature inert).
+  siblingDeposits?: InvRow[]
   isVi: boolean
   onClose: () => void
   onRenewed: () => void
@@ -119,6 +125,50 @@ export function MaturityResolveBody({
   const [redepositTouched, setRedepositTouched] = useState(false)
   const [markFulfilled, setMarkFulfilled] = useState(true)
 
+  // ── Merge siblings ──────────────────────────────────────────────────────────
+  // Sibling bank deposits in this goal that can be settled early and folded into
+  // the re-deposit. A book is renewed as a whole (never a tranche), so exclude
+  // grouped rows and the merge UI altogether when `inv` is itself a book.
+  const mergeable = (siblingDeposits ?? []).filter(
+    (s) => s.id !== inv.id && s.type === 'bank' && !s.depositGroupId && (s.principal ?? s.value ?? 0) > 0,
+  )
+  // Ordered the way the RPC's per-source allocation windows: (investmentDate, id).
+  const mergeableOrdered = [...mergeable].sort(
+    (a, b) => (a.investmentDate ?? '').localeCompare(b.investmentDate ?? '') || a.id.localeCompare(b.id),
+  )
+  const [mergeSel, setMergeSel] = useState<Record<string, boolean>>({})
+  const [mergeRecv, setMergeRecv] = useState<Record<string, string>>({})
+  const [mergeTotal, setMergeTotal] = useState('')
+  const [, setMergeTotalTouched] = useState(false)
+
+  const selectedSources = mergeableOrdered.filter((s) => mergeSel[s.id])
+  const mergeReceivedTotal = selectedSources.reduce((sum, s) => sum + (Number(mergeRecv[s.id]) || 0), 0)
+
+  // Toggle a source; on first select, prefill its received with the current value
+  // (the user edits it down to the real cash if the early settlement is penalised).
+  function toggleSource(s: InvRow) {
+    const on = !mergeSel[s.id]
+    setMergeSel((prev) => ({ ...prev, [s.id]: on }))
+    if (on && (mergeRecv[s.id] === undefined || mergeRecv[s.id] === '')) {
+      setMergeRecv((prev) => ({ ...prev, [s.id]: String(Math.round(s.value ?? s.principal ?? 0)) }))
+    }
+  }
+
+  // Editing the single TOTAL splits it across the selected sources with the same
+  // cumulative-window allocation the SQL uses — so Σ(received) === the total the
+  // user typed, exactly (no rounding drift between client preview and server).
+  function onMergeTotalChange(v: string) {
+    setMergeTotal(v); setMergeTotalTouched(true)
+    const total = Math.round(Number(v) || 0)
+    const sel = mergeableOrdered.filter((s) => mergeSel[s.id])
+    const alloc = allocateCumulative(total, sel.map((s) => Math.round(s.principal ?? s.value ?? 0)))
+    setMergeRecv((prev) => {
+      const next = { ...prev }
+      sel.forEach((s, i) => { next[s.id] = String(alloc[i]) })
+      return next
+    })
+  }
+
   useEffect(() => {
     // Combine needs the deposit's goal scope. When the caller doesn't wire it
     // (goalId omitted), stay in plain renew-only mode and skip the lookup.
@@ -150,7 +200,9 @@ export function MaturityResolveBody({
     ? (pickedSavingId ? combineLink.candidates.find((c) => c.saving_id === pickedSavingId) ?? null : combineLink.match)
     : null
   const linkedAmt = pickedCand ? pickedCand.amount_vnd : 0
-  const canCombine = !!combineLink
+  // Combine is offered when there's a recurring to fold in OR sibling deposits to
+  // merge — both routes settle-and-re-deposit. Inert when neither exists.
+  const canCombine = !!combineLink || mergeable.length > 0
 
   const iNum = Number(interest) || 0
   const tNum = Number(term) || 0
@@ -158,10 +210,14 @@ export function MaturityResolveBody({
   // back to the current principal rather than writing 0₫ to the deposit.
   const newAmountNum = newAmount.trim() === '' ? null : Number(newAmount)
   const redepositNum = redeposit.trim() === '' ? 0 : Number(redeposit)
+  // In combine mode the re-deposit field holds the BASE (principal + interest +
+  // recurring); the merged-in sibling cash is added ON TOP for the new principal.
+  // Submit sends the BASE and the per-source received list — the RPC re-sums
+  // Σ(received) server-side, so the net-worth invariant can't drift.
   const newPrincipal = mode === 'withdraw'
     ? principal
     : mode === 'combine'
-      ? redepositNum
+      ? redepositNum + mergeReceivedTotal
       : renewalPrincipal(mode, principal, iNum, newAmountNum)
 
   // Suggested re-deposit = principal + interest + this month's recurring, until
@@ -217,6 +273,12 @@ export function MaturityResolveBody({
     redepositHint: (amt: string) => `Gợi ý ${amt} (gốc + lãi + định kỳ) — sửa nếu thực tế khác.`,
     markDeposited: (amt: string) => `Đánh dấu đã gửi định kỳ tháng này (${amt})`,
     confirmCombine: 'Lưu sổ mới',
+    mergeSub: 'Gộp sổ tiết kiệm khác vào lần gửi lại',
+    mergeTitle: 'Gộp sổ khác',
+    mergeHint: 'Chọn các sổ để tất toán sớm và gộp vào lần gửi lại này.',
+    mergeReceivedLabel: 'Thực nhận',
+    mergeTotalLabel: 'Tổng gộp thêm',
+    mergePenalty: 'Tất toán trước hạn có thể bị phạt lãi — nhập số tiền thực nhận, không phải giá trị hiện tại.',
   } : {
     summarySuffix: 'yr', perYr: 'yr', mo: 'mo',
     why: matured
@@ -245,12 +307,20 @@ export function MaturityResolveBody({
     redepositHint: (amt: string) => `Suggested ${amt} (principal + interest + recurring) — edit if reality differs.`,
     markDeposited: (amt: string) => `Mark this month's recurring as deposited (${amt})`,
     confirmCombine: 'Save new deposit',
+    mergeSub: 'Fold other deposits into the re-deposit',
+    mergeTitle: 'Merge other deposits',
+    mergeHint: 'Pick deposits to settle early and fold into this re-deposit.',
+    mergeReceivedLabel: 'Received',
+    mergeTotalLabel: 'Total merged in',
+    mergePenalty: 'Early settlement may forfeit interest — enter the cash received, not the current value.',
   }
 
   const POLICIES: { id: Mode; icon: React.ReactNode; label: string; sub: string; danger?: boolean }[] = [
     ...(canCombine ? [{
       id: 'combine' as Mode, icon: <Plus size={16} />, label: t.combineLabel,
-      sub: combineLink?.ambiguous && !pickedCand ? t.combineSubPick : t.combineSub(fmtCompact(linkedAmt)),
+      sub: combineLink
+        ? (combineLink.ambiguous && !pickedCand ? t.combineSubPick : t.combineSub(fmtCompact(linkedAmt)))
+        : t.mergeSub,
     }] : []),
     { id: 'principal_interest', icon: <RefreshCw size={16} />, label: isVi ? 'Tái tục gốc + lãi' : 'Renew principal + interest', sub: isVi ? 'Cộng lãi vào gốc cho kỳ mới' : 'Roll interest into the new principal' },
     { id: 'principal_only', icon: <RefreshCw size={16} />, label: isVi ? 'Tái tục chỉ gốc' : 'Renew principal only', sub: isVi ? 'Lãi chuyển ra ngoài (về ví)' : 'Interest paid out to your wallet' },
@@ -274,7 +344,10 @@ export function MaturityResolveBody({
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
-          amount_vnd: Math.round(newPrincipal),
+          // Merge combine sends the BASE (re-deposit field), NOT base + Σreceived:
+          // the RPC adds the received cash so client and server can't disagree.
+          // Every other path sends the full new principal.
+          amount_vnd: mode === 'combine' ? Math.round(redepositNum) : Math.round(newPrincipal),
           interest_rate: Number(rate),
           expiry_date: newMaturity,
           // Anchor the new cycle's accrual to the OLD maturity date (baseDate) so
@@ -293,6 +366,11 @@ export function MaturityResolveBody({
           // is not also counted as a separate synthesized contribution.
           fulfill_recurring: mode === 'combine' && pickedCand && markFulfilled
             ? { saving_id: pickedCand.saving_id, ym: fulfillYm, amount: linkedAmt }
+            : undefined,
+          // Merge combine: the sibling deposits being settled early and folded in.
+          // The route closes each (full withdrawal) and adds its received to D.
+          merge_sources: mode === 'combine' && selectedSources.length > 0
+            ? selectedSources.map((s) => ({ tx_id: s.id, received: Math.round(Number(mergeRecv[s.id]) || 0) }))
             : undefined,
         }),
       })
@@ -451,6 +529,64 @@ export function MaturityResolveBody({
             </div>
             <p style={{ margin: '7px 2px 0', fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.45 }}>{t.redepositHint(fmtCompact(principal + iNum + linkedAmt))}</p>
           </div>
+
+          {/* Merge sibling deposits — settle each early, fold the cash into the
+              new principal. Hidden for a book (renewed whole) and when none qualify. */}
+          {!isBook && mergeable.length > 0 && (
+            <div style={{ border: '1px solid var(--c-line)', borderRadius: 12, padding: '11px 13px', display: 'grid', gap: 9 }}>
+              <div>
+                <div style={fieldLabel}>{t.mergeTitle}</div>
+                <p style={{ margin: '0 0 2px', fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.45 }}>{t.mergeHint}</p>
+              </div>
+              <div style={{ display: 'grid', gap: 7 }}>
+                {mergeableOrdered.map((s) => {
+                  const sel = !!mergeSel[s.id]
+                  return (
+                    <div key={s.id} style={{ display: 'grid', gap: 7 }}>
+                      <button type="button" data-testid={`merge-source-${s.id}`} onClick={() => toggleSource(s)}
+                        style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '9px 11px', borderRadius: 10, cursor: 'pointer', textAlign: 'left',
+                          border: `1.5px solid ${sel ? 'var(--c-navy)' : 'var(--c-line)'}`, background: sel ? 'var(--c-navy-tint)' : 'var(--c-card)', fontFamily: 'inherit' }}>
+                        <span style={{ width: 18, height: 18, borderRadius: 9, flexShrink: 0, border: `1.5px solid ${sel ? 'var(--c-btn-primary)' : 'var(--c-line-strong)'}`, background: sel ? 'var(--c-btn-primary)' : 'transparent', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                          {sel && <Check size={11} color="#fff" strokeWidth={3} />}
+                        </span>
+                        <span style={{ flex: 1, minWidth: 0, fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.name}</span>
+                        <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(s.value ?? s.principal ?? 0)}</span>
+                      </button>
+                      {sel && (
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingLeft: 28 }}>
+                          <span style={{ fontSize: 11, color: 'var(--c-muted)', flexShrink: 0 }}>{t.mergeReceivedLabel}</span>
+                          <div style={{ position: 'relative', flex: 1 }}>
+                            <input data-testid={`merge-received-${s.id}`} type="number" value={mergeRecv[s.id] ?? ''}
+                              onChange={(e) => { setMergeRecv((prev) => ({ ...prev, [s.id]: e.target.value })); setMergeTotal(''); setMergeTotalTouched(false) }}
+                              style={{ ...moneyInput, padding: '7px 24px 7px 10px', fontSize: 13 }} />
+                            <span style={{ position: 'absolute', right: 9, top: '50%', transform: 'translateY(-50%)', fontSize: 12, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </div>
+
+              {selectedSources.length > 0 && (
+                <>
+                  {/* One editable TOTAL that splits across the selected sources */}
+                  {selectedSources.length > 1 && (
+                    <div>
+                      <div style={fieldLabel}>{t.mergeTotalLabel}</div>
+                      <div style={{ position: 'relative' }}>
+                        <input data-testid="merge-total" type="number" value={mergeTotal === '' ? String(mergeReceivedTotal) : mergeTotal}
+                          onChange={(e) => onMergeTotalChange(e.target.value)} style={moneyInput} />
+                        <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
+                      </div>
+                    </div>
+                  )}
+                  {selectedSources.length === 1 && <input data-testid="merge-total" type="hidden" value={String(mergeReceivedTotal)} readOnly />}
+                  <p data-testid="merge-penalty-caption" style={{ margin: 0, fontSize: 11, color: 'var(--c-warn)', lineHeight: 1.45 }}>{t.mergePenalty}</p>
+                </>
+              )}
+            </div>
+          )}
 
           {/* New term + rate */}
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
@@ -620,11 +756,12 @@ export function MaturityResolveBody({
 
 // ─── Mobile bottom-sheet wrapper ───────────────────────────────────────────
 export function MaturityResolveSheet({
-  open, inv, goalId, isVi, onClose, onRenewed, onWithdraw,
+  open, inv, goalId, siblingDeposits, isVi, onClose, onRenewed, onWithdraw,
 }: {
   open: boolean
   inv: InvRow | null
   goalId?: string | null
+  siblingDeposits?: InvRow[]
   isVi: boolean
   onClose: () => void
   onRenewed: () => void
@@ -657,7 +794,7 @@ export function MaturityResolveSheet({
           <h2 style={{ margin: '0 0 14px', fontSize: 17, fontWeight: 700, letterSpacing: '-0.01em' }}>
             {isVi ? 'Xử lý đáo hạn' : 'Handle maturity'}
           </h2>
-          <MaturityResolveBody inv={inv} goalId={goalId} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />
+          <MaturityResolveBody inv={inv} goalId={goalId} siblingDeposits={siblingDeposits} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />
         </div>
       </div>
     </div>
@@ -666,10 +803,11 @@ export function MaturityResolveSheet({
 
 // ─── Desktop modal wrapper ─────────────────────────────────────────────────
 export function MaturityResolveModal({
-  inv, goalId, isVi, onClose, onRenewed, onWithdraw,
+  inv, goalId, siblingDeposits, isVi, onClose, onRenewed, onWithdraw,
 }: {
   inv: InvRow
   goalId?: string | null
+  siblingDeposits?: InvRow[]
   isVi: boolean
   onClose: () => void
   onRenewed: () => void
@@ -701,7 +839,7 @@ export function MaturityResolveModal({
           <button onClick={onClose} className="cn-btn ghost" style={{ padding: 6 }} aria-label="Close"><X size={18} /></button>
         </div>
         <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto' }}>
-          <MaturityResolveBody inv={inv} goalId={goalId} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />
+          <MaturityResolveBody inv={inv} goalId={goalId} siblingDeposits={siblingDeposits} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />
         </div>
       </div>
     </div>

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { MaturityResolveBody } from '../MaturityResolveSheet'
-import { addMonths, monthsBetween } from '@/lib/maturity'
+import { addMonths, monthsBetween, allocateCumulative } from '@/lib/maturity'
 import { fmt } from '@/lib/formatters'
 import type { InvRow } from '../goalDetailShared'
 
@@ -149,6 +149,123 @@ describe('MaturityResolveBody', () => {
     expect(confirm).toBeDisabled()
     await user.click(confirm)
     expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  // ── Merge-on-renew: fold sibling bank deposits into the re-deposit ──────────
+  // With goalId wired the body fetches the goal's recurring savings; we stub an
+  // empty list so combine is reached via mergeable siblings (not a recurring),
+  // which is also the inert default for the other suites that omit goalId.
+  describe('merge sibling deposits', () => {
+    function stubEmptyRecurring() {
+      const fetchMock = vi.fn().mockImplementation((url: string) => {
+        if (typeof url === 'string' && url.startsWith('/api/v1/recurring-savings')) {
+          return Promise.resolve({ ok: true, json: async () => ({ savings: [] }) })
+        }
+        return Promise.resolve({ ok: true, json: async () => ({}) })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      return fetchMock
+    }
+
+    const sibBank: InvRow = {
+      id: 'sib-bank', name: 'Vikki sibling', type: 'bank', value: 8_000_000, gainPct: null,
+      units: null, principal: 8_000_000, interestRate: 6, expiryDate: daysFromNow(40),
+      investmentDate: daysFromNow(-150), fund: null,
+    }
+    const sibBank2: InvRow = {
+      id: 'sib-bank-2', name: 'PVCombank sibling', type: 'bank', value: 4_000_000, gainPct: null,
+      units: null, principal: 4_000_000, interestRate: 5, expiryDate: daysFromNow(60),
+      investmentDate: daysFromNow(-100), fund: null,
+    }
+    const sibBook: InvRow = {
+      id: 'sib-book', name: 'Accumulating book', type: 'bank', value: 5_000_000, gainPct: null,
+      units: null, principal: 5_000_000, interestRate: 6, expiryDate: daysFromNow(30),
+      investmentDate: daysFromNow(-90), fund: null, depositGroupId: 'book-1',
+    }
+    const sibStock: InvRow = {
+      id: 'sib-stock', name: 'VNM', type: 'stock', value: 3_000_000, gainPct: 2,
+      units: 100, principal: 3_000_000, interestRate: null, expiryDate: null,
+      investmentDate: daysFromNow(-80), fund: null,
+    }
+
+    it('lists only same-goal non-book bank siblings (excludes self, books, non-bank)', async () => {
+      const user = userEvent.setup()
+      stubEmptyRecurring()
+      render(
+        <MaturityResolveBody inv={maturedDeposit} goalId="goal-1"
+          siblingDeposits={[maturedDeposit, sibBank, sibBook, sibStock]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      // Enter combine (available because there is a mergeable sibling).
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+
+      expect(screen.getByTestId('merge-source-sib-bank')).toBeTruthy()
+      expect(screen.queryByTestId('merge-source-tx-bank-1')).toBeNull()   // self (D) excluded
+      expect(screen.queryByTestId('merge-source-sib-book')).toBeNull()    // accumulating book excluded
+      expect(screen.queryByTestId('merge-source-sib-stock')).toBeNull()   // non-bank excluded
+    })
+
+    it('prefills each selected source with its current value and shows the penalty caption', async () => {
+      const user = userEvent.setup()
+      stubEmptyRecurring()
+      render(
+        <MaturityResolveBody inv={maturedDeposit} goalId="goal-1" siblingDeposits={[sibBank]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+      expect(screen.queryByTestId('merge-penalty-caption')).toBeNull() // hidden until a source is picked
+
+      await user.click(screen.getByTestId('merge-source-sib-bank'))
+      expect((screen.getByTestId('merge-received-sib-bank') as HTMLInputElement).value).toBe('8000000')
+      expect(screen.getByTestId('merge-penalty-caption')).toBeTruthy()
+    })
+
+    it('splits the editable total across selected sources via allocateCumulative', async () => {
+      const user = userEvent.setup()
+      stubEmptyRecurring()
+      render(
+        <MaturityResolveBody inv={maturedDeposit} goalId="goal-1" siblingDeposits={[sibBank, sibBank2]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+      // Select both (ordered by investmentDate, id → sib-bank-2 opened later? -100 > -150 → sib-bank first).
+      await user.click(screen.getByTestId('merge-source-sib-bank'))
+      await user.click(screen.getByTestId('merge-source-sib-bank-2'))
+
+      fireEvent.change(screen.getByTestId('merge-total'), { target: { value: '10000000' } })
+
+      // Weights ordered by (investmentDate, id): sib-bank (−150d) then sib-bank-2 (−100d).
+      const [a1, a2] = allocateCumulative(10_000_000, [8_000_000, 4_000_000])
+      expect((screen.getByTestId('merge-received-sib-bank') as HTMLInputElement).value).toBe(String(a1))
+      expect((screen.getByTestId('merge-received-sib-bank-2') as HTMLInputElement).value).toBe(String(a2))
+    })
+
+    it('previews base + Σreceived but submits amount_vnd == BASE plus merge_sources', async () => {
+      const user = userEvent.setup()
+      const fetchMock = stubEmptyRecurring()
+      render(
+        <MaturityResolveBody inv={maturedDeposit} goalId="goal-1" siblingDeposits={[sibBank]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+      await user.click(screen.getByTestId('merge-source-sib-bank'))
+
+      // BASE = principal + interest + recurring(0) = 35,000,000 + 2,030,000.
+      const BASE = 37_030_000
+      const received = 8_000_000
+      // Preview principal includes the merged cash.
+      expect(screen.getByTestId('maturity-new-principal').textContent).toContain(fmt(BASE + received))
+
+      await user.click(screen.getByRole('button', { name: /Save new deposit/i }))
+      await waitFor(() => {
+        const renewCall = fetchMock.mock.calls.find((c) => String(c[0]).endsWith('/renew'))
+        expect(renewCall).toBeTruthy()
+      })
+      const renewCall = fetchMock.mock.calls.find((c) => String(c[0]).endsWith('/renew'))!
+      const body = JSON.parse(renewCall[1].body)
+      expect(body.amount_vnd).toBe(BASE) // BASE only — the RPC adds Σreceived
+      expect(body.merge_sources).toEqual([{ tx_id: 'sib-bank', received }])
+    })
   })
 
   it('hands off to the existing withdraw flow instead of renewing', async () => {

--- a/e2e/maturity-combine-merge.spec.ts
+++ b/e2e/maturity-combine-merge.spec.ts
@@ -66,7 +66,15 @@ test.describe('Term-deposit maturity — merge a sibling deposit into the re-dep
       await expect(panel.getByText('E2E Merge D')).toBeVisible({ timeout: 10_000 })
 
       // D's Options → Handle maturity → choose "Settle & re-deposit" (merge).
-      await panel.getByRole('button', { name: 'Options', exact: true }).first().click()
+      // The list renders BOTH D and S, in no guaranteed order — target D's own
+      // row (the matured deposit) rather than whichever Options button is first,
+      // or we'd open S's options (no "Handle maturity" → timeout).
+      const dRow = panel
+        .locator('div')
+        .filter({ has: page.getByRole('button', { name: 'Options', exact: true }) })
+        .filter({ hasText: 'E2E Merge D' })
+        .last()
+      await dRow.getByRole('button', { name: 'Options', exact: true }).click()
       await page.getByText(/^(Handle maturity|Xử lý đáo hạn)$/).click()
       await page.getByRole('button', { name: /Settle & re-deposit|Tất toán & gửi lại/i }).click()
 

--- a/e2e/maturity-combine-merge.spec.ts
+++ b/e2e/maturity-combine-merge.spec.ts
@@ -1,0 +1,128 @@
+import { test, expect, type Page } from '@playwright/test'
+import * as api from './helpers/api'
+
+// Term-deposit maturity "combine" — folding a SIBLING bank deposit into the
+// re-deposit (merge-on-renew). The bug this guards: a user settles a sibling S
+// by hand into the renewed deposit D's principal but never closes S, so S's money
+// is counted twice (in D's principal AND as a still-active standalone deposit).
+//
+// The fix closes S with a full-withdrawal (affects_progress=TRUE) inside the same
+// atomic renewal and adds Σ(received) to D server-side. This closes the loop:
+// drive the merge from the desktop goal-detail UI, then assert
+//   • the server added exactly Σ(received) to D (net-worth invariant), and
+//   • S is gone from the goal's holdings (no double-count), and
+//   • the goal's progress value did NOT jump by S's value (the bar stays steady).
+// Desktop viewport (Desktop Chrome default). The merge UI is wired in the
+// goal-detail sheet/modal — not the dashboard maturity card — so we open it there.
+
+const iso = (offsetDays: number) => new Date(Date.now() + offsetDays * 86_400_000).toISOString().slice(0, 10)
+
+async function gotoFreshDashboard(page: Page) {
+  await page.goto('/settings') // unmount DashboardClient
+  await page.evaluate(() => {
+    Object.keys(localStorage).filter((k) => k.startsWith('dashboardOverviewCache')).forEach((k) => localStorage.removeItem(k))
+  })
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/v1/dashboard/overview') && r.status() === 200, { timeout: 20_000 }),
+    page.goto('/dashboard'),
+  ])
+}
+
+// The goal's progress value + its holdings, straight from the overview API.
+async function goalSnapshot(page: Page, goalId: string): Promise<{ progressValue: number; holdingIds: string[] }> {
+  const res = await page.request.get('/api/v1/dashboard/overview')
+  expect(res.ok()).toBeTruthy()
+  const json = await res.json()
+  const g = (json.goals ?? []).find((x: { goalId: string }) => x.goalId === goalId)
+  return {
+    progressValue: g?.progressValue ?? 0,
+    holdingIds: (g?.nonFunds ?? []).map((n: { transactionId: string }) => n.transactionId),
+  }
+}
+
+test.describe('Term-deposit maturity — merge a sibling deposit into the re-deposit', () => {
+  test('settles the sibling early and folds its cash into the renewed principal, no double-count', async ({ page }) => {
+    test.slow()
+    const goal = await api.createGoal({ goal_name: 'E2E Merge Goal', target_amount: 200_000_000 })
+    // D: matured term deposit (rolls forward on renewal). S: an active sibling
+    // bank deposit in the same goal — the one we fold in.
+    const D = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 20_000_000, investment_date: iso(-380),
+      interest_rate: 6, expiry_date: iso(-15), goal_id: goal.goal_id, notes: 'E2E Merge D',
+    })
+    const S = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 8_000_000, investment_date: iso(-120),
+      interest_rate: 6, expiry_date: iso(60), goal_id: goal.goal_id, notes: 'E2E Merge S',
+    })
+    try {
+      await gotoFreshDashboard(page)
+      const before = await goalSnapshot(page, goal.goal_id)
+      expect(before.holdingIds).toContain(S.transaction_id) // S is a standalone holding
+
+      // Open the goal → desktop detail panel.
+      await page.getByText('E2E Merge Goal').first().click()
+      const panel = page.getByTestId('desktop-goal-detail')
+      await expect(panel).toBeVisible({ timeout: 10_000 })
+      await expect(panel.getByText('E2E Merge D')).toBeVisible({ timeout: 10_000 })
+
+      // D's Options → Handle maturity → choose "Settle & re-deposit" (merge).
+      await panel.getByRole('button', { name: 'Options', exact: true }).first().click()
+      await page.getByText(/^(Handle maturity|Xử lý đáo hạn)$/).click()
+      await page.getByRole('button', { name: /Settle & re-deposit|Tất toán & gửi lại/i }).click()
+
+      // Select S in the merge list; its received prefills to S's current value.
+      await page.getByTestId(`merge-source-${S.transaction_id}`).click()
+      await expect(page.getByTestId('merge-penalty-caption')).toBeVisible()
+
+      // Capture the renew request so we can prove the server (not the client)
+      // summed in the received cash: D.amount === BASE + Σ(received).
+      const [renewReq] = await Promise.all([
+        page.waitForRequest((r) => r.url().endsWith(`/${D.transaction_id}/renew`) && r.method() === 'POST'),
+        page.getByRole('button', { name: /Save new deposit|Lưu sổ mới/i }).click(),
+      ])
+      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+
+      const body = renewReq.postDataJSON()
+      const base: number = body.amount_vnd
+      const received: number = body.merge_sources[0].received
+      expect(body.merge_sources).toEqual([{ tx_id: S.transaction_id, received }])
+
+      const { createClient } = await import('@supabase/supabase-js')
+      const supabase = createClient(process.env.E2E_SUPABASE_URL!, process.env.E2E_SUPABASE_SERVICE_ROLE_KEY!)
+
+      // Net-worth invariant: D's principal grew by EXACTLY the received cash.
+      await expect.poll(async () => {
+        const { data } = await supabase
+          .from('investment_transactions').select('amount_vnd')
+          .eq('transaction_id', D.transaction_id).single()
+        return data?.amount_vnd
+      }, { timeout: 15_000 }).toBe(base + received)
+
+      // S was fully closed: one withdrawal child, full principal, affects_progress TRUE.
+      const { data: wds } = await supabase
+        .from('investment_transactions')
+        .select('amount_vnd, principal_withdrawn, affects_progress, transaction_type')
+        .eq('parent_transaction_id', S.transaction_id)
+      expect(wds).toHaveLength(1)
+      expect(wds![0]).toMatchObject({
+        transaction_type: 'withdrawal',
+        principal_withdrawn: 8_000_000, // S's full effective principal
+        amount_vnd: received,
+        affects_progress: true,
+      })
+
+      // Loop closed via the rendered overview: S is gone from the goal's holdings
+      // (settled, not duplicated), and the progress value did NOT jump by S's
+      // value — the merge is an internal transfer, so the bar stays steady.
+      await gotoFreshDashboard(page)
+      const after = await goalSnapshot(page, goal.goal_id)
+      expect(after.holdingIds).not.toContain(S.transaction_id)
+      expect(after.progressValue).toBeLessThan(before.progressValue + 8_000_000 / 2) // no double-count
+      expect(after.progressValue).toBeGreaterThan(before.progressValue - 8_000_000)  // didn't lose the money either
+    } finally {
+      await api.deleteTransactionCascade(S.transaction_id)
+      await api.deleteTransactionCascade(D.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+})

--- a/e2e/maturity-combine-merge.spec.ts
+++ b/e2e/maturity-combine-merge.spec.ts
@@ -133,4 +133,51 @@ test.describe('Term-deposit maturity — merge a sibling deposit into the re-dep
       await api.deleteGoal(goal.goal_id)
     }
   })
+
+  // Server-side guard: the route trusts the client for `received`, but the RPC
+  // must not. A received far larger than the source's own value would let D
+  // (principal = BASE + Σ received) balloon while S only closes its real
+  // principal — net worth minted from nothing. The whole renewal must abort and
+  // leave D untouched. Driven at the API layer (no UI) since the UI never sends
+  // an out-of-range value.
+  test('rejects a received far larger than the source value, leaving the deposit untouched', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Merge Bound', target_amount: 200_000_000 })
+    const D = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 20_000_000, investment_date: iso(-380),
+      interest_rate: 6, expiry_date: iso(-15), goal_id: goal.goal_id, notes: 'E2E Bound D',
+    })
+    const S = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 8_000_000, investment_date: iso(-120),
+      interest_rate: 6, expiry_date: iso(60), goal_id: goal.goal_id, notes: 'E2E Bound S',
+    })
+    try {
+      // Claim 100× S's principal as "received" — well past the ×10 sanity bound.
+      const res = await page.request.post(`/api/v1/investment-transactions/${D.transaction_id}/renew`, {
+        data: {
+          amount_vnd: 20_000_000, // BASE
+          interest_rate: 6,
+          investment_date: iso(-15),
+          expiry_date: iso(350),
+          merge_sources: [{ tx_id: S.transaction_id, received: 8_000_000 * 100 }],
+        },
+      })
+      expect(res.ok()).toBeFalsy() // rejected, not silently accepted
+
+      const { createClient } = await import('@supabase/supabase-js')
+      const supabase = createClient(process.env.E2E_SUPABASE_URL!, process.env.E2E_SUPABASE_SERVICE_ROLE_KEY!)
+
+      // The renewal rolled back wholesale: D is unchanged and S is still active
+      // (not closed) — no partial write, no inflation.
+      const { data: d } = await supabase
+        .from('investment_transactions').select('amount_vnd').eq('transaction_id', D.transaction_id).single()
+      expect(d?.amount_vnd).toBe(20_000_000)
+      const { data: sWds } = await supabase
+        .from('investment_transactions').select('transaction_id').eq('parent_transaction_id', S.transaction_id)
+      expect(sWds ?? []).toHaveLength(0)
+    } finally {
+      await api.deleteTransactionCascade(S.transaction_id)
+      await api.deleteTransactionCascade(D.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
 })

--- a/lib/__tests__/depositValuation.test.ts
+++ b/lib/__tests__/depositValuation.test.ts
@@ -106,6 +106,86 @@ describe('valueNonFundHolding', () => {
     expect(valueNonFundHolding(active, buggyMap, null, ASOF)!.effectiveAmount).toBe(2_000_000)
   })
 
+  // Merge-on-renew (fold a sibling bank deposit into a renewing term deposit).
+  // The combine flow settles a sibling S EARLY and adds the cash received to the
+  // renewed deposit D's principal. We replay the overview route's TWO-map
+  // accumulation (route lines 262–296): net worth sums valueNonFundHolding over
+  // parentWdMapAll (every withdrawal), progress sums it over parentWdMap (only
+  // affects_progress=true). The source-closing withdrawal must be
+  // affects_progress=TRUE so S's progress contribution → 0 while D's growth adds
+  // it back — an internal transfer, no double-count. See plans/functional-
+  // frolicking-sun.md constraints 2–3.
+  describe('merge-on-renew sibling fold', () => {
+    // No rate → interest 0 → currentValue == effectiveAmount, so the money maths
+    // is exact. D = the renewing deposit, S = the sibling settled into it.
+    const BASE = 70_000_000   // D's principal before the merge
+    const S_EFF = 8_000_000   // S's effective (remaining) principal
+
+    // Mirror the overview accumulation: net worth uses the …All map (every
+    // withdrawal lowers it), progress uses the filtered map (steady bar).
+    const netWorth = (holdings: NonFundHoldingRow[], maps: ReturnType<typeof buildWithdrawalMaps>) =>
+      holdings.reduce((s, h) => s + (valueNonFundHolding(h, maps.parentWdMapAll, null, ASOF)?.currentValue ?? 0), 0)
+    const progress = (holdings: NonFundHoldingRow[], maps: ReturnType<typeof buildWithdrawalMaps>) =>
+      holdings.reduce((s, h) => s + (valueNonFundHolding(h, maps.parentWdMap, null, ASOF)?.currentValue ?? 0), 0)
+
+    const D = (amount: number) => bank({ transaction_id: 'D', amount_vnd: amount })
+    const S = bank({ transaction_id: 'S', amount_vnd: S_EFF })
+    // The full-close withdrawal the RPC writes against S: principal_withdrawn =
+    // S's effective principal (so S's valuation nets to 0). Valuation keys off
+    // principal_withdrawn — the cash received only changes D's principal, which
+    // these fixtures model directly as BASE + received.
+    const closeS = (affectsProgress = true): WithdrawalRow =>
+      withdrawal({ transaction_id: 'wd-S', parent_transaction_id: 'S', principal_withdrawn: S_EFF, affects_progress: affectsProgress })
+
+    it('held-to-value (received == S_eff): net worth AND progress both stay steady', () => {
+      const before = [D(BASE), S]
+      const mapsBefore = buildWithdrawalMaps([])
+      const nwBefore = netWorth(before, mapsBefore)
+      const pgBefore = progress(before, mapsBefore)
+
+      // After: D grew by the received cash, S is fully closed.
+      const received = S_EFF
+      const after = [D(BASE + received), S]
+      const mapsAfter = buildWithdrawalMaps([closeS()])
+
+      expect(netWorth(after, mapsAfter)).toBe(nwBefore)   // net worth steady (no penalty)
+      expect(progress(after, mapsAfter)).toBe(pgBefore)    // the required progress invariant
+    })
+
+    it('early settlement (received < S_eff): net worth and progress both fall by exactly the penalty, never double-count', () => {
+      const before = [D(BASE), S]
+      const mapsBefore = buildWithdrawalMaps([])
+      const nwBefore = netWorth(before, mapsBefore)
+      const pgBefore = progress(before, mapsBefore)
+
+      const received = 6_000_000
+      const penalty = S_EFF - received // 2,000,000 forfeited interest/penalty
+      const after = [D(BASE + received), S]
+      const mapsAfter = buildWithdrawalMaps([closeS()])
+
+      expect(netWorth(after, mapsAfter)).toBe(nwBefore - penalty)
+      expect(progress(after, mapsAfter)).toBe(pgBefore - penalty)
+    })
+
+    it('negative control: affects_progress=FALSE double-counts S (progress bumps by the received amount)', () => {
+      const before = [D(BASE), S]
+      const pgBefore = progress(before, buildWithdrawalMaps([]))
+
+      const received = S_EFF
+      const after = [D(BASE + received), S]
+      // WRONG flag: the close is excluded from the progress map, so S keeps its
+      // full contribution while D also grew — S counted twice.
+      const mapsBad = buildWithdrawalMaps([closeS(false)])
+
+      expect(progress(after, mapsBad)).toBe(pgBefore + received) // documents why the flag MUST be true
+    })
+
+    it('drops the fully-closed source from net worth (its …All valuation is null)', () => {
+      const maps = buildWithdrawalMaps([closeS()])
+      expect(valueNonFundHolding(S, maps.parentWdMapAll, null, ASOF)).toBeNull()
+    })
+  })
+
   describe('gold', () => {
     it('values remaining units at the gold price and reduces units by the sale', () => {
       const { parentWdMap } = buildWithdrawalMaps([

--- a/lib/__tests__/mergeAllocation.test.ts
+++ b/lib/__tests__/mergeAllocation.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { allocateCumulative } from '../maturity'
+
+// allocateCumulative splits an integer `total` across ordered `weights` using the
+// exact cumulative-window method the withdraw/collapse SQL uses
+// (20260618000009 lines 89–95): alloc_i = round(total·cum_i/Σ) − round(total·cum_(i-1)/Σ).
+// The rounding residual lands on the slices so Σ alloc === total EXACTLY — the
+// invariant the merge-on-renew net-worth guarantee leans on (client preview and
+// server allocation must never diverge).
+describe('allocateCumulative', () => {
+  it('splits equal weights with the residual on a slice, summing to total', () => {
+    const alloc = allocateCumulative(100, [1, 1, 1])
+    expect(alloc).toEqual([33, 34, 33])
+    expect(alloc.reduce((a, b) => a + b, 0)).toBe(100)
+  })
+
+  it('splits unequal weights proportionally', () => {
+    const alloc = allocateCumulative(1000, [1, 3])
+    expect(alloc).toEqual([250, 750])
+    expect(alloc.reduce((a, b) => a + b, 0)).toBe(1000)
+  })
+
+  it('gives the whole total to a single source', () => {
+    expect(allocateCumulative(500, [7])).toEqual([500])
+  })
+
+  it('keeps Σ === total exactly even when the proportional split is not integral', () => {
+    const alloc = allocateCumulative(10, [1, 1, 1])
+    expect(alloc).toEqual([3, 4, 3])
+    expect(alloc.reduce((a, b) => a + b, 0)).toBe(10)
+  })
+
+  it('returns all-zero (Σ === total) when total is 0', () => {
+    const alloc = allocateCumulative(0, [5, 9, 2])
+    expect(alloc).toEqual([0, 0, 0])
+    expect(alloc.reduce((a, b) => a + b, 0)).toBe(0)
+  })
+
+  it('returns all-zero when the weights sum to 0 (no div-by-zero)', () => {
+    expect(allocateCumulative(100, [0, 0])).toEqual([0, 0])
+  })
+
+  // SQL-parity worked example: the same numbers Postgres' round() produces for a
+  // two-source close. round() rounds half away from zero; Math.round matches it
+  // for the non-negative money values this only ever handles.
+  it('matches the SQL window allocation byte-for-byte on a worked example', () => {
+    const total = 8_483_563
+    const weights = [3_000_000, 5_000_000] // Σ = 8,000,000
+    const sum = 8_000_000
+    const cum1 = 3_000_000
+    const cum2 = 8_000_000
+    const a1 = Math.round((total * cum1) / sum) - 0
+    const a2 = Math.round((total * cum2) / sum) - Math.round((total * cum1) / sum)
+    expect(allocateCumulative(total, weights)).toEqual([a1, a2])
+    expect(a1 + a2).toBe(total)
+  })
+})

--- a/lib/maturity.ts
+++ b/lib/maturity.ts
@@ -111,6 +111,31 @@ export function monthsBetween(fromIso: string, toIso: string): number {
   return months
 }
 
+// Split an integer `total` across ordered `weights` with the exact cumulative-
+// window method the withdraw/collapse SQL uses (20260618000009 lines 89–95):
+//   alloc_i = round(total·cum_i/Σ) − round(total·cum_(i-1)/Σ)
+// The rounding residual falls on the slices so Σ alloc === total EXACTLY. Used by
+// the merge-on-renew combine flow to split one editable "merged in" total across
+// the selected source deposits the same way the RPC's per-source allocation
+// would — so the client preview and the server can never disagree on net worth.
+// `weights` MUST be ordered by (investmentDate, id) to match the SQL window.
+// Postgres round() rounds half away from zero; Math.round agrees with it for the
+// non-negative money values this only ever handles.
+export function allocateCumulative(total: number, weights: number[]): number[] {
+  const sum = weights.reduce((a, w) => a + w, 0)
+  if (sum <= 0) return weights.map(() => 0)
+  const out: number[] = []
+  let cum = 0
+  let prevRounded = 0
+  for (const w of weights) {
+    cum += w
+    const rounded = Math.round((total * cum) / sum)
+    out.push(rounded - prevRounded)
+    prevRounded = rounded
+  }
+  return out
+}
+
 // The principal that the next cycle starts with, per the chosen renewal mode.
 export function renewalPrincipal(
   mode: RenewMode,

--- a/supabase/migrations/20260619000001_renew_term_deposit_with_merge.sql
+++ b/supabase/migrations/20260619000001_renew_term_deposit_with_merge.sql
@@ -1,0 +1,220 @@
+-- Renew a term deposit AND fold sibling bank deposits into it, atomically.
+--
+-- The maturity "combine" flow lets the user settle one or more sibling bank
+-- deposits in the same goal EARLY and roll the cash they release into the
+-- deposit being renewed (D). Done by hand this is the live double-count bug: the
+-- user inflates D's re-deposit amount to include a sibling S's value but never
+-- closes S, so S's money is counted twice — once inside D's principal and again
+-- as a still-active standalone deposit (see plans/functional-frolicking-sun.md
+-- for the two confirmed live cases).
+--
+-- This function makes the fold a first-class, all-or-nothing operation:
+--   • each source S is fully closed with ONE withdrawal row
+--       (principal_withdrawn = S's effective principal, amount_vnd = cash
+--        received, affects_progress = TRUE);
+--   • D rolls forward with amount_vnd = p_amount_vnd (the BASE: principal +
+--     interest + any recurring) PLUS Σ(received). The client sends only the BASE
+--     and the per-source received amounts — the server sums them, so the
+--     net-worth invariant (Δ principal == Σ received) can never diverge.
+--
+-- affects_progress = TRUE on the close is load-bearing: S's progress
+-- contribution drops to 0 while D's growth adds it back, so the goal bar is
+-- steady (an internal transfer). FALSE would double-count — S would keep its
+-- progress weight while D also grew (proven in lib/__tests__/depositValuation).
+--
+-- Body otherwise mirrors 20260617000002 (the accumulating-book-guarded renewal):
+-- the D lock + validation and the four coupled writes are identical; the merge
+-- loop is inserted BEFORE the roll-forward so v_merge_total is known when D rolls.
+-- A brand-new signature, so drop any prior exact overload first (precedent:
+-- 20260616000002 line 18). The plain renew_term_deposit is left untouched.
+drop function if exists public.renew_term_deposit_with_merge(
+  uuid, bigint, numeric, date, date, bigint, uuid, text, bigint, text, uuid[], bigint[]
+);
+
+create or replace function public.renew_term_deposit_with_merge(
+  p_tx_id uuid,
+  p_amount_vnd bigint,            -- BASE only; the RPC adds Σ(received)
+  p_interest_rate numeric,
+  p_expiry_date date,
+  p_investment_date date,
+  p_interest_earned_vnd bigint,
+  p_fulfill_saving_id uuid default null,
+  p_fulfill_ym text default null,
+  p_fulfill_amount bigint default null,
+  p_fulfill_source text default null,
+  p_merge_source_ids uuid[] default '{}',
+  p_merge_received bigint[] default '{}'
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_old public.investment_transactions;
+  v_snapshot_id uuid;
+  v_renewed public.investment_transactions;
+  v_src public.investment_transactions;
+  v_sid uuid;
+  v_recv bigint;
+  v_src_eff bigint;
+  v_merge_total bigint := 0;
+  v_n integer;
+  v_i integer;
+begin
+  select * into v_old
+    from public.investment_transactions
+   where transaction_id = p_tx_id
+   for update;
+  if not found then
+    raise exception 'renew_term_deposit_with_merge: transaction not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_old.asset_type is distinct from 'bank' then
+    raise exception 'renew_term_deposit_with_merge: only bank term deposits can be renewed'
+      using errcode = 'check_violation';
+  end if;
+  if v_old.interest_rate is null or v_old.expiry_date is null then
+    raise exception 'renew_term_deposit_with_merge: only bank term deposits can be renewed'
+      using errcode = 'check_violation';
+  end if;
+  -- An accumulating book is renewed as a whole, not one tranche at a time.
+  if v_old.deposit_group_id is not null then
+    raise exception 'renew_term_deposit_with_merge: cannot renew an accumulating book'
+      using errcode = 'check_violation';
+  end if;
+  if p_investment_date > current_date + 1 then
+    raise exception 'renew_term_deposit_with_merge: investment date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+  if p_expiry_date is not null and p_expiry_date <= p_investment_date then
+    raise exception 'renew_term_deposit_with_merge: new maturity must be after the investment date'
+      using errcode = 'check_violation';
+  end if;
+
+  -- 0) Merge step (before roll-forward): close each source and accumulate the
+  --    cash it releases. The withdrawals are parented to the SOURCE, not D, so
+  --    step 3's re-parent (parent = p_tx_id) never touches them.
+  v_n := coalesce(array_length(p_merge_source_ids, 1), 0);
+  if v_n <> coalesce(array_length(p_merge_received, 1), 0) then
+    raise exception 'renew_term_deposit_with_merge: merge source/received length mismatch'
+      using errcode = 'check_violation';
+  end if;
+  for v_i in 1 .. v_n loop
+    v_sid := p_merge_source_ids[v_i];
+    v_recv := p_merge_received[v_i];
+    if v_sid = p_tx_id then
+      raise exception 'renew_term_deposit_with_merge: a deposit cannot merge into itself'
+        using errcode = 'check_violation';
+    end if;
+    if v_recv is null or v_recv < 0 then
+      raise exception 'renew_term_deposit_with_merge: received amount must be non-negative'
+        using errcode = 'check_violation';
+    end if;
+    select * into v_src
+      from public.investment_transactions
+     where transaction_id = v_sid
+     for update;
+    if not found then
+      raise exception 'renew_term_deposit_with_merge: merge source not found'
+        using errcode = 'no_data_found';
+    end if;
+    -- Source must be a plain, active bank deposit owned by the same user and in
+    -- the same goal as D (an internal transfer within one goal). Books, renewal
+    -- snapshots and withdrawals are excluded.
+    if v_src.user_id <> v_old.user_id then
+      raise exception 'renew_term_deposit_with_merge: merge source belongs to another user'
+        using errcode = 'check_violation';
+    end if;
+    if v_src.goal_id is distinct from v_old.goal_id then
+      raise exception 'renew_term_deposit_with_merge: merge source is in a different goal'
+        using errcode = 'check_violation';
+    end if;
+    if v_src.asset_type is distinct from 'bank' or v_src.deposit_group_id is not null
+       or v_src.transaction_type is distinct from 'investment'
+       or v_src.renewed_from_transaction_id is not null then
+      raise exception 'renew_term_deposit_with_merge: merge source is not a plain active bank deposit'
+        using errcode = 'check_violation';
+    end if;
+    -- Close only what is left after any prior partial withdrawals.
+    v_src_eff := v_src.amount_vnd - coalesce((
+      select sum(w.principal_withdrawn) from public.investment_transactions w
+       where w.parent_transaction_id = v_sid and w.transaction_type = 'withdrawal'
+    ), 0);
+    if v_src_eff <= 0 then
+      raise exception 'renew_term_deposit_with_merge: merge source is already fully withdrawn'
+        using errcode = 'check_violation';
+    end if;
+    insert into public.investment_transactions (
+      user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
+      investment_date, amount_vnd, principal_withdrawn, affects_progress
+    ) values (
+      v_src.user_id, v_src.goal_id, 'bank', 'withdrawal', v_sid,
+      p_investment_date, v_recv, v_src_eff, true
+    );
+    -- Unlink any recurring saving that fed the now-closed source (mirror
+    -- 20260618000009 lines 110–117) so nothing tries to top it up later.
+    update public.recurring_savings
+       set linked_deposit_tx_id = null, updated_at = now()
+     where linked_deposit_tx_id = v_sid and user_id = v_old.user_id;
+    v_merge_total := v_merge_total + v_recv;
+  end loop;
+
+  -- 1) Roll the active row forward to the new cycle. Net-worth invariant: the
+  --    amount added to D's principal equals exactly Σ(received) the sources
+  --    released — the server adds it so the client can never inflate D alone.
+  update public.investment_transactions
+     set amount_vnd      = p_amount_vnd + v_merge_total,
+         interest_rate   = p_interest_rate,
+         expiry_date     = p_expiry_date,
+         investment_date = p_investment_date,
+         updated_at      = now()
+   where transaction_id = p_tx_id
+  returning * into v_renewed;
+
+  -- 2) Append the history snapshot of the closed cycle (dates from v_old).
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, amount_vnd,
+    investment_date, expiry_date, interest_rate, notes,
+    renewed_from_transaction_id, interest_earned_vnd, affects_progress
+  ) values (
+    v_old.user_id, v_old.goal_id, 'bank', 'investment', v_old.amount_vnd,
+    v_old.investment_date, v_old.expiry_date, v_old.interest_rate, v_old.notes,
+    p_tx_id, p_interest_earned_vnd, false
+  )
+  returning transaction_id into v_snapshot_id;
+
+  -- 3) Re-parent the closed cycle's partial-withdrawal rows onto the snapshot.
+  update public.investment_transactions
+     set parent_transaction_id = v_snapshot_id
+   where parent_transaction_id = p_tx_id
+     and transaction_type = 'withdrawal';
+
+  -- 4) Combine flow only: record this month's recurring saving as fulfilled.
+  if p_fulfill_saving_id is not null and p_fulfill_ym is not null then
+    if not exists (
+      select 1 from public.recurring_savings
+       where saving_id = p_fulfill_saving_id and user_id = v_old.user_id
+    ) then
+      raise exception 'renew_term_deposit_with_merge: recurring saving not found'
+        using errcode = 'no_data_found';
+    end if;
+    insert into public.recurring_saving_fulfillments (
+      user_id, recurring_saving_id, ym, amount_vnd, source
+    ) values (
+      v_old.user_id, p_fulfill_saving_id, p_fulfill_ym,
+      coalesce(p_fulfill_amount, 0), coalesce(p_fulfill_source, 'maturity-combine')
+    )
+    on conflict (recurring_saving_id, ym) do update
+      set amount_vnd = excluded.amount_vnd,
+          source     = excluded.source,
+          updated_at = now();
+  end if;
+
+  return v_renewed;
+end;
+$$;
+
+grant execute on function public.renew_term_deposit_with_merge(
+  uuid, bigint, numeric, date, date, bigint, uuid, text, bigint, text, uuid[], bigint[]
+) to authenticated;

--- a/supabase/migrations/20260619000001_renew_term_deposit_with_merge.sql
+++ b/supabase/migrations/20260619000001_renew_term_deposit_with_merge.sql
@@ -17,10 +17,15 @@
 --     and the per-source received amounts — the server sums them, so the
 --     net-worth invariant (Δ principal == Σ received) can never diverge.
 --
--- affects_progress = TRUE on the close is load-bearing: S's progress
--- contribution drops to 0 while D's growth adds it back, so the goal bar is
--- steady (an internal transfer). FALSE would double-count — S would keep its
--- progress weight while D also grew (proven in lib/__tests__/depositValuation).
+-- affects_progress = TRUE on the close is load-bearing: it removes S's full
+-- effective principal from the goal bar while D's growth adds the cash received
+-- back. When held to value (received == S's effective principal) the two cancel
+-- and the bar is steady — an internal transfer. When the source is settled EARLY
+-- for less (received < effective principal) the bar correctly DROPS by exactly
+-- the forfeited penalty (real money lost), it does not stay flat. What TRUE
+-- guarantees is no double-count either way; FALSE would keep S's progress weight
+-- while D also grew, counting it twice. Both cases are proven in
+-- lib/__tests__/depositValuation (held-to-value vs early-settlement penalty).
 --
 -- Body otherwise mirrors 20260617000002 (the accumulating-book-guarded renewal):
 -- the D lock + validation and the four coupled writes are identical; the merge
@@ -100,6 +105,16 @@ begin
     raise exception 'renew_term_deposit_with_merge: merge source/received length mismatch'
       using errcode = 'check_violation';
   end if;
+  -- Acquire every source row lock up front in a deterministic (sorted) order, so
+  -- two concurrent merges that share a source can't deadlock by locking it in
+  -- opposite array orders. The per-source `for update` in the loop below then
+  -- just re-reads an already-held lock. (Low-risk for a single-user app, but
+  -- cheap insurance against the ordering hazard.)
+  perform 1
+    from public.investment_transactions
+   where transaction_id = any(p_merge_source_ids)
+   order by transaction_id
+     for update;
   for v_i in 1 .. v_n loop
     v_sid := p_merge_source_ids[v_i];
     v_recv := p_merge_received[v_i];
@@ -143,6 +158,17 @@ begin
     ), 0);
     if v_src_eff <= 0 then
       raise exception 'renew_term_deposit_with_merge: merge source is already fully withdrawn'
+        using errcode = 'check_violation';
+    end if;
+    -- Sanity-bound the cash received against the source's OWN value: settling S
+    -- releases at most its effective principal plus interest, never a multiple of
+    -- it. Without this the server trusts the client's received outright, so a
+    -- buggy/malicious caller could inflate D (principal = BASE + Σ received) from
+    -- nothing while S only closes its real principal. Mirror the ×10 bound the
+    -- renewal route already applies to interest_earned_vnd — generous enough to
+    -- never reject a real held-to-maturity value, tight enough to cap abuse.
+    if v_recv > v_src_eff * 10 then
+      raise exception 'renew_term_deposit_with_merge: received amount is unreasonably large for the source'
         using errcode = 'check_violation';
     end if;
     insert into public.investment_transactions (


### PR DESCRIPTION
## Problem

The maturity **combine** flow (`MaturityResolveSheet`) only knew how to fold one **recurring saving** into a renewed deposit. But users also consolidate at maturity by hand-editing the re-deposit amount to include a **sibling bank deposit's** value — and that sibling is never closed. It stays active, so its money is counted twice (in the renewed principal **and** as a standalone deposit).

Confirmed live double-counts: goal *PVCombank* (sibling `eb779c55`, +8.48M still active) and *Ba xây nhà* (a Vikki case of the same class).

## What this does

Adds a first-class "merge other deposits" step to the combine flow:

- Select sibling bank deposits in the same goal, settle each **early** (full close), and add the cash received to the renewed principal — **atomically**.
- New RPC `renew_term_deposit_with_merge` (the plain `renew_term_deposit` is untouched). The route picks it when `merge_sources` is present.
- **Net-worth invariant** (server-enforced): the client sends only the BASE (`principal + interest + recurring`); the RPC sums `Σ(received)` and adds it to D's principal, so client and server can't diverge.
- **Progress-bar invariant**: the source-closing withdrawal uses `affects_progress=TRUE` — S's progress contribution → 0 while D's growth adds it back (an internal transfer; `FALSE` would double-count, proven by a negative-control test).
- A single editable TOTAL splits across sources via `allocateCumulative`, byte-identical to the existing SQL window allocation, so `Σ(received)` is exact.

## Files

- `lib/maturity.ts` — `allocateCumulative`
- `supabase/migrations/20260619000001_renew_term_deposit_with_merge.sql` (new)
- `app/api/v1/investment-transactions/[id]/renew/route.ts` — branch on `merge_sources`
- `app/assets/components/MaturityResolveSheet.tsx` + both goal-detail render sites (`GoalDetailSheet`, `DesktopGoalDetail`) now pass `goalId` + `siblingDeposits`

## Tests (TDD)

- `lib/__tests__/mergeAllocation.test.ts` — `allocateCumulative` incl. SQL-parity example
- `depositValuation.test.ts` — net-worth/progress invariants replaying the overview's two-map accumulation, plus the `affects_progress=FALSE` double-count negative control
- `MaturityResolveSheet.test.tsx` — sibling list filtering, prefill, total split, **submit sends `amount_vnd == BASE` + `merge_sources`**
- `e2e/maturity-combine-merge.spec.ts` (new) — drives the merge from goal detail; asserts D grew by exactly `Σ(received)`, S fully closed (`affects_progress=true`), S gone from holdings, progress steady

Local gate run: `npm test -- --run` (706 ✓), `npm run lint` (no new errors), `npx tsc --noEmit` clean.

## Not in this PR

The one-off data fix for the already-orphaned `eb779c55` + confirming the Vikki case — delivered separately as SQL the user reviews/runs (the books must be paused first).

⚠️ Touches a DB migration + the valuation surface, so **run full E2E (WSL2) before merging** — local-only, couldn't run from the Windows shell here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)