### PR TITLE
feat(insurance): delete an individual logged payment (reversibility)

### DIFF
--- a/app/api/v1/insurance-savings/[id]/route.ts
+++ b/app/api/v1/insurance-savings/[id]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
+
+// Reverse an ad-hoc logged contribution. Plan-derived history rows are computed
+// (not stored) and never reach here. RLS also scopes deletes to the owner; the
+// explicit user_id filter keeps the 404 path honest.
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+
+  let savingsId: string
+  try {
+    savingsId = validateUUID(id, 'savings_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data, error } = await supabase
+    .from('insurance_savings')
+    .delete()
+    .eq('id', savingsId)
+    .eq('user_id', user.id)
+    .select('id')
+
+  if (error) return NextResponse.json({ error: 'Failed to delete savings' }, { status: 500 })
+  if (!data || data.length === 0) return NextResponse.json({ error: 'Savings entry not found' }, { status: 404 })
+  return NextResponse.json({ message: 'Savings entry deleted.' })
+}

--- a/app/assets/components/DesktopInsuranceDetail.tsx
+++ b/app/assets/components/DesktopInsuranceDetail.tsx
@@ -58,6 +58,10 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
   const [settleMode, setSettleMode] = useState(false)
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [deleting, setDeleting] = useState(false)
+  // Per-row reversal of an ad-hoc logged payment (kind:'logged'). Plan entries are
+  // computed, not stored, so they have no row to delete.
+  const [deleteEntryId, setDeleteEntryId] = useState<string | null>(null)
+  const [deletingEntry, setDeletingEntry] = useState(false)
 
   const [history, setHistory] = useState<HistoryEntry[] | null>(null)
   const [historyLoading, setHistoryLoading] = useState(false)
@@ -155,6 +159,23 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
       toast.error(isVi ? 'Không thể xoá thành viên' : "Couldn't remove member")
     } finally {
       setDeleting(false)
+    }
+  }
+
+  async function handleDeleteSavings() {
+    if (!deleteEntryId) return
+    setDeletingEntry(true)
+    try {
+      const res = await fetch(`/api/v1/insurance-savings/${deleteEntryId}`, { method: 'DELETE' })
+      if (!res.ok) throw new Error('delete failed')
+      setDeleteEntryId(null)
+      await loadHistory()
+      // Refresh the dashboard so the member's Saved progress drops to match.
+      onChanged?.()
+    } catch {
+      toast.error(isVi ? 'Không thể xoá khoản đã ghi nhận' : "Couldn't delete the logged payment")
+    } finally {
+      setDeletingEntry(false)
     }
   }
 
@@ -412,6 +433,22 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
                       <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>
                         {fmt(p.amount)}
                       </span>
+                      {/* Only ad-hoc logged payments are individually reversible; plan
+                          contributions are computed from the monthly plan, not stored. */}
+                      {!isPlan && (
+                        <button
+                          data-testid={`insurance-delete-savings-${p.id}`}
+                          onClick={() => setDeleteEntryId(p.id)}
+                          aria-label={isVi ? 'Xoá khoản này' : 'Delete this payment'}
+                          style={{
+                            display: 'flex', alignItems: 'center', justifyContent: 'center',
+                            width: 26, height: 26, borderRadius: 6, flexShrink: 0,
+                            background: 'transparent', border: 'none', cursor: 'pointer', color: 'var(--c-muted)',
+                          }}
+                        >
+                          <Trash2 size={13} />
+                        </button>
+                      )}
                     </div>
                   )
                 })}
@@ -522,6 +559,74 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
               >
                 <Trash2 size={14} />
                 {isVi ? 'Xóa' : 'Remove'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {deleteEntryId && (
+        <div
+          onClick={() => !deletingEntry && setDeleteEntryId(null)}
+          style={{
+            position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)',
+            zIndex: 210, display: 'flex', alignItems: 'center', justifyContent: 'center',
+            padding: 24, backdropFilter: 'blur(2px)',
+          }}
+        >
+          <div
+            onClick={(e) => e.stopPropagation()}
+            role="dialog"
+            aria-modal="true"
+            aria-label={isVi ? 'Xoá khoản đã ghi nhận?' : 'Delete logged payment?'}
+            style={{
+              width: '100%', maxWidth: 380, background: 'var(--c-card)',
+              borderRadius: 16, padding: 20,
+              boxShadow: '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)',
+              display: 'flex', flexDirection: 'column', gap: 12,
+            }}
+          >
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <h3 style={{ margin: 0, fontSize: 15, fontWeight: 700 }}>
+                {isVi ? 'Xoá khoản đã ghi nhận?' : 'Delete logged payment?'}
+              </h3>
+              <button
+                onClick={() => !deletingEntry && setDeleteEntryId(null)}
+                aria-label={isVi ? 'Đóng' : 'Close'}
+                className="cn-btn ghost"
+                style={{ padding: 6 }}
+              >
+                <X size={16} />
+              </button>
+            </div>
+            <p style={{ margin: 0, fontSize: 12, color: 'var(--c-muted)', lineHeight: 1.5 }}>
+              {isVi
+                ? 'Khoản này sẽ bị xoá và tiến độ tích lũy sẽ giảm tương ứng.'
+                : 'This payment will be removed and the saved progress will drop accordingly.'}
+            </p>
+            <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+              <button
+                onClick={() => setDeleteEntryId(null)}
+                disabled={deletingEntry}
+                className="cn-btn ghost"
+                style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}
+              >
+                {isVi ? 'Hủy' : 'Cancel'}
+              </button>
+              <button
+                data-testid="insurance-delete-savings-confirm"
+                onClick={handleDeleteSavings}
+                disabled={deletingEntry}
+                style={{
+                  flex: 2, padding: '10px 0', fontSize: 13, fontWeight: 600,
+                  background: 'var(--c-neg)', color: '#fff', border: 'none',
+                  borderRadius: 10, cursor: deletingEntry ? 'not-allowed' : 'pointer',
+                  fontFamily: 'inherit', opacity: deletingEntry ? 0.6 : 1,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7,
+                }}
+              >
+                <Trash2 size={14} />
+                {isVi ? 'Xóa' : 'Delete'}
               </button>
             </div>
           </div>

--- a/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
@@ -93,6 +93,72 @@ describe('DesktopInsuranceDetail — history load error vs empty', () => {
   })
 })
 
