### PR TITLE
fix(overview): address modal/sheet review findings

### DIFF
--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { X, TrendingUp, Building2, Coins, ArrowUpRight, ArrowDownRight, ArrowDownToLine, Wallet, Shield } from 'lucide-react'
-import { useTranslations } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { todayIso } from '@/lib/dates'
 
@@ -147,6 +147,7 @@ function groupThousands(value: string): string {
 export default function AddTransactionSheet({ open, onClose, onSaved, desktop, existing, prefill }: Props) {
   const t = useTranslations('addTx')
   const tc = useTranslations('common')
+  const isVI = useLocale() === 'vi'
 
   const [mounted, setMounted] = useState(open)
   const [funds, setFunds] = useState<Fund[]>([])
@@ -620,7 +621,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
           <div>
             <label style={labelStyle}>{t('assetType')}</label>
             <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 6 }}>
-              {ASSET_TYPES.map(({ v, Icon, enLabel, color, bg }) => {
+              {ASSET_TYPES.map(({ v, Icon, enLabel, viLabel, color, bg }) => {
                 const active = assetType === v
                 return (
                   <button
@@ -639,7 +640,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
                     }}
                   >
                     <Icon size={16} strokeWidth={active ? 2 : 1.6} />
-                    {enLabel}
+                    {isVI ? viLabel : enLabel}
                   </button>
                 )
               })}

--- a/app/assets/components/DownloadReportSheet.tsx
+++ b/app/assets/components/DownloadReportSheet.tsx
@@ -19,13 +19,14 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
   const [mounted, setMounted] = useState(false)
   const [exporting, setExporting] = useState(false)
   const [success, setSuccess] = useState(false)
-  const [format, setFormat] = useState<'pdf' | 'csv'>('pdf')
+  const [error, setError] = useState('')
 
   useEffect(() => {
     if (open) {
       setMounted(true)
       setSuccess(false)
       setExporting(false)
+      setError('')
     } else {
       const t = setTimeout(() => setMounted(false), 220)
       return () => clearTimeout(t)
@@ -34,12 +35,13 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
 
   async function handleExport() {
     setExporting(true)
+    setError('')
     try {
       await onExport()
       setSuccess(true)
       setTimeout(() => { onClose() }, 2000)
     } catch {
-      /* ignore */
+      setError(isVI ? 'Không thể xuất báo cáo. Vui lòng thử lại.' : 'Couldn’t export the report. Please try again.')
     }
     setExporting(false)
   }
@@ -57,7 +59,6 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
     goals: 'Mục tiêu đang theo dõi',
     sections: 'Nội dung báo cáo',
     includes: ['Tổng quan tài sản ròng', 'Chi tiết từng mục tiêu', 'Phân bổ theo loại tài sản', 'Khoản chưa phân bổ', 'Lịch sử giao dịch'],
-    format: 'Định dạng',
     export: 'Xuất báo cáo',
     cancel: 'Hủy',
     done: 'Đã xuất báo cáo',
@@ -71,7 +72,6 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
     goals: 'Goals tracked',
     sections: 'Report includes',
     includes: ['Net worth overview', 'Per-goal breakdown', 'Asset type allocation', 'Unallocated holdings', 'Transaction history'],
-    format: 'Format',
     export: 'Export report',
     cancel: 'Cancel',
     done: 'Report exported',
@@ -141,32 +141,10 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
                 </div>
               </div>
 
-              {/* Format picker */}
-              <div>
-                <div style={{ fontSize: 11, color: 'var(--c-muted)', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', marginBottom: 8 }}>
-                  {t.format}
-                </div>
-                <div style={{ display: 'flex', gap: 8 }}>
-                  {(['pdf', 'csv'] as const).map(f => (
-                    <button
-                      key={f}
-                      onClick={() => setFormat(f)}
-                      aria-pressed={format === f}
-                      style={{
-                        flex: 1, padding: '10px', borderRadius: 10,
-                        background: format === f ? 'var(--c-btn-primary)' : 'var(--c-card)',
-                        color: format === f ? '#fff' : 'var(--c-muted)',
-                        border: `1px solid ${format === f ? 'var(--c-btn-primary)' : 'var(--c-line)'}`,
-                        fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit',
-                        textTransform: 'uppercase', letterSpacing: '0.04em',
-                        transition: 'all 120ms',
-                      }}
-                    >
-                      {f}
-                    </button>
-                  ))}
-                </div>
-              </div>
+              {/* Export error */}
+              {error && (
+                <p role="alert" style={{ margin: 0, fontSize: 13, color: 'var(--c-neg, #dc2626)', textAlign: 'center' }}>{error}</p>
+              )}
 
               {/* Actions */}
               <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
@@ -186,7 +164,7 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
                   onClick={handleExport}
                   disabled={exporting}
                   data-testid="export-report-btn"
-                  aria-label={exporting ? 'exporting' : `${t.export} · ${format.toUpperCase()}`}
+                  aria-label={exporting ? 'exporting' : t.export}
                   style={{
                     flex: 2, padding: '11px 0', fontSize: 13, fontWeight: 600,
                     background: 'var(--c-btn-primary)', border: 'none',
@@ -204,7 +182,7 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
                   )}
                   {exporting
                     ? (isVI ? 'Đang xuất…' : 'Exporting…')
-                    : `${t.export} · ${format.toUpperCase()}`}
+                    : t.export}
                 </button>
               </div>
             </div>

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useMemo } from 'react'
-import { useLocale, useTranslations } from 'next-intl'
+import { useLocale } from 'next-intl'
 import { ArrowDownRight, ArrowDownToLine, Building, Check, Coins, Shield, TrendingUp, Wallet, X } from 'lucide-react'
 import { fmt } from '@/lib/formatters'
 import { todayIso } from '@/lib/dates'
@@ -60,7 +60,11 @@ const TYPE_COLOR = {
 
 export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValue, goalTargetAmount, onClose, onSuccess, desktop }: Props) {
   const locale = useLocale()
-  const t = useTranslations('Dashboard')
+  // Generic fallback shown when the API fails without a message. Inline-localized
+  // to match the rest of this file (no next-intl t() here).
+  const sellError = locale === 'vi'
+    ? 'Đã xảy ra lỗi. Vui lòng thử lại.'
+    : 'An error occurred. Please try again.'
 
   const [amount, setAmount] = useState('')
   const [units, setUnits] = useState('')
@@ -212,8 +216,8 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
           }),
         })
         if (!res.ok) {
-          const { error: e } = await res.json().catch(() => ({ error: t('sellError') }))
-          setError(e ?? t('sellError'))
+          const { error: e } = await res.json().catch(() => ({ error: sellError }))
+          setError(e ?? sellError)
           setSaving(false)
           return
         }
