### PR TITLE
fix(overview): retry state for fund-history + sell-holdings fetch failures

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -286,6 +286,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
   const [goalPickerFundItem, setGoalPickerFundItem] = useState<{ name: string; value: number; type: string } | null>(null)
   const [purchaseHistory, setPurchaseHistory] = useState<PurchaseHistory[]>([])
   const [historyLoading, setHistoryLoading] = useState(false)
+  const [historyError, setHistoryError] = useState(false)
   const [nonFundPickerTxId, setNonFundPickerTxId] = useState<string | null>(null)
   const [nonFundPickerItem, setNonFundPickerItem] = useState<{ name: string; value: number; type: string } | null>(null)
   const [goalSort, setGoalSort] = useState<SortValue>('manual')
@@ -450,18 +451,21 @@ export default function DashboardClient({ userId }: { userId: string }) {
   async function handleFundClick(fundId: string) {
     setFundDetailId(fundId)
     setPurchaseHistory([])
+    setHistoryError(false)
     setHistoryLoading(true)
     try {
       const res = await fetch(`/api/v1/fund-investments?fund_id=${fundId}`)
-      if (res.ok) {
-        const items = await res.json()
-        setPurchaseHistory(
-          (items as Array<{ nav_at_purchase: number; units_purchased: number; investment_date: string | null; created_at: string }>)
-            .map((i) => ({ purchase_date: i.investment_date ?? i.created_at, units: i.units_purchased, nav_at_purchase: i.nav_at_purchase }))
-            .sort((a, b) => new Date(b.purchase_date).getTime() - new Date(a.purchase_date).getTime())
-        )
-      }
-    } catch { /* show sheet without history */ }
+      if (!res.ok) throw new Error('load failed')
+      const items = await res.json()
+      setPurchaseHistory(
+        (items as Array<{ nav_at_purchase: number; units_purchased: number; investment_date: string | null; created_at: string }>)
+          .map((i) => ({ purchase_date: i.investment_date ?? i.created_at, units: i.units_purchased, nav_at_purchase: i.nav_at_purchase }))
+          .sort((a, b) => new Date(b.purchase_date).getTime() - new Date(a.purchase_date).getTime())
+      )
+    } catch {
+      // Distinguish a failed load from a genuinely empty history.
+      setHistoryError(true)
+    }
     setHistoryLoading(false)
   }
 
@@ -1072,7 +1076,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
       {/* Transaction History Sheet */}
       <TransactionHistorySheet
         open={!!(fundDetailId && detailFund)}
-        onClose={() => { setFundDetailId(null); setPurchaseHistory([]); setHistoryLoading(false) }}
+        onClose={() => { setFundDetailId(null); setPurchaseHistory([]); setHistoryLoading(false); setHistoryError(false) }}
         fundName={detailFund?.fundName ?? ''}
         currentNAV={detailFund?.currentNAV ?? 0}
         quantity={detailFund?.quantity ?? 0}