+describe('DesktopInsuranceDetail — delete a logged payment', () => {
+  it('deletes the logged savings row, re-fetches history and signals onChanged', async () => {
+    let deletedId: string | null = null
+    let savingsCall = 0
+    vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+      if (typeof url === 'string' && url.includes('/insurance-savings/') && init?.method === 'DELETE') {
+        deletedId = url.split('/insurance-savings/')[1]
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+      }
+      if (typeof url === 'string' && url.includes('/savings')) {
+        savingsCall += 1
+        const entries = savingsCall === 1
+          ? [{ id: 's1', amount: 1_500_000, date: '2026-03-15', kind: 'logged' }]
+          : []
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ entries, totalSaved: savingsCall === 1 ? 1_500_000 : 0 }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    }))
+    const onChanged = vi.fn()
+    render(<DesktopInsuranceDetail ins={ins} locale="en" onClose={vi.fn()} onChanged={onChanged} />)
+
+    await screen.findByText('Logged payment')
+    fireEvent.click(screen.getByTestId('insurance-delete-savings-s1'))
+    fireEvent.click(screen.getByTestId('insurance-delete-savings-confirm'))
+
+    await waitFor(() => expect(deletedId).toBe('s1'))
+    await waitFor(() => expect(onChanged).toHaveBeenCalled())
+    // History re-fetched → the row is gone.
+    await waitFor(() => expect(screen.queryByText('Logged payment')).not.toBeInTheDocument())
+  })
+
+  it('shows an error toast and keeps the row when the delete fails', async () => {
+    toastErrorMock.mockClear()
+    vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+      if (typeof url === 'string' && url.includes('/insurance-savings/') && init?.method === 'DELETE') {
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({}) })
+      }
+      if (typeof url === 'string' && url.includes('/savings')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ entries: [{ id: 's1', amount: 1_500_000, date: '2026-03-15', kind: 'logged' }], totalSaved: 1_500_000 }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    }))
+    render(<DesktopInsuranceDetail ins={ins} locale="en" onClose={vi.fn()} onChanged={vi.fn()} />)
+
+    await screen.findByText('Logged payment')
+    fireEvent.click(screen.getByTestId('insurance-delete-savings-s1'))
+    fireEvent.click(screen.getByTestId('insurance-delete-savings-confirm'))
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
+    expect(screen.getByText('Logged payment')).toBeInTheDocument()
+  })
+
+  it('does not offer delete on an auto monthly-plan entry (not a stored row)', async () => {
+    vi.stubGlobal('fetch', vi.fn((url: string) => {
+      if (typeof url === 'string' && url.includes('/savings')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ entries: [{ id: 'plan-p1', amount: 1_000_000, date: '2026-03-01', kind: 'plan' }], totalSaved: 1_000_000 }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    }))
+    render(<DesktopInsuranceDetail ins={ins} locale="en" onClose={vi.fn()} onChanged={vi.fn()} />)
+
+    await screen.findByText('Monthly plan')
+    expect(screen.queryByTestId('insurance-delete-savings-plan-p1')).not.toBeInTheDocument()
+  })
+})
+
 describe('DesktopInsuranceDetail — delete failure feedback', () => {
   it('shows an error toast and keeps the member (no onChanged/onClose) when the delete fails', async () => {
     toastErrorMock.mockClear()

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -116,6 +116,29 @@ export async function deleteInsuranceMember(memberId: string) {
   await supabase.from('insurance_members').delete().eq('member_id', memberId)
 }
 
+export async function createInsuranceSaving(data: {
+  insurance_member_id: string
+  amount_saved_vnd: number
+  saved_date?: string
+}) {
+  const userId = await getTestUserId()
+  const { data: row, error } = await supabase
+    .from('insurance_savings')
+    .insert({ user_id: userId, ...data })
+    .select()
+    .single()
+  if (error) throw error
+  return row
+}
+
+export async function countInsuranceSavings(memberId: string): Promise<number> {
+  const { count } = await supabase
+    .from('insurance_savings')
+    .select('id', { count: 'exact', head: true })
+    .eq('insurance_member_id', memberId)
+  return count ?? 0
+}
+
 export async function createFixedExpense(data: {
   expense_name: string
   amount_vnd: number

--- a/e2e/insurance.spec.ts
+++ b/e2e/insurance.spec.ts
@@ -106,6 +106,49 @@ test('edit an insurance member annual premium', async ({ page }) => {
   }, { timeout: 10_000 }).toBe(24_000_000)
 })
 
+test('delete a logged payment from the history and the saved progress drops', async ({ page }) => {
+  await api.deleteAllInsuranceMembersByName('E2E Dash Undo Payment')
+  const member = await api.createInsuranceMember({
+    member_name: 'E2E Dash Undo Payment',
+    relationship: 'Self',
+    annual_payment_vnd: 12_000_000,
+  })
+  cleanup.add(() => api.deleteInsuranceMember(member.member_id))
+
+  // Seed an ad-hoc logged contribution in the current cycle.
+  const today = new Date().toISOString().slice(0, 10)
+  const saving = await api.createInsuranceSaving({
+    insurance_member_id: member.member_id,
+    amount_saved_vnd: 1_500_000,
+    saved_date: today,
+  })
+  expect(await api.countInsuranceSavings(member.member_id)).toBe(1)
+
+  await gotoDashboardFresh(page)
+  const row = page.getByTestId('insurance-row').filter({ hasText: 'E2E Dash Undo Payment' }).first()
+  await expect(row).toBeVisible({ timeout: 10_000 })
+  await row.click()
+
+  const panel = page.getByTestId('insurance-detail-panel')
+  await expect(panel).toBeVisible({ timeout: 5_000 })
+  // The logged payment is listed in the history.
+  await expect(panel.getByText(/Logged payment|Đã ghi nhận/)).toBeVisible({ timeout: 10_000 })
+
+  // Delete it and confirm.
+  await panel.getByTestId(`insurance-delete-savings-${saving.id}`).click()
+  await Promise.all([
+    page.waitForResponse(
+      (r) => r.url().includes(`/api/v1/insurance-savings/${saving.id}`) && r.request().method() === 'DELETE' && r.status() < 400,
+      { timeout: 20_000 }
+    ),
+    page.getByTestId('insurance-delete-savings-confirm').click(),
+  ])
+
+  // Closes the loop: the row is gone from the DB (saved progress drops to match).
+  await expect.poll(async () => await api.countInsuranceSavings(member.member_id), { timeout: 10_000 }).toBe(0)
+  await expect(panel.getByText(/Logged payment|Đã ghi nhận/)).not.toBeVisible({ timeout: 10_000 })
+})
+
 test('delete an insurance member', async ({ page }) => {
   await api.deleteAllInsuranceMembersByName('E2E Dash Delete Insurance')
   const member = await api.createInsuranceMember({


### PR DESCRIPTION
## What

Part of the Overview UX-audit **reversibility** theme. Insurance payment history was append-only: an ad-hoc contribution logged by mistake could only be cleared by deleting the whole member (losing everything). Now each **logged** payment has a trash control that, after a confirm, removes just that contribution — and the member's **Saved** progress drops to match.

## Change

- **New endpoint** `DELETE /api/v1/insurance-savings/[id]` — UUID-validated, owner-scoped (`user_id` filter on top of RLS), `404` when no row matches. No migration (rows already have stable UUIDs).
- **`DesktopInsuranceDetail`** (also rendered by the mobile `InsuranceDetailSheet`): per-row trash button on `kind:'logged'` rows + a confirm dialog. On success it re-fetches the history and calls `onChanged` so the dashboard Saved figure updates; on failure it shows a `toast.error` and keeps the row (consistent with #395).
- Auto **monthly-plan** rows are computed (not stored), so they get **no** delete affordance.

## TDD

- Component (`DesktopInsuranceDetail.test.tsx`): delete → DELETE called with the row id + history re-fetched + `onChanged`; failure → toast + row stays; plan rows expose no delete button.
- E2E (`insurance.spec.ts`): seed a logged saving → open detail → delete + confirm → **assert the row is gone from the DB** (closes the loop on saved progress). Added `createInsuranceSaving` / `countInsuranceSavings` E2E helpers.

## Verification

- `npm test -- --run` → **839 passed** (+3)
- `npx tsc --noEmit` → 0 errors
- `npm run lint` → only the pre-existing repo-wide `react-hooks/set-state-in-effect` (unchanged count)
- `npx playwright test e2e/insurance.spec.ts --project=chromium` → **5 passed** (incl. the new delete-payment loop; existing add/edit/delete-member still green)

## Not in this PR
- **Undo mark-paid** — overwrites the prior `last_payment_date`/`payment_date`, so it needs a snapshot migration; separate PR.
- **PR-C** — insurance mislabels + goal "add to goal" CTA + explain "Unallocated".

🤖 Generated with [Claude Code](https://claude.com/claude-code)