### PR TITLE
feat(goal): "Add to this goal" CTA from the goal detail

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -16,7 +16,7 @@ import { SellWithdrawSheet, type SellItem } from './components/SellWithdrawSheet
 import GoalDetailSheet from './components/GoalDetailSheet'
 import AssignGoalSheet from './components/AssignGoalSheet'
 import DownloadReportSheet from './components/DownloadReportSheet'
-import AddTransactionSheet from './components/AddTransactionSheet'
+import AddTransactionSheet, { type PrefillTransaction } from './components/AddTransactionSheet'
 import RecentActivityCard from './components/RecentActivityCard'
 import MaturityActionCard from './components/MaturityActionCard'
 import { MaturityResolveSheet, MaturityResolveModal } from './components/MaturityResolveSheet'
@@ -313,6 +313,9 @@ export default function DashboardClient({ userId }: { userId: string }) {
   const [showReportSheet, setShowReportSheet] = useState(false)
   const [selectedInsuranceId, setSelectedInsuranceId] = useState<string | null>(null)
   const [desktopAddTxOpen, setDesktopAddTxOpen] = useState(false)
+  // When set, the add-transaction sheet opens prefilled (e.g. "Add to this goal"
+  // from a goal detail). Cleared on close so the plain FAB/button path stays blank.
+  const [addTxPrefill, setAddTxPrefill] = useState<PrefillTransaction | null>(null)
   const [showAddInsurance, setShowAddInsurance] = useState(false)
   const selectedGoal = data?.goals.find((g) => g.goalId === selectedGoalId) ?? null
   // Derive the selected insurance from fresh data (mirrors selectedGoal) so the
@@ -733,7 +736,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                 <div style={{ display: 'flex', gap: 8 }}>
                   <button
                     data-testid="desktop-add-tx-btn"
-                    onClick={() => setDesktopAddTxOpen(true)}
+                    onClick={() => { setAddTxPrefill(null); setDesktopAddTxOpen(true) }}
                     className="cn-btn"
                     style={{ padding: '8px 14px', fontSize: 13, gap: 6 }}
                   >
@@ -889,6 +892,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                     // so the panel stays open and the renewal summary is visible.
                     onRenewed={() => fetchData({ force: true })}
                     refreshKey={historyKey}
+                    onAddToGoal={() => { setAddTxPrefill({ goal_id: selectedGoal.goalId }); setDesktopAddTxOpen(true) }}
                   />
                 ) : selectedInsurance ? (
                   <DesktopInsuranceDetail
@@ -1200,14 +1204,18 @@ export default function DashboardClient({ userId }: { userId: string }) {
         onClose={() => setGoalDetailOpen(false)}
         onDataChanged={() => fetchData({ force: true })}
         refreshKey={historyKey}
+        onAddToGoal={selectedGoal ? () => { setAddTxPrefill({ goal_id: selectedGoal.goalId }); setDesktopAddTxOpen(true) } : undefined}
       />
 
-      {/* Desktop: Add Transaction Sheet */}
+      {/* Add Transaction Sheet — opened by the desktop button (blank) or by a
+          goal detail's "Add to this goal" CTA (prefilled). Renders as a bottom
+          sheet on mobile via desktop={isDesktop}. */}
       <AddTransactionSheet
         open={desktopAddTxOpen}
-        onClose={() => setDesktopAddTxOpen(false)}
-        onSaved={() => fetchData({ force: true })}
+        onClose={() => { setDesktopAddTxOpen(false); setAddTxPrefill(null) }}
+        onSaved={() => { fetchData({ force: true }); setHistoryKey((k) => k + 1) }}
         desktop={isDesktop}
+        prefill={addTxPrefill}
       />
 
       {/* Download Report Sheet */}

--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -696,6 +696,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
             <div>
               <label style={labelStyle}>{t('goal')}</label>
               <select
+                data-testid="addtx-goal-select"
                 value={goalId}
                 onChange={(e) => setGoalId(e.target.value)}
                 style={{ ...inputStyle }}

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useMemo } from 'react'
-import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield, RefreshCw, PiggyBank, GitMerge } from 'lucide-react'
+import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield, RefreshCw, PiggyBank, GitMerge, Plus } from 'lucide-react'
 import { toast } from 'sonner'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
