### PR TITLE
feat(insurance): undo an accidental mark-paid (snapshot migration)

### DIFF
--- a/app/api/v1/insurance-members/[id]/mark-paid/route.ts
+++ b/app/api/v1/insurance-members/[id]/mark-paid/route.ts
@@ -25,7 +25,7 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
   // Fetch member — distinguish 404 vs 403
   const { data: member, error: fetchError } = await supabase
     .from('insurance_members')
-    .select('member_id, user_id, member_name, annual_payment_vnd, monthly_premium_vnd, payment_date, updated_at')
+    .select('member_id, user_id, member_name, annual_payment_vnd, monthly_premium_vnd, payment_date, last_payment_date, updated_at')
     .eq('member_id', memberId)
     .single()
 
@@ -59,12 +59,15 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
   // funded the now-settled cycle; progress for the next cycle is computed from
   // contributions made after last_payment_date (see isInCurrentCycle).
 
-  // Advance payment_date by 1 year and record last_payment_date
+  // Advance payment_date by 1 year and record last_payment_date. Snapshot the two
+  // dates we're overwriting so the settlement can be undone (one level back).
   const { data: updated, error: updateError } = await supabase
     .from('insurance_members')
     .update({
       payment_date: nextPaymentDate,
       last_payment_date: paidISO,
+      prev_payment_date: member.payment_date,
+      prev_last_payment_date: member.last_payment_date,
       updated_at: now.toISOString(),
     })
     .eq('member_id', memberId)

--- a/app/api/v1/insurance-members/[id]/mark-paid/undo/route.ts
+++ b/app/api/v1/insurance-members/[id]/mark-paid/undo/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
+
+function err(status: number, code: string, message: string) {
+  return NextResponse.json({ error: code, message }, { status })
+}
+
+// Reverse the most recent mark-paid: restore the dates it overwrote (from the
+// snapshot) and clear the snapshot so undo is one-shot per settlement. Only
+// applicable while the member is in a settled state (last_payment_date set).
+export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+
+  let memberId: string
+  try {
+    memberId = validateUUID(id, 'member_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return err(400, 'INVALID_MEMBER_ID', 'Invalid member ID format')
+    throw e
+  }
+
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return err(401, 'UNAUTHORIZED', 'Authentication required')
+
+  const { data: member, error: fetchError } = await supabase
+    .from('insurance_members')
+    .select('member_id, user_id, member_name, payment_date, last_payment_date, prev_payment_date, prev_last_payment_date')
+    .eq('member_id', memberId)
+    .single()
+
+  if (fetchError || !member) return err(404, 'NOT_FOUND', 'Insurance member not found')
+  if (member.user_id !== user.id) return err(403, 'FORBIDDEN', "You don't have permission to undo this payment")
+  if (!member.last_payment_date) return err(409, 'NOT_SETTLED', 'There is no settlement to undo')
+
+  // Restore the snapshot when present. Fallback (legacy rows settled before the
+  // snapshot existed): roll payment_date back a year and clear last_payment_date,
+  // which is the deterministic inverse of mark-paid's forward step.
+  const restoredPaymentDate = member.prev_payment_date ?? (
+    member.payment_date
+      ? (() => {
+          const d = new Date(member.payment_date)
+          d.setFullYear(d.getFullYear() - 1)
+          return d.toISOString().split('T')[0]
+        })()
+      : null
+  )
+
+  const { error: updateError } = await supabase
+    .from('insurance_members')
+    .update({
+      payment_date: restoredPaymentDate,
+      last_payment_date: member.prev_last_payment_date,
+      prev_payment_date: null,
+      prev_last_payment_date: null,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('member_id', memberId)
+    .eq('user_id', user.id)
+
+  if (updateError) {
+    console.error('[mark-paid/undo] Failed to restore', { member_id: memberId, error: updateError.message })
+    return err(500, 'INTERNAL_ERROR', 'An error occurred while processing your request')
+  }
+
+  console.log(`[AUDIT] mark-paid/undo: reverted settlement at ${new Date().toISOString()}`)
+
+  return NextResponse.json({
+    data: {
+      member_id: memberId,
+      name: member.member_name,
+      payment_date: restoredPaymentDate,
+      last_payment_date: member.prev_last_payment_date,
+    },
+  })
+}

--- a/app/assets/components/DesktopInsuranceDetail.tsx
+++ b/app/assets/components/DesktopInsuranceDetail.tsx
@@ -62,6 +62,7 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
   // computed, not stored, so they have no row to delete.
   const [deleteEntryId, setDeleteEntryId] = useState<string | null>(null)
   const [deletingEntry, setDeletingEntry] = useState(false)
+  const [undoingPaid, setUndoingPaid] = useState(false)
 
   const [history, setHistory] = useState<HistoryEntry[] | null>(null)
   const [historyLoading, setHistoryLoading] = useState(false)
@@ -176,6 +177,21 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
       toast.error(isVi ? 'Không thể xoá khoản đã ghi nhận' : "Couldn't delete the logged payment")
     } finally {
       setDeletingEntry(false)
+    }
+  }
+
+  async function handleUndoMarkPaid() {
+    setUndoingPaid(true)
+    try {
+      const res = await fetch(`/api/v1/insurance-members/${ins.insuranceId}/mark-paid/undo`, { method: 'POST' })
+      if (!res.ok) throw new Error('undo failed')
+      // Reverts the settlement: due date rolls back and the member leaves the
+      // paid state. Refresh the dashboard so the panel re-renders from fresh data.
+      onChanged?.()
+    } catch {
+      toast.error(isVi ? 'Không thể hoàn tác' : "Couldn't undo the payment")
+    } finally {
+      setUndoingPaid(false)
     }
   }
 
