### PR TITLE
fix(overview): persist net-worth chart range across the breakpoint (#5)

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -26,6 +26,7 @@ import { actionableBooks } from './maturityCardItems'
 import { collapseUnallocatedBooks } from './unallocatedBooks'
 import type { InvRow } from './components/goalDetailShared'
 import { loadOverview, overviewErrorText, getCachedOverview, setCachedOverview, computeAllocationTotals } from './overviewData'
+import { fetchNetWorthHistory, type TimeRange, type ChartPoint } from './components/netWorthHistory'
 
 import TransactionHistorySheet from './components/TransactionHistorySheet'
 import DesktopNetWorthPanel from './components/DesktopNetWorthPanel'
@@ -329,6 +330,17 @@ export default function DashboardClient({ userId }: { userId: string }) {
     setSelectedInsuranceId(null)
     setGoalDetailOpen(false)
   }, [isDesktop])
+
+  // Net-worth history + selected range live here (not inside the two net-worth
+  // cards) so the range the user picks survives a desktop↔mobile breakpoint
+  // switch — each card used to own its own range and reset to 1Y on remount (#5).
+  const [timeRange, setTimeRange] = useState<TimeRange>('1Y')
+  const [history, setHistory] = useState<ChartPoint[]>([])
+  useEffect(() => {
+    let cancelled = false
+    fetchNetWorthHistory(timeRange).then((h) => { if (!cancelled) setHistory(h) })
+    return () => { cancelled = true }
+  }, [timeRange, historyKey])
 
   const fetchDataRef = useRef<(opts?: { force?: boolean }) => Promise<void>>(async () => {})
   const hasDataRef = useRef(false)
@@ -887,10 +899,12 @@ export default function DashboardClient({ userId }: { userId: string }) {
                     allocationTotals={allocationTotals}
                     goldUnits={data.goldUnits}
                     locale={locale}
-                    refreshKey={historyKey}
                     refreshing={refreshing}
                     navUpdatedAt={data.netWorth.navUpdatedAt}
                     onDownloadReport={() => setShowReportSheet(true)}
+                    history={history}
+                    timeRange={timeRange}
+                    onRangeChange={setTimeRange}
                   />
                 )}
               </div>
