### PR TITLE
refactor(funds): lift fund/goal fetch to FundLibraryClient (#10)

### DIFF
--- a/app/(app)/funds/FundLibraryClient.tsx
+++ b/app/(app)/funds/FundLibraryClient.tsx
@@ -2,12 +2,18 @@
 
 import MobileFundLibraryView from './components/MobileFundLibraryView'
 import DesktopFundLibraryView from './components/DesktopFundLibraryView'
+import { useFundsData } from './components/useFundsData'
 
 export default function FundLibraryClient() {
+  // Own the data layer once and share it with both always-mounted views, so the
+  // page fetches funds + goals a single time and a mutation in either view
+  // updates the one shared copy (#10).
+  const data = useFundsData()
+
   return (
     <>
-      <MobileFundLibraryView />
-      <DesktopFundLibraryView />
+      <MobileFundLibraryView {...data} />
+      <DesktopFundLibraryView {...data} />
     </>
   )
 }

--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { useTranslations, useLocale } from 'next-intl'
 import { Plus, RefreshCw, Search, X } from 'lucide-react'
@@ -8,26 +8,10 @@ import { fmtCompact, fmtNav } from '@/lib/formatters'
 import { Skeleton } from '@/app/components/ui/Skeleton'
 import { SyncPill } from '@/app/components/ui/SyncPill'
 import { FundsEmptyState } from './FundsEmptyState'
+import type { Fund, Goal, FundType, FundsData } from './useFundsData'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
-
-type FundType = 'balanced' | 'equity' | 'debt' | 'gold'
-
-type Fund = {
-  id: string
-  name: string
-  code: string
-  fund_type: FundType
-  nav: number
-  nav_source_url: string | null
-  is_dca: boolean
-  dca_monthly_amount_vnd: number | null
-  dca_goal_id: string | null
-  created_at: string
-  updated_at: string
-}
-
-type Goal = { goal_id: string; goal_name: string }
+// Fund/Goal/FundType are shared with the mobile view via useFundsData.
 
 type SortKey = 'code' | 'nav' | 'name'
 type TypeFilter = 'all' | 'equity' | 'debt' | 'balanced'
@@ -51,37 +35,6 @@ const TYPE_FILTERS: { v: TypeFilter; label: string; labelVi: string }[] = [
 // Selectable fund types in the create/edit form. Gold is excluded (handled
 // separately via byType) to match MobileFundLibraryView's FORM_TYPES.
 const FORM_TYPES = (Object.keys(TYPE_META) as FundType[]).filter(ft => ft !== 'gold')
-
-// ─── Cache ────────────────────────────────────────────────────────────────────
-
-const CACHE_KEY = 'fundLibraryCache'
-const CACHE_TTL = 2 * 60 * 1000
-
-function getCache(): Fund[] | null {
-  try {
-    const raw = localStorage.getItem(CACHE_KEY)
-    if (!raw) return null
-    const { data, ts } = JSON.parse(raw)
-    if (Date.now() - ts > CACHE_TTL) return null
-    return data
-  } catch { return null }
-}
-function setCache(data: Fund[]) {
-  try { localStorage.setItem(CACHE_KEY, JSON.stringify({ data, ts: Date.now() })) } catch {}
-}
-function bustCache() {
-  try { localStorage.removeItem(CACHE_KEY) } catch {}
-}
-
-// ─── Cross-view sync ──────────────────────────────────────────────────────────
-// Both MobileFundLibraryView and DesktopFundLibraryView are always mounted.
-// When one mutates fund data it dispatches this event so the other reloads.
-let _suppressNotify = false
-function notifyFundsUpdated() {
-  _suppressNotify = true
-  window.dispatchEvent(new CustomEvent('cairn:funds-updated'))
-  _suppressNotify = false
-}
 
 // ─── Small components ─────────────────────────────────────────────────────────
 
@@ -325,18 +278,12 @@ function FormField({ label, children }: { label: string; children: ReactNode }) 
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
-export default function DesktopFundLibraryView() {
+export default function DesktopFundLibraryView({ funds, setFunds, goals, loading, error, reload }: FundsData) {
   const t = useTranslations('funds')
   const tc = useTranslations('common')
   const locale = useLocale()
 
-  // Fund data
-  const [funds, setFunds] = useState<Fund[]>(() => getCache() ?? [])
-  const [loading, setLoading] = useState(() => !getCache())
-  const [error, setError] = useState<string | null>(null)
-
-  // Savings goals (DCA target options)
-  const [goals, setGoals] = useState<Goal[]>([])
+  // funds / goals / loading / error / reload come from FundLibraryClient (#10).
 
   // Table state
   const [query, setQuery] = useState('')
@@ -373,41 +320,6 @@ export default function DesktopFundLibraryView() {
     setToasts(p => [...p, { id, msg, ok }])
     setTimeout(() => setToasts(p => p.filter(t => t.id !== id)), 3000)
   }, [])
-
-  // Data loading
-  const loadFunds = useCallback(async (force = false) => {
-    if (force) bustCache()
-    setError(null)
-    try {
-      const res = await fetch('/api/funds')
-      if (!res.ok) throw new Error()
-      const { funds: data } = await res.json()
-      setCache(data)
-      setFunds(data)
-    } catch {
-      setError(t('loadError'))
-    } finally {
-      setLoading(false)
-    }
-  }, [t])
-
-  useEffect(() => { loadFunds() }, [loadFunds])
-
-  // Load savings goals once for the DCA target dropdown.
-  useEffect(() => {
-    let cancelled = false
-    fetch('/api/v1/savings-goals')
-      .then(res => res.ok ? res.json() : { goals: [] })
-      .then(({ goals: data }) => { if (!cancelled) setGoals(data ?? []) })
-      .catch(() => {})
-    return () => { cancelled = true }
-  }, [])
-
-  useEffect(() => {
-    const handler = () => { if (!_suppressNotify) loadFunds(true) }
-    window.addEventListener('cairn:funds-updated', handler)
-    return () => window.removeEventListener('cairn:funds-updated', handler)
-  }, [loadFunds])
 
   // Relative NAV age per fund (#9) — same buckets as the mobile card.
   const relDate = (str: string) => {
@@ -449,9 +361,7 @@ export default function DesktopFundLibraryView() {
       const { results } = await res.json()
       const updated = results.filter((r: { nav?: number }) => r.nav !== undefined).length
       const failed = results.filter((r: { error?: string }) => r.error).length
-      bustCache()
-      await loadFunds(true)
-      notifyFundsUpdated()
+      await reload()
       addToast(t('navRefreshDone', { updated, failed }), failed === 0 || updated > 0)
     } catch {
       addToast(t('toastRefreshFailed'), false)
@@ -489,9 +399,7 @@ export default function DesktopFundLibraryView() {
       const data = await res.json()
       if (!res.ok) { setFormError(res.status === 409 ? t('codeExists') : data.error || t('error')); return }
       closeModal()
-      bustCache()
-      await loadFunds(true)
-      notifyFundsUpdated()
+      await reload()
       addToast(modalMode === 'edit' ? t('toastUpdated') : t('toastAdded'))
     } catch {
       setFormError(t('error'))
@@ -519,9 +427,7 @@ export default function DesktopFundLibraryView() {
         body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: false, dca_monthly_amount_vnd: null }),
       })
       if (!res.ok) throw new Error()
-      bustCache()
-      await loadFunds(true)
-      notifyFundsUpdated()
+      await reload()
     } catch {
       setFunds(p => p.map(f => f.id === fund.id ? { ...f, is_dca: true } : f))
       addToast(t('toastDcaFailed'), false)
@@ -547,9 +453,7 @@ export default function DesktopFundLibraryView() {
         body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: amount, dca_goal_id: fund.dca_goal_id }),
       })
       if (!res.ok) throw new Error()
