### PR TITLE
feat(deposits): multi-source merge UX — destination bank + provenance (PR1)

### DIFF
--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { ValidationError, validateAmount, validateDate, validateRate, validateUUID } from '@/lib/validation'
+import { ValidationError, validateAmount, validateBankCode, validateDate, validateRate, validateUUID } from '@/lib/validation'
 import { isFutureInvestmentDate } from '@/lib/dates'
 import { isTermDeposit } from '@/lib/maturity'
 
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const body = await request.json()
-  const { amount_vnd, interest_rate, expiry_date, investment_date, interest_earned_vnd, fulfill_recurring, merge_sources } = body
+  const { amount_vnd, interest_rate, expiry_date, investment_date, interest_earned_vnd, fulfill_recurring, merge_sources, bank_code } = body
 
   let txId: string
   let cleanAmount: number
@@ -41,6 +41,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   // When non-empty, amount_vnd is the BASE and the RPC adds Σ(received).
   const cleanMergeSourceIds: string[] = []
   const cleanMergeReceived: number[] = []
+  // Multi-source merge only: destination bank for the combined re-deposit. null
+  // (or omitted) leaves D's existing bank untouched (the RPC coalesces).
+  let cleanBankCode: string | null = null
   try {
     txId = validateUUID(id, 'transaction_id')
     cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
@@ -77,6 +80,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
         cleanMergeReceived.push(Math.round(r))
       }
     }
