### PR TITLE
test(e2e): cascade-clean book-withdrawal tranches so full closes don't orphan withdrawals

### DIFF
--- a/e2e/book-withdrawal.spec.ts
+++ b/e2e/book-withdrawal.spec.ts
@@ -45,8 +45,7 @@ test.describe('Whole-book withdrawal (full close)', () => {
       // A full close SETTLES the book — the group is cleared so it can't be revived.
       expect(rows.find((r) => r.transaction_id === anchor.transaction_id)!.deposit_group_id).toBeNull()
     } finally {
-      await api.deleteDepositGroup(anchor.transaction_id)
-      await api.deleteTransactionCascade(anchor.transaction_id)
+      await api.deleteBookCascade(anchor.transaction_id, [topUp.transaction_id])
       await api.deleteGoal(goal.goal_id)
     }
   })
@@ -57,9 +56,9 @@ test.describe('Whole-book withdrawal (full close)', () => {
     const anchor = await (await page.request.post('/api/v1/investment-transactions', {
       data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Close UI Book', amount_vnd: 30_000_000, interest_rate: 3.0, investment_date: iso(-60), expiry_date: iso(60) },
     })).json()
-    await page.request.post('/api/v1/investment-transactions', {
+    const topUp = await (await page.request.post('/api/v1/investment-transactions', {
       data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 20_000_000, interest_rate: 3.6, investment_date: iso(-20) },
-    })
+    })).json()
     try {
       await gotoFreshDashboard(page)
       await page.getByText('E2E Book Close UI').first().click()
@@ -84,8 +83,7 @@ test.describe('Whole-book withdrawal (full close)', () => {
       expect((all.transactions as Array<{ transaction_id: string; deposit_group_id: string | null }>)
         .find((r) => r.transaction_id === anchor.transaction_id)!.deposit_group_id).toBeNull()
     } finally {
-      await api.deleteDepositGroup(anchor.transaction_id)
-      await api.deleteTransactionCascade(anchor.transaction_id)
+      await api.deleteBookCascade(anchor.transaction_id, [topUp.transaction_id])
       await api.deleteGoal(goal.goal_id)
     }
   })
@@ -116,8 +114,7 @@ test.describe('Whole-book withdrawal (full close)', () => {
       expect(revive.status()).toBe(400) // link no longer points at that book
     } finally {
       await api.deleteRecurringSaving(saving.saving_id)
-      await api.deleteDepositGroup(anchor.transaction_id)
-      await api.deleteTransactionCascade(anchor.transaction_id)
+      await api.deleteBookCascade(anchor.transaction_id)
       await api.deleteGoal(goal.goal_id)
     }
   })
@@ -148,8 +145,7 @@ test.describe('Whole-book withdrawal (full close)', () => {
       // Total withdrawn = exactly the requested principal (no rounding drift).
       expect(wdFor(anchor.transaction_id) + wdFor(topUp.transaction_id)).toBe(10_000_000)
     } finally {
-      await api.deleteDepositGroup(anchor.transaction_id)
-      await api.deleteTransactionCascade(anchor.transaction_id)
+      await api.deleteBookCascade(anchor.transaction_id, [topUp.transaction_id])
       await api.deleteGoal(goal.goal_id)
     }
   })

--- a/e2e/book-withdrawal.spec.ts
+++ b/e2e/book-withdrawal.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test'
 import * as api from './helpers/api'
+import { makeCleanupStack } from './helpers/cleanup'
 
 // Book withdrawal for accumulating ("Loại 2") books — full close AND partial. A
 // full close writes one withdrawal per tranche at full principal; a partial spreads
@@ -7,6 +8,14 @@ import * as api from './helpers/api'
 // Drives the API + the UI (withdraw from goal-detail).
 
 const iso = (d: number) => new Date(Date.now() + d * 86_400_000).toISOString().slice(0, 10)
