### PR TITLE
fix(nav): make mobile add-transaction FAB contextual

### DIFF
--- a/app/components/layouts/AuthenticatedLayout.tsx
+++ b/app/components/layouts/AuthenticatedLayout.tsx
@@ -4,11 +4,11 @@ import { useEffect, useState } from 'react'
 import { useRouter, usePathname } from 'next/navigation'
 import { createBrowserClient } from '@supabase/ssr'
 import { toast } from 'sonner'
-import { Plus } from 'lucide-react'
 import { NavigationProvider, useNavigation } from '../navigation/NavigationContext'
 import Sidebar from '../navigation/Sidebar'
 import Header from '../navigation/Header'
 import MobileBottomTabs from '../navigation/MobileBottomTabs'
+import MobileAddTransactionFab from '../navigation/MobileAddTransactionFab'
 import MobileTopBar from '../navigation/MobileTopBar'
 import OfflineBanner from '@/app/components/OfflineBanner'
 import AddTransactionSheet from '@/app/assets/components/AddTransactionSheet'
@@ -73,26 +73,9 @@ function AuthenticatedLayoutInner({ children, email, initials }: { children: Rea
         </main>
       </div>
 
-      {/* Mobile FAB — add transaction.
-          The button's inline `display: flex` would override a `md:hidden` class
-          (inline > class specificity), so the wrapper handles md+ hiding. */}
-      <div className="md:hidden">
-        <button
-          onClick={() => setShowAddTx(true)}
-          aria-label="Add transaction"
-          style={{
-            position: 'fixed', right: 16, bottom: 80,
-            width: 52, height: 52, borderRadius: 26,
-            background: 'var(--c-btn-primary)', color: '#fff',
-            border: 'none',
-            display: 'flex', alignItems: 'center', justifyContent: 'center',
-            boxShadow: '0 6px 16px rgba(15, 42, 74, 0.25), 0 2px 4px rgba(15, 42, 74, 0.1)',
-            cursor: 'pointer', zIndex: 35,
-          }}
-        >
-          <Plus size={22} strokeWidth={2.2} />
-        </button>
-      </div>
+      {/* Mobile FAB — add transaction. Contextual: only on Overview & Funds, and
+          it yields on Overview while term deposits need a maturity decision. */}
+      <MobileAddTransactionFab onClick={() => setShowAddTx(true)} />
 
       {/* Mobile bottom tab navigation */}
       <MobileBottomTabs />

--- a/app/components/navigation/MobileAddTransactionFab.tsx
+++ b/app/components/navigation/MobileAddTransactionFab.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { usePathname } from 'next/navigation'
+import { Plus } from 'lucide-react'
+import { useMaturingDepositsCount } from './useMaturingDepositsCount'
+
+// Where the mobile "add transaction" FAB is contextual. It only belongs on
+// Overview and Funds — on Plan you add via the plan's own rows, and Settings has
+// nothing to add. On Overview it additionally yields while term deposits need a
+// maturity decision, so the floating button can never sit on top of the
+// "Cần xử lý" card's action button.
+export function shouldShowMobileFab(pathname: string, maturingCount: number): boolean {
+  const onOverview = pathname.startsWith('/dashboard')
+  const onFunds = pathname.startsWith('/funds')
+  return (onOverview && maturingCount === 0) || onFunds
+}
+
+export default function MobileAddTransactionFab({ onClick }: { onClick: () => void }) {
+  const pathname = usePathname()
+  const maturingCount = useMaturingDepositsCount()
+
+  if (!shouldShowMobileFab(pathname, maturingCount)) return null
+
+  // The button's inline `display: flex` would override a `md:hidden` class
+  // (inline > class specificity), so the wrapper handles md+ hiding.
+  return (
+    <div className="md:hidden">
+      <button
+        onClick={onClick}
+        aria-label="Add transaction"
+        style={{
+          position: 'fixed', right: 16, bottom: 80,
+          width: 52, height: 52, borderRadius: 26,
+          background: 'var(--c-btn-primary)', color: '#fff',
+          border: 'none',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          boxShadow: '0 6px 16px rgba(15, 42, 74, 0.25), 0 2px 4px rgba(15, 42, 74, 0.1)',
+          cursor: 'pointer', zIndex: 35,
+        }}
+      >
+        <Plus size={22} strokeWidth={2.2} />
+      </button>
+    </div>
+  )
+}

--- a/app/components/navigation/__tests__/MobileAddTransactionFab.test.tsx
+++ b/app/components/navigation/__tests__/MobileAddTransactionFab.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { usePathname } from 'next/navigation'
+import MobileAddTransactionFab, { shouldShowMobileFab } from '../MobileAddTransactionFab'
+import { useMaturingDepositsCount } from '../useMaturingDepositsCount'
+
+vi.mock('next/navigation', () => ({ usePathname: vi.fn() }))
+vi.mock('../useMaturingDepositsCount', () => ({ useMaturingDepositsCount: vi.fn() }))
+
+const mockPathname = vi.mocked(usePathname)
+const mockCount = vi.mocked(useMaturingDepositsCount)
+
+function fab() {
+  return screen.queryByRole('button', { name: 'Add transaction' })
+}
+
+beforeEach(() => {
+  mockPathname.mockReturnValue('/dashboard')
+  mockCount.mockReturnValue(0)
+})
+
+describe('MobileAddTransactionFab — where it renders', () => {
+  it('shows on Overview when no maturities need a decision', () => {
+    mockPathname.mockReturnValue('/dashboard')
+    mockCount.mockReturnValue(0)
+    render(<MobileAddTransactionFab onClick={() => {}} />)
+    expect(fab()).toBeInTheDocument()
+  })
+
+  it('hides on Overview while term deposits need a maturity decision (so it cannot cover the action card)', () => {
+    mockPathname.mockReturnValue('/dashboard')
+    mockCount.mockReturnValue(2)
+    render(<MobileAddTransactionFab onClick={() => {}} />)
+    expect(fab()).not.toBeInTheDocument()
+  })
+
+  it('shows on Funds', () => {
+    mockPathname.mockReturnValue('/funds')
+    render(<MobileAddTransactionFab onClick={() => {}} />)
+    expect(fab()).toBeInTheDocument()
+  })
+
+  it('shows on Funds even when maturities are pending (Funds is not gated by maturity)', () => {
+    mockPathname.mockReturnValue('/funds')
+    mockCount.mockReturnValue(3)
+    render(<MobileAddTransactionFab onClick={() => {}} />)
+    expect(fab()).toBeInTheDocument()
+  })
+
+  it('shows on a Funds sub-route', () => {
+    mockPathname.mockReturnValue('/funds/abc-123')
+    render(<MobileAddTransactionFab onClick={() => {}} />)
+    expect(fab()).toBeInTheDocument()
+  })
+
+  it('hides on Plan (it has its own add affordances)', () => {
+    mockPathname.mockReturnValue('/planning')
+    render(<MobileAddTransactionFab onClick={() => {}} />)
+    expect(fab()).not.toBeInTheDocument()
+  })
+
+  it('hides on Settings (no add action there)', () => {
+    mockPathname.mockReturnValue('/settings')
+    render(<MobileAddTransactionFab onClick={() => {}} />)
+    expect(fab()).not.toBeInTheDocument()
+  })
+
+  it('calls onClick when tapped', () => {
+    const onClick = vi.fn()
+    mockPathname.mockReturnValue('/dashboard')
+    render(<MobileAddTransactionFab onClick={onClick} />)
+    fireEvent.click(fab()!)
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('shouldShowMobileFab — rule', () => {
+  it('Overview: shown only with zero maturing deposits', () => {
+    expect(shouldShowMobileFab('/dashboard', 0)).toBe(true)
+    expect(shouldShowMobileFab('/dashboard', 1)).toBe(false)
+  })
+
+  it('Funds: always shown regardless of maturities', () => {
+    expect(shouldShowMobileFab('/funds', 0)).toBe(true)
+    expect(shouldShowMobileFab('/funds', 5)).toBe(true)
+  })
+
+  it('Plan and Settings: never shown', () => {
+    expect(shouldShowMobileFab('/planning', 0)).toBe(false)
+    expect(shouldShowMobileFab('/settings', 0)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Problem

The mobile **Add transaction** FAB was rendered unconditionally in `AuthenticatedLayout`, so it appeared on **every** mobile route — including **Settings** and **Plan**, where it's out of context. With its fixed bottom-right position it could also sit on top of the dashboard maturity **"Cần xử lý"** card's action button.

This is the production counterpart of findings **#2** and **#3** in the design review `REVIEW-add-transaction.md` (the prototype was fixed separately on claude.ai/design). Findings #1 (gold provider) and #4 (linkage) were already clean in production, so this PR is FAB-only.

## Change

- New `MobileAddTransactionFab` component encapsulating the FAB + its visibility rule:
  - shows only on **Overview** (`/dashboard`) and **Funds** (`/funds`)
  - on Overview, **yields while term deposits need a maturity decision** (reuses the existing `useMaturingDepositsCount`), so it can't cover the maturity card's CTA
  - hidden on **Plan** (its own add affordances) and **Settings** (nothing to add)
- `AuthenticatedLayout` now renders `<MobileAddTransactionFab onClick=… />` instead of the inline button (−21/+4).
- Pure `shouldShowMobileFab(pathname, count)` helper exported for the rule.

## Tests (TDD)

New `MobileAddTransactionFab.test.tsx` — written first (red → green). Asserts the **rendered** outcome (button present/absent) across Overview (0 vs N maturing), Funds (incl. sub-route + pending maturities), Plan, Settings, and the click handler; plus unit tests for the rule.

## Verification

- `npm test -- --run` → 821 passed (73 files), incl. 11 new
- `npx eslint` on the changed files → clean (repo has pre-existing lint errors in untouched files: `ThemeProvider.tsx`, `OfflineBanner.tsx`)

Please confirm on the Vercel preview that the FAB is absent on Settings/Plan, present on Funds, and disappears on the dashboard when there are deposits awaiting a maturity decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)