@@ -53,9 +53,13 @@ interface Props {
    * requiring a hard page reload.
    */
   refreshKey?: number
+  /** Opens the Add-transaction flow prefilled with this goal, so a new
+   *  contribution is logged straight to it (the goal detail was otherwise a
+   *  dead end — no way to add money from here). */
+  onAddToGoal?: () => void
 }
 
-export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged, onRenewed, refreshKey }: Props) {
+export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged, onRenewed, refreshKey, onAddToGoal }: Props) {
   const isVi = locale === 'vi'
   const [tab, setTab] = useState<'investments' | 'calculator' | 'history'>('investments')
   const [transactions, setTransactions] = useState<InvestmentTx[]>([])
@@ -300,6 +304,20 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
             ))}
           </div>
         </div>
+
+        {/* Add to this goal — turns the detail panel from a dead end into a place
+            you can fund the goal from. Opens the Add-transaction flow prefilled. */}
+        {onAddToGoal && (
+          <button
+            data-testid="goal-add-to-goal"
+            onClick={onAddToGoal}
+            className="cn-btn primary"
+            style={{ width: '100%', justifyContent: 'center', gap: 7 }}
+          >
+            <Plus size={15} strokeWidth={2.4} />
+            {isVi ? 'Thêm vào mục tiêu' : 'Add to this goal'}
+          </button>
+        )}
 
         {/* Composition */}
         {segs.length > 0 && (

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import {
   ChevronLeft, ChevronRight, MoreHorizontal,
-  Edit2, Trash2, Calendar, Download, ArrowDownRight, ArrowUpRight, Target, RefreshCw, PiggyBank, GitMerge,
+  Edit2, Trash2, Calendar, Download, ArrowDownRight, ArrowUpRight, Target, RefreshCw, PiggyBank, GitMerge, Plus,
 } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { toast } from 'sonner'
@@ -53,6 +53,9 @@ interface Props {
    * without requiring a hard page reload.
    */
   refreshKey?: number
+  /** Opens the Add-transaction flow prefilled with this goal, so a new
+   *  contribution is logged straight to it (the sheet was otherwise a dead end). */
+  onAddToGoal?: () => void
 }
 
 function GoalActionsSheet({
@@ -762,7 +765,7 @@ function UnassignConfirmSheet({
   )
 }
 
-export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, refreshKey }: Props) {
+export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, refreshKey, onAddToGoal }: Props) {
   const isVI = useLocale() === 'vi'
   const [mounted, setMounted] = useState(false)
   const [activeTab, setActiveTab] = useState<'investments' | 'calculator' | 'history'>('investments')
@@ -1073,6 +1076,20 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
               ))}
             </div>
           </div>
