### PR TITLE
fix(plan): surface confirmations + honest error feedback (UX audit PR-1)

### DIFF
--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { toast } from 'sonner'
 import { useTranslations, useLocale } from 'next-intl'
 import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import MobilePlanningView from './components/MobilePlanningView'
@@ -148,12 +149,10 @@ export default function PlanningClient() {
   const [funds, setFunds] = useState<Fund[]>(initialCache?.funds ?? [])
   const [goals, setGoals] = useState<Goal[]>(initialCache?.goals ?? [])
   const [loading, setLoading] = useState(!initialCache)
-  const [, setToast] = useState('')
 
-  const showToast = useCallback((msg: string) => {
-    setToast(msg)
-    setTimeout(() => setToast(''), 3000)
-  }, [])
+  // Surface confirmations through the globally-mounted sonner Toaster (neutral —
+  // onToast carries both confirmations and the "book has matured" warning).
+  const showToast = useCallback((msg: string) => { toast(msg) }, [])
 
   const fetchPlan = useCallback(async (opts?: { force?: boolean }) => {
     if (opts?.force) bustPlanCache(month, year)

--- a/app/(app)/planning/__tests__/PlanningClient.test.tsx
+++ b/app/(app)/planning/__tests__/PlanningClient.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, within, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import PlanningClient from '../PlanningClient'
+
+// PlanningClient owns the toast sink for the whole Plan page. Regression guard:
+// it used to keep a local `useState` toast that was never rendered, so every
+// confirmation ("Income updated", "Skipped X", …) was silently dropped. It must
+// route through the globally-mounted sonner Toaster instead.
+const { toastMock } = vi.hoisted(() => {
+  const fn = vi.fn()
+  return { toastMock: Object.assign(fn, { error: vi.fn(), success: vi.fn() }) }
+})
+vi.mock('sonner', () => ({ toast: toastMock }))
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+
+vi.mock('@/app/components/navigation/NavigationContext', () => ({
+  useNavigation: () => ({ setMobileTopBar: vi.fn() }),
+}))
+
+const FULL_PLAN = {
+  id: 'plan-1', month: 5, year: 2026, salary_vnd: 45_000_000,
+  fixed_expense_overrides: [], fixed_expenses: [], excluded_insurance: [],
+  insurance_overrides: [], insurance_members: [], fund_investments: [],
+  direct_savings: [], other_expenses: [], goals: [], funds: [],
+  recurring_savings: [], recurring_saving_overrides: [], dca_skips: [], recurring_fulfillments: [],
+}
+
+describe('PlanningClient — toast delivery', () => {
+  it('surfaces a confirmation toast (via sonner) after a successful income edit', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      const u = String(url)
+      // GET the full monthly plan (initial load + refetch after save).
+      if (u.includes('/api/v1/monthly-plans?')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(FULL_PLAN) })
+      }
+      // PATCH the income update.
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(FULL_PLAN) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    toastMock.mockClear()
+    try {
+      render(<PlanningClient />)
+      const desktop = screen.getByTestId('desktop-planning')
+      const editBtn = await within(desktop).findByRole('button', { name: 'Edit income' })
+      await userEvent.click(editBtn)
+      const input = await within(desktop).findByPlaceholderText('e.g. 45,000,000')
+      await userEvent.clear(input)
+      await userEvent.type(input, '50000000')
+      await userEvent.click(within(desktop).getByRole('button', { name: 'Save' }))
+      // The dead-sink bug meant toast was never called; now it reaches sonner.
+      await waitFor(() => expect(toastMock).toHaveBeenCalled())
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -7,6 +7,7 @@ import {
   MoreHorizontal, Check, RefreshCw, X, Plus, Settings, TrendingUp,
 } from 'lucide-react'
 import { useLocale } from 'next-intl'
+import { toast } from 'sonner'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import { DesktopPlanningSkeleton } from './PlanningSkeleton'
 import FixedExpenseManager from './FixedExpenseManager'
@@ -449,6 +450,7 @@ export default function DesktopPlanningView({
 }: Props) {
   const locale = useLocale()
   const isVI = locale === 'vi'
+  const failMsg = isVI ? 'Có lỗi, vui lòng thử lại' : 'Something went wrong — please try again'
 
   // ── Modal state ──
   const [showIncome, setShowIncome] = useState(false)
@@ -533,6 +535,7 @@ export default function DesktopPlanningView({
           body: JSON.stringify({ salary_vnd: num }),
         })
         if (res.ok) { setShowIncome(false); onRefresh(); onToast(isVI ? 'Đã cập nhật thu nhập' : 'Income updated') }
+        else { toast.error(failMsg) }
       } else {
         const res = await fetch('/api/v1/monthly-plans', {
           method: 'POST',
@@ -543,16 +546,17 @@ export default function DesktopPlanningView({
           const p = await res.json()
           setShowIncome(false)
           onPlanCreated({ id: p.id, month: p.month, year: p.year, salary_vnd: p.salary_vnd })
-        }
+        } else { toast.error(failMsg) }
       }
-    } finally { setSaving(false) }
+    } catch { toast.error(failMsg) } finally { setSaving(false) }
   }
 
   async function handleDeletePlan() {
     if (!plan) return
     setSaving(true)
     try {
-      await fetch(`/api/v1/monthly-plans/${plan.id}`, { method: 'DELETE' })
+      const res = await fetch(`/api/v1/monthly-plans/${plan.id}`, { method: 'DELETE' }).catch(() => null)
+      if (!res?.ok) { toast.error(failMsg); return }
       setShowDelete(false)
       onPlanDeleted()
       onToast(isVI ? `Đã xoá kế hoạch ${monthLabel}` : `Plan for ${monthLabel} deleted`)
@@ -561,37 +565,43 @@ export default function DesktopPlanningView({
 
   async function handleFESkip(fe: FixedExpense) {
     if (!plan) return
-    await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`, {
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ fixed_expense_id: fe.expense_id, monthly_amount_override_vnd: 0 }),
-    })
+    }).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     onRefresh(); onToast(isVI ? `Đã bỏ qua ${fe.expense_name}` : `Skipped ${fe.expense_name}`)
   }
 
   async function handleFERestore(fe: FixedExpense) {
     if (!plan) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`)
-    if (!res.ok) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     const overrides: Array<{ id: string; fixed_expense_id: string }> = await res.json()
     const match = overrides.find(o => o.fixed_expense_id === fe.expense_id)
-    if (match) await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides/${match.id}`, { method: 'DELETE' })
+    if (match) {
+      const del = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides/${match.id}`, { method: 'DELETE' }).catch(() => null)
+      if (!del?.ok) { toast.error(failMsg); return }
+    }
     onRefresh(); onToast(isVI ? `Đã khôi phục ${fe.expense_name}` : `Restored ${fe.expense_name}`)
   }
 
   async function handleInsSkip(m: InsuranceMember) {
     if (!plan) return
-    await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance`, {
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ member_id: m.member_id }),
-    })
+    }).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     onRefresh(); onToast(isVI ? `Đã bỏ qua ${m.member_name}` : `Skipped ${m.member_name}`)
   }
 
   async function handleInsRestore(m: InsuranceMember) {
     if (!plan) return
-    await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance/${m.member_id}`, { method: 'DELETE' })
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance/${m.member_id}`, { method: 'DELETE' }).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     const oRes = await fetch(`/api/v1/monthly-plans/${plan.id}/insurance-overrides`)
     if (oRes.ok) {
       const overrides: Array<{ id: string; member_id: string }> = await oRes.json()
@@ -603,37 +613,43 @@ export default function DesktopPlanningView({
 
   async function handleRecSkip(item: { recurringId?: string; name: string }) {
     if (!plan || !item.recurringId) return
-    await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`, {
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ recurring_saving_id: item.recurringId, monthly_amount_override_vnd: 0 }),
-    })
+    }).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     onRefresh(); onToast(isVI ? `Đã bỏ qua ${item.name}` : `Skipped ${item.name}`)
   }
 
   async function handleRecRestore(item: { recurringId?: string; name: string }) {
     if (!plan || !item.recurringId) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`)
-    if (!res.ok) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     const overrides: Array<{ id: string; recurring_saving_id: string }> = await res.json()
     const match = overrides.find(o => o.recurring_saving_id === item.recurringId)
-    if (match) await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides/${match.id}`, { method: 'DELETE' })
+    if (match) {
+      const del = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides/${match.id}`, { method: 'DELETE' }).catch(() => null)
+      if (!del?.ok) { toast.error(failMsg); return }
+    }
     onRefresh(); onToast(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
   }
 
   async function handleDcaSkip(item: { fundId?: string | null; name: string }) {
     if (!plan || !item.fundId) return
-    await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips`, {
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ fund_id: item.fundId }),
-    })
+    }).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     onRefresh(); onToast(isVI ? `Đã bỏ qua ${item.name}` : `Skipped ${item.name}`)
   }
 
   async function handleDcaRestore(item: { fundId?: string | null; name: string }) {
     if (!plan || !item.fundId) return
-    await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips/${item.fundId}`, { method: 'DELETE' })
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips/${item.fundId}`, { method: 'DELETE' }).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     onRefresh(); onToast(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
   }
 
