### PR TITLE
test(e2e): fix stale planning-FAB assertion (contextual FAB)

### DIFF
--- a/e2e/add-transaction.spec.ts
+++ b/e2e/add-transaction.spec.ts
@@ -17,10 +17,18 @@ test('FAB is visible on dashboard', async ({ page }) => {
   await expect(page.getByRole('button', { name: /add transaction/i })).toBeVisible()
 })
 
-test('FAB is visible on planning page', async ({ page }) => {
+// The FAB is contextual (PR #390): it belongs only on Overview and Funds. On Plan
+// you add via the plan's own rows, so the FAB must NOT appear there.
+test('FAB is hidden on planning page', async ({ page }) => {
   await page.goto('/planning')
   await page.waitForLoadState('networkidle')
-  await expect(page.getByRole('button', { name: /add transaction/i })).toBeVisible()
+  await expect(page.getByRole('button', { name: /add transaction/i })).toHaveCount(0)
+})
+
+test('FAB is hidden on settings page', async ({ page }) => {
+  await page.goto('/settings')
+  await page.waitForLoadState('networkidle')
+  await expect(page.getByRole('button', { name: /add transaction/i })).toHaveCount(0)
 })
 
 test('FAB is visible on funds page', async ({ page }) => {


### PR DESCRIPTION
## What

The e2e test `FAB is visible on planning page` was failing — but **not** because of a flaky/date fixture. PR #390 deliberately made the mobile add-transaction FAB **contextual**: `shouldShowMobileFab` returns true only on `/dashboard` (no maturing deposits) or `/funds`. The FAB is intentionally hidden on `/planning` and `/settings`.

The e2e spec was never updated to match, so it correctly failed against the new behavior. This was a stale-test break, the exact kind [[feedback_check_e2e_selectors_on_dom_changes]] warns about.

## Change (test-only)

- `FAB is visible on planning page` → `FAB is hidden on planning page` (asserts `toHaveCount(0)`)
- Added `FAB is hidden on settings page` for parity with the unit-test contract in `MobileAddTransactionFab.test.tsx`

No source changes. Dashboard/funds visibility assertions unchanged.

## Verification

- `npx playwright test e2e/add-transaction.spec.ts --project=chromium` → **14 passed** (local Supabase stack)
- `npm run lint` → only pre-existing repo-wide `react-hooks/set-state-in-effect` errors; `e2e/` is outside the lint scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)