### PR TITLE
feat(plan): show insurance Relationship + Default on the Plan page

### DIFF
--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -14,6 +14,7 @@ import RecurringSavingManager from './RecurringSavingManager'
 import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
 import { buildByGoal, resolveRecurringSavings, DEPOSIT_BACKED_FULFILLMENT_SOURCES, type GoalItem } from '@/lib/planning'
+import { relationshipLabel } from '@/app/assets/components/insuranceShared'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
   InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, RecurringFulfillment, DcaSkip, Fund, Goal,
@@ -105,12 +106,15 @@ function PlanTable({ icon, iconColor, title, total, defaultOpen = true, action, 
 
 // ─── Table header row ─────────────────────────────────────────────────────────
 
-function THead({ col1, col2 }: { col1: string; col2: string }) {
+function THead({ col1, col2, colRel, colDefault }: { col1: string; col2: string; colRel?: string; colDefault?: string }) {
+  const thBase = { fontSize: 10, fontWeight: 600 as const, letterSpacing: '0.06em', textTransform: 'uppercase' as const, color: 'var(--c-muted)' }
   return (
     <thead>
       <tr style={{ background: 'var(--c-card-2)', borderBottom: '1px solid var(--c-line)' }}>
-        <th style={{ padding: '8px 16px', textAlign: 'left', fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase' as const, color: 'var(--c-muted)' }}>{col1}</th>
-        <th style={{ padding: '8px 12px', textAlign: 'right', fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase' as const, color: 'var(--c-muted)' }}>{col2}</th>
+        <th style={{ padding: '8px 16px', textAlign: 'left', ...thBase }}>{col1}</th>
+        {colRel != null && <th style={{ padding: '8px 12px', textAlign: 'left', ...thBase }}>{colRel}</th>}
+        {colDefault != null && <th style={{ padding: '8px 12px', textAlign: 'right', ...thBase }}>{colDefault}</th>}
+        <th style={{ padding: '8px 12px', textAlign: 'right', ...thBase }}>{col2}</th>
         <th style={{ width: 40 }} />
       </tr>
     </thead>
@@ -137,8 +141,8 @@ function MenuBtn({ icon, label, onClick, danger, noBorder }: {
   )
 }
 
-function DPlanRow({ primary, secondary, amount, muted, last, isVI, onSkip, onRestore, onOverride }: {
-  primary: string; secondary?: string | null; amount: number; muted?: boolean
+function DPlanRow({ primary, secondary, amount, relationship, defaultAmount, muted, last, isVI, onSkip, onRestore, onOverride }: {
+  primary: string; secondary?: string | null; amount: number; relationship?: string; defaultAmount?: number; muted?: boolean
   last?: boolean; isVI: boolean; onSkip?: () => void; onRestore?: () => void; onOverride?: () => void
 }) {
   const [open, setOpen] = useState(false)
@@ -159,6 +163,14 @@ function DPlanRow({ primary, secondary, amount, muted, last, isVI, onSkip, onRes
         <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--c-ink)', textDecoration: muted ? 'line-through' : 'none' }}>{primary}</div>
         {secondary && <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 1 }}>{secondary}</div>}
       </td>
+      {relationship != null && (
+        <td style={{ padding: '11px 12px', verticalAlign: 'middle', fontSize: 12, color: 'var(--c-muted)' }}>{relationship}</td>
+      )}
+      {defaultAmount != null && (
+        <td style={{ padding: '11px 12px', textAlign: 'right', verticalAlign: 'middle' }}>
+          <span style={{ fontSize: 12, color: 'var(--c-muted)', fontVariantNumeric: 'tabular-nums' }}>{fmt(defaultAmount)}</span>
+        </td>
+      )}
       <td style={{ padding: '11px 12px', textAlign: 'right', verticalAlign: 'middle' }}>
         <span style={{ fontSize: 13, fontWeight: 600, color: muted ? 'var(--c-muted)' : 'var(--c-ink)', textDecoration: muted ? 'line-through' : 'none', fontVariantNumeric: 'tabular-nums' }}>
           {fmt(amount)}
@@ -985,25 +997,33 @@ export default function DesktopPlanningView({
 
               {/* Insurance */}
               <PlanTable icon={<Shield size={15} />} iconColor="var(--c-accent-insurance,#7c3aed)" title={isVI ? 'Bảo hiểm' : 'Insurance'} total={insTotal}>
-                <THead col1={isVI ? 'Thành viên' : 'Member'} col2={isVI ? 'Đóng góp' : 'Contribution'} />
+                <THead
+                  col1={isVI ? 'Thành viên' : 'Member'}
+                  colRel={isVI ? 'Quan hệ' : 'Relationship'}
+                  colDefault={isVI ? 'Mặc định' : 'Default'}
+                  col2={isVI ? 'Tháng này' : 'This month'}
+                />
                 <tbody>
                   {insuranceMembers.length === 0 ? (
-                    <tr><td colSpan={3} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có bảo hiểm' : 'No insurance members'}</td></tr>
+                    <tr><td colSpan={5} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có bảo hiểm' : 'No insurance members'}</td></tr>
                   ) : insuranceMembers.map((m, i) => {
-                    const monthly    = m.monthlyOverride ?? Math.round(m.annual_payment_vnd / 12)
+                    const defaultMonthly = Math.round(m.annual_payment_vnd / 12)
+                    const monthly    = m.monthlyOverride ?? defaultMonthly
                     const isOverridden = !m.excluded && m.monthlyOverride != null
                     return (
                       <DPlanRow
                         key={m.member_id}
                         primary={m.member_name}
-                        secondary={m.excluded ? (isVI ? 'Bỏ qua tháng này' : 'Skipped') : isOverridden ? (isVI ? '(đã ghi đè)' : '(overridden)') : (isVI ? 'Đóng góp tháng' : 'Monthly contribution')}
+                        relationship={relationshipLabel(m.relationship, isVI)}
+                        defaultAmount={defaultMonthly}
+                        secondary={m.excluded ? (isVI ? 'Bỏ qua tháng này' : 'Skipped') : isOverridden ? (isVI ? '(đã ghi đè)' : '(overridden)') : null}
                         amount={m.excluded ? 0 : monthly}
                         muted={m.excluded}
                         last={i === insuranceMembers.length - 1}
                         isVI={isVI}
                         onSkip={() => handleInsSkip(m)}
                         onRestore={m.excluded || m.monthlyOverride != null ? () => handleInsRestore(m) : undefined}
-                        onOverride={() => { const d = Math.round(m.annual_payment_vnd / 12); setOverrideModal({ id: m.member_id, name: m.member_name, defaultAmount: d, type: 'ins' }); setOverrideVal(String(m.monthlyOverride ?? d)) }}
+                        onOverride={() => { setOverrideModal({ id: m.member_id, name: m.member_name, defaultAmount: defaultMonthly, type: 'ins' }); setOverrideVal(String(m.monthlyOverride ?? defaultMonthly)) }}
                       />
                     )
                   })}

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -13,6 +13,7 @@ import RecurringSavingManager from './RecurringSavingManager'
 import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
 import { buildByGoal, resolveRecurringSavings, DEPOSIT_BACKED_FULFILLMENT_SOURCES, type GoalRow, type GoalItem } from '@/lib/planning'
+import { relationshipLabel } from '@/app/assets/components/insuranceShared'
 import { MobilePlanningSkeleton } from './PlanningSkeleton'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
@@ -1406,9 +1407,15 @@ export default function MobilePlanningView({
                   const defaultMonthly = Math.round(m.annual_payment_vnd / 12)
                   const hasOverride = m.monthlyOverride != null && m.monthlyOverride !== defaultMonthly
                   const thisMonth = m.excluded ? 0 : (m.monthlyOverride ?? defaultMonthly)
+                  // A phone has no room for Relationship/Default columns (the desktop
+                  // table carries those), so the relationship rides the subtitle line.
+                  // When overridden, append the default so the user still sees it.
+                  const rel = relationshipLabel(m.relationship, isVI)
                   const secondary = m.excluded
                     ? (isVI ? 'Bỏ qua tháng này' : 'Skipped')
-                    : hasOverride ? (isVI ? '(đã ghi đè)' : '(overridden)') : (isVI ? 'Đóng góp tháng' : 'Monthly contribution')
+                    : hasOverride
+                      ? `${rel ? rel + ' · ' : ''}${isVI ? 'mặc định ' : 'default '}${fmt(defaultMonthly)}`
+                      : (rel || (isVI ? 'Đóng góp tháng' : 'Monthly contribution'))
                   return (
                     <PlanLineItem
                       key={m.member_id}

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -1,8 +1,8 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DesktopPlanningView from '../DesktopPlanningView'
-import type { MonthlyPlan, FundInvestment, DirectSaving, RecurringSaving, RecurringFulfillment } from '../../PlanningClient'
+import type { MonthlyPlan, FundInvestment, DirectSaving, RecurringSaving, RecurringFulfillment, InsuranceMember } from '../../PlanningClient'
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
@@ -181,5 +181,29 @@ describe('DesktopPlanningView — recurring bank "Saved" deposit', () => {
     } finally {
       vi.unstubAllGlobals()
     }
+  })
+})
+
+describe('DesktopPlanningView — insurance Relationship + Default columns', () => {
+  // 14,000,000 / 12 = 1,166,667 — the default monthly contribution.
+  const insuranceMembers: InsuranceMember[] = [
+    { member_id: 'i1', member_name: 'John', relationship: 'Spouse', annual_payment_vnd: 14_000_000, payment_date: null },
+  ]
+
+  it('renders the Relationship and Default column headers', () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} insuranceMembers={insuranceMembers} />)
+    expect(screen.getByText('Relationship')).toBeInTheDocument()
+    expect(screen.getByText('Default')).toBeInTheDocument()
+  })
+
+  it('shows the member relationship label', () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} insuranceMembers={insuranceMembers} />)
+    expect(screen.getByText('Spouse')).toBeInTheDocument()
+  })
+
+  it('shows the default monthly amount (annual ÷ 12) alongside this month', () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} insuranceMembers={insuranceMembers} />)
+    // Default column + This-month column both show 1,166,667 when not overridden.
+    expect(screen.getAllByText('₫ 1166667').length).toBeGreaterThan(0)
   })
 })

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -230,6 +230,12 @@ describe('MobilePlanningView — insurance section', () => {
     expect(screen.getByText('John')).toBeInTheDocument()
   })
 
+  it('shows the member relationship label as the row subtitle', () => {
+    // baseInsuranceMembers[0].relationship === 'Self' → en label "Self"
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} insuranceMembers={baseInsuranceMembers} />)
+    expect(screen.getByText('Self')).toBeInTheDocument()
+  })
+
   it('shows "Skipped" for an excluded insurance member', () => {
     const excludedMembers: InsuranceMember[] = [
       {

--- a/app/assets/components/insuranceShared.ts
+++ b/app/assets/components/insuranceShared.ts
@@ -17,6 +17,15 @@ export const COVERAGE_OPTIONS: { value: string; label: string; labelVi: string }
   { value: 'Other', label: 'Other', labelVi: 'Khác' },
 ]
 
+// Localized label for a stored relationship/coverage value (Self/Spouse/…),
+// reusing COVERAGE_OPTIONS as the single source of truth. Falls back to the raw
+// value for anything not in the option list, and to '' for empty.
+export function relationshipLabel(value: string | null | undefined, isVi: boolean): string {
+  if (!value) return ''
+  const opt = COVERAGE_OPTIONS.find((o) => o.value === value)
+  return opt ? (isVi ? opt.labelVi : opt.label) : value
+}
+
 // Dot / badge colour by status — identical across all insurance views.
 export const STATUS_COLOR: Record<string, string> = {
   on_track:  'var(--c-muted)',


### PR DESCRIPTION
## What

The Monthly Plan **insurance** section only showed **Member + Contribution**. The design (Cairn Redesign prototype) calls for the richer table — **Member · Relationship · Default · This month** — so each member's relationship and default monthly (annual ÷ 12) are visible alongside the effective amount.

Before (live `main`): `MEMBER | CONTRIBUTION`
After (this PR): `MEMBER | RELATIONSHIP | DEFAULT | THIS MONTH`

## Changes

- **Desktop** (`DesktopPlanningView.tsx`): `THead` and `DPlanRow` now take optional `relationship` / `defaultAmount`, so **only the insurance table** renders the two extra columns — Fixed expenses stay two-column, unchanged. Header label `Contribution` → `This month` to match the design.
- **Mobile** (`MobilePlanningView.tsx`): a phone has no room for extra columns (the prototype's mobile row doesn't add them either), so the **relationship rides the row subtitle** (replacing the generic "Monthly contribution"). An overridden row appends the default amount so it's still visible.
- **Shared** (`insuranceShared.ts`): new `relationshipLabel(value, isVi)` reusing `COVERAGE_OPTIONS` as the single source of truth (Self→Bản thân, Spouse→Vợ/Chồng, Child→Con, Parent→Cha/Mẹ, Other→Khác).

## Tests (TDD, red-first)

- `DesktopPlanningView.test.tsx`: asserts the **Relationship** and **Default** headers render, the member's relationship label shows, and the default monthly (annual ÷ 12) appears.
- `MobilePlanningView.test.tsx`: asserts the relationship shows as the row subtitle.
- Full suite green: **716/716**. Lint clean on changed files.

## Notes

- The data was already present (`InsuranceMember.relationship` + `annual_payment_vnd`); this is display-only — no API/DB/migration changes.
- Legacy `InsuranceSection.tsx` is **not** the rendered component (the Plan page uses `Desktop/MobilePlanningView`); left untouched here.
- E2E: the only planning-spec insurance touchpoint asserts the section **title** is visible (`planning-desktop.spec.ts:130`), which is unchanged — no selector breakage. Dashboard insurance selectors are unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)