### PR TITLE
feat(deposits): auto-detect merge clusters on the maturity card (PR3)

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -21,6 +21,7 @@ import RecentActivityCard from './components/RecentActivityCard'
 import MaturityActionCard from './components/MaturityActionCard'
 import { MaturityResolveSheet, MaturityResolveModal } from './components/MaturityResolveSheet'
 import { isActionableTermDeposit, MATURING_COUNT_EVENT } from '@/lib/maturity'
+import { detectMergeClusters } from '@/lib/mergeCluster'
 import { actionableBooks } from './maturityCardItems'
 import { collapseUnallocatedBooks } from './unallocatedBooks'
 import type { InvRow } from './components/goalDetailShared'
@@ -92,6 +93,12 @@ export interface NonFundUnallocatedItem {
   // Set on a tranche of an accumulating book — keeps the book out of the
   // maturity "needs attention" card (it isn't renewed via the single-row flow).
   depositGroupId?: string | null
+  // Structured bank (FK) + currency + pledged flag — null/false on legacy
+  // deposits. Drive the merge destination-bank default and the eligibility
+  // "same currency" / "not pledged" rules (see lib/mergeEligibility).
+  bankCode?: string | null
+  currency?: string | null
+  isPledged?: boolean | null
 }
 
 export interface DashboardData {
@@ -209,12 +216,23 @@ function nonFundToInvRow(it: NonFundUnallocatedItem, isVi: boolean): InvRow {
     investmentDate: it.investmentDate,
     fund: null,
     depositGroupId: it.depositGroupId ?? null,
+    bankCode: it.type === 'bank' ? (it.bankCode ?? null) : null,
+    currency: it.currency ?? null,
+    isPledged: it.isPledged ?? false,
   }
 }
 
 // A maturing deposit plus the context needed to act on it: the goal it belongs
 // to (null when unassigned) and the raw item for the withdraw flow.
