### PR TITLE
fix(plan): keyboard a11y for plan modals & sheets — Esc + focus trap (UX audit PR-5a)

### DIFF
--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -15,6 +15,7 @@ import RecurringSavingManager from './RecurringSavingManager'
 import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
 import AddInsuranceMemberModal from '@/app/assets/components/AddInsuranceMemberModal'
+import { useDialogA11y } from './useDialogA11y'
 import { buildByGoal, resolveRecurringSavings, DEPOSIT_BACKED_FULFILLMENT_SOURCES, type GoalItem } from '@/lib/planning'
 import { relationshipLabel } from '@/app/assets/components/insuranceShared'
 import type {
@@ -48,16 +49,21 @@ const LONG_MONTHS_VI  = ['Tháng 1','Tháng 2','Tháng 3','Tháng 4','Tháng 5',
 function DModal({ onClose, title, width = 400, children }: {
   onClose: () => void; title: string; width?: number; children: React.ReactNode
 }) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  useDialogA11y(dialogRef, true, onClose)
   return (
     <div
       onClick={onClose}
       style={{ position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)', zIndex: 200, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24, backdropFilter: 'blur(2px)', animation: 'fade-in 150ms ease' }}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
+        aria-label={title}
+        tabIndex={-1}
         onClick={e => e.stopPropagation()}
-        style={{ width: '100%', maxWidth: width, maxHeight: 'calc(100vh - 48px)', background: 'var(--c-card)', borderRadius: 16, boxShadow: '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)', display: 'flex', flexDirection: 'column', overflow: 'hidden', animation: 'modal-in 200ms cubic-bezier(0.2,0.8,0.2,1)' }}
+        style={{ width: '100%', maxWidth: width, maxHeight: 'calc(100vh - 48px)', background: 'var(--c-card)', borderRadius: 16, boxShadow: '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)', display: 'flex', flexDirection: 'column', overflow: 'hidden', animation: 'modal-in 200ms cubic-bezier(0.2,0.8,0.2,1)', outline: 'none' }}
       >
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0 }}>
           <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{title}</h3>

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -14,6 +14,7 @@ import RecurringSavingManager from './RecurringSavingManager'
 import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
 import AddInsuranceMemberModal from '@/app/assets/components/AddInsuranceMemberModal'
+import { useDialogA11y } from './useDialogA11y'
 import { buildByGoal, resolveRecurringSavings, DEPOSIT_BACKED_FULFILLMENT_SOURCES, type GoalRow, type GoalItem } from '@/lib/planning'
 import { relationshipLabel } from '@/app/assets/components/insuranceShared'
 import { MobilePlanningSkeleton } from './PlanningSkeleton'
@@ -94,6 +95,8 @@ function TrashIcon({ size = 16, color = 'currentColor' }: { size?: number; color
 
 function Sheet({ open, onClose, title, children }: { open: boolean; onClose: () => void; title: string; children: React.ReactNode }) {
   const [mounted, setMounted] = useState(false)
+  const dialogRef = useRef<HTMLDivElement>(null)
+  useDialogA11y(dialogRef, open && mounted, onClose)
   useEffect(() => {
     if (open) setMounted(true)
     else { const t = setTimeout(() => setMounted(false), 220); return () => clearTimeout(t) }
@@ -110,12 +113,17 @@ function Sheet({ open, onClose, title, children }: { open: boolean; onClose: () 
       onClick={onClose}
     >
       <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        tabIndex={-1}
         style={{
           width: '100%', background: 'var(--c-card)', borderRadius: '16px 16px 0 0',
           // overflow:hidden forces iOS WebKit to clip the rounded top corners —
           // without it the slide-up transform composites the layer and the
           // corners render square (issue #319).
-          overflow: 'hidden',
+          overflow: 'hidden', outline: 'none',
           paddingBottom: 'env(safe-area-inset-bottom,0)',
           animation: open ? 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' : 'slide-down 180ms ease forwards',
         }}

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -243,6 +243,32 @@ describe('DesktopPlanningView — allocation card amounts never wrap', () => {
   })
 })
 
+describe('DesktopPlanningView — modal focus a11y (DModal)', () => {
+  it('closes the income modal on Escape', async () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Edit income' }))
+    expect(await screen.findByPlaceholderText('e.g. 45,000,000')).toBeInTheDocument()
+    await userEvent.keyboard('{Escape}')
+    expect(screen.queryByPlaceholderText('e.g. 45,000,000')).not.toBeInTheDocument()
+  })
+
+  it('moves focus into the dialog on open (no autofocus field)', async () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Delete plan' }))
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog.contains(document.activeElement)).toBe(true)
+  })
+
+  it('restores focus to the trigger when the modal closes', async () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} />)
+    const trigger = screen.getByRole('button', { name: 'Delete plan' })
+    await userEvent.click(trigger)
+    await screen.findByRole('dialog')
+    await userEvent.keyboard('{Escape}')
+    expect(document.activeElement).toBe(trigger)
+  })
+})
+
 describe('DesktopPlanningView — save error feedback (no false success)', () => {
   const fixedExpenses: FixedExpense[] = [{ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000 }]
 

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -595,6 +595,23 @@ describe('MobilePlanningView — save error feedback (no false success)', () => 
   })
 })
 