+    if (bank_code != null && bank_code !== '') cleanBankCode = validateBankCode(bank_code, 'bank_code')
   } catch (e) {
     if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
     throw e
@@ -146,6 +150,8 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
           p_fulfill_source: cleanFulfillSavingId ? 'maturity-combine' : null,
           p_merge_source_ids: cleanMergeSourceIds,
           p_merge_received: cleanMergeReceived,
+          // Destination bank for the combined deposit; null = leave D's bank as is.
+          p_bank_code: cleanBankCode,
         })
         .single()
     : await supabase

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -112,7 +112,7 @@ export function MaturityResolveBody({
   const [maturityOverride, setMaturityOverride] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
-  const [done, setDone] = useState<null | { newPrincipal: number; newMaturity: string }>(null)
+  const [done, setDone] = useState<null | { newPrincipal: number; newMaturity: string; sources: string[] }>(null)
 
   // ── Combine ("settle & re-deposit", merge recurring) ────────────────────────
   // A recurring bank saving due for this goal this month can be folded into the
@@ -140,9 +140,23 @@ export function MaturityResolveBody({
   const [mergeRecv, setMergeRecv] = useState<Record<string, string>>({})
   const [mergeTotal, setMergeTotal] = useState('')
   const [, setMergeTotalTouched] = useState(false)
+  // Destination bank for the combined re-deposit (multi-source merge). Defaults to
+  // the settling deposit's bank; the user can move the money to another bank.
+  const [banks, setBanks] = useState<{ code: string; name: string }[]>([])
+  const [destBank, setDestBank] = useState<string>(inv.bankCode ?? '')
 
   const selectedSources = mergeableOrdered.filter((s) => mergeSel[s.id])
   const mergeReceivedTotal = selectedSources.reduce((sum, s) => sum + (Number(mergeRecv[s.id]) || 0), 0)
+  // Provenance for the multi-source merge: the new deposit combines the anchor (D)
+  // with every folded source, so "N nguồn" counts D + the selected sources. "M
+  // ngân hàng" is the distinct real banks among them — a NULL bank_code (a legacy
+  // deposit with no bank set) is excluded so it doesn't inflate the bank count.
+  const combinedBankCodes = new Set<string>()
+  if (inv.bankCode) combinedBankCodes.add(inv.bankCode)
+  selectedSources.forEach((s) => { if (s.bankCode) combinedBankCodes.add(s.bankCode) })
+  const mergeSourceCount = selectedSources.length + 1
+  const mergeBankCount = combinedBankCodes.size
+  const isMultiSource = selectedSources.length > 1
 
   // Toggle a source; on first select, prefill its received with the current value
   // (the user edits it down to the real cash if the early settlement is penalised).
@@ -168,6 +182,22 @@ export function MaturityResolveBody({
       return next
     })
   }
+
+  // Load the bank reference list once for the destination picker — only when
+  // there are siblings to merge (the picker is merge-only), so plain renewals
+  // make no extra request. Failure is non-fatal — the picker just shows "no bank".
+  useEffect(() => {
+    if (mergeable.length === 0) return
+    let cancelled = false
+    fetch('/api/v1/banks')
+      .then((r) => (r.ok ? r.json() : []))
+      // The route returns a bare array of { code, name, logo_url } (same as the
+      // deposit form's selector); tolerate a non-array just in case.
+      .then((d: unknown) => { if (!cancelled) setBanks(Array.isArray(d) ? d as { code: string; name: string }[] : []) })
+      .catch(() => {})
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   useEffect(() => {
     // Combine needs the deposit's goal scope. When the caller doesn't wire it
@@ -275,10 +305,15 @@ export function MaturityResolveBody({
     confirmCombine: 'Lưu sổ mới',
     mergeSub: 'Gộp sổ tiết kiệm khác vào lần gửi lại',
     mergeTitle: 'Gộp sổ khác',
+    mergeTitleMulti: 'Gộp nhiều nguồn',
     mergeHint: 'Chọn các sổ để tất toán sớm và gộp vào lần gửi lại này.',
     mergeReceivedLabel: 'Thực nhận',
     mergeTotalLabel: 'Tổng gộp thêm',
     mergePenalty: 'Tất toán trước hạn có thể bị phạt lãi — nhập số tiền thực nhận, không phải giá trị hiện tại.',
+    destBankLabel: 'Ngân hàng đích',
+    destBankNone: 'Không chọn',
+    provenance: (n: number, m: number) => `Gộp từ ${n} nguồn · ${m} ngân hàng`,
+    mergedSourcesLabel: 'Đã gộp',
   } : {
     summarySuffix: 'yr', perYr: 'yr', mo: 'mo',
     why: matured
@@ -309,10 +344,15 @@ export function MaturityResolveBody({
     confirmCombine: 'Save new deposit',
     mergeSub: 'Fold other deposits into the re-deposit',
     mergeTitle: 'Merge other deposits',
+    mergeTitleMulti: 'Merge multiple sources',
     mergeHint: 'Pick deposits to settle early and fold into this re-deposit.',
     mergeReceivedLabel: 'Received',
     mergeTotalLabel: 'Total merged in',
     mergePenalty: 'Early settlement may forfeit interest — enter the cash received, not the current value.',
+    destBankLabel: 'Destination bank',
+    destBankNone: 'No bank',
+    provenance: (n: number, m: number) => `Combined from ${n} sources · ${m} banks`,
+    mergedSourcesLabel: 'Merged in',
   }
 
   const POLICIES: { id: Mode; icon: React.ReactNode; label: string; sub: string; danger?: boolean }[] = [
@@ -372,6 +412,9 @@ export function MaturityResolveBody({
           merge_sources: mode === 'combine' && selectedSources.length > 0
             ? selectedSources.map((s) => ({ tx_id: s.id, received: Math.round(Number(mergeRecv[s.id]) || 0) }))
             : undefined,
+          // Destination bank for the combined re-deposit (multi-source merge only).
+          // '' (no bank picked) → null; the RPC leaves the existing bank untouched.
+          bank_code: mode === 'combine' && selectedSources.length > 0 ? (destBank || null) : undefined,
         }),
       })
       if (!res.ok) {
@@ -380,7 +423,10 @@ export function MaturityResolveBody({
         setSaving(false)
         return
       }
-      setDone({ newPrincipal: Math.round(newPrincipal), newMaturity })
+      setDone({
+        newPrincipal: Math.round(newPrincipal), newMaturity,
+        sources: mode === 'combine' ? selectedSources.map((s) => s.name) : [],
+      })
       setTimeout(() => { onRenewed(); onClose() }, 1700)
     } catch {
       setError(isVi ? 'Lỗi kết nối' : 'Connection error')
@@ -399,6 +445,11 @@ export function MaturityResolveBody({
         <div style={{ fontSize: 13, color: 'var(--c-muted)', marginTop: 6, lineHeight: 1.5 }}>
           {t.renewedSub(fmtCompact(done.newPrincipal), newMaturityFmt)}
         </div>
+        {done.sources.length > 0 && (
+          <div data-testid="maturity-renewed-sources" style={{ marginTop: 10, fontSize: 12, color: 'var(--c-muted)', lineHeight: 1.5 }}>
+            {t.mergedSourcesLabel}: {done.sources.join(', ')}
+          </div>
+        )}
       </div>
     )
   }
@@ -535,7 +586,7 @@ export function MaturityResolveBody({
           {!isBook && mergeable.length > 0 && (
             <div style={{ border: '1px solid var(--c-line)', borderRadius: 12, padding: '11px 13px', display: 'grid', gap: 9 }}>
               <div>
-                <div style={fieldLabel}>{t.mergeTitle}</div>
+                <div data-testid="merge-section-title" style={fieldLabel}>{isMultiSource ? t.mergeTitleMulti : t.mergeTitle}</div>
                 <p style={{ margin: '0 0 2px', fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.45 }}>{t.mergeHint}</p>
               </div>
               <div style={{ display: 'grid', gap: 7 }}>
@@ -570,6 +621,18 @@ export function MaturityResolveBody({
 
               {selectedSources.length > 0 && (
                 <>
+                  {/* Provenance — how many sources/banks fold into the new deposit */}
+                  <p data-testid="merge-provenance" style={{ margin: 0, fontSize: 11, fontWeight: 600, color: 'var(--c-navy)', lineHeight: 1.45 }}>
+                    {t.provenance(mergeSourceCount, mergeBankCount)}
+                  </p>
+                  {/* Destination bank for the combined re-deposit (default = D's bank) */}
+                  <div>
+                    <div style={fieldLabel}>{t.destBankLabel}</div>
+                    <select data-testid="merge-dest-bank" value={destBank} onChange={(e) => setDestBank(e.target.value)} style={{ ...moneyInput, fontWeight: 600 }}>
+                      <option value="">{t.destBankNone}</option>
+                      {banks.map((b) => <option key={b.code} value={b.code}>{b.name}</option>)}
+                    </select>
+                  </div>
                   {/* One editable TOTAL that splits across the selected sources */}
                   {selectedSources.length > 1 && (
                     <div>

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -268,6 +268,126 @@ describe('MaturityResolveBody', () => {
     })
   })
 
+  // ── Multi-source merge UX (PR1) ─────────────────────────────────────────────
+  // Destination bank picker, "Gộp nhiều nguồn" label + provenance when >1 source,
+  // and the success state listing what was folded in.
+  describe('multi-source merge UX', () => {
+    const BANKS = [
+      { code: 'TCB', name: 'Techcombank' },
+      { code: 'VCB', name: 'Vietcombank' },
+      { code: 'MB', name: 'MB Bank' },
+    ]
+    function stubBanksAndRecurring() {
+      const fetchMock = vi.fn().mockImplementation((url: string) => {
+        if (typeof url === 'string' && url.startsWith('/api/v1/recurring-savings')) {
+          return Promise.resolve({ ok: true, json: async () => ({ savings: [] }) })
+        }
+        if (typeof url === 'string' && url.startsWith('/api/v1/banks')) {
+          // The real route returns a bare array of { code, name, logo_url }.
+          return Promise.resolve({ ok: true, json: async () => BANKS })
+        }
+        return Promise.resolve({ ok: true, json: async () => ({}) })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      return fetchMock
+    }
+
+    // Anchor (D) sits at TCB; siblings at VCB / MB / no-bank.
+    const anchorTCB: InvRow = { ...maturedDeposit, bankCode: 'TCB' }
+    const sibVCB: InvRow = {
+      id: 'sib-vcb', name: 'Vikki VCB', type: 'bank', value: 8_000_000, gainPct: null,
+      units: null, principal: 8_000_000, interestRate: 6, expiryDate: daysFromNow(40),
+      investmentDate: daysFromNow(-150), fund: null, bankCode: 'VCB',
+    }
+    const sibMB: InvRow = {
+      id: 'sib-mb', name: 'PVCombank MB', type: 'bank', value: 4_000_000, gainPct: null,
+      units: null, principal: 4_000_000, interestRate: 5, expiryDate: daysFromNow(60),
+      investmentDate: daysFromNow(-100), fund: null, bankCode: 'MB',
+    }
+    const sibNoBank: InvRow = {
+      id: 'sib-nobank', name: 'Legacy no bank', type: 'bank', value: 3_000_000, gainPct: null,
+      units: null, principal: 3_000_000, interestRate: 5, expiryDate: daysFromNow(50),
+      investmentDate: daysFromNow(-120), fund: null, bankCode: null,
+    }
+
+    it('shows a destination bank picker defaulting to the anchor bank once a source is selected', async () => {
+      const user = userEvent.setup()
+      stubBanksAndRecurring()
+      render(
+        <MaturityResolveBody inv={anchorTCB} goalId="goal-1" siblingDeposits={[anchorTCB, sibVCB]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+      expect(screen.queryByTestId('merge-dest-bank')).toBeNull() // hidden until a source is picked
+      await user.click(screen.getByTestId('merge-source-sib-vcb'))
+      const sel = (await screen.findByTestId('merge-dest-bank')) as HTMLSelectElement
+      expect(sel.value).toBe('TCB') // defaults to the settling deposit's bank
+    })
+
+    it('labels the section "Merge multiple sources" and shows provenance only when >1 source is selected', async () => {
+      const user = userEvent.setup()
+      stubBanksAndRecurring()
+      render(
+        <MaturityResolveBody inv={anchorTCB} goalId="goal-1" siblingDeposits={[anchorTCB, sibVCB, sibMB]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+      await user.click(screen.getByTestId('merge-source-sib-vcb'))
+      // One source folded → 2 deposits combine, but the "multiple sources" label
+      // only kicks in past one selected sibling.
+      expect(screen.getByTestId('merge-section-title').textContent).toMatch(/Merge other deposits/i)
+
+      await user.click(screen.getByTestId('merge-source-sib-mb'))
+      expect(screen.getByTestId('merge-section-title').textContent).toMatch(/Merge multiple sources/i)
+      // Provenance counts the anchor + folded sources (3) and their distinct banks
+      // (TCB, VCB, MB = 3).
+      const prov = screen.getByTestId('merge-provenance').textContent ?? ''
+      expect(prov).toMatch(/3 sources/i)
+      expect(prov).toMatch(/3 banks/i)
+    })
+
+    it('excludes NULL-bank sources from the bank count and submits the chosen destination bank_code', async () => {
+      const user = userEvent.setup()
+      const fetchMock = stubBanksAndRecurring()
+      render(
+        <MaturityResolveBody inv={anchorTCB} goalId="goal-1" siblingDeposits={[anchorTCB, sibVCB, sibNoBank]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+      await user.click(screen.getByTestId('merge-source-sib-vcb'))
+      await user.click(screen.getByTestId('merge-source-sib-nobank'))
+      // 3 sources combine (anchor + 2) but only TCB + VCB are real banks → 2 banks.
+      const prov = screen.getByTestId('merge-provenance').textContent ?? ''
+      expect(prov).toMatch(/3 sources/i)
+      expect(prov).toMatch(/2 banks/i)
+
+      // Move the destination to MB and confirm it rides the request.
+      fireEvent.change(screen.getByTestId('merge-dest-bank'), { target: { value: 'MB' } })
+      await user.click(screen.getByRole('button', { name: /Save new deposit/i }))
+      await waitFor(() => {
+        const renewCall = fetchMock.mock.calls.find((c) => String(c[0]).endsWith('/renew'))
+        expect(renewCall).toBeTruthy()
+      })
+      const renewCall = fetchMock.mock.calls.find((c) => String(c[0]).endsWith('/renew'))!
+      expect(JSON.parse(renewCall[1].body).bank_code).toBe('MB')
+    })
+
+    it('lists the merged sources in the success state', async () => {
+      const user = userEvent.setup()
+      stubBanksAndRecurring()
+      render(
+        <MaturityResolveBody inv={anchorTCB} goalId="goal-1" siblingDeposits={[anchorTCB, sibVCB]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+      await user.click(screen.getByTestId('merge-source-sib-vcb'))
+      await user.click(screen.getByRole('button', { name: /Save new deposit/i }))
+
+      const sources = await screen.findByTestId('maturity-renewed-sources')
+      expect(sources.textContent).toContain('Vikki VCB')
+    })
+  })
+
   it('hands off to the existing withdraw flow instead of renewing', async () => {
     const user = userEvent.setup()
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })

--- a/app/assets/components/__tests__/goalDetailShared.test.tsx
+++ b/app/assets/components/__tests__/goalDetailShared.test.tsx
@@ -54,6 +54,33 @@ describe('buildInvRows', () => {
     expect(rows[0].units).toBeNull()
   })
 
+  it('carries bank_code through to InvRow.bankCode for bank deposits (null for non-bank)', () => {
+    const rows = buildInvRows(
+      [
+        baseTx({ transaction_id: 'b1', asset_type: 'bank', amount_vnd: 5_000_000, interest_rate: 6, bank_code: 'VCB' }),
+        baseTx({ transaction_id: 'g1', asset_type: 'gold', amount_vnd: 9_000_000, units: 1 }),
+      ],
+      [], 9_200_000, false,
+    )
+    const bank = rows.find((r) => r.id === 'b1')!
+    const gold = rows.find((r) => r.id === 'g1')!
+    expect(bank.bankCode).toBe('VCB')
+    expect(gold.bankCode ?? null).toBeNull() // structured bank only applies to bank deposits
+  })
+
+  it('uses the anchor tranche bank_code for an accumulating book row', () => {
+    const rows = buildInvRows(
+      [
+        baseTx({ transaction_id: 'book', asset_type: 'bank', amount_vnd: 2_000_000, interest_rate: 6, deposit_group_id: 'book', bank_code: 'MB', investment_date: daysFromNow(-30) }),
+        baseTx({ transaction_id: 'tr2', asset_type: 'bank', amount_vnd: 1_000_000, interest_rate: 6, deposit_group_id: 'book', bank_code: 'MB', investment_date: daysFromNow(-10) }),
+      ],
+      [], null, false,
+    )
+    expect(rows).toHaveLength(1)
+    expect(rows[0].depositGroupId).toBe('book')
+    expect(rows[0].bankCode).toBe('MB')
+  })
+
   it('caps a matured deposit at its term interest (frozen, simple interest)', () => {
     // Term 2025-01-01 → 2025-07-01 (181 days). Interest is capped at maturity, so
     // the value is deterministic regardless of when the test runs (today is past

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -215,6 +215,10 @@ export interface InvRow {
   // share. Keeps the whole book out of the single-row term renew path and tells
   // the UI to offer a top-up. null for term / one-off holdings.
   depositGroupId?: string | null
+  // Structured bank reference (FK to banks.code) for a bank deposit; null for a
+  // non-bank holding or a deposit with no bank set yet. Drives the multi-source
+  // merge destination-bank default and the "N nguồn · M ngân hàng" provenance.
+  bankCode?: string | null
   // The book's tranches (top-ups), newest first, for the detail view. Each is one
   // underlying row; present only on an accumulating book row.
   tranches?: InvTranche[] | null
@@ -255,6 +259,8 @@ export interface GoalDetailTx {
   // Accumulating book grouping: set on every tranche of a book (anchor row's =
   // its own transaction_id). null/undefined for term / one-off holdings.
   deposit_group_id?: string | null
+  // Structured bank reference (FK to banks.code); null until the user sets it.
+  bank_code?: string | null
 }
 
 // Roll up a deposit's renewal history from the snapshot rows that point at it.
@@ -370,7 +376,7 @@ export function buildInvRows(
       }
     }
 
-    return { id: tx.transaction_id, name, type: tx.asset_type, value, gainPct, units, principal, interestRate: tx.interest_rate ?? null, expiryDate: tx.expiry_date ?? null, investmentDate: fund ? null : (tx.investment_date ?? null), fund: fund ?? null, depositGroupId: null }
+    return { id: tx.transaction_id, name, type: tx.asset_type, value, gainPct, units, principal, interestRate: tx.interest_rate ?? null, expiryDate: tx.expiry_date ?? null, investmentDate: fund ? null : (tx.investment_date ?? null), fund: fund ?? null, depositGroupId: null, bankCode: tx.asset_type === 'bank' ? (tx.bank_code ?? null) : null }
   }).filter((row): row is InvRow => row !== null)
 
   // One InvRow per accumulating book: value each tranche on its own locked rate
@@ -404,6 +410,7 @@ export function buildInvRows(
       investmentDate: tranches[tranches.length - 1].date, // earliest tranche opened the book
       fund: null,
       depositGroupId: groupId,
+      bankCode: anchor.bank_code ?? null, // bank is book-level; the anchor carries it
       tranches,
     }
   }).filter((row): row is InvRow => row !== null)

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -148,6 +148,8 @@ export async function createTransaction(data: {
   fund_id?: string
   goal_id?: string
   notes?: string
+  // Structured bank reference (FK to banks.code) — used by the multi-source merge.
+  bank_code?: string
   // Set to mark this row a renewal snapshot of a closed cycle (excluded from net
   // worth and from the recurring deposit-suppression pool).
   renewed_from_transaction_id?: string

--- a/e2e/maturity-combine-merge.spec.ts
+++ b/e2e/maturity-combine-merge.spec.ts
@@ -134,6 +134,72 @@ test.describe('Term-deposit maturity — merge a sibling deposit into the re-dep
     }
   })
 
+  // Multi-source merge UX (PR1): the combined re-deposit lands at a chosen
+  // destination bank, and the provenance reflects how many sources/banks fold in.
+  // D sits at VCB, S at MB → "2 sources · 2 banks". We move the destination to
+  // TCB and assert the renewed deposit's bank_code persisted as TCB.
+  test('folds a sibling across banks and persists the chosen destination bank', async ({ page }) => {
+    test.slow()
+    const goal = await api.createGoal({ goal_name: 'E2E Dest Bank Goal', target_amount: 200_000_000 })
+    const D = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 20_000_000, investment_date: iso(-380),
+      interest_rate: 6, expiry_date: iso(-15), goal_id: goal.goal_id, notes: 'E2E Dest D', bank_code: 'VCB',
+    })
+    const S = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 8_000_000, investment_date: iso(-120),
+      interest_rate: 6, expiry_date: iso(60), goal_id: goal.goal_id, notes: 'E2E Dest S', bank_code: 'MB',
+    })
+    try {
+      await gotoFreshDashboard(page)
+      await page.getByText('E2E Dest Bank Goal').first().click()
+      const panel = page.getByTestId('desktop-goal-detail')
+      await expect(panel).toBeVisible({ timeout: 10_000 })
+      await expect(panel.getByText('E2E Dest D')).toBeVisible({ timeout: 10_000 })
+
+      const dRow = panel
+        .locator('div')
+        .filter({ has: page.getByRole('button', { name: 'Options', exact: true }) })
+        .filter({ hasText: 'E2E Dest D' })
+        .last()
+      await dRow.getByRole('button', { name: 'Options', exact: true }).click()
+      await page.getByText(/^(Handle maturity|Xử lý đáo hạn)$/).click()
+      await page.getByRole('button', { name: /Settle & re-deposit|Tất toán & gửi lại/i }).click()
+
+      await page.getByTestId(`merge-source-${S.transaction_id}`).click()
+
+      // Provenance: anchor (VCB) + sibling (MB) = 2 sources across 2 banks.
+      const prov = page.getByTestId('merge-provenance')
+      await expect(prov).toContainText(/2 (nguồn|sources)/i)
+      await expect(prov).toContainText(/2 (ngân hàng|banks)/i)
+
+      // The destination picker defaults to D's bank (VCB); move it to TCB.
+      const dest = page.getByTestId('merge-dest-bank')
+      await expect(dest).toHaveValue('VCB')
+      await dest.selectOption('TCB')
+
+      const [renewReq] = await Promise.all([
+        page.waitForRequest((r) => r.url().endsWith(`/${D.transaction_id}/renew`) && r.method() === 'POST'),
+        page.getByRole('button', { name: /Save new deposit|Lưu sổ mới/i }).click(),
+      ])
+      expect(renewReq.postDataJSON().bank_code).toBe('TCB')
+      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+
+      const { createClient } = await import('@supabase/supabase-js')
+      const supabase = createClient(process.env.E2E_SUPABASE_URL!, process.env.E2E_SUPABASE_SERVICE_ROLE_KEY!)
+      // The renewed deposit moved to the chosen destination bank.
+      await expect.poll(async () => {
+        const { data } = await supabase
+          .from('investment_transactions').select('bank_code')
+          .eq('transaction_id', D.transaction_id).single()
+        return data?.bank_code
+      }, { timeout: 15_000 }).toBe('TCB')
+    } finally {
+      await api.deleteTransactionCascade(S.transaction_id)
+      await api.deleteTransactionCascade(D.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
   // Server-side guard: the route trusts the client for `received`, but the RPC
   // must not. A received far larger than the source's own value would let D
   // (principal = BASE + Σ received) balloon while S only closes its real

--- a/supabase/migrations/20260620000003_renew_merge_with_dest_bank.sql
+++ b/supabase/migrations/20260620000003_renew_merge_with_dest_bank.sql
@@ -1,0 +1,233 @@
+-- Multi-source merge: let the combined re-deposit land at a chosen destination
+-- bank (PR1 of "Gộp nhiều nguồn").
+--
+-- The merge flow folds sibling deposits (possibly across different banks) into
+-- the deposit being renewed (D). The user picks where the combined money sits —
+-- the destination bank — defaulting to D's current bank. So renew_term_deposit_with_merge
+-- gains p_bank_code and applies it to D in the roll-forward (step 1).
+--
+-- Semantics: bank_code = coalesce(p_bank_code, bank_code). A NULL p_bank_code
+-- means "leave D's bank unchanged" (so a caller that doesn't pass it, or a user
+-- who picks "no bank", never wipes an existing bank on renewal). Setting it to a
+-- different code moves the combined deposit to that bank.
+--
+-- Adding a parameter changes the signature, so DROP the prior 12-arg version
+-- first (a bare create-or-replace would register a second overload and make
+-- name-resolved calls ambiguous — the exact PR0 pitfall, see
+-- 20260620000002). The body is otherwise identical to 20260619000001; only the
+-- new param and the step-1 bank_code assignment are added.
+drop function if exists public.renew_term_deposit_with_merge(
+  uuid, bigint, numeric, date, date, bigint, uuid, text, bigint, text, uuid[], bigint[]
+);
+
+create or replace function public.renew_term_deposit_with_merge(
+  p_tx_id uuid,
+  p_amount_vnd bigint,            -- BASE only; the RPC adds Σ(received)
+  p_interest_rate numeric,
+  p_expiry_date date,
+  p_investment_date date,
+  p_interest_earned_vnd bigint,
+  p_fulfill_saving_id uuid default null,
+  p_fulfill_ym text default null,
+  p_fulfill_amount bigint default null,
+  p_fulfill_source text default null,
+  p_merge_source_ids uuid[] default '{}',
+  p_merge_received bigint[] default '{}',
+  p_bank_code text default null
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_old public.investment_transactions;
+  v_snapshot_id uuid;
+  v_renewed public.investment_transactions;
+  v_src public.investment_transactions;
+  v_sid uuid;
+  v_recv bigint;
+  v_src_eff bigint;
+  v_merge_total bigint := 0;
+  v_n integer;
+  v_i integer;
+begin
+  select * into v_old
+    from public.investment_transactions
+   where transaction_id = p_tx_id
+   for update;
+  if not found then
+    raise exception 'renew_term_deposit_with_merge: transaction not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_old.asset_type is distinct from 'bank' then
+    raise exception 'renew_term_deposit_with_merge: only bank term deposits can be renewed'
+      using errcode = 'check_violation';
+  end if;
+  if v_old.interest_rate is null or v_old.expiry_date is null then
+    raise exception 'renew_term_deposit_with_merge: only bank term deposits can be renewed'
+      using errcode = 'check_violation';
+  end if;
+  -- An accumulating book is renewed as a whole, not one tranche at a time.
+  if v_old.deposit_group_id is not null then
+    raise exception 'renew_term_deposit_with_merge: cannot renew an accumulating book'
+      using errcode = 'check_violation';
+  end if;
+  if p_investment_date > current_date + 1 then
+    raise exception 'renew_term_deposit_with_merge: investment date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+  if p_expiry_date is not null and p_expiry_date <= p_investment_date then
+    raise exception 'renew_term_deposit_with_merge: new maturity must be after the investment date'
+      using errcode = 'check_violation';
+  end if;
+
+  -- 0) Merge step (before roll-forward): close each source and accumulate the
+  --    cash it releases. The withdrawals are parented to the SOURCE, not D, so
+  --    step 3's re-parent (parent = p_tx_id) never touches them.
+  v_n := coalesce(array_length(p_merge_source_ids, 1), 0);
+  if v_n <> coalesce(array_length(p_merge_received, 1), 0) then
+    raise exception 'renew_term_deposit_with_merge: merge source/received length mismatch'
+      using errcode = 'check_violation';
+  end if;
+  -- Acquire every source row lock up front in a deterministic (sorted) order, so
+  -- two concurrent merges that share a source can't deadlock by locking it in
+  -- opposite array orders. The per-source `for update` in the loop below then
+  -- just re-reads an already-held lock. (Low-risk for a single-user app, but
+  -- cheap insurance against the ordering hazard.)
+  perform 1
+    from public.investment_transactions
+   where transaction_id = any(p_merge_source_ids)
+   order by transaction_id
+     for update;
+  for v_i in 1 .. v_n loop
+    v_sid := p_merge_source_ids[v_i];
+    v_recv := p_merge_received[v_i];
+    if v_sid = p_tx_id then
+      raise exception 'renew_term_deposit_with_merge: a deposit cannot merge into itself'
+        using errcode = 'check_violation';
+    end if;
+    if v_recv is null or v_recv < 0 then
+      raise exception 'renew_term_deposit_with_merge: received amount must be non-negative'
+        using errcode = 'check_violation';
+    end if;
+    select * into v_src
+      from public.investment_transactions
+     where transaction_id = v_sid
+     for update;
+    if not found then
+      raise exception 'renew_term_deposit_with_merge: merge source not found'
+        using errcode = 'no_data_found';
+    end if;
+    -- Source must be a plain, active bank deposit owned by the same user and in
+    -- the same goal as D (an internal transfer within one goal). Books, renewal
+    -- snapshots and withdrawals are excluded.
+    if v_src.user_id <> v_old.user_id then
+      raise exception 'renew_term_deposit_with_merge: merge source belongs to another user'
+        using errcode = 'check_violation';
+    end if;
+    if v_src.goal_id is distinct from v_old.goal_id then
+      raise exception 'renew_term_deposit_with_merge: merge source is in a different goal'
+        using errcode = 'check_violation';
+    end if;
+    if v_src.asset_type is distinct from 'bank' or v_src.deposit_group_id is not null
+       or v_src.transaction_type is distinct from 'investment'
+       or v_src.renewed_from_transaction_id is not null then
+      raise exception 'renew_term_deposit_with_merge: merge source is not a plain active bank deposit'
+        using errcode = 'check_violation';
+    end if;
+    -- Close only what is left after any prior partial withdrawals.
+    v_src_eff := v_src.amount_vnd - coalesce((
+      select sum(w.principal_withdrawn) from public.investment_transactions w
+       where w.parent_transaction_id = v_sid and w.transaction_type = 'withdrawal'
+    ), 0);
+    if v_src_eff <= 0 then
+      raise exception 'renew_term_deposit_with_merge: merge source is already fully withdrawn'
+        using errcode = 'check_violation';
+    end if;
+    -- Sanity-bound the cash received against the source's OWN value: settling S
+    -- releases at most its effective principal plus interest, never a multiple of
+    -- it. Without this the server trusts the client's received outright, so a
+    -- buggy/malicious caller could inflate D (principal = BASE + Σ received) from
+    -- nothing while S only closes its real principal. Mirror the ×10 bound the
+    -- renewal route already applies to interest_earned_vnd — generous enough to
+    -- never reject a real held-to-maturity value, tight enough to cap abuse.
+    if v_recv > v_src_eff * 10 then
+      raise exception 'renew_term_deposit_with_merge: received amount is unreasonably large for the source'
+        using errcode = 'check_violation';
+    end if;
+    insert into public.investment_transactions (
+      user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
+      investment_date, amount_vnd, principal_withdrawn, affects_progress
+    ) values (
+      v_src.user_id, v_src.goal_id, 'bank', 'withdrawal', v_sid,
+      p_investment_date, v_recv, v_src_eff, true
+    );
+    -- Unlink any recurring saving that fed the now-closed source (mirror
+    -- 20260618000009 lines 110–117) so nothing tries to top it up later.
+    update public.recurring_savings
+       set linked_deposit_tx_id = null, updated_at = now()
+     where linked_deposit_tx_id = v_sid and user_id = v_old.user_id;
+    v_merge_total := v_merge_total + v_recv;
+  end loop;
+
+  -- 1) Roll the active row forward to the new cycle. Net-worth invariant: the
+  --    amount added to D's principal equals exactly Σ(received) the sources
+  --    released — the server adds it so the client can never inflate D alone.
+  --    bank_code moves to the chosen destination; NULL p_bank_code leaves it as is.
+  update public.investment_transactions
+     set amount_vnd      = p_amount_vnd + v_merge_total,
+         interest_rate   = p_interest_rate,
+         expiry_date     = p_expiry_date,
+         investment_date = p_investment_date,
+         bank_code       = coalesce(p_bank_code, bank_code),
+         updated_at      = now()
+   where transaction_id = p_tx_id
+  returning * into v_renewed;
+
+  -- 2) Append the history snapshot of the closed cycle (dates from v_old).
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, amount_vnd,
+    investment_date, expiry_date, interest_rate, notes,
+    renewed_from_transaction_id, interest_earned_vnd, affects_progress
+  ) values (
+    v_old.user_id, v_old.goal_id, 'bank', 'investment', v_old.amount_vnd,
+    v_old.investment_date, v_old.expiry_date, v_old.interest_rate, v_old.notes,
+    p_tx_id, p_interest_earned_vnd, false
+  )
+  returning transaction_id into v_snapshot_id;
+
+  -- 3) Re-parent the closed cycle's partial-withdrawal rows onto the snapshot.
+  update public.investment_transactions
+     set parent_transaction_id = v_snapshot_id
+   where parent_transaction_id = p_tx_id
+     and transaction_type = 'withdrawal';
+
+  -- 4) Combine flow only: record this month's recurring saving as fulfilled.
+  if p_fulfill_saving_id is not null and p_fulfill_ym is not null then
+    if not exists (
+      select 1 from public.recurring_savings
+       where saving_id = p_fulfill_saving_id and user_id = v_old.user_id
+    ) then
+      raise exception 'renew_term_deposit_with_merge: recurring saving not found'
+        using errcode = 'no_data_found';
+    end if;
+    insert into public.recurring_saving_fulfillments (
+      user_id, recurring_saving_id, ym, amount_vnd, source
+    ) values (
+      v_old.user_id, p_fulfill_saving_id, p_fulfill_ym,
+      coalesce(p_fulfill_amount, 0), coalesce(p_fulfill_source, 'maturity-combine')
+    )
+    on conflict (recurring_saving_id, ym) do update
+      set amount_vnd = excluded.amount_vnd,
+          source     = excluded.source,
+          updated_at = now();
+  end if;
+
+  return v_renewed;
+end;
+$$;
+
+grant execute on function public.renew_term_deposit_with_merge(
+  uuid, bigint, numeric, date, date, bigint, uuid, text, bigint, text, uuid[], bigint[], text
+) to authenticated;


### PR DESCRIPTION
**PR1 of "Gộp nhiều nguồn"** — the multi-source combine UX layered on the existing merge data layer (`renew_term_deposit_with_merge`). Independent of PR0 (#368, merged).

## What changed (user-visible)
- **Destination bank picker** in the merge section, shown once ≥1 source is selected, defaulting to the settling deposit's bank. The combined re-deposit lands at the chosen bank.
- **"Gộp nhiều nguồn"** section label once more than one source is folded in (vs "Gộp sổ khác" for a single one).
- **Provenance** line **"Gộp từ N nguồn · M ngân hàng"** — N = anchor + folded sources; M = distinct real banks (NULL `bank_code` excluded so a legacy no-bank deposit doesn't inflate the count).
- **Success state** lists the merged sources.

## Plumbing + backend
- `InvRow.bankCode` + `GoalDetailTx.bank_code`; `buildInvRows` carries `bank_code` through (bank rows + book anchor).
- `renew_term_deposit_with_merge` gains `p_bank_code` (coalesce semantics — NULL leaves D's bank untouched, so a renewal never wipes it). Drops the prior 12-arg signature first (adding a param would otherwise register a second overload → ambiguous calls — the PR0 lesson).
- Renew route validates `bank_code` and passes `p_bank_code` to the merge RPC.

## Testing (TDD)
- Unit tests written first: `buildInvRows` bankCode plumbing; picker default, dynamic label, provenance (incl. NULL-bank exclusion), submit payload, success list.
- E2E extends `maturity-combine-merge.spec.ts` with a cross-bank fold (D at VCB, S at MB → "2 sources · 2 banks"), moves the destination to TCB, and asserts the renewed deposit's `bank_code` persisted.
- **724 unit tests pass; tsc + lint clean; full E2E green (293 passed, 0 failed).**
- The full E2E run caught a real bug unit tests missed: `/api/v1/banks` returns a bare array (not `{ banks }`), so the fetch + its stub were corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)