### PR TITLE
fix(overview): migrate empty state + error banner to design tokens (#1, #2)

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -34,6 +34,7 @@ import DesktopInsuranceList from './components/DesktopInsuranceList'
 import DesktopInsuranceDetail from './components/DesktopInsuranceDetail'
 import InsuranceEmpty from './components/InsuranceEmpty'
 import AddInsuranceMemberModal from './components/AddInsuranceMemberModal'
+import { OverviewEmptyState } from './components/OverviewEmptyState'
 import DesktopGoalDetail from './components/DesktopGoalDetail'
 
 export interface FundBreakdownItem {
@@ -654,9 +655,12 @@ export default function DashboardClient({ userId }: { userId: string }) {
 
         {/* Error state */}
         {error && (
-          <div className="mb-6 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl flex items-center justify-between">
-            <p className="text-sm text-red-700 dark:text-red-400">{error}</p>
-            <button onClick={() => fetchData({ force: true })} className="text-sm text-red-600 dark:text-red-400 font-medium hover:underline ml-4">{tc('tryAgain')}</button>
+          <div
+            className="mb-6 flex items-center justify-between"
+            style={{ padding: 16, background: 'var(--c-neg-tint)', border: '1px solid var(--c-neg)', borderRadius: 12 }}
+          >
+            <p className="text-sm" style={{ color: 'var(--c-neg)', margin: 0 }}>{error}</p>
+            <button onClick={() => fetchData({ force: true })} className="text-sm font-medium hover:underline ml-4" style={{ color: 'var(--c-neg)' }}>{tc('tryAgain')}</button>
           </div>
         )}
 
@@ -676,55 +680,10 @@ export default function DashboardClient({ userId }: { userId: string }) {
 
         {/* Empty state */}
         {!loading && !error && isEmpty && (
-          <div className="flex flex-col items-center py-16 px-4">
-            {/* Icon */}
-            <div className="w-20 h-20 rounded-2xl bg-indigo-50 dark:bg-indigo-900/20 flex items-center justify-center mb-6">
-              <span className="text-4xl">📊</span>
-            </div>
-
-            {/* Title & description */}
-            <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-2">{t('empty')}</h2>
-            <p className="text-gray-500 dark:text-gray-400 text-center max-w-sm mb-10">
-              {t('emptyDesc')}
-            </p>
-
-            {/* Action cards */}
-            <div className="w-full max-w-md space-y-3 mb-8">
-              {[
-                { icon: '🎯', title: t('addGoal'), desc: t('addGoalDesc') },
-                { icon: '💰', title: t('addFund'), desc: t('addFundDesc') },
-                { icon: '🛡️', title: t('addInsurance'), desc: t('addInsuranceDesc') },
-              ].map(({ icon, title, desc }) => (
-                <a
-                  key={title}
-                  href="/settings"
-                  className="flex items-center gap-4 bg-white dark:bg-gray-900 border border-gray-100 dark:border-gray-700 rounded-xl px-5 py-4 shadow-sm hover:shadow-md hover:border-indigo-100 dark:hover:border-indigo-700 transition-all group"
-                >
-                  <div className="w-10 h-10 rounded-lg bg-indigo-50 dark:bg-indigo-900/20 flex items-center justify-center flex-shrink-0 text-xl">
-                    {icon}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <p className="font-semibold text-gray-900 dark:text-gray-100 text-sm">{title}</p>
-                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-0.5">{desc}</p>
-                  </div>
-                  <span className="text-gray-300 dark:text-gray-600 group-hover:text-indigo-500 transition-colors text-lg">→</span>
-                </a>
-              ))}
-            </div>
-
-            {/* Divider + Settings button */}
-            <div className="flex items-center gap-3 w-full max-w-md mb-5">
-              <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
-              <span className="text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">{t('orManage')}</span>
-              <div className="flex-1 h-px bg-gray-200 dark:bg-gray-700" />
-            </div>
-            <a
-              href="/settings"
-              className="px-6 py-2.5 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors"
-            >
-              {t('settingsLink')}
-            </a>
-          </div>
+          <OverviewEmptyState
+            onAddGoal={() => setShowGoalForm(true)}
+            onAddInsurance={() => setShowAddInsurance(true)}
+          />
         )}
 
 

--- a/app/assets/components/OverviewEmptyState.tsx
+++ b/app/assets/components/OverviewEmptyState.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+import { BarChart3, Target, Wallet, Shield, ChevronRight } from 'lucide-react'
+
+// First-run onboarding shown when the account has no goals / funds / insurance.
+// Migrated off the legacy raw-Tailwind-indigo + emoji markup to Cairn design
+// tokens + lucide icons so it matches the rest of the app (#363 review #1).
+// The goal/insurance actions open the in-page sheets (onAddGoal/onAddInsurance)
+// instead of bouncing the user to /settings; only the fund action navigates,
+// to the real fund library page.
+
+const cardStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: 14,
+  width: '100%',
+  textAlign: 'left',
+  background: 'var(--c-card)',
+  border: '1px solid var(--c-line)',
+  borderRadius: 12,
+  padding: '14px 18px',
+  boxShadow: 'var(--shadow-card)',
+  cursor: 'pointer',
+  fontFamily: 'inherit',
+  color: 'inherit',
+  textDecoration: 'none',
+}
+
+const iconBox: React.CSSProperties = {
+  width: 40,
+  height: 40,
+  borderRadius: 10,
+  flexShrink: 0,
+  background: 'var(--c-navy-tint)',
+  color: 'var(--c-navy)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}
+
+function ActionRow({ Icon, title, desc }: { Icon: typeof Target; title: string; desc: string }) {
+  return (
+    <>
+      <span style={iconBox}><Icon size={20} strokeWidth={1.75} /></span>
+      <span style={{ flex: 1, minWidth: 0 }}>
+        <span style={{ display: 'block', fontWeight: 600, fontSize: 14, color: 'var(--c-ink)' }}>{title}</span>
+        <span style={{ display: 'block', fontSize: 12, color: 'var(--c-muted)', marginTop: 2 }}>{desc}</span>
+      </span>
+      <ChevronRight size={18} color="var(--c-muted-2)" style={{ flexShrink: 0 }} />
+    </>
+  )
+}
+
+export function OverviewEmptyState({ onAddGoal, onAddInsurance }: { onAddGoal: () => void; onAddInsurance: () => void }) {
+  const t = useTranslations('dashboard')
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '64px 16px' }}>
+      {/* Hero icon */}
+      <div style={{ width: 80, height: 80, borderRadius: 20, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: 24 }}>
+        <BarChart3 size={36} strokeWidth={1.5} />
+      </div>
+
+      {/* Title & description */}
+      <h2 style={{ fontSize: 24, fontWeight: 700, color: 'var(--c-ink)', margin: '0 0 8px', textAlign: 'center' }}>{t('empty')}</h2>
+      <p style={{ color: 'var(--c-muted)', textAlign: 'center', maxWidth: 360, margin: '0 0 40px', lineHeight: 1.5 }}>{t('emptyDesc')}</p>
+
+      {/* Action cards */}
+      <div style={{ width: '100%', maxWidth: 420, display: 'grid', gap: 12, marginBottom: 32 }}>
+        <button type="button" onClick={onAddGoal} style={cardStyle}>
+          <ActionRow Icon={Target} title={t('addGoal')} desc={t('addGoalDesc')} />
+        </button>
+        <a href="/funds" style={cardStyle}>
+          <ActionRow Icon={Wallet} title={t('addFund')} desc={t('addFundDesc')} />
+        </a>
+        <button type="button" onClick={onAddInsurance} style={cardStyle}>
+          <ActionRow Icon={Shield} title={t('addInsurance')} desc={t('addInsuranceDesc')} />
+        </button>
+      </div>
+
+      {/* Divider + Settings link */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12, width: '100%', maxWidth: 420, marginBottom: 20 }}>
+        <div style={{ flex: 1, height: 1, background: 'var(--c-line)' }} />
+        <span style={{ fontSize: 12, color: 'var(--c-muted)', whiteSpace: 'nowrap' }}>{t('orManage')}</span>
+        <div style={{ flex: 1, height: 1, background: 'var(--c-line)' }} />
+      </div>
+      <a
+        href="/settings"
+        style={{ padding: '10px 24px', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, borderRadius: 10, textDecoration: 'none' }}
+      >
+        {t('settingsLink')}
+      </a>
+    </div>
+  )
+}

