### PR TITLE
feat(deposits): Ví chờ gộp — merge holding pool (Gộp nhiều nguồn PR4)

### DIFF
--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -235,7 +235,11 @@ function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRec
   }
 
   return (
-    <tr style={{ borderBottom: '1px solid var(--c-line)', background: 'var(--c-card)', opacity: skipped ? 0.5 : 1 }}>
+    <tr
+      data-testid={item.isRecurring && item.recurringId ? `plan-recurring-${item.recurringId}` : undefined}
+      data-recorded={item.isRecurring ? (recorded ? 'true' : 'false') : undefined}
+      style={{ borderBottom: '1px solid var(--c-line)', background: 'var(--c-card)', opacity: skipped ? 0.5 : 1 }}
+    >
       <td style={{ padding: '9px 16px 9px 44px', verticalAlign: 'middle' }}>
         <div style={{ fontSize: 12, fontWeight: 500, textDecoration: skipped ? 'line-through' : 'none' }}>{item.name}</div>
         <div style={{ fontSize: 10, color: item.overridden ? 'var(--c-navy)' : recorded ? 'var(--c-pos)' : 'var(--c-muted)', marginTop: 1 }}>
@@ -912,8 +916,8 @@ export default function DesktopPlanningView({
                           )}
                         </td>
                         <td style={{ padding: '10px 12px', textAlign: 'right', verticalAlign: 'top' }}>
-                          <div style={{ fontSize: 13, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>{fmt(g.totalAllocated)}</div>
-                          <div style={{ fontSize: 10, color: g.contributed > 0 ? 'var(--c-pos)' : 'var(--c-muted)', marginTop: 2, fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
+                          <div data-testid={`plan-goal-planned-${g.goalId}`} data-planned={g.totalAllocated} style={{ fontSize: 13, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>{fmt(g.totalAllocated)}</div>
+                          <div data-testid={`plan-goal-contributed-${g.goalId}`} data-contributed={g.contributed} style={{ fontSize: 10, color: g.contributed > 0 ? 'var(--c-pos)' : 'var(--c-muted)', marginTop: 2, fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
                             {g.contributed > 0 ? `${fmt(g.contributed)} ${isVI ? 'đã góp' : 'in'}` : (isVI ? 'Chưa góp' : 'Nothing yet')}
                           </div>
                         </td>

--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { isNavStale, insuranceStatus, isPlanMonthRealized, isInCurrentCycle, realizedRecurringContributions } from '@/lib/finance'
 import { buildWithdrawalMaps } from '@/lib/withdrawalProgress'
+import { heldForMergeContributions } from '@/lib/heldForMerge'
 import { valueNonFundHolding } from '@/lib/depositValuation'
 import { shouldWriteSnapshot } from '@/lib/snapshots'
 
@@ -74,7 +75,7 @@ export async function GET() {
       // Snapshot-free view — renewal history rows can't reach the net-worth /
       // goal / allocation totals (defence on top of the app-side filter below).
       .from('active_investment_transactions')
-      .select('transaction_id, goal_id, amount_vnd, interest_rate, investment_date, asset_type, transaction_type, units, unit_price, units_withdrawn, principal_withdrawn, fund_id, parent_transaction_id, renewed_from_transaction_id, deposit_group_id, expiry_date, notes, affects_progress, bank_code, currency, is_pledged, funds(id, name, nav, updated_at, fund_type)')
+      .select('transaction_id, goal_id, amount_vnd, interest_rate, investment_date, asset_type, transaction_type, units, unit_price, units_withdrawn, principal_withdrawn, fund_id, parent_transaction_id, renewed_from_transaction_id, deposit_group_id, expiry_date, notes, affects_progress, bank_code, currency, is_pledged, held_for_merge, merge_target_goal_id, consumed_by_inv_id, funds(id, name, nav, updated_at, fund_type)')
       .eq('user_id', user.id),
     supabase
       .from('insurance_members')
@@ -401,6 +402,26 @@ export async function GET() {
       g.progressValue += c.amount // no withdrawals involved — counts toward the bar too
       g.totalInvested += c.amount
       g.transactionCount += 1
+    }
+  }
+
+  // "Ví chờ gộp" (merge holding pool): a settle-with-hold closed an earlier-
+  // maturing deposit (its withdrawal already removed the principal from net worth
+  // AND the bar above), but the cash is parked for a future merge. Add each
+  // still-pooled holding back to its target goal so the value never dips — exactly
+  // like recurring contributions, and for the same reason there is no deposit row
+  // to count it. A consumed holding (merge done) is skipped: its cash now lives in
+  // the renewed deposit's principal, already counted in the holdings pass.
+  const heldContributions = heldForMergeContributions(withdrawals)
+  for (const h of heldContributions) {
+    totalAssets += h.amount
+    totalInvestedGlobal += h.amount
+    nonFundByType.bank += h.amount
+    if (goalMap.has(h.goalId)) {
+      const g = goalMap.get(h.goalId)!
+      g.currentValue += h.amount
+      g.progressValue += h.amount
+      g.totalInvested += h.amount
     }
   }
 

--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -193,6 +193,10 @@ export async function GET() {
       goalId: string
     }>
     nonFunds: NonFundEntry[]
+    // "Ví chờ gộp": settle-with-hold settlements still in the pool, surfaced so the
+    // goal card can show a "đang chờ gộp" chip (with unhold) and the anchor's merge
+    // sheet can preselect them. transactionId is the held WITHDRAWAL row.
+    heldForMerge: Array<{ transactionId: string; amount: number; anchorInvId: string | null; name: string | null }>
   }>()
 
   for (const goal of goals) {
@@ -207,6 +211,7 @@ export async function GET() {
       transactionCount: 0,
       funds: [],
       nonFunds: [],
+      heldForMerge: [],
     })
   }
 
@@ -413,6 +418,12 @@ export async function GET() {
   // to count it. A consumed holding (merge done) is skipped: its cash now lives in
   // the renewed deposit's principal, already counted in the holdings pass.
   const heldContributions = heldForMergeContributions(withdrawals)
+  // The held WITHDRAWAL has no name of its own — its label is the source deposit
+  // it closed (parent_transaction_id). Map every active row's id → notes so the
+  // chip can read "Sổ VCB 3 th." rather than a bare amount.
+  const nameById = new Map<string, string | null>()
+  for (const tx of allTxsRaw) nameById.set(tx.transaction_id, tx.notes ?? null)
+  const wById = new Map(withdrawals.map((w) => [w.transaction_id, w]))
   for (const h of heldContributions) {
     totalAssets += h.amount
     totalInvestedGlobal += h.amount
@@ -422,6 +433,13 @@ export async function GET() {
       g.currentValue += h.amount
       g.progressValue += h.amount
       g.totalInvested += h.amount
+      const parentId = wById.get(h.transactionId)?.parent_transaction_id ?? null
+      g.heldForMerge.push({
+        transactionId: h.transactionId,
+        amount: h.amount,
+        anchorInvId: h.anchorInvId,
+        name: parentId ? nameById.get(parentId) ?? null : null,
+      })
     }
   }
 
@@ -452,6 +470,7 @@ export async function GET() {
       transactionCount: g.transactionCount,
       funds: g.funds,
       nonFunds: g.nonFunds,
+      heldForMerge: g.heldForMerge,
     }
   })
 

--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const body = await request.json()
-  const { amount_vnd, interest_rate, expiry_date, investment_date, interest_earned_vnd, fulfill_recurring, merge_sources, bank_code } = body
+  const { amount_vnd, interest_rate, expiry_date, investment_date, interest_earned_vnd, fulfill_recurring, merge_sources, bank_code, held_sources } = body
 
   let txId: string
   let cleanAmount: number
@@ -44,6 +44,10 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   // Multi-source merge only: destination bank for the combined re-deposit. null
   // (or omitted) leaves D's existing bank untouched (the RPC coalesces).
   let cleanBankCode: string | null = null
+  // Held-pool consume: ids of held settlement (withdrawal) rows to fold into this
+  // re-deposit. They carry their OWN cash (stored amount_vnd), so unlike live
+  // merge sources there is no client-supplied received — just the ids.
+  const cleanHeldSourceIds: string[] = []
   try {
     txId = validateUUID(id, 'transaction_id')
     cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
@@ -81,6 +85,15 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       }
     }
     if (bank_code != null && bank_code !== '') cleanBankCode = validateBankCode(bank_code, 'bank_code')
+    if (held_sources != null) {
+      if (!Array.isArray(held_sources)) throw new ValidationError('held_sources must be an array')
+      for (const h of held_sources) {
+        // Accept either a bare id or a { tx_id } object, matching merge_sources' shape.
+        const hid = validateUUID(typeof h === 'string' ? h : h?.tx_id, 'held_sources.tx_id')
+        if (hid === txId) throw new ValidationError('a deposit cannot merge into itself')
+        cleanHeldSourceIds.push(hid)
+      }
+    }
   } catch (e) {
     if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
     throw e
@@ -134,7 +147,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   // it ALSO closes each source and adds Σ(received) to the principal. amount_vnd
   // is then the BASE (principal + interest + recurring) — the RPC, not the
   // client, sums in the received cash, so the net-worth invariant can't diverge.
-  const hasMerge = cleanMergeSourceIds.length > 0
+  const hasMerge = cleanMergeSourceIds.length > 0 || cleanHeldSourceIds.length > 0
   const { data: renewed, error: renewErr } = hasMerge
     ? await supabase
         .rpc('renew_term_deposit_with_merge', {
@@ -152,6 +165,8 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
           p_merge_received: cleanMergeReceived,
           // Destination bank for the combined deposit; null = leave D's bank as is.
           p_bank_code: cleanBankCode,
+          // Held-pool holdings to consume (fold their parked cash into D).
+          p_held_source_ids: cleanHeldSourceIds,
         })
         .single()
     : await supabase

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -196,6 +196,28 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
+  // "Bỏ chờ gộp" (unhold) is a DELETE on the held withdrawal row — it re-opens the
+  // source deposit. That is only safe while the holding is still parked. Once a
+  // merge has consumed it (consumed_by_inv_id set), its cash already lives folded
+  // in the anchor's principal, so deleting the withdrawal would re-open the source
+  // and double-count. The chip is hidden once consumed, but a stale tab (or a
+  // direct call) must not get through — guard server-side with a 409 rather than
+  // trusting the UI. (One cheap SELECT only when the row is a consumed holding.)
+  const { data: holding } = await supabase
+    .from('investment_transactions')
+    .select('consumed_by_inv_id')
+    .eq('transaction_id', txId)
+    .eq('user_id', user.id)
+    .eq('held_for_merge', true)
+    .not('consumed_by_inv_id', 'is', null)
+    .maybeSingle()
+  if (holding) {
+    return NextResponse.json(
+      { error: 'This holding has already been merged in. Undo the merge before removing it.' },
+      { status: 409 },
+    )
+  }
+
   const { error } = await supabase
     .from('investment_transactions')
     .delete()

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -196,24 +196,26 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  // "Bỏ chờ gộp" (unhold) is a DELETE on the held withdrawal row — it re-opens the
-  // source deposit. That is only safe while the holding is still parked. Once a
-  // merge has consumed it (consumed_by_inv_id set), its cash already lives folded
-  // in the anchor's principal, so deleting the withdrawal would re-open the source
-  // and double-count. The chip is hidden once consumed, but a stale tab (or a
-  // direct call) must not get through — guard server-side with a 409 rather than
-  // trusting the UI. (One cheap SELECT only when the row is a consumed holding.)
-  const { data: holding } = await supabase
+  // A merge folds a source's cash into the anchor's principal and closes the source
+  // with a withdrawal stamped consumed_by_inv_id = the anchor. Deleting that
+  // withdrawal would re-open the source at full value while its cash still sits in
+  // the anchor → double-count. This applies to BOTH fold paths:
+  //   • held ("Để dành gộp"): the held withdrawal, consumed when the merge runs;
+  //   • live: the plain withdrawal the merge RPC opens for a sibling source.
+  // Both carry consumed_by_inv_id, so the guard keys on that marker alone (not on
+  // held_for_merge). The UI hides the affordances once consumed, but a stale tab or
+  // the ledger's per-row delete (shown on every row) must not get through — guard
+  // server-side with a 409 rather than trusting the UI. (One cheap SELECT.)
+  const { data: folded } = await supabase
     .from('investment_transactions')
     .select('consumed_by_inv_id')
     .eq('transaction_id', txId)
     .eq('user_id', user.id)
-    .eq('held_for_merge', true)
     .not('consumed_by_inv_id', 'is', null)
     .maybeSingle()
-  if (holding) {
+  if (folded) {
     return NextResponse.json(
-      { error: 'This holding has already been merged in. Undo the merge before removing it.' },
+      { error: 'This settlement has already been merged into another deposit. Undo the merge before removing it.' },
       { status: 409 },
     )
   }

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -55,7 +55,7 @@ export async function POST(request: NextRequest) {
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const body = await request.json()
-  const { goal_id, asset_type, transaction_type = 'investment', investment_date, amount_vnd, unit_price, units, interest_rate, notes, fund_id, plan_id, expiry_date, parent_transaction_id, principal_withdrawn, units_withdrawn, affects_progress, accumulating, tops_up_deposit_id, bank_code } = body
+  const { goal_id, asset_type, transaction_type = 'investment', investment_date, amount_vnd, unit_price, units, interest_rate, notes, fund_id, plan_id, expiry_date, parent_transaction_id, principal_withdrawn, units_withdrawn, affects_progress, accumulating, tops_up_deposit_id, bank_code, held_for_merge, merge_target_goal_id, merge_anchor_inv_id } = body
 
   const isWithdrawal = transaction_type === 'withdrawal'
 
@@ -76,6 +76,12 @@ export async function POST(request: NextRequest) {
   let cleanUnitsWithdrawn: number | null = null
   let cleanTopsUpId: string | null = null
   let cleanBankCode: string | null = null
+  // "Ví chờ gộp": a settle-with-hold parks the closed deposit's cash for a future
+  // merge. Only meaningful on a withdrawal; the target goal/anchor say where the
+  // pool synthesizes the cash back to and which deposit it's waiting on.
+  const cleanHeldForMerge = isWithdrawal && held_for_merge === true
+  let cleanMergeTargetGoalId: string | null = null
+  let cleanMergeAnchorInvId: string | null = null
 
   try {
     cleanTxType = validateEnum(transaction_type, ['investment', 'withdrawal'] as const, 'transaction_type')
@@ -106,6 +112,10 @@ export async function POST(request: NextRequest) {
     if (units_withdrawn != null && units_withdrawn !== '') cleanUnitsWithdrawn = validateAmount(units_withdrawn, 'units_withdrawn')
     if (tops_up_deposit_id) cleanTopsUpId = validateUUID(tops_up_deposit_id, 'tops_up_deposit_id')
     if (bank_code != null && bank_code !== '') cleanBankCode = validateBankCode(bank_code, 'bank_code')
+    if (cleanHeldForMerge) {
+      if (merge_target_goal_id) cleanMergeTargetGoalId = validateUUID(merge_target_goal_id, 'merge_target_goal_id')
+      if (merge_anchor_inv_id) cleanMergeAnchorInvId = validateUUID(merge_anchor_inv_id, 'merge_anchor_inv_id')
+    }
   } catch (e) {
     if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
     throw e
@@ -213,6 +223,11 @@ export async function POST(request: NextRequest) {
       // Structured bank only applies to bank deposits; funds/gold have no bank.
       // A top-up tranche inherits the book's bank (effectiveBankCode).
       bank_code: effectiveAssetType === 'bank' ? effectiveBankCode : null,
+      // Held-for-merge pool flags (withdrawal only). The target goal defaults to
+      // the withdrawal's own goal (= the closed source's goal) when not given.
+      held_for_merge: cleanHeldForMerge,
+      merge_target_goal_id: cleanHeldForMerge ? (cleanMergeTargetGoalId ?? effectiveGoalId) : null,
+      merge_anchor_inv_id: cleanHeldForMerge ? cleanMergeAnchorInvId : null,
     })
     .select()
     .single()

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
 
   let query = supabase
     .from('investment_transactions')
-    .select('transaction_id, goal_id, asset_type, transaction_type, parent_transaction_id, renewed_from_transaction_id, deposit_group_id, interest_earned_vnd, investment_date, amount_vnd, unit_price, units, interest_rate, expiry_date, notes, fund_id, bank_code, currency, is_pledged, principal_withdrawn, units_withdrawn, affects_progress, savings_goals(goal_name), funds(id, name, nav)', { count: 'exact' })
+    .select('transaction_id, goal_id, asset_type, transaction_type, parent_transaction_id, renewed_from_transaction_id, deposit_group_id, interest_earned_vnd, investment_date, amount_vnd, unit_price, units, interest_rate, expiry_date, notes, fund_id, bank_code, currency, is_pledged, principal_withdrawn, units_withdrawn, affects_progress, held_for_merge, consumed_by_inv_id, merge_anchor_inv_id, savings_goals(goal_name), funds(id, name, nav)', { count: 'exact' })
     .eq('user_id', user.id)
     .order('investment_date', { ascending: false })
     .range(offset, offset + limit - 1)

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -233,5 +233,20 @@ export async function POST(request: NextRequest) {
     .single()
 
   if (error) return NextResponse.json({ error: 'Failed to create transaction' }, { status: 500 })
+
+  // Holding a deposit for merge closes its source. If a recurring saving was
+  // linked to that source (linked_deposit_tx_id), the link now points at a closed
+  // deposit and would dangle until the merge consumes it. Clear it on hold —
+  // mirrors what the merge RPC does for its live sources (20260620000005 lines
+  // 174-178) so the recurring line never tops up a settled deposit. Scoped to the
+  // hold path; a plain withdrawal's pre-existing dangle is a separate concern.
+  if (cleanHeldForMerge && cleanParentTxId) {
+    await supabase
+      .from('recurring_savings')
+      .update({ linked_deposit_tx_id: null, updated_at: new Date().toISOString() })
+      .eq('linked_deposit_tx_id', cleanParentTxId)
+      .eq('user_id', user.id)
+  }
+
   return NextResponse.json(transaction, { status: 201 })
 }

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -198,6 +198,17 @@ export async function POST(request: NextRequest) {
     depositGroupId = explicitTxId
   }
 
+  // Net-worth safety for a held settlement. A held withdrawal removes its source
+  // from net worth, and the dashboard synthesizes the parked cash back ONLY via
+  // merge_target_goal_id. If that can't be resolved — an unassigned deposit
+  // settled with no explicit target — the cash leaves net worth and is never
+  // added back: money silently lost, surfaced nowhere. The UI always supplies a
+  // goal, so reject the unguarded API path rather than mis-state total assets.
+  const resolvedHeldTargetGoalId = cleanMergeTargetGoalId ?? effectiveGoalId
+  if (cleanHeldForMerge && !resolvedHeldTargetGoalId) {
+    return NextResponse.json({ error: 'A held-for-merge settlement must resolve a target goal.' }, { status: 400 })
+  }
+
   const { data: transaction, error } = await supabase
     .from('investment_transactions')
     .insert({
@@ -226,7 +237,7 @@ export async function POST(request: NextRequest) {
       // Held-for-merge pool flags (withdrawal only). The target goal defaults to
       // the withdrawal's own goal (= the closed source's goal) when not given.
       held_for_merge: cleanHeldForMerge,
-      merge_target_goal_id: cleanHeldForMerge ? (cleanMergeTargetGoalId ?? effectiveGoalId) : null,
+      merge_target_goal_id: cleanHeldForMerge ? resolvedHeldTargetGoalId : null,
       merge_anchor_inv_id: cleanHeldForMerge ? cleanMergeAnchorInvId : null,
     })
     .select()

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -66,6 +66,10 @@ export interface GoalData {
   transactionCount: number
   funds: FundBreakdownItem[]
   nonFunds?: NonFundUnallocatedItem[]
+  // "Ví chờ gộp": settle-with-hold settlements still pooled in this goal. Shown as
+  // a "đang chờ gộp" chip (with unhold) and preselected in the anchor's merge sheet.
+  // transactionId is the held WITHDRAWAL row. Optional for cached payloads.
+  heldForMerge?: Array<{ transactionId: string; amount: number; anchorInvId: string | null; name: string | null }>
 }
 
 export interface InsuranceData {
@@ -232,6 +236,9 @@ interface MaturingDep {
   // merge UI can fold close-maturing siblings into this re-deposit. Computed lazily
   // (only on open) to keep it off the hot maturingDeposits list.
   siblings?: InvRow[]
+  // Pooled "Ví chờ gộp" holdings in this goal, attached on open so the merge sheet
+  // can preselect them as held_sources (consumed in place, no second withdrawal).
+  heldSiblings?: { id: string; name: string | null; amount: number }[]
 }
 
 // Build the SellWithdrawSheet payload for a non-fund holding (bank/gold/stock).
@@ -582,10 +589,23 @@ export default function DashboardClient({ userId }: { userId: string }) {
       .map((it) => nonFundToInvRow(it, isVi))
   }
 
+  // The goal's pooled "Ví chờ gộp" holdings, for preselect in the anchor's merge
+  // sheet. Empty for an unassigned deposit (the pool is goal-scoped).
+  function goalHeldSiblings(goalId: string | null): { id: string; name: string | null; amount: number }[] {
+    if (!data || goalId == null) return []
+    const goal = data.goals.find((g) => g.goalId === goalId)
+    return (goal?.heldForMerge ?? []).map((h) => ({ id: h.transactionId, name: h.name, amount: h.amount }))
+  }
+
   // Open the resolve flow for a maturing deposit, attaching the goal's siblings so
-  // the merge UI is available (and close-maturing ones preselect).
+  // the merge UI is available (and close-maturing ones preselect) plus any pooled
+  // holdings waiting to be folded into this anchor.
   function openResolve(dep: MaturingDep) {
-    setResolveDep({ ...dep, siblings: goalSiblingInvRows(dep.goalId, dep.inv.id) })
+    setResolveDep({
+      ...dep,
+      siblings: goalSiblingInvRows(dep.goalId, dep.inv.id),
+      heldSiblings: goalHeldSiblings(dep.goalId),
+    })
   }
 
   // Resolve a maturing deposit by its id (used by the card's "handle" + the
@@ -1168,6 +1188,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
           inv={resolveDep?.inv ?? null}
           goalId={resolveDep?.goalId ?? null}
           siblingDeposits={resolveDep?.siblings}
+          heldSiblings={resolveDep?.heldSiblings}
           isVi={isVi}
           onClose={() => setResolveDep(null)}
           onRenewed={() => { setResolveDep(null); fetchData({ force: true }) }}
@@ -1179,6 +1200,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
           inv={resolveDep.inv}
           goalId={resolveDep.goalId ?? null}
           siblingDeposits={resolveDep.siblings}
+          heldSiblings={resolveDep.heldSiblings}
           isVi={isVi}
           onClose={() => setResolveDep(null)}
           onRenewed={() => { setResolveDep(null); fetchData({ force: true }) }}

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -1,12 +1,12 @@
 'use client'
 
 import { useState, useEffect, useMemo } from 'react'
-import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield, RefreshCw, PiggyBank } from 'lucide-react'
+import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield, RefreshCw, PiggyBank, GitMerge } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
 import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, AffectsProgressControl, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { MaturityResolveModal } from './MaturityResolveSheet'
-import { fmtTxDate } from './transactionUtils'
+import { fmtTxDate, txKind } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 import { todayIso } from '@/lib/dates'
 
@@ -28,6 +28,8 @@ interface InvestmentTx {
   renewed_from_transaction_id?: string | null
   interest_earned_vnd?: number | null
   is_recurring?: boolean
+  held_for_merge?: boolean | null
+  consumed_by_inv_id?: string | null
 }
 
 interface Props {
@@ -503,8 +505,16 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                 </p>
               )}
               {!txLoading && transactions.map((tx, i) => {
-                const isWithdraw = tx.transaction_type === 'withdrawal'
                 const isRenewed = !!tx.renewed_from_transaction_id
+                // Held/merged settlements parked their cash — render neutral (like a
+                // snapshot), never the red "−" of a real withdrawal.
+                const kind = txKind(tx)
+                const isWithdraw = kind === 'withdrawal'
+                const neutral = isRenewed || kind === 'held' || kind === 'consumed'
+                const ink = neutral ? 'var(--c-muted)' : isWithdraw ? 'var(--c-neg)' : 'var(--c-pos)'
+                const fill = neutral ? 'var(--c-card-2)' : isWithdraw ? 'var(--c-neg-tint)' : 'var(--c-pos-tint)'
+                const DirIcon = isRenewed ? RefreshCw : kind === 'held' ? PiggyBank : kind === 'consumed' ? GitMerge : isWithdraw ? ArrowDownRight : ArrowUpRight
+                const sign = isWithdraw ? '-' : kind === 'investment' ? '+' : ''
                 const name = tx.fund_name ?? tx.notes ?? (isVi ? 'Khoản đầu tư' : 'Investment')
                 return (
                   <div key={tx.transaction_id} data-testid={isRenewed ? 'history-renewed-row' : undefined} style={{
@@ -515,16 +525,10 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                   }}>
                     <div style={{
                       width: 28, height: 28, borderRadius: 7, flexShrink: 0,
-                      background: isRenewed ? 'var(--c-card-2)' : isWithdraw ? 'var(--c-neg-tint)' : 'var(--c-pos-tint)',
-                      color: isRenewed ? 'var(--c-muted)' : isWithdraw ? 'var(--c-neg)' : 'var(--c-pos)',
+                      background: fill, color: ink,
                       display: 'flex', alignItems: 'center', justifyContent: 'center',
                     }}>
-                      {isRenewed
-                        ? <RefreshCw size={13} strokeWidth={2.2} />
-                        : isWithdraw
-                          ? <ArrowDownRight size={13} strokeWidth={2.2} />
-                          : <ArrowUpRight size={13} strokeWidth={2.2} />
-                      }
+                      <DirIcon size={13} strokeWidth={2.2} />
                     </div>
                     <div style={{ flex: 1, minWidth: 0 }}>
                       <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 6 }}>
@@ -534,13 +538,18 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                             {isVi ? 'Đã tái tục' : 'Renewed'}
                           </span>
                         )}
+                        {(kind === 'held' || kind === 'consumed') && (
+                          <span style={{ flexShrink: 0, fontSize: 9.5, fontWeight: 600, padding: '1px 6px', borderRadius: 999, background: 'var(--c-card-2)', color: 'var(--c-muted)' }}>
+                            {kind === 'held' ? (isVi ? 'Chờ gộp' : 'For merge') : (isVi ? 'Đã gộp' : 'Merged')}
+                          </span>
+                        )}
                       </div>
                       <div style={{ fontSize: 10, color: 'var(--c-muted)', marginTop: 1 }}>
                         {fmtTxDate(tx.investment_date, locale)}
                       </div>
                     </div>
-                    <span style={{ fontSize: 12, fontWeight: 600, color: isRenewed ? 'var(--c-muted)' : isWithdraw ? 'var(--c-neg)' : 'var(--c-pos)', fontVariantNumeric: 'tabular-nums', flexShrink: 0 }}>
-                      {isWithdraw ? '-' : '+'}{fmtCompact(tx.amount_vnd)}
+                    <span style={{ fontSize: 12, fontWeight: 600, color: ink, fontVariantNumeric: 'tabular-nums', flexShrink: 0 }}>
+                      {sign}{fmtCompact(tx.amount_vnd)}
                     </span>
                   </div>
                 )

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield, RefreshCw, PiggyBank, GitMerge } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, AffectsProgressControl, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
+import { GD_COLORS, buildCompositionSegments, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, AffectsProgressControl, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { MaturityResolveModal } from './MaturityResolveSheet'
 import { fmtTxDate, txKind } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
@@ -162,10 +162,10 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
   // Build investment rows (shared with the mobile sheet's valuation logic).
   const invRows: InvRow[] = buildInvRows(transactions, goal.funds, goldPricePerChi, isVi)
 
-  // Composition segments
-  const breakdown: Record<string, number> = {}
-  invRows.forEach((inv) => { breakdown[inv.type] = (breakdown[inv.type] ?? 0) + inv.value })
-  const segs = Object.entries(breakdown).map(([k, v]) => ({ label: k, value: v, color: GD_COLORS[k] ?? '#94a3b8' }))
+  // Composition segments — held-for-merge cash is folded back in (see helper) so the
+  // bar reconciles with the headline instead of summing short.
+  const heldCompValue = (goal.heldForMerge ?? []).reduce((a, h) => a + h.amount, 0)
+  const segs = buildCompositionSegments(invRows, heldCompValue, isVi)
   const segsTotal = segs.reduce((a, x) => a + x.value, 0)
 
   // Calculator
@@ -281,7 +281,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
 
         {/* Composition */}
         {segs.length > 0 && (
-          <div className="cn-card" style={{ padding: '14px 16px' }}>
+          <div data-testid="goal-composition" className="cn-card" style={{ padding: '14px 16px' }}>
             <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--c-muted)', marginBottom: 10 }}>
               {isVi ? 'Cơ cấu' : 'Composition'}
             </div>

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useMemo } from 'react'
-import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield, RefreshCw } from 'lucide-react'
+import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield, RefreshCw, PiggyBank } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
 import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, AffectsProgressControl, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
@@ -178,6 +178,19 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
 
   const visibleInvRows = invRows.filter((inv) => !unassignedIds.includes(inv.id))
 
+  // "Bỏ chờ gộp" — delete the held settlement row, restoring the original deposit;
+  // onDataChanged re-fetches so the chip drops and the deposit reappears.
+  const [unholdingId, setUnholdingId] = useState<string | null>(null)
+  async function handleUnhold(heldTxId: string) {
+    setUnholdingId(heldTxId)
+    try {
+      const res = await fetch(`/api/v1/investment-transactions/${heldTxId}`, { method: 'DELETE' })
+      if (res.ok) onDataChanged()
+    } finally {
+      setUnholdingId(null)
+    }
+  }
+
   return (
     <>
       <div data-testid="desktop-goal-detail" style={{ display: 'flex', flexDirection: 'column', gap: 14, animation: 'slide-right 200ms cubic-bezier(0.2,0.8,0.2,1)' }}>
@@ -310,6 +323,29 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
           {/* Investments tab */}
           {tab === 'investments' && (
             <>
+              {/* "Ví chờ gộp" — pooled settle-with-hold settlements, each with a
+                  "Bỏ chờ gộp" action that restores the original deposit. */}
+              {(goal.heldForMerge ?? []).length > 0 && (
+                <div data-testid="held-pool-section" style={{ padding: '8px 16px 12px', borderBottom: '1px solid var(--c-line)', display: 'grid', gap: 8 }}>
+                  {(goal.heldForMerge ?? []).map((h) => (
+                    <div key={h.transactionId} data-testid={`held-chip-${h.transactionId}`} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                      <div style={{ width: 32, height: 32, borderRadius: 8, background: 'var(--c-card-2)', color: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                        <PiggyBank size={15} />
+                      </div>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{h.name ?? (isVi ? 'Sổ chờ gộp' : 'Held deposit')}</div>
+                        <div style={{ fontSize: 11.5, color: 'var(--c-muted)', marginTop: 1, fontVariantNumeric: 'tabular-nums' }}>
+                          {fmtCompact(h.amount)} · {isVi ? 'Đang chờ gộp' : 'Held for merge'}
+                        </div>
+                      </div>
+                      <button type="button" data-testid={`unhold-${h.transactionId}`} onClick={() => handleUnhold(h.transactionId)} disabled={unholdingId === h.transactionId}
+                        style={{ flexShrink: 0, fontSize: 12, fontWeight: 600, color: 'var(--c-navy)', background: 'none', border: '1px solid var(--c-line)', borderRadius: 8, padding: '5px 10px', cursor: unholdingId === h.transactionId ? 'default' : 'pointer', opacity: unholdingId === h.transactionId ? 0.6 : 1, fontFamily: 'inherit' }}>
+                        {isVi ? 'Bỏ chờ gộp' : 'Unhold'}
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
               {txLoading && <TxRowsSkeleton />}
               {!txLoading && visibleInvRows.length === 0 && (
                 <p style={{ color: 'var(--c-muted)', fontSize: 13, textAlign: 'center', padding: '20px 0' }}>
@@ -567,6 +603,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
           inv={actionInv}
           goalId={goal.goalId}
           siblingDeposits={invRows}
+          heldSiblings={(goal.heldForMerge ?? []).map((h) => ({ id: h.transactionId, name: h.name, amount: h.amount }))}
           isVi={isVi}
           onClose={() => setShowResolve(false)}
           onRenewed={() => { setShowResolve(false); (onRenewed ?? onDataChanged)() }}

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import {
   ChevronLeft, ChevronRight, MoreHorizontal,
-  Edit2, Trash2, Calendar, Download, ArrowDownRight, ArrowUpRight, Target, RefreshCw, PiggyBank,
+  Edit2, Trash2, Calendar, Download, ArrowDownRight, ArrowUpRight, Target, RefreshCw, PiggyBank, GitMerge,
 } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
@@ -12,7 +12,7 @@ import TransactionHistorySheet, { type PurchaseHistoryRow } from './TransactionH
 import { SellWithdrawSheet, type SellItem } from './SellWithdrawSheet'
 import { MaturityResolveSheet } from './MaturityResolveSheet'
 import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
-import { fmtTxDate } from './transactionUtils'
+import { fmtTxDate, txKind } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 
 interface InvestmentTx {
@@ -35,6 +35,8 @@ interface InvestmentTx {
   renewed_from_transaction_id?: string | null
   interest_earned_vnd?: number | null
   is_recurring?: boolean
+  held_for_merge?: boolean | null
+  consumed_by_inv_id?: string | null
 }
 
 interface Props {
@@ -1242,8 +1244,16 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
                 </p>
               )}
               {!txLoading && transactions.map((tx, i) => {
-                const isWithdraw = tx.transaction_type === 'withdrawal'
                 const isRenewed = !!tx.renewed_from_transaction_id
+                // Held/merged settlements parked their cash — render neutral (like a
+                // snapshot), never the red "−" of a real withdrawal.
+                const kind = txKind(tx)
+                const isWithdraw = kind === 'withdrawal'
+                const neutral = isRenewed || kind === 'held' || kind === 'consumed'
+                const ink = neutral ? 'var(--c-muted)' : isWithdraw ? 'var(--c-neg)' : 'var(--c-pos)'
+                const fill = neutral ? 'var(--c-card-2)' : isWithdraw ? 'var(--c-neg-tint)' : 'var(--c-pos-tint)'
+                const DirIcon = isRenewed ? RefreshCw : kind === 'held' ? PiggyBank : kind === 'consumed' ? GitMerge : isWithdraw ? ArrowDownRight : ArrowUpRight
+                const sign = isWithdraw ? '-' : kind === 'investment' ? '+' : ''
                 const name = tx.fund_name ?? tx.notes ?? (isVI ? 'Khoản đầu tư' : 'Investment')
                 return (
                   <div
@@ -1258,16 +1268,10 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
                   >
                     <div style={{
                       width: 32, height: 32, borderRadius: 8, flexShrink: 0,
-                      background: isRenewed ? 'var(--c-card-2)' : isWithdraw ? 'var(--c-neg-tint)' : 'var(--c-pos-tint)',
-                      color: isRenewed ? 'var(--c-muted)' : isWithdraw ? 'var(--c-neg)' : 'var(--c-pos)',
+                      background: fill, color: ink,
                       display: 'flex', alignItems: 'center', justifyContent: 'center',
                     }}>
-                      {isRenewed
-                        ? <RefreshCw size={14} strokeWidth={2.2} />
-                        : isWithdraw
-                          ? <ArrowDownRight size={14} strokeWidth={2.2} />
-                          : <ArrowUpRight size={14} strokeWidth={2.2} />
-                      }
+                      <DirIcon size={14} strokeWidth={2.2} />
                     </div>
                     <div style={{ flex: 1, minWidth: 0 }}>
                       <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 6 }}>
@@ -1277,13 +1281,18 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
                             {isVI ? 'Đã tái tục' : 'Renewed'}
                           </span>
                         )}
+                        {(kind === 'held' || kind === 'consumed') && (
+                          <span style={{ flexShrink: 0, fontSize: 10, fontWeight: 600, padding: '1px 7px', borderRadius: 999, background: 'var(--c-card-2)', color: 'var(--c-muted)' }}>
+                            {kind === 'held' ? (isVI ? 'Chờ gộp' : 'For merge') : (isVI ? 'Đã gộp' : 'Merged')}
+                          </span>
+                        )}
                       </div>
                       <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2 }}>
                         {fmtTxDate(tx.investment_date, isVI ? 'vi' : 'en')}
                       </div>
                     </div>
-                    <span style={{ fontSize: 13, fontWeight: 600, color: isRenewed ? 'var(--c-muted)' : isWithdraw ? 'var(--c-neg)' : 'var(--c-pos)', fontVariantNumeric: 'tabular-nums' }}>
-                      {isWithdraw ? '-' : '+'}{fmtCompact(tx.amount_vnd)}
+                    <span style={{ fontSize: 13, fontWeight: 600, color: ink, fontVariantNumeric: 'tabular-nums' }}>
+                      {sign}{fmtCompact(tx.amount_vnd)}
                     </span>
                   </div>
                 )

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -11,7 +11,7 @@ import type { GoalData, FundBreakdownItem } from '../DashboardClient'
 import TransactionHistorySheet, { type PurchaseHistoryRow } from './TransactionHistorySheet'
 import { SellWithdrawSheet, type SellItem } from './SellWithdrawSheet'
 import { MaturityResolveSheet } from './MaturityResolveSheet'
-import { GD_COLORS, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
+import { GD_COLORS, buildCompositionSegments, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { fmtTxDate, txKind } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 
@@ -843,10 +843,10 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
 
   const detailFund = fundDetailId ? (fundMap.get(fundDetailId) ?? null) : null
 
-  // Composition breakdown by asset type
-  const breakdown: Record<string, number> = {}
-  invRows.forEach((inv) => { breakdown[inv.type] = (breakdown[inv.type] ?? 0) + inv.value })
-  const segs = Object.entries(breakdown).map(([k, v]) => ({ label: k, value: v, color: GD_COLORS[k] ?? 'var(--c-muted)' }))
+  // Composition breakdown by asset type — held-for-merge cash is folded back in (see
+  // helper) so the bar reconciles with the headline instead of summing short.
+  const heldCompValue = (goal.heldForMerge ?? []).reduce((a, h) => a + h.amount, 0)
+  const segs = buildCompositionSegments(invRows, heldCompValue, isVI)
 
   return (
     <>
@@ -953,7 +953,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
 
           {/* Composition bar */}
           {segs.length > 0 && (
-            <div style={{ background: 'var(--c-card)', borderRadius: 16, padding: 16, marginBottom: 16, boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }}>
+            <div data-testid="goal-composition" style={{ background: 'var(--c-card)', borderRadius: 16, padding: 16, marginBottom: 16, boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }}>
               <p style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)', marginBottom: 10 }}>
                 {isVI ? 'Cơ cấu' : 'Composition'}
               </p>

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import {
   ChevronLeft, ChevronRight, MoreHorizontal,
-  Edit2, Trash2, Calendar, Download, ArrowDownRight, ArrowUpRight, Target, RefreshCw,
+  Edit2, Trash2, Calendar, Download, ArrowDownRight, ArrowUpRight, Target, RefreshCw, PiggyBank,
 } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
@@ -741,6 +741,20 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
     setActionsOpen(false)
   }
 
+  // "Bỏ chờ gộp" — delete the held settlement row, which restores the original
+  // deposit (its withdrawal no longer subtracts). onDataChanged re-fetches the
+  // overview, so the chip drops and the deposit reappears in the list.
+  const [unholdingId, setUnholdingId] = useState<string | null>(null)
+  async function handleUnhold(heldTxId: string) {
+    setUnholdingId(heldTxId)
+    try {
+      const res = await fetch(`/api/v1/investment-transactions/${heldTxId}`, { method: 'DELETE' })
+      if (res.ok) onDataChanged()
+    } finally {
+      setUnholdingId(null)
+    }
+  }
+
   // Mirror of DesktopGoalDetail.handleUnassign — fund rows aggregate every
   // fund-investment under the same fund, non-fund rows correspond to a
   // single investment_transactions row.
@@ -999,6 +1013,29 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
           {/* Investments tab */}
           {activeTab === 'investments' && (
             <div style={{ background: 'var(--c-card)', borderRadius: 16, padding: '0 14px', boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }}>
+              {/* "Ví chờ gộp" — settle-with-hold settlements still pooled. Each shows
+                  a chip with "Bỏ chờ gộp" that restores the original deposit. */}
+              {(goal.heldForMerge ?? []).length > 0 && (
+                <div data-testid="held-pool-section" style={{ padding: '12px 0', borderBottom: '1px solid var(--c-line)', display: 'grid', gap: 8 }}>
+                  {(goal.heldForMerge ?? []).map((h) => (
+                    <div key={h.transactionId} data-testid={`held-chip-${h.transactionId}`} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                      <div style={{ width: 32, height: 32, borderRadius: 8, background: 'var(--c-card-2)', color: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                        <PiggyBank size={15} />
+                      </div>
+                      <div style={{ flex: 1, minWidth: 0 }}>
+                        <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{h.name ?? (isVI ? 'Sổ chờ gộp' : 'Held deposit')}</div>
+                        <div style={{ fontSize: 11.5, color: 'var(--c-muted)', marginTop: 1, fontVariantNumeric: 'tabular-nums' }}>
+                          {fmtCompact(h.amount)} · {isVI ? 'Đang chờ gộp' : 'Held for merge'}
+                        </div>
+                      </div>
+                      <button type="button" data-testid={`unhold-${h.transactionId}`} onClick={() => handleUnhold(h.transactionId)} disabled={unholdingId === h.transactionId}
+                        style={{ flexShrink: 0, fontSize: 12, fontWeight: 600, color: 'var(--c-navy)', background: 'none', border: '1px solid var(--c-line)', borderRadius: 8, padding: '5px 10px', cursor: unholdingId === h.transactionId ? 'default' : 'pointer', opacity: unholdingId === h.transactionId ? 0.6 : 1, fontFamily: 'inherit' }}>
+                        {isVI ? 'Bỏ chờ gộp' : 'Unhold'}
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
               {txLoading && <TxRowsSkeleton />}
               {!txLoading && invRows.length === 0 && (
                 <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0' }}>
@@ -1294,6 +1331,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
         inv={actionInv}
         goalId={goal.goalId}
         siblingDeposits={invRows}
+        heldSiblings={(goal.heldForMerge ?? []).map((h) => ({ id: h.transactionId, name: h.name, amount: h.amount }))}
         isVi={isVI}
         onClose={() => setResolveOpen(false)}
         onRenewed={() => { setResolveOpen(false); onDataChanged() }}

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -17,7 +17,7 @@
 // (the parent wires `onWithdraw`).
 
 import { useState, useEffect } from 'react'
-import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X, Plus, Wallet, Lock, SlidersHorizontal } from 'lucide-react'
+import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X, Plus, Wallet, Lock, SlidersHorizontal, PiggyBank, GitMerge } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import { fmtMaturity, type InvRow } from './goalDetailShared'
 import {
@@ -64,7 +64,7 @@ function MoneyField({ label, value, onChange, testId }: { label: string; value: 
  * parent's existing Sell/Withdraw flow.
  */
 export function MaturityResolveBody({
-  inv, goalId, siblingDeposits, isVi, onClose, onRenewed, onWithdraw,
+  inv, goalId, siblingDeposits, heldSiblings, isVi, onClose, onRenewed, onWithdraw,
 }: {
   inv: InvRow
   // The goal this deposit is assigned to (null = unallocated). Used to find the
@@ -75,6 +75,11 @@ export function MaturityResolveBody({
   // that prevents the "inflate the principal but leave the sibling active"
   // double-count. Omitted by callers that don't wire it (feature inert).
   siblingDeposits?: InvRow[]
+  // "Ví chờ gộp" holdings in this goal — earlier-maturing deposits already settled
+  // with "Để dành gộp", their cash parked. When `inv` is the anchor they merge
+  // into, they appear preselected in the merge section and submit as held_sources
+  // (consumed in place — no second withdrawal). `id` is the held WITHDRAWAL row.
+  heldSiblings?: { id: string; name: string | null; amount: number }[]
   isVi: boolean
   onClose: () => void
   onRenewed: () => void
@@ -114,6 +119,8 @@ export function MaturityResolveBody({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const [done, setDone] = useState<null | { newPrincipal: number; newMaturity: string; sources: string[] }>(null)
+  // Settle-with-hold success: the deposit was parked in the pool (no re-deposit).
+  const [heldDone, setHeldDone] = useState<null | { anchorName: string }>(null)
 
   // ── Combine ("settle & re-deposit", merge recurring) ────────────────────────
   // A recurring bank saving due for this goal this month can be folded into the
@@ -156,6 +163,22 @@ export function MaturityResolveBody({
   const [banks, setBanks] = useState<{ code: string; name: string }[]>([])
   const [destBank, setDestBank] = useState<string>(inv.bankCode ?? '')
 
+  // ── Settle-with-hold ("Để dành gộp") ─────────────────────────────────────────
+  // When THIS maturing deposit has a later-maturing eligible anchor in the same
+  // goal, "Không tái tục — rút" forks into two cards: park the cash for that merge
+  // (default) vs withdraw to the wallet. holdReceived is the cash that lands (the
+  // user edits it down if early settlement is penalised).
+  const [holdChoice, setHoldChoice] = useState<'hold' | 'cash'>('hold')
+  const [holdReceived, setHoldReceived] = useState(String(Math.round(inv.value ?? principal)))
+  // ── Held-pool consume (when THIS deposit is the anchor) ───────────────────────
+  // The goal's pooled holdings, all preselected to fold in. heldSel records only
+  // explicit deselects (a deselected holding is unheld → restored to a deposit).
+  const pooledHeld = heldSiblings ?? []
+  const [heldSel, setHeldSel] = useState<Record<string, boolean>>({})
+  const isHeldSelected = (id: string) => heldSel[id] ?? true
+  const selectedHeld = pooledHeld.filter((h) => isHeldSelected(h.id))
+  const heldReceivedTotal = selectedHeld.reduce((sum, h) => sum + h.amount, 0)
+
   // Classify each mergeable sibling against the anchor (D). Same-goal is already
   // guaranteed (siblings are this goal's holdings), so we don't pass goal ids.
   const classifications = classifyMergeSources(
@@ -164,6 +187,26 @@ export function MaturityResolveBody({
     windowDays,
   )
   const classOf = new Map(classifications.map((c) => [c.source.id, c]))
+
+  // Eligible HOLD anchors: this deposit can be settled-with-hold only when a
+  // LATER-maturing sibling in the same goal is an eligible merge target for it
+  // (same window/currency/not-pledged, via the shared PR2 predicate — D as anchor,
+  // THIS deposit as the source). No anchor ⇒ plain withdraw, no hold fork (per the
+  // owner's gate). The nearest later maturity is the default anchor.
+  const holdAnchors = goalId == null || isBook
+    ? []
+    : (siblingDeposits ?? [])
+        .filter((s) => s.id !== inv.id && s.type === 'bank' && !s.depositGroupId && (s.principal ?? s.value ?? 0) > 0)
+        .filter((s) => (s.expiryDate ?? '') > (inv.expiryDate ?? '')) // anchor matures later
+        .filter((s) => classifyMergeSources(
+          { id: s.id, type: s.type, expiryDate: s.expiryDate, principal: s.principal, value: s.value, depositGroupId: s.depositGroupId, currency: s.currency, isPledged: s.isPledged },
+          [{ id: inv.id, type: inv.type, expiryDate: inv.expiryDate, principal: inv.principal, value: inv.value, depositGroupId: inv.depositGroupId, currency: inv.currency, isPledged: inv.isPledged }],
+          windowDays,
+        )[0]?.eligible)
+        .sort((a, b) => (a.expiryDate ?? '').localeCompare(b.expiryDate ?? ''))
+  const holdAnchor = holdAnchors[0] ?? null
+  const canHold = !!holdAnchor
+  const holdReceivedNum = holdReceived.trim() === '' ? 0 : Number(holdReceived)
 
   // Effective selection: an explicit toggle wins; an overridden source is on; else
   // the eligibility default.
@@ -287,14 +330,21 @@ export function MaturityResolveBody({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  // Open straight into combine mode when this anchor has pooled holdings waiting —
+  // the whole point of resolving it is to fold them in (mount-only).
+  useEffect(() => {
+    if (pooledHeld.length > 0) setMode('combine')
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
   // The candidate currently chosen to fold in (explicit pick, else the match).
   const pickedCand: RecurringLinkCandidate | null = combineLink
     ? (pickedSavingId ? combineLink.candidates.find((c) => c.saving_id === pickedSavingId) ?? null : combineLink.match)
     : null
   const linkedAmt = pickedCand ? pickedCand.amount_vnd : 0
-  // Combine is offered when there's a recurring to fold in OR sibling deposits to
-  // merge — both routes settle-and-re-deposit. Inert when neither exists.
-  const canCombine = !!combineLink || mergeable.length > 0
+  // Combine is offered when there's a recurring to fold in, sibling deposits to
+  // merge, OR pooled holdings waiting to be consumed — all settle-and-re-deposit.
+  const canCombine = !!combineLink || mergeable.length > 0 || pooledHeld.length > 0
 
   const iNum = Number(interest) || 0
   const tNum = Number(term) || 0
@@ -309,7 +359,7 @@ export function MaturityResolveBody({
   const newPrincipal = mode === 'withdraw'
     ? principal
     : mode === 'combine'
-      ? redepositNum + mergeReceivedTotal
+      ? redepositNum + mergeReceivedTotal + heldReceivedTotal
       : renewalPrincipal(mode, principal, iNum, newAmountNum)
 
   // Suggested re-deposit = principal + interest + this month's recurring, until
@@ -384,6 +434,19 @@ export function MaturityResolveBody({
     reasonPledged: 'Đang thế chấp — bị phong toả',
     reasonGoal: 'Khác mục tiêu',
     reasonBlocked: 'Chưa đủ điều kiện',
+    holdNudge: (anchor: string, date: string) => `«${anchor}» đáo hạn ${date} cùng mục tiêu — để dành gộp thay vì rút?`,
+    holdForkPrompt: 'Tất toán sổ này thế nào?',
+    holdCardTitle: 'Để dành gộp',
+    holdCardSub: (anchor: string) => `Giữ tiền chờ gộp vào «${anchor}» — không rời mục tiêu`,
+    cashCardTitle: 'Rút ra ví',
+    cashCardSub: 'Tiền rời khỏi mục tiêu như rút thường',
+    holdReceivedLabel: 'Số tiền thực nhận',
+    holdConfirm: 'Xác nhận để dành',
+    holdDone: 'Đã để dành gộp',
+    holdDoneSub: (anchor: string) => `Đang chờ gộp vào «${anchor}»`,
+    heldSectionTitle: 'Ví chờ gộp',
+    heldSectionHint: 'Các sổ đã tất toán để dành — gộp vào lần gửi lại này.',
+    heldUnholdHint: 'Bỏ chọn để giữ lại trong ví chờ gộp.',
   } : {
     summarySuffix: 'yr', perYr: 'yr', mo: 'mo',
     why: matured
@@ -431,6 +494,19 @@ export function MaturityResolveBody({
     reasonPledged: 'Pledged as collateral',
     reasonGoal: 'Different goal',
     reasonBlocked: 'Not eligible yet',
+    holdNudge: (anchor: string, date: string) => `“${anchor}” matures ${date} in the same goal — hold for merge instead of withdrawing?`,
+    holdForkPrompt: 'How do you want to settle this?',
+    holdCardTitle: 'Hold for merge',
+    holdCardSub: (anchor: string) => `Keep the cash for merging into “${anchor}” — stays in the goal`,
+    cashCardTitle: 'Withdraw to wallet',
+    cashCardSub: 'Money leaves the goal, like a normal withdrawal',
+    holdReceivedLabel: 'Cash received',
+    holdConfirm: 'Confirm hold',
+    holdDone: 'Held for merge',
+    holdDoneSub: (anchor: string) => `Waiting to merge into “${anchor}”`,
+    heldSectionTitle: 'Merge holding pool',
+    heldSectionHint: 'Deposits already settled and parked — fold them into this re-deposit.',
+    heldUnholdHint: 'Deselect to leave it in the pool.',
   }
 
   // Human-readable reason for a blocked source.
@@ -459,8 +535,51 @@ export function MaturityResolveBody({
     { id: 'withdraw' as Mode, icon: <ArrowDownToLine size={16} />, label: isVi ? 'Không tái tục — rút' : 'Don’t renew — withdraw', sub: isVi ? 'Rút toàn bộ số dư' : 'Withdraw the full balance', danger: true },
   ]
 
+  // Settle this deposit with "Để dành gộp": post a held withdrawal that closes it
+  // (removing its principal from net worth + the bar) but flags the cash for a
+  // future merge into the chosen anchor — the overview synthesizes it straight
+  // back, so the goal value never dips. No re-deposit happens here.
+  async function handleHold() {
+    if (!holdAnchor || !(holdReceivedNum > 0)) return
+    setSaving(true); setError('')
+    try {
+      const res = await fetch('/api/v1/investment-transactions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          transaction_type: 'withdrawal',
+          asset_type: 'bank',
+          goal_id: goalId,
+          parent_transaction_id: inv.id,
+          investment_date: todayIso(),
+          amount_vnd: Math.round(holdReceivedNum),
+          principal_withdrawn: Math.round(principal),
+          affects_progress: true,
+          held_for_merge: true,
+          merge_target_goal_id: goalId,
+          merge_anchor_inv_id: holdAnchor.id,
+        }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setError(body.error ?? (isVi ? 'Không thể để dành' : 'Could not hold'))
+        setSaving(false)
+        return
+      }
+      setHeldDone({ anchorName: holdAnchor.name })
+      setTimeout(() => { onRenewed(); onClose() }, 1700)
+    } catch {
+      setError(isVi ? 'Lỗi kết nối' : 'Connection error')
+      setSaving(false)
+    }
+  }
+
   async function handleConfirm() {
-    if (mode === 'withdraw') { onClose(); setTimeout(onWithdraw, 60); return }
+    if (mode === 'withdraw') {
+      // The hold fork only exists when there's an eligible anchor; default is hold.
+      if (canHold && holdChoice === 'hold') { await handleHold(); return }
+      onClose(); setTimeout(onWithdraw, 60); return
+    }
     if (!canRenew) return
     setSaving(true); setError('')
     try {
@@ -504,6 +623,11 @@ export function MaturityResolveBody({
           // Destination bank for the combined re-deposit (multi-source merge only).
           // '' (no bank picked) → null; the RPC leaves the existing bank untouched.
           bank_code: mode === 'combine' && selectedSources.length > 0 ? (destBank || null) : undefined,
+          // "Ví chờ gộp": pooled holdings to consume. The RPC stamps each
+          // consumed and folds its parked cash into D — no second withdrawal.
+          held_sources: mode === 'combine' && selectedHeld.length > 0
+            ? selectedHeld.map((h) => h.id)
+            : undefined,
         }),
       })
       if (!res.ok) {
@@ -514,7 +638,9 @@ export function MaturityResolveBody({
       }
       setDone({
         newPrincipal: Math.round(newPrincipal), newMaturity,
-        sources: mode === 'combine' ? selectedSources.map((s) => s.name) : [],
+        sources: mode === 'combine'
+          ? [...selectedSources.map((s) => s.name), ...selectedHeld.map((h) => h.name ?? (isVi ? 'Sổ chờ gộp' : 'Held deposit'))]
+          : [],
       })
       setTimeout(() => { onRenewed(); onClose() }, 1700)
     } catch {
@@ -539,6 +665,21 @@ export function MaturityResolveBody({
             {t.mergedSourcesLabel}: {done.sources.join(', ')}
           </div>
         )}
+      </div>
+    )
+  }
+
+  // ─── Settle-with-hold success ───
+  if (heldDone) {
+    return (
+      <div data-testid="maturity-held" style={{ padding: '24px 4px 8px', textAlign: 'center' }}>
+        <div style={{ width: 56, height: 56, borderRadius: 28, background: 'var(--c-card-2)', color: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 14px' }}>
+          <PiggyBank size={26} strokeWidth={2.2} />
+        </div>
+        <div style={{ fontSize: 15, fontWeight: 700 }}>{t.holdDone}</div>
+        <div style={{ fontSize: 13, color: 'var(--c-muted)', marginTop: 6, lineHeight: 1.5 }}>
+          {t.holdDoneSub(heldDone.anchorName)}
+        </div>
       </div>
     )
   }
@@ -573,6 +714,18 @@ export function MaturityResolveBody({
         <AlertTriangle size={15} color="var(--c-warn)" strokeWidth={2.2} style={{ flexShrink: 0, marginTop: 1 }} />
         <p style={{ margin: 0, fontSize: 12.5, color: 'var(--c-warn)', lineHeight: 1.5 }}>{t.why}</p>
       </div>
+
+      {/* Discoverability nudge: a later-maturing sibling in this goal makes this
+          deposit a hold-for-merge candidate. Surfaced up top so the option isn't
+          buried; the actual commit lives in the withdraw fork below. */}
+      {canHold && holdAnchor && (
+        <div data-testid="maturity-hold-nudge" style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '11px 13px', background: 'var(--c-card-2)', borderRadius: 10 }}>
+          <PiggyBank size={15} color="var(--c-navy)" strokeWidth={2.2} style={{ flexShrink: 0, marginTop: 1 }} />
+          <p style={{ margin: 0, fontSize: 12.5, color: 'var(--c-ink)', lineHeight: 1.5 }}>
+            {t.holdNudge(holdAnchor.name, fmtMaturity(holdAnchor.expiryDate, isVi)?.formatted ?? '')}
+          </p>
+        </div>
+      )}
 
       {/* Decision picker */}
       <div>
@@ -785,6 +938,38 @@ export function MaturityResolveBody({
             </div>
           )}
 
+          {/* "Ví chờ gộp" — pooled holdings to consume (preselected). Deselecting
+              one just leaves it in the pool; restoring the deposit is the holdings
+              chip's "Bỏ chờ gộp" action. Shown even with no live siblings. */}
+          {!isBook && pooledHeld.length > 0 && (
+            <div data-testid="merge-held-pool" style={{ border: '1px solid var(--c-line)', borderRadius: 12, padding: '11px 13px', display: 'grid', gap: 9 }}>
+              <div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+                  <GitMerge size={14} color="var(--c-navy)" style={{ flexShrink: 0 }} />
+                  <div style={{ ...fieldLabel, marginBottom: 0 }}>{t.heldSectionTitle}</div>
+                </div>
+                <p style={{ margin: '4px 0 0', fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.45 }}>{t.heldSectionHint}</p>
+              </div>
+              <div style={{ display: 'grid', gap: 7 }}>
+                {pooledHeld.map((h) => {
+                  const sel = isHeldSelected(h.id)
+                  return (
+                    <button key={h.id} type="button" data-testid={`merge-held-${h.id}`} onClick={() => setHeldSel((prev) => ({ ...prev, [h.id]: !sel }))}
+                      style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '9px 11px', borderRadius: 10, cursor: 'pointer', textAlign: 'left',
+                        border: `1.5px solid ${sel ? 'var(--c-navy)' : 'var(--c-line)'}`, background: sel ? 'var(--c-navy-tint)' : 'var(--c-card)', fontFamily: 'inherit' }}>
+                      <span style={{ width: 18, height: 18, borderRadius: 9, flexShrink: 0, border: `1.5px solid ${sel ? 'var(--c-btn-primary)' : 'var(--c-line-strong)'}`, background: sel ? 'var(--c-btn-primary)' : 'transparent', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                        {sel && <Check size={11} color="#fff" strokeWidth={3} />}
+                      </span>
+                      <span style={{ flex: 1, minWidth: 0, fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{h.name ?? (isVi ? 'Sổ chờ gộp' : 'Held deposit')}</span>
+                      <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(h.amount)}</span>
+                    </button>
+                  )
+                })}
+              </div>
+              <p style={{ margin: 0, fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.45 }}>{t.heldUnholdHint}</p>
+            </div>
+          )}
+
           {/* New term + rate */}
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
             <div>
@@ -924,9 +1109,50 @@ export function MaturityResolveBody({
       )}
 
       {mode === 'withdraw' && (
-        <div style={{ border: '1px solid var(--c-line)', borderRadius: 12, padding: '12px 14px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: 'var(--c-card-2)' }}>
-          <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-muted)' }}>{t.totalPayout}</span>
-          <span style={{ fontSize: 16, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>{fmt(payout)}</span>
+        <div style={{ display: 'grid', gap: 12 }}>
+          {/* Hold fork — only when a later-maturing eligible anchor exists. Two
+              clear cards (hold preselected), per the owner's design. */}
+          {canHold && holdAnchor && (
+            <div data-testid="maturity-hold-fork" style={{ display: 'grid', gap: 8 }}>
+              <div style={fieldLabel}>{t.holdForkPrompt}</div>
+              {([
+                { id: 'hold' as const, icon: <PiggyBank size={16} />, title: t.holdCardTitle, sub: t.holdCardSub(holdAnchor.name) },
+                { id: 'cash' as const, icon: <ArrowDownToLine size={16} />, title: t.cashCardTitle, sub: t.cashCardSub },
+              ]).map((c) => {
+                const active = holdChoice === c.id
+                const accent = c.id === 'cash' ? 'var(--c-neg)' : 'var(--c-navy)'
+                return (
+                  <button key={c.id} type="button" data-testid={`maturity-hold-card-${c.id}`} onClick={() => setHoldChoice(c.id)} style={{
+                    width: '100%', textAlign: 'left', padding: '11px 12px',
+                    background: active ? (c.id === 'cash' ? 'var(--c-neg-tint)' : 'var(--c-navy-tint)') : 'var(--c-card)',
+                    border: `1.5px solid ${active ? accent : 'var(--c-line)'}`, borderRadius: 12, cursor: 'pointer',
+                    fontFamily: 'inherit', display: 'flex', alignItems: 'center', gap: 11,
+                  }}>
+                    <div style={{ width: 34, height: 34, borderRadius: 9, background: active ? 'var(--c-card)' : 'var(--c-card-2)', color: accent, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>{c.icon}</div>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontSize: 13.5, fontWeight: 600, color: active ? accent : 'var(--c-ink)' }}>{c.title}</div>
+                      <div style={{ fontSize: 11.5, color: 'var(--c-muted)', marginTop: 1, lineHeight: 1.4 }}>{c.sub}</div>
+                    </div>
+                    <div style={{ width: 18, height: 18, borderRadius: 9, border: `1.5px solid ${active ? accent : 'var(--c-line-strong)'}`, background: active ? accent : 'transparent', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                      {active && <Check size={11} strokeWidth={3} color="#fff" />}
+                    </div>
+                  </button>
+                )
+              })}
+              {/* Cash received when holding — defaults to current value; edit down
+                  if early settlement was penalised. */}
+              {holdChoice === 'hold' && (
+                <div style={{ paddingTop: 2 }}>
+                  <MoneyField label={t.holdReceivedLabel} value={holdReceived} onChange={setHoldReceived} testId="maturity-hold-received" />
+                </div>
+              )}
+            </div>
+          )}
+
+          <div style={{ border: '1px solid var(--c-line)', borderRadius: 12, padding: '12px 14px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: 'var(--c-card-2)' }}>
+            <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-muted)' }}>{t.totalPayout}</span>
+            <span style={{ fontSize: 16, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>{fmt(payout)}</span>
+          </div>
         </div>
       )}
 
@@ -935,17 +1161,24 @@ export function MaturityResolveBody({
       {/* Actions */}
       <div style={{ display: 'flex', gap: 8 }}>
         <button type="button" onClick={onClose} className="cn-btn ghost" style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}>{t.cancel}</button>
-        <button type="button" onClick={handleConfirm} disabled={saving || (mode !== 'withdraw' && !canRenew)} style={{
-          flex: 2, justifyContent: 'center', gap: 7, padding: '10px 14px', borderRadius: 10, border: 'none',
-          fontSize: 14, fontWeight: 600, fontFamily: 'inherit',
-          cursor: saving || (mode !== 'withdraw' && !canRenew) ? 'default' : 'pointer',
-          opacity: saving || (mode !== 'withdraw' && !canRenew) ? 0.6 : 1, color: '#fff',
-          background: mode === 'withdraw' ? 'var(--c-neg)' : 'var(--c-btn-primary)',
-          display: 'flex', alignItems: 'center',
-        }}>
-          {mode === 'withdraw' ? <ArrowDownToLine size={14} strokeWidth={2.2} /> : mode === 'combine' ? <Plus size={14} strokeWidth={2.2} /> : <RefreshCw size={14} strokeWidth={2.2} />}
-          {mode === 'withdraw' ? t.confirmWithdraw : mode === 'combine' ? t.confirmCombine : t.confirmRenew}
-        </button>
+        {(() => {
+          // Holding posts instead of withdrawing — navy CTA + piggy icon, never the
+          // red withdraw button (the money is staying in the goal).
+          const holding = mode === 'withdraw' && canHold && holdChoice === 'hold'
+          const disabled = saving || (mode !== 'withdraw' && !canRenew) || (holding && !(holdReceivedNum > 0))
+          return (
+            <button type="button" onClick={handleConfirm} disabled={disabled} style={{
+              flex: 2, justifyContent: 'center', gap: 7, padding: '10px 14px', borderRadius: 10, border: 'none',
+              fontSize: 14, fontWeight: 600, fontFamily: 'inherit',
+              cursor: disabled ? 'default' : 'pointer', opacity: disabled ? 0.6 : 1, color: '#fff',
+              background: mode === 'withdraw' && !holding ? 'var(--c-neg)' : 'var(--c-btn-primary)',
+              display: 'flex', alignItems: 'center',
+            }}>
+              {holding ? <PiggyBank size={14} strokeWidth={2.2} /> : mode === 'withdraw' ? <ArrowDownToLine size={14} strokeWidth={2.2} /> : mode === 'combine' ? <Plus size={14} strokeWidth={2.2} /> : <RefreshCw size={14} strokeWidth={2.2} />}
+              {holding ? t.holdConfirm : mode === 'withdraw' ? t.confirmWithdraw : mode === 'combine' ? t.confirmCombine : t.confirmRenew}
+            </button>
+          )
+        })()}
       </div>
     </div>
   )
@@ -953,12 +1186,13 @@ export function MaturityResolveBody({
 
 // ─── Mobile bottom-sheet wrapper ───────────────────────────────────────────
 export function MaturityResolveSheet({
-  open, inv, goalId, siblingDeposits, isVi, onClose, onRenewed, onWithdraw,
+  open, inv, goalId, siblingDeposits, heldSiblings, isVi, onClose, onRenewed, onWithdraw,
 }: {
   open: boolean
   inv: InvRow | null
   goalId?: string | null
   siblingDeposits?: InvRow[]
+  heldSiblings?: { id: string; name: string | null; amount: number }[]
   isVi: boolean
   onClose: () => void
   onRenewed: () => void
@@ -991,7 +1225,7 @@ export function MaturityResolveSheet({
           <h2 style={{ margin: '0 0 14px', fontSize: 17, fontWeight: 700, letterSpacing: '-0.01em' }}>
             {isVi ? 'Xử lý đáo hạn' : 'Handle maturity'}
           </h2>
-          <MaturityResolveBody inv={inv} goalId={goalId} siblingDeposits={siblingDeposits} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />
+          <MaturityResolveBody inv={inv} goalId={goalId} siblingDeposits={siblingDeposits} heldSiblings={heldSiblings} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />
         </div>
       </div>
     </div>
@@ -1000,11 +1234,12 @@ export function MaturityResolveSheet({
 
 // ─── Desktop modal wrapper ─────────────────────────────────────────────────
 export function MaturityResolveModal({
-  inv, goalId, siblingDeposits, isVi, onClose, onRenewed, onWithdraw,
+  inv, goalId, siblingDeposits, heldSiblings, isVi, onClose, onRenewed, onWithdraw,
 }: {
   inv: InvRow
   goalId?: string | null
   siblingDeposits?: InvRow[]
+  heldSiblings?: { id: string; name: string | null; amount: number }[]
   isVi: boolean
   onClose: () => void
   onRenewed: () => void
@@ -1036,7 +1271,7 @@ export function MaturityResolveModal({
           <button onClick={onClose} className="cn-btn ghost" style={{ padding: 6 }} aria-label="Close"><X size={18} /></button>
         </div>
         <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto' }}>
-          <MaturityResolveBody inv={inv} goalId={goalId} siblingDeposits={siblingDeposits} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />
+          <MaturityResolveBody inv={inv} goalId={goalId} siblingDeposits={siblingDeposits} heldSiblings={heldSiblings} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />
         </div>
       </div>
     </div>

--- a/app/assets/components/RecentActivityCard.tsx
+++ b/app/assets/components/RecentActivityCard.tsx
@@ -2,13 +2,13 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useTranslations } from 'next-intl'
-import { Calendar, ArrowUpRight, ArrowDownRight, ArrowRight } from 'lucide-react'
+import { Calendar, ArrowUpRight, ArrowDownRight, ArrowRight, PiggyBank, GitMerge } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
 import TransactionLedgerSheet from './TransactionLedgerSheet'
 import {
   type LedgerTransaction,
   type AssetType,
-  isWithdrawal,
+  txDir,
   txPrimaryName,
   fmtTxDate,
 } from './transactionUtils'
@@ -82,10 +82,12 @@ export default function RecentActivityCard({ locale, desktop, refreshKey, onChan
     </div>
   ) : (
     txs.map((tx, i) => {
-      const withdrawal = isWithdrawal(tx)
-      const color = withdrawal ? 'var(--c-neg)' : 'var(--c-pos)'
-      const badgeColor = withdrawal ? 'var(--c-neg)' : (ASSET_BADGE[tx.asset_type as AssetType] ?? 'var(--c-muted)')
-      const badgeText = withdrawal ? tt('withdrawal') : assetLabel(tx)
+      // Held/merged settlements read neutrally — never the red "−" of a spend.
+      const { kind, tone, sign } = txDir(tx)
+      const color = tone === 'pos' ? 'var(--c-pos)' : tone === 'neg' ? 'var(--c-neg)' : 'var(--c-muted)'
+      const badgeColor = kind === 'investment' ? (ASSET_BADGE[tx.asset_type as AssetType] ?? 'var(--c-muted)') : color
+      const badgeText = kind === 'held' ? tt('held') : kind === 'consumed' ? tt('merged') : kind === 'withdrawal' ? tt('withdrawal') : assetLabel(tx)
+      const DirIcon = kind === 'held' ? PiggyBank : kind === 'consumed' ? GitMerge : kind === 'withdrawal' ? ArrowDownRight : ArrowUpRight
       const goalName = tx.savings_goals?.goal_name ?? tt('noGoal')
       return (
         <div
@@ -94,7 +96,7 @@ export default function RecentActivityCard({ locale, desktop, refreshKey, onChan
           style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '11px 14px', borderBottom: i < txs.length - 1 ? '1px solid var(--c-line)' : 'none' }}
         >
           <div style={{ width: 30, height: 30, borderRadius: 8, background: `color-mix(in srgb, ${color} 12%, transparent)`, color, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-            {withdrawal ? <ArrowDownRight size={14} strokeWidth={2.2} /> : <ArrowUpRight size={14} strokeWidth={2.2} />}
+            <DirIcon size={14} strokeWidth={2.2} />
           </div>
           <div style={{ flex: 1, minWidth: 0 }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
@@ -110,7 +112,7 @@ export default function RecentActivityCard({ locale, desktop, refreshKey, onChan
             </div>
           </div>
           <span className="tabular" style={{ fontSize: 12, fontWeight: 600, color, flexShrink: 0, fontVariantNumeric: 'tabular-nums' }}>
-            {withdrawal ? '−' : '+'}{fmtCompact(tx.amount_vnd)}
+            {sign}{fmtCompact(tx.amount_vnd)}
           </span>
         </div>
       )

--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -2,13 +2,13 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslations } from 'next-intl'
-import { Plus, Download, Edit2, Trash, ChevronLeft, ChevronRight, X, Calendar, ArrowUpRight, ArrowDownRight } from 'lucide-react'
+import { Plus, Download, Edit2, Trash, ChevronLeft, ChevronRight, X, Calendar, ArrowUpRight, ArrowDownRight, PiggyBank, GitMerge } from 'lucide-react'
 import AmountInput from '@/app/components/ui/AmountInput'
 import DecimalInput from '@/app/components/ui/DecimalInput'
 import { fmtCompact, fmtNav, fmtUnits } from '@/lib/formatters'
 import { parseExcelPaste, type ParsedRow } from '@/lib/parseExcelPaste'
 import AddTransactionSheet from './AddTransactionSheet'
-import { ASSET_TYPES, type AssetType, type LedgerTransaction, isWithdrawal, txPrimaryName, fmtTxDate } from './transactionUtils'
+import { ASSET_TYPES, type AssetType, type LedgerTransaction, isWithdrawal, txKind, txPrimaryName, fmtTxDate } from './transactionUtils'
 
 interface Goal { goal_id: string; goal_name: string }
 interface Fund { id: string; name: string; code: string; nav: number }
@@ -336,9 +336,15 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
   const totalPages = Math.max(1, Math.ceil(total / 20))
   const hasFilters = !!(filters.asset_type || filters.goal_id || filters.from_date || filters.to_date)
 
-  const dirMeta = (tx: LedgerTransaction) => isWithdrawal(tx)
-    ? { Icon: ArrowDownRight, color: 'var(--c-neg)', label: t('withdrawal') }
-    : { Icon: ArrowUpRight, color: 'var(--c-pos)', label: t('investment') }
+  // Held/merged settlements read neutrally — parked cash, not a red "−" spend.
+  const dirMeta = (tx: LedgerTransaction) => {
+    switch (txKind(tx)) {
+      case 'held': return { Icon: PiggyBank, color: 'var(--c-muted)', label: t('held') }
+      case 'consumed': return { Icon: GitMerge, color: 'var(--c-muted)', label: t('merged') }
+      case 'withdrawal': return { Icon: ArrowDownRight, color: 'var(--c-neg)', label: t('withdrawal') }
+      default: return { Icon: ArrowUpRight, color: 'var(--c-pos)', label: t('investment') }
+    }
+  }
 
   // ── Type badge (icon chip + direction label + asset pill) ──
   const TxBadge = ({ tx }: { tx: LedgerTransaction }) => {
@@ -364,10 +370,12 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
   )
 
   const amountCell = (tx: LedgerTransaction) => {
-    const w = isWithdrawal(tx)
+    const k = txKind(tx)
+    const neg = k === 'withdrawal'
+    const held = k === 'held' || k === 'consumed'
     return (
-      <span className="tabular" style={{ fontSize: 13, fontWeight: 600, color: w ? 'var(--c-neg)' : 'var(--c-ink)', whiteSpace: 'nowrap', fontVariantNumeric: 'tabular-nums' }}>
-        {w ? '−' : ''}{fmtCompact(tx.amount_vnd)}
+      <span className="tabular" style={{ fontSize: 13, fontWeight: 600, color: neg ? 'var(--c-neg)' : held ? 'var(--c-muted)' : 'var(--c-ink)', whiteSpace: 'nowrap', fontVariantNumeric: 'tabular-nums' }}>
+        {neg ? '−' : ''}{fmtCompact(tx.amount_vnd)}
       </span>
     )
   }

--- a/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
@@ -182,6 +182,45 @@ describe('DesktopGoalDetail — History date matches Recent activity (issue #300
   })
 })
 
+describe('DesktopGoalDetail — held settlement reads neutrally in History', () => {
+  // A parked ("Để dành gộp") settlement is a withdrawal whose cash is still held for
+  // a merge. In History it must carry the neutral "For merge" pill, not render as a
+  // red "−" withdrawal. Locks that the History tab calls txKind at render time.
+  const heldTx = {
+    transaction_id: 'tx-held-1',
+    transaction_type: 'withdrawal',
+    held_for_merge: true,
+    consumed_by_inv_id: null,
+    asset_type: 'bank',
+    fund_id: null,
+    fund_name: null,
+    parent_transaction_id: 'src-1',
+    investment_date: '2026-06-01',
+    amount_vnd: 10_000_000,
+    interest_rate: null,
+    notes: 'Parked deposit',
+    principal_withdrawn: 10_000_000,
+    units_withdrawn: null,
+  }
+
+  beforeEach(() => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [heldTx] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+  })
+
+  it('shows the neutral "For merge" pill in the History tab', async () => {
+    render(<DesktopGoalDetail {...baseProps} />)
+    await userEvent.click(await screen.findByRole('button', { name: 'History' }))
+    // The pill renders ONLY for kind held/consumed — its presence proves txKind ran
+    // and the row did not fall through to the red withdrawal branch.
+    expect(await screen.findByText('For merge')).toBeInTheDocument()
+  })
+})
+
 describe('DesktopGoalDetail — bank maturity in Options modal (issue #263)', () => {
   const mockBankTx = {
     transaction_id: 'tx-bank-1',

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -125,6 +125,42 @@ describe('GoalDetailSheet — History date matches Recent activity (issue #300)'
   })
 })
 
+describe('GoalDetailSheet — held settlement reads neutrally in History', () => {
+  // Mobile mirror of the desktop History check: a parked settlement must show the
+  // neutral "For merge" pill, not a red "−" withdrawal. Locks that the mobile History
+  // tab calls txKind at render time.
+  const heldTx = {
+    transaction_id: 'tx-held-m1',
+    transaction_type: 'withdrawal',
+    held_for_merge: true,
+    consumed_by_inv_id: null,
+    asset_type: 'bank',
+    fund_id: null,
+    fund_name: null,
+    investment_date: '2026-06-01',
+    amount_vnd: 10_000_000,
+    units: null,
+    unit_price: null,
+    interest_rate: null,
+    expiry_date: null,
+    notes: 'Parked deposit',
+    principal_withdrawn: 10_000_000,
+    units_withdrawn: null,
+  }
+
+  it('shows the neutral "For merge" pill in the History tab', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [heldTx] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+    render(<GoalDetailSheet {...baseProps} />)
+    await userEvent.click(await screen.findByRole('button', { name: 'History' }))
+    expect(await screen.findByText('For merge')).toBeInTheDocument()
+  })
+})
+
 describe('GoalDetailSheet — transaction history integration', () => {
   it('opens TransactionHistorySheet when "Transaction history" is tapped on a fund', async () => {
     render(<GoalDetailSheet {...baseProps} />)

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -486,6 +486,129 @@ describe('MaturityResolveBody', () => {
     })
   })
 
+  // ── "Ví chờ gộp" holding pool (PR4) ─────────────────────────────────────────
+  // A deposit maturing before a later eligible anchor in the same goal can be
+  // settled-with-hold (park the cash for that merge); the anchor's sheet then
+  // shows pooled holdings preselected and folds them in as held_sources.
+  describe('merge holding pool', () => {
+    function stubHold() {
+      const fetchMock = vi.fn().mockImplementation((url: string) => {
+        if (typeof url === 'string' && url.startsWith('/api/v1/recurring-savings')) {
+          return Promise.resolve({ ok: true, json: async () => ({ savings: [] }) })
+        }
+        return Promise.resolve({ ok: true, json: async () => ({}) })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      return fetchMock
+    }
+
+    // This deposit matured 2 days ago; a sibling in the same goal matures in 3 days
+    // (gap 5 ≤ window 7) → an eligible LATER anchor, so the hold fork appears.
+    const sourceNow: InvRow = {
+      id: 'src', name: 'VCB 3m', type: 'bank', value: 10_500_000, gainPct: null,
+      units: null, principal: 10_000_000, interestRate: 6, expiryDate: daysFromNow(-2),
+      investmentDate: daysFromNow(-90), fund: null,
+    }
+    const laterAnchor: InvRow = {
+      id: 'anc', name: 'MB 6m', type: 'bank', value: 20_000_000, gainPct: null,
+      units: null, principal: 20_000_000, interestRate: 6, expiryDate: daysFromNow(3),
+      investmentDate: daysFromNow(-180), fund: null,
+    }
+
+    it('nudges, preselects "hold", and posts a held settlement when an eligible later anchor exists', async () => {
+      const user = userEvent.setup()
+      const fetchMock = stubHold()
+      render(
+        <MaturityResolveBody inv={sourceNow} goalId="goal-1" siblingDeposits={[laterAnchor]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      // Discoverability nudge names the anchor.
+      expect((await screen.findByTestId('maturity-hold-nudge')).textContent).toContain('MB 6m')
+
+      // Enter the withdraw branch → the 2-card fork appears with "hold" preselected.
+      await user.click(screen.getByRole('button', { name: /Don.t renew/i }))
+      expect(screen.getByTestId('maturity-hold-fork')).toBeTruthy()
+      // The received field (hold path) is shown, defaulted to the current value.
+      expect((screen.getByTestId('maturity-hold-received') as HTMLInputElement).value).toBe('10500000')
+
+      await user.click(screen.getByRole('button', { name: /Confirm hold/i }))
+      await waitFor(() => {
+        const post = fetchMock.mock.calls.find((c) => c[0] === '/api/v1/investment-transactions' && c[1]?.method === 'POST')
+        expect(post).toBeTruthy()
+      })
+      const post = fetchMock.mock.calls.find((c) => c[0] === '/api/v1/investment-transactions' && c[1]?.method === 'POST')!
+      expect(JSON.parse(post[1].body)).toMatchObject({
+        transaction_type: 'withdrawal',
+        parent_transaction_id: 'src',
+        amount_vnd: 10_500_000,
+        held_for_merge: true,
+        merge_target_goal_id: 'goal-1',
+        merge_anchor_inv_id: 'anc',
+        affects_progress: true,
+      })
+    })
+
+    it('shows no hold fork (plain withdraw) when the only siblings mature earlier', async () => {
+      const user = userEvent.setup()
+      const onWithdraw = vi.fn()
+      stubHold()
+      const earlierSib: InvRow = { ...laterAnchor, id: 'early', expiryDate: daysFromNow(-9) }
+      render(
+        <MaturityResolveBody inv={sourceNow} goalId="goal-1" siblingDeposits={[earlierSib]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={onWithdraw} />,
+      )
+      expect(screen.queryByTestId('maturity-hold-nudge')).toBeNull()
+      await user.click(screen.getByRole('button', { name: /Don.t renew/i }))
+      expect(screen.queryByTestId('maturity-hold-fork')).toBeNull()
+      // Falls through to the plain withdraw hand-off.
+      await user.click(screen.getByRole('button', { name: /Mark for withdrawal/i }))
+      await waitFor(() => expect(onWithdraw).toHaveBeenCalled())
+    })
+
+    it('preselects pooled holdings on the anchor and folds them in as held_sources', async () => {
+      const user = userEvent.setup()
+      const fetchMock = stubHold()
+      render(
+        <MaturityResolveBody inv={maturedDeposit} goalId="goal-1"
+          heldSiblings={[{ id: 'held-w', name: 'VCB 3m', amount: 8_000_000 }]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      // Opens straight into combine; the pooled holding is listed (preselected).
+      const held = await screen.findByTestId('merge-held-held-w')
+      expect(held.textContent).toContain('VCB 3m')
+      // Preview folds the held cash into the new principal (BASE 37.03M + 8M).
+      expect(screen.getByTestId('maturity-new-principal').textContent).toContain(fmt(37_030_000 + 8_000_000))
+
+      await user.click(screen.getByRole('button', { name: /Save new deposit/i }))
+      await waitFor(() => {
+        const renewCall = fetchMock.mock.calls.find((c) => String(c[0]).endsWith('/renew'))
+        expect(renewCall).toBeTruthy()
+      })
+      const renewCall = fetchMock.mock.calls.find((c) => String(c[0]).endsWith('/renew'))!
+      const body = JSON.parse(renewCall[1].body)
+      expect(body.amount_vnd).toBe(37_030_000) // BASE only — the RPC adds the held cash
+      expect(body.held_sources).toEqual(['held-w'])
+    })
+
+    it('deselecting a pooled holding drops it from held_sources (left in the pool)', async () => {
+      const user = userEvent.setup()
+      const fetchMock = stubHold()
+      render(
+        <MaturityResolveBody inv={maturedDeposit} goalId="goal-1"
+          heldSiblings={[{ id: 'held-w', name: 'VCB 3m', amount: 8_000_000 }]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByTestId('merge-held-held-w')) // deselect
+      await user.click(screen.getByRole('button', { name: /Save new deposit/i }))
+      await waitFor(() => {
+        const renewCall = fetchMock.mock.calls.find((c) => String(c[0]).endsWith('/renew'))
+        expect(renewCall).toBeTruthy()
+      })
+      const body = JSON.parse(fetchMock.mock.calls.find((c) => String(c[0]).endsWith('/renew'))![1].body)
+      expect(body.held_sources).toBeUndefined()
+    })
+  })
+
   it('hands off to the existing withdraw flow instead of renewing', async () => {
     const user = userEvent.setup()
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })

--- a/app/assets/components/__tests__/RecentActivityCard.test.tsx
+++ b/app/assets/components/__tests__/RecentActivityCard.test.tsx
@@ -51,3 +51,47 @@ describe('RecentActivityCard — first-load skeleton', () => {
     expect(screen.getByText('recentActivityEmpty')).toBeInTheDocument()
   })
 })
+
+// A held-for-merge settlement is a withdrawal whose cash was PARKED for a merge, not
+// spent. It must NOT render as the red "−" loss of a real withdrawal. The txKind/txDir
+// unit tests prove the logic; this proves the CARD actually calls it at render time —
+// the gap a logic-only test can't catch if the component forgets the branch. (tt mock
+// returns the key, so badge text == the i18n key.)
+describe('RecentActivityCard — held-for-merge rows read neutrally', () => {
+  const base = {
+    asset_type: 'bank', investment_date: '2026-06-01', amount_vnd: 10_000_000,
+    savings_goals: { goal_name: 'House' },
+  }
+  const heldTx = { ...base, transaction_id: 'h1', transaction_type: 'withdrawal', held_for_merge: true, consumed_by_inv_id: null }
+  const consumedTx = { ...base, transaction_id: 'c1', transaction_type: 'withdrawal', held_for_merge: true, consumed_by_inv_id: 'anchor-1' }
+  const withdrawTx = { ...base, transaction_id: 'w1', transaction_type: 'withdrawal' }
+
+  const mockTxs = (list: unknown[]) => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ transactions: list, total: list.length }) })
+  }
+
+  it('a held settlement shows the neutral "held" badge — not "withdrawal", no "−"', async () => {
+    mockTxs([heldTx])
+    render(<RecentActivityCard locale="en" />)
+    const row = await screen.findByTestId('recent-activity-row')
+    expect(screen.getByText('held')).toBeInTheDocument()
+    expect(screen.queryByText('withdrawal')).toBeNull()
+    expect(row.textContent).not.toContain('−')
+  })
+
+  it('a consumed holding shows "merged", still neutral', async () => {
+    mockTxs([consumedTx])
+    render(<RecentActivityCard locale="en" />)
+    const row = await screen.findByTestId('recent-activity-row')
+    expect(screen.getByText('merged')).toBeInTheDocument()
+    expect(row.textContent).not.toContain('−')
+  })
+
+  it('a plain withdrawal still reads as a red "−" (the neutral assertions are not vacuous)', async () => {
+    mockTxs([withdrawTx])
+    render(<RecentActivityCard locale="en" />)
+    const row = await screen.findByTestId('recent-activity-row')
+    expect(screen.getByText('withdrawal')).toBeInTheDocument()
+    expect(row.textContent).toContain('−')
+  })
+})

--- a/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
+++ b/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import TransactionLedgerSheet from '../TransactionLedgerSheet'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (k: string) => k,
+}))
+// Nested sheets fetch/render on their own; stub them so this test only exercises
+// the ledger rows.
+vi.mock('../AddTransactionSheet', () => ({ default: () => null }))
+
+// The ledger ("Xem tất cả") shares txKind with the Recent activity card and the
+// goal-detail History tab. A held-for-merge settlement is parked cash, not a spend,
+// so it must read neutrally here too — never the red "−" of a withdrawal. This locks
+// that the LEDGER calls txKind at render time (a logic-only txKind test can't).
+// (t mock returns the key, so the direction label == the i18n key.)
+describe('TransactionLedgerSheet — held-for-merge rows read neutrally', () => {
+  const base = {
+    asset_type: 'bank', investment_date: '2026-06-01', amount_vnd: 10_000_000,
+    savings_goals: { goal_name: 'House' },
+  }
+  const heldTx = { ...base, transaction_id: 'h1', transaction_type: 'withdrawal', held_for_merge: true, consumed_by_inv_id: null }
+  const withdrawTx = { ...base, transaction_id: 'w1', transaction_type: 'withdrawal' }
+
+  const mockTxs = (list: unknown[]) => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('savings-goals')) return Promise.resolve({ ok: true, json: async () => ({ goals: [] }) })
+      if (url.includes('/api/funds')) return Promise.resolve({ ok: true, json: async () => ({ funds: [] }) })
+      if (url.includes('investment-transactions')) return Promise.resolve({ ok: true, json: async () => ({ transactions: list, total: list.length }) })
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+  }
+
+  beforeEach(() => { mockTxs([]) })
+
+  const props = { open: true, desktop: true, locale: 'en', onClose: vi.fn() }
+
+  it('a held settlement reads as "held" with no minus sign', async () => {
+    mockTxs([heldTx])
+    render(<TransactionLedgerSheet {...props} />)
+    const row = await screen.findByTestId('tx-ledger-row')
+    expect(screen.getByText('held')).toBeInTheDocument()
+    expect(screen.queryByText('withdrawal')).toBeNull()
+    expect(row.textContent).not.toContain('−')
+  })
+
+  it('a plain withdrawal still reads as a red "−" (so the neutral assertion is not vacuous)', async () => {
+    mockTxs([withdrawTx])
+    render(<TransactionLedgerSheet {...props} />)
+    const row = await screen.findByTestId('tx-ledger-row')
+    expect(screen.getByText('withdrawal')).toBeInTheDocument()
+    expect(row.textContent).toContain('−')
+  })
+})

--- a/app/assets/components/__tests__/goalComposition.test.ts
+++ b/app/assets/components/__tests__/goalComposition.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { buildCompositionSegments } from '../goalDetailShared'
+
+// The goal-detail "Cơ cấu / Composition" segments are built from the active
+// investment rows. Held-for-merge cash CLOSED its source deposit, so it is absent
+// from those rows — yet it still counts toward the goal's headline value via the
+// overview synthesis. Without a held segment the bar sums SHORT of the headline.
+// buildCompositionSegments adds that segment so the two reconcile.
+describe('buildCompositionSegments — held-for-merge reconciliation', () => {
+  const rows = [
+    { type: 'bank', value: 20_000_000 },
+    { type: 'gold', value: 5_000_000 },
+  ]
+
+  it('with no held cash, segments are exactly the asset rows', () => {
+    const segs = buildCompositionSegments(rows, 0, true)
+    expect(segs.map((s) => s.label)).toEqual(['bank', 'gold'])
+    expect(segs.reduce((a, s) => a + s.value, 0)).toBe(25_000_000)
+  })
+
+  it('adds a neutral held segment so the total reconciles with the headline', () => {
+    const segs = buildCompositionSegments(rows, 10_000_000, true)
+    const held = segs.find((s) => s.label === 'Chờ gộp')
+    expect(held).toBeDefined()
+    expect(held!.value).toBe(10_000_000)
+    // Held cash is parked, not invested — it must not borrow an asset colour.
+    expect(held!.color).toBe('var(--c-muted)')
+    // The whole point: bank + gold + held == headline (asset rows + held synthesis).
+    expect(segs.reduce((a, s) => a + s.value, 0)).toBe(35_000_000)
+  })
+
+  it('localizes the held label (English)', () => {
+    const segs = buildCompositionSegments(rows, 1, false)
+    expect(segs.some((s) => s.label === 'For merge')).toBe(true)
+  })
+
+  it('omits the held segment when there is no held cash', () => {
+    const segs = buildCompositionSegments(rows, 0, false)
+    expect(segs.some((s) => s.label === 'For merge')).toBe(false)
+  })
+})

--- a/app/assets/components/__tests__/transactionUtils.test.ts
+++ b/app/assets/components/__tests__/transactionUtils.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { txKind, txDir } from '../transactionUtils'
+
+// A held-for-merge settlement is a withdrawal whose cash was PARKED for a future
+// merge, not spent — so across the History tab, Recent activity, and the ledger it
+// must read neutrally (no red "−" loss). Once the merge consumes it it reads as
+// "merged". These pure helpers are the single source of that distinction.
+describe('txKind / txDir — held-for-merge labeling', () => {
+  it('a plain investment is positive (+)', () => {
+    const tx = { transaction_type: 'investment' }
+    expect(txKind(tx)).toBe('investment')
+    expect(txDir(tx)).toMatchObject({ kind: 'investment', tone: 'pos', sign: '+' })
+  })
+
+  it('a plain withdrawal is negative (−)', () => {
+    const tx = { transaction_type: 'withdrawal' }
+    expect(txKind(tx)).toBe('withdrawal')
+    expect(txDir(tx)).toMatchObject({ kind: 'withdrawal', tone: 'neg', sign: '−' })
+  })
+
+  it('a held (unconsumed) settlement is neutral with no loss sign', () => {
+    const tx = { transaction_type: 'withdrawal', held_for_merge: true, consumed_by_inv_id: null }
+    expect(txKind(tx)).toBe('held')
+    // The whole point: NOT 'neg', and the sign carries no "−".
+    expect(txDir(tx)).toMatchObject({ kind: 'held', tone: 'muted', sign: '' })
+  })
+
+  it('a consumed holding reads as merged, still neutral', () => {
+    const tx = { transaction_type: 'withdrawal', held_for_merge: true, consumed_by_inv_id: 'anchor-id' }
+    expect(txKind(tx)).toBe('consumed')
+    expect(txDir(tx)).toMatchObject({ kind: 'consumed', tone: 'muted', sign: '' })
+  })
+
+  it('held_for_merge=false is just a plain withdrawal', () => {
+    expect(txKind({ transaction_type: 'withdrawal', held_for_merge: false })).toBe('withdrawal')
+  })
+
+  it('a missing transaction_type defaults to investment (no held flags)', () => {
+    expect(txKind({})).toBe('investment')
+  })
+})

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -19,6 +19,29 @@ export const GD_COLORS: Record<string, string> = {
   stock: '#7c3aed',
 }
 
+export interface CompositionSeg { label: string; value: number; color: string }
+
+// Build the goal-detail "Cơ cấu / Composition" segments. The asset segments come
+// from the active investment rows; held-for-merge cash closed its source deposit so
+// it is ABSENT from those rows, yet still counts toward the goal's headline value via
+// the overview synthesis (lib/heldForMerge). Add it as its own neutral segment so the
+// bar reconciles with the headline instead of summing short. Shared by both views.
+export function buildCompositionSegments(
+  rows: { type: string; value: number }[],
+  heldValue: number,
+  isVi: boolean,
+): CompositionSeg[] {
+  const breakdown: Record<string, number> = {}
+  rows.forEach((r) => { breakdown[r.type] = (breakdown[r.type] ?? 0) + r.value })
+  const segs: CompositionSeg[] = Object.entries(breakdown).map(([label, value]) => ({
+    label, value, color: GD_COLORS[label] ?? 'var(--c-muted)',
+  }))
+  if (heldValue > 0) {
+    segs.push({ label: isVi ? 'Chờ gộp' : 'For merge', value: heldValue, color: 'var(--c-muted)' })
+  }
+  return segs
+}
+
 export function calcDeadlineMonths(targetDate: string | null): number {
   if (!targetDate) return 12
   const [ty, tm] = targetDate.split('-').map(Number)

--- a/app/assets/components/transactionUtils.ts
+++ b/app/assets/components/transactionUtils.ts
@@ -18,6 +18,11 @@ export interface LedgerTransaction {
   notes: string | null
   principal_withdrawn?: number | null
   units_withdrawn?: number | null
+  // "Ví chờ gộp": a withdrawal that PARKED its cash for a future merge rather than
+  // spending it. consumed_by_inv_id is set once the merge folds it in.
+  held_for_merge?: boolean | null
+  consumed_by_inv_id?: string | null
+  merge_anchor_inv_id?: string | null
   savings_goals?: { goal_name: string } | null
   funds?: { id: string; name: string; nav: number } | { id: string; name: string; nav: number }[] | null
 }
@@ -36,6 +41,44 @@ export function fundNameOf(tx: LedgerTransaction): string | null {
 
 export function isWithdrawal(tx: LedgerTransaction): boolean {
   return tx.transaction_type === 'withdrawal'
+}
+
+// The display semantics of a row, beyond plain investment/withdrawal. A held-for-
+// merge settlement is a withdrawal whose cash was PARKED for a future merge, not
+// spent — so it must read NEUTRALLY (no red "−" loss) everywhere it appears
+// (History tab, Recent activity, ledger). Once the merge consumes it
+// (consumed_by_inv_id set), it reads as "merged". Centralizing this here is the
+// whole fix: all three surfaces branch on transaction_type alone today.
+export type TxKind = 'investment' | 'withdrawal' | 'held' | 'consumed'
+
+// The minimal row shape txKind needs — both LedgerTransaction (card/ledger) and
+// the goal-detail history rows satisfy it structurally.
+export interface TxKindFields {
+  transaction_type?: string
+  held_for_merge?: boolean | null
+  consumed_by_inv_id?: string | null
+}
+
+export function txKind(tx: TxKindFields): TxKind {
+  if (tx.transaction_type !== 'withdrawal') return 'investment'
+  if (tx.held_for_merge === true) return tx.consumed_by_inv_id != null ? 'consumed' : 'held'
+  return 'withdrawal'
+}
+
+export interface TxDir {
+  kind: TxKind
+  // Semantic tone the row renders in: gains positive, spends negative, held/merged
+  // neutral. Each surface maps this to its own color tokens.
+  tone: 'pos' | 'neg' | 'muted'
+  // Amount prefix. Held/merged carry NO sign — the cash isn't a loss, it's parked.
+  sign: '+' | '−' | ''
+}
+
+export function txDir(tx: TxKindFields): TxDir {
+  const kind = txKind(tx)
+  if (kind === 'investment') return { kind, tone: 'pos', sign: '+' }
+  if (kind === 'withdrawal') return { kind, tone: 'neg', sign: '−' }
+  return { kind, tone: 'muted', sign: '' } // held / consumed — neutral, parked cash
 }
 
 // Per the data model (decision: match real schema), every row is either an

--- a/e2e/maturity-combine-holding.spec.ts
+++ b/e2e/maturity-combine-holding.spec.ts
@@ -137,6 +137,19 @@ test.describe('Term-deposit maturity — "Ví chờ gộp" holding pool', () => 
       const { data: held } = await supabase
         .from('investment_transactions').select('consumed_by_inv_id').eq('transaction_id', heldId).single()
       expect(held?.consumed_by_inv_id).toBe(A.transaction_id)
+
+      // A stale tab still showing the "Bỏ chờ gộp" chip must NOT be able to unhold a
+      // holding the merge already consumed — deleting it would re-open D1 while its
+      // cash already lives in A's principal (double-count). The server guards with a
+      // 409 instead of trusting the UI to have hidden the chip.
+      const staleUnhold = await page.request.delete(`/api/v1/investment-transactions/${heldId}`)
+      expect(staleUnhold.status()).toBe(409)
+      // The row survives the rejected delete, and the goal value is unmoved.
+      const stillThere = await page.request.get(`/api/v1/investment-transactions/${heldId}`)
+      expect(stillThere.ok()).toBeTruthy()
+      const afterReject = await goalSnapshot(page, goal.goal_id)
+      expect(afterReject.holdingIds).not.toContain(D1.transaction_id)
+      expect(Math.abs(afterReject.progressValue - before.progressValue)).toBeLessThan(1_000_000)
     } finally {
       await api.deleteTransactionCascade(A.transaction_id)
       await api.deleteTransactionCascade(D1.transaction_id)

--- a/e2e/maturity-combine-holding.spec.ts
+++ b/e2e/maturity-combine-holding.spec.ts
@@ -204,6 +204,71 @@ test.describe('Term-deposit maturity — "Ví chờ gộp" holding pool', () => 
     }
   })
 
+  test('deleting a LIVE-merge settlement is blocked — its cash already lives in the anchor (double-count)', async ({ page }) => {
+    test.slow()
+    // The held path is guarded above; this is the OTHER fold path. Merging a sibling
+    // STRAIGHT into the anchor (no "để dành") makes the RPC open a plain withdrawal
+    // for the source and fold its cash into D's principal. The ledger's "Xem tất cả"
+    // shows a delete button on every row, including that withdrawal — deleting it
+    // re-opens the source at full value while its cash still sits in D → +source
+    // double-count, with no warning. The server must reject it the same as a consumed
+    // holding (the withdrawal carries the same consumed_by_inv_id marker now).
+    const goal = await api.createGoal({ goal_name: 'E2E LiveMerge Goal', target_amount: 200_000_000 })
+    const D = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 20_000_000, investment_date: iso(-380),
+      interest_rate: 6, expiry_date: iso(-1), goal_id: goal.goal_id, notes: 'E2E LiveMerge Anchor',
+    })
+    const B = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 10_000_000, investment_date: iso(-370),
+      interest_rate: 6, expiry_date: iso(-3), goal_id: goal.goal_id, notes: 'E2E LiveMerge Source',
+    })
+    const { createClient } = await import('@supabase/supabase-js')
+    const supabase = createClient(process.env.E2E_SUPABASE_URL!, process.env.E2E_SUPABASE_SERVICE_ROLE_KEY!)
+    try {
+      // Merge B into D as a LIVE source (renew API directly). The renewal rolls D
+      // forward to a fresh deposit, so the goal value legitimately settles to a new
+      // baseline (accrued interest resets) — capture THAT as the reference. The
+      // invariant under test is that the rejected delete doesn't move it from there.
+      const renewRes = await page.request.post(`/api/v1/investment-transactions/${D.transaction_id}/renew`, {
+        data: {
+          amount_vnd: 20_000_000, interest_rate: 6, expiry_date: iso(180), investment_date: iso(0),
+          interest_earned_vnd: 0, merge_sources: [{ tx_id: B.transaction_id, received: 10_000_000 }],
+        },
+      })
+      expect(renewRes.ok()).toBeTruthy()
+
+      // The RPC opened a plain withdrawal parented to B and folded its cash into D —
+      // and now stamps consumed_by_inv_id = D on that withdrawal (the guard's marker).
+      const { data: wd } = await supabase
+        .from('investment_transactions')
+        .select('transaction_id, consumed_by_inv_id')
+        .eq('parent_transaction_id', B.transaction_id)
+        .eq('transaction_type', 'withdrawal')
+        .single()
+      const liveWithdrawalId = wd!.transaction_id as string
+      expect(wd!.consumed_by_inv_id).toBe(D.transaction_id)
+
+      await gotoFreshDashboard(page)
+      const afterMerge = await goalSnapshot(page, goal.goal_id)
+
+      // Deleting that withdrawal would re-open B while its cash sits in D → reject 409.
+      const del = await page.request.delete(`/api/v1/investment-transactions/${liveWithdrawalId}`)
+      expect(del.status()).toBe(409)
+
+      // The withdrawal survives, so the value stays exactly where the merge left it —
+      // NOT +B (the double-count the guard prevents).
+      const stillThere = await page.request.get(`/api/v1/investment-transactions/${liveWithdrawalId}`)
+      expect(stillThere.ok()).toBeTruthy()
+      await gotoFreshDashboard(page)
+      const afterReject = await goalSnapshot(page, goal.goal_id)
+      expect(Math.abs(afterReject.progressValue - afterMerge.progressValue)).toBeLessThan(1_000_000)
+    } finally {
+      await api.deleteTransactionCascade(D.transaction_id)
+      await api.deleteTransactionCascade(B.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
   test('rejects a held settlement that resolves no target goal (would silently lose net worth)', async ({ page }) => {
     // The held cash leaves net worth and is synthesized back ONLY via
     // merge_target_goal_id. With no goal AND no explicit target it resolves to

--- a/e2e/maturity-combine-holding.spec.ts
+++ b/e2e/maturity-combine-holding.spec.ts
@@ -252,6 +252,13 @@ test.describe('Term-deposit maturity — "Ví chờ gộp" holding pool', () => 
         page.getByText('E2E Held Label Goal').first().click(),
       ])
       await expect(panel).toBeVisible({ timeout: 10_000 })
+
+      // The composition bar folds the held cash back in as its own neutral segment so
+      // it reconciles with the headline instead of summing short — held closed its
+      // source deposit, so it is absent from the asset rows. Before the fix this goal
+      // (20M anchor + 10M parked) showed only the bank segment.
+      await expect(page.getByTestId('goal-composition').getByText(/Chờ gộp|For merge/)).toBeVisible({ timeout: 10_000 })
+
       await panel.getByText(/^(Lịch sử|History)$/).click()
 
       // The parked settlement reads as "Chờ gộp" / "For merge" — a neutral badge

--- a/e2e/maturity-combine-holding.spec.ts
+++ b/e2e/maturity-combine-holding.spec.ts
@@ -204,6 +204,22 @@ test.describe('Term-deposit maturity — "Ví chờ gộp" holding pool', () => 
     }
   })
 
+  test('rejects a held settlement that resolves no target goal (would silently lose net worth)', async ({ page }) => {
+    // The held cash leaves net worth and is synthesized back ONLY via
+    // merge_target_goal_id. With no goal AND no explicit target it resolves to
+    // null → heldForMergeContributions skips it → the money vanishes from total
+    // assets, shown nowhere. The UI always supplies a goal; the raw API must not
+    // accept the unresolvable case.
+    const res = await page.request.post('/api/v1/investment-transactions', {
+      data: {
+        transaction_type: 'withdrawal', asset_type: 'bank', investment_date: iso(0),
+        amount_vnd: 5_000_000, principal_withdrawn: 5_000_000, affects_progress: true,
+        held_for_merge: true, // no goal_id, no merge_target_goal_id
+      },
+    })
+    expect(res.status()).toBe(400)
+  })
+
   test('a held settlement reads neutrally in the History tab — not a red withdrawal', async ({ page }) => {
     test.slow()
     const goal = await api.createGoal({ goal_name: 'E2E Held Label Goal', target_amount: 200_000_000 })

--- a/e2e/maturity-combine-holding.spec.ts
+++ b/e2e/maturity-combine-holding.spec.ts
@@ -203,6 +203,51 @@ test.describe('Term-deposit maturity — "Ví chờ gộp" holding pool', () => 
       await api.deleteGoal(goal.goal_id)
     }
   })
+
+  test('a held settlement reads neutrally in the History tab — not a red withdrawal', async ({ page }) => {
+    test.slow()
+    const goal = await api.createGoal({ goal_name: 'E2E Held Label Goal', target_amount: 200_000_000 })
+    const D1 = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 10_000_000, investment_date: iso(-370),
+      interest_rate: 6, expiry_date: iso(-5), goal_id: goal.goal_id, notes: 'E2E Held Label D1',
+    })
+    const A = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 20_000_000, investment_date: iso(-380),
+      interest_rate: 6, expiry_date: iso(-1), goal_id: goal.goal_id, notes: 'E2E Held Label Anchor',
+    })
+    try {
+      // Park D1 (held withdrawal) directly — the hold UI is covered above; here the
+      // point is purely how the settlement is LABELLED downstream.
+      const holdRes = await page.request.post('/api/v1/investment-transactions', {
+        data: {
+          goal_id: goal.goal_id, transaction_type: 'withdrawal', asset_type: 'bank',
+          investment_date: iso(0), amount_vnd: 10_000_000, principal_withdrawn: 10_000_000,
+          affects_progress: true, parent_transaction_id: D1.transaction_id,
+          held_for_merge: true, merge_target_goal_id: goal.goal_id, merge_anchor_inv_id: A.transaction_id,
+        },
+      })
+      expect(holdRes.status()).toBe(201)
+
+      // Open the goal detail and its History tab (it fetches the goal's tx list).
+      await gotoFreshDashboard(page)
+      const panel = page.getByTestId('desktop-goal-detail')
+      await Promise.all([
+        page.waitForResponse((r) => r.url().includes('/api/v1/investment-transactions?goal_id=') && r.status() === 200, { timeout: 20_000 }),
+        page.getByText('E2E Held Label Goal').first().click(),
+      ])
+      await expect(panel).toBeVisible({ timeout: 10_000 })
+      await panel.getByText(/^(Lịch sử|History)$/).click()
+
+      // The parked settlement reads as "Chờ gộp" / "For merge" — a neutral badge
+      // this code path renders ONLY for a held row (before the fix it was a red
+      // down-arrow withdrawal). Its presence is the red→green proof.
+      await expect(panel.getByText(/Chờ gộp|For merge/).first()).toBeVisible({ timeout: 10_000 })
+    } finally {
+      await api.deleteTransactionCascade(A.transaction_id)
+      await api.deleteTransactionCascade(D1.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
 })
 
 // The dashboard side of the invariant is covered above (progressValue never dips,

--- a/e2e/maturity-combine-holding.spec.ts
+++ b/e2e/maturity-combine-holding.spec.ts
@@ -1,0 +1,193 @@
+import { test, expect, type Page } from '@playwright/test'
+import * as api from './helpers/api'
+
+// "Ví chờ gộp" (merge holding pool) — PR4 of "Gộp nhiều nguồn". An earlier-
+// maturing deposit can be settled with "Để dành gộp": it is closed by a held
+// withdrawal, but its cash stays earmarked to the goal (synthesized straight back,
+// so the goal value never dips and it never shows as a stray deposit). When the
+// anchor matures the merge consumes the holding — folds the parked cash into the
+// re-deposit with NO second withdrawal, so nothing is double-counted. Changing
+// your mind ("Bỏ chờ gộp") restores the original deposit.
+//
+// Closes the loop on the rendered overview at every step:
+//   • hold → goal value unchanged, the deposit leaves holdings, a held entry
+//     appears (the cash keeps counting), and
+//   • consume → goal value STILL unchanged (no double-count) and the held entry
+//     is gone, and
+//   • unhold → the original deposit is back and the value is unchanged.
+// Desktop viewport — the flow is driven from the goal-detail panel (same place
+// the merge spec opens it).
+
+const iso = (offsetDays: number) => new Date(Date.now() + offsetDays * 86_400_000).toISOString().slice(0, 10)
+
+async function gotoFreshDashboard(page: Page) {
+  await page.goto('/settings') // unmount DashboardClient
+  await page.evaluate(() => {
+    Object.keys(localStorage).filter((k) => k.startsWith('dashboardOverviewCache')).forEach((k) => localStorage.removeItem(k))
+  })
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/v1/dashboard/overview') && r.status() === 200, { timeout: 20_000 }),
+    page.goto('/dashboard'),
+  ])
+}
+
+// The goal's progress value, holdings, and pooled-holding entries, from the
+// overview API (the source of truth the UI renders).
+async function goalSnapshot(page: Page, goalId: string): Promise<{
+  progressValue: number; holdingIds: string[]; held: { transactionId: string; amount: number }[]
+}> {
+  const res = await page.request.get('/api/v1/dashboard/overview')
+  expect(res.ok()).toBeTruthy()
+  const json = await res.json()
+  const g = (json.goals ?? []).find((x: { goalId: string }) => x.goalId === goalId)
+  return {
+    progressValue: g?.progressValue ?? 0,
+    holdingIds: (g?.nonFunds ?? []).map((n: { transactionId: string }) => n.transactionId),
+    held: (g?.heldForMerge ?? []).map((h: { transactionId: string; amount: number }) => ({ transactionId: h.transactionId, amount: h.amount })),
+  }
+}
+
+// Open the goal-detail panel and run a deposit's row → Options → Handle maturity.
+async function openHandleMaturity(page: Page, goalName: string, depositNotes: string) {
+  const panel = page.getByTestId('desktop-goal-detail')
+  // The panel fetches its OWN tx list on open; wait for that response so the
+  // investments tab is populated before we hunt for a deposit row (otherwise we
+  // can race the empty-state "no investments yet").
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/v1/investment-transactions?goal_id=') && r.status() === 200, { timeout: 20_000 }),
+    page.getByText(goalName).first().click(),
+  ])
+  await expect(panel).toBeVisible({ timeout: 10_000 })
+  await expect(panel.getByText(depositNotes)).toBeVisible({ timeout: 10_000 })
+  // The list renders every deposit; target the row that actually names this one
+  // (Options buttons are otherwise indistinguishable).
+  const row = panel.locator('div')
+    .filter({ has: page.getByRole('button', { name: 'Options', exact: true }) })
+    .filter({ hasText: depositNotes })
+    .last()
+  await row.getByRole('button', { name: 'Options', exact: true }).click()
+  await page.getByText(/^(Handle maturity|Xử lý đáo hạn)$/).click()
+}
+
+test.describe('Term-deposit maturity — "Ví chờ gộp" holding pool', () => {
+  test('holds an earlier deposit, then consumes it into the anchor with no double-count', async ({ page }) => {
+    test.slow()
+    const goal = await api.createGoal({ goal_name: 'E2E Hold Goal', target_amount: 200_000_000 })
+    // D1 matured 5d ago (the earlier deposit we hold). A matured 1d ago (the later
+    // anchor, gap 4 ≤ window 7) — its merge sheet will consume the holding.
+    const D1 = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 10_000_000, investment_date: iso(-370),
+      interest_rate: 6, expiry_date: iso(-5), goal_id: goal.goal_id, notes: 'E2E Hold D1',
+    })
+    const A = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 20_000_000, investment_date: iso(-380),
+      interest_rate: 6, expiry_date: iso(-1), goal_id: goal.goal_id, notes: 'E2E Hold Anchor',
+    })
+    try {
+      await gotoFreshDashboard(page)
+      const before = await goalSnapshot(page, goal.goal_id)
+      expect(before.holdingIds).toContain(D1.transaction_id)
+
+      // ── Hold D1 for merge into A ──
+      await openHandleMaturity(page, 'E2E Hold Goal', 'E2E Hold D1')
+      // The nudge names the anchor, and the withdraw branch forks (hold preselected).
+      await expect(page.getByTestId('maturity-hold-nudge')).toBeVisible()
+      await page.getByRole('button', { name: /Don.t renew|Không tái tục/i }).click()
+      await expect(page.getByTestId('maturity-hold-fork')).toBeVisible()
+      const [holdReq] = await Promise.all([
+        page.waitForRequest((r) => r.url().endsWith('/api/v1/investment-transactions') && r.method() === 'POST'),
+        page.getByRole('button', { name: /Confirm hold|Xác nhận để dành/i }).click(),
+      ])
+      expect(holdReq.postDataJSON()).toMatchObject({
+        transaction_type: 'withdrawal', parent_transaction_id: D1.transaction_id,
+        held_for_merge: true, merge_target_goal_id: goal.goal_id, merge_anchor_inv_id: A.transaction_id,
+      })
+      await expect(page.getByTestId('maturity-held')).toBeVisible({ timeout: 20_000 })
+
+      // Held: D1 left the holdings list but the goal value held steady (cash parked,
+      // synthesized straight back), and a pooled entry now carries it.
+      await gotoFreshDashboard(page)
+      const afterHold = await goalSnapshot(page, goal.goal_id)
+      expect(afterHold.holdingIds).not.toContain(D1.transaction_id)
+      expect(afterHold.held).toHaveLength(1)
+      expect(Math.abs(afterHold.progressValue - before.progressValue)).toBeLessThan(1_000_000)
+      const heldId = afterHold.held[0].transactionId
+
+      // ── Consume the holding into A ──
+      await openHandleMaturity(page, 'E2E Hold Goal', 'E2E Hold Anchor')
+      // Opens straight into combine; the pooled holding is listed + preselected.
+      await expect(page.getByTestId(`merge-held-${heldId}`)).toBeVisible({ timeout: 10_000 })
+      const [renewReq] = await Promise.all([
+        page.waitForRequest((r) => r.url().endsWith(`/${A.transaction_id}/renew`) && r.method() === 'POST'),
+        page.getByRole('button', { name: /Save new deposit|Lưu sổ mới/i }).click(),
+      ])
+      expect(renewReq.postDataJSON().held_sources).toEqual([heldId])
+      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+
+      // Consumed: the pool is empty and the goal value STILL matches the start —
+      // the held cash moved into A's principal, never counted twice.
+      await gotoFreshDashboard(page)
+      const afterConsume = await goalSnapshot(page, goal.goal_id)
+      expect(afterConsume.held).toHaveLength(0)
+      expect(Math.abs(afterConsume.progressValue - before.progressValue)).toBeLessThan(1_000_000)
+
+      // The holding row is consumed in place — no second withdrawal opened.
+      const { createClient } = await import('@supabase/supabase-js')
+      const supabase = createClient(process.env.E2E_SUPABASE_URL!, process.env.E2E_SUPABASE_SERVICE_ROLE_KEY!)
+      const { data: held } = await supabase
+        .from('investment_transactions').select('consumed_by_inv_id').eq('transaction_id', heldId).single()
+      expect(held?.consumed_by_inv_id).toBe(A.transaction_id)
+    } finally {
+      await api.deleteTransactionCascade(A.transaction_id)
+      await api.deleteTransactionCascade(D1.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
+  test('"Bỏ chờ gộp" restores the original deposit', async ({ page }) => {
+    test.slow()
+    const goal = await api.createGoal({ goal_name: 'E2E Unhold Goal', target_amount: 200_000_000 })
+    const D1 = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 10_000_000, investment_date: iso(-370),
+      interest_rate: 6, expiry_date: iso(-5), goal_id: goal.goal_id, notes: 'E2E Unhold D1',
+    })
+    const A = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 20_000_000, investment_date: iso(-380),
+      interest_rate: 6, expiry_date: iso(-1), goal_id: goal.goal_id, notes: 'E2E Unhold Anchor',
+    })
+    try {
+      await gotoFreshDashboard(page)
+      const before = await goalSnapshot(page, goal.goal_id)
+
+      // Hold D1.
+      await openHandleMaturity(page, 'E2E Unhold Goal', 'E2E Unhold D1')
+      await page.getByRole('button', { name: /Don.t renew|Không tái tục/i }).click()
+      await Promise.all([
+        page.waitForRequest((r) => r.url().endsWith('/api/v1/investment-transactions') && r.method() === 'POST'),
+        page.getByRole('button', { name: /Confirm hold|Xác nhận để dành/i }).click(),
+      ])
+      await expect(page.getByTestId('maturity-held')).toBeVisible({ timeout: 20_000 })
+
+      await gotoFreshDashboard(page)
+      const afterHold = await goalSnapshot(page, goal.goal_id)
+      expect(afterHold.holdingIds).not.toContain(D1.transaction_id)
+      const heldId = afterHold.held[0].transactionId
+
+      // Open the goal detail → the "Đang chờ gộp" chip with its "Bỏ chờ gộp" action.
+      await page.getByText('E2E Unhold Goal').first().click()
+      await expect(page.getByTestId('desktop-goal-detail')).toBeVisible({ timeout: 10_000 })
+      await page.getByTestId(`unhold-${heldId}`).click()
+
+      // Restored: D1 is back in the holdings and the value is unchanged.
+      await expect.poll(async () => (await goalSnapshot(page, goal.goal_id)).holdingIds, { timeout: 15_000 })
+        .toContain(D1.transaction_id)
+      const restored = await goalSnapshot(page, goal.goal_id)
+      expect(restored.held).toHaveLength(0)
+      expect(Math.abs(restored.progressValue - before.progressValue)).toBeLessThan(1_000_000)
+    } finally {
+      await api.deleteTransactionCascade(A.transaction_id)
+      await api.deleteTransactionCascade(D1.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+})

--- a/e2e/maturity-combine-holding.spec.ts
+++ b/e2e/maturity-combine-holding.spec.ts
@@ -204,3 +204,126 @@ test.describe('Term-deposit maturity — "Ví chờ gộp" holding pool', () => 
     }
   })
 })
+
+// The dashboard side of the invariant is covered above (progressValue never dips,
+// never double-counts). This block closes the OTHER half on the Plan page: a goal
+// with a monthly plan + a due recurring saving must not have its CONTRIBUTED /
+// PLANNED perturbed merely by parking a deposit, and when the anchor's merge folds
+// that recurring in, the line must read "đã ghi nhận" (recorded) exactly once — no
+// double-count from the held cash ALSO landing there. Asserts the RENDERED Plan
+// (data-* on the by-goal rows), not just the stored fulfillment.
+test.describe('Term-deposit holding pool — Plan-page invariant', () => {
+  test.use({ viewport: { width: 1280, height: 800 } })
+
+  const now = new Date()
+  const PMONTH = now.getMonth() + 1
+  const PYEAR = now.getFullYear()
+  const YM = `${PYEAR}-${String(PMONTH).padStart(2, '0')}`
+
+  // Navigate to the Plan page for the current month and wait for its data.
+  async function gotoPlanning(page: Page) {
+    await page.goto('/settings') // unmount, force a fresh fetch
+    await Promise.all([
+      page.waitForResponse((r) => r.url().includes('/api/v1/monthly-plans') && r.status() === 200, { timeout: 20_000 }),
+      page.goto('/planning'),
+    ])
+    await expect(page.getByTestId('desktop-planning')).toBeVisible({ timeout: 10_000 })
+  }
+
+  // The goal's PLANNED / CONTRIBUTED as the by-goal row renders them (data-* carry
+  // the exact numbers buildByGoal computed, so we read the rendered value directly).
+  async function planGoal(page: Page, goalId: string): Promise<{ planned: number; contributed: number }> {
+    const planned = await page.getByTestId(`plan-goal-planned-${goalId}`).getAttribute('data-planned')
+    const contributed = await page.getByTestId(`plan-goal-contributed-${goalId}`).getAttribute('data-contributed')
+    return { planned: Number(planned), contributed: Number(contributed) }
+  }
+
+  test('parking a deposit leaves the plan untouched; a fold-on-consume records the recurring exactly once', async ({ page }) => {
+    test.slow()
+    const REC = 3_000_000
+    const goal = await api.createGoal({ goal_name: 'E2E Plan Hold Goal', target_amount: 200_000_000 })
+    const plan = await api.createMonthlyPlan({ month: PMONTH, year: PYEAR, salary_vnd: 30_000_000 })
+    // D1 matured 5d ago; A matured 1d ago (the anchor). A recurring saving for the
+    // goal is due this month AND is linked to D1 (it had been feeding that deposit)
+    // — so holding D1 must also unlink it (hygiene: no dangling link to a closed row).
+    const D1 = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 10_000_000, investment_date: iso(-370),
+      interest_rate: 6, expiry_date: iso(-5), goal_id: goal.goal_id, notes: 'E2E Plan Hold D1',
+    })
+    const A = await api.createTransaction({
+      asset_type: 'bank', amount_vnd: 20_000_000, investment_date: iso(-380),
+      interest_rate: 6, expiry_date: iso(-1), goal_id: goal.goal_id, notes: 'E2E Plan Hold Anchor',
+    })
+    const rec = await api.createRecurringSaving({
+      name: 'E2E Plan Recurring', goal_id: goal.goal_id, amount_vnd: REC,
+      effective_from: `${YM}-01`, linked_deposit_tx_id: D1.transaction_id,
+    })
+    const { createClient } = await import('@supabase/supabase-js')
+    const svc = createClient(process.env.E2E_SUPABASE_URL!, process.env.E2E_SUPABASE_SERVICE_ROLE_KEY!)
+    const recRow = page.getByTestId(`plan-recurring-${rec.saving_id}`)
+    try {
+      // ── Baseline: planned = the recurring; nothing contributed; line not recorded ──
+      await gotoPlanning(page)
+      const base = await planGoal(page, goal.goal_id)
+      expect(base.planned).toBe(REC)
+      expect(base.contributed).toBe(0)
+      await expect(recRow).toHaveAttribute('data-recorded', 'false')
+
+      // ── Park D1 (hold for merge into A) ──
+      const holdRes = await page.request.post('/api/v1/investment-transactions', {
+        data: {
+          goal_id: goal.goal_id, transaction_type: 'withdrawal', asset_type: 'bank',
+          investment_date: iso(0), amount_vnd: 10_000_000, principal_withdrawn: 10_000_000,
+          affects_progress: true, parent_transaction_id: D1.transaction_id,
+          held_for_merge: true, merge_target_goal_id: goal.goal_id, merge_anchor_inv_id: A.transaction_id,
+        },
+      })
+      expect(holdRes.status()).toBe(201)
+      const heldId = (await holdRes.json()).transaction_id
+
+      // Hygiene: the recurring's link to the now-closed D1 is cleared on hold.
+      const { data: afterHoldLink } = await svc
+        .from('recurring_savings').select('linked_deposit_tx_id').eq('saving_id', rec.saving_id).single()
+      expect(afterHoldLink?.linked_deposit_tx_id).toBeNull()
+
+      // ── Assert A: the plan is exactly as it was — holding touches none of it ──
+      await gotoPlanning(page)
+      const afterHold = await planGoal(page, goal.goal_id)
+      expect(afterHold.planned).toBe(REC)
+      expect(afterHold.contributed).toBe(0)
+      await expect(recRow).toHaveAttribute('data-recorded', 'false')
+
+      // ── Consume D1 into A and fold this month's recurring in the same renewal ──
+      const renewRes = await page.request.post(`/api/v1/investment-transactions/${A.transaction_id}/renew`, {
+        data: {
+          amount_vnd: 20_000_000, interest_rate: 6, expiry_date: iso(180), investment_date: iso(0),
+          interest_earned_vnd: 0, held_sources: [heldId],
+          fulfill_recurring: { saving_id: rec.saving_id, ym: YM, amount: REC },
+        },
+      })
+      expect(renewRes.ok()).toBeTruthy()
+
+      // ── Assert B: recorded EXACTLY ONCE — the line reads recorded, contributed
+      //    rose by precisely the recurring amount (not twice), and the data layer
+      //    holds a single fulfillment row. The held cash went into A's principal,
+      //    NOT into the plan's contributed. ──
+      await gotoPlanning(page)
+      const afterFold = await planGoal(page, goal.goal_id)
+      expect(afterFold.planned).toBe(REC)
+      expect(afterFold.contributed).toBe(REC)
+      await expect(recRow).toHaveAttribute('data-recorded', 'true')
+      await expect(recRow.getByText(/Đã gửi|Saved/).first()).toBeVisible()
+
+      const { data: fulfillments } = await svc
+        .from('recurring_saving_fulfillments').select('*').eq('recurring_saving_id', rec.saving_id)
+      expect(fulfillments).toHaveLength(1)
+    } finally {
+      await api.deleteRecurringFulfillments(rec.saving_id)
+      await api.deleteRecurringSaving(rec.saving_id)
+      await api.deleteMonthlyPlan(plan.id)
+      await api.deleteTransactionCascade(A.transaction_id)
+      await api.deleteTransactionCascade(D1.transaction_id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+})

--- a/lib/__tests__/heldForMerge.test.ts
+++ b/lib/__tests__/heldForMerge.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest'
+import { heldForMergeContributions, type HeldWithdrawalRow } from '../heldForMerge'
+
+// A held settlement (withdrawal) row as the overview reads it. Only the fields the
+// synthesizer needs; everything else on the real row is irrelevant here.
+const mk = (over: Partial<HeldWithdrawalRow>): HeldWithdrawalRow => ({
+  amount_vnd: 8_000_000,
+  merge_target_goal_id: 'g1',
+  held_for_merge: true,
+  consumed_by_inv_id: null,
+  ...over,
+})
+
+describe('heldForMergeContributions', () => {
+  it('synthesizes one contribution per held, unconsumed row, keyed to its target goal', () => {
+    const out = heldForMergeContributions([mk({ amount_vnd: 8_000_000, merge_target_goal_id: 'g1' })])
+    expect(out).toEqual([{ goalId: 'g1', amount: 8_000_000 }])
+  })
+
+  it('drops a consumed holding (its cash now lives in the renewed deposit)', () => {
+    const out = heldForMergeContributions([mk({ consumed_by_inv_id: 'D-renewed' })])
+    expect(out).toEqual([])
+  })
+
+  it('ignores a non-held withdrawal (plain settle-to-cash)', () => {
+    expect(heldForMergeContributions([mk({ held_for_merge: false })])).toEqual([])
+  })
+
+  it('skips a holding with no target goal (nothing to add it back to)', () => {
+    expect(heldForMergeContributions([mk({ merge_target_goal_id: null })])).toEqual([])
+  })
+
+  it('skips a non-positive held amount', () => {
+    expect(heldForMergeContributions([mk({ amount_vnd: 0 })])).toEqual([])
+  })
+
+  it('keeps each holding separate (no per-goal aggregation — the caller sums)', () => {
+    const out = heldForMergeContributions([
+      mk({ amount_vnd: 5_000_000, merge_target_goal_id: 'g1' }),
+      mk({ amount_vnd: 3_000_000, merge_target_goal_id: 'g1' }),
+      mk({ amount_vnd: 2_000_000, merge_target_goal_id: 'g2' }),
+    ])
+    expect(out).toEqual([
+      { goalId: 'g1', amount: 5_000_000 },
+      { goalId: 'g1', amount: 3_000_000 },
+      { goalId: 'g2', amount: 2_000_000 },
+    ])
+  })
+
+  it('tolerates null/undefined held flags (legacy rows) as not held', () => {
+    const out = heldForMergeContributions([
+      { amount_vnd: 1_000_000, merge_target_goal_id: 'g1', held_for_merge: null, consumed_by_inv_id: null },
+    ])
+    expect(out).toEqual([])
+  })
+})

--- a/lib/__tests__/heldForMerge.test.ts
+++ b/lib/__tests__/heldForMerge.test.ts
@@ -4,22 +4,23 @@ import { heldForMergeContributions, type HeldWithdrawalRow } from '../heldForMer
 // A held settlement (withdrawal) row as the overview reads it. Only the fields the
 // synthesizer needs; everything else on the real row is irrelevant here.
 const mk = (over: Partial<HeldWithdrawalRow>): HeldWithdrawalRow => ({
+  transaction_id: 'w1',
   amount_vnd: 8_000_000,
   merge_target_goal_id: 'g1',
+  merge_anchor_inv_id: 'D',
   held_for_merge: true,
   consumed_by_inv_id: null,
   ...over,
 })
 
 describe('heldForMergeContributions', () => {
-  it('synthesizes one contribution per held, unconsumed row, keyed to its target goal', () => {
-    const out = heldForMergeContributions([mk({ amount_vnd: 8_000_000, merge_target_goal_id: 'g1' })])
-    expect(out).toEqual([{ goalId: 'g1', amount: 8_000_000 }])
+  it('synthesizes one contribution per held, unconsumed row, carrying id + anchor', () => {
+    const out = heldForMergeContributions([mk({ transaction_id: 'w1', amount_vnd: 8_000_000, merge_target_goal_id: 'g1', merge_anchor_inv_id: 'D' })])
+    expect(out).toEqual([{ transactionId: 'w1', goalId: 'g1', amount: 8_000_000, anchorInvId: 'D' }])
   })
 
   it('drops a consumed holding (its cash now lives in the renewed deposit)', () => {
-    const out = heldForMergeContributions([mk({ consumed_by_inv_id: 'D-renewed' })])
-    expect(out).toEqual([])
+    expect(heldForMergeContributions([mk({ consumed_by_inv_id: 'D-renewed' })])).toEqual([])
   })
 
   it('ignores a non-held withdrawal (plain settle-to-cash)', () => {
@@ -34,22 +35,24 @@ describe('heldForMergeContributions', () => {
     expect(heldForMergeContributions([mk({ amount_vnd: 0 })])).toEqual([])
   })
 
+  it('carries a null anchor through (the anchor is informational only)', () => {
+    const out = heldForMergeContributions([mk({ transaction_id: 'w2', merge_anchor_inv_id: null })])
+    expect(out).toEqual([{ transactionId: 'w2', goalId: 'g1', amount: 8_000_000, anchorInvId: null }])
+  })
+
   it('keeps each holding separate (no per-goal aggregation — the caller sums)', () => {
     const out = heldForMergeContributions([
-      mk({ amount_vnd: 5_000_000, merge_target_goal_id: 'g1' }),
-      mk({ amount_vnd: 3_000_000, merge_target_goal_id: 'g1' }),
-      mk({ amount_vnd: 2_000_000, merge_target_goal_id: 'g2' }),
+      mk({ transaction_id: 'a', amount_vnd: 5_000_000, merge_target_goal_id: 'g1' }),
+      mk({ transaction_id: 'b', amount_vnd: 3_000_000, merge_target_goal_id: 'g1' }),
+      mk({ transaction_id: 'c', amount_vnd: 2_000_000, merge_target_goal_id: 'g2' }),
     ])
-    expect(out).toEqual([
-      { goalId: 'g1', amount: 5_000_000 },
-      { goalId: 'g1', amount: 3_000_000 },
-      { goalId: 'g2', amount: 2_000_000 },
-    ])
+    expect(out.map((h) => h.transactionId)).toEqual(['a', 'b', 'c'])
+    expect(out.reduce((s, h) => s + h.amount, 0)).toBe(10_000_000)
   })
 
   it('tolerates null/undefined held flags (legacy rows) as not held', () => {
     const out = heldForMergeContributions([
-      { amount_vnd: 1_000_000, merge_target_goal_id: 'g1', held_for_merge: null, consumed_by_inv_id: null },
+      { transaction_id: 'x', amount_vnd: 1_000_000, merge_target_goal_id: 'g1', merge_anchor_inv_id: null, held_for_merge: null, consumed_by_inv_id: null },
     ])
     expect(out).toEqual([])
   })

--- a/lib/heldForMerge.ts
+++ b/lib/heldForMerge.ts
@@ -1,0 +1,39 @@
+// "Ví chờ gộp" (merge holding pool) synthesis — PR4 of "Gộp nhiều nguồn".
+//
+// A held settlement is a withdrawal row (held_for_merge=true) that closed an
+// earlier-maturing deposit while parking its cash for a future merge. Closing the
+// deposit removed its principal from both net worth and the goal bar; this helper
+// turns each still-in-the-pool holding back into a per-goal contribution so the
+// caller can add it where the deposit used to count — net effect zero, the cash
+// keeps counting, and it never reappears as a deposit row.
+//
+// Pure + deterministic, mirroring realizedRecurringContributions (lib/finance):
+// one synthesized contribution per holding, the caller sums them into the goal.
+// A holding leaves the pool the moment a merge stamps consumed_by_inv_id — its
+// cash then lives in the renewed deposit's principal, so we must stop adding it.
+
+export interface HeldWithdrawalRow {
+  amount_vnd: number
+  // The goal the held cash stays earmarked to. NULL = nothing to add it back to.
+  merge_target_goal_id: string | null
+  held_for_merge?: boolean | null
+  // Set once a merge folds the holding into the renewed deposit. NULL = still pooled.
+  consumed_by_inv_id?: string | null
+}
+
+export interface HeldContribution {
+  goalId: string
+  amount: number
+}
+
+export function heldForMergeContributions(rows: HeldWithdrawalRow[]): HeldContribution[] {
+  const out: HeldContribution[] = []
+  for (const r of rows) {
+    if (r.held_for_merge !== true) continue // not held (legacy/plain withdrawal)
+    if (r.consumed_by_inv_id != null) continue // already folded into a re-deposit
+    if (!r.merge_target_goal_id) continue // no goal to credit
+    if (!(r.amount_vnd > 0)) continue
+    out.push({ goalId: r.merge_target_goal_id, amount: r.amount_vnd })
+  }
+  return out
+}

--- a/lib/heldForMerge.ts
+++ b/lib/heldForMerge.ts
@@ -13,17 +13,25 @@
 // cash then lives in the renewed deposit's principal, so we must stop adding it.
 
 export interface HeldWithdrawalRow {
+  transaction_id: string
   amount_vnd: number
   // The goal the held cash stays earmarked to. NULL = nothing to add it back to.
   merge_target_goal_id: string | null
+  // The deposit the user means to fold this into — informational (surfaced as
+  // "đang chờ gộp vào …"); may be NULL.
+  merge_anchor_inv_id?: string | null
   held_for_merge?: boolean | null
   // Set once a merge folds the holding into the renewed deposit. NULL = still pooled.
   consumed_by_inv_id?: string | null
 }
 
 export interface HeldContribution {
+  // The held WITHDRAWAL row's id — what the UI passes back as a held_source to
+  // consume, and what the unhold (Bỏ chờ gộp) action deletes to restore the deposit.
+  transactionId: string
   goalId: string
   amount: number
+  anchorInvId: string | null
 }
 
 export function heldForMergeContributions(rows: HeldWithdrawalRow[]): HeldContribution[] {
@@ -33,7 +41,12 @@ export function heldForMergeContributions(rows: HeldWithdrawalRow[]): HeldContri
     if (r.consumed_by_inv_id != null) continue // already folded into a re-deposit
     if (!r.merge_target_goal_id) continue // no goal to credit
     if (!(r.amount_vnd > 0)) continue
-    out.push({ goalId: r.merge_target_goal_id, amount: r.amount_vnd })
+    out.push({
+      transactionId: r.transaction_id,
+      goalId: r.merge_target_goal_id,
+      amount: r.amount_vnd,
+      anchorInvId: r.merge_anchor_inv_id ?? null,
+    })
   }
   return out
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -314,6 +314,8 @@
     "assetCash": "Cash",
     "withdrawal": "Withdrawal",
     "investment": "Investment",
+    "held": "For merge",
+    "merged": "Merged",
     "gainLoss": "Gain/Loss",
     "amountReceived": "Received",
     "noGoal": "Unassigned",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -314,6 +314,8 @@
     "assetCash": "Tiền mặt",
     "withdrawal": "Rút tiền",
     "investment": "Đầu tư",
+    "held": "Chờ gộp",
+    "merged": "Đã gộp",
     "gainLoss": "Lãi/Lỗ",
     "amountReceived": "Nhận được",
     "noGoal": "Chưa gán",

--- a/supabase/migrations/20260620000004_add_held_for_merge_pool.sql
+++ b/supabase/migrations/20260620000004_add_held_for_merge_pool.sql
@@ -1,0 +1,50 @@
+-- "Ví chờ gộp" (merge holding pool) — PR4 of "Gộp nhiều nguồn".
+--
+-- An earlier-maturing deposit can mature days before the deposit it should merge
+-- into (the anchor D). Forcing the user to either leave it idle or settle it to
+-- loose cash (which drops the goal) is the gap this closes. They can now settle
+-- it with "Để dành gộp" (hold for merge): the deposit is closed by a normal
+-- withdrawal row, but that row is FLAGGED as held — its cash stays earmarked to
+-- the goal and the intended anchor, and the dashboard/Plan synthesize it back so
+-- the goal value never dips. When the anchor matures, the merge consumes the
+-- holding (folds the held cash into D and stamps consumed_by_inv_id) instead of
+-- opening a second withdrawal.
+--
+-- Decision (owner): the pool is a FLAG ON THE SETTLEMENT (withdrawal) row, NOT a
+-- zero-interest deposit row — held cash has left the bank product, so it must not
+-- leak into NAV / maturity sweeps / any asset_type='bank' aggregation. These four
+-- columns live only on withdrawal rows (held_for_merge=true); they are NULL/false
+-- on every deposit and on plain (non-held) withdrawals.
+alter table public.investment_transactions
+  -- Marks a settlement (withdrawal) whose cash is parked for a future merge.
+  add column if not exists held_for_merge boolean not null default false,
+  -- The goal the held cash stays earmarked to (so the synthesizer knows where to
+  -- add it back). Mirrors the source deposit's goal_id at hold time.
+  add column if not exists merge_target_goal_id uuid references public.savings_goals(goal_id),
+  -- The deposit the user intends to fold this into (the anchor). Informational /
+  -- for surfacing "đang chờ gộp vào …"; not a hard constraint at merge time.
+  add column if not exists merge_anchor_inv_id uuid references public.investment_transactions(transaction_id),
+  -- Set to the renewed anchor's id once the merge folds this holding in. NULL =
+  -- still in the pool (synthesized back to the goal); non-NULL = consumed (the
+  -- cash now lives in that deposit's principal, so stop synthesizing it).
+  add column if not exists consumed_by_inv_id uuid references public.investment_transactions(transaction_id);
+
+-- The pool query is "held, unconsumed" — a partial index keeps it cheap and makes
+-- the intent explicit (the overwhelming majority of withdrawals are not held).
+create index if not exists investment_transactions_held_for_merge_idx
+  on public.investment_transactions (merge_target_goal_id)
+  where held_for_merge and consumed_by_inv_id is null;
+
+-- active_investment_transactions is a SELECT * view whose column list froze at
+-- creation (see 20260620000001), so it does NOT expose columns added afterwards.
+-- The dashboard overview reads the held-pool columns FROM THIS VIEW to synthesize
+-- the held cash, so it must be re-expanded or the select errors and the overview
+-- 500s. CREATE OR REPLACE re-expands `*` to the current columns (the four new
+-- ones append at the end, which replace allows). security_invoker stays on
+-- (required — see 20260613000003).
+create or replace view public.active_investment_transactions
+  with (security_invoker = true) as
+  select * from public.investment_transactions
+  where renewed_from_transaction_id is null;
+
+grant select on public.active_investment_transactions to authenticated;

--- a/supabase/migrations/20260620000004_add_held_for_merge_pool.sql
+++ b/supabase/migrations/20260620000004_add_held_for_merge_pool.sql
@@ -19,8 +19,13 @@ alter table public.investment_transactions
   -- Marks a settlement (withdrawal) whose cash is parked for a future merge.
   add column if not exists held_for_merge boolean not null default false,
   -- The goal the held cash stays earmarked to (so the synthesizer knows where to
-  -- add it back). Mirrors the source deposit's goal_id at hold time.
-  add column if not exists merge_target_goal_id uuid references public.savings_goals(goal_id),
+  -- add it back). Mirrors the source deposit's goal_id at hold time. Deliberately
+  -- NOT a FK to savings_goals: investment_transactions already has goal_id ->
+  -- savings_goals, and a SECOND FK to the same table makes every PostgREST
+  -- `savings_goals(goal_name)` embed on this table ambiguous ("more than one
+  -- relationship found" → 500). The row's own goal_id FK already enforces goal
+  -- existence + delete cascade, so this app-managed mirror needs no constraint.
+  add column if not exists merge_target_goal_id uuid,
   -- The deposit the user intends to fold this into (the anchor). Informational /
   -- for surfacing "đang chờ gộp vào …"; not a hard constraint at merge time.
   add column if not exists merge_anchor_inv_id uuid references public.investment_transactions(transaction_id),

--- a/supabase/migrations/20260620000005_renew_merge_consume_held.sql
+++ b/supabase/migrations/20260620000005_renew_merge_consume_held.sql
@@ -20,7 +20,9 @@
 -- Adding a parameter changes the signature, so DROP the prior 13-arg version first
 -- (a bare create-or-replace registers a second overload and makes name-resolved
 -- calls ambiguous — the PR0 pitfall, see 20260620000002/0003). Body is identical
--- to 20260620000003 except the new param and the step-0b held-consume loop.
+-- to 20260620000003 except the new param, the step-0b held-consume loop, and the
+-- step-0 live withdrawal now stamping consumed_by_inv_id = D (so the DELETE guard
+-- blocks deleting a folded settlement on BOTH the held and live paths, not just held).
 drop function if exists public.renew_term_deposit_with_merge(
   uuid, bigint, numeric, date, date, bigint, uuid, text, bigint, text, uuid[], bigint[], text
 );
@@ -164,12 +166,16 @@ begin
       raise exception 'renew_term_deposit_with_merge: received amount is unreasonably large for the source'
         using errcode = 'check_violation';
     end if;
+    -- Stamp the withdrawal as folded into D (consumed_by_inv_id = D). Its cash now
+    -- lives in D's principal, so deleting this row from the ledger would re-open the
+    -- source at full value while the cash still sits in D — a double-count. The DELETE
+    -- route guards any withdrawal carrying this marker (held OR live) with a 409.
     insert into public.investment_transactions (
       user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
-      investment_date, amount_vnd, principal_withdrawn, affects_progress
+      investment_date, amount_vnd, principal_withdrawn, affects_progress, consumed_by_inv_id
     ) values (
       v_src.user_id, v_src.goal_id, 'bank', 'withdrawal', v_sid,
-      p_investment_date, v_recv, v_src_eff, true
+      p_investment_date, v_recv, v_src_eff, true, p_tx_id
     );
     -- Unlink any recurring saving that fed the now-closed source (mirror
     -- 20260618000009 lines 110–117) so nothing tries to top it up later.

--- a/supabase/migrations/20260620000005_renew_merge_consume_held.sql
+++ b/supabase/migrations/20260620000005_renew_merge_consume_held.sql
@@ -223,6 +223,12 @@ begin
     update public.investment_transactions
        set consumed_by_inv_id = p_tx_id, updated_at = now()
      where transaction_id = v_hid;
+    -- Backstop the hold-time unlink (POST clears it when the holding is created):
+    -- a recurring saving linked to the now-consumed source must not keep pointing
+    -- at it. The held row's parent IS that source deposit; clear any link to it.
+    update public.recurring_savings
+       set linked_deposit_tx_id = null, updated_at = now()
+     where linked_deposit_tx_id = v_src.parent_transaction_id and user_id = v_old.user_id;
     v_merge_total := v_merge_total + v_src.amount_vnd;
   end loop;
 

--- a/supabase/migrations/20260620000005_renew_merge_consume_held.sql
+++ b/supabase/migrations/20260620000005_renew_merge_consume_held.sql
@@ -1,0 +1,288 @@
+-- "Ví chờ gộp" consume — PR4 of "Gộp nhiều nguồn".
+--
+-- A held settlement (see 20260620000004) already closed its source deposit with a
+-- withdrawal row and parked the cash in the pool. When the anchor (D) finally
+-- matures and the user merges, we must NOT open a second withdrawal for that
+-- source — it is already closed. Instead the merge CONSUMES the holding: fold its
+-- cash into D's new principal and stamp consumed_by_inv_id = D so the dashboard /
+-- Plan stop synthesizing it back (the cash now lives in D's principal).
+--
+-- So renew_term_deposit_with_merge gains p_held_source_ids: the ids of held
+-- withdrawal rows to consume. They are additive to the live p_merge_source_ids
+-- path — a single merge can fold both live siblings AND pooled holdings into D.
+--
+-- Net-worth invariant holds either way: a live source releases v_recv (client-
+-- supplied, ×10-bounded); a held source releases its OWN stored amount_vnd, which
+-- the client cannot inflate at merge time (it passes ids only — the RPC reads the
+-- trusted row). Both accumulate into v_merge_total, which is exactly what D grows
+-- by.
+--
+-- Adding a parameter changes the signature, so DROP the prior 13-arg version first
+-- (a bare create-or-replace registers a second overload and makes name-resolved
+-- calls ambiguous — the PR0 pitfall, see 20260620000002/0003). Body is identical
+-- to 20260620000003 except the new param and the step-0b held-consume loop.
+drop function if exists public.renew_term_deposit_with_merge(
+  uuid, bigint, numeric, date, date, bigint, uuid, text, bigint, text, uuid[], bigint[], text
+);
+
+create or replace function public.renew_term_deposit_with_merge(
+  p_tx_id uuid,
+  p_amount_vnd bigint,            -- BASE only; the RPC adds Σ(received) + Σ(held)
+  p_interest_rate numeric,
+  p_expiry_date date,
+  p_investment_date date,
+  p_interest_earned_vnd bigint,
+  p_fulfill_saving_id uuid default null,
+  p_fulfill_ym text default null,
+  p_fulfill_amount bigint default null,
+  p_fulfill_source text default null,
+  p_merge_source_ids uuid[] default '{}',
+  p_merge_received bigint[] default '{}',
+  p_bank_code text default null,
+  p_held_source_ids uuid[] default '{}'
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_old public.investment_transactions;
+  v_snapshot_id uuid;
+  v_renewed public.investment_transactions;
+  v_src public.investment_transactions;
+  v_sid uuid;
+  v_recv bigint;
+  v_src_eff bigint;
+  v_merge_total bigint := 0;
+  v_n integer;
+  v_i integer;
+  v_hn integer;
+  v_hid uuid;
+begin
+  select * into v_old
+    from public.investment_transactions
+   where transaction_id = p_tx_id
+   for update;
+  if not found then
+    raise exception 'renew_term_deposit_with_merge: transaction not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_old.asset_type is distinct from 'bank' then
+    raise exception 'renew_term_deposit_with_merge: only bank term deposits can be renewed'
+      using errcode = 'check_violation';
+  end if;
+  if v_old.interest_rate is null or v_old.expiry_date is null then
+    raise exception 'renew_term_deposit_with_merge: only bank term deposits can be renewed'
+      using errcode = 'check_violation';
+  end if;
+  -- An accumulating book is renewed as a whole, not one tranche at a time.
+  if v_old.deposit_group_id is not null then
+    raise exception 'renew_term_deposit_with_merge: cannot renew an accumulating book'
+      using errcode = 'check_violation';
+  end if;
+  if p_investment_date > current_date + 1 then
+    raise exception 'renew_term_deposit_with_merge: investment date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+  if p_expiry_date is not null and p_expiry_date <= p_investment_date then
+    raise exception 'renew_term_deposit_with_merge: new maturity must be after the investment date'
+      using errcode = 'check_violation';
+  end if;
+
+  -- 0) Merge step (before roll-forward): close each LIVE source and accumulate the
+  --    cash it releases. The withdrawals are parented to the SOURCE, not D, so
+  --    step 3's re-parent (parent = p_tx_id) never touches them.
+  v_n := coalesce(array_length(p_merge_source_ids, 1), 0);
+  if v_n <> coalesce(array_length(p_merge_received, 1), 0) then
+    raise exception 'renew_term_deposit_with_merge: merge source/received length mismatch'
+      using errcode = 'check_violation';
+  end if;
+  -- Acquire every source row lock up front in a deterministic (sorted) order, so
+  -- two concurrent merges that share a source can't deadlock by locking it in
+  -- opposite array orders. The per-source `for update` in the loop below then
+  -- just re-reads an already-held lock. (Low-risk for a single-user app, but
+  -- cheap insurance against the ordering hazard.)
+  perform 1
+    from public.investment_transactions
+   where transaction_id = any(p_merge_source_ids)
+   order by transaction_id
+     for update;
+  for v_i in 1 .. v_n loop
+    v_sid := p_merge_source_ids[v_i];
+    v_recv := p_merge_received[v_i];
+    if v_sid = p_tx_id then
+      raise exception 'renew_term_deposit_with_merge: a deposit cannot merge into itself'
+        using errcode = 'check_violation';
+    end if;
+    if v_recv is null or v_recv < 0 then
+      raise exception 'renew_term_deposit_with_merge: received amount must be non-negative'
+        using errcode = 'check_violation';
+    end if;
+    select * into v_src
+      from public.investment_transactions
+     where transaction_id = v_sid
+     for update;
+    if not found then
+      raise exception 'renew_term_deposit_with_merge: merge source not found'
+        using errcode = 'no_data_found';
+    end if;
+    -- Source must be a plain, active bank deposit owned by the same user and in
+    -- the same goal as D (an internal transfer within one goal). Books, renewal
+    -- snapshots and withdrawals are excluded.
+    if v_src.user_id <> v_old.user_id then
+      raise exception 'renew_term_deposit_with_merge: merge source belongs to another user'
+        using errcode = 'check_violation';
+    end if;
+    if v_src.goal_id is distinct from v_old.goal_id then
+      raise exception 'renew_term_deposit_with_merge: merge source is in a different goal'
+        using errcode = 'check_violation';
+    end if;
+    if v_src.asset_type is distinct from 'bank' or v_src.deposit_group_id is not null
+       or v_src.transaction_type is distinct from 'investment'
+       or v_src.renewed_from_transaction_id is not null then
+      raise exception 'renew_term_deposit_with_merge: merge source is not a plain active bank deposit'
+        using errcode = 'check_violation';
+    end if;
+    -- Close only what is left after any prior partial withdrawals.
+    v_src_eff := v_src.amount_vnd - coalesce((
+      select sum(w.principal_withdrawn) from public.investment_transactions w
+       where w.parent_transaction_id = v_sid and w.transaction_type = 'withdrawal'
+    ), 0);
+    if v_src_eff <= 0 then
+      raise exception 'renew_term_deposit_with_merge: merge source is already fully withdrawn'
+        using errcode = 'check_violation';
+    end if;
+    -- Sanity-bound the cash received against the source's OWN value: settling S
+    -- releases at most its effective principal plus interest, never a multiple of
+    -- it. Without this the server trusts the client's received outright, so a
+    -- buggy/malicious caller could inflate D (principal = BASE + Σ received) from
+    -- nothing while S only closes its real principal. Mirror the ×10 bound the
+    -- renewal route already applies to interest_earned_vnd — generous enough to
+    -- never reject a real held-to-maturity value, tight enough to cap abuse.
+    if v_recv > v_src_eff * 10 then
+      raise exception 'renew_term_deposit_with_merge: received amount is unreasonably large for the source'
+        using errcode = 'check_violation';
+    end if;
+    insert into public.investment_transactions (
+      user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
+      investment_date, amount_vnd, principal_withdrawn, affects_progress
+    ) values (
+      v_src.user_id, v_src.goal_id, 'bank', 'withdrawal', v_sid,
+      p_investment_date, v_recv, v_src_eff, true
+    );
+    -- Unlink any recurring saving that fed the now-closed source (mirror
+    -- 20260618000009 lines 110–117) so nothing tries to top it up later.
+    update public.recurring_savings
+       set linked_deposit_tx_id = null, updated_at = now()
+     where linked_deposit_tx_id = v_sid and user_id = v_old.user_id;
+    v_merge_total := v_merge_total + v_recv;
+  end loop;
+
+  -- 0b) Held-pool consume: each held settlement already closed its source and
+  --     parked the cash. Fold that cash into D and stamp it consumed — NO new
+  --     withdrawal (the source is already closed; opening another would
+  --     double-close it). The client passes ids only, so the released amount is
+  --     the trusted stored amount_vnd, not a client value — no ×10 bound needed.
+  v_hn := coalesce(array_length(p_held_source_ids, 1), 0);
+  perform 1
+    from public.investment_transactions
+   where transaction_id = any(p_held_source_ids)
+   order by transaction_id
+     for update;
+  for v_i in 1 .. v_hn loop
+    v_hid := p_held_source_ids[v_i];
+    if v_hid = p_tx_id then
+      raise exception 'renew_term_deposit_with_merge: a deposit cannot merge into itself'
+        using errcode = 'check_violation';
+    end if;
+    select * into v_src
+      from public.investment_transactions
+     where transaction_id = v_hid
+     for update;
+    if not found then
+      raise exception 'renew_term_deposit_with_merge: held source not found'
+        using errcode = 'no_data_found';
+    end if;
+    if v_src.user_id <> v_old.user_id then
+      raise exception 'renew_term_deposit_with_merge: held source belongs to another user'
+        using errcode = 'check_violation';
+    end if;
+    if v_src.transaction_type is distinct from 'withdrawal' or coalesce(v_src.held_for_merge, false) = false then
+      raise exception 'renew_term_deposit_with_merge: source is not a held settlement'
+        using errcode = 'check_violation';
+    end if;
+    if v_src.consumed_by_inv_id is not null then
+      raise exception 'renew_term_deposit_with_merge: held source already consumed'
+        using errcode = 'check_violation';
+    end if;
+    if v_src.goal_id is distinct from v_old.goal_id then
+      raise exception 'renew_term_deposit_with_merge: held source is in a different goal'
+        using errcode = 'check_violation';
+    end if;
+    update public.investment_transactions
+       set consumed_by_inv_id = p_tx_id, updated_at = now()
+     where transaction_id = v_hid;
+    v_merge_total := v_merge_total + v_src.amount_vnd;
+  end loop;
+
+  -- 1) Roll the active row forward to the new cycle. Net-worth invariant: the
+  --    amount added to D's principal equals exactly Σ(received) + Σ(held) the
+  --    sources released — the server adds it so the client can never inflate D
+  --    alone. bank_code moves to the chosen destination; NULL leaves it as is.
+  update public.investment_transactions
+     set amount_vnd      = p_amount_vnd + v_merge_total,
+         interest_rate   = p_interest_rate,
+         expiry_date     = p_expiry_date,
+         investment_date = p_investment_date,
+         bank_code       = coalesce(p_bank_code, bank_code),
+         updated_at      = now()
+   where transaction_id = p_tx_id
+  returning * into v_renewed;
+
+  -- 2) Append the history snapshot of the closed cycle (dates from v_old).
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, amount_vnd,
+    investment_date, expiry_date, interest_rate, notes,
+    renewed_from_transaction_id, interest_earned_vnd, affects_progress
+  ) values (
+    v_old.user_id, v_old.goal_id, 'bank', 'investment', v_old.amount_vnd,
+    v_old.investment_date, v_old.expiry_date, v_old.interest_rate, v_old.notes,
+    p_tx_id, p_interest_earned_vnd, false
+  )
+  returning transaction_id into v_snapshot_id;
+
+  -- 3) Re-parent the closed cycle's partial-withdrawal rows onto the snapshot.
+  update public.investment_transactions
+     set parent_transaction_id = v_snapshot_id
+   where parent_transaction_id = p_tx_id
+     and transaction_type = 'withdrawal';
+
+  -- 4) Combine flow only: record this month's recurring saving as fulfilled.
+  if p_fulfill_saving_id is not null and p_fulfill_ym is not null then
+    if not exists (
+      select 1 from public.recurring_savings
+       where saving_id = p_fulfill_saving_id and user_id = v_old.user_id
+    ) then
+      raise exception 'renew_term_deposit_with_merge: recurring saving not found'
+        using errcode = 'no_data_found';
+    end if;
+    insert into public.recurring_saving_fulfillments (
+      user_id, recurring_saving_id, ym, amount_vnd, source
+    ) values (
+      v_old.user_id, p_fulfill_saving_id, p_fulfill_ym,
+      coalesce(p_fulfill_amount, 0), coalesce(p_fulfill_source, 'maturity-combine')
+    )
+    on conflict (recurring_saving_id, ym) do update
+      set amount_vnd = excluded.amount_vnd,
+          source     = excluded.source,
+          updated_at = now();
+  end if;
+
+  return v_renewed;
+end;
+$$;
+
+grant execute on function public.renew_term_deposit_with_merge(
+  uuid, bigint, numeric, date, date, bigint, uuid, text, bigint, text, uuid[], bigint[], text, uuid[]
+) to authenticated;

--- a/supabase/migrations/20260620000006_renew_merge_stamp_live_source.sql
+++ b/supabase/migrations/20260620000006_renew_merge_stamp_live_source.sql
@@ -1,29 +1,23 @@
--- "Ví chờ gộp" consume — PR4 of "Gộp nhiều nguồn".
+-- Guard live-merge settlements from deletion — follow-up to 20260620000005.
 --
--- A held settlement (see 20260620000004) already closed its source deposit with a
--- withdrawal row and parked the cash in the pool. When the anchor (D) finally
--- matures and the user merges, we must NOT open a second withdrawal for that
--- source — it is already closed. Instead the merge CONSUMES the holding: fold its
--- cash into D's new principal and stamp consumed_by_inv_id = D so the dashboard /
--- Plan stop synthesizing it back (the cash now lives in D's principal).
+-- The DELETE route (investment-transactions/[id]) blocks deleting a withdrawal that
+-- has been folded into another deposit (consumed_by_inv_id set), because deleting it
+-- would re-open the source at full value while its cash already lives in the anchor's
+-- principal — a double-count. The HELD path stamps consumed_by_inv_id when a merge
+-- consumes a holding (step 0b above), so it was already guarded. The LIVE path —
+-- merging a sibling straight into D (step 0) — opened a plain withdrawal WITHOUT that
+-- marker, so the ledger's per-row delete could still double-count. Same hazard, the
+-- held guard merely exposed the asymmetry (predates the holding pool).
 --
--- So renew_term_deposit_with_merge gains p_held_source_ids: the ids of held
--- withdrawal rows to consume. They are additive to the live p_merge_source_ids
--- path — a single merge can fold both live siblings AND pooled holdings into D.
+-- Fix: the live-source withdrawal now also stamps consumed_by_inv_id = D, so the
+-- guard keys on that one marker for both paths.
 --
--- Net-worth invariant holds either way: a live source releases v_recv (client-
--- supplied, ×10-bounded); a held source releases its OWN stored amount_vnd, which
--- the client cannot inflate at merge time (it passes ids only — the RPC reads the
--- trusted row). Both accumulate into v_merge_total, which is exactly what D grows
--- by.
---
--- Adding a parameter changes the signature, so DROP the prior 13-arg version first
--- (a bare create-or-replace registers a second overload and makes name-resolved
--- calls ambiguous — the PR0 pitfall, see 20260620000002/0003). Body is identical
--- to 20260620000003 except the new param and the step-0b held-consume loop.
-drop function if exists public.renew_term_deposit_with_merge(
-  uuid, bigint, numeric, date, date, bigint, uuid, text, bigint, text, uuid[], bigint[], text
-);
+-- This is a SEPARATE migration (not an in-place edit of 005) on purpose: a database
+-- whose ledger already records 005 as applied would never re-run an edited 005, so
+-- the patched function would never reach it. Appending a forward migration makes
+-- every database — fresh or already-005'd — converge on the stamped function. The
+-- signature is unchanged, so a bare create-or-replace replaces the body cleanly with
+-- no DROP (and no overload ambiguity).
 
 create or replace function public.renew_term_deposit_with_merge(
   p_tx_id uuid,
@@ -164,12 +158,17 @@ begin
       raise exception 'renew_term_deposit_with_merge: received amount is unreasonably large for the source'
         using errcode = 'check_violation';
     end if;
+    -- Stamp the withdrawal as folded into D (consumed_by_inv_id = D). Its cash now
+    -- lives in D's principal, so deleting this row from the ledger would re-open the
+    -- source at full value while the cash still sits in D — a double-count. The
+    -- DELETE route guards any withdrawal carrying this marker (held OR live) with a
+    -- 409. (This is the only change from 20260620000005.)
     insert into public.investment_transactions (
       user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
-      investment_date, amount_vnd, principal_withdrawn, affects_progress
+      investment_date, amount_vnd, principal_withdrawn, affects_progress, consumed_by_inv_id
     ) values (
       v_src.user_id, v_src.goal_id, 'bank', 'withdrawal', v_sid,
-      p_investment_date, v_recv, v_src_eff, true
+      p_investment_date, v_recv, v_src_eff, true, p_tx_id
     );
     -- Unlink any recurring saving that fed the now-closed source (mirror
     -- 20260618000009 lines 110–117) so nothing tries to top it up later.


### PR DESCRIPTION
## Gộp nhiều nguồn — PR4: "Ví chờ gộp" (merge holding pool)

The last (and highest-risk) PR of the multi-source merge plan. An earlier-maturing
deposit can mature days before the deposit it should merge into. Until now the user
had to either leave it idle or settle it to loose cash (which drops the goal). They
can now settle it with **"Để dành gộp"**: it's closed, but its cash stays earmarked
to the goal and is synthesized straight back — so the goal value never dips and it
never shows as a stray deposit. When the anchor matures, the merge **consumes** the
holding (folds the parked cash in, no second withdrawal). Changing your mind
(**"Bỏ chờ gộp"**) restores the original deposit.

**Decision (owner):** the pool is a *flag on the settlement (withdrawal) row*, not a
zero-interest deposit row — held cash has left the bank product, so it must not leak
into NAV / maturity sweeps.

### What's in it
- **Migration** `…0004`: `held_for_merge` / `merge_target_goal_id` /
  `merge_anchor_inv_id` / `consumed_by_inv_id` on `investment_transactions` + a
  partial index on the held-unconsumed pool + view re-expand. `…0005`:
  `renew_term_deposit_with_merge` gains `p_held_source_ids` to consume holdings.
- **Synthesis** (`lib/heldForMerge`, TDD): the overview adds each pooled holding
  back to its goal's value (mirroring recurring fulfillments); a consumed holding
  is skipped. Each goal also returns `heldForMerge[]` for the UI.
- **UI** (resolve sheet): a discoverability nudge + a 2-card **hold vs withdraw**
  fork, gated by the PR2 eligibility detector (only when a later eligible anchor
  exists). The anchor's sheet preselects pooled holdings as `held_sources`. A
  **"Đang chờ gộp"** chip with **"Bỏ chờ gộp"** in goal detail restores the deposit.

### Net-worth invariant
Hold removes the deposit's principal and synthesizes the cash back → net zero.
Consume moves the cash from synthesis into the anchor's principal → net zero. No
double-count on **dashboard or Plan**.

### Heads-up for reviewers
Dropping the `merge_target_goal_id → savings_goals` FK is deliberate: a second FK to
`savings_goals` made every PostgREST `savings_goals(goal_name)` embed on
`investment_transactions` ambiguous (→ 500 on the goal-detail tx list, recent
activity, monthly-plans). The row's own `goal_id` FK already enforces existence +
cascade. Caught by the full local E2E.

### Tests
- Unit: 771 green (new `heldForMerge` lib + 4 resolve-sheet tests).
- **Full local E2E: 299 passed / 0 failed**, incl. new `maturity-combine-holding.spec.ts`
  (hold → no value drop; consume → no double-count + `consumed_by_inv_id` stamped;
  unhold → restored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
