### PR TITLE
fix(overview): error toast when a goal/insurance action fails (silent-failure pass)

### DIFF
--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo } from 'react'
 import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield, RefreshCw, PiggyBank, GitMerge } from 'lucide-react'
+import { toast } from 'sonner'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
 import { GD_COLORS, buildCompositionSegments, calcDeadlineMonths, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, AffectsProgressControl, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
@@ -123,7 +124,12 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
     setIsDeleting(true)
     try {
       const res = await fetch(`/api/v1/savings-goals/${goal.goalId}`, { method: 'DELETE' })
-      if (res.ok) { setDeleteOpen(false); onDataChanged() }
+      if (!res.ok) throw new Error('delete failed')
+      setDeleteOpen(false)
+      onDataChanged()
+    } catch {
+      // Keep the confirm modal open so the user can retry; don't claim success.
+      toast.error(isVi ? 'Không thể xoá mục tiêu' : "Couldn't delete goal")
     } finally {
       setIsDeleting(false)
     }
@@ -138,24 +144,28 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
         if (!res.ok) throw new Error('fetch failed')
         const data = await res.json() as { investments?: Array<{ id: string }> }
         const investments = data.investments ?? []
-        await Promise.all(investments.map((fi) =>
+        const results = await Promise.all(investments.map((fi) =>
           fetch(`/api/v1/fund-investments/${fi.id}/goal`, {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ goal_id: null }),
           })
         ))
+        if (results.some((r) => !r.ok)) throw new Error('unassign failed')
       } else {
-        await fetch(`/api/v1/investment-transactions/${actionInv.id}/assign`, {
+        const res = await fetch(`/api/v1/investment-transactions/${actionInv.id}/assign`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ goal_id: null }),
         })
+        if (!res.ok) throw new Error('unassign failed')
       }
       setUnassignedIds((prev) => [...prev, actionInv.id])
       setShowUnassignConfirm(false)
       setActionInv(null)
       onDataChanged()
+    } catch {
+      toast.error(isVi ? 'Không thể huỷ liên kết' : "Couldn't unassign")
     } finally {
       setUnassigning(false)
     }
@@ -196,7 +206,10 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
     setUnholdingId(heldTxId)
     try {
       const res = await fetch(`/api/v1/investment-transactions/${heldTxId}`, { method: 'DELETE' })
-      if (res.ok) onDataChanged()
+      if (!res.ok) throw new Error('unhold failed')
+      onDataChanged()
+    } catch {
+      toast.error(isVi ? 'Không thể bỏ chờ gộp' : "Couldn't cancel the merge hold")
     } finally {
       setUnholdingId(null)
     }

--- a/app/assets/components/DesktopInsuranceDetail.tsx
+++ b/app/assets/components/DesktopInsuranceDetail.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { Check, ChevronLeft, Edit2, Plus, Trash2, Calendar, X } from 'lucide-react'
+import { toast } from 'sonner'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import { STATUS_COLOR, BAR_COLOR_DETAIL, COVERAGE_OPTIONS, insurancePaidState, insuranceStatusLabel } from './insuranceShared'
 import type { InsuranceData } from '../DashboardClient'
@@ -145,11 +146,13 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
     setDeleting(true)
     try {
       const res = await fetch(`/api/v1/insurance-members/${ins.insuranceId}`, { method: 'DELETE' })
-      if (res.ok) {
-        setShowDeleteConfirm(false)
-        onChanged?.()
-        onClose()
-      }
+      if (!res.ok) throw new Error('delete failed')
+      setShowDeleteConfirm(false)
+      onChanged?.()
+      onClose()
+    } catch {
+      // Keep the confirm dialog open so the user can retry; don't claim success.
+      toast.error(isVi ? 'Không thể xoá thành viên' : "Couldn't remove member")
     } finally {
       setDeleting(false)
     }

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -6,6 +6,7 @@ import {
   Edit2, Trash2, Calendar, Download, ArrowDownRight, ArrowUpRight, Target, RefreshCw, PiggyBank, GitMerge,
 } from 'lucide-react'
 import { useLocale } from 'next-intl'
+import { toast } from 'sonner'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData, FundBreakdownItem } from '../DashboardClient'
 import TransactionHistorySheet, { type PurchaseHistoryRow } from './TransactionHistorySheet'
@@ -841,11 +842,16 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
     setIsDeleting(true)
     try {
       const res = await fetch(`/api/v1/savings-goals/${goal.goalId}`, { method: 'DELETE' })
-      if (res.ok) { onDataChanged(); onClose() }
+      if (!res.ok) throw new Error('delete failed')
+      onDataChanged()
+      onClose()
+      setActionsOpen(false)
+    } catch {
+      // Keep the confirm sheet open so the user can retry; don't claim success.
+      toast.error(isVI ? 'Không thể xoá mục tiêu' : "Couldn't delete goal")
     } finally {
       setIsDeleting(false)
     }
