### PR TITLE
fix(overview): clear goal/insurance selection when crossing the breakpoint (#4)

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -319,6 +319,17 @@ export default function DashboardClient({ userId }: { userId: string }) {
   const selectedInsurance = data?.insurance.find((i) => i.insuranceId === selectedInsuranceId) ?? null
   const PULL_THRESHOLD = 65
 
+  // Goal/insurance selection is rendered differently per breakpoint — desktop
+  // shows a right-side panel, mobile a sheet gated by separate state. Crossing
+  // the 768px boundary (resize/rotate) would otherwise leave a desktop goal
+  // selection set-but-invisible (then pop back open on the next resize) or
+  // unexpectedly auto-open the mobile insurance sheet. Clear selection on flip.
+  useEffect(() => {
+    setSelectedGoalId(null)
+    setSelectedInsuranceId(null)
+    setGoalDetailOpen(false)
+  }, [isDesktop])
+
   const fetchDataRef = useRef<(opts?: { force?: boolean }) => Promise<void>>(async () => {})
   const hasDataRef = useRef(false)
   const touchStartY = useRef(-1)

--- a/e2e/dashboard-desktop.spec.ts
+++ b/e2e/dashboard-desktop.spec.ts
@@ -54,6 +54,32 @@ test.describe('Desktop overview layout', () => {
     await expect(page.getByTestId('desktop-overview')).not.toBeVisible()
   })
 
+  test('crossing the desktop↔mobile breakpoint clears a goal selection (#4)', async ({ page }) => {
+    // Selecting a goal on desktop only shows a right-side panel; mobile gates its
+    // goal sheet on different state. Crossing 768px used to leave the selection
+    // set-but-invisible, so resizing back to desktop popped the stale goal detail
+    // open again. The fix clears selection when the breakpoint flips.
+    const goal = await api.createGoal({ goal_name: 'E2E Resize Selection Goal', target_amount: 20_000_000 })
+    try {
+      await gotoFreshDashboard(page)
+
+      // Select the goal on desktop → right panel shows its detail.
+      await page.getByText('E2E Resize Selection Goal', { exact: true }).first().click()
+      await expect(page.getByTestId('desktop-goal-detail')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('desktop-net-worth-panel')).not.toBeVisible()
+
+      // Shrink to mobile, then back to desktop. Selection should have been cleared,
+      // so the right panel reverts to net worth instead of restoring the goal detail.
+      await page.setViewportSize({ width: 390, height: 844 })
+      await page.setViewportSize({ width: 1280, height: 800 })
+
+      await expect(page.getByTestId('desktop-net-worth-panel')).toBeVisible({ timeout: 8_000 })
+      await expect(page.getByTestId('desktop-goal-detail')).not.toBeVisible()
+    } finally {
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
   test('sidebar has light background (not dark navy)', async ({ page }) => {
     const sidebar = page.getByTestId('desktop-sidebar')
     await expect(sidebar).toBeVisible({ timeout: 10_000 })


### PR DESCRIPTION
Addresses **#4 🟢** from the Overview-page review.

## Problem
Selecting a goal on **desktop** only sets `selectedGoalId` (rendered as a right-side panel). **Mobile** gates its `GoalDetailSheet` on a *different* flag (`goalDetailOpen`). So dragging the viewport across the 768px boundary left the selection **set-but-invisible** — and resizing back to desktop popped the stale goal detail open again. A selected **insurance** would instead auto-open the mobile sheet after a resize. No crash, just surprising state.

## Fix
Reset `selectedGoalId` / `selectedInsuranceId` / `goalDetailOpen` whenever `isDesktop` flips:
```ts
useEffect(() => {
  setSelectedGoalId(null)
  setSelectedInsuranceId(null)
  setGoalDetailOpen(false)
}, [isDesktop])
```

## Test (TDD)
New case in `e2e/dashboard-desktop.spec.ts` (verified **red** before the fix):
select a goal on desktop → resize to mobile → resize back to desktop → assert the right panel reverted to the **net-worth panel** (selection cleared) instead of restoring the stale `desktop-goal-detail`.

## Verification
- New test red before fix, green after.
- `npx playwright test e2e/dashboard-desktop.spec.ts --project=chromium` — 21 passed
- `npm test -- --run` — 792 passed · `npx tsc --noEmit` — clean · eslint — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)