### PR TITLE
fix(cron): constant-time CRON_SECRET comparison

### DIFF
--- a/app/api/cron/refresh-gold/route.ts
+++ b/app/api/cron/refresh-gold/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { scrapeGoldPrice } from '@/lib/scrape-gold'
+import { verifyCronAuth } from '@/lib/cron-auth'
 
 const supabaseAdmin = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -8,8 +9,7 @@ const supabaseAdmin = createClient(
 )
 
 export async function GET(request: Request) {
-  const authHeader = request.headers.get('Authorization')
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (!verifyCronAuth(request.headers.get('Authorization'), process.env.CRON_SECRET)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 

--- a/app/api/cron/refresh-navs/route.ts
+++ b/app/api/cron/refresh-navs/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 import { createClient } from '@supabase/supabase-js'
 import { scrapeFundNav } from '@/lib/scrape-fund-nav'
+import { verifyCronAuth } from '@/lib/cron-auth'
 
 const supabaseAdmin = createClient(
   process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -8,8 +9,7 @@ const supabaseAdmin = createClient(
 )
 
 export async function GET(request: Request) {
-  const authHeader = request.headers.get('Authorization')
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
+  if (!verifyCronAuth(request.headers.get('Authorization'), process.env.CRON_SECRET)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 

--- a/lib/__tests__/cronAuth.test.ts
+++ b/lib/__tests__/cronAuth.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest'
+import { verifyCronAuth } from '../cron-auth'
+
+describe('verifyCronAuth', () => {
+  const secret = 'topsecret123'
+
+  it('accepts the exact Bearer token', () => {
+    expect(verifyCronAuth(`Bearer ${secret}`, secret)).toBe(true)
+  })
+
+  it('rejects a wrong token of the same length', () => {
+    expect(verifyCronAuth('Bearer topsecret124', secret)).toBe(false)
+  })
+
+  it('rejects a missing Authorization header', () => {
+    expect(verifyCronAuth(null, secret)).toBe(false)
+  })
+
+  it('rejects a token without the Bearer prefix', () => {
+    expect(verifyCronAuth(secret, secret)).toBe(false)
+  })
+
+  it('rejects a token that is a prefix of the secret (no length-mismatch throw)', () => {
+    expect(verifyCronAuth(`Bearer ${secret.slice(0, -1)}`, secret)).toBe(false)
+    expect(verifyCronAuth(`Bearer ${secret}extra`, secret)).toBe(false)
+  })
+
+  it('fails closed when no secret is configured', () => {
+    expect(verifyCronAuth(`Bearer ${secret}`, undefined)).toBe(false)
+    expect(verifyCronAuth('Bearer ', '')).toBe(false)
+  })
+})

--- a/lib/cron-auth.ts
+++ b/lib/cron-auth.ts
@@ -1,0 +1,17 @@
+import { createHash, timingSafeEqual } from 'crypto'
+
+// Constant-time check of a cron request's `Authorization` header against
+// CRON_SECRET. A plain `!==` string compare short-circuits on the first
+// differing byte, leaking the secret one character at a time via response
+// timing. We instead SHA-256 both sides and timingSafeEqual the fixed 32-byte
+// digests — equal-length buffers (so timingSafeEqual never throws on a length
+// mismatch) and no per-byte early exit, so neither the secret's value nor its
+// length is observable from timing.
+//
+// Fails closed: a missing header or an unset/empty secret returns false.
+export function verifyCronAuth(authHeader: string | null, secret: string | undefined): boolean {
+  if (!secret) return false
+  const expected = createHash('sha256').update(`Bearer ${secret}`).digest()
+  const actual = createHash('sha256').update(authHeader ?? '').digest()
+  return timingSafeEqual(actual, expected)
+}


### PR DESCRIPTION
## What

Both cron auth guards (`/api/cron/refresh-gold`, `/api/cron/refresh-navs`) compared the `Authorization` header to `` `Bearer ${CRON_SECRET}` `` with `!==`. A plain string compare short-circuits on the first differing byte, so the response timing leaks the secret one character at a time (a classic timing side-channel on a bearer token).

## Change

- New `lib/cron-auth.ts` → `verifyCronAuth(authHeader, secret)`:
  - SHA-256s both sides and `timingSafeEqual`s the fixed 32-byte digests → no per-byte early exit, and equal-length buffers so `timingSafeEqual` never throws on a length mismatch (so neither the secret's value nor its length is observable from timing).
  - **Fails closed**: missing header or unset/empty secret → `false`.
- Both cron routes now call it instead of the `!==` compare.

## Surfaced by

The deposit/maturity security review — this was the only service-role-keyed surface and the one finding with a genuine (if low) security angle. No deposit/maturity code changed.

## Tests (TDD)

- `lib/__tests__/cronAuth.test.ts` — exact match accepts; wrong/short/long/prefix-less tokens reject; missing header rejects; fails closed with no secret. Written red-first.
- Full suite green: **712/712**. Lint clean on changed files (the 27 pre-existing repo lint errors are unrelated).

## Risk

Low. Behaviour is identical for valid/invalid tokens; only the comparison method changed. No DB/schema/migration changes; no user-facing surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)