### PR TITLE
fix(funds): clearing a saved DCA amount no longer silently disables it

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -294,6 +294,11 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
   // DCA inline edit
   const [dcaEditId, setDcaEditId] = useState<string | null>(null)
   const [dcaEditValue, setDcaEditValue] = useState('')
+  // True only while editing a DCA that was *just* toggled on and never persisted.
+  // Distinguishes "cancel a brand-new enable" (revert to off) from "clear an
+  // already-saved amount" (a no-op cancel — the server still has DCA on, so
+  // flipping the local row off would desync until the next reload) (#2).
+  const [dcaEditIsNew, setDcaEditIsNew] = useState(false)
   // Funds with an in-flight DCA PUT — toggle/goal-select disabled until it lands
   // (parity with mobile's togglingIds, prevents overlapping PUTs on fast clicks).
   const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set())
@@ -416,6 +421,7 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
     if (turningOn) {
       setDcaEditId(fund.id)
       setDcaEditValue('')
+      setDcaEditIsNew(true)
       return
     }
 
@@ -440,11 +446,18 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
     const amount = Number(dcaEditValue)
     const valid = dcaEditValue !== '' && !isNaN(amount) && amount > 0
     if (!valid) {
-      setFunds(p => p.map(f => f.id === fund.id ? { ...f, is_dca: false, dca_monthly_amount_vnd: null } : f))
+      // Only a brand-new, never-persisted enable reverts to off. Clearing an
+      // already-saved amount is a no-op cancel; the saved row stays as the
+      // server has it (#2). Turning DCA off is done via the toggle.
+      if (dcaEditIsNew) {
+        setFunds(p => p.map(f => f.id === fund.id ? { ...f, is_dca: false, dca_monthly_amount_vnd: null } : f))
+      }
       setDcaEditId(null)
+      setDcaEditIsNew(false)
       return
     }
     setDcaEditId(null)