-    setActionsOpen(false)
   }
 
   // "Bỏ chờ gộp" — delete the held settlement row, which restores the original
@@ -856,7 +862,10 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
     setUnholdingId(heldTxId)
     try {
       const res = await fetch(`/api/v1/investment-transactions/${heldTxId}`, { method: 'DELETE' })
-      if (res.ok) onDataChanged()
+      if (!res.ok) throw new Error('unhold failed')
+      onDataChanged()
+    } catch {
+      toast.error(isVI ? 'Không thể bỏ chờ gộp' : "Couldn't cancel the merge hold")
     } finally {
       setUnholdingId(null)
     }
@@ -874,24 +883,28 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
         if (!res.ok) throw new Error('fetch failed')
         const data = await res.json() as { investments?: Array<{ id: string }> }
         const investments = data.investments ?? []
-        await Promise.all(investments.map((fi) =>
+        const results = await Promise.all(investments.map((fi) =>
           fetch(`/api/v1/fund-investments/${fi.id}/goal`, {
             method: 'PATCH',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ goal_id: null }),
           })
         ))
+        if (results.some((r) => !r.ok)) throw new Error('unassign failed')
       } else {
-        await fetch(`/api/v1/investment-transactions/${actionInv.id}/assign`, {
+        const res = await fetch(`/api/v1/investment-transactions/${actionInv.id}/assign`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ goal_id: null }),
         })
+        if (!res.ok) throw new Error('unassign failed')
       }
       setUnassignedIds((prev) => [...prev, actionInv.id])
       setUnassignConfirmOpen(false)
       setActionInv(null)
       onDataChanged()
+    } catch {
+      toast.error(isVI ? 'Không thể huỷ liên kết' : "Couldn't unassign")
     } finally {
       setUnassigning(false)
     }

--- a/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
@@ -4,6 +4,9 @@ import userEvent from '@testing-library/user-event'
 import DesktopGoalDetail from '../DesktopGoalDetail'
 import type { GoalData } from '../../DashboardClient'
 
+const { toastErrorMock } = vi.hoisted(() => ({ toastErrorMock: vi.fn() }))
+vi.mock('sonner', () => ({ toast: { error: toastErrorMock, success: vi.fn() } }))
+
 const mockGoal: GoalData = {
   goalId: 'goal-1',
   goalName: 'House Fund',
@@ -24,6 +27,39 @@ const baseProps = {
   onClose: vi.fn(),
   onDataChanged: vi.fn(),
 }
+
+describe('DesktopGoalDetail — delete failure feedback', () => {
+  beforeEach(() => {
+    toastErrorMock.mockClear()
+    global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('savings-goals') && init?.method === 'DELETE') {
+        return Promise.resolve({ ok: false, json: async () => ({}) })
+      }
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+  })
+
+  it('shows an error toast and keeps the goal (no onDataChanged) when the delete fails', async () => {
+    const onDataChanged = vi.fn()
+    render(<DesktopGoalDetail {...baseProps} onDataChanged={onDataChanged} />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Goal options' }))
+    await userEvent.click(await screen.findByText('Delete goal'))
+
+    // Confirm modal
+    await screen.findByText('Delete goal?')
+    await userEvent.click(await screen.findByRole('button', { name: 'Delete goal' }))
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
+    // A failed delete must NOT signal success.
+    expect(onDataChanged).not.toHaveBeenCalled()
+    // The confirm modal stays open so the user can retry.
+    expect(screen.getByText('Delete goal?')).toBeInTheDocument()
+  })
+})
 
 describe('DesktopGoalDetail — investments load error vs empty', () => {
   const mockBankTx = {

--- a/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
@@ -3,6 +3,9 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import DesktopInsuranceDetail from '../DesktopInsuranceDetail'
 import type { InsuranceData } from '../../DashboardClient'
 
+const { toastErrorMock } = vi.hoisted(() => ({ toastErrorMock: vi.fn() }))
+vi.mock('sonner', () => ({ toast: { error: toastErrorMock, success: vi.fn() } }))
+
 const ins: InsuranceData = {
   insuranceId: 'ins-1',
   insuranceName: 'John Doe',
@@ -87,6 +90,32 @@ describe('DesktopInsuranceDetail — history load error vs empty', () => {
 
     expect(await screen.findByText('Logged payment')).toBeInTheDocument()
     expect(screen.queryByTestId('load-error')).not.toBeInTheDocument()
+  })
+})
+
+describe('DesktopInsuranceDetail — delete failure feedback', () => {
+  it('shows an error toast and keeps the member (no onChanged/onClose) when the delete fails', async () => {
+    toastErrorMock.mockClear()
+    vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+      if (typeof url === 'string' && url.includes('insurance-members') && init?.method === 'DELETE') {
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({}) })
+      }
+      if (typeof url === 'string' && url.includes('/savings')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ entries: [], totalSaved: 0 }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    }))
+    const onChanged = vi.fn()
+    const onClose = vi.fn()
+
+    render(<DesktopInsuranceDetail ins={ins} locale="en" onClose={onClose} onChanged={onChanged} />)
+
+    fireEvent.click(screen.getByTestId('insurance-remove-btn'))
+    fireEvent.click(screen.getByTestId('insurance-remove-confirm'))
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
+    expect(onChanged).not.toHaveBeenCalled()
+    expect(onClose).not.toHaveBeenCalled()
   })
 })
 

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -9,6 +9,9 @@ vi.mock('next-intl', () => ({
   useTranslations: () => (k: string) => k,
 }))
 
