### PR TITLE
fix(deposits): stop iOS autozoom on the maturity/merge sheet fields

### DIFF
--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -40,7 +40,7 @@ const fieldLabel: React.CSSProperties = {
 }
 const moneyInput: React.CSSProperties = {
   display: 'block', width: '100%', boxSizing: 'border-box',
-  padding: '10px 12px', fontFamily: 'inherit', fontSize: 15,
+  padding: '10px 12px', fontFamily: 'inherit', fontSize: 16,
   fontVariantNumeric: 'tabular-nums', fontWeight: 600,
   background: 'var(--c-canvas,#faf9f7)', border: '1.5px solid var(--c-line)',
   borderRadius: 10, color: 'var(--c-ink)', outline: 'none',
@@ -896,7 +896,7 @@ export function MaturityResolveBody({
                           <div style={{ position: 'relative', flex: 1 }}>
                             <input data-testid={`merge-received-${s.id}`} type="number" value={mergeRecv[s.id] ?? ''}
                               onChange={(e) => { setMergeRecv((prev) => ({ ...prev, [s.id]: e.target.value })); setMergeTotal(''); setMergeTotalTouched(false) }}
-                              style={{ ...moneyInput, padding: '7px 24px 7px 10px', fontSize: 13 }} />
+                              style={{ ...moneyInput, padding: '7px 24px 7px 10px', fontSize: 16 }} />
                             <span style={{ position: 'absolute', right: 9, top: '50%', transform: 'translateY(-50%)', fontSize: 12, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
                           </div>
                         </div>

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -609,6 +609,58 @@ describe('MaturityResolveBody', () => {
     })
   })
 
+  // ── iOS Safari autozoom guard ───────────────────────────────────────────────
+  // iOS zooms the viewport on focus of any native field sized < 16px and never
+  // resets it — jolting the bottom sheet so the save button drifts out of reach.
+  // The globals.css 16px floor (input/textarea/select) is an element-selector, so
+  // these inline-styled fields must carry >= 16px themselves to be protected.
+  describe('iOS autozoom guard (fields must be >= 16px)', () => {
+    function fontPx(el: Element): number {
+      return parseFloat((el as HTMLElement).style.fontSize || getComputedStyle(el).fontSize || '0')
+    }
+
+    function stubEmptyRecurring() {
+      const fetchMock = vi.fn().mockImplementation((url: string) => {
+        if (typeof url === 'string' && url.startsWith('/api/v1/recurring-savings')) {
+          return Promise.resolve({ ok: true, json: async () => ({ savings: [] }) })
+        }
+        return Promise.resolve({ ok: true, json: async () => [] })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      return fetchMock
+    }
+
+    it('renders the renew form fields (term, rate, maturity date) at >= 16px', async () => {
+      const user = userEvent.setup()
+      render(
+        <MaturityResolveBody inv={maturedDeposit} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      expect(fontPx(screen.getByTestId('maturity-term-input'))).toBeGreaterThanOrEqual(16)
+      expect(fontPx(screen.getByTestId('maturity-date-input'))).toBeGreaterThanOrEqual(16)
+      // The "Change amount" field shares the same moneyInput style.
+      await user.click(screen.getByRole('button', { name: /Change amount/i }))
+      expect(fontPx(screen.getByTestId('maturity-new-amount'))).toBeGreaterThanOrEqual(16)
+    })
+
+    it('renders the per-source merge-received field at >= 16px', async () => {
+      const user = userEvent.setup()
+      stubEmptyRecurring()
+      const sibBank: InvRow = {
+        id: 'sib-bank', name: 'Vikki sibling', type: 'bank', value: 8_000_000, gainPct: null,
+        units: null, principal: 8_000_000, interestRate: 6, expiryDate: daysFromNow(40),
+        investmentDate: daysFromNow(-150), fund: null,
+      }
+      render(
+        <MaturityResolveBody inv={maturedDeposit} goalId="goal-1" siblingDeposits={[sibBank]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+      await user.click(screen.getByTestId('merge-override-sib-bank'))
+      // The compact per-source "received" field is the worst offender (was 13px).
+      expect(fontPx(screen.getByTestId('merge-received-sib-bank'))).toBeGreaterThanOrEqual(16)
+    })
+  })
+
   it('hands off to the existing withdraw flow instead of renewing', async () => {
     const user = userEvent.setup()
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })


### PR DESCRIPTION
## Bug — Autozoom (mobile, iOS Safari)

Tapping **any** input in the "Gộp nhiều nguồn" / "Xử lý đáo hạn" bottom sheet on iPhone makes Safari zoom the viewport on focus and never reset it → the sheet jumps and **"Lưu sổ mới" drifts out of reach**. Not in the prior review.

## Root cause

iOS Safari auto-zooms when a focused native field has `font-size < 16px`. `globals.css` has a floor:

```css
@media (max-width: 768px) { input, textarea, select { font-size: 16px; } }
```

…but as its own comment notes, that's an **element selector** — higher-specificity **inline styles win**. `MaturityResolveSheet.tsx` styles every field with the inline `moneyInput` (`fontSize: 15`) plus the compact per-source "received" field at `fontSize: 13`. So the floor never applies and every field (amount, interest, term, rate, maturity date, received, total, dest-bank select) auto-zooms.

## Fix

- `moneyInput.fontSize` **15 → 16** — one change covers amount/term/rate/date/dest-bank `<select>`/merge-total/change-amount.
- per-source `merge-received` field **13 → 16**.

No `maximum-scale` added: the 16px floor is the codebase's chosen strategy (documented in globals.css) and it keeps pinch-zoom working — disabling it would be an a11y regression.

## Tests (TDD)

Added an "iOS autozoom guard" suite asserting the **user-visible outcome** — the rendered fields carry `font-size >= 16px` (renew form: term/date/change-amount; merge: per-source received). Red before the fix (`15`/`13` failed), green after.

- `npm test -- --run` → 790 passed
- `npm run lint` → both changed files clean (pre-existing problems elsewhere only)

Chromium E2E can't reproduce iOS autozoom (same as issue #362), so this is unit-guarded.