@@ -715,7 +731,8 @@ export default function DesktopPlanningView({
         : overrideModal.type === 'rec'
           ? { recurring_saving_id: overrideModal.id, monthly_amount_override_vnd: num }
           : { member_id: overrideModal.id, monthly_amount_override_vnd: num }
-      await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) })
+      const res = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }).catch(() => null)
+      if (!res?.ok) { toast.error(failMsg); return }
       setOverrideModal(null)
       onRefresh(); onToast(isVI ? 'Đã lưu' : 'Saved')
     } finally { setSaving(false) }
@@ -735,11 +752,12 @@ export default function DesktopPlanningView({
       const url = isEdit
         ? `/api/v1/monthly-plans/${plan.id}/other-expenses/${(otherModal as OtherExpense).id}`
         : `/api/v1/monthly-plans/${plan.id}/other-expenses`
-      await fetch(url, {
+      const res = await fetch(url, {
         method: isEdit ? 'PUT' : 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ description: otherDesc.trim(), amount_vnd: Number(otherAmt) }),
-      })
+      }).catch(() => null)
+      if (!res?.ok) { toast.error(failMsg); return }
       setOtherModal(null)
       onRefresh()
       onToast(isVI ? 'Đã lưu' : 'Saved')

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, useEffect, useRef } from 'react'
 import { useLocale } from 'next-intl'
