### PR TITLE
fix(funds): keep DCA goal when editing the monthly amount (#1)

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -241,6 +241,7 @@ function DcaToggle({ fund, editId, editValue, goals, goalLabel, unallocatedLabel
         isEditing ? (
           <input
             autoFocus
+            data-testid={`dca-amount-input-${fund.id}`}
             type="text"
             inputMode="numeric"
             placeholder="Amount"
@@ -261,6 +262,7 @@ function DcaToggle({ fund, editId, editValue, goals, goalLabel, unallocatedLabel
           />
         ) : (
           <button
+            data-testid={`dca-amount-btn-${fund.id}`}
             onClick={e => { e.stopPropagation(); onEditStart() }}
             style={{
               fontSize: 11, fontWeight: 500, padding: '2px 8px',
@@ -510,7 +512,7 @@ export default function DesktopFundLibraryView() {
       const res = await fetch(`/api/funds/${fund.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: amount }),
+        body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: amount, dca_goal_id: fund.dca_goal_id }),
       })
       if (!res.ok) throw new Error()
       bustCache()

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -404,6 +404,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
             isEditing ? (
               <input
                 autoFocus
+                data-testid={`dca-amount-input-${fund.id}`}
                 type="text"
                 inputMode="numeric"
                 value={dcaEditValue ? Number(dcaEditValue).toLocaleString('en-US') : ''}
@@ -419,6 +420,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
             ) : fund.dca_monthly_amount_vnd ? (
               <button
                 type="button"
+                data-testid={`dca-amount-btn-${fund.id}`}
                 onClick={() => { setDcaEditId(fund.id); setDcaEditValue(String(fund.dca_monthly_amount_vnd)) }}
                 style={{ fontSize: 11, fontWeight: 500, padding: '2px 8px', background: 'var(--c-navy-tint)', color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)', borderRadius: 6, cursor: 'pointer', fontFamily: 'inherit' }}
               >
@@ -697,7 +699,7 @@ export default function MobileFundLibraryView() {
 
     setTogglingIds((prev) => new Set([...prev, fund.id]))
     try {
-      const res = await fetch(`/api/funds/${fund.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: amount }) })
+      const res = await fetch(`/api/funds/${fund.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: amount, dca_goal_id: fund.dca_goal_id }) })
       if (!res.ok) throw new Error()
       bustCache()
       await loadFunds({ force: true })

--- a/e2e/funds-desktop.spec.ts
+++ b/e2e/funds-desktop.spec.ts
@@ -185,3 +185,45 @@ test('desktop funds DCA goal selection persists across reload', async ({ page })
   const rowAfter = page.getByTestId('desktop-funds-table').getByTestId(`fund-row-${fund.id}`)
   await expect(rowAfter.getByTestId(`dca-goal-${fund.id}`)).toHaveValue(goal.goal_id, { timeout: 8_000 })
 })
+
+test('desktop funds: editing the DCA amount keeps the assigned goal (#1)', async ({ page }) => {
+  // Regression: handleSaveDcaAmount used to omit dca_goal_id from the PUT body,
+  // so the API reset dca_goal_id to null. Editing the amount of a DCA fund that
+  // already has a goal must NOT silently revert the goal to Unallocated.
+  const goal = await api.createGoal({ goal_name: 'E2E Desktop DCA Amount-Edit Goal' })
+  cleanup.add(() => api.deleteGoal(goal.goal_id))
+  const fund = await api.createFund({
+    name: 'E2E Desktop DCA Amount Edit',
+    code: 'DTDAE1',
+    fund_type: 'equity',
+    nav: 15000,
+    is_dca: true,
+    dca_monthly_amount_vnd: 3_000_000,
+    dca_goal_id: goal.goal_id,
+  })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  const table = page.getByTestId('desktop-funds-table')
+  const row = table.getByTestId(`fund-row-${fund.id}`)
+  // Goal starts assigned.
+  await expect(row.getByTestId(`dca-goal-${fund.id}`)).toHaveValue(goal.goal_id, { timeout: 8_000 })
+
+  // Re-edit just the amount.
+  await row.getByTestId(`dca-amount-btn-${fund.id}`).click()
+  const input = row.getByTestId(`dca-amount-input-${fund.id}`)
+  await expect(input).toBeVisible({ timeout: 5_000 })
+  await input.fill('5000000')
+  await Promise.all([
+    page.waitForResponse(r => r.url().includes(`/api/funds/${fund.id}`) && r.request().method() === 'PUT' && r.ok()),
+    input.press('Enter'),
+  ])
+
+  // After reload the goal must still be assigned (not reset to Unallocated).
+  await page.reload()
+  await page.waitForLoadState('networkidle')
+  const rowAfter = page.getByTestId('desktop-funds-table').getByTestId(`fund-row-${fund.id}`)
+  await expect(rowAfter.getByTestId(`dca-goal-${fund.id}`)).toHaveValue(goal.goal_id, { timeout: 8_000 })
+})

--- a/e2e/funds.spec.ts
+++ b/e2e/funds.spec.ts
@@ -215,6 +215,48 @@ test('mobile funds DCA goal selection persists', async ({ page }) => {
   await expect(cardAfter.getByTestId(`dca-goal-${fund.id}`)).toHaveValue(goal.goal_id, { timeout: 8_000 })
 })
 
+test('mobile funds: editing the DCA amount keeps the assigned goal (#1)', async ({ page }) => {
+  // Regression: handleSaveDcaAmount used to omit dca_goal_id from the PUT body,
+  // so the API reset dca_goal_id to null. Editing the amount of a DCA fund that
+  // already has a goal must NOT silently revert the goal to Unallocated.
+  const goal = await api.createGoal({ goal_name: 'E2E DCA Amount-Edit Goal' })
+  cleanup.add(() => api.deleteGoal(goal.goal_id))
+  const fund = await api.createFund({
+    name: 'E2E DCA Amount Edit Fund',
+    code: 'E2EDAE',
+    fund_type: 'equity',
+    nav: 15000,
+    is_dca: true,
+    dca_monthly_amount_vnd: 3_000_000,
+    dca_goal_id: goal.goal_id,
+  })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  const mf = page.getByTestId('mobile-funds')
+  const card = mf.getByTestId(`fund-card-${fund.id}`)
+  // Goal starts assigned.
+  await expect(card.getByTestId(`dca-goal-${fund.id}`)).toHaveValue(goal.goal_id, { timeout: 8_000 })
+
+  // Re-edit just the amount.
+  await card.getByTestId(`dca-amount-btn-${fund.id}`).click()
+  const input = card.getByTestId(`dca-amount-input-${fund.id}`)
+  await expect(input).toBeVisible({ timeout: 5_000 })
+  await input.fill('5000000')
+  await Promise.all([
+    page.waitForResponse(r => r.url().includes(`/api/funds/${fund.id}`) && r.request().method() === 'PUT' && r.ok()),
+    input.press('Enter'),
+  ])
+
+  // After reload the goal must still be assigned (not reset to Unallocated).
+  await page.reload()
+  await page.waitForLoadState('networkidle')
+  const cardAfter = page.getByTestId('mobile-funds').getByTestId(`fund-card-${fund.id}`)
+  await expect(cardAfter.getByTestId(`dca-goal-${fund.id}`)).toHaveValue(goal.goal_id, { timeout: 8_000 })
+})
+
 test('mobile funds shows empty state when no funds exist', async ({ page }) => {
   // We test the empty-data scenario by verifying the page loads without crashing, then rely on the no-results test above for the UI state
   await page.goto('/funds')


### PR DESCRIPTION
## What
From the Funds-page review (`REVIEW-funds-page.md`, item #1 🟠 — the only real function bug).

Editing a DCA fund's **monthly amount** silently reset its assigned **goal** back to Unallocated.

## Why
`handleSaveDcaAmount` (both `MobileFundLibraryView` and `DesktopFundLibraryView`) sent the `PUT /api/funds/[id]` body **without** `dca_goal_id`. The API computes:

```ts
dca_goal_id: is_dca === true && dca_goal_id ? dca_goal_id : null
```

so an absent field (`undefined`) is written as `null`. After the follow-up `loadFunds(force)`, the goal re-reads as Unallocated. `handleSetDcaGoal` already sent the field — this was a plain asymmetry between the two handlers.

## Fix
Add `dca_goal_id: fund.dca_goal_id` to both amount-save PUT bodies.

## Tests (TDD)
- New e2e specs (mobile `funds.spec.ts`, desktop `funds-desktop.spec.ts`): seed a DCA fund with a goal assigned, re-edit the amount, reload, assert the goal is **still** selected.
- Confirmed **red** before the fix (goal value → `""`) and **green** after.
- Added `dca-amount-btn` / `dca-amount-input` testids to drive the inline amount edit.

## Local checks
- `npm test -- --run` → 806 passing
- `npm run lint` → no new problems (count unchanged vs main: 53 pre-existing)
- Targeted e2e: full `funds.spec.ts` (17) + `funds-desktop.spec.ts` (13) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)