+const { toastErrorMock } = vi.hoisted(() => ({ toastErrorMock: vi.fn() }))
+vi.mock('sonner', () => ({ toast: { error: toastErrorMock, success: vi.fn() } }))
+
 const mockFund = {
   fundId: 'fund-1',
   fundName: 'VNINDEX ETF',
@@ -76,6 +79,33 @@ const baseProps = {
   onClose: vi.fn(),
   onDataChanged: vi.fn(),
 }
+
+describe('GoalDetailSheet — delete failure feedback', () => {
+  it('shows an error toast and keeps the sheet open (no onClose) when the delete fails', async () => {
+    toastErrorMock.mockClear()
+    global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('savings-goals') && init?.method === 'DELETE') {
+        return Promise.resolve({ ok: false, json: async () => ({}) })
+      }
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+    const onClose = vi.fn()
+    const onDataChanged = vi.fn()
+
+    render(<GoalDetailSheet {...baseProps} onClose={onClose} onDataChanged={onDataChanged} />)
+
+    await userEvent.click(await screen.findByTestId('goal-options-btn'))
+    await userEvent.click(await screen.findByTestId('goal-delete-action'))
+    await userEvent.click(await screen.findByTestId('goal-delete-confirm'))
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
+    expect(onClose).not.toHaveBeenCalled()
+    expect(onDataChanged).not.toHaveBeenCalled()
+  })
+})
 
 describe('GoalDetailSheet — investments load error vs empty', () => {
   // A goal with no overview funds, so the investments list depends entirely on


### PR DESCRIPTION
## What

First of the three remaining Overview UX-audit items (theme: **reversibility/safety → error handling**). Several destructive mutation handlers failed silently — `if (res.ok) { …success… }` with no `else`, or an unchecked `await fetch(...)`. On a network/API error the sheet would close (or the button just reset) as if it worked; the goal/member looked gone until the next overview re-fetch brought it back.

## Change

Every failing action now shows a `sonner` `toast.error` and **skips the success side-effects** — no `onClose`/`onDataChanged`, and the confirm dialog stays open so the user can retry.

| Component | Handlers fixed |
|---|---|
| `GoalDetailSheet` (mobile) | delete goal, unhold (bỏ chờ gộp), unassign |
| `DesktopGoalDetail` | delete goal, unhold, unassign |
| `DesktopInsuranceDetail` | remove member |

`unassign` additionally now checks the `PATCH`/`PUT` responses — previously a partial `Promise.all` failure was swallowed.

Reuses the existing `sonner` toast system already wired in `AuthenticatedLayout` (the same one Settings uses). The already-safe handlers (edit goal, edit member, log/mark-paid payment — they show inline errors) were left untouched.

## TDD

Added a red→green failure test per surface (delete returns `{ ok: false }` → assert `toast.error` fired **and** no success callback / dialog stays open):
- `DesktopGoalDetail.test.tsx`, `DesktopInsuranceDetail.test.tsx`, `GoalDetailSheet.test.tsx`

## Verification

- `npm test -- --run` → **836 passed** (+3)
- `npx tsc --noEmit` → 0 errors
- `npm run lint` → only pre-existing repo-wide `react-hooks/set-state-in-effect` (unchanged count)
- E2E `goals` + `goal-detail-desktop` + `assign-goal-desktop` + `insurance` (`--project=chromium`) → **30 passed** — the delete/edit/assign **happy paths** still work

## Not in this PR (deferred, per the audit plan)
- **PR-A2** — insurance payment reversibility (undo mark-paid + delete a logged savings row; needs backend endpoints)
- **PR-C** — mislabels ("Coverage type"/"Start date") + goal "add to goal" CTA + explain "Unallocated"

🤖 Generated with [Claude Code](https://claude.com/claude-code)