### PR TITLE
fix(insurance): correct mislabeled relationship + payment-date fields

### DIFF
--- a/app/assets/components/AddInsuranceMemberModal.tsx
+++ b/app/assets/components/AddInsuranceMemberModal.tsx
@@ -66,11 +66,11 @@ export default function AddInsuranceMemberModal({ open, onClose, onCreated, loca
   const t = isVi
     ? { title: 'Thêm thành viên BH', name: 'Họ tên', namePh: 'VD. Linh Nguyễn',
         coverage: 'Mối quan hệ', premium: 'Phí bảo hiểm năm (₫)',
-        start: 'Ngày bắt đầu', monthly: 'Đóng góp hàng tháng',
+        start: 'Ngày đóng phí', monthly: 'Đóng góp hàng tháng',
         save: 'Thêm thành viên', cancel: 'Hủy' }
     : { title: 'Add insurance member', name: 'Full name', namePh: 'e.g. Linh Nguyen',
-        coverage: 'Coverage type', premium: 'Annual premium (₫)',
-        start: 'Start date', monthly: 'Monthly contribution',
+        coverage: 'Relationship', premium: 'Annual premium (₫)',
+        start: 'Payment date', monthly: 'Monthly contribution',
         save: 'Add member', cancel: 'Cancel' }
 
   async function handleSubmit() {
@@ -166,7 +166,7 @@ export default function AddInsuranceMemberModal({ open, onClose, onCreated, loca
         </div>
       </div>
 
-      {/* Start date */}
+      {/* Annual premium due date */}
       <FormField label={t.start}>
         <input
           type="date"

--- a/app/assets/components/DesktopInsuranceDetail.tsx
+++ b/app/assets/components/DesktopInsuranceDetail.tsx
@@ -209,7 +209,7 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
           <Field label={isVi ? 'Họ tên' : 'Full name'}>
             <input value={editName} onChange={(e) => setEditName(e.target.value)} className="cn-input" autoFocus />
           </Field>
-          <Field label={isVi ? 'Mối quan hệ' : 'Coverage type'}>
+          <Field label={isVi ? 'Mối quan hệ' : 'Relationship'}>
             <div style={{ display: 'flex', gap: 8 }}>
               {COVERAGE_OPTIONS.map((o) => {
                 const active = editCoverage === o.value
@@ -245,7 +245,7 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
               {fmtCompact(editPremium / 12)} / {isVi ? 'tháng' : 'month'}
             </div>
           </Field>
-          <Field label={isVi ? 'Ngày bắt đầu' : 'Start date'}>
+          <Field label={isVi ? 'Ngày đóng phí' : 'Payment date'}>
             <input type="date" value={editDate} onChange={(e) => setEditDate(e.target.value)} className="cn-input" />
           </Field>
           {editError && <div role="alert" style={{ fontSize: 12, color: 'var(--c-neg)' }}>{editError}</div>}

--- a/app/assets/components/__tests__/AddInsuranceMemberModal.test.tsx
+++ b/app/assets/components/__tests__/AddInsuranceMemberModal.test.tsx
@@ -31,6 +31,16 @@ describe('AddInsuranceMemberModal — responsive presentation', () => {
     expect(screen.getByRole('button', { name: /add member/i })).toBeInTheDocument()
   })
 
+  it('labels the relationship picker and the payment-date field accurately (not "Coverage type"/"Start date")', () => {
+    render(<AddInsuranceMemberModal open onClose={vi.fn()} locale="en" />)
+    // The picker holds relationships (Self/Spouse/Parent…), not coverage tiers.
+    expect(screen.getByText('Relationship')).toBeInTheDocument()
+    expect(screen.queryByText('Coverage type')).not.toBeInTheDocument()
+    // The date is the annual premium due date, not a policy start date.
+    expect(screen.getByText('Payment date')).toBeInTheDocument()
+    expect(screen.queryByText('Start date')).not.toBeInTheDocument()
+  })
+
   it('offers the full relationship set including Parent and Other (no Husband/Wife)', () => {
     render(<AddInsuranceMemberModal open onClose={vi.fn()} locale="en" />)
     for (const label of ['Self', 'Spouse', 'Child', 'Parent', 'Other']) {

--- a/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
@@ -185,6 +185,18 @@ describe('DesktopInsuranceDetail — delete failure feedback', () => {
   })
 })
 
+describe('DesktopInsuranceDetail — edit-form labels are accurate', () => {
+  it('labels the relationship picker "Relationship" and the date "Payment date" (not "Coverage type"/"Start date")', () => {
+    render(<DesktopInsuranceDetail ins={ins} locale="en" onClose={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('insurance-edit-btn'))
+
+    expect(screen.getByText('Relationship')).toBeInTheDocument()
+    expect(screen.queryByText('Coverage type')).not.toBeInTheDocument()
+    expect(screen.getByText('Payment date')).toBeInTheDocument()
+    expect(screen.queryByText('Start date')).not.toBeInTheDocument()
+  })
+})
+
 describe('DesktopInsuranceDetail — coverage round-trips through relationship', () => {
   it('preselects the member’s coverage in the edit form and offers Parent/Other', async () => {
     const parentIns = { ...ins, coverageType: 'Parent' } as InsuranceData


### PR DESCRIPTION
## What

Part of the Overview UX-audit **words-are-UI** cleanup. Two insurance form labels described the wrong thing:

| Field | Was (EN) | Now (EN) | Why |
|---|---|---|---|
| Relationship picker | **Coverage type** | **Relationship** | It sets `relationship` (Self/Spouse/Parent/Child/Other), not a coverage tier |
| Date field | **Start date** / **Ngày bắt đầu** | **Payment date** / **Ngày đóng phí** | It edits the annual premium due date (`payment_date`, which mark-paid rolls forward a year) — not a policy start date |

Applied in both the **Add-member modal** and the **detail edit form**. The Vietnamese relationship label ("Mối quan hệ") was already correct and is unchanged.

Copy-only — no behavior change.

## TDD

Added label assertions to `AddInsuranceMemberModal.test.tsx` and `DesktopInsuranceDetail.test.tsx` (assert the accurate labels appear and the old wrong ones are gone). Confirmed via grep that no test/E2E selector keyed off the old strings.

## Verification

- `npm test -- --run` → **841 passed** (+2)
- `npx tsc --noEmit` → 0 errors
- `npm run lint` → only the pre-existing repo-wide `react-hooks/set-state-in-effect` (unchanged)

## Remaining audit items
- **Undo mark-paid** — needs a snapshot migration + a one-level-undo design decision (separate PR)
- **Goal "add to goal" CTA** + explain **"Unallocated"** (separate PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)