### PR TITLE
fix(overview): bucket all fund types into allocation bar; drop dead cashTotal (#3, #6)

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -25,7 +25,7 @@ import { detectMergeClusters } from '@/lib/mergeCluster'
 import { actionableBooks } from './maturityCardItems'
 import { collapseUnallocatedBooks } from './unallocatedBooks'
 import type { InvRow } from './components/goalDetailShared'
-import { loadOverview, overviewErrorText, getCachedOverview, setCachedOverview } from './overviewData'
+import { loadOverview, overviewErrorText, getCachedOverview, setCachedOverview, computeAllocationTotals } from './overviewData'
 
 import TransactionHistorySheet from './components/TransactionHistorySheet'
 import DesktopNetWorthPanel from './components/DesktopNetWorthPanel'
@@ -524,16 +524,9 @@ export default function DashboardClient({ userId }: { userId: string }) {
     return goals
   })() : []
 
-  // Compute asset allocation totals for pie chart
-  const allocationTotals = data ? (() => {
-    const allFundItems = [...data.goals.flatMap((g) => g.funds), ...data.unallocated.funds]
-    const equityTotal = allFundItems.filter((f) => f.fundType === 'equity').reduce((s, f) => s + f.currentValue, 0)
-    const bondTotal = allFundItems.filter((f) => f.fundType === 'debt').reduce((s, f) => s + f.currentValue, 0)
-    const balancedTotal = allFundItems.filter((f) => f.fundType === 'balanced').reduce((s, f) => s + f.currentValue, 0)
-    const { bank: bankTotal, gold: goldTotal, stock: stockTotal } = data.byType
-    const cashTotal = 0
-    return { equityTotal, bondTotal, balancedTotal, bankTotal, goldTotal, stockTotal, cashTotal }
-  })() : null
+  // Asset-allocation buckets for the allocation bar. fundTotal sums all fund
+  // types (incl. unexpected ones) so nothing drops out of the bar (#3).
+  const allocationTotals = data ? computeAllocationTotals(data) : null
 
   // Find fund item for detail modal
   const allFunds = data ? [...data.unallocated.funds, ...data.goals.flatMap((g) => g.funds)] : []
