### PR TITLE
fix(maturity): group thousands in the maturity money inputs

### DIFF
--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -19,6 +19,7 @@
 import { useState, useEffect } from 'react'
 import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X, Plus, Wallet, Lock, SlidersHorizontal, PiggyBank, GitMerge } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
+import AmountInput from '@/app/components/ui/AmountInput'
 import { fmtMaturity, type InvRow } from './goalDetailShared'
 import {
   depositMaturityState,
@@ -46,14 +47,34 @@ const moneyInput: React.CSSProperties = {
   borderRadius: 10, color: 'var(--c-ink)', outline: 'none',
 }
 
+// Money entry core: a digit-grouped amount field (₫ suffix). Reused by every
+// money input in the maturity flow so large VND amounts stay readable
+// (e.g. "37,030,000" rather than "37030000"). `AmountInput` keeps the value raw
+// (digits only) while displaying thousands separators and a numeric keypad.
+// `compact` is the tight in-row variant (per-source merge cash); `style` merges
+// onto the field (e.g. the navy-bordered re-deposit amount).
+function MoneyInputCore({ value, onChange, testId, style, compact }: {
+  value: string; onChange: (v: string) => void; testId?: string;
+  style?: React.CSSProperties; compact?: boolean
+}) {
+  return (
+    <div style={{ position: 'relative', ...(compact ? { flex: 1 } : null) }}>
+      <AmountInput
+        data-testid={testId}
+        value={value}
+        onChange={onChange}
+        style={compact ? { ...moneyInput, padding: '7px 24px 7px 10px', fontSize: 16, ...style } : { ...moneyInput, ...style }}
+      />
+      <span style={{ position: 'absolute', right: compact ? 9 : 12, top: '50%', transform: 'translateY(-50%)', fontSize: compact ? 12 : 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
+    </div>
+  )
+}
+
 function MoneyField({ label, value, onChange, testId }: { label: string; value: string; onChange: (v: string) => void; testId?: string }) {
   return (
     <div>
       <div style={fieldLabel}>{label}</div>
-      <div style={{ position: 'relative' }}>
-        <input data-testid={testId} type="number" value={value} onChange={(e) => onChange(e.target.value)} style={moneyInput} />
-        <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
-      </div>
+      <MoneyInputCore value={value} onChange={onChange} testId={testId} />
     </div>
   )
 }
@@ -814,12 +835,9 @@ export function MaturityResolveBody({
           {/* Re-deposit amount (suggested = principal + interest + recurring) */}
           <div>
             <div style={fieldLabel}>{t.redepositAmount}</div>
-            <div style={{ position: 'relative' }}>
-              <input data-testid="maturity-redeposit" type="number" value={redeposit}
-                onChange={(e) => { setRedeposit(e.target.value); setRedepositTouched(true) }}
-                style={{ ...moneyInput, borderColor: 'var(--c-navy)' }} />
-              <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
-            </div>
+            <MoneyInputCore testId="maturity-redeposit" value={redeposit}
+              onChange={(v) => { setRedeposit(v); setRedepositTouched(true) }}
+              style={{ borderColor: 'var(--c-navy)' }} />
             <p style={{ margin: '7px 2px 0', fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.45 }}>{t.redepositHint(fmtCompact(principal + iNum + linkedAmt))}</p>
           </div>
 
@@ -893,12 +911,8 @@ export function MaturityResolveBody({
                       {sel && (
                         <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingLeft: 28 }}>
                           <span style={{ fontSize: 11, color: 'var(--c-muted)', flexShrink: 0 }}>{t.mergeReceivedLabel}</span>
-                          <div style={{ position: 'relative', flex: 1 }}>
-                            <input data-testid={`merge-received-${s.id}`} type="number" value={mergeRecv[s.id] ?? ''}
-                              onChange={(e) => { setMergeRecv((prev) => ({ ...prev, [s.id]: e.target.value })); setMergeTotal(''); setMergeTotalTouched(false) }}
-                              style={{ ...moneyInput, padding: '7px 24px 7px 10px', fontSize: 16 }} />
-                            <span style={{ position: 'absolute', right: 9, top: '50%', transform: 'translateY(-50%)', fontSize: 12, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
-                          </div>
+                          <MoneyInputCore compact testId={`merge-received-${s.id}`} value={mergeRecv[s.id] ?? ''}
+                            onChange={(v) => { setMergeRecv((prev) => ({ ...prev, [s.id]: v })); setMergeTotal(''); setMergeTotalTouched(false) }} />
                         </div>
                       )}
                     </div>
@@ -924,11 +938,8 @@ export function MaturityResolveBody({
                   {selectedSources.length > 1 && (
                     <div>
                       <div style={fieldLabel}>{t.mergeTotalLabel}</div>
-                      <div style={{ position: 'relative' }}>
-                        <input data-testid="merge-total" type="number" value={mergeTotal === '' ? String(mergeReceivedTotal) : mergeTotal}
-                          onChange={(e) => onMergeTotalChange(e.target.value)} style={moneyInput} />
-                        <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
-                      </div>
+                      <MoneyInputCore testId="merge-total" value={mergeTotal === '' ? String(mergeReceivedTotal) : mergeTotal}
+                        onChange={onMergeTotalChange} />
                     </div>
                   )}
                   {selectedSources.length === 1 && <input data-testid="merge-total" type="hidden" value={String(mergeReceivedTotal)} readOnly />}

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -205,6 +205,18 @@ describe('MaturityResolveBody', () => {
       expect(screen.queryByTestId('merge-source-sib-stock')).toBeNull()   // non-bank excluded
     })
 
+    it('formats the re-deposit amount with thousands separators', async () => {
+      const user = userEvent.setup()
+      stubEmptyRecurring()
+      render(
+        <MaturityResolveBody inv={maturedDeposit} goalId="goal-1" siblingDeposits={[sibBank]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+      // Default = principal + interest + recurring(0) = 37,030,000, shown grouped.
+      expect((screen.getByTestId('maturity-redeposit') as HTMLInputElement).value).toBe('37,030,000')
+    })
+
     it('prefills each selected source with its current value and shows the penalty caption', async () => {
       const user = userEvent.setup()
       stubEmptyRecurring()
@@ -217,7 +229,8 @@ describe('MaturityResolveBody', () => {
 
       // sibBank matures far past the anchor → out of window, folded in via override.
       await user.click(screen.getByTestId('merge-override-sib-bank'))
-      expect((screen.getByTestId('merge-received-sib-bank') as HTMLInputElement).value).toBe('8000000')
+      // Money fields render thousands separators (user-visible), not the raw digits.
+      expect((screen.getByTestId('merge-received-sib-bank') as HTMLInputElement).value).toBe('8,000,000')
       expect(screen.getByTestId('merge-penalty-caption')).toBeTruthy()
     })
 
@@ -238,8 +251,8 @@ describe('MaturityResolveBody', () => {
 
       // Weights ordered by (investmentDate, id): sib-bank (−150d) then sib-bank-2 (−100d).
       const [a1, a2] = allocateCumulative(10_000_000, [8_000_000, 4_000_000])
-      expect((screen.getByTestId('merge-received-sib-bank') as HTMLInputElement).value).toBe(String(a1))
-      expect((screen.getByTestId('merge-received-sib-bank-2') as HTMLInputElement).value).toBe(String(a2))
+      expect((screen.getByTestId('merge-received-sib-bank') as HTMLInputElement).value).toBe(a1.toLocaleString('en-US'))
+      expect((screen.getByTestId('merge-received-sib-bank-2') as HTMLInputElement).value).toBe(a2.toLocaleString('en-US'))
     })
 
     it('previews base + Σreceived but submits amount_vnd == BASE plus merge_sources', async () => {
@@ -431,7 +444,7 @@ describe('MaturityResolveBody', () => {
       await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
 
       // In-window → preselected, so its received field is already shown + prefilled.
-      expect((await screen.findByTestId('merge-received-sib-in') as HTMLInputElement).value).toBe('6000000')
+      expect((await screen.findByTestId('merge-received-sib-in') as HTMLInputElement).value).toBe('6,000,000')
       // Out-of-window → not selected; offered behind an override, no received field yet.
       expect(screen.getByTestId('merge-override-sib-out')).toBeTruthy()
       expect(screen.queryByTestId('merge-received-sib-out')).toBeNull()
@@ -451,7 +464,7 @@ describe('MaturityResolveBody', () => {
       // Push the window past the 52-day gap → it becomes eligible and auto-selects.
       fireEvent.change(screen.getByTestId('merge-window-slider'), { target: { value: '60' } })
       expect(screen.queryByTestId('merge-override-sib-out')).toBeNull()
-      expect((screen.getByTestId('merge-received-sib-out') as HTMLInputElement).value).toBe('8000000')
+      expect((screen.getByTestId('merge-received-sib-out') as HTMLInputElement).value).toBe('8,000,000')
     })
 
     it('hard-blocks a different-currency sibling with no override', async () => {
@@ -480,7 +493,7 @@ describe('MaturityResolveBody', () => {
       await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
       await user.click(screen.getByTestId('merge-override-sib-out'))
 
-      expect((screen.getByTestId('merge-received-sib-out') as HTMLInputElement).value).toBe('8000000')
+      expect((screen.getByTestId('merge-received-sib-out') as HTMLInputElement).value).toBe('8,000,000')
       // Anchor + the one folded source = 2 sources of provenance.
       expect(screen.getByTestId('merge-provenance').textContent).toMatch(/2 sources/i)
     })
@@ -529,7 +542,7 @@ describe('MaturityResolveBody', () => {
       await user.click(screen.getByRole('button', { name: /Don.t renew/i }))
       expect(screen.getByTestId('maturity-hold-fork')).toBeTruthy()
       // The received field (hold path) is shown, defaulted to the current value.
-      expect((screen.getByTestId('maturity-hold-received') as HTMLInputElement).value).toBe('10500000')
+      expect((screen.getByTestId('maturity-hold-received') as HTMLInputElement).value).toBe('10,500,000')
 
       await user.click(screen.getByRole('button', { name: /Confirm hold/i }))
       await waitFor(() => {


### PR DESCRIPTION
## What

The term-deposit maturity flow (renew / combine / withdraw-and-hold) entered every money amount through raw `<input type="number">` fields, so large VND principals rendered as an unbroken run of digits (e.g. `37030000`) that's hard to read and easy to mis-key.

This routes all five money inputs — re-deposit amount, per-source merge cash, merge total, hold-received, and the change-amount/interest fields — through a shared `MoneyInputCore` that reuses the existing `AmountInput`:

- Digit-grouped display (`37,030,000`)
- Numeric keypad preserved (`inputMode="numeric"`)
- Value kept raw for submission — **no change to any request payload**

## Tests (TDD)

- Updated the `MaturityResolveSheet` unit tests to assert the new user-visible grouped values (e.g. `'8,000,000'`), plus a dedicated test for the re-deposit field formatting. Red → green confirmed.
- Full unit suite green (876 tests).
- Targeted E2E: `maturity-combine-merge` + `maturity-combine-cluster` pass (these exercise the reformatted merge-received fields). `accumulating-collapse` failures observed were environmental (dashboard maturity-action-card / API seeding flakiness, unrelated to this display change). The E2E that reads `maturity-new-amount` already strips non-digits, so grouping is safe there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)