### PR TITLE
fix(funds): desktop DCA in-flight guard (#8) + per-fund NAV age (#9)

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -210,10 +210,11 @@ const SortTh = ({ label, sortKey, active, asc, onSort, align = 'right' }: {
 
 // ─── DCA toggle (inline) ──────────────────────────────────────────────────────
 
-function DcaToggle({ fund, editId, editValue, goals, goalLabel, unallocatedLabel, onToggle, onEditStart, onEditChange, onEditCommit, onEditCancel, onGoalChange }: {
+function DcaToggle({ fund, editId, editValue, toggling, goals, goalLabel, unallocatedLabel, onToggle, onEditStart, onEditChange, onEditCommit, onEditCancel, onGoalChange }: {
   fund: Fund
   editId: string | null
   editValue: string
+  toggling: boolean
   goals: Goal[]
   goalLabel: string
   unallocatedLabel: string
@@ -232,12 +233,13 @@ function DcaToggle({ fund, editId, editValue, goals, goalLabel, unallocatedLabel
       <button
         data-testid="dca-toggle"
         aria-label={fund.is_dca ? t('disableDca') : t('enableDca')}
+        disabled={toggling}
         onClick={e => { e.stopPropagation(); onToggle() }}
         style={{
           width: 34, height: 19, borderRadius: 999,
           background: fund.is_dca ? 'var(--c-btn-primary)' : 'var(--c-line-strong)',
-          border: 'none', cursor: 'pointer', position: 'relative',
-          transition: 'background 180ms', flexShrink: 0,
+          border: 'none', cursor: toggling ? 'not-allowed' : 'pointer', position: 'relative',
+          transition: 'background 180ms', flexShrink: 0, opacity: toggling ? 0.5 : 1,
         }}
       >
         <span style={{
@@ -292,6 +294,7 @@ function DcaToggle({ fund, editId, editValue, goals, goalLabel, unallocatedLabel
           value={fund.dca_goal_id ?? ''}
           title={goalLabel}
           aria-label={goalLabel}
+          disabled={toggling}
           onClick={e => e.stopPropagation()}
           onChange={e => { e.stopPropagation(); onGoalChange(e.target.value || null) }}
           style={{
@@ -344,6 +347,9 @@ export default function DesktopFundLibraryView() {
   // DCA inline edit
   const [dcaEditId, setDcaEditId] = useState<string | null>(null)
   const [dcaEditValue, setDcaEditValue] = useState('')
+  // Funds with an in-flight DCA PUT — toggle/goal-select disabled until it lands
+  // (parity with mobile's togglingIds, prevents overlapping PUTs on fast clicks).
+  const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set())
 
   // Modals
   const [modalMode, setModalMode] = useState<'add' | 'edit' | null>(null)
@@ -402,6 +408,16 @@ export default function DesktopFundLibraryView() {
     window.addEventListener('cairn:funds-updated', handler)
     return () => window.removeEventListener('cairn:funds-updated', handler)
   }, [loadFunds])
+
+  // Relative NAV age per fund (#9) — same buckets as the mobile card.
+  const relDate = (str: string) => {
+    const mins = Math.floor((Date.now() - new Date(str).getTime()) / 60000)
+    if (mins < 1) return t('relJustNow')
+    if (mins < 60) return t('relMinutes', { m: mins })
+    const h = Math.floor(mins / 60)
+    if (h < 24) return t('relHours', { h })
+    return t('relDays', { d: Math.floor(h / 24) })
+  }
 
   // Sorting
   const handleSort = (key: SortKey) => {
@@ -495,6 +511,7 @@ export default function DesktopFundLibraryView() {
       return
     }
 
+    setTogglingIds(p => new Set(p).add(fund.id))
     try {
       const res = await fetch(`/api/funds/${fund.id}`, {
         method: 'PUT',
@@ -508,6 +525,8 @@ export default function DesktopFundLibraryView() {
     } catch {
       setFunds(p => p.map(f => f.id === fund.id ? { ...f, is_dca: true } : f))
       addToast(t('toastDcaFailed'), false)
+    } finally {
+      setTogglingIds(p => { const s = new Set(p); s.delete(fund.id); return s })
     }
   }
 
@@ -520,6 +539,7 @@ export default function DesktopFundLibraryView() {
       return
     }
     setDcaEditId(null)
+    setTogglingIds(p => new Set(p).add(fund.id))
     try {
       const res = await fetch(`/api/funds/${fund.id}`, {
         method: 'PUT',
@@ -533,12 +553,15 @@ export default function DesktopFundLibraryView() {
     } catch {
       setFunds(p => p.map(f => f.id === fund.id ? { ...f, is_dca: false, dca_monthly_amount_vnd: null } : f))
       addToast(t('toastDcaFailed'), false)
+    } finally {
+      setTogglingIds(p => { const s = new Set(p); s.delete(fund.id); return s })
     }
   }
 
   async function handleSetDcaGoal(fund: Fund, goalId: string | null) {
     const prevGoalId = fund.dca_goal_id
     setFunds(p => p.map(f => f.id === fund.id ? { ...f, dca_goal_id: goalId } : f))
+    setTogglingIds(p => new Set(p).add(fund.id))
     try {
       const res = await fetch(`/api/funds/${fund.id}`, {
         method: 'PUT',
@@ -552,6 +575,8 @@ export default function DesktopFundLibraryView() {
     } catch {
       setFunds(p => p.map(f => f.id === fund.id ? { ...f, dca_goal_id: prevGoalId } : f))
       addToast(t('toastGoalFailed'), false)
+    } finally {
+      setTogglingIds(p => { const s = new Set(p); s.delete(fund.id); return s })
     }
   }
 
@@ -743,6 +768,11 @@ export default function DesktopFundLibraryView() {
                         <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>
                           {fmtNav(fund.nav)}
                         </span>
+                        {fund.nav_source_url && fund.updated_at && (
+                          <div style={{ fontSize: 10, color: 'var(--c-muted)', marginTop: 2 }}>
+                            {t('updatedAgo', { time: relDate(fund.updated_at) })}
+                          </div>
+                        )}
                       </td>
 
                       {/* DCA */}
@@ -751,6 +781,7 @@ export default function DesktopFundLibraryView() {
                           fund={fund}
                           editId={dcaEditId}
                           editValue={dcaEditValue}
+                          toggling={togglingIds.has(fund.id)}
                           goals={goals}
                           goalLabel={t('dcaGoalLabel')}
                           unallocatedLabel={t('dcaGoalUnallocated')}

--- a/e2e/funds-desktop.spec.ts
+++ b/e2e/funds-desktop.spec.ts
@@ -59,6 +59,51 @@ test('desktop funds form placeholders + action aria-labels are localized (vi)', 
   await expect(modal.getByPlaceholder(/^vd:/i).first()).toBeVisible()
 })
 
+test('desktop funds row shows per-fund NAV age when a source URL is set (#9)', async ({ page }) => {
+  // #9: mobile cards show "Updated …" per fund; the desktop table didn't expose
+  // NAV age at all. A fund with a nav_source_url now shows the relative age
+  // under its NAV (just-created → "Cập nhật vừa xong" / "Updated just now").
+  const fund = await api.createFund({
+    name: 'E2E Desktop NAV Age', code: 'DTAGE1', fund_type: 'equity', nav: 18000,
+    nav_source_url: 'https://example.com/nav',
+  })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  const row = page.getByTestId('desktop-funds-table').getByTestId(`fund-row-${fund.id}`)
+  await expect(row).toBeVisible({ timeout: 10_000 })
+  await expect(row.getByText(/cập nhật|updated/i)).toBeVisible()
+})
+
+test('desktop funds DCA toggle is disabled while the update is in flight (#8)', async ({ page }) => {
+  // #8: the desktop DCA handlers had no in-flight guard (mobile dims + disables
+  // via togglingIds), so fast clicks could fire overlapping PUTs. The toggle is
+  // now disabled until the PUT resolves.
+  const fund = await api.createFund({
+    name: 'E2E Desktop DCA Guard', code: 'DTGRD1', fund_type: 'equity', nav: 15000,
+    is_dca: true, dca_monthly_amount_vnd: 2_000_000,
+  })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  // Delay the PUT so the in-flight window is observable.
+  await page.route(`**/api/funds/${fund.id}`, async route => {
+    if (route.request().method() === 'PUT') await new Promise(r => setTimeout(r, 1200))
+    await route.continue()
+  })
+
+  const row = page.getByTestId('desktop-funds-table').getByTestId(`fund-row-${fund.id}`)
+  const toggle = row.getByTestId('dca-toggle')
+  await expect(toggle).toBeEnabled({ timeout: 8_000 })
+  await toggle.click()
+  // While the PUT is outstanding the toggle must be disabled.
+  await expect(toggle).toBeDisabled()
+})
+
 test('desktop funds NAV uses the shared ₫ + 2-decimal format (#6)', async ({ page }) => {
   // #6: the desktop table showed a bare "55.000" (no decimals, no unit) while
   // mobile showed "55.000,00 VND". Both now render the shared fmtNav: "₫ 55.000,00".

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -325,6 +325,7 @@ export async function createFund(data: {
   code: string
   fund_type: string
   nav: number
+  nav_source_url?: string
   is_dca?: boolean
   dca_monthly_amount_vnd?: number
   dca_goal_id?: string


### PR DESCRIPTION
Desktop parity follow-ups from the funds-page review (the two 🟢 optional items that are bug-adjacent). #10 (lift fetch to parent) follows in a separate PR.

## Changes
- **#8 In-flight DCA guard** — the desktop toggle/amount/goal handlers had no guard, so rapid clicks could fire overlapping PUTs. Added a `togglingIds` set (mirroring mobile) that disables + dims the toggle and disables the goal `<select>` until the PUT resolves.
- **#9 Per-fund NAV age** — the mobile card shows "Updated …" per fund; the desktop table exposed no NAV age. Funds with a `nav_source_url` now show the relative age under the NAV, reusing the same buckets (`relJustNow`/`relMinutes`/`relHours`/`relDays`) — no new strings.

## Tests (TDD)
- **E2E #8:** route-delay the PUT, click the toggle, assert it's `toBeDisabled()` while in flight (red before — desktop never disabled it).
- **E2E #9:** a fund with a `nav_source_url` shows its NAV age (`Cập nhật …`).
- Extended the `createFund` e2e helper with `nav_source_url`.
- Local: `npm test -- --run` (809 pass), `npm run lint` (53 baseline, 0 new), `e2e/funds-desktop.spec.ts --project=chromium` (20 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)