### PR TITLE
fix(ledger): label mobile date filters so iOS blank date inputs stay identifiable (#362)

### DIFF
--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -427,9 +427,16 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
                       {goals.map((g) => <option key={g.goal_id} value={g.goal_id}>{g.goal_name}</option>)}
                     </select>
                   </div>
-                  <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-                    <input type="date" value={dateFrom} onChange={(e) => setDateFilter('from_date', e.target.value, setDateFrom)} aria-label={t('lblFrom')} className="cn-input tabular" style={{ width: '100%', minWidth: 0, boxSizing: 'border-box' }} />
-                    <input type="date" value={dateTo} onChange={(e) => setDateFilter('to_date', e.target.value, setDateTo)} aria-label={t('lblTo')} className="cn-input tabular" style={{ width: '100%', minWidth: 0, boxSizing: 'border-box' }} />
+                  {/* iOS renders an empty <input type=date> fully blank (no
+                      placeholder), so each date field needs a visible label to
+                      stay identifiable — matches the desktop toolbar (#362). */}
+                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+                    <Field label={t('lblFrom')}>
+                      <input type="date" value={dateFrom} onChange={(e) => setDateFilter('from_date', e.target.value, setDateFrom)} aria-label={t('lblFrom')} className="cn-input tabular" style={{ width: '100%', minWidth: 0, boxSizing: 'border-box' }} />
+                    </Field>
+                    <Field label={t('lblTo')}>
+                      <input type="date" value={dateTo} onChange={(e) => setDateFilter('to_date', e.target.value, setDateTo)} aria-label={t('lblTo')} className="cn-input tabular" style={{ width: '100%', minWidth: 0, boxSizing: 'border-box' }} />
+                    </Field>
                   </div>
                   <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
                     <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{t('totalCount', { count: total })}</span>

--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -27,6 +27,14 @@ const labelStyle: React.CSSProperties = {
   color: 'var(--c-muted)', marginBottom: 6,
 }
 
+// Mobile date filters (#362): WebkitAppearance:none stops iOS Safari from sizing
+// the native date control to its intrinsic width (which ignores width:100% and
+// clips on the right); maxWidth pins it to the grid cell.
+const dateFilterStyle: React.CSSProperties = {
+  width: '100%', maxWidth: '100%', minWidth: 0,
+  boxSizing: 'border-box', WebkitAppearance: 'none', appearance: 'none',
+}
+
 interface AppliedFilters { asset_type: string; goal_id: string; from_date: string; to_date: string }
 const EMPTY_FILTERS: AppliedFilters = { asset_type: '', goal_id: '', from_date: '', to_date: '' }
 
@@ -427,15 +435,18 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
                       {goals.map((g) => <option key={g.goal_id} value={g.goal_id}>{g.goal_name}</option>)}
                     </select>
                   </div>
-                  {/* iOS renders an empty <input type=date> fully blank (no
-                      placeholder), so each date field needs a visible label to
-                      stay identifiable — matches the desktop toolbar (#362). */}
-                  <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
+                  {/* iOS quirks (#362): an empty <input type=date> renders fully
+                      blank (no placeholder) AND ignores width:100%, sizing to its
+                      intrinsic content so it overflows / gets clipped on the right.
+                      Fix: visible From/To labels (like desktop) + shrinkable
+                      minmax(0,1fr) columns + appearance:none/max-width so the native
+                      control is clamped to its cell. */}
+                  <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)', gap: 8 }}>
                     <Field label={t('lblFrom')}>
-                      <input type="date" value={dateFrom} onChange={(e) => setDateFilter('from_date', e.target.value, setDateFrom)} aria-label={t('lblFrom')} className="cn-input tabular" style={{ width: '100%', minWidth: 0, boxSizing: 'border-box' }} />
+                      <input type="date" value={dateFrom} onChange={(e) => setDateFilter('from_date', e.target.value, setDateFrom)} aria-label={t('lblFrom')} className="cn-input tabular" style={dateFilterStyle} />
                     </Field>
                     <Field label={t('lblTo')}>