@@ -310,6 +326,21 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
                   <div style={{ flex: 1, fontSize: 12, color: 'var(--c-pos)', fontWeight: 500 }}>
                     {isVi ? `Phí ${paidYear} đã thanh toán` : `${paidYear} premium settled`}
                   </div>
+                  {/* Reverse an accidental settlement — rolls the due date back and
+                      restores the saved progress (issue: mark-paid was one-way). */}
+                  <button
+                    data-testid="insurance-undo-mark-paid"
+                    onClick={handleUndoMarkPaid}
+                    disabled={undoingPaid}
+                    style={{
+                      flexShrink: 0, background: 'transparent', border: 'none',
+                      fontSize: 11, fontWeight: 600, color: 'var(--c-pos)',
+                      textDecoration: 'underline', cursor: undoingPaid ? 'default' : 'pointer',
+                      fontFamily: 'inherit', opacity: undoingPaid ? 0.6 : 1, padding: 0,
+                    }}
+                  >
+                    {undoingPaid ? (isVi ? 'Đang hoàn tác…' : 'Undoing…') : (isVi ? 'Hoàn tác' : 'Undo')}
+                  </button>
                 </div>
                 <div style={{ fontSize: 11, color: 'var(--c-muted)', marginBottom: 6, fontWeight: 600, letterSpacing: '0.04em', textTransform: 'uppercase' }}>
                   {isVi ? `Tích lũy cho ${paidYear! + 1}` : `Saving for ${paidYear! + 1}`}

--- a/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopInsuranceDetail.test.tsx
@@ -219,6 +219,68 @@ describe('DesktopInsuranceDetail — coverage round-trips through relationship',
   })
 })
 