+
+// Books leak withdrawal rows if torn down naively (parent_transaction_id is ON
+// DELETE SET NULL), and a full close clears the group so the membership is gone by
+// teardown time. Each test snapshots its tranche set while the book is still grouped
+// and registers a cascade on the stack — the stack runs LIFO with a per-fn catch, so
+// one failing step can't strand the rest (raw try/finally did).
+const cleanup = makeCleanupStack()
+test.afterEach(() => cleanup.run())
 
 async function gotoFreshDashboard(page: Page) {
   await page.goto('/settings')
@@ -22,105 +31,103 @@ async function gotoFreshDashboard(page: Page) {
 test.describe('Whole-book withdrawal (full close)', () => {
   test('closing a book writes a withdrawal per tranche and zeroes the holding', async ({ page }) => {
     const goal = await api.createGoal({ goal_name: 'E2E Book Withdraw Goal', target_amount: 100_000_000 })
+    cleanup.add(() => api.deleteGoal(goal.goal_id))
     const anchor = await (await page.request.post('/api/v1/investment-transactions', {
       data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Withdraw Book', amount_vnd: 30_000_000, interest_rate: 3.0, investment_date: iso(-60), expiry_date: iso(60) },
     })).json()
     const topUp = await (await page.request.post('/api/v1/investment-transactions', {
       data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 20_000_000, interest_rate: 3.6, investment_date: iso(-20) },
     })).json()
-    try {
-      const res = await page.request.post(`/api/v1/investment-transactions/${anchor.transaction_id}/withdraw-book`, {
-        data: { withdraw_principal: 50_000_000, total_received: 50_500_000, investment_date: iso(0), affects_progress: true },
-      })
-      expect(res.status()).toBe(200)
-      expect((await res.json()).withdrawn_tranches).toBe(2)
+    const tranches = await api.snapshotBookTranches(anchor.transaction_id)
+    cleanup.add(() => api.deleteBookCascade(anchor.transaction_id, tranches))
 
-      const all = await (await page.request.get('/api/v1/investment-transactions?asset_type=bank&limit=1000')).json()
-      const rows = all.transactions as Array<{ transaction_id: string; deposit_group_id: string | null; transaction_type: string; parent_transaction_id: string | null; principal_withdrawn: number | null }>
-      // Each tranche got a full-principal withdrawal row → 30M + 20M out.
-      const trancheIds = [anchor.transaction_id, topUp.transaction_id]
-      const withdrawals = rows.filter((r) => r.transaction_type === 'withdrawal' && r.parent_transaction_id != null && trancheIds.includes(r.parent_transaction_id))
-      expect(withdrawals).toHaveLength(2)
-      expect(withdrawals.reduce((s, w) => s + (w.principal_withdrawn ?? 0), 0)).toBe(50_000_000)
-      // A full close SETTLES the book — the group is cleared so it can't be revived.
-      expect(rows.find((r) => r.transaction_id === anchor.transaction_id)!.deposit_group_id).toBeNull()
-    } finally {
-      await api.deleteBookCascade(anchor.transaction_id, [topUp.transaction_id])
-      await api.deleteGoal(goal.goal_id)
-    }
+    const res = await page.request.post(`/api/v1/investment-transactions/${anchor.transaction_id}/withdraw-book`, {
+      data: { withdraw_principal: 50_000_000, total_received: 50_500_000, investment_date: iso(0), affects_progress: true },
+    })
+    expect(res.status()).toBe(200)
+    expect((await res.json()).withdrawn_tranches).toBe(2)
+
+    const all = await (await page.request.get('/api/v1/investment-transactions?asset_type=bank&limit=1000')).json()
+    const rows = all.transactions as Array<{ transaction_id: string; deposit_group_id: string | null; transaction_type: string; parent_transaction_id: string | null; principal_withdrawn: number | null }>
+    // Each tranche got a full-principal withdrawal row → 30M + 20M out.
+    const trancheIds = [anchor.transaction_id, topUp.transaction_id]
+    const withdrawals = rows.filter((r) => r.transaction_type === 'withdrawal' && r.parent_transaction_id != null && trancheIds.includes(r.parent_transaction_id))
+    expect(withdrawals).toHaveLength(2)
+    expect(withdrawals.reduce((s, w) => s + (w.principal_withdrawn ?? 0), 0)).toBe(50_000_000)
+    // A full close SETTLES the book — the group is cleared so it can't be revived.
+    expect(rows.find((r) => r.transaction_id === anchor.transaction_id)!.deposit_group_id).toBeNull()
   })
 
   test('full close from the goal-detail Withdraw action removes the book', async ({ page }) => {
     test.slow()
     const goal = await api.createGoal({ goal_name: 'E2E Book Close UI', target_amount: 100_000_000 })
+    cleanup.add(() => api.deleteGoal(goal.goal_id))
     const anchor = await (await page.request.post('/api/v1/investment-transactions', {
       data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Close UI Book', amount_vnd: 30_000_000, interest_rate: 3.0, investment_date: iso(-60), expiry_date: iso(60) },
     })).json()
-    const topUp = await (await page.request.post('/api/v1/investment-transactions', {
+    await page.request.post('/api/v1/investment-transactions', {
       data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 20_000_000, interest_rate: 3.6, investment_date: iso(-20) },
-    })).json()
-    try {
-      await gotoFreshDashboard(page)
-      await page.getByText('E2E Book Close UI').first().click()
-      const panel = page.getByTestId('desktop-goal-detail')
-      await expect(panel).toBeVisible({ timeout: 5_000 })
-      await panel.getByRole('button', { name: 'Options', exact: true }).first().click()
-      // Withdraw is offered for a book → editable sheet; "All" = full close.
-      await page.getByRole('button', { name: /Withdraw|Rút tiền/i }).first().click()
-      await expect(page.getByTestId('sell-amount-input')).toBeVisible({ timeout: 5_000 })
-      await page.getByTestId('sell-all-btn').click()
-      const [resp] = await Promise.all([
-        page.waitForResponse((r) => r.url().includes('/withdraw-book') && r.request().method() === 'POST'),
-        page.getByTestId('sell-confirm-btn').click(),
-      ])
-      expect(resp.status()).toBe(200)
+    })
+    const tranches = await api.snapshotBookTranches(anchor.transaction_id)
+    cleanup.add(() => api.deleteBookCascade(anchor.transaction_id, tranches))
 
-      // The book is settled: full close cleared the group (no live book remains).
-      const all = await (await page.request.get('/api/v1/investment-transactions?asset_type=bank&limit=1000')).json()
-      const stillGrouped = (all.transactions as Array<{ deposit_group_id: string | null }>)
-        .filter((r) => r.deposit_group_id === anchor.transaction_id)
-      expect(stillGrouped).toHaveLength(0)
-      expect((all.transactions as Array<{ transaction_id: string; deposit_group_id: string | null }>)
-        .find((r) => r.transaction_id === anchor.transaction_id)!.deposit_group_id).toBeNull()
-    } finally {
-      await api.deleteBookCascade(anchor.transaction_id, [topUp.transaction_id])
-      await api.deleteGoal(goal.goal_id)
-    }
+    await gotoFreshDashboard(page)
+    await page.getByText('E2E Book Close UI').first().click()
+    const panel = page.getByTestId('desktop-goal-detail')
+    await expect(panel).toBeVisible({ timeout: 5_000 })
+    await panel.getByRole('button', { name: 'Options', exact: true }).first().click()
+    // Withdraw is offered for a book → editable sheet; "All" = full close.
+    await page.getByRole('button', { name: /Withdraw|Rút tiền/i }).first().click()
+    await expect(page.getByTestId('sell-amount-input')).toBeVisible({ timeout: 5_000 })
+    await page.getByTestId('sell-all-btn').click()
+    const [resp] = await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/withdraw-book') && r.request().method() === 'POST'),
+      page.getByTestId('sell-confirm-btn').click(),
+    ])
+    expect(resp.status()).toBe(200)
+
+    // The book is settled: full close cleared the group (no live book remains).
+    const all = await (await page.request.get('/api/v1/investment-transactions?asset_type=bank&limit=1000')).json()
+    const stillGrouped = (all.transactions as Array<{ deposit_group_id: string | null }>)
+      .filter((r) => r.deposit_group_id === anchor.transaction_id)
+    expect(stillGrouped).toHaveLength(0)
+    expect((all.transactions as Array<{ transaction_id: string; deposit_group_id: string | null }>)
+      .find((r) => r.transaction_id === anchor.transaction_id)!.deposit_group_id).toBeNull()
   })
 
   test('a full close settles the book — group cleared + recurring unlinked, no resurrection', async ({ page }) => {
     const goal = await api.createGoal({ goal_name: 'E2E Close Settle Goal', target_amount: 100_000_000 })
+    cleanup.add(() => api.deleteGoal(goal.goal_id))
     // A live (non-matured) book with a recurring linked to it — the early-close vector.
     const anchor = await (await page.request.post('/api/v1/investment-transactions', {
       data: { asset_type: 'bank', accumulating: true, goal_id: goal.goal_id, notes: 'E2E Close Settle Book', amount_vnd: 30_000_000, interest_rate: 3.0, investment_date: iso(-30), expiry_date: iso(90) },
     })).json()
+    const tranches = await api.snapshotBookTranches(anchor.transaction_id)
+    cleanup.add(() => api.deleteBookCascade(anchor.transaction_id, tranches))
     const saving = await api.createRecurringSaving({ name: 'E2E Close Settle Rec', goal_id: goal.goal_id, amount_vnd: 2_000_000, linked_deposit_tx_id: anchor.transaction_id })
-    try {
-      const res = await page.request.post(`/api/v1/investment-transactions/${anchor.transaction_id}/withdraw-book`, {
-        data: { withdraw_principal: 30_000_000, total_received: 30_200_000, investment_date: iso(0), affects_progress: true },
-      })
-      expect(res.status()).toBe(200)
+    cleanup.add(() => api.deleteRecurringSaving(saving.saving_id))
 
-      // The book is truly settled: the anchor is no longer a book (group cleared)…
-      const anchorNow = await (await page.request.get(`/api/v1/investment-transactions/${anchor.transaction_id}`)).json()
-      expect(anchorNow.deposit_group_id).toBeNull()
-      // …and the recurring's link was nulled (the book it fed is gone).
-      const savingNow = await api.getRecurringSaving(saving.saving_id)
-      expect(savingNow!.linked_deposit_tx_id).toBeNull()
-      // A resurrection attempt (recurring top-up) now fails cleanly, not revives it.
-      const revive = await page.request.post(`/api/v1/recurring-savings/${saving.saving_id}/topup`, {
-        data: { book_id: anchor.transaction_id, amount_vnd: 2_000_000, interest_rate: 3.0, investment_date: iso(0), ym: `${new Date().getFullYear()}-${String(new Date().getMonth() + 1).padStart(2, '0')}` },
-      })
-      expect(revive.status()).toBe(400) // link no longer points at that book
-    } finally {
-      await api.deleteRecurringSaving(saving.saving_id)
-      await api.deleteBookCascade(anchor.transaction_id)
-      await api.deleteGoal(goal.goal_id)
-    }
+    const res = await page.request.post(`/api/v1/investment-transactions/${anchor.transaction_id}/withdraw-book`, {
+      data: { withdraw_principal: 30_000_000, total_received: 30_200_000, investment_date: iso(0), affects_progress: true },
+    })
+    expect(res.status()).toBe(200)
+
+    // The book is truly settled: the anchor is no longer a book (group cleared)…
+    const anchorNow = await (await page.request.get(`/api/v1/investment-transactions/${anchor.transaction_id}`)).json()
+    expect(anchorNow.deposit_group_id).toBeNull()
+    // …and the recurring's link was nulled (the book it fed is gone).
+    const savingNow = await api.getRecurringSaving(saving.saving_id)
+    expect(savingNow!.linked_deposit_tx_id).toBeNull()
+    // A resurrection attempt (recurring top-up) now fails cleanly, not revives it.
+    const revive = await page.request.post(`/api/v1/recurring-savings/${saving.saving_id}/topup`, {
+      data: { book_id: anchor.transaction_id, amount_vnd: 2_000_000, interest_rate: 3.0, investment_date: iso(0), ym: `${new Date().getFullYear()}-${String(new Date().getMonth() + 1).padStart(2, '0')}` },
+    })
+    expect(revive.status()).toBe(400) // link no longer points at that book
   })
 
   test('a partial withdrawal spreads across tranches proportionally and leaves the book', async ({ page }) => {
     const goal = await api.createGoal({ goal_name: 'E2E Partial Goal', target_amount: 100_000_000 })
+    cleanup.add(() => api.deleteGoal(goal.goal_id))
     // Book: 40M anchor + 10M top-up = 50M principal. Withdraw 10M (1/5) → each
     // tranche loses 1/5: anchor 8M, top-up 2M.
     const anchor = await (await page.request.post('/api/v1/investment-transactions', {
@@ -129,24 +136,22 @@ test.describe('Whole-book withdrawal (full close)', () => {
     const topUp = await (await page.request.post('/api/v1/investment-transactions', {
       data: { tops_up_deposit_id: anchor.transaction_id, asset_type: 'bank', amount_vnd: 10_000_000, interest_rate: 3.6, investment_date: iso(-20) },
     })).json()
-    try {
-      const res = await page.request.post(`/api/v1/investment-transactions/${anchor.transaction_id}/withdraw-book`, {
-        data: { withdraw_principal: 10_000_000, total_received: 10_100_000, investment_date: iso(0), affects_progress: true },
-      })
-      expect(res.status()).toBe(200)
+    const tranches = await api.snapshotBookTranches(anchor.transaction_id)
+    cleanup.add(() => api.deleteBookCascade(anchor.transaction_id, tranches))
 
-      const all = await (await page.request.get('/api/v1/investment-transactions?asset_type=bank&limit=1000')).json()
-      const rows = all.transactions as Array<{ transaction_type: string; parent_transaction_id: string | null; principal_withdrawn: number | null }>
-      const wdFor = (txId: string) => rows.filter((r) => r.transaction_type === 'withdrawal' && r.parent_transaction_id === txId)
-        .reduce((s, w) => s + (w.principal_withdrawn ?? 0), 0)
-      // Proportional: 1/5 of each tranche's principal.
-      expect(wdFor(anchor.transaction_id)).toBe(8_000_000)
-      expect(wdFor(topUp.transaction_id)).toBe(2_000_000)
-      // Total withdrawn = exactly the requested principal (no rounding drift).
-      expect(wdFor(anchor.transaction_id) + wdFor(topUp.transaction_id)).toBe(10_000_000)
-    } finally {
-      await api.deleteBookCascade(anchor.transaction_id, [topUp.transaction_id])
-      await api.deleteGoal(goal.goal_id)
-    }
+    const res = await page.request.post(`/api/v1/investment-transactions/${anchor.transaction_id}/withdraw-book`, {
+      data: { withdraw_principal: 10_000_000, total_received: 10_100_000, investment_date: iso(0), affects_progress: true },
+    })
+    expect(res.status()).toBe(200)
+
+    const all = await (await page.request.get('/api/v1/investment-transactions?asset_type=bank&limit=1000')).json()
+    const rows = all.transactions as Array<{ transaction_type: string; parent_transaction_id: string | null; principal_withdrawn: number | null }>
+    const wdFor = (txId: string) => rows.filter((r) => r.transaction_type === 'withdrawal' && r.parent_transaction_id === txId)
+      .reduce((s, w) => s + (w.principal_withdrawn ?? 0), 0)
+    // Proportional: 1/5 of each tranche's principal.
+    expect(wdFor(anchor.transaction_id)).toBe(8_000_000)
+    expect(wdFor(topUp.transaction_id)).toBe(2_000_000)
+    // Total withdrawn = exactly the requested principal (no rounding drift).
+    expect(wdFor(anchor.transaction_id) + wdFor(topUp.transaction_id)).toBe(10_000_000)
   })
 })

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -144,6 +144,33 @@ export async function deleteDepositGroup(groupId: string) {
   await supabase.from('investment_transactions').delete().eq('deposit_group_id', groupId)
 }
 
+// Fully tear down an accumulating book: every tranche AND every withdrawal child
+// of those tranches. parent_transaction_id is ON DELETE SET NULL, so deleting the
+// tranches first (as deleteDepositGroup does) ORPHANS their withdrawal rows — they
+// linger as unassigned withdrawals that pollute later specs' global views (the
+// dashboard recent-activity card, page-wide text queries). A book partially
+// withdrawn writes a withdrawal PER tranche, so this matters whenever a book test
+// touched withdrawals.
+//
+// Discovery is the subtle part: a PARTIAL withdrawal leaves the book intact, so
+// tranches are still findable by deposit_group_id. But a FULL close SETTLES the
+// book and CLEARS deposit_group_id on every tranche — so the group query finds
+// nothing and any top-up tranche (plus its withdrawal child) would survive
+// undiscovered. Callers that create top-up tranches must therefore pass those ids
+// explicitly; we union them with whatever is still grouped. Order is load-bearing:
+// delete the children first (by parent, while the links are still valid), THEN the
+// tranches and the anchor.
+export async function deleteBookCascade(anchorId: string, extraTrancheIds: string[] = []) {
+  const { data: grouped } = await supabase
+    .from('investment_transactions')
+    .select('transaction_id')
+    .eq('deposit_group_id', anchorId)
+  const ids = [...new Set([anchorId, ...extraTrancheIds, ...(grouped ?? []).map((t) => t.transaction_id)])]
+  await supabase.from('investment_transactions').delete().in('parent_transaction_id', ids)
+  await supabase.from('investment_transactions').delete().eq('deposit_group_id', anchorId)
+  await supabase.from('investment_transactions').delete().in('transaction_id', ids)
+}
+
 // Insert a withdrawal row against an existing deposit, mirroring what the
 // SellWithdraw flow POSTs (transaction_type='withdrawal', linked by
 // parent_transaction_id, asset_type null). Returns the created row.

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -144,6 +144,19 @@ export async function deleteDepositGroup(groupId: string) {
   await supabase.from('investment_transactions').delete().eq('deposit_group_id', groupId)
 }
 
+// Snapshot every tranche id of a live accumulating book (anchor + all top-ups),
+// taken WHILE the book is still grouped. A full close later CLEARS deposit_group_id
+// on every tranche, so after the close the membership is unrecoverable from the DB.
+// Capture this right after building the book and hand it to deleteBookCascade — the
+// teardown then can't silently miss a top-up the caller forgot to track by hand.
+export async function snapshotBookTranches(anchorId: string): Promise<string[]> {
+  const { data: grouped } = await supabase
+    .from('investment_transactions')
+    .select('transaction_id')
+    .eq('deposit_group_id', anchorId)
+  return [...new Set([anchorId, ...(grouped ?? []).map((t) => t.transaction_id)])]
+}
+
 // Fully tear down an accumulating book: every tranche AND every withdrawal child
 // of those tranches. parent_transaction_id is ON DELETE SET NULL, so deleting the
 // tranches first (as deleteDepositGroup does) ORPHANS their withdrawal rows — they
@@ -156,10 +169,15 @@ export async function deleteDepositGroup(groupId: string) {
 // tranches are still findable by deposit_group_id. But a FULL close SETTLES the
 // book and CLEARS deposit_group_id on every tranche — so the group query finds
 // nothing and any top-up tranche (plus its withdrawal child) would survive
-// undiscovered. Callers that create top-up tranches must therefore pass those ids
-// explicitly; we union them with whatever is still grouped. Order is load-bearing:
-// delete the children first (by parent, while the links are still valid), THEN the
-// tranches and the anchor.
+// undiscovered. Pass the pre-close snapshot from snapshotBookTranches so the full
+// set is known regardless; we union it with whatever is still grouped. Order is
+// load-bearing: delete the children first (by parent, while the links are still
+// valid), THEN the tranches and the anchor.
+//
+// Not covered: renewal-history snapshots (renewed_from_transaction_id), which
+// deleteTransactionCascade sweeps. Books settle via the collapse/withdraw path and
+// never produce those, so it's out of scope here — revisit if a book test ever
+// renews a tranche.
 export async function deleteBookCascade(anchorId: string, extraTrancheIds: string[] = []) {
   const { data: grouped } = await supabase
     .from('investment_transactions')


### PR DESCRIPTION
## Problem

The `book-withdrawal.spec.ts` full-close tests left orphaned withdrawal rows in the shared local DB, which polluted later specs in the same run — `goal-detail-desktop.spec.ts:78`/`:133` and `recent-activity.spec.ts:82` failed because of phantom **Rút tiền** rows they never created.

**Root cause:** the full-close tests tore down with `deleteDepositGroup(anchor) + deleteTransactionCascade(anchor)`. A full close **clears `deposit_group_id` on every tranche**, so `deleteDepositGroup` matched nothing — and any top-up tranche plus its withdrawal child survived. Because `parent_transaction_id` is `ON DELETE SET NULL`, those withdrawals were orphaned into global "unassigned" rows that bled into every subsequent spec's page-wide views.

## Fix

New helper `deleteBookCascade(anchorId, extraTrancheIds = [])`:

- **Partial-withdrawal case** — book is intact, tranches still findable by `deposit_group_id` (unioned in automatically).
- **Full-close case** — group is gone, so the caller passes the explicit tranche ids it created; we union them in.
- Deletes withdrawal children **first** (while parent links are valid), then the tranches/anchor.

All four book-withdrawal tests now use it, passing their top-up ids.

## Verification

`book-withdrawal + goal-detail-desktop + recent-activity` → **22/22 pass**, no leaked withdrawals between specs (previously `goal-detail-desktop:78/:133` and `recent-activity:82` failed). `tsc` clean; lint shows only the pre-existing baseline (no new issues in the changed files).

This is a test-only change (E2E helpers + spec teardown) — no app or migration changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)