-                      <input type="date" value={dateTo} onChange={(e) => setDateFilter('to_date', e.target.value, setDateTo)} aria-label={t('lblTo')} className="cn-input tabular" style={{ width: '100%', minWidth: 0, boxSizing: 'border-box' }} />
+                      <input type="date" value={dateTo} onChange={(e) => setDateFilter('to_date', e.target.value, setDateTo)} aria-label={t('lblTo')} className="cn-input tabular" style={dateFilterStyle} />
                     </Field>
                   </div>
                   <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -35,6 +35,14 @@ const dateFilterStyle: React.CSSProperties = {
   boxSizing: 'border-box', WebkitAppearance: 'none', appearance: 'none',
 }
 
+// iOS Safari shows NOTHING in an empty <input type=date> (no native placeholder),
+// so we overlay our own. pointerEvents:none lets taps fall through to the input;
+// the .cn-date-empty class blanks Chrome's native "mm/dd/yyyy" so they don't stack.
+const datePlaceholderStyle: React.CSSProperties = {
+  position: 'absolute', left: 12, top: '50%', transform: 'translateY(-50%)',
+  fontSize: 16, color: 'var(--c-muted)', pointerEvents: 'none',
+}
+
 interface AppliedFilters { asset_type: string; goal_id: string; from_date: string; to_date: string }
 const EMPTY_FILTERS: AppliedFilters = { asset_type: '', goal_id: '', from_date: '', to_date: '' }
 
@@ -438,15 +446,21 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
                   {/* iOS quirks (#362): an empty <input type=date> renders fully
                       blank (no placeholder) AND ignores width:100%, sizing to its
                       intrinsic content so it overflows / gets clipped on the right.
-                      Fix: visible From/To labels (like desktop) + shrinkable
-                      minmax(0,1fr) columns + appearance:none/max-width so the native
-                      control is clamped to its cell. */}
+                      Fix: visible From/To labels + an overlaid placeholder for the
+                      blank empty state + shrinkable minmax(0,1fr) columns and
+                      appearance:none/max-width so the control is clamped to its cell. */}
                   <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr) minmax(0, 1fr)', gap: 8 }}>
                     <Field label={t('lblFrom')}>
-                      <input type="date" value={dateFrom} onChange={(e) => setDateFilter('from_date', e.target.value, setDateFrom)} aria-label={t('lblFrom')} className="cn-input tabular" style={dateFilterStyle} />
+                      <div style={{ position: 'relative' }}>
+                        <input type="date" value={dateFrom} onChange={(e) => setDateFilter('from_date', e.target.value, setDateFrom)} aria-label={t('lblFrom')} className={`cn-input tabular${dateFrom ? '' : ' cn-date-empty'}`} style={dateFilterStyle} />
+                        {!dateFrom && <span aria-hidden style={datePlaceholderStyle}>{t('datePlaceholder')}</span>}
+                      </div>
                     </Field>
                     <Field label={t('lblTo')}>
-                      <input type="date" value={dateTo} onChange={(e) => setDateFilter('to_date', e.target.value, setDateTo)} aria-label={t('lblTo')} className="cn-input tabular" style={dateFilterStyle} />
+                      <div style={{ position: 'relative' }}>
+                        <input type="date" value={dateTo} onChange={(e) => setDateFilter('to_date', e.target.value, setDateTo)} aria-label={t('lblTo')} className={`cn-input tabular${dateTo ? '' : ' cn-date-empty'}`} style={dateFilterStyle} />
+                        {!dateTo && <span aria-hidden style={datePlaceholderStyle}>{t('datePlaceholder')}</span>}
+                      </div>
                     </Field>
                   </div>
                   <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>

--- a/app/globals.css
+++ b/app/globals.css
@@ -327,6 +327,11 @@
   input, textarea, select { font-size: 16px; }
 }
 