+
+          {/* Add to this goal — opens the Add-transaction flow prefilled, so the
+              sheet is a place you can fund the goal from, not just inspect it. */}
+          {onAddToGoal && (
+            <button
+              data-testid="goal-add-to-goal"
+              onClick={onAddToGoal}
+              className="cn-btn primary"
+              style={{ width: '100%', justifyContent: 'center', gap: 7, marginBottom: 16 }}
+            >
+              <Plus size={16} strokeWidth={2.4} />
+              {isVI ? 'Thêm vào mục tiêu' : 'Add to this goal'}
+            </button>
+          )}
 
           {/* Composition bar */}
           {segs.length > 0 && (

--- a/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
@@ -28,6 +28,22 @@ const baseProps = {
   onDataChanged: vi.fn(),
 }
 
+describe('DesktopGoalDetail — add-to-goal CTA', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn().mockImplementation(() =>
+      Promise.resolve({ ok: true, json: async () => ({ transactions: [] }) }),
+    )
+  })
+
+  it('renders an "Add to this goal" CTA and calls onAddToGoal when clicked', async () => {
+    const onAddToGoal = vi.fn()
+    render(<DesktopGoalDetail {...baseProps} onAddToGoal={onAddToGoal} />)
+
+    await userEvent.click(await screen.findByTestId('goal-add-to-goal'))
+    expect(onAddToGoal).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('DesktopGoalDetail — delete failure feedback', () => {
   beforeEach(() => {
     toastErrorMock.mockClear()

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -80,6 +80,16 @@ const baseProps = {
   onDataChanged: vi.fn(),
 }
 
+describe('GoalDetailSheet — add-to-goal CTA', () => {
+  it('renders an "Add to this goal" CTA and calls onAddToGoal when clicked', async () => {
+    const onAddToGoal = vi.fn()
+    render(<GoalDetailSheet {...baseProps} onAddToGoal={onAddToGoal} />)
+
+    await userEvent.click(await screen.findByTestId('goal-add-to-goal'))
+    expect(onAddToGoal).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('GoalDetailSheet — delete failure feedback', () => {
   it('shows an error toast and keeps the sheet open (no onClose) when the delete fails', async () => {
     toastErrorMock.mockClear()

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -71,6 +71,19 @@ test.describe('Desktop goal detail panel', () => {
     await expect(page.getByTestId('desktop-net-worth-panel')).toBeVisible({ timeout: 10_000 })
   })
 
+  test('"Add to this goal" opens the Add-transaction sheet preselected to this goal', async ({ page }) => {
+    await page.getByText('E2E Desktop Goal').first().click()
+    await expect(page.getByTestId('desktop-goal-detail')).toBeVisible({ timeout: 5_000 })
+
+    await page.getByTestId('goal-add-to-goal').click()
+
+    // The sheet opens and the goal selector is pre-set to this goal, so a new
+    // contribution is logged straight to it (the panel was otherwise a dead end).
+    const goalSelect = page.getByTestId('addtx-goal-select')
+    await expect(goalSelect).toBeVisible({ timeout: 5_000 })
+    await expect(goalSelect).toHaveValue(goalId)
+  })
+
   // Issue #261: after fully withdrawing a bank deposit from the goal detail,
   // it must no longer appear on the Investments tab. Attach the deposit to the
   // shared goal (reliably rendered) — the Investments tab fetches transactions


### PR DESCRIPTION
## What

Final Overview UX-audit item: the goal detail (mobile sheet + desktop panel) was a **dead end** — you could inspect a goal but had no way to put money into it. You had to back out to the global Add-transaction FAB and re-pick the goal each time.

Adds a primary **"Add to this goal"** CTA (Thêm vào mục tiêu) that opens the Add-transaction flow **prefilled with this goal**, so a new fund/bank/gold contribution lands straight on it.

## How

- Reuses `AddTransactionSheet`'s existing `prefill.goal_id` path (already POSTs `goal_id`).
- `DashboardClient` owns a single sheet and routes both entries through it: the blank desktop button (prefill cleared) and the prefilled CTA. It renders as a bottom sheet on mobile via `desktop={isDesktop}`.
- On save it bumps `historyKey` so an open goal detail refreshes in place.
- Both `DesktopGoalDetail` and the mobile `GoalDetailSheet` take an optional `onAddToGoal` and render the CTA only when provided.

Per your pick: **opens Add-transaction with the goal preselected** (vs assign-from-unallocated).

## TDD

- Component: `DesktopGoalDetail` + `GoalDetailSheet` render `goal-add-to-goal` and fire `onAddToGoal` on click.
- E2E (`goal-detail-desktop.spec.ts`): click a goal → "Add to this goal" → the sheet opens with `addtx-goal-select` **preselected to that goal** (the DashboardClient wiring the unit tests can't reach). The save→POST-with-`goal_id` is already unit-covered in `AddTransactionSheet.test.tsx`.

## Verification

- `npm test -- --run` → **845 passed** (+2)
- `npx tsc --noEmit` → 0 errors
- `npm run lint` → only the pre-existing repo-wide `react-hooks/set-state-in-effect` (unchanged)
- E2E `goal-detail-desktop` + `add-transaction` (`--project=chromium`) → **26 passed** (incl. the new CTA test)

## Remaining audit item
- **Undo mark-paid** — next PR (needs the snapshot migration we discussed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)