### PR TITLE
fix(funds): keep mobile DCA goal select inside the card (#363)

### DIFF
--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -378,7 +378,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
 
       {/* Row 2: NAV + DCA */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', paddingTop: 8, borderTop: '1px solid var(--c-line)', gap: 8 }}>
-        <div>
+        <div style={{ flexShrink: 0 }}>
           <div style={{ fontSize: 10, color: 'var(--c-muted)', marginBottom: 2, textTransform: 'uppercase', letterSpacing: '0.05em', fontWeight: 600 }}>NAV</div>
           <div style={{ fontSize: 13, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>
             {fund.nav.toLocaleString('vi-VN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} VND
@@ -388,7 +388,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
           )}
         </div>
 
-        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, flex: 1, minWidth: 0, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
           <span style={{ fontSize: 10, color: 'var(--c-muted)', textTransform: 'uppercase', letterSpacing: '0.05em', fontWeight: 600 }}>DCA</span>
           <button
             type="button"
@@ -447,6 +447,10 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
                 // 16px (not 13) so iOS Safari doesn't zoom the viewport on focus
                 // and persist that zoom across reloads (#321).
                 fontSize: 16, fontWeight: 500, padding: '3px 6px', maxWidth: 130,
+                // minWidth:0 lets the select shrink below its content width so a long
+                // goal name truncates with an ellipsis instead of overflowing the card
+                // and getting hard-clipped at the right edge (#363).
+                minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
                 border: '1px solid var(--c-line)', borderRadius: 6,
                 background: 'var(--c-card)', color: 'var(--c-muted)',
                 fontFamily: 'inherit', cursor: 'pointer', appearance: 'none', outline: 'none',

--- a/e2e/funds.spec.ts
+++ b/e2e/funds.spec.ts
@@ -159,6 +159,35 @@ test('mobile funds DCA shows goal target dropdown when enabled', async ({ page }
   await expect(select).toHaveValue('')
 })
 
+test('mobile funds DCA goal select stays within the card for long goal names (#363)', async ({ page }) => {
+  // A long goal name must truncate inside the select, not overflow the card's
+  // right edge and get hard-clipped at the card border (issue #363).
+  const goal = await api.createGoal({ goal_name: 'Đại học của Trang tại Vương Quốc Anh năm 2030' })
+  cleanup.add(() => api.deleteGoal(goal.goal_id))
+  const fund = await api.createFund({ name: 'E2E Long Goal Cutoff Fund', code: 'E2ELGC', fund_type: 'equity', nav: 33353.63 })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  const mf = page.getByTestId('mobile-funds')
+  const card = mf.getByTestId(`fund-card-${fund.id}`)
+  await card.getByRole('button', { name: /dca/i }).click()
+  const select = card.getByTestId(`dca-goal-${fund.id}`)
+  await expect(select).toBeVisible({ timeout: 5_000 })
+  await Promise.all([
+    page.waitForResponse(r => r.url().includes(`/api/funds/${fund.id}`) && r.request().method() === 'PUT' && r.ok()),
+    select.selectOption(goal.goal_id),
+  ])
+
+  const cardBox = await card.boundingBox()
+  const selBox = await select.boundingBox()
+  expect(cardBox).not.toBeNull()
+  expect(selBox).not.toBeNull()
+  // Select's right edge must not extend past the card's right edge.
+  expect(selBox!.x + selBox!.width).toBeLessThanOrEqual(cardBox!.x + cardBox!.width + 0.5)
+})
+
 test('mobile funds DCA goal selection persists', async ({ page }) => {
   const goal = await api.createGoal({ goal_name: 'E2E Mobile DCA Goal Target' })
   cleanup.add(() => api.deleteGoal(goal.goal_id))


### PR DESCRIPTION
Fixes #363 — *Mobile · Funds · Cutoff for goal*.

## Problem
On the mobile Fund library, the DCA **goal target** `<select>` overflowed past the card's right edge when the goal name was long (e.g. *"Đại học của Trang…"*), getting hard-clipped at the card border with no ellipsis.

**Cause:** the right-side DCA controls group was `flexShrink: 0`, so it never shrank; the `<select>` (`maxWidth: 130`, default `min-width: auto`) couldn't shrink either, pushing the group past the card's right padding.

## Fix
- NAV (left) stays fixed (`flexShrink: 0`) — it's a bounded number.
- DCA controls group becomes shrinkable (`flex: 1; minWidth: 0`).
- The goal `<select>` gets `minWidth: 0` + `overflow/textOverflow: ellipsis` so a long name truncates **inside** the card instead of overflowing.

Toggle and amount pill keep their sizes; only the goal name truncates.

## Test (TDD)
Added an E2E case in `e2e/funds.spec.ts` that selects a long goal name and asserts the select's right edge never extends past the card's right edge — closing the loop on the rendered outcome, not just stored data.

## Verification
- `npm test -- --run` — 792 passed
- `npm run lint` — no new issues (the file's 2 pre-existing errors are untouched)
- Targeted E2E (`e2e/funds.spec.ts`) couldn't run in this session (local Supabase/WSL2 stack not up); to be validated on the Vercel preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)