-      bustCache()
-      await loadFunds(true)
-      notifyFundsUpdated()
+      await reload()
     } catch {
       setFunds(p => p.map(f => f.id === fund.id ? { ...f, is_dca: false, dca_monthly_amount_vnd: null } : f))
       addToast(t('toastDcaFailed'), false)
@@ -569,9 +473,7 @@ export default function DesktopFundLibraryView() {
         body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: fund.dca_monthly_amount_vnd, dca_goal_id: goalId }),
       })
       if (!res.ok) throw new Error()
-      bustCache()
-      await loadFunds(true)
-      notifyFundsUpdated()
+      await reload()
     } catch {
       setFunds(p => p.map(f => f.id === fund.id ? { ...f, dca_goal_id: prevGoalId } : f))
       addToast(t('toastGoalFailed'), false)
@@ -588,9 +490,7 @@ export default function DesktopFundLibraryView() {
       const res = await fetch(`/api/funds/${deleteTarget.id}`, { method: 'DELETE' })
       if (!res.ok && res.status !== 204) throw new Error()
       setDeleteTarget(null)
-      bustCache()
-      await loadFunds(true)
-      notifyFundsUpdated()
+      await reload()
       addToast(t('toastDeleted'))
     } catch {
       addToast(t('toastDeleteFailed'), false)
@@ -712,8 +612,8 @@ export default function DesktopFundLibraryView() {
           </div>
         ) : error ? (
           <div className="cn-card" style={{ padding: 48, textAlign: 'center' }}>
-            <p style={{ color: 'var(--c-neg)', marginBottom: 16, fontSize: 14 }}>{error}</p>
-            <button onClick={() => loadFunds()} className="cn-btn primary" style={{ padding: '8px 20px' }}>{tc('tryAgain')}</button>
+            <p style={{ color: 'var(--c-neg)', marginBottom: 16, fontSize: 14 }}>{t('loadError')}</p>
+            <button onClick={() => reload()} className="cn-btn primary" style={{ padding: '8px 20px' }}>{tc('tryAgain')}</button>
           </div>
         ) : funds.length === 0 ? (
           <div className="cn-card" style={{ padding: 64 }}>

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -8,6 +8,7 @@ import { Skeleton } from '@/app/components/ui/Skeleton'
 import { SyncPill } from '@/app/components/ui/SyncPill'
 import { fmtNav, fmtCompact } from '@/lib/formatters'
 import { FundsEmptyState } from './FundsEmptyState'
+import type { Fund, Goal, FundType, FundsData } from './useFundsData'
 
 // Matches the design's exact icon paths (stroke-based, strokeWidth 1.75)
 const IconEdit = ({ size = 14, color = 'currentColor' }: { size?: number; color?: string }) => (
@@ -22,50 +23,12 @@ const IconTrash = ({ size = 14, color = 'currentColor' }: { size?: number; color
   </svg>
 )
 // ─── Types ───────────────────────────────────────────────────────────────────
-
-type FundType = 'balanced' | 'equity' | 'debt' | 'gold'
-
-type Fund = {
-  id: string
-  name: string
-  code: string
-  fund_type: FundType
-  nav: number
-  nav_source_url: string | null
-  is_dca: boolean
-  dca_monthly_amount_vnd: number | null
-  dca_goal_id: string | null
-  created_at: string
-  updated_at: string
-}
-
-type Goal = { goal_id: string; goal_name: string }
+// Fund/Goal/FundType are shared with the desktop view via useFundsData.
 
 type Toast = { id: number; message: string; type: 'success' | 'error' }
 type SortKey = 'code' | 'nav' | 'name'
 
 // ─── Constants ───────────────────────────────────────────────────────────────
-
-const CACHE_KEY = 'fundLibraryCache'
-const CACHE_TTL = 2 * 60 * 1000
-
-function getCache(): Fund[] | null {
-  try {
-    const raw = localStorage.getItem(CACHE_KEY)
-    if (!raw) return null
-    const { data, ts } = JSON.parse(raw)
-    if (Date.now() - ts > CACHE_TTL) return null
-    return data
-  } catch { return null }
-}
-
-function setCache(data: Fund[]) {
-  try { localStorage.setItem(CACHE_KEY, JSON.stringify({ data, ts: Date.now() })) } catch {}
-}
-
-function bustCache() {
-  try { localStorage.removeItem(CACHE_KEY) } catch {}
-}
 
 const TYPE_META: Record<FundType, { label: string; labelVi: string; color: string; bg: string }> = {
   equity:   { label: 'Stock',    labelVi: 'Cổ phiếu',   color: 'var(--c-fund-equity)',   bg: 'var(--c-fund-equity-bg)' },
@@ -89,14 +52,6 @@ const SORT_OPTIONS: Array<{ v: SortKey; key: 'colCode' | 'colNav' | 'colName' }>
 ]
 
 let toastSeq = 0
-
-// ─── Cross-view sync ──────────────────────────────────────────────────────────
-let _suppressNotify = false
-function notifyFundsUpdated() {
-  _suppressNotify = true
-  window.dispatchEvent(new CustomEvent('cairn:funds-updated'))
-  _suppressNotify = false
-}
 
 // ─── Sort dropdown ────────────────────────────────────────────────────────────
 
@@ -474,18 +429,15 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
-export default function MobileFundLibraryView() {
+export default function MobileFundLibraryView({ funds, setFunds, goals, loading, error, reload }: FundsData) {
   const t = useTranslations('funds')
   const tc = useTranslations('common')
   const locale = useLocale()
   const { setMobileTopBar } = useNavigation()
 
   // ── Data ──────────────────────────────────────────────────────────────────
-  const [funds, setFunds] = useState<Fund[]>(() => getCache() ?? [])
-  const [loading, setLoading] = useState(() => !getCache())
-  const [error, setError] = useState<string | null>(null)
+  // funds / goals / loading / error / reload come from FundLibraryClient (#10).
   const [refreshing, setRefreshing] = useState(false)
-  const [goals, setGoals] = useState<Goal[]>([])
 
   // ── UI state ──────────────────────────────────────────────────────────────
   const [query, setQuery] = useState('')
@@ -519,40 +471,6 @@ export default function MobileFundLibraryView() {
     setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 3000)
   }, [])
 
-  const loadFunds = useCallback(async (opts?: { force?: boolean }) => {
-    if (opts?.force) bustCache()
-    setError(null)
-    try {
-      const res = await fetch('/api/funds')
-      if (!res.ok) throw new Error()
-      const data = await res.json()
-      setCache(data.funds)
-      setFunds(data.funds)
-    } catch {
-      setError(t('loadError'))
-    } finally {
-      setLoading(false)
-    }
-  }, [t])
-
-  useEffect(() => { loadFunds() }, [loadFunds])
-
-  // Load savings goals once for the DCA target dropdown.
-  useEffect(() => {
-    let cancelled = false
-    fetch('/api/v1/savings-goals')
-      .then((res) => res.ok ? res.json() : { goals: [] })
-      .then(({ goals: data }) => { if (!cancelled) setGoals(data ?? []) })
-      .catch(() => {})
-    return () => { cancelled = true }
-  }, [])
-
-  useEffect(() => {
-    const handler = () => { if (!_suppressNotify) loadFunds({ force: true }) }
-    window.addEventListener('cairn:funds-updated', handler)
-    return () => window.removeEventListener('cairn:funds-updated', handler)
-  }, [loadFunds])
-
   const handleRefreshNav = useCallback(async () => {
     setRefreshing(true)
     try {
@@ -560,16 +478,14 @@ export default function MobileFundLibraryView() {
       const { results } = await res.json()
       const updated = results.filter((r: { nav?: number }) => r.nav !== undefined).length
       const failed = results.filter((r: { error?: string }) => r.error).length
-      bustCache()
-      await loadFunds({ force: true })
-      notifyFundsUpdated()
+      await reload()
       addToast(t('navRefreshDone', { updated, failed }), failed > 0 && updated === 0 ? 'error' : 'success')
     } catch {
       addToast(t('toastRefreshFailed'), 'error')
     } finally {
       setRefreshing(false)
     }
-  }, [loadFunds, addToast, t])
+  }, [reload, addToast, t])
 
   useEffect(() => {
     setMobileTopBar({
@@ -638,9 +554,7 @@ export default function MobileFundLibraryView() {
       }
       setAddOpen(false)
       setEditFund(null)
-      bustCache()
-      await loadFunds({ force: true })
-      notifyFundsUpdated()
+      await reload()
       addToast(existingId ? t('toastUpdated') : t('toastAdded'))
     } catch {
       setFormError(t('error'))
@@ -656,9 +570,7 @@ export default function MobileFundLibraryView() {
       const res = await fetch(`/api/funds/${deleteFund.id}`, { method: 'DELETE' })
       if (!res.ok && res.status !== 204) throw new Error()
       setDeleteFund(null)
-      bustCache()
-      await loadFunds({ force: true })
-      notifyFundsUpdated()
+      await reload()
       addToast(t('toastDeleted'))
     } catch {
       addToast(t('toastDeleteFailed'), 'error')
@@ -682,9 +594,7 @@ export default function MobileFundLibraryView() {
     try {
       const res = await fetch(`/api/funds/${fund.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: false, dca_monthly_amount_vnd: null }) })
       if (!res.ok) throw new Error()
-      bustCache()
-      await loadFunds({ force: true })
-      notifyFundsUpdated()
+      await reload()
     } catch {
       setFunds((prev) => prev.map((f) => f.id === fund.id ? { ...f, is_dca: true } : f))
       addToast(t('toastDcaFailed'), 'error')
@@ -706,9 +616,7 @@ export default function MobileFundLibraryView() {
     try {
       const res = await fetch(`/api/funds/${fund.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: amount, dca_goal_id: fund.dca_goal_id }) })
       if (!res.ok) throw new Error()
-      bustCache()
-      await loadFunds({ force: true })
-      notifyFundsUpdated()
+      await reload()
     } catch {
       setFunds((prev) => prev.map((f) => f.id === fund.id ? { ...f, is_dca: false, dca_monthly_amount_vnd: null } : f))
       addToast(t('toastDcaFailed'), 'error')
@@ -724,9 +632,7 @@ export default function MobileFundLibraryView() {
     try {
       const res = await fetch(`/api/funds/${fund.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: fund.dca_monthly_amount_vnd, dca_goal_id: goalId }) })
       if (!res.ok) throw new Error()
-      bustCache()
-      await loadFunds({ force: true })
-      notifyFundsUpdated()
+      await reload()
     } catch {
       setFunds((prev) => prev.map((f) => f.id === fund.id ? { ...f, dca_goal_id: prevGoalId } : f))
       addToast(t('toastGoalFailed'), 'error')
@@ -809,8 +715,8 @@ export default function MobileFundLibraryView() {
         {/* Error */}
         {!loading && error && (
           <div style={{ padding: '32px 20px', textAlign: 'center', background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 16 }}>
-            <p style={{ color: 'var(--c-neg)', fontSize: 13, margin: '0 0 12px' }}>{error}</p>
-            <button onClick={() => loadFunds()} style={{ padding: '8px 16px', fontSize: 13, fontWeight: 600, background: 'var(--c-btn-primary)', color: '#fff', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit' }}>
+            <p style={{ color: 'var(--c-neg)', fontSize: 13, margin: '0 0 12px' }}>{t('loadError')}</p>
+            <button onClick={() => reload()} style={{ padding: '8px 16px', fontSize: 13, fontWeight: 600, background: 'var(--c-btn-primary)', color: '#fff', border: 'none', borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit' }}>
               {tc('tryAgain')}
             </button>
           </div>

--- a/app/(app)/funds/components/useFundsData.ts
+++ b/app/(app)/funds/components/useFundsData.ts
@@ -1,0 +1,100 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+
+// ─── Shared types ─────────────────────────────────────────────────────────────
+
+export type FundType = 'balanced' | 'equity' | 'debt' | 'gold'
+
+export type Fund = {
+  id: string
+  name: string
+  code: string
+  fund_type: FundType
+  nav: number
+  nav_source_url: string | null
+  is_dca: boolean
+  dca_monthly_amount_vnd: number | null
+  dca_goal_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type Goal = { goal_id: string; goal_name: string }
+
+export interface FundsData {
+  funds: Fund[]
+  setFunds: Dispatch<SetStateAction<Fund[]>>
+  goals: Goal[]
+  loading: boolean
+  error: boolean
+  /** Bust the cache and refetch funds from the server. */
+  reload: () => Promise<void>
+}
+
+// ─── Cache ──────────────────────────────────────────────────────────────────
+
+const CACHE_KEY = 'fundLibraryCache'
+const CACHE_TTL = 2 * 60 * 1000
+
+function getCache(): Fund[] | null {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY)
+    if (!raw) return null
+    const { data, ts } = JSON.parse(raw)
+    if (Date.now() - ts > CACHE_TTL) return null
+    return data
+  } catch { return null }
+}
+function setCache(data: Fund[]) {
+  try { localStorage.setItem(CACHE_KEY, JSON.stringify({ data, ts: Date.now() })) } catch {}
+}
+function bustCache() {
+  try { localStorage.removeItem(CACHE_KEY) } catch {}
+}
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+// Single owner of the Fund Library's data layer. Both MobileFundLibraryView and
+// DesktopFundLibraryView are always mounted (FundLibraryClient renders both,
+// toggled by CSS). Owning funds + savings-goals here means one fetch on mount
+// and one reload per mutation instead of two of each — and the two views now
+// read the same shared state, so the old cross-view 'cairn:funds-updated' event
+// (and its _suppressNotify guard) is no longer needed (#10).
+export function useFundsData(): FundsData {
+  const [funds, setFunds] = useState<Fund[]>(() => getCache() ?? [])
+  const [loading, setLoading] = useState(() => !getCache())
+  const [error, setError] = useState(false)
+  const [goals, setGoals] = useState<Goal[]>([])
+
+  const reload = useCallback(async () => {
+    bustCache()
+    setError(false)
+    try {
+      const res = await fetch('/api/funds')
+      if (!res.ok) throw new Error()
+      const { funds: data } = await res.json()
+      setCache(data)
+      setFunds(data)
+    } catch {
+      setError(true)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { reload() }, [reload])
+
+  // Savings goals for the DCA target dropdown — loaded once.
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/v1/savings-goals')
+      .then((res) => res.ok ? res.json() : { goals: [] })
+      .then(({ goals: data }) => { if (!cancelled) setGoals(data ?? []) })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [])
+
+  return { funds, setFunds, goals, loading, error, reload }
+}


### PR DESCRIPTION
Last item from the funds-page review (the 🟢 "double fetch" note).

## Problem
Both views are always mounted (`FundLibraryClient` renders both, CSS-toggled), so each independently fetched `/api/funds` + `/api/v1/savings-goals` on mount (~4 requests) and reloaded on every mutation — kept in sync by a cross-view `cairn:funds-updated` event with a module-scoped `_suppressNotify` guard.

## Change
New `useFundsData` hook owns `funds` + `goals` + `loading` + `error` + `reload` (and the 2-min cache). `FundLibraryClient` calls it once and spreads it into both views as props. Because the two views now read one shared copy:
- the page fetches funds + goals **once**;
- a mutation in either view updates the shared state (the hidden view reflects it with **no reload**), so the `cairn:funds-updated` event + `_suppressNotify` are **deleted**;
- the duplicated `Fund`/`Goal`/`FundType` types + cache helpers collapse into the hook — one definition instead of two (net −88 lines).

## Verification
Pure refactor, no behavior change — the existing funds E2E suite is the regression gate:
- mobile funds **21✓**, desktop funds incl. the cross-view "DCA enabled on desktop reflects on mobile viewport" test **20✓**, input-zoom **4✓**
- `npm test -- --run` **809✓**, `npm run lint` 53 baseline (**0 new**, verified by stash-compare), `tsc` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)