@@ -1082,6 +1086,8 @@ export default function DashboardClient({ userId }: { userId: string }) {
         profitLossPercentage={detailFund?.profitLossPercentage ?? 0}
         purchaseHistory={purchaseHistory}
         loading={historyLoading}
+        error={historyError}
+        onRetry={() => { if (fundDetailId) handleFundClick(fundDetailId) }}
       />
 
       {/* Assign Goal Sheet — funds */}

--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -5,6 +5,7 @@ import { X, TrendingUp, Building2, Coins, ArrowUpRight, ArrowDownRight, ArrowDow
 import { useLocale, useTranslations } from 'next-intl'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { todayIso } from '@/lib/dates'
+import LoadError from './LoadError'
 
 interface Fund { id: string; name: string; nav: number; code: string | null; fund_type?: string }
 interface Goal { goal_id: string; goal_name: string }
@@ -184,6 +185,9 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
   // sell fields — holdings collected lazily from the overview
   const [holdings, setHoldings] = useState<Holding[]>([])
   const [holdingsLoaded, setHoldingsLoaded] = useState(false)
+  const [holdingsError, setHoldingsError] = useState(false)
+  // Bumped by the retry button to re-run the holdings fetch after a failure.
+  const [holdingsReload, setHoldingsReload] = useState(0)
   const [holdingKey, setHoldingKey] = useState('')
   const [sellAmount, setSellAmount] = useState('')        // fund / bank sell amount (₫)
   const [fundSellUnits, setFundSellUnits] = useState('')  // fund sell units (linked to amount)
@@ -276,11 +280,14 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
   // switches to "Sell" — most opens are buys, so we don't pay for it up front.
   useEffect(() => {
     if (!open || dir !== 'sell' || holdingsLoaded) return
+    setHoldingsError(false)
     fetch('/api/v1/dashboard/overview')
-      .then(r => r.json())
+      .then(r => { if (!r.ok) throw new Error('load failed'); return r.json() })
       .then((d) => { setHoldings(collectHoldings(d ?? {})); setHoldingsLoaded(true) })
-      .catch(() => setHoldingsLoaded(true))
-  }, [open, dir, holdingsLoaded])
+      // A failed load must show a retry — not the "no holdings" empty state,
+      // which would falsely tell a user with holdings they have nothing to sell.
+      .catch(() => setHoldingsError(true))
+  }, [open, dir, holdingsLoaded, holdingsReload])
 
   // Lock background scroll while the sheet is open so the page behind it can't move.
   useEffect(() => {
@@ -981,7 +988,11 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
 
           {/* Sell / withdraw — pick a holding, then confirm the amount */}
           {dir === 'sell' && (
-            sellHoldings.length === 0 ? (
+            holdingsError ? (
+              <div style={{ padding: '8px 16px', background: 'var(--c-card-2)', borderRadius: 12, border: '1px dashed var(--c-line)' }}>
+                <LoadError isVI={isVI} onRetry={() => { setHoldingsError(false); setHoldingsReload((n) => n + 1) }} compact />
+              </div>
+            ) : sellHoldings.length === 0 ? (
               <div style={{ padding: '24px 16px', textAlign: 'center', background: 'var(--c-card-2)', borderRadius: 12, border: '1px dashed var(--c-line)' }}>
                 <div style={{ width: 40, height: 40, borderRadius: 20, background: 'var(--c-card)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', color: 'var(--c-muted)', marginBottom: 10 }}>
                   <Wallet size={18} />

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -785,6 +785,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   const [fundDetailId, setFundDetailId] = useState<string | null>(null)
   const [purchaseHistory, setPurchaseHistory] = useState<PurchaseHistoryRow[]>([])
   const [historyLoading, setHistoryLoading] = useState(false)
+  const [historyError, setHistoryError] = useState(false)
   const [monthlyContrib, setMonthlyContrib] = useState('')
 
   useEffect(() => {
@@ -899,19 +900,22 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   async function openFundDetail(fund: FundBreakdownItem) {
     setFundDetailId(fund.fundId)
     setPurchaseHistory([])
+    setHistoryError(false)
     setHistoryLoading(true)
     try {
       const res = await fetch(`/api/v1/fund-investments?fund_id=${fund.fundId}`)
-      if (res.ok) {
-        const items = await res.json()
-        setPurchaseHistory(
-          (items as Array<{ nav_at_purchase: number | null; units_purchased: number | null; investment_date: string | null; created_at: string; is_dca_seeded?: boolean }>)
-            .filter((i) => !(i.is_dca_seeded && i.units_purchased == null))
-            .map((i) => ({ purchase_date: i.investment_date ?? i.created_at, units: i.units_purchased, nav_at_purchase: i.nav_at_purchase }))
-            .sort((a, b) => new Date(b.purchase_date).getTime() - new Date(a.purchase_date).getTime())
-        )
-      }
-    } catch { /* ignore */ }
+      if (!res.ok) throw new Error('load failed')
+      const items = await res.json()
+      setPurchaseHistory(
+        (items as Array<{ nav_at_purchase: number | null; units_purchased: number | null; investment_date: string | null; created_at: string; is_dca_seeded?: boolean }>)
+          .filter((i) => !(i.is_dca_seeded && i.units_purchased == null))
+          .map((i) => ({ purchase_date: i.investment_date ?? i.created_at, units: i.units_purchased, nav_at_purchase: i.nav_at_purchase }))
+          .sort((a, b) => new Date(b.purchase_date).getTime() - new Date(a.purchase_date).getTime())
+      )
+    } catch {
+      // Distinguish a failed load from a genuinely empty history.
+      setHistoryError(true)
+    }
     setHistoryLoading(false)
   }
 
@@ -1492,7 +1496,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
 
       <TransactionHistorySheet
         open={!!(fundDetailId && detailFund)}
-        onClose={() => { setFundDetailId(null); setPurchaseHistory([]); setHistoryLoading(false) }}
+        onClose={() => { setFundDetailId(null); setPurchaseHistory([]); setHistoryLoading(false); setHistoryError(false) }}
         fundName={detailFund?.fundName ?? ''}
         currentNAV={detailFund?.currentNAV ?? 0}
         quantity={detailFund?.quantity ?? 0}
@@ -1502,6 +1506,8 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
         profitLossPercentage={detailFund?.profitLossPercentage ?? 0}
         purchaseHistory={purchaseHistory}
         loading={historyLoading}
+        error={historyError}
+        onRetry={() => { if (detailFund) openFundDetail(detailFund) }}
       />
     </>
   )

--- a/app/assets/components/TransactionHistorySheet.tsx
+++ b/app/assets/components/TransactionHistorySheet.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, ArrowUpRight, ArrowDownRight, Plus } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmtCompact, fmtNav, fmtPct, fmtUnits } from '@/lib/formatters'
 import { TxRowsSkeleton } from './Skeletons'
+import LoadError from './LoadError'
 
 export interface PurchaseHistoryRow {
   purchase_date: string
@@ -24,13 +25,16 @@ interface Props {
   profitLossPercentage: number
   purchaseHistory: PurchaseHistoryRow[]
   loading?: boolean
+  /** The history fetch failed — show a retry state instead of "no history". */
+  error?: boolean
+  onRetry?: () => void
   onAddTransaction?: () => void
 }
 
 export default function TransactionHistorySheet({
   open, onClose,
   fundName, currentNAV, quantity, currentValue, purchasePrice,
-  profitLoss, profitLossPercentage, purchaseHistory, loading, onAddTransaction,
+  profitLoss, profitLossPercentage, purchaseHistory, loading, error, onRetry, onAddTransaction,
 }: Props) {
   const isVI = useLocale() === 'vi'
   const [mounted, setMounted] = useState(false)
@@ -171,12 +175,15 @@ export default function TransactionHistorySheet({
           </div>
           <div style={{ background: 'var(--c-card)', borderRadius: 16, padding: '0 14px', boxShadow: '0 1px 3px rgba(0,0,0,0.06)' }}>
             {loading && <TxRowsSkeleton />}
-            {!loading && purchaseHistory.length === 0 && (
+            {!loading && error && (
+              <LoadError isVI={isVI} onRetry={() => onRetry?.()} />
+            )}
+            {!loading && !error && purchaseHistory.length === 0 && (
               <p style={{ color: 'var(--c-muted)', fontSize: 14, textAlign: 'center', padding: '24px 0' }}>
                 {isVI ? 'Chưa có lịch sử giao dịch' : 'No transaction history'}
               </p>
             )}
-            {!loading && purchaseHistory.map((row, i) => {
+            {!loading && !error && purchaseHistory.map((row, i) => {
               const amountPaid = row.units != null && row.nav_at_purchase != null
                 ? Math.round(row.units * row.nav_at_purchase)
                 : null

--- a/app/assets/components/__tests__/AddTransactionSheet.test.tsx
+++ b/app/assets/components/__tests__/AddTransactionSheet.test.tsx
@@ -56,6 +56,43 @@ describe('AddTransactionSheet — background scroll lock (issue #219)', () => {
   })
 })
 
+describe('AddTransactionSheet — sell holdings load error vs empty', () => {
+  it('shows a retry state (not "no holdings") when the holdings fetch fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) })))
+
+    render(<AddTransactionSheet open onClose={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'sell' }))
+
+    await waitFor(() => expect(screen.getByTestId('load-error')).toBeInTheDocument())
+    expect(screen.queryByText('noHoldings')).not.toBeInTheDocument()
+  })
+
+  it('retry re-fetches and clears the error (genuine empty after a successful reload)', async () => {
+    // Key off the overview URL — the sheet fires other fetches on open that
+    // would otherwise consume a blind call counter.
+    let overviewCalls = 0
+    vi.stubGlobal('fetch', vi.fn((url: string) => {
+      if (String(url).includes('/dashboard/overview')) {
+        overviewCalls += 1
+        if (overviewCalls === 1) return Promise.resolve({ ok: false, json: () => Promise.resolve({}) })
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+    }))
+
+    render(<AddTransactionSheet open onClose={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'sell' }))
+    await waitFor(() => expect(screen.getByTestId('load-error')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('load-error-retry'))
+
+    // A successful (but empty) reload clears the error and shows the genuine
+    // "no holdings" state.
+    await waitFor(() => expect(screen.getByText('noHoldings')).toBeInTheDocument())
+    expect(screen.queryByTestId('load-error')).not.toBeInTheDocument()
+  })
+})
+
 describe('AddTransactionSheet — goal selector (issue #232)', () => {
   // /api/v1/savings-goals returns { goals: [...] }, not a bare array — the goal
   // selector must read that shape or it stays empty/hidden.

--- a/app/assets/components/__tests__/TransactionHistorySheet.test.tsx
+++ b/app/assets/components/__tests__/TransactionHistorySheet.test.tsx
@@ -82,6 +82,19 @@ describe('TransactionHistorySheet', () => {
     expect(screen.getByText('No transaction history')).toBeInTheDocument()
   })
 
+  it('shows a retry state (not the empty copy) when error=true', () => {
+    render(<TransactionHistorySheet {...baseProps} purchaseHistory={[]} loading={false} error onRetry={vi.fn()} />)
+    expect(screen.getByTestId('load-error')).toBeInTheDocument()
+    expect(screen.queryByText('No transaction history')).not.toBeInTheDocument()
+  })
+
+  it('calls onRetry when the retry button is clicked', async () => {
+    const onRetry = vi.fn()
+    render(<TransactionHistorySheet {...baseProps} purchaseHistory={[]} loading={false} error onRetry={onRetry} />)
+    await userEvent.click(screen.getByTestId('load-error-retry'))
+    expect(onRetry).toHaveBeenCalledOnce()
+  })
+
   it('calls onClose when back button is clicked', async () => {
     const onClose = vi.fn()
     render(<TransactionHistorySheet {...baseProps} onClose={onClose} />)


### PR DESCRIPTION
## Vấn đề (UX audit — P2/P3 error handling, tiếp PR #392)

Hai surface fetch còn lại vẫn để **lỗi tải giả dạng "trống"**:
- **TransactionHistorySheet** (lịch sử mua của một quỹ) — không có error state, lỗi → "Chưa có lịch sử giao dịch".
- **AddTransactionSheet** (chế độ Bán) — lỗi fetch holdings → "Bạn chưa có khoản nào để bán", kể cả khi user có holdings.

## Thay đổi (tái dùng `LoadError` từ #392)

- **TransactionHistorySheet**: thêm props `error`/`onRetry`. Cả 2 parent (`DashboardClient.handleFundClick` + `GoalDetailSheet.openFundDetail`) giờ track `historyError`, throw khi `!ok`, và truyền retry chạy lại fetch → lỗi hiện "Thử lại" thay vì "không có lịch sử".
- **AddTransactionSheet (Bán)**: fetch holdings (`dashboard/overview`) phân biệt lỗi-tải với thật-sự-rỗng; retry chạy lại qua reload counter (effect không còn tự đánh dấu loaded khi lỗi).

## Test (TDD)

- TransactionHistorySheet: test prop-driven `error` → `load-error` (không phải copy "trống"); retry gọi `onRetry`.
- AddTransactionSheet: vào chế độ Bán, fetch holdings fail → `load-error`; retry → fetch lại, clear lỗi. (4 test mới, red→green.)

## Đã chạy local

- ✅ `npm test -- --run` — **833 passed**
- ✅ `npx tsc --noEmit` — **0 lỗi**
- ✅ `npm run lint` — không thêm loại lỗi mới
- ✅ **E2E** — 63 passed trên bộ spec phủ surface đã đụng (dashboard, goal-detail-desktop, goals, add-transaction, recent-activity, assign). 1 fail **pre-existing không liên quan**: `add-transaction.spec.ts:20 FAB visible on planning page` — đã xác nhận **cũng fail trên main** (cây sạch); do planning June-2026 fixtures hết hạn theo lịch (hôm nay 28/06), không phải do PR này.

## Phạm vi / Defer

Khép lại mạch **read-fetch error-vs-empty** trong Overview (#392 + #393). Defer sang PR riêng: **silent ACTION failures** (delete/unassign/unhold ở goals + insurance) — đây là mảng feedback cho *mutation*, khác pattern load-retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)