### PR TITLE
fix(plan): insurance Add-member path + section parity (UX audit PR-4)

### DIFF
--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -14,6 +14,7 @@ import FixedExpenseManager from './FixedExpenseManager'
 import RecurringSavingManager from './RecurringSavingManager'
 import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
+import AddInsuranceMemberModal from '@/app/assets/components/AddInsuranceMemberModal'
 import { buildByGoal, resolveRecurringSavings, DEPOSIT_BACKED_FULFILLMENT_SOURCES, type GoalItem } from '@/lib/planning'
 import { relationshipLabel } from '@/app/assets/components/insuranceShared'
 import type {
@@ -465,6 +466,7 @@ export default function DesktopPlanningView({
   const [otherDesc, setOtherDesc] = useState('')
   const [otherAmt, setOtherAmt] = useState('')
   const [showFEManage, setShowFEManage] = useState(false)
+  const [showAddInsurance, setShowAddInsurance] = useState(false)
   const [showRSManage, setShowRSManage] = useState(false)
   // When set, the recurring manager opens straight on this saving's edit form.
   const [rsEditId, setRsEditId] = useState<string | null>(null)
@@ -1044,7 +1046,22 @@ export default function DesktopPlanningView({
               </PlanTable>
 
               {/* Insurance */}
-              <PlanTable icon={<Shield size={15} />} iconColor="var(--c-accent-insurance,#7c3aed)" title={isVI ? 'Bảo hiểm' : 'Insurance'} total={insTotal}>
+              <PlanTable
+                icon={<Shield size={15} />}
+                iconColor="var(--c-accent-insurance,#7c3aed)"
+                title={isVI ? 'Bảo hiểm' : 'Insurance'}
+                total={insTotal}
+                action={
+                  <button
+                    data-testid="desktop-add-insurance"
+                    onClick={() => setShowAddInsurance(true)}
+                    style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '5px 10px', fontSize: 12, fontWeight: 600, color: 'var(--c-navy)', background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', borderRadius: 8 }}
+                  >
+                    <Plus size={14} strokeWidth={2.4} />
+                    {isVI ? 'Thêm thành viên' : 'Add member'}
+                  </button>
+                }
+              >
                 <THead
                   col1={isVI ? 'Thành viên' : 'Member'}
                   colRel={isVI ? 'Quan hệ' : 'Relationship'}
@@ -1241,6 +1258,14 @@ export default function DesktopPlanningView({
           <FixedExpenseManager onChange={onRefresh} onToast={onToast} />
         </DModal>
       )}
+
+      <AddInsuranceMemberModal
+        open={showAddInsurance}
+        desktop
+        locale={locale}
+        onClose={() => setShowAddInsurance(false)}
+        onCreated={() => { onRefresh(); onToast(isVI ? 'Đã thêm thành viên' : 'Member added') }}
+      />
 
       {showRSManage && (
         <DModal onClose={() => setShowRSManage(false)} title={isVI ? 'Tiết kiệm định kỳ' : 'Recurring savings'} width={460}>

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -13,6 +13,7 @@ import FixedExpenseManager from './FixedExpenseManager'
 import RecurringSavingManager from './RecurringSavingManager'
 import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
+import AddInsuranceMemberModal from '@/app/assets/components/AddInsuranceMemberModal'
 import { buildByGoal, resolveRecurringSavings, DEPOSIT_BACKED_FULFILLMENT_SOURCES, type GoalRow, type GoalItem } from '@/lib/planning'
 import { relationshipLabel } from '@/app/assets/components/insuranceShared'
 import { MobilePlanningSkeleton } from './PlanningSkeleton'
@@ -1059,6 +1060,7 @@ export default function MobilePlanningView({
   const [buyEdit, setBuyEdit] = useState<EditableTransaction | null>(null)
   const [prefillTx, setPrefillTx] = useState<PrefillTransaction | null>(null)
   const [bookTopUp, setBookTopUp] = useState<BookTopUpTarget | null>(null)
+  const [showAddInsurance, setShowAddInsurance] = useState(false)
   const [overrideTarget, setOverrideTarget] = useState<{ type: 'fe' | 'ins' | 'rec'; id: string; name: string; defaultAmount: number } | null>(null)
 
   const monthLabel = getMonthLabel(month, year)
@@ -1450,15 +1452,33 @@ export default function MobilePlanningView({
               </BudgetSection>
 
             {/* Insurance section */}
-            {insuranceMembers.length > 0 && (
-              <BudgetSection
+            {/* Shown even with no members (parity with desktop + the other
+                sections) so insurance isn't a hidden dead-end — Add member opens
+                the same modal the dashboard uses. */}
+            <BudgetSection
                 icon={Shield}
                 iconColor="var(--c-accent-insurance)"
                 title={isVI ? 'Bảo hiểm' : 'Insurance'}
                 count={`${insuranceMembers.length} ${isVI ? 'thành viên' : insuranceMembers.length === 1 ? 'member' : 'members'}`}
                 total={totalInsurance}
                 testId="section-insurance"
+                action={
+                  <button
+                    data-testid="mobile-add-insurance"
+                    onClick={() => setShowAddInsurance(true)}
+                    aria-label={isVI ? 'Thêm thành viên bảo hiểm' : 'Add insurance member'}
+                    style={{ display: 'flex', alignItems: 'center', gap: 4, padding: '4px 8px', fontSize: 12, fontWeight: 600, color: 'var(--c-navy)', background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', borderRadius: 6 }}
+                  >
+                    <Plus size={14} strokeWidth={2.4} />
+                    {isVI ? 'Thêm' : 'Add'}
+                  </button>
+                }
               >
+                {insuranceMembers.length === 0 && (
+                  <div style={{ padding: '14px', fontSize: 13, color: 'var(--c-muted)' }}>
+                    {isVI ? 'Chưa có thành viên bảo hiểm.' : 'No insurance members yet.'}
+                  </div>
+                )}
                 {insuranceMembers.map((m, i) => {
                   const defaultMonthly = Math.round(m.annual_payment_vnd / 12)
                   const hasOverride = m.monthlyOverride != null && m.monthlyOverride !== defaultMonthly
@@ -1489,7 +1509,6 @@ export default function MobilePlanningView({
                   )
                 })}
               </BudgetSection>
-            )}
 
             {/* Other expenses section */}
             <BudgetSection
@@ -1632,6 +1651,13 @@ export default function MobilePlanningView({
         isVi={isVI}
         onClose={() => setBookTopUp(null)}
         onDone={() => { onToast(isVI ? 'Đã nạp vào sổ' : 'Topped up book'); onRefresh() }}
+      />
+
+      <AddInsuranceMemberModal
+        open={showAddInsurance}
+        locale={locale}
+        onClose={() => setShowAddInsurance(false)}
+        onCreated={() => { onToast(isVI ? 'Đã thêm thành viên' : 'Member added'); onRefresh() }}
       />
     </div>
   )

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -307,6 +307,19 @@ describe('DesktopPlanningView — save error feedback (no false success)', () =>
   })
 })
 
+describe('DesktopPlanningView — insurance Add member (no dead-end)', () => {
+  it('offers an Add member action even when there are no members', () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} insuranceMembers={[]} />)
+    expect(screen.getByTestId('desktop-add-insurance')).toBeInTheDocument()
+  })
+
+  it('opens the add-insurance modal when Add member is clicked', async () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} insuranceMembers={[]} />)
+    await userEvent.click(screen.getByTestId('desktop-add-insurance'))
+    expect(await screen.findByTestId('add-insurance-modal')).toBeInTheDocument()
+  })
+})
+
 describe('DesktopPlanningView — insurance Relationship + Default columns', () => {
   // 14,000,000 / 12 = 1,166,667 — the default monthly contribution.
   const insuranceMembers: InsuranceMember[] = [

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -595,6 +595,19 @@ describe('MobilePlanningView — save error feedback (no false success)', () => 
   })
 })
 
+describe('MobilePlanningView — insurance section parity + Add member', () => {
+  it('shows the insurance section even when there are no members', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} insuranceMembers={[]} />)
+    expect(screen.getByTestId('section-insurance')).toBeInTheDocument()
+  })
+
+  it('offers an Add member action and opens the add-insurance sheet', async () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} insuranceMembers={[]} />)
+    await userEvent.click(screen.getByTestId('mobile-add-insurance'))
+    expect(await screen.findByTestId('add-insurance-modal')).toBeInTheDocument()
+  })
+})
+
 describe('MobilePlanningView — overridden-item restore parity + recurring deep-link edit', () => {
   it('offers "Restore default" on an OVERRIDDEN (not skipped) fixed expense', async () => {
     const fixedExpenses: FixedExpense[] = [{ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000, override: 10_000_000 }]


### PR DESCRIPTION
**PR-4 of the Plan-page UX audit** (theme: desktop/mobile parity + no dead-ends). Follows #403, #405, #406.

## What was wrong
Insurance was a dead end on the Plan page:
- **Desktop** showed a "No insurance members" row with **no action** — every other section (Fixed expenses, Recurring savings) has a header action, insurance had none.
- **Mobile** hid the insurance section **entirely** when there were zero members → no way to add one, and the two platforms diverged.

Result: from the Plan page there was no path to add an insurance member.

## What this does
- Both views render the insurance section **always** (mobile no longer hides it at zero members), with an empty message on mobile.
- Both views expose an **Add member / Thêm thành viên** header action that opens the existing `AddInsuranceMemberModal` (desktop centered modal / mobile bottom sheet). On create → refresh the plan + toast.

Reuses the same modal the dashboard insurance area uses, so no new CRUD surface. Editing/removing a member still lives in the insurance detail; from Plan you can now at least add.

## Tests
- Desktop + mobile expose the Add action with **zero** members and open the add-insurance modal.
- Mobile renders the insurance section even when empty.

## Verification
- `npm test -- --run` → **870 passed** (95 in planning).
- `npm run lint` → no new errors in changed files (same pre-existing count as `main`).
- E2E not run locally (WSL2 stack). Please confirm Add-member on the Vercel preview (desktop + mobile widths).

## Follow-ups
PR-5 a11y (Esc/focus-trap on the plan modals/sheets, kebab menu semantics, ≥44px touch targets).