@@ -239,7 +243,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
         })
         if (!res.ok) {
           const { error: e } = await res.json()
-          setError(e ?? t('sellError'))
+          setError(e ?? sellError)
           setSaving(false)
           return
         }
@@ -266,7 +270,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
         })
         if (!res.ok) {
           const { error: e } = await res.json()
-          setError(e ?? t('sellError'))
+          setError(e ?? sellError)
           setSaving(false)
           return
         }
@@ -280,7 +284,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
         onClose()
       }, 2000)
     } catch {
-      setError(t('sellError'))
+      setError(sellError)
     }
     setSaving(false)
   }

--- a/app/assets/components/__tests__/AddTransactionSheet.test.tsx
+++ b/app/assets/components/__tests__/AddTransactionSheet.test.tsx
@@ -2,11 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import AddTransactionSheet from '../AddTransactionSheet'
 
+let mockLocale = 'en'
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key,
+  useLocale: () => mockLocale,
 }))
 
 beforeEach(() => {
+  mockLocale = 'en'
   document.body.style.overflow = ''
   vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => Promise.resolve([]) })))
 })
@@ -349,6 +352,27 @@ describe('AddTransactionSheet — gold unit (issue #232)', () => {
       expect(body.unit_price).toBe(9_200_000)  // ₫ per chỉ
       expect(body.amount_vnd).toBe(92_000_000) // total unchanged
     })