+/* Empty <input type=date>: iOS shows nothing, Chrome shows a native "mm/dd/yyyy".
+   We overlay our own placeholder (#362), so blank Chrome's native text on the
+   empty state to avoid stacking two placeholders. Cleared once a value is set. */
+.cn-date-empty::-webkit-datetime-edit { color: transparent; }
+
 /* ── Loading vocabulary (issue #235) ───────────────────────────────────────
    One indicator language across the app: the brand cairn-stone loader for
    spinners, and the .sk shimmer primitive for skeleton screens. */

--- a/e2e/recent-activity.spec.ts
+++ b/e2e/recent-activity.spec.ts
@@ -54,6 +54,34 @@ test.describe('Recent activity — mobile', () => {
     await page.getByTestId('recent-activity-view-all').click()
     await expect(page.getByTestId('tx-ledger')).toBeVisible({ timeout: 5_000 })
   })
+
+  // Issue #362: on iOS an empty <input type="date"> renders fully blank (no
+  // "mm/dd/yyyy" placeholder like Chrome), so the date filters looked like two
+  // empty boxes "off UI". They must carry visible From/To labels like desktop.
+  test('mobile date filters show visible From/To labels', async ({ page }) => {
+    const tx = await api.createTransaction({
+      asset_type: 'bank',
+      amount_vnd: 5_000_000,
+      investment_date: new Date().toISOString().slice(0, 10),
+      interest_rate: 5,
+      notes: 'E2E 362 filter',
+    })
+    try {
+      await page.goto('/dashboard')
+      await page.waitForLoadState('networkidle')
+      await page.getByTestId('recent-activity-view-all').click()
+
+      const ledger = page.getByTestId('tx-ledger')
+      await expect(ledger).toBeVisible({ timeout: 5_000 })
+      // The filter row (gated on having transactions) renders both date inputs…
+      await expect(ledger.locator('input[type="date"]')).toHaveCount(2)
+      // …each labeled, so a blank iOS date field is still identifiable.
+      await expect(ledger.getByText('From', { exact: true })).toBeVisible()
+      await expect(ledger.getByText('To', { exact: true })).toBeVisible()
+    } finally {
+      await api.deleteTransactionCascade(tx.transaction_id)
+    }
+  })
 })
 
 // ─── Data-backed: an investment renders as a positive (+) row ────────────────