+describe('MobilePlanningView — sheet focus a11y (Sheet)', () => {
+  it('exposes role=dialog + aria-modal on an open sheet', async () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Edit income' }))
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+  })
+
+  it('closes a sheet on Escape', async () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Edit income' }))
+    expect(await screen.findByTestId('mobile-salary-input')).toBeInTheDocument()
+    await userEvent.keyboard('{Escape}')
+    await waitFor(() => expect(screen.queryByTestId('mobile-salary-input')).not.toBeInTheDocument())
+  })
+})
+
 describe('MobilePlanningView — insurance section parity + Add member', () => {
   it('shows the insurance section even when there are no members', () => {
     render(<MobilePlanningView {...defaultProps} plan={basePlan} insuranceMembers={[]} />)

--- a/app/(app)/planning/components/useDialogA11y.ts
+++ b/app/(app)/planning/components/useDialogA11y.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef, type RefObject } from 'react'
+
+// Shared dialog accessibility for the Plan page's modal/sheet wrappers (DModal,
+// Sheet). While active it:
+//   • closes on Escape,
+//   • moves focus into the dialog on open (unless something inside is already
+//     focused, e.g. an autoFocus field) and restores it to the previously
+//     focused element on close,
+//   • traps Tab/Shift+Tab within the dialog.
+// Effects key only on [active, ref] — onClose is read through a ref so an inline
+// `onClose={() => …}` (new identity each render) doesn't re-run focus handling
+// and steal focus mid-interaction.
+
+const FOCUSABLE = [
+  'a[href]', 'button:not([disabled])', 'textarea:not([disabled])',
+  'input:not([disabled])', 'select:not([disabled])', '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+export function useDialogA11y(
+  ref: RefObject<HTMLElement | null>,
+  active: boolean,
+  onClose: () => void,
+) {
+  const onCloseRef = useRef(onClose)
+  useEffect(() => { onCloseRef.current = onClose })
+
+  // Focus in on open; restore on close.
+  useEffect(() => {
+    if (!active) return
+    const node = ref.current
+    const prevFocused = document.activeElement as HTMLElement | null
+    if (node && !node.contains(document.activeElement)) {
+      const els = Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE))
+      ;(els[0] ?? node).focus?.()
+    }
+    return () => { prevFocused?.focus?.() }
+  }, [active, ref])
+
+  // Escape to close + Tab trap.
+  useEffect(() => {
+    if (!active) return
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') { e.stopPropagation(); onCloseRef.current(); return }
+      if (e.key !== 'Tab') return
+      const node = ref.current
+      if (!node) return
+      const els = Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE))
+      if (els.length === 0) { e.preventDefault(); return }
+      const first = els[0]
+      const last = els[els.length - 1]
+      const activeEl = document.activeElement
+      if (e.shiftKey) {
+        if (activeEl === first || !node.contains(activeEl)) { e.preventDefault(); last.focus() }
+      } else if (activeEl === last || !node.contains(activeEl)) {
+        e.preventDefault(); first.focus()
+      }
+    }
+    document.addEventListener('keydown', onKey, true)
+    return () => document.removeEventListener('keydown', onKey, true)
+  }, [active, ref])
+}


### PR DESCRIPTION
**PR-5a of the Plan-page UX audit** (theme: accessibility). First of two a11y PRs. Follows #403, #405, #406, #407.

## What was wrong
The Plan page's shared **`DModal`** (desktop) and **`Sheet`** (mobile) wrappers had:
- no **Escape** handler — keyboard users couldn't close them;
- no **focus management** — Tab escaped to the page behind, and focus wasn't restored on close;
- the mobile `Sheet` had **no dialog semantics** (no `role="dialog"`/`aria-modal`, title was a plain `<p>`).

## What this does
A small shared `useDialogA11y(ref, active, onClose)` hook applied to both wrappers:
- **Escape closes.**
- **Focus moves into the dialog on open** (respecting an existing `autoFocus` field) and is **restored to the trigger on close**.
- **Tab / Shift+Tab trapped** within the dialog.
- `Sheet` now carries `role="dialog"` + `aria-modal` + `aria-label`; `DModal` gets `aria-label` from its title.
- Latest `onClose` is read via a ref so an inline `onClose={() => …}` doesn't re-run focus handling and steal focus mid-interaction.

Because it lives in the two wrappers, it covers **every** plan modal/sheet at once: income, delete-plan, override, other-expense, manage fixed expenses, manage recurring savings.

## Tests
- Escape closes a `DModal` (income) and a `Sheet` (salary).
- Focus moves into a no-autofocus dialog (delete-plan) and is restored to the trigger on Escape.
- The mobile `Sheet` exposes `role="dialog"` + `aria-modal`.

## Verification
- `npm test -- --run` → **876 passed** (100 in planning).
- `npm run lint` → no new errors in changed files; the new hook is lint-clean.
- E2E not run locally (WSL2 stack). Please sanity-check Esc + tabbing on the Vercel preview (desktop modals + mobile sheets).

## Follow-up
**PR-5b** — kebab menu semantics (`role=menu/menuitem`) + ≥44px touch targets on the row controls.