### PR TITLE
feat(overview): explain what "Unallocated" means

### DIFF
--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -534,6 +534,9 @@ export default function UnallocatedSection({
 
           {open && (
             <div style={{ borderTop: '1px solid var(--c-line)' }}>
+              <p style={{ margin: 0, padding: '10px 16px', fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.5, borderBottom: '1px solid var(--c-line)' }}>
+                {t('unallocatedHint')}
+              </p>
               {renderRows('12px 16px')}
             </div>
           )}
@@ -650,6 +653,9 @@ export default function UnallocatedSection({
             overflow: 'hidden',
             padding: '4px 14px',
           }}>
+            <p style={{ margin: 0, padding: '8px 0', fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.5, borderBottom: '1px solid var(--c-line)' }}>
+              {t('unallocatedHint')}
+            </p>
             {renderRows('12px 0')}
           </div>
         )}

--- a/app/assets/components/__tests__/UnallocatedSection.test.tsx
+++ b/app/assets/components/__tests__/UnallocatedSection.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import UnallocatedSection from '../UnallocatedSection'
+
+// Resolve real English copy from the catalog so the assertion checks rendered text.
+vi.mock('next-intl', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const en = require('../../../../messages/en.json')
+  const resolve = (ns: string | undefined, key: string) => {
+    const dict = ns ? en[ns] : en
+    return key.split('.').reduce((o: Record<string, unknown> | undefined, k: string) =>
+      (o == null ? undefined : o[k] as Record<string, unknown>), dict) ?? key
+  }
+  return {
+    useTranslations: (ns?: string) => (key: string) => resolve(ns, key),
+    useLocale: () => 'en',
+  }
+})
+
+const baseProps = {
+  unallocatedAmount: 9_000_000,
+  funds: [],
+  nonFunds: [],
+  onFundClick: vi.fn(),
+  onAssignToGoal: vi.fn(),
+  onSellFund: vi.fn(),
+  onAssignNonFundToGoal: vi.fn(),
+  onSellNonFund: vi.fn(),
+}
+
+describe('UnallocatedSection — explains what "Unallocated" means', () => {
+  it('shows a one-line hint when the section is expanded (mobile)', () => {
+    render(<UnallocatedSection {...baseProps} />)
+    expect(screen.getByText(/not yet linked to a goal/i)).toBeInTheDocument()
+  })
+
+  it('shows the hint in the desktop card too', () => {
+    render(<UnallocatedSection {...baseProps} desktopCard />)
+    expect(screen.getByText(/not yet linked to a goal/i)).toBeInTheDocument()
+  })
+})

--- a/messages/en.json
+++ b/messages/en.json
@@ -467,6 +467,7 @@
     "sectionGoals": "Goals",
     "sectionUnallocated": "Unallocated",
     "availableToAssign": "available to assign",
+    "unallocatedHint": "Holdings not yet linked to a goal — assign them to count toward a goal's progress.",
     "recentActivity": "Recent activity",
     "viewAll": "View all",
     "recentActivityEmpty": "No transactions yet",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -467,6 +467,7 @@
     "sectionGoals": "Mục tiêu",
     "sectionUnallocated": "Chưa phân bổ",
     "availableToAssign": "có thể gán cho mục tiêu",
+    "unallocatedHint": "Các khoản đầu tư chưa gắn với mục tiêu nào — hãy gán để tính vào tiến độ của mục tiêu.",
     "recentActivity": "Hoạt động gần đây",
     "viewAll": "Xem tất cả",
     "recentActivityEmpty": "Chưa có giao dịch",


### PR DESCRIPTION
## What

Final small item from the Overview UX-audit **words-are-UI** theme. The Unallocated section never explained itself — a first-time user sees a bucket of money separated from goals with no reason given (the only hint was "{amount} available to assign").

Adds a one-line caption at the top of the **expanded** section, in both the desktop card and the mobile list:

> Holdings not yet linked to a goal — assign them to count toward a goal's progress.

(VI: "Các khoản đầu tư chưa gắn với mục tiêu nào — hãy gán để tính vào tiến độ của mục tiêu.")

New i18n key `dashboard.unallocatedHint` (en + vi). Additive copy — no behavior or layout-structure change, no selector changes.

## TDD

New `UnallocatedSection.test.tsx` renders the section (mobile + desktop card) and asserts the hint text shows when expanded (resolving real `en.json` copy).

## Verification

- `npm test -- --run` → **843 passed** (+2; i18n key-parity test still green)
- `npx tsc --noEmit` → 0 errors
- `npm run lint` → only the pre-existing repo-wide `react-hooks/set-state-in-effect` (unchanged)
- E2E `unallocated-book` + `assign-goal-desktop` + `dashboard-desktop` (`--project=chromium`) → **34 passed**

## Remaining audit items (need your input)
- **Undo mark-paid** — needs a snapshot migration + a one-level-undo design decision
- **Goal "add to goal" CTA** — needs a UX decision on what the button opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)