+import { toast } from 'sonner'
 import {
   Wallet, Target, Shield, ShoppingCart,
   ChevronDown, ChevronUp,
@@ -1002,6 +1003,7 @@ export default function MobilePlanningView({
 }: Props) {
   const locale = useLocale()
   const isVI = locale === 'vi'
+  const failMsg = isVI ? 'Có lỗi, vui lòng thử lại' : 'Something went wrong — please try again'
   const [sheet, setSheet] = useState<SheetState>(null)
   // Recording a DCA buy opens the canonical Add-Transaction sheet in edit mode,
   // pre-filled from the planned investment, so saving completes that same
@@ -1059,64 +1061,70 @@ export default function MobilePlanningView({
 
   async function handleSkipFE(expense: FixedExpense) {
     if (!plan) return
-    await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`, {
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ fixed_expense_id: expense.expense_id, monthly_amount_override_vnd: 0 }),
-    })
+    }).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     onToast(isVI ? `Đã bỏ qua ${expense.expense_name}` : `Skipped ${expense.expense_name}`)
     onRefresh()
   }
 
   async function handleRestoreFE(expense: FixedExpense) {
     if (!plan) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`)
-    if (!res.ok) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     const overrides: Array<{ id: string; fixed_expense_id: string }> = await res.json()
     const match = overrides.find((o) => o.fixed_expense_id === expense.expense_id)
     if (!match) return
-    await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides/${match.id}`, { method: 'DELETE' })
+    const del = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides/${match.id}`, { method: 'DELETE' }).catch(() => null)
+    if (!del?.ok) { toast.error(failMsg); return }
     onToast(isVI ? `Đã khôi phục ${expense.expense_name}` : `Restored ${expense.expense_name}`)
     onRefresh()
   }
 
   async function handleSkipIns(member: InsuranceMember) {
     if (!plan) return
-    await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance`, {
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ member_id: member.member_id }),
-    })
+    }).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     onToast(isVI ? `Đã bỏ qua ${member.member_name}` : `Skipped ${member.member_name}`)
     onRefresh()
   }
 
   async function handleRestoreIns(member: InsuranceMember) {
     if (!plan) return
-    await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance/${member.member_id}`, { method: 'DELETE' })
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance/${member.member_id}`, { method: 'DELETE' }).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     onToast(isVI ? `Đã khôi phục ${member.member_name}` : `Restored ${member.member_name}`)
     onRefresh()
   }
 
   async function handleSkipRec(item: GoalItem) {
     if (!plan || !item.recurringId) return
-    await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`, {
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ recurring_saving_id: item.recurringId, monthly_amount_override_vnd: 0 }),
-    })
+    }).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     onToast(isVI ? `Đã bỏ qua ${item.name}` : `Skipped ${item.name}`)
     onRefresh()
   }
 
   async function handleRestoreRec(item: GoalItem) {
     if (!plan || !item.recurringId) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`)
-    if (!res.ok) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     const overrides: Array<{ id: string; recurring_saving_id: string }> = await res.json()
     const match = overrides.find((o) => o.recurring_saving_id === item.recurringId)
     if (!match) return
-    await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides/${match.id}`, { method: 'DELETE' })
+    const del = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides/${match.id}`, { method: 'DELETE' }).catch(() => null)
+    if (!del?.ok) { toast.error(failMsg); return }
     onToast(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
     onRefresh()
   }
@@ -1129,18 +1137,20 @@ export default function MobilePlanningView({
 
   async function handleDcaSkip(item: GoalItem) {
     if (!plan || !item.fundId) return
-    await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips`, {
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ fund_id: item.fundId }),
-    })
+    }).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     onToast(isVI ? `Đã bỏ qua ${item.name}` : `Skipped ${item.name}`)
     onRefresh()
   }
 
   async function handleDcaRestore(item: GoalItem) {
     if (!plan || !item.fundId) return
-    await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips/${item.fundId}`, { method: 'DELETE' })
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips/${item.fundId}`, { method: 'DELETE' }).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     onToast(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
     onRefresh()
   }
