### PR TITLE
fix(plan): distinguish a failed load from an empty month (UX audit PR-2)

### DIFF
--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -149,6 +149,9 @@ export default function PlanningClient() {
   const [funds, setFunds] = useState<Fund[]>(initialCache?.funds ?? [])
   const [goals, setGoals] = useState<Goal[]>(initialCache?.goals ?? [])
   const [loading, setLoading] = useState(!initialCache)
+  // A failed load (≠ 404) must not masquerade as the legit "no plan yet" empty
+  // state — the API returns 404 only when the month genuinely has no plan.
+  const [loadError, setLoadError] = useState(false)
 
   // Surface confirmations through the globally-mounted sonner Toaster (neutral —
   // onToast carries both confirmations and the "book has matured" warning).
@@ -157,8 +160,16 @@ export default function PlanningClient() {
   const fetchPlan = useCallback(async (opts?: { force?: boolean }) => {
     if (opts?.force) bustPlanCache(month, year)
 
-    const res = await fetch(`/api/v1/monthly-plans?month=${month}&year=${year}&full=true`)
+    let res: Response
+    try {
+      res = await fetch(`/api/v1/monthly-plans?month=${month}&year=${year}&full=true`)
+    } catch {
+      setLoadError(true)
+      setLoading(false)
+      return
+    }
     if (res.ok) {
+      setLoadError(false)
       const p = await res.json()
 
       const overrideMap = new Map(
@@ -211,7 +222,9 @@ export default function PlanningClient() {
       setRecurringSavingOverrides(fresh.recurringSavingOverrides)
       setDcaSkips(fresh.dcaSkips)
       setRecurringFulfillments(fresh.recurringFulfillments)
-    } else {
+    } else if (res.status === 404) {
+      // Genuine "no plan for this month yet" → the empty state.
+      setLoadError(false)
       bustPlanCache(month, year)
       setPlan(null)
       setInvestments([])
@@ -224,14 +237,20 @@ export default function PlanningClient() {
       setDcaSkips([])
       setRecurringFulfillments([])
       // Still load fixed expenses and insurance even without a plan
-      const [expRes, insRes] = await Promise.all([
-        fetch('/api/v1/fixed-expenses'),
-        fetch('/api/v1/insurance-members'),
-      ])
-      const { expenses } = expRes.ok ? await expRes.json() : { expenses: [] }
-      setFixedExpenses((expenses ?? []).map((e: { expense_id: string; expense_name: string; amount_vnd: number }) => ({ ...e })))
-      const { members } = insRes.ok ? await insRes.json() : { members: [] }
-      setInsuranceMembers(members ?? [])
+      try {
+        const [expRes, insRes] = await Promise.all([
+          fetch('/api/v1/fixed-expenses'),
+          fetch('/api/v1/insurance-members'),
+        ])
+        const { expenses } = expRes.ok ? await expRes.json() : { expenses: [] }
+        setFixedExpenses((expenses ?? []).map((e: { expense_id: string; expense_name: string; amount_vnd: number }) => ({ ...e })))
+        const { members } = insRes.ok ? await insRes.json() : { members: [] }
+        setInsuranceMembers(members ?? [])
+      } catch { /* leave fixed/insurance empty — the month is still a valid empty plan */ }
+    } else {
+      // 401 / 500 / etc — a real failure. Keep whatever's shown and surface an
+      // error state with retry rather than pretending the month is empty.
+      setLoadError(true)
     }
     setLoading(false)
   }, [month, year])
@@ -308,6 +327,8 @@ export default function PlanningClient() {
         funds={funds}
         goals={goals}
         loading={loading}
+        error={loadError}
+        onRetry={refetch}
         onPlanCreated={(p) => { setPlan(p); refetch() }}
         onPlanDeleted={() => {
           bustPlanCache(month, year)
@@ -338,6 +359,8 @@ export default function PlanningClient() {
         funds={funds}
         goals={goals}
         loading={loading}
+        error={loadError}
+        onRetry={refetch}
         onPrev={navigatePrev}
         onNext={navigateNext}
         onToday={navigateToday}

--- a/app/(app)/planning/__tests__/PlanningClient.test.tsx
+++ b/app/(app)/planning/__tests__/PlanningClient.test.tsx
@@ -31,6 +31,80 @@ const FULL_PLAN = {
   recurring_savings: [], recurring_saving_overrides: [], dca_skips: [], recurring_fulfillments: [],
 }
 
+describe('PlanningClient — error vs empty on plan fetch', () => {
+  it('shows an error state (not the empty "set income" state) when the fetch fails with 500', async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({ error: 'boom' }) }))
+    vi.stubGlobal('fetch', fetchMock)
+    try {
+      render(<PlanningClient />)
+      // Error state appears in both the desktop + mobile views.
+      expect((await screen.findAllByTestId('planning-error-state')).length).toBeGreaterThan(0)
+      // It must NOT be mistaken for the legit "no plan yet" empty state.
+      expect(screen.queryByTestId('planning-empty-state')).not.toBeInTheDocument()
+      // A retry affordance is offered.
+      expect(screen.getAllByRole('button', { name: /Try again/i }).length).toBeGreaterThan(0)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('shows the empty state on 404 (no plan yet), not the error state', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      const u = String(url)
+      if (u.includes('/api/v1/monthly-plans?')) {
+        return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({ error: 'Plan not found for this month' }) })
+      }
+      // The 404 branch still loads master fixed expenses + insurance members.
+      if (u.includes('fixed-expenses')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ expenses: [] }) })
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ members: [] }) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    try {
+      render(<PlanningClient />)
+      expect((await screen.findAllByTestId('planning-empty-state')).length).toBeGreaterThan(0)
+      expect(screen.queryByTestId('planning-error-state')).not.toBeInTheDocument()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('does not get stuck on the skeleton when the fetch rejects (network error) → shows error', async () => {
+    const fetchMock = vi.fn(() => Promise.reject(new Error('offline')))
+    vi.stubGlobal('fetch', fetchMock)
+    try {
+      render(<PlanningClient />)
+      expect((await screen.findAllByTestId('planning-error-state')).length).toBeGreaterThan(0)
+      expect(screen.queryByTestId('planning-loading')).not.toBeInTheDocument()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('retry refetches and renders the plan once the request succeeds', async () => {
+    let call = 0
+    const fetchMock = vi.fn((url: string) => {
+      const u = String(url)
+      if (u.includes('/api/v1/monthly-plans?')) {
+        call += 1
+        if (call === 1) return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({ error: 'boom' }) })
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(FULL_PLAN) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    try {
+      render(<PlanningClient />)
+      const retry = (await screen.findAllByRole('button', { name: /Try again/i }))[0]
+      await userEvent.click(retry)
+      await waitFor(() => expect(screen.queryByTestId('planning-error-state')).not.toBeInTheDocument())
+      // The plan content (income editor) is now shown.
+      expect((await screen.findAllByRole('button', { name: 'Edit income' })).length).toBeGreaterThan(0)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})
+
 describe('PlanningClient — toast delivery', () => {
   it('surfaces a confirmation toast (via sonner) after a successful income edit', async () => {
     const fetchMock = vi.fn((url: string) => {

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -432,6 +432,8 @@ interface Props {
   funds: Fund[]
   goals: Goal[]
   loading: boolean
+  error: boolean
+  onRetry: () => void
   onPrev: () => void
   onNext: () => void
   onToday: () => void
@@ -445,8 +447,8 @@ interface Props {
 
 export default function DesktopPlanningView({
   month, year, plan, investments, savings, fixedExpenses, insuranceMembers,
-  otherExpenses, recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, loading,
-  onPrev, onNext, onToday, onPlanCreated, onPlanDeleted, onRefresh, onToast,
+  otherExpenses, recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, loading, error,
+  onRetry, onPrev, onNext, onToday, onPlanCreated, onPlanDeleted, onRefresh, onToast,
 }: Props) {
   const locale = useLocale()
   const isVI = locale === 'vi'
@@ -823,6 +825,28 @@ export default function DesktopPlanningView({
             <div data-testid="planning-loading">
               <DesktopPlanningSkeleton />
             </div>
+          ) : error ? (
+            /* Error state — distinct from the "no plan yet" empty state */
+            <div
+              data-testid="planning-error-state"
+              style={{ padding: '60px 20px', textAlign: 'center', background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 16, maxWidth: 480, margin: '0 auto' }}
+            >
+              <div style={{ width: 52, height: 52, borderRadius: 26, background: 'var(--c-neg-tint,#fef2f2)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', marginBottom: 14, color: 'var(--c-neg)' }}>
+                <svg viewBox="0 0 24 24" width={24} height={24} fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M12 9v4M12 17h.01M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" />
+                </svg>
+              </div>
+              <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700 }}>
+                {isVI ? 'Không tải được kế hoạch' : "Couldn't load this plan"}
+              </h3>
+              <p style={{ margin: '6px 0 18px', fontSize: 13, color: 'var(--c-muted)' }}>
+                {isVI ? 'Đã xảy ra lỗi khi tải. Vui lòng thử lại.' : 'Something went wrong while loading. Please try again.'}
+              </p>
+              <button onClick={onRetry} className="cn-btn primary" style={{ padding: '10px 18px' }}>
+                <RefreshCw size={14} />
+                {isVI ? 'Thử lại' : 'Try again'}
+              </button>
+            </div>
           ) : !plan ? (
             /* Empty state */
             <div
@@ -1083,7 +1107,7 @@ export default function DesktopPlanningView({
         </div>
 
         {/* Right — allocation sidebar */}
-        {plan && (
+        {plan && !error && (
           <div style={{ width: 280, flexShrink: 0, overflowY: 'auto', padding: '20px 20px 40px 4px', borderLeft: '1px solid var(--c-line)' }}>
             <AllocationCard
               salary={plan.salary_vnd}

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -39,6 +39,8 @@ interface Props {
   funds: Fund[]
   goals: Goal[]
   loading?: boolean
+  error?: boolean
+  onRetry?: () => void
   onPlanCreated: (plan: MonthlyPlan) => void
   onPlanDeleted: () => void
   onRefresh: () => void
@@ -457,6 +459,42 @@ function NoPlanState({ monthLabel, onSetSalary, isVI }: { monthLabel: string; on
       >
         <Plus size={14} strokeWidth={2.4} />
         {isVI ? 'Thêm thu nhập' : 'Set income'}
+      </button>
+    </div>
+  )
+}
+
+// ─── PlanErrorState ──────────────────────────────────────────────────────────
+// A failed load (≠ 404) — distinct from the "no plan yet" empty state, with retry.
+
+function PlanErrorState({ isVI, onRetry }: { isVI: boolean; onRetry?: () => void }) {
+  return (
+    <div data-testid="planning-error-state" style={{
+      padding: '44px 20px', textAlign: 'center',
+      background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 16,
+    }}>
+      <div style={{ width: 48, height: 48, borderRadius: 24, background: 'var(--c-neg-tint)', display: 'inline-flex', alignItems: 'center', justifyContent: 'center', marginBottom: 12, color: 'var(--c-neg)' }}>
+        <svg viewBox="0 0 24 24" width={22} height={22} fill="none" stroke="currentColor" strokeWidth={1.75} strokeLinecap="round" strokeLinejoin="round">
+          <path d="M12 9v4M12 17h.01M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" />
+        </svg>
+      </div>
+      <h3 style={{ margin: 0, fontSize: 15, fontWeight: 600, color: 'var(--c-ink)' }}>
+        {isVI ? 'Không tải được kế hoạch' : "Couldn't load this plan"}
+      </h3>
+      <p style={{ margin: '4px 0 16px', fontSize: 12, color: 'var(--c-muted)' }}>
+        {isVI ? 'Đã xảy ra lỗi khi tải. Vui lòng thử lại.' : 'Something went wrong while loading. Please try again.'}
+      </p>
+      <button
+        onClick={onRetry}
+        style={{
+          display: 'inline-flex', alignItems: 'center', gap: 6,
+          padding: '9px 16px', borderRadius: 10, border: 'none',
+          background: 'var(--c-btn-primary)', color: '#fff', fontSize: 13, fontWeight: 600,
+          cursor: 'pointer', fontFamily: 'inherit',
+        }}
+      >
+        <RefreshCw size={14} />
+        {isVI ? 'Thử lại' : 'Try again'}
       </button>
     </div>
   )
@@ -998,8 +1036,8 @@ function MenuItem({ icon, label, onClick, danger, noBorder }: {
 
 export default function MobilePlanningView({
   month, year, plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,
-  recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, loading,
-  onPlanCreated, onPlanDeleted, onRefresh, onToast,
+  recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, loading, error,
+  onRetry, onPlanCreated, onPlanDeleted, onRefresh, onToast,
 }: Props) {
   const locale = useLocale()
   const isVI = locale === 'vi'
@@ -1261,6 +1299,8 @@ export default function MobilePlanningView({
       <div style={{ padding: '4px 16px 100px', display: 'grid', gap: 10 }}>
         {loading ? (
           <MobilePlanningSkeleton />
+        ) : error ? (
+          <PlanErrorState isVI={isVI} onRetry={onRetry} />
         ) : !plan ? (
           <NoPlanState monthLabel={monthLabel} isVI={isVI} onSetSalary={() => setSheet({ type: 'salary' })} />
         ) : (


### PR DESCRIPTION
**PR-2 of the Plan-page UX audit** (theme: error ≠ empty). Follows #403.

## What was wrong
When the plan fetch returned a non-OK status, `PlanningClient` cleared all state and fell into the **"Chưa có kế hoạch — nhập thu nhập"** empty state. So a 500 (or an auth blip) looked identical to a month that genuinely has no plan yet — inviting the user to re-enter income and risk a duplicate. A network **throw** was worse: with no `catch`, `loading` never flipped to false and the page sat on the skeleton forever.

## What this does
The API returns **404** only when the month truly has no plan. Now:
- **404** → empty state (unchanged).
- **Any other non-OK status, or a thrown fetch** → a distinct **error state** with a *Thử lại / Try again* retry button; `loading` is always cleared (no stuck skeleton).
- The desktop allocation sidebar is hidden in the error state so stale numbers don't sit beside the error.

## Tests (TDD — `PlanningClient`, rendered outcome)
- 500 → error state shown, empty state **not** shown.
- 404 → empty state shown, error state **not** shown.
- network reject → error state, skeleton gone (guards the stuck-loading bug).
- retry → refetches and renders the plan on success.

## Verification
- `npm test -- --run` → **860 passed** (85 in planning).
- `npm run lint` → no new errors in changed files (same pre-existing `react-hooks/set-state-in-effect` count as `main`).
- E2E not run locally (needs the WSL2 Supabase stack). Please sanity-check the error state on the Vercel preview (e.g. throttle/offline).

## Follow-ups
PR-3 mobile restore-default parity + recurring deep-link edit · PR-4 insurance empty/parity · PR-5 a11y.