### PR TITLE
fix(funds): exclude gold from desktop create/edit Type dropdown (#3)

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -47,6 +47,10 @@ const TYPE_FILTERS: { v: TypeFilter; label: string; labelVi: string }[] = [
   { v: 'balanced', label: 'Balanced', labelVi: 'Cân bằng' },
 ]
 
+// Selectable fund types in the create/edit form. Gold is excluded (handled
+// separately via byType) to match MobileFundLibraryView's FORM_TYPES.
+const FORM_TYPES = (Object.keys(TYPE_META) as FundType[]).filter(ft => ft !== 'gold')
+
 // ─── Cache ────────────────────────────────────────────────────────────────────
 
 const CACHE_KEY = 'fundLibraryCache'
@@ -854,8 +858,8 @@ export default function DesktopFundLibraryView() {
                   onChange={e => setFormType(e.target.value as FundType)}
                   className="cn-input"
                 >
-                  {Object.entries(TYPE_META).map(([v, m]) => (
-                    <option key={v} value={v}>{locale === 'vi' ? m.labelVi : m.label}</option>
+                  {FORM_TYPES.map(v => (
+                    <option key={v} value={v}>{locale === 'vi' ? TYPE_META[v].labelVi : TYPE_META[v].label}</option>
                   ))}
                 </select>
               </FormField>

--- a/e2e/funds-desktop.spec.ts
+++ b/e2e/funds-desktop.spec.ts
@@ -80,6 +80,24 @@ test('desktop funds add fund button opens add modal', async ({ page }) => {
   await expect(page.getByTestId('fund-modal-title')).toHaveText(/add fund|thêm quỹ/i)
 })
 
+test('desktop funds add modal Type dropdown excludes gold, matching mobile (#3)', async ({ page }) => {
+  // Parity: mobile filters gold out of the create form (gold is handled
+  // separately via byType), but the desktop <select> listed it. Gold must
+  // not be selectable when creating a fund on desktop either.
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  const toolbar = page.getByTestId('desktop-funds-toolbar')
+  await toolbar.getByRole('button', { name: /add fund|thêm quỹ/i }).click()
+
+  const modal = page.getByTestId('fund-modal')
+  await expect(modal).toBeVisible({ timeout: 5_000 })
+  const typeSelect = modal.locator('select')
+  // The three allowed types are present; gold is not.
+  await expect(typeSelect.locator('option')).toHaveCount(3)
+  await expect(typeSelect.locator('option[value="gold"]')).toHaveCount(0)
+})
+
 test('desktop funds edit button opens edit modal prefilled', async ({ page }) => {
   const fund = await api.createFund({ name: 'E2E Desktop Edit Fund', code: 'DTEDT1', fund_type: 'balanced', nav: 42000 })
   cleanup.add(() => api.deleteFund(fund.id))


### PR DESCRIPTION
## What
Review items **#3 / G** — parity fix.

The desktop add/edit fund form's Type `<select>` listed every `TYPE_META` entry, **including gold**, while `MobileFundLibraryView` filters gold out (`FORM_TYPES`) because gold is handled separately (`byType`). So a `fund_type='gold'` fund could be created from desktop but not mobile.

## Fix
Add a desktop `FORM_TYPES = Object.keys(TYPE_META).filter(ft => ft !== 'gold')` (mirrors mobile) and map the `<select>` over it instead of all of `TYPE_META`.

Editing a pre-existing gold fund now behaves exactly as it already does on mobile (gold simply isn't preselected) — so this is parity-consistent, not a new edge.

## Tests (TDD)
New e2e: open the desktop add modal, assert the Type dropdown has exactly **3** options and **no** `option[value="gold"]`. Confirmed red before the fix, green after.

## Local checks
- Targeted e2e (gold + adjacent add/edit modal tests): green
- `tsc --noEmit`: clean
- `npm run lint`: 0 new problems

🤖 Generated with [Claude Code](https://claude.com/claude-code)