@@ -1222,27 +1232,22 @@ export default function MobilePlanningView({
     setSheet({ type: 'override-ins', member })
   }
 
+  // The single source of truth for an override write. SimpleOverrideSheet is now
+  // presentational (it used to POST too — double-writing, and to the wrong
+  // endpoint for recurring), so this is the only request that fires.
   async function handleOverrideSave(amount: number) {
     if (!plan || !overrideTarget) return
-    if (overrideTarget.type === 'fe') {
-      await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ fixed_expense_id: overrideTarget.id, monthly_amount_override_vnd: amount }),
-      })
-    } else if (overrideTarget.type === 'rec') {
-      await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ recurring_saving_id: overrideTarget.id, monthly_amount_override_vnd: amount }),
-      })
-    } else {
-      await fetch(`/api/v1/monthly-plans/${plan.id}/insurance-overrides`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ member_id: overrideTarget.id, monthly_amount_override_vnd: amount }),
-      })
-    }
+    const { url, body } = overrideTarget.type === 'fe'
+      ? { url: `/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`, body: { fixed_expense_id: overrideTarget.id, monthly_amount_override_vnd: amount } }
+      : overrideTarget.type === 'rec'
+        ? { url: `/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`, body: { recurring_saving_id: overrideTarget.id, monthly_amount_override_vnd: amount } }
+        : { url: `/api/v1/monthly-plans/${plan.id}/insurance-overrides`, body: { member_id: overrideTarget.id, monthly_amount_override_vnd: amount } }
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).catch(() => null)
+    if (!res?.ok) { toast.error(failMsg); return }
     setSheet(null)
     setOverrideTarget(null)
     onToast(isVI ? 'Đã ghi đè' : 'Override saved')