+  })
+})
+
+describe('AddTransactionSheet — asset-type chips are localized', () => {
+  // Regression: ASSET_TYPES carries viLabel but the chips rendered enLabel
+  // hardcoded, so the vi locale still showed "Fund / Bank / Gold".
+  it('renders English labels in the en locale', () => {
+    render(<AddTransactionSheet open onClose={vi.fn()} />)
+    expect(screen.getByText('Fund')).toBeInTheDocument()
+    expect(screen.getByText('Bank')).toBeInTheDocument()
+    expect(screen.getByText('Gold')).toBeInTheDocument()
+  })
+
+  it('renders Vietnamese labels in the vi locale', () => {
+    mockLocale = 'vi'
+    render(<AddTransactionSheet open onClose={vi.fn()} />)
+    expect(screen.getByText('Quỹ')).toBeInTheDocument()
+    expect(screen.getByText('Ngân hàng')).toBeInTheDocument()
+    expect(screen.getByText('Vàng')).toBeInTheDocument()
+    // The English labels must no longer be present.
+    expect(screen.queryByText('Fund')).not.toBeInTheDocument()
   })
 })
 

--- a/app/assets/components/__tests__/DownloadReportSheet.test.tsx
+++ b/app/assets/components/__tests__/DownloadReportSheet.test.tsx
@@ -56,31 +56,20 @@ describe('DownloadReportSheet — structure', () => {
   })
 })
 
-// ─── Format picker ─────────────────────────────────────────────────────────────
+// ─── Format ──────────────────────────────────────────────────────────────────────
+// The CSV option was a dead control (export always produced a PDF), so it was
+// removed — exports are PDF-only until a real CSV path exists.
 
-describe('DownloadReportSheet — format picker', () => {
-  it('renders Format label', () => {
+describe('DownloadReportSheet — format', () => {
+  it('does not render a CSV format option', () => {
     render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
-    expect(screen.getByText(/^format$/i)).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /^csv$/i })).not.toBeInTheDocument()
   })
 
-  it('renders PDF and CSV buttons', () => {
+  it('does not render a PDF/CSV picker toggle', () => {
     render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
-    expect(screen.getByRole('button', { name: /^pdf$/i })).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /^csv$/i })).toBeInTheDocument()
-  })
-
-  it('PDF is selected by default', () => {
-    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
-    const pdfBtn = screen.getByRole('button', { name: /^pdf$/i })
-    expect(pdfBtn).toHaveAttribute('aria-pressed', 'true')
-  })
-
-  it('selecting CSV updates selection', async () => {
-    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
-    await userEvent.click(screen.getByRole('button', { name: /^csv$/i }))
-    expect(screen.getByRole('button', { name: /^csv$/i })).toHaveAttribute('aria-pressed', 'true')
-    expect(screen.getByRole('button', { name: /^pdf$/i })).toHaveAttribute('aria-pressed', 'false')
+    // No format-picker buttons (aria-pressed toggles) remain.
+    expect(screen.queryByRole('button', { name: /^pdf$/i })).not.toBeInTheDocument()
   })
 })
 
@@ -104,15 +93,11 @@ describe('DownloadReportSheet — actions', () => {
     expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument()
   })
 
-  it('export button shows selected format', () => {
+  it('export button reads "Export report" without a format suffix', () => {
     render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
-    expect(screen.getByRole('button', { name: /export report · pdf/i })).toBeInTheDocument()
-  })
-
-  it('export button updates format label when CSV is selected', async () => {
-    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
-    await userEvent.click(screen.getByRole('button', { name: /^csv$/i }))
-    expect(screen.getByRole('button', { name: /export report · csv/i })).toBeInTheDocument()
+    const btn = screen.getByRole('button', { name: /export report/i })
+    expect(btn).toBeInTheDocument()
+    expect(btn.getAttribute('aria-label')).not.toMatch(/·/)
   })
 
   it('calls onClose when Cancel is clicked', async () => {
@@ -138,6 +123,15 @@ describe('DownloadReportSheet — actions', () => {
     await userEvent.click(screen.getByRole('button', { name: /export report/i }))
     expect(screen.getByRole('button', { name: /exporting/i })).toBeDisabled()
     resolve()
+  })
+
+  it('surfaces an error and re-enables the button when export fails', async () => {
+    const onExport = vi.fn().mockRejectedValue(new Error('boom'))
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={onExport} />)
+    await userEvent.click(screen.getByRole('button', { name: /export report/i }))
+    await waitFor(() => expect(screen.getByText(/couldn’t export|could not export|failed/i)).toBeInTheDocument())
+    // Not stuck in the exporting state.
+    expect(screen.getByRole('button', { name: /export report/i })).not.toBeDisabled()
   })
 })
 

--- a/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
+++ b/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
@@ -182,6 +182,30 @@ describe('SellWithdrawSheet — gold sell (quantity × price) (issue #232)', () 
   })
 })
 
