### PR TITLE
fix(overview): show retry state instead of empty when a sheet's fetch fails

### DIFF
--- a/app/assets/components/AssignGoalSheet.tsx
+++ b/app/assets/components/AssignGoalSheet.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { Check, X, TrendingUp, Building2, Coins, ArrowRight } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmt, fmtCompact } from '@/lib/formatters'
+import LoadError from './LoadError'
 
 interface GoalOption {
   id: string
@@ -45,11 +46,33 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, item, deskto
   const [mounted, setMounted] = useState(false)
   const [goals, setGoals] = useState<GoalOption[]>([])
   const [goalsLoading, setGoalsLoading] = useState(false)
+  const [goalsError, setGoalsError] = useState(false)
   const [selected, setSelected] = useState<string | null>(null)
   const [confirming, setConfirming] = useState(false)
   const [error, setError] = useState('')
   const [success, setSuccess] = useState(false)
   const [successName, setSuccessName] = useState('')
+
+  // A failed goals fetch shows a retry state — never an empty "no goals" list,
+  // which would read as "you have no goals" on a transient network error.
+  const loadGoals = useCallback(() => {
+    setGoalsLoading(true)
+    setGoalsError(false)
+    fetch('/api/v1/savings-goals?stats=true')
+      .then((r) => { if (!r.ok) throw new Error('load failed'); return r.json() })
+      .then((res: { goals?: Array<{ goal_id: string; goal_name: string; current_value?: number; target_amount?: number | null; progress_percentage?: number | null }> }) => {
+        const rows = res.goals ?? []
+        setGoals(rows.map((g) => ({
+          id: g.goal_id,
+          name: g.goal_name,
+          currentValue: g.current_value ?? 0,
+          targetAmount: g.target_amount ?? null,
+          progressPercent: g.progress_percentage ?? null,
+        })))
+      })
+      .catch(() => setGoalsError(true))
+      .finally(() => setGoalsLoading(false))
+  }, [])
 
   useEffect(() => {
     if (open) {
@@ -57,26 +80,12 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, item, deskto
       setSelected(null)
       setError('')
       setSuccess(false)
-      setGoalsLoading(true)
-      fetch('/api/v1/savings-goals?stats=true')
-        .then((r) => r.ok ? r.json() : { goals: [] })
-        .then((res: { goals?: Array<{ goal_id: string; goal_name: string; current_value?: number; target_amount?: number | null; progress_percentage?: number | null }> }) => {
-          const rows = res.goals ?? []
-          setGoals(rows.map((g) => ({
-            id: g.goal_id,
-            name: g.goal_name,
-            currentValue: g.current_value ?? 0,
-            targetAmount: g.target_amount ?? null,
-            progressPercent: g.progress_percentage ?? null,
-          })))
-        })
-        .catch(() => setGoals([]))
-        .finally(() => setGoalsLoading(false))
+      loadGoals()
     } else {
       const t = setTimeout(() => setMounted(false), 220)
       return () => clearTimeout(t)
     }
-  }, [open])
+  }, [open, loadGoals])
 
   async function handleConfirm() {
     if (!selected) return
@@ -155,12 +164,15 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, item, deskto
               {isVI ? 'Đang tải…' : 'Loading…'}
             </p>
           )}
