### PR TITLE
fix(funds): polish — touch targets, empty state, NAV/DCA format, toast tokens (#4-7,C,D)

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -231,7 +231,7 @@ function DcaToggle({ fund, editId, editValue, goals, goalLabel, unallocatedLabel
     <div style={{ display: 'inline-flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', justifyContent: 'center' }}>
       <button
         data-testid="dca-toggle"
-        aria-label="DCA"
+        aria-label={fund.is_dca ? t('disableDca') : t('enableDca')}
         onClick={e => { e.stopPropagation(); onToggle() }}
         style={{
           width: 34, height: 19, borderRadius: 999,
@@ -771,7 +771,7 @@ export default function DesktopFundLibraryView() {
                             onClick={e => openEditModal(fund, e)}
                             className="cn-btn ghost"
                             style={{ padding: 6 }}
-                            aria-label="Edit"
+                            aria-label={t('editFund')}
                           >
                             <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="var(--c-muted)" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
                               <path d="M4 20h4l10-10-4-4L4 16z" />
@@ -782,7 +782,7 @@ export default function DesktopFundLibraryView() {
                             onClick={e => { e.stopPropagation(); setDeleteTarget(fund) }}
                             className="cn-btn ghost"
                             style={{ padding: 6 }}
-                            aria-label="Delete"
+                            aria-label={t('deleteBtn')}
                           >
                             <svg width={13} height={13} viewBox="0 0 24 24" fill="none" stroke="var(--c-neg)" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
                               <path d="M3 6h18M8 6V4h8v2M6 6l1 14h10l1-14" />
@@ -834,7 +834,7 @@ export default function DesktopFundLibraryView() {
                 value={formName}
                 onChange={e => setFormName(e.target.value)}
                 className="cn-input"
-                placeholder="e.g., VFMVF1 Equity Fund"
+                placeholder={t('namePlaceholder')}
                 autoFocus
                 maxLength={255}
               />
@@ -845,7 +845,7 @@ export default function DesktopFundLibraryView() {
                   value={formCode}
                   onChange={e => setFormCode(e.target.value.toUpperCase())}
                   className="cn-input"
-                  placeholder="VFMVF1"
+                  placeholder={t('codePlaceholder')}
                   maxLength={50}
                   style={{ fontFamily: 'var(--font-mono, monospace)', fontSize: 13 }}
                 />
@@ -871,7 +871,7 @@ export default function DesktopFundLibraryView() {
                 onChange={e => setFormNav(e.target.value)}
                 className="cn-input"
                 style={{ fontVariantNumeric: 'tabular-nums' }}
-                placeholder="e.g. 36120"
+                placeholder={t('navPlaceholder')}
               />
             </FormField>
             <FormField label={t('navSourceLabel')}>
@@ -880,7 +880,7 @@ export default function DesktopFundLibraryView() {
                 value={formNavUrl}
                 onChange={e => setFormNavUrl(e.target.value)}
                 className="cn-input"
-                placeholder="https://..."
+                placeholder={t('navUrlPlaceholder')}
               />
             </FormField>
             <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>

--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -4,9 +4,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { useTranslations, useLocale } from 'next-intl'
 import { Plus, RefreshCw, Search, X } from 'lucide-react'
-import { fmtCompact } from '@/lib/formatters'
+import { fmtCompact, fmtNav } from '@/lib/formatters'
 import { Skeleton } from '@/app/components/ui/Skeleton'
 import { SyncPill } from '@/app/components/ui/SyncPill'
+import { FundsEmptyState } from './FundsEmptyState'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -582,7 +583,7 @@ export default function DesktopFundLibraryView() {
       {/* Toast notifications */}
       <div style={{ position: 'fixed', top: 16, right: 16, zIndex: 300, display: 'flex', flexDirection: 'column', gap: 8 }}>
         {toasts.map(t => (
-          <div key={t.id} style={{ padding: '8px 16px', borderRadius: 10, background: t.ok ? '#047857' : '#b91c1c', color: '#fff', fontSize: 13, fontWeight: 500, boxShadow: '0 4px 12px rgba(0,0,0,0.15)', animation: 'pop-in 200ms ease' }}>
+          <div key={t.id} style={{ padding: '8px 16px', borderRadius: 10, background: t.ok ? 'var(--c-pos)' : 'var(--c-neg)', color: '#fff', fontSize: 13, fontWeight: 500, boxShadow: '0 4px 12px rgba(0,0,0,0.15)', animation: 'pop-in 200ms ease' }}>
             {t.msg}
           </div>
         ))}
@@ -690,11 +691,8 @@ export default function DesktopFundLibraryView() {
             <button onClick={() => loadFunds()} className="cn-btn primary" style={{ padding: '8px 20px' }}>{tc('tryAgain')}</button>
           </div>
         ) : funds.length === 0 ? (
-          <div className="cn-card" style={{ padding: 64, textAlign: 'center' }}>
-            <div style={{ fontSize: 40, marginBottom: 12 }}>📚</div>
-            <h2 style={{ margin: '0 0 6px', fontSize: 16, fontWeight: 600 }}>{t('empty')}</h2>
-            <p style={{ margin: '0 0 20px', color: 'var(--c-muted)', fontSize: 13 }}>{t('emptyDesc')}</p>
-            <button onClick={openAddModal} className="cn-btn primary" style={{ padding: '8px 20px' }}>{t('add')}</button>
+          <div className="cn-card" style={{ padding: 64 }}>
+            <FundsEmptyState onAdd={openAddModal} />
           </div>
         ) : (
           <div className="cn-card" style={{ overflow: 'hidden' }} data-testid="desktop-funds-table">
@@ -743,7 +741,7 @@ export default function DesktopFundLibraryView() {
                       {/* NAV */}
                       <td style={{ padding: '13px 12px', textAlign: 'right', verticalAlign: 'middle' }}>
                         <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>
-                          {fund.nav.toLocaleString('vi-VN')}
+                          {fmtNav(fund.nav)}
                         </span>
                       </td>
 

--- a/app/(app)/funds/components/FundsEmptyState.tsx
+++ b/app/(app)/funds/components/FundsEmptyState.tsx
@@ -1,0 +1,41 @@
+'use client'
+
+import { useTranslations } from 'next-intl'
+import { Library, Plus } from 'lucide-react'
+
+// First-run state for the Fund Library when the account has no funds yet.
+// Migrated off the raw 📚 emoji to a lucide icon + design tokens so it matches
+// the Overview empty state (OverviewEmptyState, #363 review #1). Both the mobile
+// and desktop views wrap this in their own card container; this component only
+// owns the centered icon + copy + add action.
+export function FundsEmptyState({ onAdd }: { onAdd: () => void }) {
+  const t = useTranslations('funds')
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+      <div
+        style={{
+          width: 56, height: 56, borderRadius: 14, marginBottom: 14,
+          background: 'var(--c-navy-tint)', color: 'var(--c-navy)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+        }}
+      >
+        <Library size={26} strokeWidth={1.75} />
+      </div>
+      <h3 style={{ margin: '0 0 4px', fontSize: 16, fontWeight: 600, color: 'var(--c-ink)' }}>{t('empty')}</h3>
+      <p style={{ margin: '0 0 16px', fontSize: 13, color: 'var(--c-muted)', maxWidth: 320, lineHeight: 1.5 }}>{t('emptyDesc')}</p>
+      <button
+        type="button"
+        onClick={onAdd}
+        style={{
+          display: 'inline-flex', alignItems: 'center', gap: 6, padding: '9px 16px',
+          fontSize: 13, fontWeight: 600, background: 'var(--c-btn-primary)', color: '#fff',
+          border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
+        }}
+      >
+        <Plus size={14} strokeWidth={2.4} />
+        {t('add')}
+      </button>
+    </div>
+  )
+}

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -6,15 +6,8 @@ import { Plus, RefreshCw, Search, X, ChevronDown, Check } from 'lucide-react'
 import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import { Skeleton } from '@/app/components/ui/Skeleton'
 import { SyncPill } from '@/app/components/ui/SyncPill'
-
-function fmtCompactDca(n: number): string {
-  const abs = Math.abs(n)
-  const sign = n < 0 ? '-' : ''
-  if (abs >= 1_000_000_000) return `${sign}${(abs / 1_000_000_000).toFixed(1)}B ₫`
-  if (abs >= 1_000_000) return `${sign}${(abs / 1_000_000).toFixed(1)}M ₫`
-  if (abs >= 1_000) return `${sign}${(abs / 1_000).toFixed(0)}K ₫`
-  return `${sign}${abs.toLocaleString('vi-VN')} ₫`
-}
+import { fmtNav, fmtCompact } from '@/lib/formatters'
+import { FundsEmptyState } from './FundsEmptyState'
 
 // Matches the design's exact icon paths (stroke-based, strokeWidth 1.75)
 const IconEdit = ({ size = 14, color = 'currentColor' }: { size?: number; color?: string }) => (
@@ -372,11 +365,12 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
           </div>
           <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{fund.name}</div>
         </div>
-        <div style={{ display: 'flex', gap: 2, flexShrink: 0 }}>
-          <button onClick={onEdit} aria-label="Edit fund" style={{ padding: 6, background: 'transparent', border: 'none', borderRadius: 8, cursor: 'pointer', display: 'flex', alignItems: 'center' }}>
+        <div style={{ display: 'flex', flexShrink: 0 }}>
+          {/* ≥44px touch targets (#4): icons stay 14px but the button fills 44×44. */}
+          <button onClick={onEdit} aria-label="Edit fund" style={{ minWidth: 44, minHeight: 44, padding: 6, background: 'transparent', border: 'none', borderRadius: 8, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <IconEdit size={14} color="var(--c-muted)" />
           </button>
-          <button onClick={onDelete} aria-label="Delete fund" style={{ padding: 6, background: 'transparent', border: 'none', borderRadius: 8, cursor: 'pointer', display: 'flex', alignItems: 'center' }}>
+          <button onClick={onDelete} aria-label="Delete fund" style={{ minWidth: 44, minHeight: 44, padding: 6, background: 'transparent', border: 'none', borderRadius: 8, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <IconTrash size={14} color="var(--c-neg)" />
           </button>
         </div>
@@ -387,7 +381,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
         <div style={{ flexShrink: 0 }}>
           <div style={{ fontSize: 10, color: 'var(--c-muted)', marginBottom: 2, textTransform: 'uppercase', letterSpacing: '0.05em', fontWeight: 600 }}>NAV</div>
           <div style={{ fontSize: 13, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>
-            {fund.nav.toLocaleString('vi-VN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })} VND
+            {fmtNav(fund.nav)}
           </div>
           {fund.nav_source_url && fund.updated_at && (
             <div style={{ fontSize: 10, color: 'var(--c-muted)', marginTop: 1 }}>{t('updatedAgo', { time: relDate(fund.updated_at) })}</div>
@@ -396,14 +390,18 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
 
         <div style={{ display: 'flex', alignItems: 'center', gap: 6, flex: 1, minWidth: 0, flexWrap: 'wrap', justifyContent: 'flex-end' }}>
           <span style={{ fontSize: 10, color: 'var(--c-muted)', textTransform: 'uppercase', letterSpacing: '0.05em', fontWeight: 600 }}>DCA</span>
+          {/* ≥44px touch target (#4): the 36×20 track keeps its look but the
+              tappable button fills 44×44 around it. */}
           <button
             type="button"
             onClick={onToggleDca}
             disabled={toggling}
             aria-label={fund.is_dca ? 'Disable DCA' : 'Enable DCA'}
-            style={{ width: 36, height: 20, borderRadius: 10, background: fund.is_dca ? 'var(--c-btn-primary)' : 'var(--c-line-strong)', border: 'none', cursor: toggling ? 'not-allowed' : 'pointer', position: 'relative', transition: 'background 180ms', flexShrink: 0, opacity: toggling ? 0.5 : 1 }}
+            style={{ minWidth: 44, minHeight: 44, padding: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: toggling ? 'not-allowed' : 'pointer', flexShrink: 0, opacity: toggling ? 0.5 : 1 }}
           >
-            <span style={{ position: 'absolute', top: 2, left: fund.is_dca ? 18 : 2, width: 16, height: 16, borderRadius: 8, background: '#fff', boxShadow: '0 1px 3px rgba(0,0,0,0.2)', transition: 'left 180ms' }} />
+            <span style={{ display: 'block', position: 'relative', width: 36, height: 20, borderRadius: 10, background: fund.is_dca ? 'var(--c-btn-primary)' : 'var(--c-line-strong)', transition: 'background 180ms' }}>
+              <span style={{ position: 'absolute', top: 2, left: fund.is_dca ? 18 : 2, width: 16, height: 16, borderRadius: 8, background: '#fff', boxShadow: '0 1px 3px rgba(0,0,0,0.2)', transition: 'left 180ms' }} />
+            </span>
           </button>
 
           {fund.is_dca && (
@@ -430,7 +428,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
                 onClick={() => { setDcaEditId(fund.id); setDcaEditValue(String(fund.dca_monthly_amount_vnd)) }}
                 style={{ fontSize: 11, fontWeight: 500, padding: '2px 8px', background: 'var(--c-navy-tint)', color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)', borderRadius: 6, cursor: 'pointer', fontFamily: 'inherit' }}
               >
-                {fmtCompactDca(fund.dca_monthly_amount_vnd)}
+                {fmtCompact(fund.dca_monthly_amount_vnd)}
               </button>
             ) : (
               <button
@@ -820,14 +818,8 @@ export default function MobileFundLibraryView() {
 
         {/* Empty state */}
         {!loading && !error && funds.length === 0 && (
-          <div style={{ padding: '44px 20px', textAlign: 'center', background: 'var(--c-card)', border: '1px dashed var(--c-line-strong)', borderRadius: 16 }}>
-            <div style={{ fontSize: 32, marginBottom: 10 }}>📚</div>
-            <h3 style={{ margin: '0 0 4px', fontSize: 15, fontWeight: 600, color: 'var(--c-ink)' }}>{t('empty')}</h3>
-            <p style={{ margin: '0 0 14px', fontSize: 12, color: 'var(--c-muted)' }}>{t('emptyDesc')}</p>
-            <button onClick={() => { setFormError(null); setAddOpen(true) }} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, padding: '8px 14px', fontSize: 13, fontWeight: 600, background: 'var(--c-btn-primary)', color: '#fff', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit' }}>
-              <Plus size={14} />
-              {t('add')}
-            </button>
+          <div style={{ padding: '44px 20px', background: 'var(--c-card)', border: '1px dashed var(--c-line-strong)', borderRadius: 16 }}>
+            <FundsEmptyState onAdd={() => { setFormError(null); setAddOpen(true) }} />
           </div>
         )}
 

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -278,12 +278,12 @@ function FundForm({ existing, title, onClose, onSave, saving, formError }: {
       )}
       <div style={{ display: 'grid', gap: 6 }}>
         <label style={labelStyle}>{t('nameLabel')}</label>
-        <input value={name} onChange={(e) => setName(e.target.value)} maxLength={255} placeholder="e.g., Vanguard S&P 500 ETF" style={inputStyle} />
+        <input value={name} onChange={(e) => setName(e.target.value)} maxLength={255} placeholder={t('namePlaceholder')} style={inputStyle} />
       </div>
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
         <div style={{ display: 'grid', gap: 6 }}>
           <label style={labelStyle}>{t('codeLabel')}</label>
-          <input value={code} onChange={(e) => setCode(e.target.value.toUpperCase())} maxLength={50} placeholder="e.g., VOO" style={{ ...inputStyle, fontFamily: 'var(--font-mono,monospace)' }} />
+          <input value={code} onChange={(e) => setCode(e.target.value.toUpperCase())} maxLength={50} placeholder={t('codePlaceholder')} style={{ ...inputStyle, fontFamily: 'var(--font-mono,monospace)' }} />
         </div>
         <div style={{ display: 'grid', gap: 6 }}>
           <label style={labelStyle}>{t('typeLabel')}</label>
@@ -292,11 +292,11 @@ function FundForm({ existing, title, onClose, onSave, saving, formError }: {
       </div>
       <div style={{ display: 'grid', gap: 6 }}>
         <label style={labelStyle}>{t('navLabel')}</label>
-        <input type="number" value={nav} onChange={(e) => setNav(e.target.value)} min="0.01" step="0.01" placeholder="e.g., 450.25" style={{ ...inputStyle, fontVariantNumeric: 'tabular-nums' }} />
+        <input type="number" value={nav} onChange={(e) => setNav(e.target.value)} min="0.01" step="0.01" placeholder={t('navPlaceholder')} style={{ ...inputStyle, fontVariantNumeric: 'tabular-nums' }} />
       </div>
       <div style={{ display: 'grid', gap: 6 }}>
         <label style={labelStyle}>{t('navSourceLabel')}</label>
-        <input type="url" value={navUrl} onChange={(e) => setNavUrl(e.target.value)} placeholder="https://..." style={inputStyle} />
+        <input type="url" value={navUrl} onChange={(e) => setNavUrl(e.target.value)} placeholder={t('navUrlPlaceholder')} style={inputStyle} />
       </div>
       <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
         <button onClick={onClose} disabled={saving} style={{ flex: 1, padding: '10px 14px', fontSize: 13, fontWeight: 600, border: '1px solid var(--c-line)', borderRadius: 10, background: 'var(--c-card)', color: 'var(--c-ink)', cursor: 'pointer', fontFamily: 'inherit' }}>
@@ -367,10 +367,10 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
         </div>
         <div style={{ display: 'flex', flexShrink: 0 }}>
           {/* ≥44px touch targets (#4): icons stay 14px but the button fills 44×44. */}
-          <button onClick={onEdit} aria-label="Edit fund" style={{ minWidth: 44, minHeight: 44, padding: 6, background: 'transparent', border: 'none', borderRadius: 8, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <button onClick={onEdit} aria-label={t('editFund')} style={{ minWidth: 44, minHeight: 44, padding: 6, background: 'transparent', border: 'none', borderRadius: 8, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <IconEdit size={14} color="var(--c-muted)" />
           </button>
-          <button onClick={onDelete} aria-label="Delete fund" style={{ minWidth: 44, minHeight: 44, padding: 6, background: 'transparent', border: 'none', borderRadius: 8, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <button onClick={onDelete} aria-label={t('deleteBtn')} style={{ minWidth: 44, minHeight: 44, padding: 6, background: 'transparent', border: 'none', borderRadius: 8, cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <IconTrash size={14} color="var(--c-neg)" />
           </button>
         </div>
@@ -396,7 +396,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
             type="button"
             onClick={onToggleDca}
             disabled={toggling}
-            aria-label={fund.is_dca ? 'Disable DCA' : 'Enable DCA'}
+            aria-label={fund.is_dca ? t('disableDca') : t('enableDca')}
             style={{ minWidth: 44, minHeight: 44, padding: 0, display: 'inline-flex', alignItems: 'center', justifyContent: 'center', background: 'transparent', border: 'none', cursor: toggling ? 'not-allowed' : 'pointer', flexShrink: 0, opacity: toggling ? 0.5 : 1 }}
           >
             <span style={{ display: 'block', position: 'relative', width: 36, height: 20, borderRadius: 10, background: fund.is_dca ? 'var(--c-btn-primary)' : 'var(--c-line-strong)', transition: 'background 180ms' }}>
@@ -580,7 +580,7 @@ export default function MobileFundLibraryView() {
           <button
             onClick={handleRefreshNav}
             disabled={refreshing || !funds.some((f) => f.nav_source_url)}
-            aria-label="Refresh NAV"
+            aria-label={t('refreshNav')}
             style={{ padding: 8, background: 'transparent', border: '1px solid var(--c-line)', borderRadius: 10, cursor: 'pointer', display: 'flex', alignItems: 'center', opacity: refreshing || !funds.some((f) => f.nav_source_url) ? 0.4 : 1 }}
           >
             <RefreshCw size={16} color="var(--c-ink)" />
@@ -590,7 +590,7 @@ export default function MobileFundLibraryView() {
             style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '6px 12px', fontSize: 12, fontWeight: 600, background: 'var(--c-btn-primary)', color: '#fff', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit' }}
           >
             <Plus size={14} strokeWidth={2.5} />
-            Add
+            {t('add')}
           </button>
         </div>
       ),

--- a/app/(app)/funds/components/__tests__/FundsEmptyState.test.tsx
+++ b/app/(app)/funds/components/__tests__/FundsEmptyState.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { FundsEmptyState } from '../FundsEmptyState'
+
+// Mock next-intl so t('key') returns the key — keeps assertions language-agnostic.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+describe('FundsEmptyState', () => {
+  it('renders the empty title, description and add action', () => {
+    render(<FundsEmptyState onAdd={() => {}} />)
+    expect(screen.getByText('empty')).toBeInTheDocument()
+    expect(screen.getByText('emptyDesc')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /add/i })).toBeInTheDocument()
+  })
+
+  it('calls onAdd when the add button is clicked', () => {
+    const onAdd = vi.fn()
+    render(<FundsEmptyState onAdd={onAdd} />)
+    fireEvent.click(screen.getByRole('button', { name: /add/i }))
+    expect(onAdd).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses a lucide icon + design tokens, not the 📚 emoji (#5)', () => {
+    const { container } = render(<FundsEmptyState onAdd={() => {}} />)
+    // Hero glyph is a lucide SVG now, not an emoji.
+    expect(container.querySelector('svg')).not.toBeNull()
+    expect(container.innerHTML).not.toMatch(/📚/)
+    // No raw hex colors — tokens only.
+    expect(container.innerHTML).not.toMatch(/#[0-9a-fA-F]{6}/)
+  })
+})

--- a/e2e/funds-desktop.spec.ts
+++ b/e2e/funds-desktop.spec.ts
@@ -37,6 +37,28 @@ test('desktop funds table shows fund code, type chip, and NAV columns', async ({
   await expect(row.getByText(/55.000|55,000/)).toBeVisible()
 })
 
+test('desktop funds form placeholders + action aria-labels are localized (vi)', async ({ page }) => {
+  // Review follow-up: the desktop form placeholders and the edit/delete/DCA
+  // aria-labels were hardcoded English. The e2e session renders vi.
+  const fund = await api.createFund({ name: 'E2E Desktop i18n Labels', code: 'DTI18N', fund_type: 'equity', nav: 12000 })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  const row = page.getByTestId('desktop-funds-table').getByTestId(`fund-row-${fund.id}`)
+  await expect(row).toBeVisible({ timeout: 10_000 })
+  await expect(row.getByRole('button', { name: /sửa quỹ/i })).toBeVisible()
+  await expect(row.getByRole('button', { name: /xóa quỹ/i })).toBeVisible()
+  await expect(row.getByRole('button', { name: /bật dca/i })).toBeVisible()
+
+  // Add modal: the fund-name input placeholder is localized ("vd: …").
+  await page.getByTestId('desktop-funds-toolbar').getByRole('button', { name: /add fund|thêm quỹ/i }).click()
+  const modal = page.getByTestId('fund-modal')
+  await expect(modal).toBeVisible({ timeout: 5_000 })
+  await expect(modal.getByPlaceholder(/^vd:/i).first()).toBeVisible()
+})
+
 test('desktop funds NAV uses the shared ₫ + 2-decimal format (#6)', async ({ page }) => {
   // #6: the desktop table showed a bare "55.000" (no decimals, no unit) while
   // mobile showed "55.000,00 VND". Both now render the shared fmtNav: "₫ 55.000,00".
@@ -206,7 +228,7 @@ test('DCA enabled on desktop is reflected when switching to mobile viewport', as
   // Mobile card must show DCA as active
   const card = page.getByTestId('mobile-funds').getByTestId(`fund-card-${fund.id}`)
   await expect(card).toBeVisible({ timeout: 8_000 })
-  await expect(card.getByRole('button', { name: /disable dca/i })).toBeVisible({ timeout: 5_000 })
+  await expect(card.getByRole('button', { name: /disable dca|tắt dca/i })).toBeVisible({ timeout: 5_000 })
 })
 
 test('desktop funds DCA toggle enables inline amount input', async ({ page }) => {

--- a/e2e/funds-desktop.spec.ts
+++ b/e2e/funds-desktop.spec.ts
@@ -37,6 +37,20 @@ test('desktop funds table shows fund code, type chip, and NAV columns', async ({
   await expect(row.getByText(/55.000|55,000/)).toBeVisible()
 })
 
+test('desktop funds NAV uses the shared ₫ + 2-decimal format (#6)', async ({ page }) => {
+  // #6: the desktop table showed a bare "55.000" (no decimals, no unit) while
+  // mobile showed "55.000,00 VND". Both now render the shared fmtNav: "₫ 55.000,00".
+  const fund = await api.createFund({ name: 'E2E Desktop NAV Format', code: 'DTNAVF', fund_type: 'equity', nav: 55000 })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  const row = page.getByTestId('desktop-funds-table').getByTestId(`fund-row-${fund.id}`)
+  await expect(row).toBeVisible({ timeout: 10_000 })
+  await expect(row.getByText(/₫\s*55\.000,00/)).toBeVisible()
+})
+
 test('desktop funds type filter pill filters by equity', async ({ page }) => {
   const equityFund = await api.createFund({ name: 'E2E Desktop Equity', code: 'DTEQF', fund_type: 'equity', nav: 10000 })
   const bondFund = await api.createFund({ name: 'E2E Desktop Bond', code: 'DTBDF', fund_type: 'debt', nav: 10000 })

--- a/e2e/funds.spec.ts
+++ b/e2e/funds.spec.ts
@@ -14,8 +14,8 @@ test('mobile funds shows header with title and action buttons', async ({ page })
 
   const topBar = page.getByTestId('mobile-top-bar')
   await expect(topBar.getByText(/quỹ đầu tư|fund library/i)).toBeVisible({ timeout: 10_000 })
-  await expect(topBar.getByRole('button', { name: /add/i })).toBeVisible()
-  await expect(topBar.getByRole('button', { name: /refresh nav/i })).toBeVisible()
+  await expect(topBar.getByRole('button', { name: /add fund|thêm quỹ/i })).toBeVisible()
+  await expect(topBar.getByRole('button', { name: /refresh nav|làm mới/i })).toBeVisible()
 })
 
 test('mobile funds shows type filter chips', async ({ page }) => {
@@ -54,6 +54,30 @@ test('mobile funds renders a fund card with code, type, NAV and DCA toggle', asy
   await expect(card.getByRole('button', { name: /dca/i })).toBeVisible()
 })
 
+test('mobile funds form placeholders + action aria-labels are localized (vi)', async ({ page }) => {
+  // Review follow-up: form input placeholders and the edit/delete/toggle
+  // aria-labels were hardcoded English. The e2e session renders vi, so the
+  // accessible names + placeholders must be Vietnamese.
+  const fund = await api.createFund({ name: 'E2E i18n Labels Fund', code: 'E2EI18', fund_type: 'equity', nav: 12000 })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  const card = page.getByTestId('mobile-funds').getByTestId(`fund-card-${fund.id}`)
+  await expect(card).toBeVisible({ timeout: 10_000 })
+  // Action buttons expose Vietnamese accessible names.
+  await expect(card.getByRole('button', { name: /sửa quỹ/i })).toBeVisible()
+  await expect(card.getByRole('button', { name: /xóa quỹ/i })).toBeVisible()
+  await expect(card.getByRole('button', { name: /bật dca/i })).toBeVisible()
+
+  // Add sheet: the fund-name input placeholder is localized ("vd: …").
+  await page.getByTestId('mobile-top-bar').getByRole('button', { name: /add fund|thêm quỹ/i }).click()
+  const sheet = page.getByTestId('fund-sheet')
+  await expect(sheet).toBeVisible({ timeout: 5_000 })
+  await expect(sheet.getByPlaceholder(/^vd:/i).first()).toBeVisible()
+})
+
 test('mobile funds NAV uses the shared ₫ + 2-decimal format (#6)', async ({ page }) => {
   // #6: mobile NAV diverged from desktop ("36.120,00 VND" vs "36.120"). Both now
   // render the shared fmtNav: "₫ 45.000,00".
@@ -81,7 +105,7 @@ test('mobile funds card touch targets are at least 44px (#4)', async ({ page }) 
   const card = page.getByTestId('mobile-funds').getByTestId(`fund-card-${fund.id}`)
   await expect(card).toBeVisible({ timeout: 10_000 })
 
-  for (const name of [/dca/i, /edit fund/i, /delete fund/i]) {
+  for (const name of [/dca/i, /edit fund|sửa quỹ/i, /delete fund|xóa quỹ/i]) {
     const box = await card.getByRole('button', { name }).boundingBox()
     expect(box).not.toBeNull()
     expect(box!.width).toBeGreaterThanOrEqual(44)
@@ -133,7 +157,7 @@ test('mobile funds add button opens add fund sheet', async ({ page }) => {
   await page.waitForLoadState('networkidle')
 
   const topBar = page.getByTestId('mobile-top-bar')
-  await topBar.getByRole('button', { name: /add/i }).click()
+  await topBar.getByRole('button', { name: /add fund|thêm quỹ/i }).click()
   await expect(page.getByTestId('fund-sheet')).toBeVisible({ timeout: 5_000 })
   await expect(page.getByTestId('fund-sheet').getByText(/add fund|thêm quỹ/i)).toBeVisible()
 })
@@ -146,7 +170,7 @@ test('mobile funds edit button opens edit sheet prefilled with fund data', async
   await page.waitForLoadState('networkidle')
 
   const mf = page.getByTestId('mobile-funds')
-  await mf.getByTestId(`fund-card-${fund.id}`).getByRole('button', { name: /edit/i }).click()
+  await mf.getByTestId(`fund-card-${fund.id}`).getByRole('button', { name: /edit fund|sửa quỹ/i }).click()
   const sheet = page.getByTestId('fund-sheet')
   await expect(sheet).toBeVisible({ timeout: 5_000 })
   await expect(sheet.locator('input').first()).toHaveValue('E2E Edit Fund')
@@ -160,7 +184,7 @@ test('mobile funds delete button opens delete confirmation sheet', async ({ page
   await page.waitForLoadState('networkidle')
 
   const mf = page.getByTestId('mobile-funds')
-  await mf.getByTestId(`fund-card-${fund.id}`).getByRole('button', { name: /delete/i }).click()
+  await mf.getByTestId(`fund-card-${fund.id}`).getByRole('button', { name: /delete fund|xóa quỹ/i }).click()
   await expect(page.getByTestId('delete-fund-sheet')).toBeVisible({ timeout: 5_000 })
   await expect(page.getByTestId('delete-fund-sheet').getByText(/^(delete|xóa) E2EDEL\?$/i)).toBeVisible()
 })

--- a/e2e/funds.spec.ts
+++ b/e2e/funds.spec.ts
@@ -54,6 +54,41 @@ test('mobile funds renders a fund card with code, type, NAV and DCA toggle', asy
   await expect(card.getByRole('button', { name: /dca/i })).toBeVisible()
 })
 
+test('mobile funds NAV uses the shared ₫ + 2-decimal format (#6)', async ({ page }) => {
+  // #6: mobile NAV diverged from desktop ("36.120,00 VND" vs "36.120"). Both now
+  // render the shared fmtNav: "₫ 45.000,00".
+  const fund = await api.createFund({ name: 'E2E NAV Format Fund', code: 'E2ENAV', fund_type: 'equity', nav: 45000 })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  const card = page.getByTestId('mobile-funds').getByTestId(`fund-card-${fund.id}`)
+  await expect(card).toBeVisible({ timeout: 10_000 })
+  await expect(card.getByText(/₫\s*45\.000,00/)).toBeVisible()
+})
+
+test('mobile funds card touch targets are at least 44px (#4)', async ({ page }) => {
+  // #4: the DCA toggle (36×20) and the edit/delete icon buttons (~26px) were
+  // below the 44px recommended touch target. The visual size is unchanged but
+  // the tappable area is now ≥44×44.
+  const fund = await api.createFund({ name: 'E2E Touch Target Fund', code: 'E2ETT', fund_type: 'equity', nav: 12000 })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  const card = page.getByTestId('mobile-funds').getByTestId(`fund-card-${fund.id}`)
+  await expect(card).toBeVisible({ timeout: 10_000 })
+
+  for (const name of [/dca/i, /edit fund/i, /delete fund/i]) {
+    const box = await card.getByRole('button', { name }).boundingBox()
+    expect(box).not.toBeNull()
+    expect(box!.width).toBeGreaterThanOrEqual(44)
+    expect(box!.height).toBeGreaterThanOrEqual(44)
+  }
+})
+
 test('mobile funds search filters by code', async ({ page }) => {
   const fund = await api.createFund({ name: 'E2E Bond Search Fund', code: 'E2EBD', fund_type: 'debt', nav: 30000 })
   cleanup.add(() => api.deleteFund(fund.id))

--- a/e2e/input-zoom.spec.ts
+++ b/e2e/input-zoom.spec.ts
@@ -72,9 +72,9 @@ test.describe('Fund library — no field triggers iOS zoom', () => {
     await useEnglish(page)
     await page.goto('/funds')
     await page.waitForLoadState('networkidle')
-    await page.getByTestId('mobile-top-bar').getByRole('button', { name: /add/i }).click()
-    // The name field's placeholder confirms the form is open.
-    await expect(page.getByPlaceholder(/Vanguard|S&P/i)).toBeVisible({ timeout: 5_000 })
+    await page.getByTestId('mobile-top-bar').getByRole('button', { name: /add fund|thêm quỹ/i }).click()
+    // The sheet appearing confirms the form is open (placeholder text is i18n-driven).
+    await expect(page.getByTestId('fund-sheet')).toBeVisible({ timeout: 5_000 })
     await expectNoZoomFields(page)
   })
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -605,7 +605,14 @@
     "relMinutes": "{m}m ago",
     "relHours": "{h}h ago",
     "relDays": "{d}d ago",
-    "updatedAgo": "Updated {time}"
+    "updatedAgo": "Updated {time}",
+    "namePlaceholder": "e.g., VFMVF1 Equity Fund",
+    "codePlaceholder": "e.g., VFMVF1",
+    "navPlaceholder": "e.g., 36120",
+    "navUrlPlaceholder": "https://...",
+    "editFund": "Edit fund",
+    "enableDca": "Enable DCA",
+    "disableDca": "Disable DCA"
   },
   "planning": {
     "title": "Monthly Plan",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -605,7 +605,14 @@
     "relMinutes": "{m} phút trước",
     "relHours": "{h} giờ trước",
     "relDays": "{d} ngày trước",
-    "updatedAgo": "Cập nhật {time}"
+    "updatedAgo": "Cập nhật {time}",
+    "namePlaceholder": "vd: Quỹ cổ phiếu VFMVF1",
+    "codePlaceholder": "vd: VFMVF1",
+    "navPlaceholder": "vd: 36120",
+    "navUrlPlaceholder": "https://...",
+    "editFund": "Sửa quỹ",
+    "enableDca": "Bật DCA",
+    "disableDca": "Tắt DCA"
   },
   "planning": {
     "title": "Kế hoạch Tháng",


### PR DESCRIPTION
Final batch of the Funds-page design-review follow-ups (claude.ai/design `REVIEW-funds-page.md`). All polish-tier items; the 🟠 function bugs (#1) and i18n (#2/C/E/F/H) and gold parity (#3/G) shipped in #380/#381/#382.

## Changes
- **#4 Mobile touch targets** — the DCA toggle (36×20) and edit/delete icon buttons (~26px) were under the 44px recommendation. Visual size is unchanged; the *tappable* area now fills ≥44×44 (the toggle wraps its track in a 44×44 button; the icon buttons get `min-width`/`min-height`).
- **#5 Empty state** — extracted a shared `FundsEmptyState` off the raw `📚` emoji to a lucide `Library` icon + design tokens, mirroring `OverviewEmptyState`. Used by both views.
- **#6 NAV format** — mobile (`36.120,00 VND`) and desktop (`36.120`) diverged. Both now render the shared `fmtNav` → `₫ 36.120,00`.
- **#7 Desktop toast** — hardcoded `#047857`/`#b91c1c` → `var(--c-pos)`/`var(--c-neg)` so it follows dark-mode tokens (mobile already did).
- **#C/D DCA amount** — deduped the mobile-local `fmtCompactDca` to the shared `fmtCompact` (already `₫`-suffixed); both breakpoints now use one formatter. The desktop `₫` was already present via `fmtCompact`, so this is the unify-the-formatter part of the item.

## Tests (TDD)
- **Unit:** `FundsEmptyState` — renders title/desc/add, fires `onAdd`, no `📚`, lucide svg + tokens only (red→green).
- **E2E mobile:** card touch targets ≥44×44 (#4); NAV uses `₫ …,00` (#6).
- **E2E desktop:** NAV uses `₫ …,00` (#6).
- Ran locally: `npm test -- --run` (809 pass), `npm run lint` (53 baseline, 0 new), `e2e/funds.spec.ts --project=mobile` (20 pass), `e2e/funds-desktop.spec.ts --project=chromium` (17 pass).

#7 (toast token) is a style-only swap on a transient element, verified by code review against the mobile token usage rather than a dedicated E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)