--- a/e2e/recent-activity.spec.ts
+++ b/e2e/recent-activity.spec.ts
@@ -74,10 +74,19 @@ test.describe('Recent activity — mobile', () => {
       const ledger = page.getByTestId('tx-ledger')
       await expect(ledger).toBeVisible({ timeout: 5_000 })
       // The filter row (gated on having transactions) renders both date inputs…
-      await expect(ledger.locator('input[type="date"]')).toHaveCount(2)
+      const dateInputs = ledger.locator('input[type="date"]')
+      await expect(dateInputs).toHaveCount(2)
       // …each labeled, so a blank iOS date field is still identifiable.
       await expect(ledger.getByText('From', { exact: true })).toBeVisible()
       await expect(ledger.getByText('To', { exact: true })).toBeVisible()
+      // …and neither overflows the ledger to the right (the clipped 2nd field
+      // in the bug report). Chromium can't reproduce the iOS intrinsic-width
+      // overflow, but this guards the grid layout from gross breakage.
+      const ledgerBox = await ledger.boundingBox()
+      for (let i = 0; i < 2; i++) {
+        const box = await dateInputs.nth(i).boundingBox()
+        expect(box!.x + box!.width).toBeLessThanOrEqual(ledgerBox!.x + ledgerBox!.width + 1)
+      }
     } finally {
       await api.deleteTransactionCascade(tx.transaction_id)
     }

--- a/e2e/recent-activity.spec.ts
+++ b/e2e/recent-activity.spec.ts
@@ -79,6 +79,11 @@ test.describe('Recent activity — mobile', () => {
       // …each labeled, so a blank iOS date field is still identifiable.
       await expect(ledger.getByText('From', { exact: true })).toBeVisible()
       await expect(ledger.getByText('To', { exact: true })).toBeVisible()
+      // …and an overlaid placeholder fills the otherwise-blank iOS empty state.
+      // Both fields start empty → two placeholders; pick one and it disappears.
+      await expect(ledger.getByText('dd/mm/yyyy')).toHaveCount(2)
+      await dateInputs.first().fill('2026-06-19')
+      await expect(ledger.getByText('dd/mm/yyyy')).toHaveCount(1)
       // …and neither overflows the ledger to the right (the clipped 2nd field
       // in the bug report). Chromium can't reproduce the iOS intrinsic-width
       // overflow, but this guards the grid layout from gross breakage.

--- a/messages/en.json
+++ b/messages/en.json
@@ -283,6 +283,7 @@
     "lblAsset": "Asset",
     "lblFrom": "From",
     "lblTo": "To",
+    "datePlaceholder": "dd/mm/yyyy",
     "filterAllAssets": "All assets",
     "filterAllGoals": "All goals",
     "noMatch": "No transactions match the filters.",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -283,6 +283,7 @@
     "lblAsset": "Tài sản",
     "lblFrom": "Từ",
     "lblTo": "Đến",
+    "datePlaceholder": "dd/mm/yyyy",
     "filterAllAssets": "Mọi tài sản",
     "filterAllGoals": "Mọi mục tiêu",
     "noMatch": "Không có giao dịch khớp bộ lọc.",


### PR DESCRIPTION
Fixes #362

## Problem (mobile transaction ledger date filters, iOS Safari)

1. **Empty fields render fully blank.** iOS shows *no* placeholder for an empty `<input type="date">` (Chrome shows `mm/dd/yyyy`), so the From/To filters looked like two unexplained empty boxes "off UI".
2. **Right-side clipping.** iOS sizes the native control to its intrinsic content and ignores `width: 100%`, so the To field overflowed and was cut off at the screen edge (where the report's arrow points).

## Fix (`TransactionLedgerSheet.tsx`, `globals.css`, i18n)

- **Visible From/To labels** (`<Field>`, like the desktop toolbar) for persistent context.
- **Overlaid placeholder** — a `dd/mm/yyyy` span (`pointer-events: none`) shown while the field is empty, so the blank iOS box still reads as a date field; it clears once a date is picked. Chrome's native placeholder is blanked via `.cn-date-empty::-webkit-datetime-edit { color: transparent }` so the two don't stack.
- **No overflow** — 2-col `minmax(0, 1fr)` grid + `WebkitAppearance: none` + `maxWidth: 100%` clamp the control to its cell.

Desktop toolbar untouched.

## Test (TDD red→green)

`e2e/recent-activity.spec.ts` (mobile): seeds a transaction so the filter row renders, then asserts both date inputs render, carry visible From/To labels, show two `dd/mm/yyyy` placeholders when empty (one after picking a date), and don't overflow the ledger.

> Chromium can't reproduce the iOS-specific blank/overflow behaviour, so the e2e guards the labels/placeholder/layout; the iOS rendering itself needs a **real iPhone on the PR preview** to confirm. Note: this is a PWA — if the preview still shows the old build, clear site data / hard-reload to bust the stale service worker.

## Verification

- e2e regression: red → green
- `npm test -- --run` → **714 passing**
- Full E2E → **291 passing**, 1 skipped; the lone red was `accumulating-collapse.spec.ts` (a documented cold-dev-server timeout flake, unrelated) — passes on warm re-run, and passes identically with/without this change
- Lint: the 3 `set-state-in-effect` errors in this file are pre-existing (the fetch effects, untouched); this change adds none

🤖 Generated with [Claude Code](https://claude.com/claude-code)