### PR TITLE
fix(plan): restore-default parity (mobile) + deep-link recurring edit (UX audit PR-3)

### DIFF
--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -466,6 +466,8 @@ export default function DesktopPlanningView({
   const [otherAmt, setOtherAmt] = useState('')
   const [showFEManage, setShowFEManage] = useState(false)
   const [showRSManage, setShowRSManage] = useState(false)
+  // When set, the recurring manager opens straight on this saving's edit form.
+  const [rsEditId, setRsEditId] = useState<string | null>(null)
   // Recording a DCA buy opens the canonical Add-Transaction sheet in edit mode,
   // pre-filled from the planned investment. Saving completes the same planned
   // row (PUT), so it never double-counts against the goal.
@@ -922,7 +924,7 @@ export default function DesktopPlanningView({
                 action={
                   <button
                     data-testid="desktop-manage-savings"
-                    onClick={() => setShowRSManage(true)}
+                    onClick={() => { setRsEditId(null); setShowRSManage(true) }}
                     style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '5px 10px', fontSize: 12, fontWeight: 600, color: 'var(--c-navy)', background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', borderRadius: 8 }}
                   >
                     <Settings size={14} />
@@ -981,7 +983,7 @@ export default function DesktopPlanningView({
                           isVI={isVI}
                           onSkip={() => handleRecSkip(inv)}
                           onRestore={() => handleRecRestore(inv)}
-                          onEdit={() => setShowRSManage(true)}
+                          onEdit={() => { setRsEditId(inv.recurringId ?? null); setShowRSManage(true) }}
                           onOverride={() => {
                             setOverrideModal({ id: inv.recurringId!, name: inv.name, defaultAmount: inv.baseAmount ?? inv.amount, type: 'rec' })
                             setOverrideVal(String(inv.baseAmount ?? inv.amount))
@@ -1242,7 +1244,7 @@ export default function DesktopPlanningView({
 
       {showRSManage && (
         <DModal onClose={() => setShowRSManage(false)} title={isVI ? 'Tiết kiệm định kỳ' : 'Recurring savings'} width={460}>
-          <RecurringSavingManager goals={goals} onChange={onRefresh} onToast={onToast} />
+          <RecurringSavingManager goals={goals} onChange={onRefresh} onToast={onToast} editSavingId={rsEditId} />
         </DModal>
       )}
 

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -56,7 +56,7 @@ type SheetState =
   | { type: 'override-rec'; item: GoalItem }
   | { type: 'other-expense'; existing: OtherExpense | null }
   | { type: 'manage-fixed' }
-  | { type: 'manage-recurring' }
+  | { type: 'manage-recurring'; editId?: string }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -719,7 +719,7 @@ function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride
   onRecSkip: (item: GoalItem) => void
   onRecRestore: (item: GoalItem) => void
   onRecOverride: (item: GoalItem) => void
-  onRecEdit: () => void
+  onRecEdit: (item: GoalItem) => void
   onRecordBuy: (item: GoalItem) => void
   onRecordDeposit: (item: GoalItem) => void
   onLogContribution: () => void
@@ -788,7 +788,7 @@ function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride
           onSkip={() => onRecSkip(item)}
           onRestore={() => onRecRestore(item)}
           onOverride={() => onRecOverride(item)}
-          onEdit={onRecEdit}
+          onEdit={() => onRecEdit(item)}
           onRecordBuy={() => onRecordBuy(item)}
           onRecordDeposit={() => onRecordDeposit(item)}
           onDcaSkip={() => onDcaSkip(item)}
@@ -916,13 +916,14 @@ function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onReco
 // ─── PlanLineItem (with kebab menu) ───────────────────────────────────────────
 
 function PlanLineItem({
-  primary, secondary, amount, muted, last, isVI,
+  primary, secondary, amount, muted, overridden, last, isVI,
   onSkip, onRestore, onOverride,
 }: {
   primary: string
   secondary?: string | null
   amount: number
   muted?: boolean
+  overridden?: boolean
   last?: boolean
   isVI: boolean
   onSkip?: () => void
@@ -1000,6 +1001,15 @@ function PlanLineItem({
                   <EditIcon size={14} color="var(--c-muted)" />
                   {isVI ? 'Ghi đè số tiền' : 'Override amount'}
                 </button>
+                {overridden && onRestore && (
+                  <button
+                    onClick={() => { onRestore(); setMenuOpen(false) }}
+                    style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', borderBottom: '1px solid var(--c-line)', cursor: 'pointer', fontFamily: 'inherit', color: 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8 }}
+                  >
+                    <RefreshCw size={14} color="var(--c-muted)" />
+                    {isVI ? 'Khôi phục mặc định' : 'Restore default'}
+                  </button>
+                )}
                 <button
                   onClick={() => { onSkip?.(); setMenuOpen(false) }}
                   style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', color: 'var(--c-neg)', display: 'flex', alignItems: 'center', gap: 8 }}
@@ -1378,7 +1388,7 @@ export default function MobilePlanningView({
                     onRecSkip={handleSkipRec}
                     onRecRestore={handleRestoreRec}
                     onRecOverride={openOverrideRec}
-                    onRecEdit={() => setSheet({ type: 'manage-recurring' })}
+                    onRecEdit={(item) => setSheet({ type: 'manage-recurring', editId: item.recurringId ?? undefined })}
                     onRecordBuy={openBuy}
                     onRecordDeposit={(item) => recordRecurring(entry, item)}
                     onLogContribution={() => openContribution(entry)}
@@ -1428,6 +1438,7 @@ export default function MobilePlanningView({
                       secondary={secondary}
                       amount={thisMonth}
                       muted={isSkipped}
+                      overridden={hasOverride}
                       last={i === fixedExpenses.length - 1}
                       isVI={isVI}
                       onSkip={() => handleSkipFE(fe)}
@@ -1468,6 +1479,7 @@ export default function MobilePlanningView({
                       secondary={secondary}
                       amount={thisMonth}
                       muted={m.excluded}
+                      overridden={hasOverride}
                       last={i === insuranceMembers.length - 1}
                       isVI={isVI}
                       onSkip={() => handleSkipIns(m)}
@@ -1597,7 +1609,7 @@ export default function MobilePlanningView({
         title={isVI ? 'Tiết kiệm định kỳ' : 'Recurring savings'}
       >
         {sheet?.type === 'manage-recurring' && (
-          <RecurringSavingManager goals={goals} onChange={onRefresh} onToast={onToast} variant="sheet" />
+          <RecurringSavingManager goals={goals} onChange={onRefresh} onToast={onToast} variant="sheet" editSavingId={sheet.type === 'manage-recurring' ? sheet.editId : undefined} />
         )}
       </Sheet>
 

--- a/app/(app)/planning/components/RecurringSavingManager.tsx
+++ b/app/(app)/planning/components/RecurringSavingManager.tsx
@@ -72,9 +72,12 @@ interface Props {
   onChange: () => void
   onToast?: (msg: string) => void
   variant?: 'modal' | 'sheet'
+  // When set, open straight on this saving's edit form (deep-link from a plan
+  // line's "Edit recurring plan") instead of the list.
+  editSavingId?: string | null
 }
 
-export default function RecurringSavingManager({ goals, onChange, onToast, variant = 'modal' }: Props) {
+export default function RecurringSavingManager({ goals, onChange, onToast, variant = 'modal', editSavingId }: Props) {
   const tc = useTranslations('common')
   const isVI = useLocale() === 'vi'
 
@@ -94,9 +97,29 @@ export default function RecurringSavingManager({ goals, onChange, onToast, varia
   const fetchList = useCallback(async () => {
     const res = await fetch('/api/v1/recurring-savings')
     const data = res.ok ? await res.json() : { savings: [] }
-    setItems(data.savings ?? [])
+    const list: Saving[] = data.savings ?? []
+    setItems(list)
     setLoading(false)
-  }, [])
+    // Deep-link: open straight into the edit form for the requested saving once
+    // its data has loaded. (setState here runs after the await, not synchronously
+    // in an effect, so it doesn't cascade-render the list first.)
+    if (editSavingId) {
+      const item = list.find((s) => s.saving_id === editSavingId)
+      if (item) {
+        setEditing(item)
+        setForm({
+          name: item.name,
+          goal_id: item.goal_id ?? '',
+          amount_vnd: String(item.amount_vnd),
+          effective_from: toMonthInput(item.effective_from),
+          effective_to: toMonthInput(item.effective_to),
+          linked_deposit_tx_id: item.linked_deposit_tx_id ?? '',
+        })
+        setFormError('')
+        setMode('form')
+      }
+    }
+  }, [editSavingId])
 
   useEffect(() => { fetchList() }, [fetchList])
 

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -88,6 +88,49 @@ describe('DesktopPlanningView — goal header "+" log contribution', () => {
   })
 })
 
+describe('DesktopPlanningView — recurring deep-link edit', () => {
+  it('"Edit recurring plan" opens the manager straight on that item’s edit form', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      const u = String(url)
+      if (u.includes('/api/v1/recurring-savings')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ savings: [{ saving_id: 'rs1', name: 'VCB Savings', goal_id: 'g1', amount_vnd: 2_000_000, effective_from: null, effective_to: null, linked_deposit_tx_id: null }] }) })
+      }
+      if (u.includes('investment-transactions')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ transactions: [] }) })
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    try {
+      render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} goals={[{ goal_id: 'g1', goal_name: 'Retirement' }]} />)
+      await userEvent.click(screen.getByRole('button', { name: 'Saving actions' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Edit recurring plan' }))
+      const nameInput = await screen.findByTestId('rs-name')
+      expect((nameInput as HTMLInputElement).value).toBe('VCB Savings')
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('the "Manage savings" button opens the manager in LIST mode (no deep-link)', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      const u = String(url)
+      if (u.includes('/api/v1/recurring-savings')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ savings: [{ saving_id: 'rs1', name: 'VCB Savings', goal_id: 'g1', amount_vnd: 2_000_000, effective_from: null, effective_to: null, linked_deposit_tx_id: null }] }) })
+      }
+      if (u.includes('investment-transactions')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ transactions: [] }) })
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    try {
+      render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} goals={[{ goal_id: 'g1', goal_name: 'Retirement' }]} />)
+      await userEvent.click(screen.getByTestId('desktop-manage-savings'))
+      expect(await screen.findByTestId('rs-add')).toBeInTheDocument()
+      expect(screen.queryByTestId('rs-name')).not.toBeInTheDocument()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})
+
 describe('DesktopPlanningView — recurring bank "Saved" deposit', () => {
   it('renders a Saved button on a recurring bank saving row', () => {
     render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -594,3 +594,69 @@ describe('MobilePlanningView — save error feedback (no false success)', () => 
     }
   })
 })
+
+describe('MobilePlanningView — overridden-item restore parity + recurring deep-link edit', () => {
+  it('offers "Restore default" on an OVERRIDDEN (not skipped) fixed expense', async () => {
+    const fixedExpenses: FixedExpense[] = [{ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000, override: 10_000_000 }]
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={fixedExpenses} />)
+    await userEvent.click(screen.getByRole('button', { name: 'More options' }))
+    expect(screen.getByRole('button', { name: /Restore default/i })).toBeInTheDocument()
+  })
+
+  it('does NOT offer "Restore default" on a plain (non-overridden) fixed expense', async () => {
+    const fixedExpenses: FixedExpense[] = [{ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000 }]
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={fixedExpenses} />)
+    await userEvent.click(screen.getByRole('button', { name: 'More options' }))
+    expect(screen.queryByRole('button', { name: /Restore default/i })).not.toBeInTheDocument()
+  })
+
+  it('"Edit recurring plan" opens the manager straight on that item’s edit form', async () => {
+    const recurringSavings = [
+      { saving_id: 'rs1', name: 'VCB Savings', goal_id: 'g1', amount_vnd: 2_000_000, effective_from: null, effective_to: null, savings_goals: { goal_name: 'Retirement' } },
+    ]
+    const fetchMock = vi.fn((url: string) => {
+      const u = String(url)
+      if (u.includes('/api/v1/recurring-savings')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ savings: [{ saving_id: 'rs1', name: 'VCB Savings', goal_id: 'g1', amount_vnd: 2_000_000, effective_from: null, effective_to: null, linked_deposit_tx_id: null }] }) })
+      }
+      if (u.includes('investment-transactions')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ transactions: [] }) })
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    try {
+      render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} goals={[{ goal_id: 'g1', goal_name: 'Retirement' }]} />)
+      await userEvent.click(screen.getByText('Retirement'))
+      await userEvent.click(screen.getByRole('button', { name: 'Saving actions' }))
+      await userEvent.click(screen.getByRole('button', { name: 'Edit recurring plan' }))
+      // List mode would not render the name input; the edit form does, pre-filled.
+      const nameInput = await screen.findByTestId('rs-name')
+      expect((nameInput as HTMLInputElement).value).toBe('VCB Savings')
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('the section "Manage" button opens the manager in LIST mode (no deep-link)', async () => {
+    const recurringSavings = [
+      { saving_id: 'rs1', name: 'VCB Savings', goal_id: 'g1', amount_vnd: 2_000_000, effective_from: null, effective_to: null, savings_goals: { goal_name: 'Retirement' } },
+    ]
+    const fetchMock = vi.fn((url: string) => {
+      const u = String(url)
+      if (u.includes('/api/v1/recurring-savings')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve({ savings: [{ saving_id: 'rs1', name: 'VCB Savings', goal_id: 'g1', amount_vnd: 2_000_000, effective_from: null, effective_to: null, linked_deposit_tx_id: null }] }) })
+      }
+      if (u.includes('investment-transactions')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ transactions: [] }) })
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    try {
+      render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} goals={[{ goal_id: 'g1', goal_name: 'Retirement' }]} />)
+      await userEvent.click(screen.getByTestId('mobile-manage-savings'))
+      // List mode shows the add button; the edit form (rs-name) is absent.
+      expect(await screen.findByTestId('rs-add')).toBeInTheDocument()
+      expect(screen.queryByTestId('rs-name')).not.toBeInTheDocument()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})


### PR DESCRIPTION
**PR-3 of the Plan-page UX audit** (theme: desktop/mobile parity + clear next step). Follows #403, #405.

## Two gaps
1. **Mobile had no way back to default after an override.** The mobile `PlanLineItem` menu (fixed expenses + insurance) offered only *Override amount* / *Skip this month* for an overridden-but-not-skipped item. Desktop's `DPlanRow` has had **Restore default** all along — so overriding an amount on a phone left you stuck (re-type the default by hand). 
2. **"Edit recurring plan" dumped you in the list.** From a recurring line's kebab (both views) it opened `RecurringSavingManager` on its list, making you find the same item again.

## What this does
- Mobile `PlanLineItem` now shows **Khôi phục mặc định / Restore default** for overridden items (gated on a new `overridden` prop, reusing the existing restore handler).
- "Edit recurring plan" now **deep-links**: the views thread the saving id and `RecurringSavingManager` opens straight on that item's edit form once its list loads (the open happens after the fetch resolves — no synchronous set-state-in-effect). The section **Manage** button still opens the list (id reset to null).

## Tests
- Mobile shows "Restore default" on an overridden fixed expense; hides it on a plain one.
- Desktop + mobile: "Edit recurring plan" lands on the pre-filled edit form (`rs-name` = the item's name); the "Manage" button stays in list mode (`rs-add` present, `rs-name` absent).

## Verification
- `npm test -- --run` → **866 passed** (91 in planning).
- `npm run lint` → no new errors in changed files (same pre-existing count as `main`).
- E2E not run locally (WSL2 stack). Please confirm both flows on the Vercel preview.

## Follow-ups
PR-4 insurance empty/parity · PR-5 a11y (Esc/focus-trap, menu semantics, touch targets).