-interface MaturingDep { inv: InvRow; goalId: string | null; raw: NonFundUnallocatedItem }
+interface MaturingDep {
+  inv: InvRow
+  goalId: string | null
+  raw: NonFundUnallocatedItem
+  // The goal's other bank deposits, attached when the resolve flow opens so the
+  // merge UI can fold close-maturing siblings into this re-deposit. Computed lazily
+  // (only on open) to keep it off the hot maturingDeposits list.
+  siblings?: InvRow[]
+}
 
 // Build the SellWithdrawSheet payload for a non-fund holding (bank/gold/stock).
 function nonFundToSellItem(item: NonFundUnallocatedItem): SellItem {
@@ -538,6 +556,41 @@ export default function DashboardClient({ userId }: { userId: string }) {
       .map((b) => ({ inv: b.inv, goalId: b.goalId, raw: b.anchor })),
   ]
 
+  // Auto-detect goals whose maturing deposits fall close together, so the card can
+  // offer a one-tap "gộp lại" (merge) shortcut. The detector reuses the eligibility
+  // rules, so its count matches what the resolve sheet will preselect.
+  const mergeClusters = detectMergeClusters(
+    maturingDeposits.map((d) => ({
+      id: d.inv.id, goalId: d.goalId, type: d.inv.type, expiryDate: d.inv.expiryDate,
+      depositGroupId: d.inv.depositGroupId, principal: d.inv.principal, value: d.inv.value,
+      currency: d.inv.currency, isPledged: d.inv.isPledged,
+    })),
+  ).map((c) => ({ anchorId: c.anchorId, size: c.size }))
+
+  // A goal's OTHER bank deposits, mapped to InvRows the merge flow can fold into a
+  // re-deposit. Books are mapped too but the sheet filters them out. Empty for an
+  // unassigned deposit (merge is goal-scoped).
+  function goalSiblingInvRows(goalId: string | null, excludeId: string): InvRow[] {
+    if (!data || goalId == null) return []
+    const goal = data.goals.find((g) => g.goalId === goalId)
+    return (goal?.nonFunds ?? [])
+      .filter((it) => it.transactionId !== excludeId && it.type === 'bank')
+      .map((it) => nonFundToInvRow(it, isVi))
+  }
+
+  // Open the resolve flow for a maturing deposit, attaching the goal's siblings so
+  // the merge UI is available (and close-maturing ones preselect).
+  function openResolve(dep: MaturingDep) {
+    setResolveDep({ ...dep, siblings: goalSiblingInvRows(dep.goalId, dep.inv.id) })
+  }
+
+  // Resolve a maturing deposit by its id (used by the card's "handle" + the
+  // cluster banner, which opens on the anchor = latest maturity).
+  function resolveById(id: string) {
+    const dep = maturingDeposits.find((d) => d.inv.id === id)
+    if (dep) openResolve(dep)
+  }
+
   // Withdraw from the maturity card: open the withdraw sheet pre-targeted at the
   // deposit in one tap. A goal-assigned deposit withdraws in its goal context so
   // the withdrawal links to the goal (issue #261); an unassigned one uses the
@@ -704,7 +757,9 @@ export default function DashboardClient({ userId }: { userId: string }) {
                 <MaturityActionCard
                   items={maturingDeposits.map((d) => d.inv)}
                   isVi={isVi}
-                  onResolve={(inv) => setResolveDep(maturingDeposits.find((d) => d.inv.id === inv.id) ?? null)}
+                  onResolve={(inv) => resolveById(inv.id)}
+                  clusters={mergeClusters}
+                  onMergeCluster={resolveById}
                   style={{ marginBottom: 24 }}
                 />
                 {/* Goals */}
@@ -877,7 +932,9 @@ export default function DashboardClient({ userId }: { userId: string }) {
               <MaturityActionCard
                 items={maturingDeposits.map((d) => d.inv)}
                 isVi={isVi}
-                onResolve={(inv) => setResolveDep(maturingDeposits.find((d) => d.inv.id === inv.id) ?? null)}
+                onResolve={(inv) => resolveById(inv.id)}
+                clusters={mergeClusters}
+                onMergeCluster={resolveById}
               />
 
               {/* Goals */}
@@ -1106,6 +1163,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
           open={!!resolveDep}
           inv={resolveDep?.inv ?? null}
           goalId={resolveDep?.goalId ?? null}
+          siblingDeposits={resolveDep?.siblings}
           isVi={isVi}
           onClose={() => setResolveDep(null)}
           onRenewed={() => { setResolveDep(null); fetchData({ force: true }) }}
@@ -1116,6 +1174,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
         <MaturityResolveModal
           inv={resolveDep.inv}
           goalId={resolveDep.goalId ?? null}
+          siblingDeposits={resolveDep.siblings}
           isVi={isVi}
           onClose={() => setResolveDep(null)}
           onRenewed={() => { setResolveDep(null); fetchData({ force: true }) }}

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -556,14 +556,18 @@ export default function DashboardClient({ userId }: { userId: string }) {
       .map((b) => ({ inv: b.inv, goalId: b.goalId, raw: b.anchor })),
   ]
 
-  // Auto-detect goals whose maturing deposits fall close together, so the card can
-  // offer a one-tap "gộp lại" (merge) shortcut. The detector reuses the eligibility
-  // rules, so its count matches what the resolve sheet will preselect.
+  // Auto-detect goals whose deposits fall close together, so the card can offer a
+  // one-tap "gộp lại" (merge) shortcut. Fed from ALL the goal's bank deposits (not
+  // just the actionable ones) with an `actionable` flag: the anchor must be due now
+  // — that's what the card surfaces and the sheet opens on — but a close-maturing
+  // sibling counts even if it isn't due yet, exactly matching what the sheet
+  // preselects. Reuses the eligibility rules, so the banner can't over-promise.
   const mergeClusters = detectMergeClusters(
-    maturingDeposits.map((d) => ({
-      id: d.inv.id, goalId: d.goalId, type: d.inv.type, expiryDate: d.inv.expiryDate,
-      depositGroupId: d.inv.depositGroupId, principal: d.inv.principal, value: d.inv.value,
-      currency: d.inv.currency, isPledged: d.inv.isPledged,
+    taggedNonFunds.map(({ it, goalId }) => ({
+      id: it.transactionId, goalId, type: it.type, expiryDate: it.expiryDate,
+      depositGroupId: it.depositGroupId ?? null, principal: it.amount, value: it.currentValue,
+      currency: it.currency ?? null, isPledged: it.isPledged ?? false,
+      actionable: isActionableTermDeposit(it),
     })),
   ).map((c) => ({ anchorId: c.anchorId, size: c.size }))
 

--- a/app/assets/components/MaturityActionCard.tsx
+++ b/app/assets/components/MaturityActionCard.tsx
@@ -6,7 +6,7 @@
 // act on. Purely presentational — the parent supplies the already-filtered rows
 // (see isActionableTermDeposit) and handles the resolve flow.
 
-import { AlertTriangle, Building2, RefreshCw } from 'lucide-react'
+import { AlertTriangle, Building2, RefreshCw, GitMerge } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
 import { daysUntil } from '@/lib/maturity'
 import { GD_COLORS, type InvRow } from './goalDetailShared'
@@ -27,12 +27,20 @@ function pillFor(inv: InvRow, isVi: boolean): { text: string; color: string; bg:
   }
 }
 
+// A detected group of a goal's deposits maturing close together (see
+// detectMergeClusters). The card surfaces each as a one-tap "merge them" banner
+// that opens the resolve sheet on the anchor with the siblings preselected.
+export interface MaturityCluster { anchorId: string; size: number }
+
 export default function MaturityActionCard({
-  items, isVi, onResolve, style,
+  items, isVi, onResolve, clusters, onMergeCluster, style,
 }: {
   items: InvRow[]
   isVi: boolean
   onResolve: (inv: InvRow) => void
+  // Merge clusters among `items`. Each banner opens the sheet on its anchor.
+  clusters?: MaturityCluster[]
+  onMergeCluster?: (anchorId: string) => void
   style?: React.CSSProperties
 }) {
   if (!items.length) return null
@@ -48,6 +56,28 @@ export default function MaturityActionCard({
           {items.length}
         </span>
       </div>
+      {(clusters ?? []).map((c) => (
+        <div
+          key={c.anchorId}
+          data-testid={`merge-cluster-banner-${c.anchorId}`}
+          style={{ padding: '10px 16px', display: 'flex', alignItems: 'center', gap: 10, background: 'var(--c-card-2)', borderBottom: '1px solid var(--c-line)' }}
+        >
+          <GitMerge size={15} strokeWidth={2.2} style={{ color: GD_COLORS.bank, flexShrink: 0 }} />
+          <span style={{ fontSize: 12.5, fontWeight: 600, flex: 1, minWidth: 0 }}>
+            {isVi
+              ? `${c.size} sổ đáo hạn sát nhau`
+              : `${c.size} deposits maturing close together`}
+          </span>
+          <button
+            onClick={() => onMergeCluster?.(c.anchorId)}
+            className="cn-btn"
+            style={{ padding: '6px 12px', minHeight: 44, fontSize: 12, fontWeight: 600, gap: 5, flexShrink: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          >
+            <GitMerge size={12} strokeWidth={2.2} />
+            {isVi ? 'Gộp lại' : 'Merge'}
+          </button>
+        </div>
+      ))}
       <div style={{ padding: '4px 16px 6px' }}>
         {items.map((inv, i) => {
           const pill = pillFor(inv, isVi)

--- a/app/assets/components/__tests__/MaturityActionCard.test.tsx
+++ b/app/assets/components/__tests__/MaturityActionCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MaturityActionCard from '../MaturityActionCard'
 import type { InvRow } from '../goalDetailShared'
@@ -48,5 +48,31 @@ describe('MaturityActionCard', () => {
     expect(screen.getByText('No Expiry')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Handle/i })).toBeInTheDocument()
     expect(screen.queryByText(/overdue|Matured|Matures/i)).not.toBeInTheDocument()
+  })
+
+  it('shows no merge banner when there are no clusters', () => {
+    render(<MaturityActionCard items={[mk({ id: 'a' }), mk({ id: 'b' })]} isVi={false} onResolve={() => {}} />)
+    expect(screen.queryByTestId(/^merge-cluster-banner-/)).not.toBeInTheDocument()
+  })
+
+  it('renders a merge-cluster banner and fires onMergeCluster with the anchor id', async () => {
+    const user = userEvent.setup()
+    const onMergeCluster = vi.fn()
+    render(
+      <MaturityActionCard
+        items={[mk({ id: 'a' }), mk({ id: 'b' })]}
+        isVi
+        onResolve={() => {}}
+        clusters={[{ anchorId: 'b', size: 2 }]}
+        onMergeCluster={onMergeCluster}
+      />,
+    )
+    const banner = screen.getByTestId('merge-cluster-banner-b')
+    expect(banner).toBeInTheDocument()
+    // The count is surfaced so the call-out reads "2 sổ ...".
+    expect(banner.textContent).toMatch(/2/)
+    await user.click(within(banner).getByRole('button'))
+    expect(onMergeCluster).toHaveBeenCalledTimes(1)
+    expect(onMergeCluster).toHaveBeenCalledWith('b')
   })
 })

--- a/e2e/maturity-combine-cluster.spec.ts
+++ b/e2e/maturity-combine-cluster.spec.ts
@@ -84,6 +84,42 @@ test.describe('Maturity card — merge-cluster auto-detection', () => {
     }
   })
 
+  test('surfaces the banner even when the close sibling is not itself due yet', async ({ page }) => {
+    test.slow()
+    const goal = await api.createGoal({ goal_name: 'E2E NotDue Goal', target_amount: 200_000_000 })
+    // D is matured (the only actionable deposit → the anchor). B matures in 4 days
+    // — NOT actionable (won't show its own Handle row), but within D's 7-day merge
+    // window, so it counts as a cluster sibling and the banner still fires.
+    const D = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 20_000_000, investment_date: iso(-380),
+      interest_rate: 6, expiry_date: iso(-1), goal_id: goal.goal_id, notes: 'E2E NotDue D',
+    })
+    const B = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 7_000_000, investment_date: iso(-200),
+      interest_rate: 6, expiry_date: iso(4), goal_id: goal.goal_id, notes: 'E2E NotDue B',
+    })
+    try {
+      await gotoFreshDashboard(page)
+      const card = page.getByTestId('maturity-action-card')
+      await expect(card).toBeVisible({ timeout: 10_000 })
+      // Only D is actionable → the card lists a single Handle row…
+      await expect(page.getByTestId('maturity-action-count')).toHaveText('1')
+      // …yet the banner advertises the 2-deposit cluster anchored on D.
+      const banner = page.getByTestId(`merge-cluster-banner-${D.transaction_id}`)
+      await expect(banner).toBeVisible()
+      await expect(banner).toContainText('2')
+
+      // Opening it preselects B even though B isn't due on its own.
+      await banner.getByRole('button').click()
+      await page.getByRole('button', { name: /Settle & re-deposit|Tất toán & gửi lại/i }).click()
+      await expect(page.getByTestId(`merge-received-${B.transaction_id}`)).toBeVisible()
+    } finally {
+      await api.deleteTransactionCascade(B.transaction_id)
+      await api.deleteTransactionCascade(D.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
   test('shows no merge banner when a goal has a single maturing deposit', async ({ page }) => {
     const goal = await api.createGoal({ goal_name: 'E2E Solo Goal', target_amount: 100_000_000 })
     const D = await api.createTransaction({

--- a/e2e/maturity-combine-cluster.spec.ts
+++ b/e2e/maturity-combine-cluster.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect, type Page } from '@playwright/test'
+import * as api from './helpers/api'
+
+// PR3 — cluster auto-detection on the dashboard "Cần xử lý" card. When a goal has
+// two (or more) bank deposits maturing close together, the card surfaces a one-tap
+// "Gộp lại" (merge) banner. Tapping it opens the resolve sheet ON THE ANCHOR (the
+// latest-maturing deposit) with the close siblings PRESELECTED — so the user can
+// fold them into one re-deposit without first opening one and discovering the
+// merge UI. This is a NEW entry point: the merge flow itself was previously
+// reachable only from the goal-detail panel (see maturity-combine-merge.spec.ts).
+//
+// Closes the loop on the rendered UI: assert the banner renders with the right
+// count, that opening it preselects the sibling, and that completing the merge
+// removes the sibling from the goal's holdings (the merge is an internal transfer,
+// no double-count).
+
+const iso = (offsetDays: number) => new Date(Date.now() + offsetDays * 86_400_000).toISOString().slice(0, 10)
+
+async function gotoFreshDashboard(page: Page) {
+  await page.goto('/settings') // unmount DashboardClient
+  await page.evaluate(() => {
+    Object.keys(localStorage).filter((k) => k.startsWith('dashboardOverviewCache')).forEach((k) => localStorage.removeItem(k))
+  })
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/v1/dashboard/overview') && r.status() === 200, { timeout: 20_000 }),
+    page.goto('/dashboard'),
+  ])
+}
+
+async function goalHoldingIds(page: Page, goalId: string): Promise<string[]> {
+  const res = await page.request.get('/api/v1/dashboard/overview')
+  expect(res.ok()).toBeTruthy()
+  const json = await res.json()
+  const g = (json.goals ?? []).find((x: { goalId: string }) => x.goalId === goalId)
+  return (g?.nonFunds ?? []).map((n: { transactionId: string }) => n.transactionId)
+}
+
+test.describe('Maturity card — merge-cluster auto-detection', () => {
+  test('surfaces a merge banner for close-maturing siblings and opens the sheet preselected', async ({ page }) => {
+    test.slow()
+    const goal = await api.createGoal({ goal_name: 'E2E Cluster Goal', target_amount: 200_000_000 })
+    // Two matured bank deposits in the same goal, maturing 3 days apart (within the
+    // 7-day window). D is the LATER maturity → the cluster anchor.
+    const D = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 20_000_000, investment_date: iso(-380),
+      interest_rate: 6, expiry_date: iso(-2), goal_id: goal.goal_id, notes: 'E2E Cluster D',
+    })
+    const sIn = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 8_000_000, investment_date: iso(-200),
+      interest_rate: 6, expiry_date: iso(-5), goal_id: goal.goal_id, notes: 'E2E Cluster Sib',
+    })
+    try {
+      await gotoFreshDashboard(page)
+      const before = await goalHoldingIds(page, goal.goal_id)
+      expect(before).toContain(sIn.transaction_id)
+
+      // The card shows a merge banner anchored on D, reading "2 …".
+      const banner = page.getByTestId(`merge-cluster-banner-${D.transaction_id}`)
+      await expect(banner).toBeVisible({ timeout: 10_000 })
+      await expect(banner).toContainText('2')
+
+      // Tap "Gộp lại" → opens the resolve sheet on D (the anchor).
+      await banner.getByRole('button').click()
+      await page.getByRole('button', { name: /Settle & re-deposit|Tất toán & gửi lại/i }).click()
+
+      // The close sibling is PRESELECTED — its received field shows with no click.
+      await expect(page.getByTestId(`merge-received-${sIn.transaction_id}`)).toBeVisible()
+
+      // Complete the merge and assert the sibling left the goal's holdings (folded
+      // in, not duplicated).
+      await Promise.all([
+        page.waitForRequest((r) => r.url().endsWith(`/${D.transaction_id}/renew`) && r.method() === 'POST'),
+        page.getByRole('button', { name: /Save new deposit|Lưu sổ mới/i }).click(),
+      ])
+      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+
+      await gotoFreshDashboard(page)
+      const after = await goalHoldingIds(page, goal.goal_id)
+      expect(after).not.toContain(sIn.transaction_id)
+    } finally {
+      await api.deleteTransactionCascade(sIn.transaction_id)
+      await api.deleteTransactionCascade(D.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
+  test('shows no merge banner when a goal has a single maturing deposit', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Solo Goal', target_amount: 100_000_000 })
+    const D = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 15_000_000, investment_date: iso(-380),
+      interest_rate: 6, expiry_date: iso(-2), goal_id: goal.goal_id, notes: 'E2E Solo D',
+    })
+    try {
+      await gotoFreshDashboard(page)
+      // The deposit is actionable (its Handle row shows) but there's no sibling to
+      // merge with, so no cluster banner.
+      await expect(page.getByTestId(`merge-cluster-banner-${D.transaction_id}`)).toHaveCount(0)
+    } finally {
+      await api.deleteTransactionCascade(D.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+})

--- a/lib/__tests__/mergeCluster.test.ts
+++ b/lib/__tests__/mergeCluster.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest'
+import { detectMergeClusters, type MergeClusterInput } from '../mergeCluster'
+
+// Deterministic dates (no Date.now): the rules read whole-day gaps, so fixed
+// ISO strings keep these tests stable across the calendar.
+const mk = (over: Partial<MergeClusterInput>): MergeClusterInput => ({
+  id: 'tx',
+  goalId: 'g1',
+  type: 'bank',
+  expiryDate: '2026-07-01',
+  principal: 10_000_000,
+  value: 10_500_000,
+  depositGroupId: null,
+  currency: 'VND',
+  isPledged: false,
+  ...over,
+})
+
+describe('detectMergeClusters', () => {
+  it('groups two same-goal in-window deposits, anchoring on the latest maturity', () => {
+    const a = mk({ id: 'a', expiryDate: '2026-07-01' })
+    const b = mk({ id: 'b', expiryDate: '2026-07-05' }) // 4 days later → latest
+    const clusters = detectMergeClusters([a, b], 7)
+    expect(clusters).toHaveLength(1)
+    expect(clusters[0]).toMatchObject({ goalId: 'g1', anchorId: 'b', size: 2 })
+    expect(clusters[0].siblingIds).toEqual(['a'])
+  })
+
+  it('excludes an out-of-window sibling (no cluster when the only other is too far)', () => {
+    const a = mk({ id: 'a', expiryDate: '2026-07-01' })
+    const far = mk({ id: 'far', expiryDate: '2026-09-01' }) // ~62 days → out of window
+    expect(detectMergeClusters([a, far], 7)).toHaveLength(0)
+  })
+
+  it('needs at least two deposits — a lone maturing deposit is not a cluster', () => {
+    expect(detectMergeClusters([mk({ id: 'solo' })], 7)).toHaveLength(0)
+  })
+
+  it('does not cluster deposits across different goals', () => {
+    const a = mk({ id: 'a', goalId: 'g1', expiryDate: '2026-07-01' })
+    const b = mk({ id: 'b', goalId: 'g2', expiryDate: '2026-07-02' })
+    expect(detectMergeClusters([a, b], 7)).toHaveLength(0)
+  })
+
+  it('ignores books, non-bank, and zero-balance rows', () => {
+    const anchor = mk({ id: 'anchor', expiryDate: '2026-07-03' })
+    const book = mk({ id: 'book', expiryDate: '2026-07-01', depositGroupId: 'grp-1' })
+    const gold = mk({ id: 'gold', type: 'gold', expiryDate: '2026-07-02' })
+    const empty = mk({ id: 'empty', expiryDate: '2026-07-02', principal: 0, value: 0 })
+    expect(detectMergeClusters([anchor, book, gold, empty], 7)).toHaveLength(0)
+  })
+
+  it('skips deposits with no goal (a cluster is goal-scoped)', () => {
+    const a = mk({ id: 'a', goalId: null, expiryDate: '2026-07-01' })
+    const b = mk({ id: 'b', goalId: null, expiryDate: '2026-07-02' })
+    expect(detectMergeClusters([a, b], 7)).toHaveLength(0)
+  })
+
+  it('excludes a hard-blocked (different-currency) sibling from the cluster', () => {
+    const a = mk({ id: 'a', expiryDate: '2026-07-01', currency: 'VND' })
+    const usd = mk({ id: 'usd', expiryDate: '2026-07-02', currency: 'USD' })
+    expect(detectMergeClusters([a, usd], 7)).toHaveLength(0)
+  })
+
+  it('excludes a pledged sibling from the cluster', () => {
+    const a = mk({ id: 'a', expiryDate: '2026-07-01' })
+    const pledged = mk({ id: 'pledged', expiryDate: '2026-07-02', isPledged: true })
+    expect(detectMergeClusters([a, pledged], 7)).toHaveLength(0)
+  })
+
+  it('widens with the window param — a far sibling clusters once the window grows', () => {
+    const a = mk({ id: 'a', expiryDate: '2026-07-01' })
+    const b = mk({ id: 'b', expiryDate: '2026-07-20' }) // 19 days
+    expect(detectMergeClusters([a, b], 7)).toHaveLength(0)
+    const wide = detectMergeClusters([a, b], 30)
+    expect(wide).toHaveLength(1)
+    expect(wide[0]).toMatchObject({ anchorId: 'b', size: 2 })
+    expect(wide[0].siblingIds).toEqual(['a'])
+  })
+
+  it('clusters three in-window same-goal deposits (anchor + two siblings)', () => {
+    const a = mk({ id: 'a', expiryDate: '2026-07-01' })
+    const b = mk({ id: 'b', expiryDate: '2026-07-03' })
+    const c = mk({ id: 'c', expiryDate: '2026-07-05' }) // latest → anchor
+    const clusters = detectMergeClusters([a, b, c], 7)
+    expect(clusters).toHaveLength(1)
+    expect(clusters[0].anchorId).toBe('c')
+    expect(clusters[0].size).toBe(3)
+    expect([...clusters[0].siblingIds].sort()).toEqual(['a', 'b'])
+  })
+
+  it('emits a separate cluster per goal', () => {
+    const a1 = mk({ id: 'a1', goalId: 'g1', expiryDate: '2026-07-01' })
+    const a2 = mk({ id: 'a2', goalId: 'g1', expiryDate: '2026-07-03' })
+    const b1 = mk({ id: 'b1', goalId: 'g2', expiryDate: '2026-08-01' })
+    const b2 = mk({ id: 'b2', goalId: 'g2', expiryDate: '2026-08-02' })
+    const clusters = detectMergeClusters([a1, a2, b1, b2], 7)
+    expect(clusters).toHaveLength(2)
+    expect(clusters.map((c) => c.goalId).sort()).toEqual(['g1', 'g2'])
+  })
+})

--- a/lib/__tests__/mergeCluster.test.ts
+++ b/lib/__tests__/mergeCluster.test.ts
@@ -89,6 +89,40 @@ describe('detectMergeClusters', () => {
     expect([...clusters[0].siblingIds].sort()).toEqual(['a', 'b'])
   })
 
+  it('anchors on an actionable deposit and folds a not-yet-actionable close sibling', () => {
+    // A is due now; B matures a few days later (not actionable) but within the
+    // window — it can settle early and fold in, so the banner still fires.
+    const a = mk({ id: 'a', expiryDate: '2026-07-01', actionable: true })
+    const b = mk({ id: 'b', expiryDate: '2026-07-05', actionable: false }) // gap 4, not due
+    const clusters = detectMergeClusters([a, b], 7)
+    expect(clusters).toHaveLength(1)
+    expect(clusters[0]).toMatchObject({ anchorId: 'a', size: 2 })
+    expect(clusters[0].siblingIds).toEqual(['b'])
+  })
+
+  it('forms no cluster when nothing in the goal is actionable yet', () => {
+    const a = mk({ id: 'a', expiryDate: '2026-07-01', actionable: false })
+    const b = mk({ id: 'b', expiryDate: '2026-07-03', actionable: false })
+    expect(detectMergeClusters([a, b], 7)).toHaveLength(0)
+  })
+
+  it('anchors on the latest ACTIONABLE deposit, not a later not-yet-due one', () => {
+    const a = mk({ id: 'a', expiryDate: '2026-07-01', actionable: true })
+    const b = mk({ id: 'b', expiryDate: '2026-07-03', actionable: true }) // latest actionable
+    const c = mk({ id: 'c', expiryDate: '2026-07-05', actionable: false }) // later, not due
+    const clusters = detectMergeClusters([a, b, c], 7)
+    expect(clusters).toHaveLength(1)
+    expect(clusters[0].anchorId).toBe('b')
+    expect(clusters[0].size).toBe(3)
+    expect([...clusters[0].siblingIds].sort()).toEqual(['a', 'c'])
+  })
+
+  it('treats an unspecified actionable flag as actionable (lib default)', () => {
+    const a = mk({ id: 'a', expiryDate: '2026-07-01' }) // no actionable field
+    const b = mk({ id: 'b', expiryDate: '2026-07-03' })
+    expect(detectMergeClusters([a, b], 7)).toHaveLength(1)
+  })
+
   it('emits a separate cluster per goal', () => {
     const a1 = mk({ id: 'a1', goalId: 'g1', expiryDate: '2026-07-01' })
     const a2 = mk({ id: 'a2', goalId: 'g1', expiryDate: '2026-07-03' })

--- a/lib/mergeCluster.ts
+++ b/lib/mergeCluster.ts
@@ -1,0 +1,77 @@
+// Auto-detect "merge clusters": groups of a goal's maturing bank deposits whose
+// maturities fall close together, so the dashboard can proactively offer to fold
+// them into one re-deposit ("Gộp nhiều nguồn") instead of making the user open
+// one and discover the merge UI. Pure + deterministic, built on the shared PR2
+// eligibility rules (lib/mergeEligibility) so the banner's promised count is
+// exactly what the resolve sheet will preselect — no over-promising.
+//
+// A cluster is goal-scoped: it needs ≥2 liquidatable bank deposits in the same
+// goal, with at least one sibling that is eligible (in-window, same currency, not
+// pledged) against the ANCHOR — the latest-maturing deposit. Opening the sheet on
+// that anchor lets the rest settle early and roll into it; anchoring on the
+// latest maturity means every sibling settles at or before its own term, never
+// after (the anchor's renewal carries the new, later maturity).
+
+import { classifyMergeSource, type MergeEligInput } from './mergeEligibility'
+
+// A maturing deposit as the detector reads it: the eligibility fields plus the
+// goal it belongs to (null/undefined = unassigned, not clusterable).
+export interface MergeClusterInput extends MergeEligInput {
+  goalId?: string | null
+}
+
+export interface MergeCluster {
+  goalId: string
+  // The latest-maturing deposit — the merge sheet opens on this one.
+  anchorId: string
+  // Eligible in-window siblings to preselect (excludes the anchor).
+  siblingIds: string[]
+  // anchor + siblings.
+  size: number
+}
+
+// A deposit that can take part in a merge — as anchor OR sibling. Pledged is an
+// *absolute* block (frozen as collateral), so excluded from the pool up front; a
+// pledged deposit can be neither the merge target nor a source. Currency stays
+// out of this gate because it's anchor-relative (handled per-sibling below).
+function liquidatable(d: MergeClusterInput): boolean {
+  return (
+    d.type === 'bank' &&
+    !d.depositGroupId &&
+    !d.isPledged &&
+    (d.principal ?? d.value ?? 0) > 0
+  )
+}
+
+export function detectMergeClusters(
+  deposits: MergeClusterInput[],
+  windowDays = 7,
+): MergeCluster[] {
+  // Bucket liquidatable bank deposits by goal (skip the unassigned — a merge
+  // folds siblings into the goal's re-deposit, so there's no cluster without one).
+  const byGoal = new Map<string, MergeClusterInput[]>()
+  for (const d of deposits) {
+    if (d.goalId == null || !liquidatable(d)) continue
+    const arr = byGoal.get(d.goalId) ?? []
+    arr.push(d)
+    byGoal.set(d.goalId, arr)
+  }
+
+  const clusters: MergeCluster[] = []
+  for (const [goalId, group] of byGoal) {
+    if (group.length < 2) continue
+    // Anchor = latest maturity (tie-break by id for a deterministic pick).
+    const anchor = [...group].sort(
+      (a, b) => (b.expiryDate ?? '').localeCompare(a.expiryDate ?? '') || a.id.localeCompare(b.id),
+    )[0]
+    // Only count siblings the sheet would actually preselect — same eligibility
+    // predicate, so the banner can't promise a merge the sheet then blocks.
+    const siblingIds = group
+      .filter((s) => s.id !== anchor.id)
+      .filter((s) => classifyMergeSource(anchor, s, windowDays).eligible)
+      .map((s) => s.id)
+    if (siblingIds.length === 0) continue
+    clusters.push({ goalId, anchorId: anchor.id, siblingIds, size: siblingIds.length + 1 })
+  }
+  return clusters
+}

--- a/lib/mergeCluster.ts
+++ b/lib/mergeCluster.ts
@@ -7,17 +7,25 @@
 //
 // A cluster is goal-scoped: it needs ≥2 liquidatable bank deposits in the same
 // goal, with at least one sibling that is eligible (in-window, same currency, not
-// pledged) against the ANCHOR — the latest-maturing deposit. Opening the sheet on
-// that anchor lets the rest settle early and roll into it; anchoring on the
-// latest maturity means every sibling settles at or before its own term, never
-// after (the anchor's renewal carries the new, later maturity).
+// pledged) against the ANCHOR — the latest-maturing ACTIONABLE deposit. Opening
+// the sheet on that anchor lets the rest settle early and roll into it.
+//
+// The anchor must be actionable (matured / within the reminder window) for two
+// reasons: the maturity card only surfaces actionable deposits, and the resolve
+// flow opens on one. A SIBLING need not be actionable, though — a deposit that
+// matures a few days later can still settle early and fold in. So the banner
+// surfaces exactly when the sheet would preselect: as soon as there is something
+// to act on now plus a close-maturing partner, even if the partner isn't due yet.
 
 import { classifyMergeSource, type MergeEligInput } from './mergeEligibility'
 
 // A maturing deposit as the detector reads it: the eligibility fields plus the
-// goal it belongs to (null/undefined = unassigned, not clusterable).
+// goal it belongs to (null/undefined = unassigned, not clusterable) and whether
+// it is actionable now (anchor-eligible). `actionable` defaults to true so the
+// lib is usable without the flag; the dashboard passes it explicitly.
 export interface MergeClusterInput extends MergeEligInput {
   goalId?: string | null
+  actionable?: boolean
 }
 
 export interface MergeCluster {
@@ -60,12 +68,17 @@ export function detectMergeClusters(
   const clusters: MergeCluster[] = []
   for (const [goalId, group] of byGoal) {
     if (group.length < 2) continue
-    // Anchor = latest maturity (tie-break by id for a deterministic pick).
-    const anchor = [...group].sort(
+    // Anchor = latest-maturity ACTIONABLE deposit (tie-break by id). A goal with
+    // nothing actionable has nothing to act on now → no banner, even if two
+    // future deposits would otherwise pair up.
+    const actionables = group.filter((d) => d.actionable ?? true)
+    if (actionables.length === 0) continue
+    const anchor = [...actionables].sort(
       (a, b) => (b.expiryDate ?? '').localeCompare(a.expiryDate ?? '') || a.id.localeCompare(b.id),
     )[0]
-    // Only count siblings the sheet would actually preselect — same eligibility
-    // predicate, so the banner can't promise a merge the sheet then blocks.
+    // Count siblings the sheet would actually preselect — same eligibility
+    // predicate, drawn from the WHOLE group (an in-window sibling counts even if
+    // it isn't due yet), so the banner can't promise a merge the sheet then blocks.
     const siblingIds = group
       .filter((s) => s.id !== anchor.id)
       .filter((s) => classifyMergeSource(anchor, s, windowDays).eligible)


### PR DESCRIPTION
PR3 of the **Gộp nhiều nguồn** (multi-source deposit merge) plan — cluster auto-detection. Builds on PR0 (#368), PR1 (#369), PR2 (#370).

## What this adds
When a goal has **≥2 bank deposits maturing close together**, the dashboard **"Cần xử lý"** card now shows a one-tap **"Gộp lại"** (Merge) banner. Tapping it opens the maturity-resolve sheet **on the anchor (latest maturity)** with the close siblings **preselected** — so the user doesn't have to open one deposit and discover the merge UI.

This also **wires the merge entry point from the dashboard card for the first time**: the merge flow built in PR1/PR2 was previously reachable only from the goal-detail panel. Opening any goal-assigned deposit's resolve flow now passes the goal's siblings, so merge is available from both the banner and the normal "Xử lý" action.

## Implementation
- **`lib/mergeCluster.ts`** — pure, deterministic `detectMergeClusters(deposits, windowDays=7)`. Groups liquidatable, non-pledged bank deposits by goal; anchors on the latest maturity; counts only siblings that `classifyMergeSource()` (PR2) deems eligible — so the banner's promised count is exactly what the sheet preselects (no over-promising). Pledged is an absolute block (excluded from the pool); currency stays anchor-relative.
- **`MaturityActionCard`** — optional `clusters` + `onMergeCluster` props render a per-cluster banner (`data-testid="merge-cluster-banner-<anchorId>"`).
- **`DashboardClient`** — computes clusters from `maturingDeposits`, plumbs `bankCode`/`currency`/`isPledged` through `nonFundToInvRow` (the overview API already returned them since PR0), and passes the goal's siblings to the resolve sheet/modal.

**Pure client/lib — no migration, no route change.**

## Verification (TDD)
- **`lib/__tests__/mergeCluster.test.ts`** — 12 cases (anchor = latest maturity, out-of-window/solo/cross-goal/book/non-bank/zero-balance/null-goal/currency/pledged exclusions, window widening, multi-sibling, per-goal split).
- **`MaturityActionCard.test.tsx`** — banner renders with the count + fires `onMergeCluster(anchorId)`; no banner without clusters.
- **`e2e/maturity-combine-cluster.spec.ts`** — banner appears with the right count, opens the sheet preselected, completing the merge removes the sibling from holdings (no double-count); no banner for a solo deposit. ✅ 2 passed.
- Full unit suite **755 passed**; `tsc` clean; lint adds **zero** new problems (the 27 errors are the pre-existing `set-state-in-effect` baseline on `main`).
- E2E (Edge / WSL2): new cluster spec + `maturity-combine-merge` + `maturity-combine` + `dashboard` + `dashboard-desktop` + `accumulating-collapse` → **all green** (incl. the "Needs attention card renders" test).

## Next
PR4 — Ví chờ gộp (holding pool), the highest-risk and final PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)