### PR TITLE
fix(plan): kebab menu semantics + touch targets (UX audit PR-5b)

### DIFF
--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -142,7 +142,7 @@ function MenuBtn({ icon, label, onClick, danger, noBorder }: {
   icon: React.ReactNode; label: string; onClick: () => void; danger?: boolean; noBorder?: boolean
 }) {
   return (
-    <button onClick={onClick} style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', borderBottom: noBorder ? 'none' : '1px solid var(--c-line)', cursor: 'pointer', fontFamily: 'inherit', color: danger ? 'var(--c-neg)' : 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8 }}>
+    <button role="menuitem" onClick={onClick} style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', borderBottom: noBorder ? 'none' : '1px solid var(--c-line)', cursor: 'pointer', fontFamily: 'inherit', color: danger ? 'var(--c-neg)' : 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8 }}>
       <span style={{ color: danger ? 'var(--c-neg)' : 'var(--c-muted)' }}>{icon}</span>
       {label}
     </button>
@@ -185,13 +185,13 @@ function DPlanRow({ primary, secondary, amount, relationship, defaultAmount, mut
         </span>
       </td>
       <td style={{ padding: '11px 8px 11px 4px', textAlign: 'right', verticalAlign: 'middle', width: 36 }}>
-        <button ref={btnRef} onClick={() => open ? setOpen(false) : openMenu()} aria-label="More options" style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
+        <button ref={btnRef} onClick={() => open ? setOpen(false) : openMenu()} aria-label="More options" aria-haspopup="menu" aria-expanded={open} style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
           <MoreHorizontal size={14} />
         </button>
         {open && (
           <>
             <div onClick={() => setOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 5 }} />
-            <div style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 170, overflow: 'hidden' }}>
+            <div role="menu" style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 170, overflow: 'hidden' }}>
               {muted ? (
                 <MenuBtn icon={<Check size={13} />} label={isVI ? 'Bao gồm tháng này' : 'Include this month'} onClick={() => { onRestore?.(); setOpen(false) }} noBorder />
               ) : (
@@ -271,13 +271,13 @@ function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRec
                 <Plus size={12} strokeWidth={2.4} />{isVI ? 'Đã gửi' : 'Saved'}
               </button>
             )}
-            <button ref={btnRef} onClick={() => open ? setOpen(false) : openMenu()} aria-label="Saving actions" style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
+            <button ref={btnRef} onClick={() => open ? setOpen(false) : openMenu()} aria-label="Saving actions" aria-haspopup="menu" aria-expanded={open} style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
               <MoreHorizontal size={14} />
             </button>
             {open && (
               <>
                 <div onClick={() => setOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 5 }} />
-                <div style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 200, overflow: 'hidden' }}>
+                <div role="menu" style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 200, overflow: 'hidden' }}>
                   {skipped ? (
                     <MenuBtn icon={<Check size={13} />} label={isVI ? 'Bao gồm tháng này' : 'Include this month'} onClick={() => { onRestore(); setOpen(false) }} noBorder />
                   ) : (
@@ -307,13 +307,13 @@ function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRec
               style={{ padding: '4px 10px', fontSize: 11, fontWeight: 600, color: 'var(--c-pos)', background: 'var(--c-pos-tint)', border: '1px solid transparent', borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 4, whiteSpace: 'nowrap' }}>
               <Plus size={12} strokeWidth={2.4} />{isVI ? 'Mua' : 'Buy'}
             </button>
-            <button ref={btnRef} onClick={() => open ? setOpen(false) : openMenu()} aria-label="DCA actions" style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
+            <button ref={btnRef} onClick={() => open ? setOpen(false) : openMenu()} aria-label="DCA actions" aria-haspopup="menu" aria-expanded={open} style={{ padding: 5, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex' }}>
               <MoreHorizontal size={14} />
             </button>
             {open && (
               <>
                 <div onClick={() => setOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 5 }} />
-                <div style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 200, overflow: 'hidden' }}>
+                <div role="menu" style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 200, overflow: 'hidden' }}>
                   <MenuBtn icon={<Plus size={13} />} label={isVI ? 'Ghi nhận mua tháng này' : 'Record buy this month'} onClick={() => { onRecordBuy(); setOpen(false) }} />
                   <MenuBtn icon={<X size={13} />} label={isVI ? 'Bỏ qua tháng này' : 'Skip this month'} onClick={() => { onDcaSkip(); setOpen(false) }} danger noBorder />
                 </div>

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -869,13 +869,13 @@ function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onReco
               <Plus size={12} strokeWidth={2.4} />{isVI ? 'Đã gửi' : 'Saved'}
             </button>
           )}