@@ -902,7 +895,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                   refreshKey={historyKey}
                   refreshing={refreshing}
                   allocationBar={allocationTotals ? {
-                    fund: allocationTotals.equityTotal + allocationTotals.bondTotal + allocationTotals.balancedTotal,
+                    fund: allocationTotals.fundTotal,
                     bank: allocationTotals.bankTotal,
                     gold: allocationTotals.goldTotal,
                     stock: allocationTotals.stockTotal,

--- a/app/assets/__tests__/overviewData.test.ts
+++ b/app/assets/__tests__/overviewData.test.ts
@@ -4,9 +4,25 @@ import {
   overviewErrorText,
   getCachedOverview,
   setCachedOverview,
+  computeAllocationTotals,
   type OverviewLoadResult,
 } from '../overviewData'
-import type { DashboardData } from '../DashboardClient'
+import type { DashboardData, FundBreakdownItem } from '../DashboardClient'
+
+function fund(fundType: string, currentValue: number): FundBreakdownItem {
+  return {
+    fundId: `f-${fundType}-${currentValue}`,
+    fundName: fundType,
+    fundType,
+    quantity: 1,
+    currentNAV: currentValue,
+    currentValue,
+    purchasePrice: currentValue,
+    profitLoss: 0,
+    profitLossPercentage: 0,
+    goalId: null,
+  }
+}
 
 const sample = (assets: number): DashboardData =>
   ({
@@ -37,6 +53,45 @@ function jsonResponse(body: unknown, status = 200): Response {
 
 // The service worker's synthetic abort response for a slow /api/v1 request.
 const swOffline = () => jsonResponse({ error: 'Offline', cached: false }, 503)
+
+describe('computeAllocationTotals', () => {
+  const base = sample(0)
+
+  it('sums known fund types (equity/debt/balanced) into fundTotal', () => {
+    const data: DashboardData = {
+      ...base,
+      unallocated: { totalValue: 0, funds: [fund('equity', 100), fund('debt', 50), fund('balanced', 25)], nonFunds: [] },
+    }
+    expect(computeAllocationTotals(data).fundTotal).toBe(175)
+  })
+
+  it('buckets an unknown fund_type into fundTotal instead of dropping it (#3)', () => {
+    const data: DashboardData = {
+      ...base,
+      unallocated: { totalValue: 0, funds: [fund('equity', 100), fund('money_market', 40)], nonFunds: [] },
+    }
+    // The pre-fix code only summed equity+debt+balanced, so the 40 vanished
+    // from the allocation bar while still counting toward net worth.
+    expect(computeAllocationTotals(data).fundTotal).toBe(140)
+  })
+
+  it('includes funds held under goals as well as unallocated funds', () => {
+    const data: DashboardData = {
+      ...base,
+      goals: [{ ...({} as DashboardData['goals'][number]), funds: [fund('equity', 60)] }],
+      unallocated: { totalValue: 0, funds: [fund('debt', 30)], nonFunds: [] },
+    }
+    expect(computeAllocationTotals(data).fundTotal).toBe(90)
+  })
+
+  it('passes bank/gold/stock through from byType', () => {
+    const data: DashboardData = { ...base, byType: { bank: 200, gold: 80, stock: 33 } }
+    const t = computeAllocationTotals(data)
+    expect(t.bankTotal).toBe(200)
+    expect(t.goldTotal).toBe(80)
+    expect(t.stockTotal).toBe(33)
+  })
+})
 
 describe('loadOverview', () => {
   const noCache = { getCache: () => null, setCache: () => {} }

--- a/app/assets/components/DesktopNetWorthPanel.tsx
+++ b/app/assets/components/DesktopNetWorthPanel.tsx
@@ -5,6 +5,7 @@ import { ArrowDownToLine } from 'lucide-react'
 import { fmtCompact, fmtPct } from '@/lib/formatters'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import type { DashboardData } from '../DashboardClient'
+import type { AllocationTotals } from '../overviewData'
 
 const TIME_RANGES = ['1M', '3M', '6M', '1Y', 'All'] as const
 type TimeRange = typeof TIME_RANGES[number]
@@ -59,16 +60,6 @@ const ALLOC_COLORS: Record<string, { color: string; label: string; labelVi: stri
   stock: { color: '#7c3aed', label: 'Stock',   labelVi: 'Cổ phiếu' },
 }
 
-interface AllocationTotals {
-  equityTotal: number
-  bondTotal: number
-  balancedTotal: number
-  bankTotal: number
-  goldTotal: number
-  stockTotal: number
-  cashTotal: number
-}
-
 interface Props {
   data: DashboardData
   allocationTotals: AllocationTotals | null
@@ -96,7 +87,7 @@ export default function DesktopNetWorthPanel({ data, allocationTotals, goldUnits
 
   const segments = allocationTotals ? (() => {
     const raw: Record<string, number> = {
-      fund: allocationTotals.equityTotal + allocationTotals.bondTotal + allocationTotals.balancedTotal,
+      fund: allocationTotals.fundTotal,
       bank: allocationTotals.bankTotal,
       gold: allocationTotals.goldTotal,
       stock: allocationTotals.stockTotal,

--- a/app/assets/overviewData.ts
+++ b/app/assets/overviewData.ts
@@ -36,6 +36,28 @@ export function setCachedOverview(userId: string, data: DashboardData) {
   }
 }
 
+export interface AllocationTotals {
+  /**
+   * Every fund holding's value, regardless of `fund_type`. We deliberately sum
+   * ALL fund items (not just equity/debt/balanced) so a fund with an unexpected
+   * type — e.g. money_market/cash — still lands in the "Fund" bucket of the
+   * allocation bar instead of silently disappearing from it while still
+   * counting toward net worth (#363 review #3).
+   */
+  fundTotal: number
+  bankTotal: number
+  goldTotal: number
+  stockTotal: number
+}
+
+/** Build the allocation-bar buckets from the overview payload. Pure + testable. */
+export function computeAllocationTotals(data: DashboardData): AllocationTotals {
+  const allFundItems = [...data.goals.flatMap((g) => g.funds), ...data.unallocated.funds]
+  const fundTotal = allFundItems.reduce((sum, f) => sum + f.currentValue, 0)
+  const { bank: bankTotal, gold: goldTotal, stock: stockTotal } = data.byType
+  return { fundTotal, bankTotal, goldTotal, stockTotal }
+}
+
 export interface OverviewLoadResult {
   data: DashboardData | null
   /** Raw error string from the response body, if any (untranslated). */


### PR DESCRIPTION
Addresses **#3 🟡** and **#6 🟢** from the Overview-page review.

## Problem (#3)
Both `NetWorthCard` (mobile) and `DesktopNetWorthPanel` (desktop) built the **"Fund"** allocation segment as `equity + debt + balanced` only. The API returns the raw `fund_type`, so a fund with any other type (e.g. `money_market`/`cash`/`other`) still counted toward net worth & total assets but **disappeared from the allocation bar** — the segments stopped summing to the real fund total.

## Fix
- Extracted a pure, unit-tested **`computeAllocationTotals(data)`** into `overviewData.ts`. Its `fundTotal` sums **all** fund items regardless of `fund_type`, so unexpected types bucket into "Fund" instead of vanishing.
- Both breakpoints now read `allocationTotals.fundTotal`.
- **#6:** removed the always-zero, never-rendered `cashTotal` field (and the now-unused per-type `equity/bond/balanced` split). `DesktopNetWorthPanel` now imports the shared `AllocationTotals` type instead of duplicating it.

## Tests (TDD)
Added `computeAllocationTotals` cases to `overviewData.test.ts` (red-first):
- sums equity/debt/balanced into `fundTotal`
- **buckets an unknown `money_market` type into `fundTotal`** (the bug)
- includes funds under goals *and* unallocated
- passes bank/gold/stock through from `byType`

## Verification
- `npm test -- --run` — 796 passed (+4 new)
- `npx tsc --noEmit` — clean
- `npx playwright test e2e/dashboard.spec.ts e2e/dashboard-desktop.spec.ts --project=chromium` — 38 passed (incl. allocation-bar tests on both breakpoints)

🤖 Generated with [Claude Code](https://claude.com/claude-code)