### PR TITLE
feat(deposits): merge eligibility rules + window slider (PR2)

### DIFF
--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -17,7 +17,7 @@
 // (the parent wires `onWithdraw`).
 
 import { useState, useEffect } from 'react'
-import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X, Plus, Wallet } from 'lucide-react'
+import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X, Plus, Wallet, Lock, SlidersHorizontal } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import { fmtMaturity, type InvRow } from './goalDetailShared'
 import {
@@ -29,6 +29,7 @@ import {
   type RenewMode,
 } from '@/lib/maturity'
 import { linkedSavingFor, type RecurringLinkCandidate, type RecurringLinkResult } from '@/lib/recurringLink'
+import { classifyMergeSources, type MergeBlockReason } from '@/lib/mergeEligibility'
 import { todayIso } from '@/lib/dates'
 
 type Mode = RenewMode | 'withdraw' | 'combine'
@@ -136,16 +137,42 @@ export function MaturityResolveBody({
   const mergeableOrdered = [...mergeable].sort(
     (a, b) => (a.investmentDate ?? '').localeCompare(b.investmentDate ?? '') || a.id.localeCompare(b.id),
   )
+  // Selection is DERIVED from eligibility: an in-window sibling defaults to
+  // selected, the rest default to not. `mergeSel` records only the user's EXPLICIT
+  // overrides of that default (so widening the window can re-default an untouched
+  // source without clobbering a manual pick). `overridden` flags an out-of-window
+  // source the user chose to fold in early ("Gộp sớm?").
   const [mergeSel, setMergeSel] = useState<Record<string, boolean>>({})
+  const [overridden, setOverridden] = useState<Record<string, boolean>>({})
   const [mergeRecv, setMergeRecv] = useState<Record<string, string>>({})
   const [mergeTotal, setMergeTotal] = useState('')
   const [, setMergeTotalTouched] = useState(false)
+  // Maturity window (days): siblings maturing within this many days of the anchor
+  // are eligible. The slider widens it (folding in farther deposits = early
+  // settlement = a possible interest penalty).
+  const [windowDays, setWindowDays] = useState(7)
   // Destination bank for the combined re-deposit (multi-source merge). Defaults to
   // the settling deposit's bank; the user can move the money to another bank.
   const [banks, setBanks] = useState<{ code: string; name: string }[]>([])
   const [destBank, setDestBank] = useState<string>(inv.bankCode ?? '')
 
-  const selectedSources = mergeableOrdered.filter((s) => mergeSel[s.id])
+  // Classify each mergeable sibling against the anchor (D). Same-goal is already
+  // guaranteed (siblings are this goal's holdings), so we don't pass goal ids.
+  const classifications = classifyMergeSources(
+    { id: inv.id, type: inv.type, expiryDate: inv.expiryDate, principal: inv.principal, value: inv.value, depositGroupId: inv.depositGroupId, currency: inv.currency, isPledged: inv.isPledged },
+    mergeableOrdered.map((s) => ({ id: s.id, type: s.type, expiryDate: s.expiryDate, principal: s.principal, value: s.value, depositGroupId: s.depositGroupId, currency: s.currency, isPledged: s.isPledged })),
+    windowDays,
+  )
+  const classOf = new Map(classifications.map((c) => [c.source.id, c]))
+
+  // Effective selection: an explicit toggle wins; an overridden source is on; else
+  // the eligibility default.
+  function isSelected(id: string): boolean {
+    if (id in mergeSel) return mergeSel[id]
+    if (overridden[id]) return true
+    return !!classOf.get(id)?.eligible
+  }
+  const selectedSources = mergeableOrdered.filter((s) => isSelected(s.id))
   const mergeReceivedTotal = selectedSources.reduce((sum, s) => sum + (Number(mergeRecv[s.id]) || 0), 0)
   // Provenance for the multi-source merge: the new deposit combines the anchor (D)
   // with every folded source, so "N nguồn" counts D + the selected sources. "M
@@ -158,15 +185,50 @@ export function MaturityResolveBody({
   const mergeBankCount = combinedBankCodes.size
   const isMultiSource = selectedSources.length > 1
 
-  // Toggle a source; on first select, prefill its received with the current value
-  // (the user edits it down to the real cash if the early settlement is penalised).
-  function toggleSource(s: InvRow) {
-    const on = !mergeSel[s.id]
-    setMergeSel((prev) => ({ ...prev, [s.id]: on }))
-    if (on && (mergeRecv[s.id] === undefined || mergeRecv[s.id] === '')) {
-      setMergeRecv((prev) => ({ ...prev, [s.id]: String(Math.round(s.value ?? s.principal ?? 0)) }))
-    }
+  // Prefill a source's received with its current value (the user edits it down to
+  // the real cash if early settlement is penalised). No-op once it has a value.
+  function prefillReceived(s: InvRow) {
+    setMergeRecv((prev) =>
+      prev[s.id] === undefined || prev[s.id] === ''
+        ? { ...prev, [s.id]: String(Math.round(s.value ?? s.principal ?? 0)) }
+        : prev,
+    )
   }
+
+  // Toggle a source on/off (eligible or already-overridden). Turning an overridden
+  // source off also drops the override, so it returns to the dimmed "Gộp sớm?" row.
+  function toggleSource(s: InvRow) {
+    const on = !isSelected(s.id)
+    setMergeSel((prev) => ({ ...prev, [s.id]: on }))
+    if (on) prefillReceived(s)
+    else if (overridden[s.id]) setOverridden((prev) => { const n = { ...prev }; delete n[s.id]; return n })
+  }
+
+  // Fold an out-of-window source in early ("Gộp sớm?"): override the window block,
+  // select it, and prefill its received cash.
+  function overrideSource(s: InvRow) {
+    setOverridden((prev) => ({ ...prev, [s.id]: true }))
+    setMergeSel((prev) => ({ ...prev, [s.id]: true }))
+    prefillReceived(s)
+  }
+
+  // Keep the received map in step with the eligibility default: when the picker
+  // opens (and whenever the window widens), prefill any now-selected source that
+  // doesn't yet have a received value, so a preselected sibling never submits 0₫.
+  useEffect(() => {
+    setMergeRecv((prev) => {
+      let changed = false
+      const next = { ...prev }
+      mergeableOrdered.forEach((s) => {
+        if (isSelected(s.id) && (next[s.id] === undefined || next[s.id] === '')) {
+          next[s.id] = String(Math.round(s.value ?? s.principal ?? 0))
+          changed = true
+        }
+      })
+      return changed ? next : prev
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [windowDays])
 
   // Editing the single TOTAL splits it across the selected sources with the same
   // cumulative-window allocation the SQL uses — so Σ(received) === the total the
@@ -174,7 +236,7 @@ export function MaturityResolveBody({
   function onMergeTotalChange(v: string) {
     setMergeTotal(v); setMergeTotalTouched(true)
     const total = Math.round(Number(v) || 0)
-    const sel = mergeableOrdered.filter((s) => mergeSel[s.id])
+    const sel = mergeableOrdered.filter((s) => isSelected(s.id))
     const alloc = allocateCumulative(total, sel.map((s) => Math.round(s.principal ?? s.value ?? 0)))
     setMergeRecv((prev) => {
       const next = { ...prev }
@@ -314,6 +376,14 @@ export function MaturityResolveBody({
     destBankNone: 'Không chọn',
     provenance: (n: number, m: number) => `Gộp từ ${n} nguồn · ${m} ngân hàng`,
     mergedSourcesLabel: 'Đã gộp',
+    windowLabel: (n: number) => `Cửa sổ đáo hạn: ${n} ngày`,
+    windowHint: 'Nới cửa sổ để gộp thêm sổ — chờ lâu hơn = thiệt lãi.',
+    mergeEarly: 'Gộp sớm?',
+    reasonOutOfWindow: (n: number) => `Đáo hạn cách ${n} ngày — phá kỳ mất lãi`,
+    reasonCurrency: 'Khác loại tiền',
+    reasonPledged: 'Đang thế chấp — bị phong toả',
+    reasonGoal: 'Khác mục tiêu',
+    reasonBlocked: 'Chưa đủ điều kiện',
   } : {
     summarySuffix: 'yr', perYr: 'yr', mo: 'mo',
     why: matured
@@ -353,6 +423,25 @@ export function MaturityResolveBody({
     destBankNone: 'No bank',
     provenance: (n: number, m: number) => `Combined from ${n} sources · ${m} banks`,
     mergedSourcesLabel: 'Merged in',
+    windowLabel: (n: number) => `Maturity window: ${n} days`,
+    windowHint: 'Widen the window to fold in more deposits — waiting longer forfeits interest.',
+    mergeEarly: 'Merge early?',
+    reasonOutOfWindow: (n: number) => `Matures ${n}d apart — early settlement`,
+    reasonCurrency: 'Different currency',
+    reasonPledged: 'Pledged as collateral',
+    reasonGoal: 'Different goal',
+    reasonBlocked: 'Not eligible yet',
+  }
+
+  // Human-readable reason for a blocked source.
+  function blockReasonText(reason: MergeBlockReason | null, gapDays: number | null): string {
+    switch (reason) {
+      case 'out-of-window': return t.reasonOutOfWindow(gapDays ?? 0)
+      case 'different-currency': return t.reasonCurrency
+      case 'pledged': return t.reasonPledged
+      case 'different-goal': return t.reasonGoal
+      default: return t.reasonBlocked
+    }
   }
 
   const POLICIES: { id: Mode; icon: React.ReactNode; label: string; sub: string; danger?: boolean }[] = [
@@ -589,9 +678,51 @@ export function MaturityResolveBody({
                 <div data-testid="merge-section-title" style={fieldLabel}>{isMultiSource ? t.mergeTitleMulti : t.mergeTitle}</div>
                 <p style={{ margin: '0 0 2px', fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.45 }}>{t.mergeHint}</p>
               </div>
+
+              {/* Maturity window — widen to fold in farther-dated deposits (early
+                  settlement). Re-runs the eligibility classification live. */}
+              <div style={{ display: 'grid', gap: 5 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+                  <SlidersHorizontal size={13} color="var(--c-muted)" style={{ flexShrink: 0 }} />
+                  <span style={{ fontSize: 11.5, fontWeight: 600, color: 'var(--c-ink)' }}>{t.windowLabel(windowDays)}</span>
+                </div>
+                <input data-testid="merge-window-slider" type="range" min={1} max={90} value={windowDays}
+                  onChange={(e) => setWindowDays(Number(e.target.value))}
+                  style={{ width: '100%', accentColor: 'var(--c-navy)' }} />
+                <p style={{ margin: 0, fontSize: 10.5, color: 'var(--c-muted)', lineHeight: 1.4 }}>{t.windowHint}</p>
+              </div>
+
               <div style={{ display: 'grid', gap: 7 }}>
                 {mergeableOrdered.map((s) => {
-                  const sel = !!mergeSel[s.id]
+                  const c = classOf.get(s.id)
+                  const sel = isSelected(s.id)
+                  // A blocked source the user hasn't (yet) folded in early.
+                  const blocked = !!c && !c.eligible && !overridden[s.id] && !sel
+                  if (blocked) {
+                    return (
+                      <div key={s.id} data-testid={`merge-source-${s.id}`}
+                        style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '9px 11px', borderRadius: 10,
+                          border: '1.5px solid var(--c-line)', background: 'var(--c-card)', opacity: 0.7 }}>
+                        <span style={{ width: 18, height: 18, borderRadius: 9, flexShrink: 0, border: '1.5px solid var(--c-line-strong)', background: 'var(--c-card-2)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                          <Lock size={10} color="var(--c-muted)" />
+                        </span>
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                          <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-muted)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.name}</div>
+                          <div style={{ fontSize: 10.5, color: 'var(--c-muted)', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                            {blockReasonText(c!.reason, c!.maturityGapDays)}
+                          </div>
+                        </div>
+                        {/* Out-of-window is overridable — "Gộp sớm?" folds it in despite
+                            the window; a hard block (currency/pledged) just shows ₫ + lock. */}
+                        {c!.overridable
+                          ? <button type="button" data-testid={`merge-override-${s.id}`} onClick={() => overrideSource(s)}
+                              style={{ fontSize: 11, fontWeight: 600, color: 'var(--c-warn)', background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'inherit', flexShrink: 0, padding: 0 }}>
+                              {t.mergeEarly}
+                            </button>
+                          : <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-muted)', flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(s.value ?? s.principal ?? 0)}</span>}
+                      </div>
+                    )
+                  }
                   return (
                     <div key={s.id} style={{ display: 'grid', gap: 7 }}>
                       <button type="button" data-testid={`merge-source-${s.id}`} onClick={() => toggleSource(s)}
@@ -601,6 +732,9 @@ export function MaturityResolveBody({
                           {sel && <Check size={11} color="#fff" strokeWidth={3} />}
                         </span>
                         <span style={{ flex: 1, minWidth: 0, fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.name}</span>
+                        {/* Mark a source folded in past its window so the early-settlement
+                            risk stays visible after the override. */}
+                        {overridden[s.id] && <span style={{ fontSize: 9.5, fontWeight: 700, color: 'var(--c-warn)', flexShrink: 0, textTransform: 'uppercase', letterSpacing: '0.04em' }}>{t.mergeEarly}</span>}
                         <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(s.value ?? s.principal ?? 0)}</span>
                       </button>
                       {sel && (

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -215,7 +215,8 @@ describe('MaturityResolveBody', () => {
       await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
       expect(screen.queryByTestId('merge-penalty-caption')).toBeNull() // hidden until a source is picked
 
-      await user.click(screen.getByTestId('merge-source-sib-bank'))
+      // sibBank matures far past the anchor → out of window, folded in via override.
+      await user.click(screen.getByTestId('merge-override-sib-bank'))
       expect((screen.getByTestId('merge-received-sib-bank') as HTMLInputElement).value).toBe('8000000')
       expect(screen.getByTestId('merge-penalty-caption')).toBeTruthy()
     })
@@ -228,9 +229,10 @@ describe('MaturityResolveBody', () => {
           isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
       )
       await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
-      // Select both (ordered by investmentDate, id → sib-bank-2 opened later? -100 > -150 → sib-bank first).
-      await user.click(screen.getByTestId('merge-source-sib-bank'))
-      await user.click(screen.getByTestId('merge-source-sib-bank-2'))
+      // Both mature far past the anchor → out of window, folded in via override.
+      // (Ordered by investmentDate, id → sib-bank −150d before sib-bank-2 −100d.)
+      await user.click(screen.getByTestId('merge-override-sib-bank'))
+      await user.click(screen.getByTestId('merge-override-sib-bank-2'))
 
       fireEvent.change(screen.getByTestId('merge-total'), { target: { value: '10000000' } })
 
@@ -248,7 +250,7 @@ describe('MaturityResolveBody', () => {
           isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
       )
       await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
-      await user.click(screen.getByTestId('merge-source-sib-bank'))
+      await user.click(screen.getByTestId('merge-override-sib-bank'))
 
       // BASE = principal + interest + recurring(0) = 35,000,000 + 2,030,000.
       const BASE = 37_030_000
@@ -319,7 +321,7 @@ describe('MaturityResolveBody', () => {
       )
       await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
       expect(screen.queryByTestId('merge-dest-bank')).toBeNull() // hidden until a source is picked
-      await user.click(screen.getByTestId('merge-source-sib-vcb'))
+      await user.click(screen.getByTestId('merge-override-sib-vcb'))
       const sel = (await screen.findByTestId('merge-dest-bank')) as HTMLSelectElement
       expect(sel.value).toBe('TCB') // defaults to the settling deposit's bank
     })
@@ -332,12 +334,12 @@ describe('MaturityResolveBody', () => {
           isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
       )
       await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
-      await user.click(screen.getByTestId('merge-source-sib-vcb'))
+      await user.click(screen.getByTestId('merge-override-sib-vcb'))
       // One source folded → 2 deposits combine, but the "multiple sources" label
       // only kicks in past one selected sibling.
       expect(screen.getByTestId('merge-section-title').textContent).toMatch(/Merge other deposits/i)
 
-      await user.click(screen.getByTestId('merge-source-sib-mb'))
+      await user.click(screen.getByTestId('merge-override-sib-mb'))
       expect(screen.getByTestId('merge-section-title').textContent).toMatch(/Merge multiple sources/i)
       // Provenance counts the anchor + folded sources (3) and their distinct banks
       // (TCB, VCB, MB = 3).
@@ -354,8 +356,8 @@ describe('MaturityResolveBody', () => {
           isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
       )
       await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
-      await user.click(screen.getByTestId('merge-source-sib-vcb'))
-      await user.click(screen.getByTestId('merge-source-sib-nobank'))
+      await user.click(screen.getByTestId('merge-override-sib-vcb'))
+      await user.click(screen.getByTestId('merge-override-sib-nobank'))
       // 3 sources combine (anchor + 2) but only TCB + VCB are real banks → 2 banks.
       const prov = screen.getByTestId('merge-provenance').textContent ?? ''
       expect(prov).toMatch(/3 sources/i)
@@ -380,11 +382,107 @@ describe('MaturityResolveBody', () => {
           isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
       )
       await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
-      await user.click(screen.getByTestId('merge-source-sib-vcb'))
+      await user.click(screen.getByTestId('merge-override-sib-vcb'))
       await user.click(screen.getByRole('button', { name: /Save new deposit/i }))
 
       const sources = await screen.findByTestId('maturity-renewed-sources')
       expect(sources.textContent).toContain('Vikki VCB')
+    })
+  })
+
+  // ── Merge eligibility (PR2) ─────────────────────────────────────────────────
+  // The window rules: a sibling maturing within N days of the anchor is eligible
+  // and PRESELECTED; one maturing further out is blocked + dimmed but can be
+  // folded in via a "Gộp sớm?" override; a different-currency / pledged sibling is
+  // a HARD block (no override). The window slider re-runs the classification.
+  describe('merge eligibility', () => {
+    function stubEmptyRecurring() {
+      const fetchMock = vi.fn().mockImplementation((url: string) => {
+        if (typeof url === 'string' && url.startsWith('/api/v1/recurring-savings')) {
+          return Promise.resolve({ ok: true, json: async () => ({ savings: [] }) })
+        }
+        return Promise.resolve({ ok: true, json: async () => [] })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      return fetchMock
+    }
+
+    // Anchor (D) matured 12 days ago. An in-window sibling matures within 7 days of
+    // that; an out-of-window one is the existing far-future fixture.
+    const anchor: InvRow = { ...maturedDeposit, bankCode: 'TCB' }
+    const sibInWindow: InvRow = {
+      id: 'sib-in', name: 'VCB near', type: 'bank', value: 6_000_000, gainPct: null,
+      units: null, principal: 6_000_000, interestRate: 6, expiryDate: daysFromNow(-10), // gap 2d
+      investmentDate: daysFromNow(-180), fund: null, bankCode: 'VCB',
+    }
+    const sibOut: InvRow = {
+      id: 'sib-out', name: 'MB far', type: 'bank', value: 8_000_000, gainPct: null,
+      units: null, principal: 8_000_000, interestRate: 6, expiryDate: daysFromNow(40), // gap 52d
+      investmentDate: daysFromNow(-150), fund: null, bankCode: 'MB',
+    }
+
+    it('preselects an in-window sibling and dims an out-of-window one behind a "merge early" override', async () => {
+      const user = userEvent.setup()
+      stubEmptyRecurring()
+      render(
+        <MaturityResolveBody inv={anchor} goalId="goal-1" siblingDeposits={[anchor, sibInWindow, sibOut]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+
+      // In-window → preselected, so its received field is already shown + prefilled.
+      expect((await screen.findByTestId('merge-received-sib-in') as HTMLInputElement).value).toBe('6000000')
+      // Out-of-window → not selected; offered behind an override, no received field yet.
+      expect(screen.getByTestId('merge-override-sib-out')).toBeTruthy()
+      expect(screen.queryByTestId('merge-received-sib-out')).toBeNull()
+    })
+
+    it('widening the window via the slider reclassifies an out-of-window sibling as eligible', async () => {
+      const user = userEvent.setup()
+      stubEmptyRecurring()
+      render(
+        <MaturityResolveBody inv={anchor} goalId="goal-1" siblingDeposits={[anchor, sibOut]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+      expect(screen.getByTestId('merge-override-sib-out')).toBeTruthy()
+      expect(screen.queryByTestId('merge-received-sib-out')).toBeNull()
+
+      // Push the window past the 52-day gap → it becomes eligible and auto-selects.
+      fireEvent.change(screen.getByTestId('merge-window-slider'), { target: { value: '60' } })
+      expect(screen.queryByTestId('merge-override-sib-out')).toBeNull()
+      expect((screen.getByTestId('merge-received-sib-out') as HTMLInputElement).value).toBe('8000000')
+    })
+
+    it('hard-blocks a different-currency sibling with no override', async () => {
+      const user = userEvent.setup()
+      stubEmptyRecurring()
+      const sibUSD: InvRow = { ...sibInWindow, id: 'sib-usd', name: 'USD savings', currency: 'USD' }
+      render(
+        <MaturityResolveBody inv={anchor} goalId="goal-1" siblingDeposits={[anchor, sibUSD]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+
+      const row = await screen.findByTestId('merge-source-sib-usd')
+      expect(row.textContent).toMatch(/currency/i)              // reason shown
+      expect(screen.queryByTestId('merge-override-sib-usd')).toBeNull()   // not overridable
+      expect(screen.queryByTestId('merge-received-sib-usd')).toBeNull()   // not selectable
+    })
+
+    it('folds an out-of-window sibling in via the override, prefilling its received cash', async () => {
+      const user = userEvent.setup()
+      stubEmptyRecurring()
+      render(
+        <MaturityResolveBody inv={anchor} goalId="goal-1" siblingDeposits={[anchor, sibOut]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+      await user.click(screen.getByTestId('merge-override-sib-out'))
+
+      expect((screen.getByTestId('merge-received-sib-out') as HTMLInputElement).value).toBe('8000000')
+      // Anchor + the one folded source = 2 sources of provenance.
+      expect(screen.getByTestId('merge-provenance').textContent).toMatch(/2 sources/i)
     })
   })
 

--- a/app/assets/components/__tests__/goalDetailShared.test.tsx
+++ b/app/assets/components/__tests__/goalDetailShared.test.tsx
@@ -68,6 +68,25 @@ describe('buildInvRows', () => {
     expect(gold.bankCode ?? null).toBeNull() // structured bank only applies to bank deposits
   })
 
+  it('carries currency + is_pledged through to InvRow for the merge eligibility rules', () => {
+    const rows = buildInvRows(
+      [
+        baseTx({ transaction_id: 'usd', asset_type: 'bank', amount_vnd: 5_000_000, interest_rate: 6, currency: 'USD' }),
+        baseTx({ transaction_id: 'pledged', asset_type: 'bank', amount_vnd: 7_000_000, interest_rate: 6, is_pledged: true }),
+        baseTx({ transaction_id: 'legacy', asset_type: 'bank', amount_vnd: 3_000_000, interest_rate: 6 }),
+      ],
+      [], null, false,
+    )
+    const usd = rows.find((r) => r.id === 'usd')!
+    const pledged = rows.find((r) => r.id === 'pledged')!
+    const legacy = rows.find((r) => r.id === 'legacy')!
+    expect(usd.currency).toBe('USD')
+    expect(pledged.isPledged).toBe(true)
+    // Legacy deposits predate the columns — default to VND / not pledged.
+    expect(legacy.currency ?? 'VND').toBe('VND')
+    expect(legacy.isPledged ?? false).toBe(false)
+  })
+
   it('uses the anchor tranche bank_code for an accumulating book row', () => {
     const rows = buildInvRows(
       [

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -219,6 +219,10 @@ export interface InvRow {
   // non-bank holding or a deposit with no bank set yet. Drives the multi-source
   // merge destination-bank default and the "N nguồn · M ngân hàng" provenance.
   bankCode?: string | null
+  // Currency (default 'VND') + collateral flag. Carried for the merge eligibility
+  // rules ("same currency" / "not pledged"). null/false on legacy deposits.
+  currency?: string | null
+  isPledged?: boolean | null
   // The book's tranches (top-ups), newest first, for the detail view. Each is one
   // underlying row; present only on an accumulating book row.
   tranches?: InvTranche[] | null
@@ -261,6 +265,10 @@ export interface GoalDetailTx {
   deposit_group_id?: string | null
   // Structured bank reference (FK to banks.code); null until the user sets it.
   bank_code?: string | null
+  // Currency (default 'VND') + collateral flag for the merge eligibility rules.
+  // null/false on legacy deposits.
+  currency?: string | null
+  is_pledged?: boolean | null
 }
 
 // Roll up a deposit's renewal history from the snapshot rows that point at it.
@@ -376,7 +384,7 @@ export function buildInvRows(
       }
     }
 
-    return { id: tx.transaction_id, name, type: tx.asset_type, value, gainPct, units, principal, interestRate: tx.interest_rate ?? null, expiryDate: tx.expiry_date ?? null, investmentDate: fund ? null : (tx.investment_date ?? null), fund: fund ?? null, depositGroupId: null, bankCode: tx.asset_type === 'bank' ? (tx.bank_code ?? null) : null }
+    return { id: tx.transaction_id, name, type: tx.asset_type, value, gainPct, units, principal, interestRate: tx.interest_rate ?? null, expiryDate: tx.expiry_date ?? null, investmentDate: fund ? null : (tx.investment_date ?? null), fund: fund ?? null, depositGroupId: null, bankCode: tx.asset_type === 'bank' ? (tx.bank_code ?? null) : null, currency: tx.currency ?? null, isPledged: tx.is_pledged ?? false }
   }).filter((row): row is InvRow => row !== null)
 
   // One InvRow per accumulating book: value each tranche on its own locked rate
@@ -411,6 +419,8 @@ export function buildInvRows(
       fund: null,
       depositGroupId: groupId,
       bankCode: anchor.bank_code ?? null, // bank is book-level; the anchor carries it
+      currency: anchor.currency ?? null,
+      isPledged: anchor.is_pledged ?? false,
       tranches,
     }
   }).filter((row): row is InvRow => row !== null)

--- a/e2e/maturity-combine-merge.spec.ts
+++ b/e2e/maturity-combine-merge.spec.ts
@@ -78,8 +78,10 @@ test.describe('Term-deposit maturity — merge a sibling deposit into the re-dep
       await page.getByText(/^(Handle maturity|Xử lý đáo hạn)$/).click()
       await page.getByRole('button', { name: /Settle & re-deposit|Tất toán & gửi lại/i }).click()
 
-      // Select S in the merge list; its received prefills to S's current value.
-      await page.getByTestId(`merge-source-${S.transaction_id}`).click()
+      // S matures 60d out — well past D's, so it's out of the merge window and
+      // offered behind a "Gộp sớm?" override (early settlement). Fold it in; its
+      // received prefills to S's current value.
+      await page.getByTestId(`merge-override-${S.transaction_id}`).click()
       await expect(page.getByTestId('merge-penalty-caption')).toBeVisible()
 
       // Capture the renew request so we can prove the server (not the client)
@@ -134,6 +136,60 @@ test.describe('Term-deposit maturity — merge a sibling deposit into the re-dep
     }
   })
 
+  // Eligibility (PR2): a sibling maturing within the window of D is PRESELECTED
+  // (its received field shows without a click); one maturing far out is dimmed
+  // behind a "Gộp sớm?" override. Widening the window slider reclassifies the far
+  // sibling as eligible and auto-selects it. Pure rendered-outcome assertions.
+  test('preselects an in-window sibling, gates a far one behind the window slider', async ({ page }) => {
+    test.slow()
+    const goal = await api.createGoal({ goal_name: 'E2E Elig Goal', target_amount: 200_000_000 })
+    const D = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 20_000_000, investment_date: iso(-380),
+      interest_rate: 6, expiry_date: iso(-15), goal_id: goal.goal_id, notes: 'E2E Elig D',
+    })
+    const sIn = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 6_000_000, investment_date: iso(-200),
+      interest_rate: 6, expiry_date: iso(-12), goal_id: goal.goal_id, notes: 'E2E Elig In', // gap 3d
+    })
+    const sOut = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 9_000_000, investment_date: iso(-120),
+      interest_rate: 6, expiry_date: iso(60), goal_id: goal.goal_id, notes: 'E2E Elig Out', // gap 75d
+    })
+    try {
+      await gotoFreshDashboard(page)
+      await page.getByText('E2E Elig Goal').first().click()
+      const panel = page.getByTestId('desktop-goal-detail')
+      await expect(panel).toBeVisible({ timeout: 10_000 })
+      await expect(panel.getByText('E2E Elig D')).toBeVisible({ timeout: 10_000 })
+
+      const dRow = panel
+        .locator('div')
+        .filter({ has: page.getByRole('button', { name: 'Options', exact: true }) })
+        .filter({ hasText: 'E2E Elig D' })
+        .last()
+      await dRow.getByRole('button', { name: 'Options', exact: true }).click()
+      await page.getByText(/^(Handle maturity|Xử lý đáo hạn)$/).click()
+      await page.getByRole('button', { name: /Settle & re-deposit|Tất toán & gửi lại/i }).click()
+
+      // In-window sibling is preselected → its received field is already shown.
+      await expect(page.getByTestId(`merge-received-${sIn.transaction_id}`)).toBeVisible()
+      // Far sibling is gated behind the override, with no received field yet.
+      await expect(page.getByTestId(`merge-override-${sOut.transaction_id}`)).toBeVisible()
+      await expect(page.getByTestId(`merge-received-${sOut.transaction_id}`)).toBeHidden()
+
+      // Widen the window past the 75-day gap → the far sibling becomes eligible and
+      // auto-selects (override gone, received field appears).
+      await page.getByTestId('merge-window-slider').fill('90')
+      await expect(page.getByTestId(`merge-override-${sOut.transaction_id}`)).toBeHidden()
+      await expect(page.getByTestId(`merge-received-${sOut.transaction_id}`)).toBeVisible()
+    } finally {
+      await api.deleteTransactionCascade(sIn.transaction_id)
+      await api.deleteTransactionCascade(sOut.transaction_id)
+      await api.deleteTransactionCascade(D.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
   // Multi-source merge UX (PR1): the combined re-deposit lands at a chosen
   // destination bank, and the provenance reflects how many sources/banks fold in.
   // D sits at VCB, S at MB → "2 sources · 2 banks". We move the destination to
@@ -165,7 +221,8 @@ test.describe('Term-deposit maturity — merge a sibling deposit into the re-dep
       await page.getByText(/^(Handle maturity|Xử lý đáo hạn)$/).click()
       await page.getByRole('button', { name: /Settle & re-deposit|Tất toán & gửi lại/i }).click()
 
-      await page.getByTestId(`merge-source-${S.transaction_id}`).click()
+      // S matures 60d out → out of window; fold it in via the "Gộp sớm?" override.
+      await page.getByTestId(`merge-override-${S.transaction_id}`).click()
 
       // Provenance: anchor (VCB) + sibling (MB) = 2 sources across 2 banks.
       const prov = page.getByTestId('merge-provenance')

--- a/lib/__tests__/mergeEligibility.test.ts
+++ b/lib/__tests__/mergeEligibility.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import { classifyMergeSource, classifyMergeSources, type MergeEligInput } from '../mergeEligibility'
+
+// A YYYY-MM-DD string `n` days from the anchor's maturity, so gaps are explicit.
+function plusDays(iso: string, n: number): string {
+  const d = new Date(iso + 'T00:00:00Z')
+  d.setUTCDate(d.getUTCDate() + n)
+  return d.toISOString().slice(0, 10)
+}
+
+const ANCHOR_MAT = '2026-07-05'
+const anchor: MergeEligInput = {
+  id: 'D', type: 'bank', expiryDate: ANCHOR_MAT, principal: 50_000_000,
+  currency: 'VND', isPledged: false, goalId: 'goal-1',
+}
+
+// A liquidatable, same-currency, unpledged, same-goal bank deposit maturing `gap`
+// days from the anchor.
+function sib(over: Partial<MergeEligInput> & { id: string }): MergeEligInput {
+  return {
+    type: 'bank', expiryDate: ANCHOR_MAT, principal: 10_000_000,
+    currency: 'VND', isPledged: false, goalId: 'goal-1', ...over,
+  }
+}
+
+describe('classifyMergeSource', () => {
+  it('marks a same-goal, in-window, same-currency, unpledged bank deposit eligible', () => {
+    const c = classifyMergeSource(anchor, sib({ id: 's', expiryDate: plusDays(ANCHOR_MAT, 3) }), 7)
+    expect(c.eligible).toBe(true)
+    expect(c.reason).toBeNull()
+    expect(c.maturityGapDays).toBe(3)
+  })
+
+  it('blocks a deposit maturing outside the window — overridable ("Gộp sớm?")', () => {
+    const c = classifyMergeSource(anchor, sib({ id: 's', expiryDate: plusDays(ANCHOR_MAT, 30) }), 7)
+    expect(c.eligible).toBe(false)
+    expect(c.reason).toBe('out-of-window')
+    expect(c.overridable).toBe(true)
+    expect(c.maturityGapDays).toBe(30)
+  })
+
+  it('counts the window symmetrically — a deposit maturing earlier is still in-window', () => {
+    const c = classifyMergeSource(anchor, sib({ id: 's', expiryDate: plusDays(ANCHOR_MAT, -7) }), 7)
+    expect(c.eligible).toBe(true)
+    expect(c.maturityGapDays).toBe(7) // |−7| = 7, exactly on the boundary (inclusive)
+  })
+
+  it('blocks a different currency — a hard block (not overridable)', () => {
+    const c = classifyMergeSource(anchor, sib({ id: 's', currency: 'USD', expiryDate: plusDays(ANCHOR_MAT, 1) }), 7)
+    expect(c.eligible).toBe(false)
+    expect(c.reason).toBe('different-currency')
+    expect(c.overridable).toBe(false)
+  })
+
+  it('blocks a pledged deposit — a hard block (not overridable)', () => {
+    const c = classifyMergeSource(anchor, sib({ id: 's', isPledged: true, expiryDate: plusDays(ANCHOR_MAT, 1) }), 7)
+    expect(c.eligible).toBe(false)
+    expect(c.reason).toBe('pledged')
+    expect(c.overridable).toBe(false)
+  })
+
+  it('blocks a non-liquidatable source (a fund / book / fully-withdrawn deposit)', () => {
+    expect(classifyMergeSource(anchor, sib({ id: 'f', type: 'fund' }), 7).reason).toBe('not-liquidatable')
+    expect(classifyMergeSource(anchor, sib({ id: 'bk', depositGroupId: 'book-1' }), 7).reason).toBe('not-liquidatable')
+    expect(classifyMergeSource(anchor, sib({ id: 'z', principal: 0, value: 0 }), 7).reason).toBe('not-liquidatable')
+  })
+
+  it('blocks a different-goal source when both goals are known (hard block)', () => {
+    const c = classifyMergeSource(anchor, sib({ id: 's', goalId: 'goal-2', expiryDate: plusDays(ANCHOR_MAT, 1) }), 7)
+    expect(c.eligible).toBe(false)
+    expect(c.reason).toBe('different-goal')
+    expect(c.overridable).toBe(false)
+  })
+
+  it('skips the goal check when a goal id is missing on either side (same-goal scoping is the caller\'s job)', () => {
+    const c = classifyMergeSource({ ...anchor, goalId: null }, sib({ id: 's', goalId: 'goal-2', expiryDate: plusDays(ANCHOR_MAT, 1) }), 7)
+    expect(c.eligible).toBe(true)
+  })
+
+  it('treats an absent currency as VND (legacy deposits) so it does not falsely block', () => {
+    const c = classifyMergeSource(
+      { ...anchor, currency: null },
+      sib({ id: 's', currency: undefined, expiryDate: plusDays(ANCHOR_MAT, 1) }),
+      7,
+    )
+    expect(c.eligible).toBe(true)
+  })
+
+  it('defaults the window to 7 days', () => {
+    expect(classifyMergeSource(anchor, sib({ id: 's', expiryDate: plusDays(ANCHOR_MAT, 7) })).eligible).toBe(true)
+    expect(classifyMergeSource(anchor, sib({ id: 's', expiryDate: plusDays(ANCHOR_MAT, 8) })).eligible).toBe(false)
+  })
+
+  it('widening the window reclassifies an out-of-window source as eligible', () => {
+    const s = sib({ id: 's', expiryDate: plusDays(ANCHOR_MAT, 14) })
+    expect(classifyMergeSource(anchor, s, 7).eligible).toBe(false)
+    expect(classifyMergeSource(anchor, s, 14).eligible).toBe(true)
+  })
+
+  it('out-of-window takes precedence only after the hard blocks (currency before window)', () => {
+    // Both out-of-window AND different currency → the hard currency block wins, so
+    // the UI never offers a "Gộp sớm?" override for a deposit it can never merge.
+    const c = classifyMergeSource(anchor, sib({ id: 's', currency: 'USD', expiryDate: plusDays(ANCHOR_MAT, 30) }), 7)
+    expect(c.reason).toBe('different-currency')
+    expect(c.overridable).toBe(false)
+  })
+})
+
+describe('classifyMergeSources', () => {
+  it('classifies each sibling and preserves order', () => {
+    const out = classifyMergeSources(anchor, [
+      sib({ id: 'a', expiryDate: plusDays(ANCHOR_MAT, 2) }),
+      sib({ id: 'b', expiryDate: plusDays(ANCHOR_MAT, 40) }),
+      sib({ id: 'c', isPledged: true }),
+    ], 7)
+    expect(out.map((c) => c.source.id)).toEqual(['a', 'b', 'c'])
+    expect(out.map((c) => c.eligible)).toEqual([true, false, false])
+    expect(out.map((c) => c.reason)).toEqual([null, 'out-of-window', 'pledged'])
+  })
+})

--- a/lib/mergeEligibility.ts
+++ b/lib/mergeEligibility.ts
@@ -1,0 +1,111 @@
+// Eligibility ruleset for folding a sibling source into a maturity re-deposit
+// ("Gộp nhiều nguồn"). Pure + deterministic so the merge sheet (preselect the
+// eligible, dim the blocked) and the PR3 cluster auto-detector can share one
+// source of truth, and so the rules are unit-testable in isolation.
+//
+// The five conditions (see the design's "Bộ luật" card):
+//   1. Same goal          — every source points at one goal (the cluster key).
+//   2. Liquidatable       — an active single bank term deposit (not a fund/gold,
+//                           not an accumulating book, not fully withdrawn).
+//   3. Maturities close    — |source.maturity − anchor.maturity| ≤ window days.
+//   4. Same currency      — no mixing VND with a foreign currency.
+//   5. Not pledged        — not frozen as collateral.
+//
+// Rule 1 (same goal) is normally the *caller's* job: the merge sheet only ever
+// passes a goal's own holdings, so it's enforced by scoping. We still check it
+// here when both goal ids are known, so the cluster detector can lean on the
+// same predicate. Only rule 3 is a *soft* block — the user can override it
+// ("Gộp sớm?", accepting an early-settlement penalty); the rest are hard.
+
+export type MergeBlockReason =
+  | 'not-liquidatable'
+  | 'different-goal'
+  | 'different-currency'
+  | 'pledged'
+  | 'out-of-window'
+
+// The minimal shape the rules read. InvRow (goal-detail) is structurally
+// assignable to it; the overview NonFundEntry carries the same fields.
+export interface MergeEligInput {
+  id: string
+  type: string
+  // Maturity (YYYY-MM-DD); null for a holding with no term.
+  expiryDate: string | null
+  principal?: number | null
+  value?: number | null
+  // Set for an accumulating book — excluded from the single-deposit merge.
+  depositGroupId?: string | null
+  // null/undefined → treated as VND (legacy deposits predate the column).
+  currency?: string | null
+  isPledged?: boolean | null
+  // Optional — the goal check runs only when both sides supply one.
+  goalId?: string | null
+}
+
+export interface MergeClassification {
+  source: MergeEligInput
+  eligible: boolean
+  // The first failing rule (hard blocks before the soft window block), or null
+  // when eligible.
+  reason: MergeBlockReason | null
+  // Only the window block is overridable ("Gộp sớm?"). Hard blocks are false.
+  overridable: boolean
+  // |source.maturity − anchor.maturity| in whole days; null when either maturity
+  // is missing (so closeness can't be measured — treated as out-of-window).
+  maturityGapDays: number | null
+}
+
+const DEFAULT_CURRENCY = 'VND'
+
+// Whole-day difference between two YYYY-MM-DD dates, via UTC midnight so DST and
+// local-offset shifts can't round it off by a day.
+function dayDiff(a: string, b: string): number {
+  const ms = Date.parse(a + 'T00:00:00Z') - Date.parse(b + 'T00:00:00Z')
+  return Math.round(ms / 86_400_000)
+}
+
+function currencyOf(s: MergeEligInput): string {
+  return s.currency ?? DEFAULT_CURRENCY
+}
+
+export function classifyMergeSource(
+  anchor: MergeEligInput,
+  source: MergeEligInput,
+  windowDays = 7,
+): MergeClassification {
+  // An active single bank term deposit with a positive balance.
+  const liquidatable =
+    source.type === 'bank' &&
+    !source.depositGroupId &&
+    (source.principal ?? source.value ?? 0) > 0
+
+  const gap =
+    anchor.expiryDate && source.expiryDate
+      ? Math.abs(dayDiff(source.expiryDate, anchor.expiryDate))
+      : null
+
+  let reason: MergeBlockReason | null = null
+  let overridable = false
+  if (!liquidatable) {
+    reason = 'not-liquidatable'
+  } else if (anchor.goalId != null && source.goalId != null && source.goalId !== anchor.goalId) {
+    reason = 'different-goal'
+  } else if (currencyOf(source) !== currencyOf(anchor)) {
+    reason = 'different-currency'
+  } else if (source.isPledged) {
+    reason = 'pledged'
+  } else if (gap == null || gap > windowDays) {
+    reason = 'out-of-window'
+    overridable = true
+  }
+
+  return { source, eligible: reason === null, reason, overridable, maturityGapDays: gap }
+}
+
+export function classifyMergeSources(
+  anchor: MergeEligInput,
+  siblings: MergeEligInput[],
+  windowDays = 7,
+): MergeClassification[] {
+  return siblings.map((s) => classifyMergeSource(anchor, s, windowDays))
+}


### PR DESCRIPTION
## What

PR2 of **Gộp nhiều nguồn** (multi-source deposit merge). Adds the eligibility ruleset and surfaces it in the maturity *combine* sheet. Builds fresh off `main` after PR0 (#368) and PR1 (#369).

### The ruleset — `lib/mergeEligibility.ts`
Pure, deterministic `classifyMergeSources(anchor, siblings, windowDays=7)`. A sibling is **eligible** when it is:
1. **Liquidatable** — an active single bank term deposit (not a fund/gold, not an accumulating book, not fully withdrawn)
2. **Same goal** — checked when both goal ids are known (the sheet already scopes to one goal)
3. **Maturities close** — `|source.maturity − anchor.maturity| ≤ windowDays`
4. **Same currency**
5. **Not pledged**

Only the **window** block is soft → overridable ("Gộp sớm?", accepting an early-settlement penalty). Currency / pledged / different-goal are **hard** blocks (no override). The first failing rule wins, hard blocks before the window block.

### UI — `MaturityResolveSheet`
- Eligible siblings are **preselected** (received prefilled, so they never submit 0₫).
- Out-of-window siblings are **dimmed + reason**, foldable in via a **"Gộp sớm?"** override.
- Hard-blocked siblings are dimmed with a reason + lock, **not selectable**.
- A **window slider** re-runs the classification live; widening it auto-selects newly-eligible siblings.
- Selection is *derived* from eligibility (explicit toggles + overrides layered on top), so widening the window re-defaults an untouched source without clobbering a manual pick.

### Data plumbing
`currency` + `isPledged` now ride through `GoalDetailTx → buildInvRows → InvRow` (the overview API already returns them from PR0), so the predicates are honest. Legacy deposits default to VND / not pledged.

No DB migration, no route change — PR2 is pure client logic + a lib.

## Tests (TDD)
- `lib/__tests__/mergeEligibility.test.ts` — 13 unit tests (window symmetry, hard vs soft blocks, precedence, widening).
- `buildInvRows` carries `currency` / `isPledged` (2 tests).
- Sheet behaviour: preselect in-window, slider reclassify, hard-block no-override, "Gộp sớm?" fold-in (4 tests). Existing merge tests updated to the override path.
- Full unit suite: **742 passed**. Lint/tsc clean (no new problems).
- Targeted E2E (Edge, local WSL2 stack): `maturity-combine-merge` (5, incl. a new preselect/slider rendered-outcome test) + `maturity-combine*` / `accumulating-*` / `goal-detail-desktop` — **26 passed**.

## Follow-ups (later PRs)
- **PR3** — cluster auto-detection on the overview "Cần xử lý".
- **PR4** — Ví chờ gộp (holding pool), highest risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)