### PR TITLE
fix(planning): keep allocation-card amounts on one line (white-space: nowrap)

### DIFF
--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -352,7 +352,7 @@ function AllocationCard({ salary, totalGoalAmount, fixedTotal, insTotal, otherTo
       <div style={{ fontSize: 11, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'rgba(255,255,255,0.6)', marginBottom: 4 }}>
         {isVI ? 'Phân bổ tháng này' : "This month's allocation"}
       </div>
-      <div style={{ fontSize: 26, fontWeight: 700, letterSpacing: '-0.03em', fontVariantNumeric: 'tabular-nums' }}>
+      <div style={{ fontSize: 26, fontWeight: 700, letterSpacing: '-0.03em', fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
         {fmtCompact(totalAllocated)}
       </div>
       <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.55)', marginTop: 2 }}>
@@ -368,7 +368,7 @@ function AllocationCard({ salary, totalGoalAmount, fixedTotal, insTotal, otherTo
             <span style={{ width: 8, height: 8, borderRadius: 2, background: r.c, flexShrink: 0 }} />
             <span style={{ flex: 1, fontSize: 12, color: 'rgba(255,255,255,0.7)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.l}</span>
             <span style={{ fontSize: 12, fontWeight: 600, fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>{fmtCompact(r.v)}</span>
-            <span style={{ fontSize: 10, color: 'rgba(255,255,255,0.4)', minWidth: 30, textAlign: 'right', flexShrink: 0 }}>{pct(r.v)}</span>
+            <span style={{ fontSize: 10, color: 'rgba(255,255,255,0.4)', minWidth: 30, textAlign: 'right', flexShrink: 0, whiteSpace: 'nowrap' }}>{pct(r.v)}</span>
           </div>
         ))}
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingTop: 8, borderTop: '1px solid rgba(255,255,255,0.12)', marginTop: 2 }}>
@@ -376,7 +376,7 @@ function AllocationCard({ salary, totalGoalAmount, fixedTotal, insTotal, otherTo
           <span style={{ flex: 1, fontSize: 12, fontWeight: 600, color: remaining >= 0 ? 'rgba(255,255,255,0.8)' : '#fca5a5' }}>
             {isVI ? 'Còn lại' : 'Remaining'}
           </span>
-          <span style={{ fontSize: 13, fontWeight: 700, color: remaining >= 0 ? '#86efac' : '#fca5a5', fontVariantNumeric: 'tabular-nums' }}>
+          <span style={{ fontSize: 13, fontWeight: 700, color: remaining >= 0 ? '#86efac' : '#fca5a5', fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>
             {remaining >= 0 ? '+' : ''}{fmtCompact(remaining)}
           </span>
         </div>

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -536,7 +536,7 @@ function AllocationSummaryCard({
   const segments = rows.map((r) => ({ value: r.v, color: r.color }))
 
   return (
-    <div style={{
+    <div data-testid="planning-alloc-card" style={{
       background: 'var(--c-btn-primary)', color: '#fff',
       borderRadius: 16, padding: 16,
       border: '1px solid var(--c-line)', boxShadow: 'var(--shadow-card)',
@@ -544,7 +544,7 @@ function AllocationSummaryCard({
       <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.7)', letterSpacing: '0.06em', textTransform: 'uppercase', fontWeight: 600 }}>
         {isVI ? 'Phân bổ tháng này' : "This month's allocation"}
       </div>
-      <div style={{ fontSize: 26, fontWeight: 600, fontVariantNumeric: 'tabular-nums', letterSpacing: '-0.025em', marginTop: 4 }}>
+      <div style={{ fontSize: 26, fontWeight: 600, fontVariantNumeric: 'tabular-nums', letterSpacing: '-0.025em', marginTop: 4, whiteSpace: 'nowrap' }}>
         {fmtCompact(totalAllocated)}
       </div>
       <div style={{ fontSize: 11, color: 'rgba(255,255,255,0.6)', marginTop: 2 }}>
@@ -568,7 +568,7 @@ function AllocationSummaryCard({
             <span style={{ width: 8, height: 8, borderRadius: 2, background: r.color, flexShrink: 0 }} />
             <span style={{ flex: 1, fontSize: 12, color: 'rgba(255,255,255,0.75)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{r.l}</span>
             <span style={{ fontSize: 12, fontWeight: 600, fontVariantNumeric: 'tabular-nums', whiteSpace: 'nowrap' }}>{fmtCompact(r.v)}</span>
-            <span style={{ fontSize: 10, color: 'rgba(255,255,255,0.45)', minWidth: 30, textAlign: 'right', flexShrink: 0 }}>{pct(r.v)}</span>
+            <span style={{ fontSize: 10, color: 'rgba(255,255,255,0.45)', minWidth: 30, textAlign: 'right', flexShrink: 0, whiteSpace: 'nowrap' }}>{pct(r.v)}</span>
           </div>
         ))}
         {/* Remaining row */}
@@ -577,7 +577,7 @@ function AllocationSummaryCard({
           <span style={{ flex: 1, fontSize: 12, color: remaining >= 0 ? 'rgba(255,255,255,0.75)' : '#fca5a5', fontWeight: 600 }}>
             {isVI ? 'Còn lại' : 'Remaining'}
           </span>
-          <span style={{ fontSize: 13, fontWeight: 700, fontVariantNumeric: 'tabular-nums', color: remaining >= 0 ? '#86efac' : '#fca5a5' }}>
+          <span style={{ fontSize: 13, fontWeight: 700, fontVariantNumeric: 'tabular-nums', color: remaining >= 0 ? '#86efac' : '#fca5a5', whiteSpace: 'nowrap' }}>
             {remaining >= 0 ? '+' : ''}{fmtCompact(remaining)}
           </span>
         </div>

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DesktopPlanningView from '../DesktopPlanningView'
 import type { MonthlyPlan, FundInvestment, DirectSaving, RecurringSaving, RecurringFulfillment, InsuranceMember } from '../../PlanningClient'
@@ -181,6 +181,19 @@ describe('DesktopPlanningView — recurring bank "Saved" deposit', () => {
     } finally {
       vi.unstubAllGlobals()
     }
+  })
+})
+
+describe('DesktopPlanningView — allocation card amounts never wrap', () => {
+  it('keeps the total, remaining and per-row pct on one line so the ₫ never drops under a fallback font', () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
+    const card = screen.getByTestId('planning-alloc-card')
+    // Big total (2.0M ₫) and the matching category row — "M" and "₫" must not split.
+    within(card).getAllByText('2.0M ₫').forEach((el) => expect(el).toHaveStyle({ whiteSpace: 'nowrap' }))
+    // Remaining value (+43.0M ₫).
+    expect(within(card).getByText('+43.0M ₫')).toHaveStyle({ whiteSpace: 'nowrap' })
+    // Per-row percentage chip.
+    expect(within(card).getByText('4%', { exact: true })).toHaveStyle({ whiteSpace: 'nowrap' })
   })
 })
 

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MobilePlanningView from '../MobilePlanningView'
 import type { MonthlyPlan, FixedExpense, InsuranceMember, OtherExpense, FundInvestment, DirectSaving, RecurringFulfillment } from '../../PlanningClient'
@@ -155,6 +155,18 @@ describe('MobilePlanningView — with plan', () => {
   it("shows allocation summary card with \"This month's allocation\" label", () => {
     render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
     expect(screen.getByText(/This month's allocation/i)).toBeInTheDocument()
+  })
+
+  it('keeps the allocation card total, remaining and per-row pct on one line so the ₫ never wraps under a fallback font', () => {
+    // Fixed expenses (8.5M + 1.2M = 9.7M) drive the card → total 9.7M ₫, remaining +35.3M ₫.
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={baseFixedExpenses} />)
+    const card = screen.getByTestId('planning-alloc-card')
+    // Both the big total and the matching category row show "9.7M ₫" — neither may wrap.
+    within(card).getAllByText('9.7M ₫').forEach((el) => expect(el).toHaveStyle({ whiteSpace: 'nowrap' }))
+    // Remaining value (+35.3M ₫).
+    expect(within(card).getByText('+35.3M ₫')).toHaveStyle({ whiteSpace: 'nowrap' })
+    // Per-row percentage chip.
+    expect(within(card).getByText('22%', { exact: true })).toHaveStyle({ whiteSpace: 'nowrap' })
   })
 
   it('shows edit (pencil) and delete (trash) buttons on salary card', () => {


### PR DESCRIPTION
## What

The amount spans in the **Phân bổ tháng này** allocation card (the big total, the **Còn lại / Remaining** value, and the per-row `%` chips) were missing `white-space: nowrap`, unlike the equivalent spans elsewhere in the card (row values + the contributed line already had it).

`fmtCompact` emits values with a space before the symbol — e.g. `"10.1M ₫"`. With the web font **Be Vietnam Pro** loaded (the real user state) these fit on one line. But under a wider fallback font (before the font loads), the `₫` can wrap to a new line — this layout has almost no horizontal safety margin. The screenshots that showed the wrap were re-rendered with the fallback font.

## Change

- Added `white-space: nowrap` to the **total**, **remaining**, and per-row **pct** spans in both:
  - `DesktopPlanningView.tsx → AllocationCard`
  - `MobilePlanningView.tsx → AllocationSummaryCard`
- Gave the mobile card the same `data-testid="planning-alloc-card"` the desktop card already has, so tests can scope to it without colliding with the summary strip.

Tiny, defensive CSS-only fix — no behavior change with the font loaded.

## Tests (TDD)

Added a unit test per view asserting the total / remaining / pct spans render `white-space: nowrap`. Red before the change, green after.

- `npm test -- --run` → 792 passed
- `npm run lint` → no new problems (pre-existing `set-state-in-effect` errors only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)