--- a/app/assets/components/OverviewEmptyState.tsx
+++ b/app/assets/components/OverviewEmptyState.tsx
@@ -25,6 +25,18 @@ const cardStyle: React.CSSProperties = {
   fontFamily: 'inherit',
   color: 'inherit',
   textDecoration: 'none',
+  transition: 'box-shadow 120ms, border-color 120ms',
+}
+
+// Inline styles can't use :hover, so lift the card imperatively on hover — same
+// pattern as DesktopGoalCard, for visual consistency with the goal cards.
+function cardHoverIn(e: React.MouseEvent<HTMLElement>) {
+  e.currentTarget.style.boxShadow = 'var(--shadow-pop)'
+  e.currentTarget.style.borderColor = 'var(--c-line-strong)'
+}
+function cardHoverOut(e: React.MouseEvent<HTMLElement>) {
+  e.currentTarget.style.boxShadow = 'var(--shadow-card)'
+  e.currentTarget.style.borderColor = 'var(--c-line)'
 }
 
 const iconBox: React.CSSProperties = {
@@ -68,13 +80,13 @@ export function OverviewEmptyState({ onAddGoal, onAddInsurance }: { onAddGoal: (
 
       {/* Action cards */}
       <div style={{ width: '100%', maxWidth: 420, display: 'grid', gap: 12, marginBottom: 32 }}>
-        <button type="button" onClick={onAddGoal} style={cardStyle}>
+        <button type="button" onClick={onAddGoal} style={cardStyle} onMouseEnter={cardHoverIn} onMouseLeave={cardHoverOut}>
           <ActionRow Icon={Target} title={t('addGoal')} desc={t('addGoalDesc')} />
         </button>
-        <a href="/funds" style={cardStyle}>
+        <a href="/funds" style={cardStyle} onMouseEnter={cardHoverIn} onMouseLeave={cardHoverOut}>
           <ActionRow Icon={Wallet} title={t('addFund')} desc={t('addFundDesc')} />
         </a>
-        <button type="button" onClick={onAddInsurance} style={cardStyle}>
+        <button type="button" onClick={onAddInsurance} style={cardStyle} onMouseEnter={cardHoverIn} onMouseLeave={cardHoverOut}>
           <ActionRow Icon={Shield} title={t('addInsurance')} desc={t('addInsuranceDesc')} />
         </button>
       </div>

--- a/app/assets/components/__tests__/OverviewEmptyState.test.tsx
+++ b/app/assets/components/__tests__/OverviewEmptyState.test.tsx
@@ -36,6 +36,17 @@ describe('OverviewEmptyState', () => {
     expect(fundLink).toHaveTextContent('addFund')
   })
 
+  it('lifts the action card on hover (shadow-pop) and resets on leave', () => {
+    render(<OverviewEmptyState onAddGoal={() => {}} onAddInsurance={() => {}} />)
+    const card = screen.getByText('addGoal').closest('button') as HTMLButtonElement
+    expect(card).not.toBeNull()
+    expect(card.style.boxShadow).toBe('var(--shadow-card)')
+    fireEvent.mouseEnter(card)
+    expect(card.style.boxShadow).toBe('var(--shadow-pop)')
+    fireEvent.mouseLeave(card)
+    expect(card.style.boxShadow).toBe('var(--shadow-card)')
+  })
+
   it('uses Cairn design tokens, not raw Tailwind indigo/emoji (#1)', () => {
     const { container } = render(<OverviewEmptyState onAddGoal={() => {}} onAddInsurance={() => {}} />)
     // No leftover indigo utility classes from the pre-migration markup.

--- a/app/assets/components/__tests__/OverviewEmptyState.test.tsx
+++ b/app/assets/components/__tests__/OverviewEmptyState.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { OverviewEmptyState } from '../OverviewEmptyState'
+
+// Mock next-intl so t('key') returns the key — keeps assertions language-agnostic.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+describe('OverviewEmptyState', () => {
+  it('renders the three onboarding actions', () => {
+    render(<OverviewEmptyState onAddGoal={() => {}} onAddInsurance={() => {}} />)
+    expect(screen.getByText('addGoal')).toBeInTheDocument()
+    expect(screen.getByText('addFund')).toBeInTheDocument()
+    expect(screen.getByText('addInsurance')).toBeInTheDocument()
+  })
+
+  it('opens the in-page goal sheet instead of navigating to settings (#1)', () => {
+    const onAddGoal = vi.fn()
+    render(<OverviewEmptyState onAddGoal={onAddGoal} onAddInsurance={() => {}} />)
+    fireEvent.click(screen.getByText('addGoal'))
+    expect(onAddGoal).toHaveBeenCalledTimes(1)
+  })
+
+  it('opens the in-page insurance sheet for the insurance action (#1)', () => {
+    const onAddInsurance = vi.fn()
+    render(<OverviewEmptyState onAddGoal={() => {}} onAddInsurance={onAddInsurance} />)
+    fireEvent.click(screen.getByText('addInsurance'))
+    expect(onAddInsurance).toHaveBeenCalledTimes(1)
+  })
+
+  it('points the fund action at the funds library page', () => {
+    const { container } = render(<OverviewEmptyState onAddGoal={() => {}} onAddInsurance={() => {}} />)
+    const fundLink = container.querySelector('a[href="/funds"]')
+    expect(fundLink).not.toBeNull()
+    expect(fundLink).toHaveTextContent('addFund')
+  })
+
+  it('uses Cairn design tokens, not raw Tailwind indigo/emoji (#1)', () => {
+    const { container } = render(<OverviewEmptyState onAddGoal={() => {}} onAddInsurance={() => {}} />)
+    // No leftover indigo utility classes from the pre-migration markup.
+    expect(container.querySelector('[class*="indigo"]')).toBeNull()
+    // No emoji glyphs — icons are lucide SVGs now.
+    expect(container.querySelector('svg')).not.toBeNull()
+    expect(container.innerHTML).not.toMatch(/📊|🎯|💰|🛡️/)
+  })
+})

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -430,7 +430,7 @@
     "addInsurance": "Thêm Bảo hiểm",
     "addInsuranceDesc": "Quản lý các hợp đồng bảo hiểm",
     "orManage": "Hoặc quản lý mọi thứ trong",
-    "settingsLink": "Settings",
+    "settingsLink": "Cài đặt",
     "sectionGoals": "Mục tiêu",
     "sectionUnallocated": "Chưa phân bổ",
     "availableToAssign": "có thể gán cho mục tiêu",


### PR DESCRIPTION
Addresses **#1 🟠** and **#2 🟡** from the Overview-page review.

## Problem
The dashboard **empty state** + its 3 action cards, and the **error banner**, used raw Tailwind indigo/red utilities + emoji (`bg-indigo-50/600`, `📊🎯💰🛡️`, `bg-red-50…text-red-700`) — so the *first screen a brand-new (empty) account sees* looked like a different product from the token-based rest of the app. The 3 cards also all linked to `/settings` even though in-page sheets exist.

## Fix
- Extracted the empty state into a testable **`OverviewEmptyState`** component, migrated to Cairn tokens (`--c-navy`, `--c-card`, `--c-line`, `--c-muted`, `--c-btn-primary`) + **lucide** icons.
- Action cards now use the in-page sheets:
  - **Add goal** → opens `CreateGoalSheet` (was `/settings`)
  - **Add insurance** → opens `AddInsuranceMemberModal` (was `/settings`)
  - **Add fund** → navigates to `/funds` (the real fund library, was `/settings`)
  - The bottom "manage in Settings" link legitimately keeps `/settings`.
- Error banner now uses `--c-neg` / `--c-neg-tint` (dark-mode safe).

## Tests (TDD)
New `OverviewEmptyState.test.tsx` (written red-first):
- renders the 3 actions
- **Add goal** fires `onAddGoal` (in-page sheet, not nav) — closes the loop on the behavior change
- **Add insurance** fires `onAddInsurance`
- fund action is an `<a href="/funds">`
- asserts no `indigo` classes / emoji remain (icons are lucide SVGs)

## Verification
- `npm test -- --run` — 797 passed (+5 new)
- `npx tsc --noEmit` — clean · `eslint` on changed files — clean
- `npx playwright test e2e/dashboard.spec.ts --project=chromium` — 19 passed (incl. the empty-state test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)