@@ -1517,9 +1522,6 @@ export default function MobilePlanningView({
           onClose={() => { setSheet(null); setOverrideTarget(null) }}
           name={overrideTarget.name}
           defaultAmount={overrideTarget.defaultAmount}
-          planId={plan.id}
-          targetId={overrideTarget.id}
-          targetType={overrideTarget.type}
           isVI={isVI}
           onSaved={handleOverrideSave}
         />
@@ -1587,17 +1589,16 @@ export default function MobilePlanningView({
 // ─── SimpleOverrideSheet (used inline — keeps handleOverrideSave in parent) ───
 
 function SimpleOverrideSheet({
-  open, onClose, name, defaultAmount, planId, targetId, targetType, isVI, onSaved,
+  open, onClose, name, defaultAmount, isVI, onSaved,
 }: {
   open: boolean
   onClose: () => void
   name: string
   defaultAmount: number
-  planId: string
-  targetId: string
-  targetType: 'fe' | 'ins' | 'rec'
   isVI: boolean
-  onSaved: (amount: number) => void
+  // The parent owns the single write (and the failure toast); this sheet only
+  // collects + validates the amount, then hands it up.
+  onSaved: (amount: number) => void | Promise<void>
 }) {
   const [value, setValue] = useState(String(defaultAmount))
   const [saving, setSaving] = useState(false)
@@ -1610,19 +1611,7 @@ function SimpleOverrideSheet({
     if (!value || isNaN(num) || num <= 0) { setError(isVI ? 'Vui lòng nhập số tiền hợp lệ' : 'Please enter a valid amount'); return }
     setError('')
     setSaving(true)
-    try {
-      const endpoint = targetType === 'fe' ? 'fixed-expense-overrides' : 'insurance-overrides'
-      const body = targetType === 'fe'
-        ? { fixed_expense_id: targetId, monthly_amount_override_vnd: num }
-        : { member_id: targetId, monthly_amount_override_vnd: num }
-      await fetch(`/api/v1/monthly-plans/${planId}/${endpoint}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      })
-      onSaved(num)
-    } catch { setError(isVI ? 'Lỗi kết nối' : 'Connection error') }
-    setSaving(false)
+    try { await onSaved(num) } finally { setSaving(false) }
   }
 
   return (

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, within, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DesktopPlanningView from '../DesktopPlanningView'
-import type { MonthlyPlan, FundInvestment, DirectSaving, RecurringSaving, RecurringFulfillment, InsuranceMember } from '../../PlanningClient'
+import type { MonthlyPlan, FundInvestment, DirectSaving, RecurringSaving, RecurringFulfillment, InsuranceMember, FixedExpense } from '../../PlanningClient'
+
+const { toastErrorMock } = vi.hoisted(() => ({ toastErrorMock: vi.fn() }))
+vi.mock('sonner', () => ({ toast: Object.assign(vi.fn(), { error: toastErrorMock, success: vi.fn() }) }))
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
@@ -194,6 +197,70 @@ describe('DesktopPlanningView — allocation card amounts never wrap', () => {
     expect(within(card).getByText('+43.0M ₫')).toHaveStyle({ whiteSpace: 'nowrap' })
     // Per-row percentage chip.
     expect(within(card).getByText('4%', { exact: true })).toHaveStyle({ whiteSpace: 'nowrap' })
+  })
+})
+
+describe('DesktopPlanningView — save error feedback (no false success)', () => {
+  const fixedExpenses: FixedExpense[] = [{ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000 }]
+
+  function stubFailingFetch() {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'boom' }) }))
+    vi.stubGlobal('fetch', fetchMock)
+    return fetchMock
+  }
+
+  it('income save failure shows an error toast and keeps the modal open', async () => {
+    stubFailingFetch()
+    toastErrorMock.mockClear()
+    const onToast = vi.fn()
+    try {
+      render(<DesktopPlanningView {...defaultProps} plan={basePlan} onToast={onToast} />)
+      await userEvent.click(screen.getByRole('button', { name: 'Edit income' }))
+      const input = await screen.findByPlaceholderText('e.g. 45,000,000')
+      await userEvent.clear(input)
+      await userEvent.type(input, '50000000')
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
+      expect(onToast).not.toHaveBeenCalled()
+      expect(screen.getByPlaceholderText('e.g. 45,000,000')).toBeInTheDocument()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('override save failure shows an error toast and keeps the modal open', async () => {
+    stubFailingFetch()
+    toastErrorMock.mockClear()
+    const onToast = vi.fn()
+    try {
+      render(<DesktopPlanningView {...defaultProps} plan={basePlan} fixedExpenses={fixedExpenses} onToast={onToast} />)
+      await userEvent.click(screen.getByRole('button', { name: 'More options' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Override amount' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
+      expect(onToast).not.toHaveBeenCalled()
+      // Modal stayed open → its name (now shown in both the row and the modal)
+      // and Save button are still mounted.
+      expect(screen.getAllByText('Rent').length).toBeGreaterThan(1)
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('skip failure shows an error toast and does not report success', async () => {
+    stubFailingFetch()
+    toastErrorMock.mockClear()
+    const onToast = vi.fn()
+    try {
+      render(<DesktopPlanningView {...defaultProps} plan={basePlan} fixedExpenses={fixedExpenses} onToast={onToast} />)
+      await userEvent.click(screen.getByRole('button', { name: 'More options' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Skip this month' }))
+      await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
+      expect(onToast).not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 })
 

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -1,8 +1,11 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, within, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MobilePlanningView from '../MobilePlanningView'
 import type { MonthlyPlan, FixedExpense, InsuranceMember, OtherExpense, FundInvestment, DirectSaving, RecurringFulfillment } from '../../PlanningClient'
+
+const { toastErrorMock } = vi.hoisted(() => ({ toastErrorMock: vi.fn() }))
+vi.mock('sonner', () => ({ toast: Object.assign(vi.fn(), { error: toastErrorMock, success: vi.fn() }) }))
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
@@ -527,5 +530,67 @@ describe('MobilePlanningView — recurring savings in By goal', () => {
     await userEvent.click(screen.getByText('Retirement'))
     expect(screen.getByText('VFMVF1')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /Restore DCA/i })).toBeInTheDocument()
+  })
+})
+
+describe('MobilePlanningView — save error feedback (no false success)', () => {
+  const fixedExpenses: FixedExpense[] = [{ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000 }]
+  const recurringSavings = [
+    { saving_id: 'rs1', name: 'VCB Savings', goal_id: 'g1', amount_vnd: 2_000_000, effective_from: null, effective_to: null, savings_goals: { goal_name: 'Retirement' } },
+  ]
+
+  it('fixed-expense override failure shows an error toast and keeps the sheet open', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'boom' }) }))
+    vi.stubGlobal('fetch', fetchMock)
+    toastErrorMock.mockClear()
+    const onToast = vi.fn()
+    try {
+      render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={fixedExpenses} onToast={onToast} />)
+      await userEvent.click(screen.getByRole('button', { name: 'More options' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Override amount' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
+      expect(onToast).not.toHaveBeenCalled()
+      // Sheet stayed open → its Save button is still mounted.
+      expect(screen.getByRole('button', { name: 'Save' })).toBeInTheDocument()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('skip failure shows an error toast and does not report success', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'boom' }) }))
+    vi.stubGlobal('fetch', fetchMock)
+    toastErrorMock.mockClear()
+    const onToast = vi.fn()
+    try {
+      render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={fixedExpenses} onToast={onToast} />)
+      await userEvent.click(screen.getByRole('button', { name: 'More options' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Skip this month' }))
+      await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
+      expect(onToast).not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('recurring override writes once to the correct endpoint (not the insurance endpoint)', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
+    vi.stubGlobal('fetch', fetchMock)
+    const onToast = vi.fn()
+    try {
+      render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} goals={[{ goal_id: 'g1', goal_name: 'Retirement' }]} onToast={onToast} />)
+      await userEvent.click(screen.getByText('Retirement'))
+      await userEvent.click(screen.getByRole('button', { name: 'Saving actions' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Save more this month' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await waitFor(() => expect(onToast).toHaveBeenCalled())
+      const urls = fetchMock.mock.calls.map((c) => String(c[0]))
+      expect(urls.some((u) => u.includes('/recurring-saving-overrides'))).toBe(true)
+      // The old SimpleOverrideSheet double-POSTed to the wrong (insurance) endpoint.
+      expect(urls.some((u) => u.includes('/insurance-overrides'))).toBe(false)
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 })


### PR DESCRIPTION
**PR-1 of the Plan-page UX audit** (theme: feedback + error≠empty).

## What was wrong
- **All Plan-page toasts were silently dropped.** `PlanningClient` funnelled `onToast` into a local `useState` whose value was never rendered — so "Income updated", "Skipped X", "Đã nạp vào sổ", "Plan deleted", manager add/edit/delete, etc. never appeared, even though the app already mounts a `sonner` `<Toaster>`.
- **Fire-and-forget saves reported false success.** Income / override / other-expense saves and every skip/restore/override/dca handler called `onRefresh + onToast` without checking `res.ok`. The desktop income modal swallowed failures entirely; mobile showed them — a divergence.
- **Mobile override double-wrote.** `SimpleOverrideSheet` POSTed its own request *and* the parent POSTed again; for a recurring saving the sheet hit the **wrong** (insurance) endpoint with a recurring id.

## What this does
- Route `showToast`/`onToast` through `sonner` `toast()` (neutral — the channel also carries the "book has matured" warning).
- Every write now checks `res.ok`: on failure → error toast + modal/sheet stays open, **no** false success.
- `SimpleOverrideSheet` is now presentational; the parent owns the single correct write + failure toast.

## Tests (TDD, assert rendered outcome)
- `PlanningClient` closed-loop: a successful income edit delivers a toast to sonner (guards the dead-sink regression).
- Desktop + mobile error-path specs: failed income/override/skip → error toast, modal stays open, success callback not fired.
- Mobile recurring override writes once to `recurring-saving-overrides`, never `insurance-overrides`.

## Verification
- `npm test -- --run` → **855 passed** (81 in planning).
- `npm run lint` → no new errors in changed files (these files had 5 pre-existing `react-hooks/set-state-in-effect` errors on `main`; this branch has 4 — repo-wide rule issue, out of scope).
- E2E not run locally (needs the WSL2 Supabase stack); unit specs cover the behavior. Please confirm a couple of toasts on the Vercel preview.

## Follow-ups (later PRs from the audit)
PR-2 error≠empty on plan fetch · PR-3 mobile restore-default parity + recurring deep-link edit · PR-4 insurance empty/parity · PR-5 a11y (Esc/focus-trap, menu semantics, touch targets).