-          <button ref={btnRef} onClick={() => (menuOpen ? setMenuOpen(false) : openMenu())} aria-label="Saving actions" style={{ padding: 4, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex', flexShrink: 0 }}>
+          <button ref={btnRef} onClick={() => (menuOpen ? setMenuOpen(false) : openMenu())} aria-label="Saving actions" aria-haspopup="menu" aria-expanded={menuOpen} style={{ minWidth: 44, minHeight: 44, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
             <MoreHorizontal size={14} />
           </button>
           {menuOpen && (
             <>
               <div onClick={() => setMenuOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 5 }} />
-              <div style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 200, overflow: 'hidden' }}>
+              <div role="menu" style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 200, overflow: 'hidden' }}>
                 {skipped ? (
                   <MenuItem icon={<Check size={13} />} label={isVI ? 'Bao gồm tháng này' : 'Include this month'} onClick={() => { onRestore(); setMenuOpen(false) }} noBorder />
                 ) : (
@@ -904,13 +904,13 @@ function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onReco
           <button onClick={onRecordBuy} aria-label={isVI ? 'Ghi nhận mua' : 'Record buy'} style={{ padding: '4px 9px', fontSize: 11, fontWeight: 600, color: 'var(--c-pos)', background: 'var(--c-pos-tint)', border: '1px solid transparent', borderRadius: 7, cursor: 'pointer', fontFamily: 'inherit', display: 'inline-flex', alignItems: 'center', gap: 3, flexShrink: 0, whiteSpace: 'nowrap' }}>
             <Plus size={12} strokeWidth={2.4} />{isVI ? 'Mua' : 'Buy'}
           </button>
-          <button ref={btnRef} onClick={() => (menuOpen ? setMenuOpen(false) : openMenu())} aria-label="DCA actions" style={{ padding: 4, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex', flexShrink: 0 }}>
+          <button ref={btnRef} onClick={() => (menuOpen ? setMenuOpen(false) : openMenu())} aria-label="DCA actions" aria-haspopup="menu" aria-expanded={menuOpen} style={{ minWidth: 44, minHeight: 44, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-muted)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
             <MoreHorizontal size={14} />
           </button>
           {menuOpen && (
             <>
               <div onClick={() => setMenuOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 5 }} />
-              <div style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 200, overflow: 'hidden' }}>
+              <div role="menu" style={{ position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 6, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 8, boxShadow: '0 6px 20px rgba(15,23,42,0.12)', minWidth: 200, overflow: 'hidden' }}>
                 <MenuItem icon={<Plus size={13} />} label={isVI ? 'Ghi nhận mua tháng này' : 'Record buy this month'} onClick={() => { onRecordBuy(); setMenuOpen(false) }} />
                 <MenuItem icon={<X size={13} />} label={isVI ? 'Bỏ qua tháng này' : 'Skip this month'} onClick={() => { onDcaSkip(); setMenuOpen(false) }} danger noBorder />
               </div>
@@ -980,14 +980,16 @@ function PlanLineItem({
         ref={btnRef}
         onClick={() => menuOpen ? setMenuOpen(false) : openMenu()}
         aria-label="More options"
-        style={{ padding: 4, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 4, display: 'flex', alignItems: 'center' }}
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        style={{ minWidth: 44, minHeight: 44, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
       >
         <MoreHorizontal size={14} color="var(--c-muted)" />
       </button>
       {menuOpen && (
         <>
           <div onClick={() => setMenuOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 50 }} />
-          <div style={{
+          <div role="menu" style={{
             position: 'fixed', top: menuPos.top, right: menuPos.right, zIndex: 51,
             background: 'var(--c-card)', border: '1px solid var(--c-line)',
             borderRadius: 8, boxShadow: 'var(--shadow-pop)',
@@ -995,6 +997,7 @@ function PlanLineItem({
           }}>
             {muted ? (
               <button
+                role="menuitem"
                 onClick={() => { onRestore?.(); setMenuOpen(false) }}
                 style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', color: 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8 }}
               >
@@ -1004,6 +1007,7 @@ function PlanLineItem({
             ) : (
               <>
                 <button
+                  role="menuitem"
                   onClick={() => { onOverride?.(); setMenuOpen(false) }}
                   style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', color: 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8, borderBottom: '1px solid var(--c-line)' }}
                 >
@@ -1012,6 +1016,7 @@ function PlanLineItem({
                 </button>
                 {overridden && onRestore && (
                   <button
+                    role="menuitem"
                     onClick={() => { onRestore(); setMenuOpen(false) }}
                     style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', borderBottom: '1px solid var(--c-line)', cursor: 'pointer', fontFamily: 'inherit', color: 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8 }}
                   >
@@ -1020,6 +1025,7 @@ function PlanLineItem({
                   </button>
                 )}
                 <button
+                  role="menuitem"
                   onClick={() => { onSkip?.(); setMenuOpen(false) }}
                   style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', cursor: 'pointer', fontFamily: 'inherit', color: 'var(--c-neg)', display: 'flex', alignItems: 'center', gap: 8 }}
                 >
@@ -1042,6 +1048,7 @@ function MenuItem({ icon, label, onClick, danger, noBorder }: {
 }) {
   return (
     <button
+      role="menuitem"
       onClick={onClick}
       style={{ width: '100%', textAlign: 'left', padding: '10px 12px', fontSize: 12, background: 'transparent', border: 'none', borderBottom: noBorder ? 'none' : '1px solid var(--c-line)', cursor: 'pointer', fontFamily: 'inherit', color: danger ? 'var(--c-neg)' : 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 8 }}
     >

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -102,7 +102,7 @@ describe('DesktopPlanningView — recurring deep-link edit', () => {
     try {
       render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} goals={[{ goal_id: 'g1', goal_name: 'Retirement' }]} />)
       await userEvent.click(screen.getByRole('button', { name: 'Saving actions' }))
-      await userEvent.click(screen.getByRole('button', { name: 'Edit recurring plan' }))
+      await userEvent.click(screen.getByRole('menuitem', { name: 'Edit recurring plan' }))
       const nameInput = await screen.findByTestId('rs-name')
       expect((nameInput as HTMLInputElement).value).toBe('VCB Savings')
     } finally {
@@ -243,6 +243,19 @@ describe('DesktopPlanningView — allocation card amounts never wrap', () => {
   })
 })
 
+describe('DesktopPlanningView — kebab menu semantics', () => {
+  it('exposes a role=menu with menuitems and toggles aria-expanded', async () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} fixedExpenses={[{ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000 }]} />)
+    const trigger = screen.getByRole('button', { name: 'More options' })
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
+    expect(trigger).toHaveAttribute('aria-expanded', 'false')
+    await userEvent.click(trigger)
+    expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    const menu = screen.getByRole('menu')
+    expect(within(menu).getAllByRole('menuitem').length).toBeGreaterThan(0)
+  })
+})
+
 describe('DesktopPlanningView — modal focus a11y (DModal)', () => {
   it('closes the income modal on Escape', async () => {
     render(<DesktopPlanningView {...defaultProps} plan={basePlan} />)
@@ -304,7 +317,7 @@ describe('DesktopPlanningView — save error feedback (no false success)', () =>
     try {
       render(<DesktopPlanningView {...defaultProps} plan={basePlan} fixedExpenses={fixedExpenses} onToast={onToast} />)
       await userEvent.click(screen.getByRole('button', { name: 'More options' }))
-      await userEvent.click(screen.getByRole('button', { name: 'Override amount' }))
+      await userEvent.click(screen.getByRole('menuitem', { name: 'Override amount' }))
       await userEvent.click(screen.getByRole('button', { name: 'Save' }))
       await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
       expect(onToast).not.toHaveBeenCalled()
@@ -324,7 +337,7 @@ describe('DesktopPlanningView — save error feedback (no false success)', () =>
     try {
       render(<DesktopPlanningView {...defaultProps} plan={basePlan} fixedExpenses={fixedExpenses} onToast={onToast} />)
       await userEvent.click(screen.getByRole('button', { name: 'More options' }))
-      await userEvent.click(screen.getByRole('button', { name: 'Skip this month' }))
+      await userEvent.click(screen.getByRole('menuitem', { name: 'Skip this month' }))
       await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
       expect(onToast).not.toHaveBeenCalled()
     } finally {

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -547,7 +547,7 @@ describe('MobilePlanningView — save error feedback (no false success)', () => 
     try {
       render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={fixedExpenses} onToast={onToast} />)
       await userEvent.click(screen.getByRole('button', { name: 'More options' }))
-      await userEvent.click(screen.getByRole('button', { name: 'Override amount' }))
+      await userEvent.click(screen.getByRole('menuitem', { name: 'Override amount' }))
       await userEvent.click(screen.getByRole('button', { name: 'Save' }))
       await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
       expect(onToast).not.toHaveBeenCalled()
@@ -566,7 +566,7 @@ describe('MobilePlanningView — save error feedback (no false success)', () => 
     try {
       render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={fixedExpenses} onToast={onToast} />)
       await userEvent.click(screen.getByRole('button', { name: 'More options' }))
-      await userEvent.click(screen.getByRole('button', { name: 'Skip this month' }))
+      await userEvent.click(screen.getByRole('menuitem', { name: 'Skip this month' }))
       await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
       expect(onToast).not.toHaveBeenCalled()
     } finally {
@@ -582,7 +582,7 @@ describe('MobilePlanningView — save error feedback (no false success)', () => 
       render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} goals={[{ goal_id: 'g1', goal_name: 'Retirement' }]} onToast={onToast} />)
       await userEvent.click(screen.getByText('Retirement'))
       await userEvent.click(screen.getByRole('button', { name: 'Saving actions' }))
-      await userEvent.click(screen.getByRole('button', { name: 'Save more this month' }))
+      await userEvent.click(screen.getByRole('menuitem', { name: 'Save more this month' }))
       await userEvent.click(screen.getByRole('button', { name: 'Save' }))
       await waitFor(() => expect(onToast).toHaveBeenCalled())
       const urls = fetchMock.mock.calls.map((c) => String(c[0]))
@@ -592,6 +592,28 @@ describe('MobilePlanningView — save error feedback (no false success)', () => 
     } finally {
       vi.unstubAllGlobals()
     }
+  })
+})
+
+describe('MobilePlanningView — kebab menu semantics', () => {
+  it('plan-line kebab (fixed expense) exposes a role=menu with menuitems', async () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={[{ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000 }]} />)
+    const trigger = screen.getByRole('button', { name: 'More options' })
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
+    await userEvent.click(trigger)
+    const menu = screen.getByRole('menu')
+    expect(within(menu).getAllByRole('menuitem').length).toBeGreaterThan(0)
+  })
+
+  it('recurring-saving kebab exposes a role=menu with menuitems', async () => {
+    const recurringSavings = [
+      { saving_id: 'rs1', name: 'VCB Savings', goal_id: 'g1', amount_vnd: 2_000_000, effective_from: null, effective_to: null, savings_goals: { goal_name: 'Retirement' } },
+    ]
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} goals={[{ goal_id: 'g1', goal_name: 'Retirement' }]} />)
+    await userEvent.click(screen.getByText('Retirement'))
+    await userEvent.click(screen.getByRole('button', { name: 'Saving actions' }))
+    const menu = screen.getByRole('menu')
+    expect(within(menu).getAllByRole('menuitem').length).toBeGreaterThan(0)
   })
 })
 
@@ -630,14 +652,14 @@ describe('MobilePlanningView — overridden-item restore parity + recurring deep
     const fixedExpenses: FixedExpense[] = [{ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000, override: 10_000_000 }]
     render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={fixedExpenses} />)
     await userEvent.click(screen.getByRole('button', { name: 'More options' }))
-    expect(screen.getByRole('button', { name: /Restore default/i })).toBeInTheDocument()
+    expect(screen.getByRole('menuitem', { name: /Restore default/i })).toBeInTheDocument()
   })
 
   it('does NOT offer "Restore default" on a plain (non-overridden) fixed expense', async () => {
     const fixedExpenses: FixedExpense[] = [{ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000 }]
     render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={fixedExpenses} />)
     await userEvent.click(screen.getByRole('button', { name: 'More options' }))
-    expect(screen.queryByRole('button', { name: /Restore default/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('menuitem', { name: /Restore default/i })).not.toBeInTheDocument()
   })
 
   it('"Edit recurring plan" opens the manager straight on that item’s edit form', async () => {
@@ -657,7 +679,7 @@ describe('MobilePlanningView — overridden-item restore parity + recurring deep
       render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} goals={[{ goal_id: 'g1', goal_name: 'Retirement' }]} />)
       await userEvent.click(screen.getByText('Retirement'))
       await userEvent.click(screen.getByRole('button', { name: 'Saving actions' }))
-      await userEvent.click(screen.getByRole('button', { name: 'Edit recurring plan' }))
+      await userEvent.click(screen.getByRole('menuitem', { name: 'Edit recurring plan' }))
       // List mode would not render the name input; the edit form does, pre-filled.
       const nameInput = await screen.findByTestId('rs-name')
       expect((nameInput as HTMLInputElement).value).toBe('VCB Savings')

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -19,6 +19,7 @@
 import { useState, useEffect } from 'react'
 import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X, Plus, Wallet, Lock, SlidersHorizontal, PiggyBank, GitMerge } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
+import AmountInput from '@/app/components/ui/AmountInput'
 import { fmtMaturity, type InvRow } from './goalDetailShared'
 import {
   depositMaturityState,
@@ -46,14 +47,34 @@ const moneyInput: React.CSSProperties = {
   borderRadius: 10, color: 'var(--c-ink)', outline: 'none',
 }
 
+// Money entry core: a digit-grouped amount field (₫ suffix). Reused by every
+// money input in the maturity flow so large VND amounts stay readable
+// (e.g. "37,030,000" rather than "37030000"). `AmountInput` keeps the value raw
+// (digits only) while displaying thousands separators and a numeric keypad.
+// `compact` is the tight in-row variant (per-source merge cash); `style` merges
+// onto the field (e.g. the navy-bordered re-deposit amount).
+function MoneyInputCore({ value, onChange, testId, style, compact }: {
+  value: string; onChange: (v: string) => void; testId?: string;
+  style?: React.CSSProperties; compact?: boolean
+}) {
+  return (
+    <div style={{ position: 'relative', ...(compact ? { flex: 1 } : null) }}>
+      <AmountInput
+        data-testid={testId}
+        value={value}
+        onChange={onChange}
+        style={compact ? { ...moneyInput, padding: '7px 24px 7px 10px', fontSize: 16, ...style } : { ...moneyInput, ...style }}
+      />
+      <span style={{ position: 'absolute', right: compact ? 9 : 12, top: '50%', transform: 'translateY(-50%)', fontSize: compact ? 12 : 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
+    </div>
+  )
+}
+
 function MoneyField({ label, value, onChange, testId }: { label: string; value: string; onChange: (v: string) => void; testId?: string }) {
   return (
     <div>
       <div style={fieldLabel}>{label}</div>
-      <div style={{ position: 'relative' }}>
-        <input data-testid={testId} type="number" value={value} onChange={(e) => onChange(e.target.value)} style={moneyInput} />
-        <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
-      </div>
+      <MoneyInputCore value={value} onChange={onChange} testId={testId} />
     </div>
   )
 }
@@ -814,12 +835,9 @@ export function MaturityResolveBody({
           {/* Re-deposit amount (suggested = principal + interest + recurring) */}
           <div>
             <div style={fieldLabel}>{t.redepositAmount}</div>
-            <div style={{ position: 'relative' }}>
-              <input data-testid="maturity-redeposit" type="number" value={redeposit}
-                onChange={(e) => { setRedeposit(e.target.value); setRedepositTouched(true) }}
-                style={{ ...moneyInput, borderColor: 'var(--c-navy)' }} />
-              <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
-            </div>
+            <MoneyInputCore testId="maturity-redeposit" value={redeposit}
+              onChange={(v) => { setRedeposit(v); setRedepositTouched(true) }}
+              style={{ borderColor: 'var(--c-navy)' }} />
             <p style={{ margin: '7px 2px 0', fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.45 }}>{t.redepositHint(fmtCompact(principal + iNum + linkedAmt))}</p>
           </div>
 
@@ -893,12 +911,8 @@ export function MaturityResolveBody({
                       {sel && (
                         <div style={{ display: 'flex', alignItems: 'center', gap: 8, paddingLeft: 28 }}>
                           <span style={{ fontSize: 11, color: 'var(--c-muted)', flexShrink: 0 }}>{t.mergeReceivedLabel}</span>
-                          <div style={{ position: 'relative', flex: 1 }}>
-                            <input data-testid={`merge-received-${s.id}`} type="number" value={mergeRecv[s.id] ?? ''}
-                              onChange={(e) => { setMergeRecv((prev) => ({ ...prev, [s.id]: e.target.value })); setMergeTotal(''); setMergeTotalTouched(false) }}
-                              style={{ ...moneyInput, padding: '7px 24px 7px 10px', fontSize: 16 }} />
-                            <span style={{ position: 'absolute', right: 9, top: '50%', transform: 'translateY(-50%)', fontSize: 12, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
-                          </div>
+                          <MoneyInputCore compact testId={`merge-received-${s.id}`} value={mergeRecv[s.id] ?? ''}
+                            onChange={(v) => { setMergeRecv((prev) => ({ ...prev, [s.id]: v })); setMergeTotal(''); setMergeTotalTouched(false) }} />
                         </div>
                       )}
                     </div>
@@ -924,11 +938,8 @@ export function MaturityResolveBody({
                   {selectedSources.length > 1 && (
                     <div>
                       <div style={fieldLabel}>{t.mergeTotalLabel}</div>
-                      <div style={{ position: 'relative' }}>
-                        <input data-testid="merge-total" type="number" value={mergeTotal === '' ? String(mergeReceivedTotal) : mergeTotal}
-                          onChange={(e) => onMergeTotalChange(e.target.value)} style={moneyInput} />
-                        <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>₫</span>
-                      </div>
+                      <MoneyInputCore testId="merge-total" value={mergeTotal === '' ? String(mergeReceivedTotal) : mergeTotal}
+                        onChange={onMergeTotalChange} />
                     </div>
                   )}
                   {selectedSources.length === 1 && <input data-testid="merge-total" type="hidden" value={String(mergeReceivedTotal)} readOnly />}

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -205,6 +205,18 @@ describe('MaturityResolveBody', () => {
       expect(screen.queryByTestId('merge-source-sib-stock')).toBeNull()   // non-bank excluded
     })
 
+    it('formats the re-deposit amount with thousands separators', async () => {
+      const user = userEvent.setup()
+      stubEmptyRecurring()
+      render(
+        <MaturityResolveBody inv={maturedDeposit} goalId="goal-1" siblingDeposits={[sibBank]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+      // Default = principal + interest + recurring(0) = 37,030,000, shown grouped.
+      expect((screen.getByTestId('maturity-redeposit') as HTMLInputElement).value).toBe('37,030,000')
+    })
+
     it('prefills each selected source with its current value and shows the penalty caption', async () => {
       const user = userEvent.setup()
       stubEmptyRecurring()
@@ -217,7 +229,8 @@ describe('MaturityResolveBody', () => {
 
       // sibBank matures far past the anchor → out of window, folded in via override.
       await user.click(screen.getByTestId('merge-override-sib-bank'))
-      expect((screen.getByTestId('merge-received-sib-bank') as HTMLInputElement).value).toBe('8000000')
+      // Money fields render thousands separators (user-visible), not the raw digits.
+      expect((screen.getByTestId('merge-received-sib-bank') as HTMLInputElement).value).toBe('8,000,000')
       expect(screen.getByTestId('merge-penalty-caption')).toBeTruthy()
     })
 
@@ -238,8 +251,8 @@ describe('MaturityResolveBody', () => {
 
       // Weights ordered by (investmentDate, id): sib-bank (−150d) then sib-bank-2 (−100d).
       const [a1, a2] = allocateCumulative(10_000_000, [8_000_000, 4_000_000])
-      expect((screen.getByTestId('merge-received-sib-bank') as HTMLInputElement).value).toBe(String(a1))
-      expect((screen.getByTestId('merge-received-sib-bank-2') as HTMLInputElement).value).toBe(String(a2))
+      expect((screen.getByTestId('merge-received-sib-bank') as HTMLInputElement).value).toBe(a1.toLocaleString('en-US'))
+      expect((screen.getByTestId('merge-received-sib-bank-2') as HTMLInputElement).value).toBe(a2.toLocaleString('en-US'))
     })
 
     it('previews base + Σreceived but submits amount_vnd == BASE plus merge_sources', async () => {
@@ -431,7 +444,7 @@ describe('MaturityResolveBody', () => {
       await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
 
       // In-window → preselected, so its received field is already shown + prefilled.
-      expect((await screen.findByTestId('merge-received-sib-in') as HTMLInputElement).value).toBe('6000000')
+      expect((await screen.findByTestId('merge-received-sib-in') as HTMLInputElement).value).toBe('6,000,000')
       // Out-of-window → not selected; offered behind an override, no received field yet.
       expect(screen.getByTestId('merge-override-sib-out')).toBeTruthy()
       expect(screen.queryByTestId('merge-received-sib-out')).toBeNull()
@@ -451,7 +464,7 @@ describe('MaturityResolveBody', () => {
       // Push the window past the 52-day gap → it becomes eligible and auto-selects.
       fireEvent.change(screen.getByTestId('merge-window-slider'), { target: { value: '60' } })
       expect(screen.queryByTestId('merge-override-sib-out')).toBeNull()
-      expect((screen.getByTestId('merge-received-sib-out') as HTMLInputElement).value).toBe('8000000')
+      expect((screen.getByTestId('merge-received-sib-out') as HTMLInputElement).value).toBe('8,000,000')
     })
 
     it('hard-blocks a different-currency sibling with no override', async () => {
@@ -480,7 +493,7 @@ describe('MaturityResolveBody', () => {
       await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
       await user.click(screen.getByTestId('merge-override-sib-out'))
 
-      expect((screen.getByTestId('merge-received-sib-out') as HTMLInputElement).value).toBe('8000000')
+      expect((screen.getByTestId('merge-received-sib-out') as HTMLInputElement).value).toBe('8,000,000')
       // Anchor + the one folded source = 2 sources of provenance.
       expect(screen.getByTestId('merge-provenance').textContent).toMatch(/2 sources/i)
     })
@@ -529,7 +542,7 @@ describe('MaturityResolveBody', () => {
       await user.click(screen.getByRole('button', { name: /Don.t renew/i }))
       expect(screen.getByTestId('maturity-hold-fork')).toBeTruthy()
       // The received field (hold path) is shown, defaulted to the current value.
-      expect((screen.getByTestId('maturity-hold-received') as HTMLInputElement).value).toBe('10500000')
+      expect((screen.getByTestId('maturity-hold-received') as HTMLInputElement).value).toBe('10,500,000')
 
       await user.click(screen.getByRole('button', { name: /Confirm hold/i }))
       await waitFor(() => {


### PR DESCRIPTION
**PR-5b of the Plan-page UX audit** — the final one (theme: accessibility). Follows #403, #405, #406, #407, #408.

## What was wrong
The row kebab menus (`DPlanRow`, `DGoalItemRow`, `GoalItemRow`, `PlanLineItem`) were plain `<div>`s of `<button>`s — **no menu semantics** for screen readers — and the mobile kebab triggers were ~22px, **below a comfortable touch target**.

## What this does
- `role="menu"` on each dropdown, `role="menuitem"` on each item, `aria-haspopup="menu"` + `aria-expanded` on every trigger (desktop + mobile).
- Mobile kebab triggers now have a **≥44px hit area** (icon centered via flex, so the row height barely changes).

## Tests
- Desktop + mobile kebabs expose `role="menu"` with `menuitem`s; the trigger reports `aria-haspopup="menu"` and toggles `aria-expanded`.
- Existing tests that drove menu items via `getByRole('button', …)` were updated to `getByRole('menuitem', …)` (the role changed — this is the "check selectors when changing roles" lesson).

## Verification
- `npm test -- --run` → **886 passed** (103 in planning).
- `npm run lint` → no new errors (same pre-existing count as `main`).
- Checked the e2e specs: they don't target menu items as buttons — the "Record buy" **pill** and section actions are separate `role=button` controls, untouched.
- Please confirm on the Vercel preview that the kebab menus still open/click fine and the larger mobile tap targets look right.

## Audit complete
PR-1 #403 · PR-2 #405 · PR-3 #406 · PR-4 #407 · PR-5a #408 · **PR-5b (this)** → all 10 audit findings addressed.