### PR TITLE
fix(goals): require confirmation before deleting a goal on mobile

### DIFF
--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -133,8 +133,9 @@ function GoalActionsSheet({
             <ChevronRight size={16} color="var(--c-muted)" />
           </button>
 
-          {/* Delete */}
+          {/* Delete — opens a confirm step (does not delete on this tap) */}
           <button
+            data-testid="goal-delete-action"
             onClick={onDelete}
             disabled={isDeleting}
             style={{
@@ -168,6 +169,98 @@ function GoalActionsSheet({
           >
             {t.cancel}
           </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// Destructive-action confirm for the mobile goal-detail ⋯ menu. Mirrors the
+// desktop DeleteGoalModal so deleting a goal is never a single un-undoable tap.
+function DeleteGoalConfirmSheet({
+  open,
+  goalName,
+  isDeleting,
+  onCancel,
+  onConfirm,
+}: {
+  open: boolean
+  goalName: string
+  isDeleting: boolean
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  const isVI = useLocale() === 'vi'
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    if (open) setMounted(true)
+    else { const t = setTimeout(() => setMounted(false), 220); return () => clearTimeout(t) }
+  }, [open])
+  if (!mounted) return null
+
+  return (
+    <div
+      style={{
+        position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.2)',
+        zIndex: 170, pointerEvents: open ? 'auto' : 'none',
+      }}
+      onClick={() => { if (!isDeleting) onCancel() }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label={isVI ? 'Xoá mục tiêu?' : 'Delete goal?'}
+        style={{
+          position: 'absolute', bottom: 0, left: 0, right: 0,
+          background: 'var(--c-card)', borderRadius: '16px 16px 0 0',
+          padding: '0 0 env(safe-area-inset-bottom,0)',
+          animation: open
+            ? 'slide-up 220ms cubic-bezier(0.2, 0.8, 0.2, 1)'
+            : 'slide-down 180ms ease forwards',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '6px auto 14px' }} />
+        <div style={{ padding: '0 16px 24px', display: 'grid', gap: 16 }}>
+          <p style={{ margin: 0, fontWeight: 700, fontSize: 16, color: 'var(--c-ink)' }}>
+            {isVI ? 'Xoá mục tiêu?' : 'Delete goal?'}
+          </p>
+          <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '12px 14px', background: 'var(--c-neg-tint)', borderRadius: 10 }}>
+            <Trash2 size={15} color="var(--c-neg)" strokeWidth={2.2} style={{ flexShrink: 0, marginTop: 1 }} />
+            <p style={{ margin: 0, fontSize: 13, color: 'var(--c-neg)', lineHeight: 1.5 }}>
+              {isVI
+                ? `Mục tiêu "${goalName}" và tất cả liên kết đầu tư sẽ bị xoá vĩnh viễn.`
+                : `"${goalName}" and all linked investments will be permanently deleted.`}
+            </p>
+          </div>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <button
+              data-testid="goal-delete-cancel"
+              onClick={onCancel}
+              disabled={isDeleting}
+              style={{
+                flex: 1, padding: '12px 0', borderRadius: 10, border: '1px solid var(--c-line)',
+                background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 15,
+                cursor: isDeleting ? 'default' : 'pointer', fontFamily: 'inherit',
+              }}
+            >
+              {isVI ? 'Huỷ' : 'Cancel'}
+            </button>
+            <button
+              data-testid="goal-delete-confirm"
+              onClick={onConfirm}
+              disabled={isDeleting}
+              style={{
+                flex: 2, padding: '12px 0', borderRadius: 10, border: 'none',
+                background: 'var(--c-neg)', color: '#fff', fontSize: 15, fontWeight: 600,
+                cursor: isDeleting ? 'default' : 'pointer', opacity: isDeleting ? 0.6 : 1,
+                fontFamily: 'inherit', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6,
+              }}
+            >
+              <Trash2 size={15} />
+              {isDeleting ? (isVI ? 'Đang xoá…' : 'Deleting…') : (isVI ? 'Xoá mục tiêu' : 'Delete goal')}
+            </button>
+          </div>
         </div>
       </div>
     </div>
@@ -676,6 +769,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   const [txLoading, setTxLoading] = useState(false)
   const [actionsOpen, setActionsOpen] = useState(false)
   const [editOpen, setEditOpen] = useState(false)
+  const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [actionInv, setActionInv] = useState<InvRow | null>(null)
   const [investActionOpen, setInvestActionOpen] = useState(false)
@@ -693,6 +787,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
     if (open) {
       setMounted(true)
       setActiveTab('investments')
+      setConfirmDeleteOpen(false)
     } else {
       const t = setTimeout(() => setMounted(false), 220)
       return () => clearTimeout(t)
@@ -884,6 +979,8 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
               </h1>
             </div>
             <button
+              data-testid="goal-options-btn"
+              aria-label={isVI ? 'Tùy chọn mục tiêu' : 'Goal options'}
               onClick={() => setActionsOpen(true)}
               style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 6, color: 'var(--c-ink)', display: 'flex', alignItems: 'center', flexShrink: 0 }}
             >
@@ -1307,8 +1404,16 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
         open={actionsOpen}
         onClose={() => setActionsOpen(false)}
         onEdit={() => { setActionsOpen(false); setTimeout(() => setEditOpen(true), 60) }}
-        onDelete={handleDelete}
+        onDelete={() => { setActionsOpen(false); setTimeout(() => setConfirmDeleteOpen(true), 60) }}
         isDeleting={isDeleting}
+      />
+
+      <DeleteGoalConfirmSheet
+        open={confirmDeleteOpen}
+        goalName={goal.goalName}
+        isDeleting={isDeleting}
+        onCancel={() => setConfirmDeleteOpen(false)}
+        onConfirm={handleDelete}
       />
 
       {editOpen && (

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -99,7 +99,7 @@ describe('GoalDetailSheet — DCA pending row filtering', () => {
 
     render(<GoalDetailSheet {...baseProps} />)
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
     await waitFor(() => screen.getAllByText('Transaction history').length > 0)
     await userEvent.click(screen.getAllByText('Transaction history')[0])
     await waitFor(() => screen.getByRole('heading', { name: 'VNINDEX ETF' }))
@@ -169,7 +169,7 @@ describe('GoalDetailSheet — transaction history integration', () => {
     await waitFor(() => expect(screen.getByText('VNINDEX ETF')).toBeInTheDocument())
 
     // Tap the ⋯ options button on the fund row
-    const optionsBtn = screen.getByRole('button', { name: /options/i })
+    const optionsBtn = screen.getByRole('button', { name: 'Options', exact: true })
     await userEvent.click(optionsBtn)
 
     // InvestmentActionSheet appears — tap "Transaction history" action
@@ -186,7 +186,7 @@ describe('GoalDetailSheet — transaction history integration', () => {
     render(<GoalDetailSheet {...baseProps} />)
 
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
     await waitFor(() => screen.getAllByText('Transaction history').length > 0)
     await userEvent.click(screen.getAllByText('Transaction history')[0])
 
@@ -199,7 +199,7 @@ describe('GoalDetailSheet — transaction history integration', () => {
     render(<GoalDetailSheet {...baseProps} />)
 
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
     await waitFor(() => screen.getAllByText('Transaction history').length > 0)
     await userEvent.click(screen.getAllByText('Transaction history')[0])
     await waitFor(() => screen.getByRole('heading', { name: 'VNINDEX ETF' }))
@@ -218,7 +218,7 @@ describe('GoalDetailSheet — unassign from goal', () => {
   it('InvestmentActionSheet exposes an "Unassign from goal" option', async () => {
     render(<GoalDetailSheet {...baseProps} />)
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
     await waitFor(() =>
       expect(screen.getAllByText(/unassign from goal/i).length).toBeGreaterThan(0)
     )
@@ -227,7 +227,7 @@ describe('GoalDetailSheet — unassign from goal', () => {
   it('opens the confirmation sheet when Unassign is tapped', async () => {
     render(<GoalDetailSheet {...baseProps} />)
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
     await waitFor(() => screen.getAllByText(/unassign from goal/i).length > 0)
     // Click the action-sheet row labeled "Unassign from goal"
     await userEvent.click(screen.getAllByText(/unassign from goal/i)[0])
@@ -255,7 +255,7 @@ describe('GoalDetailSheet — unassign from goal', () => {
     const onDataChanged = vi.fn()
     render(<GoalDetailSheet {...baseProps} onDataChanged={onDataChanged} />)
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
     await waitFor(() => screen.getAllByText(/unassign from goal/i).length > 0)
     await userEvent.click(screen.getAllByText(/unassign from goal/i)[0])
     await waitFor(() => screen.getByText(/unassign from goal\?/i))
@@ -288,7 +288,7 @@ describe('GoalDetailSheet — unassign from goal', () => {
 
     render(<GoalDetailSheet {...baseProps} />)
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
     await waitFor(() => screen.getAllByText(/unassign from goal/i).length > 0)
     await userEvent.click(screen.getAllByText(/unassign from goal/i)[0])
     await waitFor(() => screen.getByText(/unassign from goal\?/i))
@@ -327,7 +327,7 @@ describe('GoalDetailSheet — investment options Sell / history (issue #224)', (
   it('opens the Sell sheet when "Sell" is tapped on a fund investment', async () => {
     render(<GoalDetailSheet {...baseProps} />)
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
     await waitFor(() => expect(screen.getByText('Sell')).toBeInTheDocument())
     await userEvent.click(screen.getByText('Sell'))
     await waitFor(() => expect(screen.getByTestId('sell-sheet')).toBeInTheDocument())
@@ -342,7 +342,7 @@ describe('GoalDetailSheet — investment options Sell / history (issue #224)', (
     })
     render(<GoalDetailSheet {...baseProps} goal={bankGoal} />)
     await waitFor(() => screen.getByText('Techcombank'))
-    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
     await waitFor(() => expect(screen.getByText('Withdraw')).toBeInTheDocument())
     await userEvent.click(screen.getByText('Withdraw'))
     await waitFor(() => expect(screen.getByTestId('sell-sheet')).toBeInTheDocument())
@@ -357,7 +357,7 @@ describe('GoalDetailSheet — investment options Sell / history (issue #224)', (
     })
     render(<GoalDetailSheet {...baseProps} goal={bankGoal} />)
     await waitFor(() => screen.getByText('Techcombank'))
-    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
     await waitFor(() => expect(screen.getByText('Transaction history')).toBeInTheDocument())
     await userEvent.click(screen.getByText('Transaction history'))
 
@@ -399,7 +399,7 @@ describe('GoalDetailSheet — bank maturity in Options sheet (issue #263)', () =
     })
     render(<GoalDetailSheet {...baseProps} goal={bankGoal} />)
     await waitFor(() => screen.getByText('Techcombank'))
-    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
 
     await waitFor(() => expect(screen.getByText('Maturity')).toBeInTheDocument())
     expect(screen.getByText('15 Aug 2030')).toBeInTheDocument()
@@ -443,7 +443,7 @@ describe('GoalDetailSheet — gold sell uses current price (issue #251)', () => 
 
     render(<GoalDetailSheet {...baseProps} goal={goldGoal} />)
     await waitFor(() => screen.getByText('PNJ Gold'))
-    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
     await waitFor(() => expect(screen.getByText('Sell')).toBeInTheDocument())
     await userEvent.click(screen.getByText('Sell'))
 
@@ -622,7 +622,7 @@ describe('GoalDetailSheet — refreshKey triggers refetch', () => {
     await waitFor(() => screen.getByText('VNINDEX ETF'))
 
     // 1) Unassign the tx
-    await userEvent.click(screen.getByRole('button', { name: /options/i }))
+    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
     await waitFor(() => screen.getAllByText(/unassign from goal/i).length > 0)
     await userEvent.click(screen.getAllByText(/unassign from goal/i)[0])
     await waitFor(() => screen.getByText(/unassign from goal\?/i))

--- a/e2e/goals.spec.ts
+++ b/e2e/goals.spec.ts
@@ -120,3 +120,42 @@ test('can delete a savings goal from the goal detail panel', async ({ page }) =>
 
   await expect.poll(async () => await api.findGoalByName('E2E Dash Delete Goal'), { timeout: 10_000 }).toBeFalsy()
 })
+
+// Mobile goal-detail is a full-screen sheet (GoalDetailSheet), distinct from the
+// desktop right panel. Deleting from its ⋯ menu must require a confirm step —
+// previously it deleted on a single tap with no undo (data-loss).
+test.describe('mobile goal-detail', () => {
+  test.use({ viewport: { width: 390, height: 844 } })
+
+  test('deleting a goal requires confirmation and does not delete on the menu tap', async ({ page }) => {
+    const goal = await api.createGoal({ goal_name: 'E2E Mobile Delete Goal' })
+    cleanup.add(() => api.deleteGoal(goal.goal_id))
+
+    await gotoDashboardFresh(page)
+    // Tap the goal card → full-screen mobile detail sheet.
+    await page.getByText('E2E Mobile Delete Goal').first().click()
+    await expect(page.getByTestId('goal-back-btn')).toBeVisible({ timeout: 10_000 })
+
+    // ⋯ → Delete goal (opens the actions sheet, then the confirm).
+    await page.getByTestId('goal-options-btn').click()
+    await page.getByTestId('goal-delete-action').click()
+
+    // A confirm dialog appears and NOTHING is deleted yet.
+    const confirmBtn = page.getByTestId('goal-delete-confirm')
+    await expect(confirmBtn).toBeVisible()
+    // Give any (buggy) immediate-delete a chance to fire before asserting survival.
+    await page.waitForTimeout(500)
+    expect(await api.findGoalByName('E2E Mobile Delete Goal')).toBeTruthy()
+
+    // Cancel keeps the goal; re-open and confirm actually deletes it.
+    await page.getByTestId('goal-delete-cancel').click()
+    await expect(confirmBtn).toBeHidden()
+    expect(await api.findGoalByName('E2E Mobile Delete Goal')).toBeTruthy()
+
+    await page.getByTestId('goal-options-btn').click()
+    await page.getByTestId('goal-delete-action').click()
+    await page.getByTestId('goal-delete-confirm').click()
+
+    await expect.poll(async () => await api.findGoalByName('E2E Mobile Delete Goal'), { timeout: 10_000 }).toBeFalsy()
+  })
+})


### PR DESCRIPTION
## Vấn đề (UX audit — P1 reversibility)

Trên **mobile**, menu ⋯ trong goal-detail xoá mục tiêu (và huỷ liên kết toàn bộ đầu tư) **chỉ với một chạm, không xác nhận** — trong khi **desktop** đã gate hành động này sau một `DeleteGoalModal`. Cùng một sản phẩm, mobile lại nguy hiểm hơn → đây là rủi ro "lỡ tay xoá mất" nghiêm trọng nhất phát hiện trong đợt rà UX trang Overview.

## Thay đổi

- Thêm `DeleteGoalConfirmSheet` (bottom sheet, mirror copy + style của desktop `DeleteGoalModal`): cảnh báo đỏ nêu tên mục tiêu, Huỷ / Xoá.
- Chạm "Xoá mục tiêu" trong menu giờ **mở confirm**; lệnh `DELETE` chỉ chạy khi bấm xác nhận. Reset confirm khi sheet đóng/mở lại.
- Thêm `aria-label` cho nút options mobile + testid (`goal-options-btn`, `goal-delete-action`, `goal-delete-confirm`, `goal-delete-cancel`).

## Test (TDD)

- **E2E mới** (`e2e/goals.spec.ts`, mobile viewport): khẳng định chạm menu **không** xoá (mục tiêu còn tồn tại sau 500ms), confirm hiện ra, Huỷ giữ lại, chỉ confirm mới xoá. → đóng vòng UI action → kết quả thực.
- **Unit**: scope 14 query về nút "Options" cấp dòng (`exact: true`) để không khớp nhầm nút header mới.

## Đã chạy local (gate trước PR)

- ✅ `npm test -- --run` — 821 passed (73 files)
- ✅ `npx playwright test e2e/goals.spec.ts --project=chromium` — 6/6 passed (gồm test mobile mới)
- ✅ `npm run lint` — không thêm loại lỗi mới; chỉ phát sinh thêm 1 instance của rule `react-hooks/set-state-in-effect` đã pre-existing toàn repo (cùng pattern mount-sheet với 5 component anh em trong chính file này)

## Phạm vi

Chỉ đụng mobile `GoalDetailSheet`; desktop (`DesktopGoalDetail`) không đổi. Đây là PR-A trong loạt fix reversibility — phần "undo thanh toán bảo hiểm" tách sang PR riêng (cần thêm endpoint backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)