@@ -903,8 +917,10 @@ export default function DashboardClient({ userId }: { userId: string }) {
               <div className="space-y-4">
                 <NetWorthCard
                   {...data.netWorth}
-                  refreshKey={historyKey}
                   refreshing={refreshing}
+                  history={history}
+                  timeRange={timeRange}
+                  onRangeChange={setTimeRange}
                   allocationBar={allocationTotals ? {
                     fund: allocationTotals.fundTotal,
                     bank: allocationTotals.bankTotal,

--- a/app/assets/components/DesktopNetWorthPanel.tsx
+++ b/app/assets/components/DesktopNetWorthPanel.tsx
@@ -1,20 +1,11 @@
 'use client'
 
-import { useState, useEffect } from 'react'
 import { ArrowDownToLine } from 'lucide-react'
 import { fmtCompact, fmtPct } from '@/lib/formatters'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import type { DashboardData } from '../DashboardClient'
 import type { AllocationTotals } from '../overviewData'
-
-const TIME_RANGES = ['1M', '3M', '6M', '1Y', 'All'] as const
-type TimeRange = typeof TIME_RANGES[number]
-
-const RANGE_PARAM: Record<TimeRange, string> = {
-  '1M': '1m', '3M': '3m', '6M': '6m', '1Y': '1y', 'All': 'all',
-}
-
-interface ChartPoint { label: string; value: number }
+import { TIME_RANGES, type TimeRange, type ChartPoint } from './netWorthHistory'
 
 function fmtTimeAgo(isoString: string, locale: string): string {
   const diffMs = Date.now() - new Date(isoString).getTime()
@@ -65,25 +56,20 @@ interface Props {
   allocationTotals: AllocationTotals | null
   goldUnits?: number
   locale: string
-  refreshKey?: number
   refreshing?: boolean
   navUpdatedAt?: string | null
   onDownloadReport: () => void
+  // History + range owned by the parent so the range persists across the
+  // desktop↔mobile breakpoint switch (#5).
+  history?: ChartPoint[]
+  timeRange?: TimeRange
+  onRangeChange?: (range: TimeRange) => void
 }
 
-export default function DesktopNetWorthPanel({ data, allocationTotals, goldUnits, locale, refreshKey, refreshing, navUpdatedAt, onDownloadReport }: Props) {
+export default function DesktopNetWorthPanel({ data, allocationTotals, goldUnits, locale, refreshing, navUpdatedAt, onDownloadReport, history = [], timeRange = '1Y', onRangeChange }: Props) {
   const { netWorth } = data
   const isPos = netWorth.overallProfitLoss >= 0
   const isVi = locale === 'vi'
-  const [timeRange, setTimeRange] = useState<TimeRange>('1Y')
-  const [history, setHistory] = useState<ChartPoint[]>([])
-
-  useEffect(() => {
-    fetch(`/api/v1/dashboard/history?range=${RANGE_PARAM[timeRange]}`, { cache: 'no-store' })
-      .then((r) => r.ok ? r.json() : [])
-      .then((d: ChartPoint[]) => setHistory(d))
-      .catch(() => setHistory([]))
-  }, [timeRange, refreshKey])
 
   const segments = allocationTotals ? (() => {
     const raw: Record<string, number> = {
@@ -160,7 +146,8 @@ export default function DesktopNetWorthPanel({ data, allocationTotals, goldUnits
           {TIME_RANGES.map((r) => (
             <button
               key={r}
-              onClick={() => setTimeRange(r)}
+              onClick={() => onRangeChange?.(r)}
+              aria-pressed={timeRange === r}
               style={{
                 flex: 1, padding: '4px 0',
                 border: 'none', cursor: 'pointer',

--- a/app/assets/components/NetWorthCard.tsx
+++ b/app/assets/components/NetWorthCard.tsx
@@ -1,19 +1,10 @@
 'use client'
 
-import { useState, useEffect } from 'react'
 import { useLocale, useTranslations } from 'next-intl'
 import { TrendingUp, TrendingDown } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
-
-const TIME_RANGES = ['1M', '3M', '6M', '1Y', 'All'] as const
-type TimeRange = typeof TIME_RANGES[number]
-
-const RANGE_PARAM: Record<TimeRange, string> = {
-  '1M': '1m', '3M': '3m', '6M': '6m', '1Y': '1y', 'All': 'all',
-}
-
-interface ChartPoint { label: string; value: number }
+import { TIME_RANGES, type TimeRange, type ChartPoint } from './netWorthHistory'
 
 // SVG sparkline — no recharts dependency
 function Sparkline({ data, positive }: { data: ChartPoint[]; positive: boolean }) {
@@ -126,26 +117,23 @@ interface Props {
   overallProfitLoss: number
   overallProfitLossPercentage: number
   allocationBar?: { fund: number; bank: number; gold: number; stock: number; goldUnits?: number }
-  refreshKey?: number
   refreshing?: boolean
+  // History + range are owned by the parent so the selected range survives a
+  // desktop↔mobile breakpoint switch (#5). Optional with safe defaults so the
+  // card still renders standalone (e.g. in unit tests).
+  history?: ChartPoint[]
+  timeRange?: TimeRange
+  onRangeChange?: (range: TimeRange) => void
 }
 
 export default function NetWorthCard({
   totalAssets, totalLiabilities, netWorth, totalInvested, currentValue,
-  overallProfitLoss, overallProfitLossPercentage, allocationBar, refreshKey, refreshing,
+  overallProfitLoss, overallProfitLossPercentage, allocationBar, refreshing,
+  history = [], timeRange = '1Y', onRangeChange,
 }: Props) {
   const locale = useLocale()
   const t = useTranslations('dashboard')
   const plPositive = overallProfitLoss >= 0
-  const [timeRange, setTimeRange] = useState<TimeRange>('1Y')
-  const [history, setHistory] = useState<ChartPoint[]>([])
-
-  useEffect(() => {
-    fetch(`/api/v1/dashboard/history?range=${RANGE_PARAM[timeRange]}`, { cache: 'no-store' })
-      .then((r) => r.ok ? r.json() : [])
-      .then((data: ChartPoint[]) => setHistory(data))
-      .catch(() => setHistory([]))
-  }, [timeRange, refreshKey])
 
   const kpis = [
     { label: t('invested'),     value: totalInvested },
@@ -155,7 +143,7 @@ export default function NetWorthCard({
   ]
 
   return (
-    <div style={{
+    <div data-testid="net-worth-card" style={{
       background: 'var(--c-card)',
       border: '1px solid var(--c-line)',
       borderRadius: 'var(--r-card)',
@@ -225,7 +213,8 @@ export default function NetWorthCard({
         {TIME_RANGES.map((r) => (
           <button
             key={r}
-            onClick={() => setTimeRange(r)}
+            onClick={() => onRangeChange?.(r)}
+            aria-pressed={timeRange === r}
             style={{
               flex: 1, padding: '5px 0',
               border: 'none', cursor: 'pointer',

--- a/app/assets/components/__tests__/netWorthHistory.test.ts
+++ b/app/assets/components/__tests__/netWorthHistory.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest'
+import { fetchNetWorthHistory, RANGE_PARAM, TIME_RANGES } from '../netWorthHistory'
+
+describe('fetchNetWorthHistory', () => {
+  it('maps every range to its API param in the request URL', async () => {
+    for (const range of TIME_RANGES) {
+      const fetchFn = vi.fn().mockResolvedValue({ ok: true, json: async () => [] })
+      await fetchNetWorthHistory(range, fetchFn as never)
+      expect(fetchFn).toHaveBeenCalledWith(
+        `/api/v1/dashboard/history?range=${RANGE_PARAM[range]}`,
+        { cache: 'no-store' },
+      )
+    }
+  })
+
+  it('returns the parsed points on a 200', async () => {
+    const points = [{ label: 'Jan', value: 10 }, { label: 'Feb', value: 20 }]
+    const fetchFn = vi.fn().mockResolvedValue({ ok: true, json: async () => points })
+    await expect(fetchNetWorthHistory('1Y', fetchFn as never)).resolves.toEqual(points)
+  })
+
+  it('returns [] on a non-ok response', async () => {
+    const fetchFn = vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) })
+    await expect(fetchNetWorthHistory('1Y', fetchFn as never)).resolves.toEqual([])
+  })
+
+  it('returns [] when the fetch rejects', async () => {
+    const fetchFn = vi.fn().mockRejectedValue(new Error('network'))
+    await expect(fetchNetWorthHistory('1Y', fetchFn as never)).resolves.toEqual([])
+  })
+})

--- a/app/assets/components/netWorthHistory.ts
+++ b/app/assets/components/netWorthHistory.ts
@@ -1,0 +1,28 @@
+// Shared net-worth history model for the Overview net-worth cards. Previously
+// NetWorthCard (mobile) and DesktopNetWorthPanel (desktop) each duplicated this
+// range list + fetch and held their own timeRange — so switching breakpoints
+// reset the selected range to 1Y (#363 review #5). The state now lives in
+// DashboardClient and is fed to both cards; this module is the shared vocabulary.
+
+export const TIME_RANGES = ['1M', '3M', '6M', '1Y', 'All'] as const
+export type TimeRange = typeof TIME_RANGES[number]
+
+export const RANGE_PARAM: Record<TimeRange, string> = {
+  '1M': '1m', '3M': '3m', '6M': '6m', '1Y': '1y', 'All': 'all',
+}
+
+export interface ChartPoint { label: string; value: number }
+
+/** Fetch the net-worth history series for a range. Resolves to [] on any failure. */
+export async function fetchNetWorthHistory(
+  range: TimeRange,
+  fetchFn: typeof fetch = fetch,
+): Promise<ChartPoint[]> {
+  try {
+    const res = await fetchFn(`/api/v1/dashboard/history?range=${RANGE_PARAM[range]}`, { cache: 'no-store' })
+    if (!res.ok) return []
+    return (await res.json()) as ChartPoint[]
+  } catch {
+    return []
+  }
+}

--- a/e2e/dashboard-desktop.spec.ts
+++ b/e2e/dashboard-desktop.spec.ts
@@ -80,6 +80,26 @@ test.describe('Desktop overview layout', () => {
     }
   })
 
+  test('net-worth chart range persists across the desktop↔mobile breakpoint (#5)', async ({ page }) => {
+    // The range was owned by each net-worth card, so crossing 768px remounted a
+    // fresh card that reset to 1Y. The state now lives in the parent and carries
+    // over. (Global setup seeds a bank tx, so the panel always renders.)
+    const panel = page.getByTestId('desktop-net-worth-panel')
+    await expect(panel).toBeVisible({ timeout: 10_000 })
+
+    // Pick a non-default range on desktop.
+    const desktop3M = panel.getByRole('button', { name: '3M', exact: true })
+    await desktop3M.click()
+    await expect(desktop3M).toHaveAttribute('aria-pressed', 'true')
+
+    // Shrink to mobile — the mobile card should still show 3M, not reset to 1Y.
+    await page.setViewportSize({ width: 390, height: 844 })
+    const card = page.getByTestId('net-worth-card')
+    await expect(card).toBeVisible({ timeout: 8_000 })
+    await expect(card.getByRole('button', { name: '3M', exact: true })).toHaveAttribute('aria-pressed', 'true')
+    await expect(card.getByRole('button', { name: '1Y', exact: true })).toHaveAttribute('aria-pressed', 'false')
+  })
+
   test('sidebar has light background (not dark navy)', async ({ page }) => {
     const sidebar = page.getByTestId('desktop-sidebar')
     await expect(sidebar).toBeVisible({ timeout: 10_000 })


### PR DESCRIPTION
Addresses **#5 🟢** from the Overview-page review.

## Problem
`NetWorthCard` (mobile) and `DesktopNetWorthPanel` (desktop) each owned their own `timeRange` + history fetch. Only one mounts per breakpoint (conditional render), so picking e.g. **3M** and then crossing the 768px boundary remounted a fresh card that reset the range back to **1Y**. (No runtime double-fetch — just the lost selection.)

## Fix
- Extracted a shared, tested **`netWorthHistory`** module: `TIME_RANGES`, `TimeRange`, `ChartPoint`, and `fetchNetWorthHistory()` — de-duplicates the range list + fetch that both cards had copy-pasted.
- **`DashboardClient`** now owns `timeRange` + `history` (one fetch, keyed on range + the existing `historyKey`) and feeds both cards.
- Both cards are now **controlled** via `history` / `timeRange` / `onRangeChange` props — optional with safe defaults so they still render standalone (existing unit tests untouched).
- Range pills gained `aria-pressed` (accessibility + made the behavior testable).

## Tests (TDD)
- New `netWorthHistory.test.ts` (red-first): maps each range to its API param, returns parsed points on 200, `[]` on non-ok / reject.
- New E2E in `dashboard-desktop.spec.ts`: pick **3M** on desktop → resize to mobile → assert the mobile card still shows **3M** pressed and **1Y** not — the range carried across the breakpoint.

## Verification
- `npm test -- --run` — 796 passed (+4 new)
- `npx tsc --noEmit` — clean · eslint — clean (one pre-existing `_i` warning, unrelated)
- `npx playwright test e2e/dashboard.spec.ts e2e/dashboard-desktop.spec.ts --project=chromium` — 39 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)