+    setDcaEditIsNew(false)
     setTogglingIds(p => new Set(p).add(fund.id))
     try {
       const res = await fetch(`/api/funds/${fund.id}`, {
@@ -686,10 +699,10 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
                           goalLabel={t('dcaGoalLabel')}
                           unallocatedLabel={t('dcaGoalUnallocated')}
                           onToggle={() => handleToggleDca(fund)}
-                          onEditStart={() => { setDcaEditId(fund.id); setDcaEditValue(String(fund.dca_monthly_amount_vnd ?? '')) }}
+                          onEditStart={() => { setDcaEditId(fund.id); setDcaEditValue(String(fund.dca_monthly_amount_vnd ?? '')); setDcaEditIsNew(false) }}
                           onEditChange={setDcaEditValue}
                           onEditCommit={() => handleSaveDcaAmount(fund)}
-                          onEditCancel={() => { setFunds(p => p.map(f => f.id === fund.id ? { ...f, is_dca: false, dca_monthly_amount_vnd: null } : f)); setDcaEditId(null) }}
+                          onEditCancel={() => { if (dcaEditIsNew) setFunds(p => p.map(f => f.id === fund.id ? { ...f, is_dca: false, dca_monthly_amount_vnd: null } : f)); setDcaEditId(null); setDcaEditIsNew(false) }}
                           onGoalChange={(goalId) => handleSetDcaGoal(fund, goalId)}
                         />
                       </td>

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -271,7 +271,7 @@ function FundForm({ existing, title, onClose, onSave, saving, formError }: {
 
 // ─── FundCard ────────────────────────────────────────────────────────────────
 
-function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel, unallocatedLabel, onEdit, onDelete, onToggleDca, onSaveDcaAmount, onGoalChange, setDcaEditId, setDcaEditValue }: {
+function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel, unallocatedLabel, onEdit, onDelete, onToggleDca, onSaveDcaAmount, onCancelDcaEdit, onGoalChange, setDcaEditId, setDcaEditValue, setDcaEditIsNew }: {
   fund: Fund
   dcaEditId: string | null
   dcaEditValue: string
@@ -283,9 +283,11 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
   onDelete: () => void
   onToggleDca: () => void
   onSaveDcaAmount: (val: string) => void
+  onCancelDcaEdit: () => void
   onGoalChange: (goalId: string | null) => void
   setDcaEditId: (id: string | null) => void
   setDcaEditValue: (v: string) => void
+  setDcaEditIsNew: (v: boolean) => void
 }) {
   const t = useTranslations('funds')
   const tc = useTranslations('common')
@@ -371,7 +373,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
                 onBlur={() => { onSaveDcaAmount(dcaEditValue); setDcaEditId(null) }}
                 onKeyDown={(e) => {
                   if (e.key === 'Enter') { onSaveDcaAmount(dcaEditValue); setDcaEditId(null) }
-                  if (e.key === 'Escape') setDcaEditId(null)
+                  if (e.key === 'Escape') onCancelDcaEdit()
                 }}
                 placeholder={`${tc('amount')} ₫`}
                 style={{ width: 90, padding: '3px 8px', fontSize: 16, border: '1px solid var(--c-navy)', borderRadius: 6, background: 'var(--c-card)', fontFamily: 'inherit', outline: 'none', color: 'var(--c-ink)' }}
@@ -380,7 +382,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
               <button
                 type="button"
                 data-testid={`dca-amount-btn-${fund.id}`}
-                onClick={() => { setDcaEditId(fund.id); setDcaEditValue(String(fund.dca_monthly_amount_vnd)) }}
+                onClick={() => { setDcaEditId(fund.id); setDcaEditValue(String(fund.dca_monthly_amount_vnd)); setDcaEditIsNew(false) }}
                 style={{ fontSize: 11, fontWeight: 500, padding: '2px 8px', background: 'var(--c-navy-tint)', color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)', borderRadius: 6, cursor: 'pointer', fontFamily: 'inherit' }}
               >
                 {fmtCompact(fund.dca_monthly_amount_vnd)}
@@ -388,7 +390,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
             ) : (
               <button
                 type="button"
-                onClick={() => { setDcaEditId(fund.id); setDcaEditValue('') }}
+                onClick={() => { setDcaEditId(fund.id); setDcaEditValue(''); setDcaEditIsNew(false) }}
                 style={{ fontSize: 11, fontWeight: 500, padding: '2px 8px', background: 'var(--c-navy-tint)', color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)', borderRadius: 6, cursor: 'pointer', fontFamily: 'inherit' }}
               >
                 {t('setAmount')}
@@ -458,6 +460,11 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
   // DCA inline edit
   const [dcaEditId, setDcaEditId] = useState<string | null>(null)
   const [dcaEditValue, setDcaEditValue] = useState('')
+  // True only while editing a DCA that was *just* toggled on and never persisted.
+  // Distinguishes "cancel a brand-new enable" (revert to off) from "clear an
+  // already-saved amount" (a no-op cancel — the server still has DCA on, so
+  // flipping the local card off would desync until the next reload) (#2).
+  const [dcaEditIsNew, setDcaEditIsNew] = useState(false)
   const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set())
 
   // Toasts
@@ -587,6 +594,7 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
     if (turningOn) {
       setDcaEditId(fund.id)
       setDcaEditValue('')
+      setDcaEditIsNew(true)
       return
     }
 
@@ -608,10 +616,17 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
     const valid = val !== '' && !isNaN(amount) && amount > 0
 
     if (!valid) {
-      setFunds((prev) => prev.map((f) => f.id === fund.id ? { ...f, is_dca: false, dca_monthly_amount_vnd: null } : f))
+      // Only a brand-new, never-persisted enable reverts to off. Clearing an
+      // already-saved amount is a no-op cancel; the saved card stays as the
+      // server has it (#2). Turning DCA off is done via the toggle.
+      if (dcaEditIsNew) {
+        setFunds((prev) => prev.map((f) => f.id === fund.id ? { ...f, is_dca: false, dca_monthly_amount_vnd: null } : f))
+      }
+      setDcaEditIsNew(false)
       return
     }
 
+    setDcaEditIsNew(false)
     setTogglingIds((prev) => new Set([...prev, fund.id]))
     try {
       const res = await fetch(`/api/funds/${fund.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: amount, dca_goal_id: fund.dca_goal_id }) })
@@ -623,6 +638,16 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
     } finally {
       setTogglingIds((prev) => { const s = new Set(prev); s.delete(fund.id); return s })
     }
+  }
+
+  // Abandon an inline amount edit (Escape). A brand-new enable reverts to off;
+  // editing an already-saved amount just closes the editor (#2).
+  function handleCancelDcaEdit(fund: Fund) {
+    if (dcaEditIsNew) {
+      setFunds((prev) => prev.map((f) => f.id === fund.id ? { ...f, is_dca: false, dca_monthly_amount_vnd: null } : f))
+    }
+    setDcaEditId(null)
+    setDcaEditIsNew(false)
   }
 
   async function handleSetDcaGoal(fund: Fund, goalId: string | null) {
@@ -753,9 +778,11 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
                 onDelete={() => setDeleteFund(fund)}
                 onToggleDca={() => handleToggleDca(fund)}
                 onSaveDcaAmount={(val) => handleSaveDcaAmount(fund, val)}
+                onCancelDcaEdit={() => handleCancelDcaEdit(fund)}
                 onGoalChange={(goalId) => handleSetDcaGoal(fund, goalId)}
                 setDcaEditId={setDcaEditId}
                 setDcaEditValue={setDcaEditValue}
+                setDcaEditIsNew={setDcaEditIsNew}
               />
             ))}
           </div>

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.dca.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.dca.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DesktopFundLibraryView from '../DesktopFundLibraryView'
+import type { Fund } from '../useFundsData'
+
+// next-intl → return the key (and append params) so assertions stay language-agnostic.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+
+vi.mock('@/lib/formatters', () => ({
+  fmtNav: (n: number) => String(n),
+  fmtCompact: (n: number) => `${n}`,
+}))
+
+function makeFund(over: Partial<Fund> = {}): Fund {
+  return {
+    id: 'f1',
+    name: 'VFMVF1 Equity Fund',
+    code: 'VFMVF1',
+    fund_type: 'equity',
+    nav: 36120,
+    nav_source_url: null,
+    is_dca: false,
+    dca_monthly_amount_vnd: null,
+    dca_goal_id: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...over,
+  }
+}
+
+// Stateful harness so the view's optimistic setFunds re-renders the row.
+function Harness({ initial, reload }: { initial: Fund[]; reload: () => Promise<void> }) {
+  const [funds, setFunds] = useState(initial)
+  return (
+    <DesktopFundLibraryView
+      funds={funds}
+      setFunds={setFunds}
+      goals={[]}
+      loading={false}
+      error={false}
+      reload={reload}
+    />
+  )
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+let reload: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn(() => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) }))
+  vi.stubGlobal('fetch', fetchMock)
+  reload = vi.fn(() => Promise.resolve())
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe('DesktopFundLibraryView — DCA amount edit must not desync from the server (#2)', () => {
+  it('clearing an already-saved DCA amount keeps the row enabled and sends NO disabling PUT', async () => {
+    render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
+
+    // The amount button reflects the saved DCA amount.
+    await userEvent.click(screen.getByTestId('dca-amount-btn-f1'))
+    const input = screen.getByTestId('dca-amount-input-f1') as HTMLInputElement
+    await userEvent.clear(input)
+    fireEvent.blur(input)
+
+    // The row must still show DCA on (toggle = "disable") and the saved amount.
+    expect(screen.getByLabelText('disableDca')).toBeInTheDocument()
+    expect(screen.getByTestId('dca-amount-btn-f1')).toBeInTheDocument()
+    // No PUT may have been sent — the server still has DCA on, flipping it locally
+    // off (the old bug) would lie until the next reload.
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('pressing Escape after clearing an existing amount cancels without disabling DCA', async () => {
+    render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
+
+    await userEvent.click(screen.getByTestId('dca-amount-btn-f1'))
+    const input = screen.getByTestId('dca-amount-input-f1')
+    await userEvent.clear(input)
+    fireEvent.keyDown(input, { key: 'Escape' })
+
+    expect(screen.getByLabelText('disableDca')).toBeInTheDocument()
+    expect(screen.getByTestId('dca-amount-btn-f1')).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('a brand-new (just-toggled-on) DCA still reverts to off when left blank — no PUT', async () => {
+    render(<Harness initial={[makeFund({ is_dca: false })]} reload={reload} />)
+
+    await userEvent.click(screen.getByLabelText('enableDca'))
+    const input = screen.getByTestId('dca-amount-input-f1')
+    fireEvent.blur(input)
+
+    expect(screen.getByLabelText('enableDca')).toBeInTheDocument()
+    expect(screen.queryByTestId('dca-amount-btn-f1')).not.toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('a valid amount edit still persists with a PUT (is_dca true) and reloads', async () => {
+    render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
+
+    await userEvent.click(screen.getByTestId('dca-amount-btn-f1'))
+    const input = screen.getByTestId('dca-amount-input-f1')
+    await userEvent.clear(input)
+    await userEvent.type(input, '3000000')
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(String(url)).toBe('/api/funds/f1')
+    expect(opts.method).toBe('PUT')
+    const body = JSON.parse(opts.body)
+    expect(body.is_dca).toBe(true)
+    expect(body.dca_monthly_amount_vnd).toBe(3_000_000)
+    await waitFor(() => expect(reload).toHaveBeenCalled())
+  })
+})

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.dca.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.dca.test.tsx
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MobileFundLibraryView from '../MobileFundLibraryView'
+import type { Fund } from '../useFundsData'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+
+vi.mock('@/lib/formatters', () => ({
+  fmtNav: (n: number) => String(n),
+  fmtCompact: (n: number) => `${n}`,
+}))
+
+vi.mock('@/app/components/navigation/NavigationContext', () => ({
+  useNavigation: () => ({ setMobileTopBar: vi.fn() }),
+}))
+
+function makeFund(over: Partial<Fund> = {}): Fund {
+  return {
+    id: 'f1',
+    name: 'VFMVF1 Equity Fund',
+    code: 'VFMVF1',
+    fund_type: 'equity',
+    nav: 36120,
+    nav_source_url: null,
+    is_dca: false,
+    dca_monthly_amount_vnd: null,
+    dca_goal_id: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...over,
+  }
+}
+
+function Harness({ initial, reload }: { initial: Fund[]; reload: () => Promise<void> }) {
+  const [funds, setFunds] = useState(initial)
+  return (
+    <MobileFundLibraryView
+      funds={funds}
+      setFunds={setFunds}
+      goals={[]}
+      loading={false}
+      error={false}
+      reload={reload}
+    />
+  )
+}
+
+let fetchMock: ReturnType<typeof vi.fn>
+let reload: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn(() => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) }))
+  vi.stubGlobal('fetch', fetchMock)
+  reload = vi.fn(() => Promise.resolve())
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe('MobileFundLibraryView — DCA amount edit must not desync from the server (#2)', () => {
+  it('clearing an already-saved DCA amount keeps the card enabled and sends NO disabling PUT', async () => {
+    render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
+
+    await userEvent.click(screen.getByTestId('dca-amount-btn-f1'))
+    const input = screen.getByTestId('dca-amount-input-f1') as HTMLInputElement
+    await userEvent.clear(input)
+    fireEvent.blur(input)
+
+    expect(screen.getByLabelText('disableDca')).toBeInTheDocument()
+    expect(screen.getByTestId('dca-amount-btn-f1')).toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('a brand-new (just-toggled-on) DCA reverts to off when left blank — no PUT', async () => {
+    render(<Harness initial={[makeFund({ is_dca: false })]} reload={reload} />)
+
+    await userEvent.click(screen.getByLabelText('enableDca'))
+    const input = screen.getByTestId('dca-amount-input-f1')
+    fireEvent.blur(input)
+
+    expect(screen.getByLabelText('enableDca')).toBeInTheDocument()
+    expect(screen.queryByTestId('dca-amount-btn-f1')).not.toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('a valid amount edit still persists with a PUT (is_dca true) and reloads', async () => {
+    render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
+
+    await userEvent.click(screen.getByTestId('dca-amount-btn-f1'))
+    const input = screen.getByTestId('dca-amount-input-f1')
+    await userEvent.clear(input)
+    await userEvent.type(input, '3000000')
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    const [url, opts] = fetchMock.mock.calls[0]
+    expect(String(url)).toBe('/api/funds/f1')
+    expect(opts.method).toBe('PUT')
+    const body = JSON.parse(opts.body)
+    expect(body.is_dca).toBe(true)
+    expect(body.dca_monthly_amount_vnd).toBe(3_000_000)
+    await waitFor(() => expect(reload).toHaveBeenCalled())
+  })
+})


### PR DESCRIPTION
## What
From the Funds Library UX audit (P1 #2). Editing a fund's already-saved DCA amount and clearing it flipped the row to **DCA off on screen** but sent **no PUT** — the server still had DCA enabled, so a reload brought it back. The UI was lying about persisted state.

## Why it happened
`handleSaveDcaAmount` (and the desktop Escape `onEditCancel`) reverted the row to `is_dca:false` on any invalid/empty amount. That's correct for a *brand-new* toggle-on that was never persisted, but wrong when editing an amount that's already saved on the server.

## Fix
Track whether the inline edit is a never-persisted enable (`dcaEditIsNew`):
- **new enable + left blank** → revert to off (unchanged behavior; nothing was persisted)
- **saved amount cleared** → no-op cancel; the row stays exactly as the server has it. Turning DCA off is done via the toggle.

Applied to **both** desktop and mobile, and to all abandon paths (blur, Enter, Escape) — desktop Escape and mobile Escape had the same desync.

## Tests (TDD)
New `*.dca.test.tsx` for both views assert the **rendered** outcome, not just state:
- clearing a saved amount → toggle stays on, amount preserved, **no disabling PUT**
- desktop Escape after clearing → same
- brand-new enable left blank → reverts to off (regression guard)
- a valid edit still PUTs `is_dca:true` with the new amount + reloads

`npm test -- --run` (funds) green; `npm run lint` clean for changed files. Full-suite Planning failures are the date-sensitive June-2026 fixtures (today 2026-06-29) — confirmed unrelated (pass in isolation).

## Related (NOT in this PR)
While fixing, I found a sibling bug: **editing a fund's name/NAV via the Add/Edit form silently wipes its DCA config** — the form PUT omits `is_dca`/`dca_*`, and the route defaults them off. Same DCA-integrity theme; will raise separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)