+describe('DesktopInsuranceDetail — undo mark-paid', () => {
+  afterEach(() => vi.useRealTimers())
+
+  const paidIns: InsuranceData = {
+    ...ins,
+    status: 'on_track',
+    amountSaved: 0,
+    savingsProgressPercentage: 0,
+    nextPaymentDate: '2027-05-28',
+    lastPaymentDate: '2026-05-28',
+  } as InsuranceData
+
+  // Render in the settled state deterministically, then hand control back to real
+  // timers so waitFor (which polls on a timer) resolves.
+  function renderPaid(onChanged = vi.fn()) {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date(2026, 4, 28))
+    const utils = render(<DesktopInsuranceDetail ins={paidIns} locale="en" onClose={vi.fn()} onChanged={onChanged} />)
+    vi.useRealTimers()
+    return { ...utils, onChanged }
+  }
+
+  it('reverts the settlement (POST .../mark-paid/undo) and refreshes', async () => {
+    let undoCalled = false
+    vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+      if (typeof url === 'string' && url.includes('/mark-paid/undo') && init?.method === 'POST') {
+        undoCalled = true
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ data: {} }) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ entries: [], totalSaved: 0 }) })
+    }))
+    const { onChanged } = renderPaid()
+
+    fireEvent.click(screen.getByTestId('insurance-undo-mark-paid'))
+
+    await waitFor(() => expect(undoCalled).toBe(true))
+    await waitFor(() => expect(onChanged).toHaveBeenCalled())
+  })
+
+  it('shows an error toast and does not refresh when the undo fails', async () => {
+    toastErrorMock.mockClear()
+    vi.stubGlobal('fetch', vi.fn((url: string, init?: RequestInit) => {
+      if (typeof url === 'string' && url.includes('/mark-paid/undo') && init?.method === 'POST') {
+        return Promise.resolve({ ok: false, json: () => Promise.resolve({}) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ entries: [], totalSaved: 0 }) })
+    }))
+    const { onChanged } = renderPaid()
+
+    fireEvent.click(screen.getByTestId('insurance-undo-mark-paid'))
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
+    expect(onChanged).not.toHaveBeenCalled()
+  })
+
+  it('offers no undo control when the member is not settled this year', () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({ entries: [], totalSaved: 0 }) })))
+    render(<DesktopInsuranceDetail ins={ins} locale="en" onClose={vi.fn()} />)
+    expect(screen.queryByTestId('insurance-undo-mark-paid')).not.toBeInTheDocument()
+  })
+})
+
 describe('DesktopInsuranceDetail — paid-for-the-year state (issue #227)', () => {
   afterEach(() => vi.useRealTimers())
 

--- a/e2e/insurance.spec.ts
+++ b/e2e/insurance.spec.ts
@@ -149,6 +149,64 @@ test('delete a logged payment from the history and the saved progress drops', as
   await expect(panel.getByText(/Logged payment|Đã ghi nhận/)).not.toBeVisible({ timeout: 10_000 })
 })
 
+test('undo mark-paid restores the due date and clears the settlement', async ({ page }) => {
+  await api.deleteAllInsuranceMembersByName('E2E Undo Paid')
+  const due = new Date()
+  due.setDate(due.getDate() + 60)
+  const dueISO = due.toISOString().slice(0, 10)
+  const member = await api.createInsuranceMember({
+    member_name: 'E2E Undo Paid',
+    relationship: 'Self',
+    annual_payment_vnd: 12_000_000,
+    payment_date: dueISO,
+  })
+  cleanup.add(() => api.deleteInsuranceMember(member.member_id))
+
+  await gotoDashboardFresh(page)
+  const row = page.getByTestId('insurance-row').filter({ hasText: 'E2E Undo Paid' }).first()
+  await expect(row).toBeVisible({ timeout: 10_000 })
+  await row.click()
+  const panel = page.getByTestId('insurance-detail-panel')
+  await expect(panel).toBeVisible({ timeout: 5_000 })
+
+  // Settle the premium via the status CTA → payment modal → confirm.
+  await panel.getByTestId('insurance-cta-status').click()
+  const modal = page.getByTestId('log-payment-modal')
+  await expect(modal).toBeVisible({ timeout: 5_000 })
+  await Promise.all([
+    page.waitForResponse(
+      (r) => r.url().includes('/mark-paid') && !r.url().includes('/undo') && r.request().method() === 'POST' && r.status() < 400,
+      { timeout: 20_000 }
+    ),
+    modal.getByRole('button', { name: /confirm|xác nhận/i }).click(),
+  ])
+
+  // Now in the settled state — the Undo control appears in the chip.
+  const undo = panel.getByTestId('insurance-undo-mark-paid')
+  await expect(undo).toBeVisible({ timeout: 8_000 })
+
+  await Promise.all([
+    page.waitForResponse(
+      (r) => r.url().includes('/mark-paid/undo') && r.request().method() === 'POST' && r.status() < 400,
+      { timeout: 20_000 }
+    ),
+    undo.click(),
+  ])
+
+  // Closes the loop: the original due date is restored and the settlement is
+  // cleared in the DB (the member leaves the paid state).
+  await expect.poll(async () => {
+    const { createClient } = await import('@supabase/supabase-js')
+    const supabase = createClient(process.env.E2E_SUPABASE_URL!, process.env.E2E_SUPABASE_SERVICE_ROLE_KEY!)
+    const { data } = await supabase
+      .from('insurance_members')
+      .select('payment_date, last_payment_date')
+      .eq('member_id', member.member_id)
+      .single()
+    return data
+  }, { timeout: 10_000 }).toMatchObject({ payment_date: dueISO, last_payment_date: null })
+})
+
 test('delete an insurance member', async ({ page }) => {
   await api.deleteAllInsuranceMembersByName('E2E Dash Delete Insurance')
   const member = await api.createInsuranceMember({

--- a/supabase/migrations/20260628000001_add_insurance_mark_paid_snapshot.sql
+++ b/supabase/migrations/20260628000001_add_insurance_mark_paid_snapshot.sql
@@ -1,0 +1,9 @@
+-- Snapshot the dates mark-paid overwrites, so a settlement can be undone.
+--
+-- mark-paid advances payment_date by a year and stamps last_payment_date = today,
+-- discarding the prior values. Without a snapshot an accidental settlement cannot
+-- be reversed. These two nullable columns hold the one-level-back state; the undo
+-- endpoint restores from them and clears them (so undo is one-shot per settlement).
+ALTER TABLE insurance_members
+  ADD COLUMN IF NOT EXISTS prev_payment_date DATE DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS prev_last_payment_date TIMESTAMP WITH TIME ZONE DEFAULT NULL;


### PR DESCRIPTION
## What

Completes the Overview UX-audit **reversibility** theme. Marking a premium paid was **one-way**: it advanced the due date a year and stamped `last_payment_date = today`, discarding the prior values — an accidental settlement couldn't be reversed in the UI.

Adds a one-level **Undo** on the settled state.

## ⚠️ Contains a production migration

`supabase/migrations/20260628000001_add_insurance_mark_paid_snapshot.sql` adds two **nullable** columns (`prev_payment_date`, `prev_last_payment_date`) to `insurance_members` with `ADD COLUMN IF NOT EXISTS` — additive and idempotent, no backfill, no data loss. The "Apply DB migrations (production)" job runs it on merge. I applied it to the local stack to run E2E.

## How

- **mark-paid** now snapshots the two dates it overwrites.
- **New** `POST /api/v1/insurance-members/[id]/mark-paid/undo` — restores from the snapshot and clears it (one-shot per settlement). For legacy rows settled before the snapshot existed, falls back to the deterministic inverse (due date −1 year, settlement cleared). Owner-scoped; `409` when there's nothing to undo.
- **`DesktopInsuranceDetail`** (also the mobile sheet): an "Undo" control in the "{year} premium settled" chip. Failure → toast; success → `onChanged` refresh.

## TDD

- Component: Undo reverts (POSTs `/mark-paid/undo`) + refreshes; failure → toast + no refresh; no Undo control when not settled.
- E2E (`insurance.spec.ts`): settle via the CTA → **Undo** → **assert the DB due date is restored and `last_payment_date` is cleared** (closes the full loop through both the snapshot write and the undo).

## Verification

- `npm test -- --run` → **848 passed** (+3)
- `npx tsc --noEmit` → 0 errors
- `npm run lint` → only the pre-existing repo-wide `react-hooks/set-state-in-effect` (unchanged)
- E2E `insurance` (6, incl. the new undo loop) + `dashboard-desktop` mark-paid → all green; the existing mark-paid flow still passes

This was the **last** open item from the Overview UX audit. 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)