### PR TITLE
fix(overview): stable daily networth — pin bank interest to UTC midnight

### DIFF
--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -64,6 +64,12 @@ export async function GET() {
   // Today's date (server local) — used both to read the existing snapshot below
   // and to upsert it at the end.
   const today = new Date().toISOString().split('T')[0]
+  // Pin interest accrual to UTC midnight so the displayed networth is stable
+  // across multiple API calls within the same day. Using Date.now() makes
+  // calcProjectedInterest return a slightly different value every millisecond —
+  // visible as a number jump when the 2-min localStorage cache expires and a
+  // fresh fetch returns a different value (issue #402).
+  const valuationAsOf = new Date(today).getTime()
 
   const [plansRes, goalsRes, txRes, insuranceRes, insuranceSavingsRes, recSavingsRes, goldPriceRes, snapshotRes] = await Promise.all([
     supabase.from('monthly_plans').select('id, month, year').eq('user_id', user.id),
@@ -278,8 +284,8 @@ export async function GET() {
       // (progress-affecting only → goal bar). They differ only when the holding
       // has an affects_progress=false withdrawal, which net worth must subtract
       // but the bar must not.
-      const valued = valueNonFundHolding(tx, parentWdMapAll, goldPricePerChi)
-      const progValued = valueNonFundHolding(tx, parentWdMap, goldPricePerChi)
+      const valued = valueNonFundHolding(tx, parentWdMapAll, goldPricePerChi, valuationAsOf)
+      const progValued = valueNonFundHolding(tx, parentWdMap, goldPricePerChi, valuationAsOf)
       // The bar holds the value any affects_progress=false withdrawal removed,
       // even after the holding is fully gone from net worth.
       const progressContribution = progValued?.currentValue ?? 0

--- a/lib/__tests__/depositValuation.test.ts
+++ b/lib/__tests__/depositValuation.test.ts
@@ -186,6 +186,26 @@ describe('valueNonFundHolding', () => {
     })
   })
 
+  // The overview route must pass a fixed "today midnight" asOf to valueNonFundHolding
+  // so that bank deposit values are stable across multiple API calls within the same day.
+  // Without this, calcProjectedInterest uses Date.now() and the networth changes every
+  // millisecond — visible as a number jump when the 2-min localStorage cache expires and
+  // a fresh fetch returns a slightly different value (issue #402).
+  it('same interest when asOf is pinned to midnight — stable-daily contract the route must honour', () => {
+    const { parentWdMap } = buildWithdrawalMaps([])
+    const deposit = bank({ amount_vnd: 100_000_000, interest_rate: 7, investment_date: '2026-01-01', expiry_date: '2027-01-01' })
+    const midnightToday = Date.UTC(2026, 6, 1)  // what the route passes — fixed per day
+
+    // Two calls with the same midnight asOf must return identical values.
+    const v1 = valueNonFundHolding(deposit, parentWdMap, null, midnightToday)!
+    const v2 = valueNonFundHolding(deposit, parentWdMap, null, midnightToday)!
+    expect(v1.currentValue).toBe(v2.currentValue)
+
+    // Contrast: calls a millisecond apart (simulating Date.now() drift) differ.
+    const v3 = valueNonFundHolding(deposit, parentWdMap, null, midnightToday + 1)!
+    expect(v3.currentValue).toBeGreaterThan(v1.currentValue)  // proves sub-day drift exists
+  })
+
   describe('gold', () => {
     it('values remaining units at the gold price and reduces units by the sale', () => {
       const { parentWdMap } = buildWithdrawalMaps([


### PR DESCRIPTION
## Summary

- `calcProjectedInterest` used `Date.now()` on every API call, making bank deposit values drift every millisecond
- When the 2-min localStorage cache expired and a fresh fetch ran, the returned networth differed from the cached value — visible as the hero number jumping on refresh (issue #402)
- Fix: compute `valuationAsOf = UTC midnight of today` once per request and pass it to both `valueNonFundHolding` calls so interest is stable all day and only advances at midnight

Gold and fund holdings are unaffected (gold uses a user-set price; funds use a daily NAV — both already stable within a day).

## Test plan

- [x] New unit test in `lib/__tests__/depositValuation.test.ts` documents the stable-daily contract: same `asOf` → same value; 1ms later → greater value (confirms sub-day drift existed)
- [x] All 855 unit tests pass (3 failing PlanningClient tests are pre-existing from in-progress plan-page work, unrelated)
- [x] Lint clean on changed files
- [ ] Verify on Vercel preview: load dashboard, wait 2+ min, refresh — networth number should stay the same if no transactions were added

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)