-          {!goalsLoading && goals.length === 0 && (
+          {!goalsLoading && goalsError && (
+            <LoadError isVI={isVI} onRetry={loadGoals} retrying={goalsLoading} />
+          )}
+          {!goalsLoading && !goalsError && goals.length === 0 && (
             <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0', margin: 0 }}>
               {isVI ? 'Chưa có mục tiêu nào' : 'No goals yet'}
             </p>
           )}
-          {!goalsLoading && goals.map((g) => {
+          {!goalsLoading && !goalsError && goals.map((g) => {
             const isSel = selected === g.id
             const isComplete = g.progressPercent != null && g.progressPercent >= 100
             const remaining = g.targetAmount != null ? Math.max(0, g.targetAmount - g.currentValue) : null

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -8,6 +8,7 @@ import { GD_COLORS, buildCompositionSegments, calcDeadlineMonths, TypeIcon, Unli
 import { MaturityResolveModal } from './MaturityResolveSheet'
 import { fmtTxDate, txKind } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
+import LoadError from './LoadError'
 import { todayIso } from '@/lib/dates'
 
 interface InvestmentTx {
@@ -59,6 +60,9 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
   const [transactions, setTransactions] = useState<InvestmentTx[]>([])
   const [goldPricePerChi, setGoldPricePerChi] = useState<number | null>(null)
   const [txLoading, setTxLoading] = useState(false)
+  const [txError, setTxError] = useState(false)
+  // Bumped by the retry button to re-run the transactions fetch.
+  const [txReload, setTxReload] = useState(0)
   const [actionsOpen, setActionsOpen] = useState(false)
   const [editOpen, setEditOpen] = useState(false)
   const [deleteOpen, setDeleteOpen] = useState(false)
@@ -76,6 +80,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
 
   useEffect(() => {
     setTxLoading(true)
+    setTxError(false)
     // The new server response is the source of truth — drop any locally
     // hidden tx IDs from the unassign flow so a re-assigned tx isn't stuck
     // behind the optimistic filter on subsequent refreshes.
@@ -85,17 +90,21 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
     // Recurring savings are plan-only (no investment_transactions row), so fetch
     // their realized contributions separately and merge into the history list.
     Promise.all([
+      // The investments list is built from these rows — a failed fetch must
+      // surface a retry, not render as "No investments yet".
       fetch(`/api/v1/investment-transactions?goal_id=${goal.goalId}&limit=200&include_history=true`, { cache: 'no-store' })
-        .then((r) => r.ok ? r.json() : { transactions: [] }),
+        .then((r) => { if (!r.ok) throw new Error('load failed'); return r.json() }),
+      // Recurring contributions are supplementary — degrade to empty on failure.
       fetch(`/api/v1/savings-goals/${goal.goalId}/recurring-contributions`, { cache: 'no-store' })
-        .then((r) => r.ok ? r.json() : { contributions: [] }),
+        .then((r) => r.ok ? r.json() : { contributions: [] })
+        .catch(() => ({ contributions: [] })),
     ])
       .then(([txRes, recRes]) => {
         const merged: InvestmentTx[] = [...(txRes.transactions ?? []), ...(recRes.contributions ?? [])]
         merged.sort((a, b) => (a.investment_date < b.investment_date ? 1 : a.investment_date > b.investment_date ? -1 : 0))
         setTransactions(merged)
       })
-      .catch(() => setTransactions([]))
+      .catch(() => { setTransactions([]); setTxError(true) })
       .finally(() => setTxLoading(false))
     // Gold is valued at the live market price per chỉ, not its purchase cost —
     // without this the sell modal would prefill the stale buy price (issue #251).
@@ -103,7 +112,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
       .then((r) => r.ok ? r.json() : null)
       .then((res) => setGoldPricePerChi(res?.price_per_chi ?? null))
       .catch(() => setGoldPricePerChi(null))
-  }, [goal.goalId, refreshKey])
+  }, [goal.goalId, refreshKey, txReload])
 
   // Reset tab when the selected goal itself changes.
   useEffect(() => {
@@ -349,7 +358,10 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                 </div>
               )}
               {txLoading && <TxRowsSkeleton />}
-              {!txLoading && visibleInvRows.length === 0 && (
+              {!txLoading && txError && (
+                <LoadError isVI={isVi} onRetry={() => setTxReload((n) => n + 1)} compact />
+              )}
+              {!txLoading && !txError && visibleInvRows.length === 0 && (
                 <p style={{ color: 'var(--c-muted)', fontSize: 13, textAlign: 'center', padding: '20px 0' }}>
                   {isVi ? 'Chưa có khoản đầu tư nào' : 'No investments yet'}
                 </p>
@@ -499,7 +511,10 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
           {tab === 'history' && (
             <>
               {txLoading && <TxRowsSkeleton />}
-              {!txLoading && transactions.length === 0 && (
+              {!txLoading && txError && (
+                <LoadError isVI={isVi} onRetry={() => setTxReload((n) => n + 1)} compact />
+              )}
+              {!txLoading && !txError && transactions.length === 0 && (
                 <p style={{ color: 'var(--c-muted)', fontSize: 13, textAlign: 'center', padding: '20px 0' }}>
                   {isVi ? 'Chưa có giao dịch nào' : 'No transactions yet'}
                 </p>

--- a/app/assets/components/DesktopInsuranceDetail.tsx
+++ b/app/assets/components/DesktopInsuranceDetail.tsx
@@ -7,6 +7,7 @@ import { STATUS_COLOR, BAR_COLOR_DETAIL, COVERAGE_OPTIONS, insurancePaidState, i
 import type { InsuranceData } from '../DashboardClient'
 import LogInsurancePaymentModal from './LogInsurancePaymentModal'
 import { TxRowsSkeleton } from './Skeletons'
+import LoadError from './LoadError'
 
 interface Props {
   ins: InsuranceData
@@ -59,6 +60,7 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
 
   const [history, setHistory] = useState<HistoryEntry[] | null>(null)
   const [historyLoading, setHistoryLoading] = useState(false)
+  const [historyError, setHistoryError] = useState(false)
 
   // Sync edit form when target member changes
   useEffect(() => {
@@ -70,18 +72,21 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
     setEditError(null)
   }, [ins.insuranceId, ins.insuranceName, ins.coverageType, ins.annualPremium, ins.nextPaymentDate])
 
+  // A failed history fetch shows a retry state — never "No payments yet", which
+  // would falsely imply a paying member never paid on a transient error.
   const loadHistory = useCallback(async () => {
     setHistoryLoading(true)
+    setHistoryError(false)
     try {
       const res = await fetch(`/api/v1/insurance-members/${ins.insuranceId}/savings`)
       if (res.ok) {
         const j = await res.json()
         setHistory(j.entries ?? [])
       } else {
-        setHistory([])
+        setHistoryError(true)
       }
     } catch {
-      setHistory([])
+      setHistoryError(true)
     } finally {
       setHistoryLoading(false)
     }
@@ -364,6 +369,8 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
             </div>
             {historyLoading && history === null ? (
               <TxRowsSkeleton rows={3} />
+            ) : historyError ? (
+              <LoadError isVI={isVi} onRetry={loadHistory} retrying={historyLoading} compact />
             ) : !history || history.length === 0 ? (
               <div style={{ padding: '14px 16px', fontSize: 12, color: 'var(--c-muted)' }}>
                 {isVi ? 'Chưa có giao dịch' : 'No payments yet'}

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -14,6 +14,7 @@ import { MaturityResolveSheet } from './MaturityResolveSheet'
 import { GD_COLORS, buildCompositionSegments, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { fmtTxDate, txKind } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
+import LoadError from './LoadError'
 
 interface InvestmentTx {
   transaction_id: string
@@ -767,6 +768,9 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   const [transactions, setTransactions] = useState<InvestmentTx[]>([])
   const [goldPricePerChi, setGoldPricePerChi] = useState<number | null>(null)
   const [txLoading, setTxLoading] = useState(false)
+  const [txError, setTxError] = useState(false)
+  // Bumped by the retry button to re-run the transactions fetch.
+  const [txReload, setTxReload] = useState(0)
   const [actionsOpen, setActionsOpen] = useState(false)
   const [editOpen, setEditOpen] = useState(false)
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false)
@@ -797,6 +801,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   useEffect(() => {
     if (!open || !goal) return
     setTxLoading(true)
+    setTxError(false)
     // The new server response is the source of truth — drop any locally
     // hidden tx IDs from the unassign flow so a re-assigned tx isn't stuck
     // behind the optimistic filter on subsequent refreshes.
@@ -806,17 +811,21 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
     // Recurring savings are plan-only (no investment_transactions row), so fetch
     // their realized contributions separately and merge into the history list.
     Promise.all([
+      // The investments list is built from these rows — a failed fetch must
+      // surface a retry, not render as "No investments yet".
       fetch(`/api/v1/investment-transactions?goal_id=${goal.goalId}&limit=200&include_history=true`, { cache: 'no-store' })
-        .then((r) => r.ok ? r.json() : { transactions: [] }),
+        .then((r) => { if (!r.ok) throw new Error('load failed'); return r.json() }),
+      // Recurring contributions are supplementary — degrade to empty on failure.
       fetch(`/api/v1/savings-goals/${goal.goalId}/recurring-contributions`, { cache: 'no-store' })
-        .then((r) => r.ok ? r.json() : { contributions: [] }),
+        .then((r) => r.ok ? r.json() : { contributions: [] })
+        .catch(() => ({ contributions: [] })),
     ])
       .then(([txRes, recRes]) => {
         const merged: InvestmentTx[] = [...(txRes.transactions ?? []), ...(recRes.contributions ?? [])]
         merged.sort((a, b) => (a.investment_date < b.investment_date ? 1 : a.investment_date > b.investment_date ? -1 : 0))
         setTransactions(merged)
       })
-      .catch(() => setTransactions([]))
+      .catch(() => { setTransactions([]); setTxError(true) })
       .finally(() => setTxLoading(false))
     // Gold is valued at the live market price per chỉ, not its purchase cost —
     // without this the sell sheet would prefill the stale buy price (issue #251).
@@ -824,7 +833,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
       .then((r) => r.ok ? r.json() : null)
       .then((res) => setGoldPricePerChi(res?.price_per_chi ?? null))
       .catch(() => setGoldPricePerChi(null))
-  }, [open, goal, refreshKey])
+  }, [open, goal, refreshKey, txReload])
 
   async function handleDelete() {
     if (!goal) return
@@ -1136,7 +1145,10 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
                 </div>
               )}
               {txLoading && <TxRowsSkeleton />}
-              {!txLoading && invRows.length === 0 && (
+              {!txLoading && txError && (
+                <LoadError isVI={isVI} onRetry={() => setTxReload((n) => n + 1)} />
+              )}
+              {!txLoading && !txError && invRows.length === 0 && (
                 <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0' }}>
                   {isVI ? 'Chưa có khoản đầu tư nào' : 'No investments yet'}
                 </p>
@@ -1335,7 +1347,10 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
           {activeTab === 'history' && (
             <div style={{ background: 'var(--c-card)', borderRadius: 16, padding: '0 14px', boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }}>
               {txLoading && <TxRowsSkeleton />}
-              {!txLoading && transactions.length === 0 && (
+              {!txLoading && txError && (
+                <LoadError isVI={isVI} onRetry={() => setTxReload((n) => n + 1)} />
+              )}
+              {!txLoading && !txError && transactions.length === 0 && (
                 <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0' }}>
                   {isVI ? 'Chưa có giao dịch nào' : 'No transactions yet'}
                 </p>

--- a/app/assets/components/LoadError.tsx
+++ b/app/assets/components/LoadError.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { RefreshCw } from 'lucide-react'
+
+/**
+ * Inline "couldn't load — try again" state for sheets/panels that fetch their
+ * own data. Use this instead of falling back to an empty list on a failed
+ * fetch, so a transient network error never reads as "you have no data".
+ * The retry button re-runs the loader.
+ *
+ * `isVI` is passed explicitly (not read via useLocale) so this works in the
+ * desktop panels that thread locale through props and render without an intl
+ * provider.
+ */
+export default function LoadError({
+  isVI,
+  onRetry,
+  retrying,
+  compact,
+}: {
+  isVI: boolean
+  onRetry: () => void
+  retrying?: boolean
+  compact?: boolean
+}) {
+  return (
+    <div
+      data-testid="load-error"
+      role="alert"
+      style={{
+        display: 'grid', gap: 10, justifyItems: 'center', textAlign: 'center',
+        padding: compact ? '16px 0' : '24px 0',
+      }}
+    >
+      <p style={{ margin: 0, fontSize: 13, color: 'var(--c-muted)', lineHeight: 1.5 }}>
+        {isVI ? 'Không tải được dữ liệu' : "Couldn't load data"}
+      </p>
+      <button
+        type="button"
+        data-testid="load-error-retry"
+        onClick={onRetry}
+        disabled={retrying}
+        style={{
+          display: 'inline-flex', alignItems: 'center', gap: 6,
+          padding: '7px 14px', borderRadius: 8,
+          border: '1px solid var(--c-line)', background: 'var(--c-card)',
+          color: 'var(--c-ink)', fontSize: 13, fontWeight: 600, fontFamily: 'inherit',
+          cursor: retrying ? 'default' : 'pointer', opacity: retrying ? 0.6 : 1,
+        }}
+      >
+        <RefreshCw size={13} strokeWidth={2.2} style={{ animation: retrying ? 'spin 1s linear infinite' : undefined }} />
+        {isVI ? 'Thử lại' : 'Try again'}
+      </button>
+    </div>
+  )
+}

--- a/app/assets/components/__tests__/AssignGoalSheet.test.tsx
+++ b/app/assets/components/__tests__/AssignGoalSheet.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
+import AssignGoalSheet from '../AssignGoalSheet'
+
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
+  useTranslations: () => (k: string) => k,
+}))
+
+const baseProps = {
+  open: true,
+  desktop: true,
+  onClose: vi.fn(),
+  onConfirm: vi.fn(),
+  item: { name: 'Techcombank', value: 50_000_000, type: 'bank' },
+}
+
+describe('AssignGoalSheet — goals load error vs empty', () => {
+  it('shows a retry state (not "No goals yet") when the goals fetch fails', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) })
+
+    render(<AssignGoalSheet {...baseProps} />)
+
+    await waitFor(() => expect(screen.getByTestId('load-error')).toBeInTheDocument())
+    expect(screen.queryByText('No goals yet')).not.toBeInTheDocument()
+  })
+
+  it('retry re-fetches and renders the goals on success', async () => {
+    let call = 0
+    global.fetch = vi.fn().mockImplementation(() => {
+      call += 1
+      if (call === 1) return Promise.resolve({ ok: false, json: async () => ({}) })
+      return Promise.resolve({
+        ok: true,
+        json: async () => ({ goals: [{ goal_id: 'g1', goal_name: 'House Fund', current_value: 1_000_000 }] }),
+      })
+    })
+
+    render(<AssignGoalSheet {...baseProps} />)
+    await waitFor(() => expect(screen.getByTestId('load-error')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('load-error-retry'))
+
+    await waitFor(() => expect(screen.getByText('House Fund')).toBeInTheDocument())
+    expect(screen.queryByTestId('load-error')).not.toBeInTheDocument()
+  })
+})

--- a/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
@@ -25,6 +25,43 @@ const baseProps = {
   onDataChanged: vi.fn(),
 }
 
+describe('DesktopGoalDetail — investments load error vs empty', () => {
+  const mockBankTx = {
+    transaction_id: 'tx-bank-err', transaction_type: 'investment', asset_type: 'bank',
+    fund_id: null, fund_name: null, investment_date: '2026-01-01', amount_vnd: 9_000_000,
+    units: null, interest_rate: 6.5, notes: 'Techcombank', principal_withdrawn: null, units_withdrawn: null,
+  }
+
+  it('shows a retry state (not "No investments yet") when the transactions fetch fails', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) })
+
+    render(<DesktopGoalDetail {...baseProps} />)
+
+    await waitFor(() => expect(screen.getByTestId('load-error')).toBeInTheDocument())
+    expect(screen.queryByText('No investments yet')).not.toBeInTheDocument()
+  })
+
+  it('retry re-fetches and renders the investments on success', async () => {
+    let call = 0
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        call += 1
+        if (call === 1) return Promise.resolve({ ok: false, json: async () => ({}) })
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [mockBankTx] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    render(<DesktopGoalDetail {...baseProps} />)
+    await waitFor(() => expect(screen.getByTestId('load-error')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByTestId('load-error-retry'))
+
+    await waitFor(() => expect(screen.getByText('Techcombank')).toBeInTheDocument())
+    expect(screen.queryByTestId('load-error')).not.toBeInTheDocument()
+  })
+})
+
 describe('DesktopGoalDetail — gold sell uses current price (issue #251)', () => {
   // Bought 1 chỉ at 9,000,000. Current market price is 9,200,000.
   const mockGoldTx = {

--- a/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
@@ -56,6 +56,40 @@ describe('DesktopInsuranceDetail — payment history (issue #223)', () => {
   })
 })
 
+describe('DesktopInsuranceDetail — history load error vs empty', () => {
+  it('shows a retry state (not "No payments yet") when the savings fetch fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) })))
+
+    render(<DesktopInsuranceDetail ins={ins} locale="en" onClose={vi.fn()} />)
+
+    expect(await screen.findByTestId('load-error')).toBeInTheDocument()
+    expect(screen.queryByText('No payments yet')).not.toBeInTheDocument()
+  })
+
+  it('retry re-fetches and renders the history on success', async () => {
+    let call = 0
+    vi.stubGlobal('fetch', vi.fn((url: string) => {
+      if (typeof url === 'string' && url.includes('/savings')) {
+        call += 1
+        if (call === 1) return Promise.resolve({ ok: false, json: () => Promise.resolve({}) })
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ entries: [{ id: 's1', amount: 1_500_000, date: '2026-03-15', kind: 'logged' }] }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    }))
+
+    render(<DesktopInsuranceDetail ins={ins} locale="en" onClose={vi.fn()} />)
+    expect(await screen.findByTestId('load-error')).toBeInTheDocument()
+
+    fireEvent.click(screen.getByTestId('load-error-retry'))
+
+    expect(await screen.findByText('Logged payment')).toBeInTheDocument()
+    expect(screen.queryByTestId('load-error')).not.toBeInTheDocument()
+  })
+})
+
 describe('DesktopInsuranceDetail — coverage round-trips through relationship', () => {
   it('preselects the member’s coverage in the edit form and offers Parent/Other', async () => {
     const parentIns = { ...ins, coverageType: 'Parent' } as InsuranceData

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -77,6 +77,46 @@ const baseProps = {
   onDataChanged: vi.fn(),
 }
 
+describe('GoalDetailSheet — investments load error vs empty', () => {
+  // A goal with no overview funds, so the investments list depends entirely on
+  // the (failing) transactions fetch.
+  const noFundGoal: GoalData = { ...mockGoal, funds: [], currentValue: 9_000_000, transactionCount: 1 }
+  const mockBankTx = {
+    transaction_id: 'tx-bank-err', transaction_type: 'investment', asset_type: 'bank',
+    fund_id: null, fund_name: null, investment_date: '2026-01-01', amount_vnd: 9_000_000,
+    units: null, interest_rate: 6.5, notes: 'Techcombank', principal_withdrawn: null, units_withdrawn: null,
+  }
+
+  it('shows a retry state (not "No investments yet") when the transactions fetch fails', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, json: async () => ({}) })
+
+    render(<GoalDetailSheet {...baseProps} goal={noFundGoal} />)
+
+    await waitFor(() => expect(screen.getByTestId('load-error')).toBeInTheDocument())
+    expect(screen.queryByText('No investments yet')).not.toBeInTheDocument()
+  })
+
+  it('retry re-fetches and renders the investments on success', async () => {
+    let call = 0
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        call += 1
+        if (call === 1) return Promise.resolve({ ok: false, json: async () => ({}) })
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [mockBankTx] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    render(<GoalDetailSheet {...baseProps} goal={noFundGoal} />)
+    await waitFor(() => expect(screen.getByTestId('load-error')).toBeInTheDocument())
+
+    await userEvent.click(screen.getByTestId('load-error-retry'))
+
+    await waitFor(() => expect(screen.getByText('Techcombank')).toBeInTheDocument())
+    expect(screen.queryByTestId('load-error')).not.toBeInTheDocument()
+  })
+})
+
 describe('GoalDetailSheet — DCA pending row filtering', () => {
   it('excludes DCA-seeded rows with null units from transaction history', async () => {
     global.fetch = vi.fn().mockImplementation((url: string) => {
@@ -99,7 +139,7 @@ describe('GoalDetailSheet — DCA pending row filtering', () => {
 
     render(<GoalDetailSheet {...baseProps} />)
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
+    await userEvent.click(screen.getByRole('button', { name: /^Options$/ }))
     await waitFor(() => screen.getAllByText('Transaction history').length > 0)
     await userEvent.click(screen.getAllByText('Transaction history')[0])
     await waitFor(() => screen.getByRole('heading', { name: 'VNINDEX ETF' }))
@@ -169,7 +209,7 @@ describe('GoalDetailSheet — transaction history integration', () => {
     await waitFor(() => expect(screen.getByText('VNINDEX ETF')).toBeInTheDocument())
 
     // Tap the ⋯ options button on the fund row
-    const optionsBtn = screen.getByRole('button', { name: 'Options', exact: true })
+    const optionsBtn = screen.getByRole('button', { name: /^Options$/ })
     await userEvent.click(optionsBtn)
 
     // InvestmentActionSheet appears — tap "Transaction history" action
@@ -186,7 +226,7 @@ describe('GoalDetailSheet — transaction history integration', () => {
     render(<GoalDetailSheet {...baseProps} />)
 
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
+    await userEvent.click(screen.getByRole('button', { name: /^Options$/ }))
     await waitFor(() => screen.getAllByText('Transaction history').length > 0)
     await userEvent.click(screen.getAllByText('Transaction history')[0])
 
@@ -199,7 +239,7 @@ describe('GoalDetailSheet — transaction history integration', () => {
     render(<GoalDetailSheet {...baseProps} />)
 
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
+    await userEvent.click(screen.getByRole('button', { name: /^Options$/ }))
     await waitFor(() => screen.getAllByText('Transaction history').length > 0)
     await userEvent.click(screen.getAllByText('Transaction history')[0])
     await waitFor(() => screen.getByRole('heading', { name: 'VNINDEX ETF' }))
@@ -218,7 +258,7 @@ describe('GoalDetailSheet — unassign from goal', () => {
   it('InvestmentActionSheet exposes an "Unassign from goal" option', async () => {
     render(<GoalDetailSheet {...baseProps} />)
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
+    await userEvent.click(screen.getByRole('button', { name: /^Options$/ }))
     await waitFor(() =>
       expect(screen.getAllByText(/unassign from goal/i).length).toBeGreaterThan(0)
     )
@@ -227,7 +267,7 @@ describe('GoalDetailSheet — unassign from goal', () => {
   it('opens the confirmation sheet when Unassign is tapped', async () => {
     render(<GoalDetailSheet {...baseProps} />)
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
+    await userEvent.click(screen.getByRole('button', { name: /^Options$/ }))
     await waitFor(() => screen.getAllByText(/unassign from goal/i).length > 0)
     // Click the action-sheet row labeled "Unassign from goal"
     await userEvent.click(screen.getAllByText(/unassign from goal/i)[0])
@@ -255,7 +295,7 @@ describe('GoalDetailSheet — unassign from goal', () => {
     const onDataChanged = vi.fn()
     render(<GoalDetailSheet {...baseProps} onDataChanged={onDataChanged} />)
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
+    await userEvent.click(screen.getByRole('button', { name: /^Options$/ }))
     await waitFor(() => screen.getAllByText(/unassign from goal/i).length > 0)
     await userEvent.click(screen.getAllByText(/unassign from goal/i)[0])
     await waitFor(() => screen.getByText(/unassign from goal\?/i))
@@ -288,7 +328,7 @@ describe('GoalDetailSheet — unassign from goal', () => {
 
     render(<GoalDetailSheet {...baseProps} />)
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
+    await userEvent.click(screen.getByRole('button', { name: /^Options$/ }))
     await waitFor(() => screen.getAllByText(/unassign from goal/i).length > 0)
     await userEvent.click(screen.getAllByText(/unassign from goal/i)[0])
     await waitFor(() => screen.getByText(/unassign from goal\?/i))
@@ -327,7 +367,7 @@ describe('GoalDetailSheet — investment options Sell / history (issue #224)', (
   it('opens the Sell sheet when "Sell" is tapped on a fund investment', async () => {
     render(<GoalDetailSheet {...baseProps} />)
     await waitFor(() => screen.getByText('VNINDEX ETF'))
-    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
+    await userEvent.click(screen.getByRole('button', { name: /^Options$/ }))
     await waitFor(() => expect(screen.getByText('Sell')).toBeInTheDocument())
     await userEvent.click(screen.getByText('Sell'))
     await waitFor(() => expect(screen.getByTestId('sell-sheet')).toBeInTheDocument())
@@ -342,7 +382,7 @@ describe('GoalDetailSheet — investment options Sell / history (issue #224)', (
     })
     render(<GoalDetailSheet {...baseProps} goal={bankGoal} />)
     await waitFor(() => screen.getByText('Techcombank'))
-    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
+    await userEvent.click(screen.getByRole('button', { name: /^Options$/ }))
     await waitFor(() => expect(screen.getByText('Withdraw')).toBeInTheDocument())
     await userEvent.click(screen.getByText('Withdraw'))
     await waitFor(() => expect(screen.getByTestId('sell-sheet')).toBeInTheDocument())
@@ -357,7 +397,7 @@ describe('GoalDetailSheet — investment options Sell / history (issue #224)', (
     })
     render(<GoalDetailSheet {...baseProps} goal={bankGoal} />)
     await waitFor(() => screen.getByText('Techcombank'))
-    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
+    await userEvent.click(screen.getByRole('button', { name: /^Options$/ }))
     await waitFor(() => expect(screen.getByText('Transaction history')).toBeInTheDocument())
     await userEvent.click(screen.getByText('Transaction history'))
 
@@ -399,7 +439,7 @@ describe('GoalDetailSheet — bank maturity in Options sheet (issue #263)', () =
     })
     render(<GoalDetailSheet {...baseProps} goal={bankGoal} />)
     await waitFor(() => screen.getByText('Techcombank'))
-    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
+    await userEvent.click(screen.getByRole('button', { name: /^Options$/ }))
 
     await waitFor(() => expect(screen.getByText('Maturity')).toBeInTheDocument())
     expect(screen.getByText('15 Aug 2030')).toBeInTheDocument()
@@ -443,7 +483,7 @@ describe('GoalDetailSheet — gold sell uses current price (issue #251)', () => 
 
     render(<GoalDetailSheet {...baseProps} goal={goldGoal} />)
     await waitFor(() => screen.getByText('PNJ Gold'))
-    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
+    await userEvent.click(screen.getByRole('button', { name: /^Options$/ }))
     await waitFor(() => expect(screen.getByText('Sell')).toBeInTheDocument())
     await userEvent.click(screen.getByText('Sell'))
 
@@ -622,7 +662,7 @@ describe('GoalDetailSheet — refreshKey triggers refetch', () => {
     await waitFor(() => screen.getByText('VNINDEX ETF'))
 
     // 1) Unassign the tx
-    await userEvent.click(screen.getByRole('button', { name: 'Options', exact: true }))
+    await userEvent.click(screen.getByRole('button', { name: /^Options$/ }))
     await waitFor(() => screen.getAllByText(/unassign from goal/i).length > 0)
     await userEvent.click(screen.getAllByText(/unassign from goal/i)[0])
     await waitFor(() => screen.getByText(/unassign from goal\?/i))


### PR DESCRIPTION
## Vấn đề (UX audit — P2 error handling)

Nhiều sheet trong Overview bắt lỗi fetch rồi **fallback về list rỗng**, nên một lỗi mạng tạm thời hiển thị **y như "bạn chưa có dữ liệu"** — người dùng tưởng không có mục tiêu / không có khoản đầu tư / chưa đóng phí nào. Lỗi và "trống" không phân biệt được.

## Thay đổi

Thêm component dùng chung **`LoadError`** (thông báo + nút "Thử lại") và dùng ở mọi sheet tự fetch dữ liệu; retry chạy lại loader.

Surface đã sửa:
- **AssignGoalSheet** — danh sách mục tiêu
- **DesktopInsuranceDetail** (+ mobile `InsuranceDetailSheet` tái dùng) — lịch sử thanh toán
- **DesktopGoalDetail** — tab Đầu tư + Lịch sử
- **GoalDetailSheet** (mobile) — tab Đầu tư + Lịch sử

Fetch chính `investment-transactions` giờ throw khi `!ok` để catch hiện lỗi; recurring contributions là phụ → degrade về rỗng. Fund rows từ overview (đã tải, tin cậy) vẫn render dưới banner lỗi nên lỗi tx tạm thời không che mất dữ liệu thật.

**Tiện thể** sửa 14 type error tiềm ẩn từ PR #391: testing-library `getByRole` **không có** option `exact` (đó là của Playwright) → dùng regex neo `/^Options$/`. `tsc --noEmit` giờ sạch toàn repo.

## Test (TDD)

Mỗi surface có unit test: fetch fail → hiện `load-error` (không phải copy "trống"); bấm retry → fetch lại và render rows. (8 test mới, đều red trước khi implement.)

## Đã chạy local

- ✅ `npm test -- --run` — **829 passed** (74 files)
- ✅ `npm run lint` — không thêm loại lỗi mới (chỉ pattern `set-state-in-effect` pre-existing trong các effect đã có sẵn setState)
- ✅ `npx tsc --noEmit` — **0 lỗi** (sửa luôn 14 lỗi PR #391 để lại)
- ⚠️ **E2E chưa chạy** — local Supabase stack (WSL2) đang down giữa chừng. Cần chạy `e2e/goals.spec.ts`, `goal-detail-desktop.spec.ts`, `assign-goal-desktop.spec.ts` + insurance trước khi merge. Happy-path render được unit test phủ; E2E để xác nhận lại ở browser.

## Phạm vi / Defer

Đây là **PR-B** trong loạt fix error/empty. Defer sang **PR-B2**: surface fetch qua props (`TransactionHistorySheet`), `AddTransactionSheet` sell-holdings, và silent ACTION failures (delete/unassign/unhold báo lỗi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)