+describe('SellWithdrawSheet — error path shows a real message (not a raw i18n key)', () => {
+  // Regression: the catch/!res.ok paths used useTranslations('Dashboard').t('sellError'),
+  // but that namespace/key never existed → the error path leaked a raw key or threw.
+  it('renders a localized error when the withdrawal fails without a server message', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) })))
+
+    const item = {
+      type: 'bank' as const, name: 'Techcombank',
+      currentValue: 5_000_000, interestRate: 6,
+      transactionId: 't1', purchasePrice: 5_000_000,
+    }
+    render(<SellWithdrawSheet item={item} open context="unallocated" onClose={vi.fn()} onSuccess={vi.fn()} />)
+
+    fireEvent.click(screen.getByTestId('sell-all-btn'))
+    fireEvent.click(screen.getByTestId('sell-confirm-btn'))
+
+    await waitFor(() => {
+      expect(screen.getByText(/an error occurred|please try again/i)).toBeInTheDocument()
+    })
+    // Must not leak the i18n key or its (wrong) namespace.
+    expect(screen.queryByText(/sellError|Dashboard\./)).not.toBeInTheDocument()
+  })
+})
+
 describe('SellWithdrawSheet — responsive presentation (#248)', () => {
   const item = {
     type: 'fund' as const, name: 'VESAF',

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -132,12 +132,12 @@ test('clicking Export data opens download report sheet', async ({ page }) => {
   await expect(page.locator('text=Portfolio report').first()).toBeVisible({ timeout: 8_000 })
 })
 
-test('download report sheet has format picker and export button', async ({ page }) => {
+test('download report sheet has an export button (PDF-only, no dead CSV picker)', async ({ page }) => {
   await page.getByRole('button', { name: /export data/i }).click()
   await expect(page.locator('text=Portfolio report').first()).toBeVisible({ timeout: 8_000 })
-  await expect(page.getByRole('button', { name: /^pdf$/i })).toBeVisible()
-  await expect(page.getByRole('button', { name: /^csv$/i })).toBeVisible()
   await expect(page.getByRole('button', { name: /export report/i })).toBeVisible()
+  // The CSV option was a dead control (always exported PDF) and was removed.
+  await expect(page.getByRole('button', { name: /^csv$/i })).toHaveCount(0)
 })
 
 test('download report sheet closes when X close button is clicked', async ({ page }) => {


### PR DESCRIPTION
## What

Fixes the four actionable findings from the **Overview modals & sheets** code review (`REVIEW-overview-modals.md`).

| # | Sev | Surface | Fix |
|---|-----|---------|-----|
| a | 🟡 | `SellWithdrawSheet` | `useTranslations('Dashboard')` — wrong namespace (only lowercase `dashboard` exists) **and** no `sellError` key, so the error path leaked a raw key or threw `MISSING_MESSAGE`. Replaced with an inline-localized string, matching the rest of the file. |
| b | 🟡 | `DownloadReportSheet` | Removed the PDF/CSV format picker. CSV was a **dead control** — `onExport()` took no args and always produced a PDF. Exports are now honestly PDF-only. |
| c | 🟢 | `DownloadReportSheet` | Export failures were swallowed (`catch {}`). Now sets an error and shows it (`role="alert"`), and the button re-enables. |
| d | 🟢 | `AddTransactionSheet` | Localized the asset-type chips. `ASSET_TYPES` carried `viLabel` but the chip rendered `enLabel` hardcoded → the vi locale showed "Fund / Bank / Gold". |

## Testing (TDD)
- Wrote/updated unit specs for each fix (red → green). Full unit suite: **810 passed**.
- Fixed `e2e/settings.spec.ts` which asserted the now-removed CSV button.
- Ran targeted E2E against the local stack: `report.spec.ts` + `settings.spec.ts` + `desktop-add-modals.spec.ts` → **46 passed**. (`desktop-add-modals` already uses bilingual regexes, so the chip localization is safe.)
- `npm run lint`: no new issues (identical 53/27/26 totals vs `main` — all pre-existing `react-hooks/set-state-in-effect` baseline).

## Out of scope
Wiring a real CSV export (chosen: drop the dead control). The review's systemic note about `isVi`-inline vs `next-intl t()` is left as-is — large, non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)