### PR TITLE
fix(funds): editing a fund's name/NAV no longer wipes its DCA config

### DIFF
--- a/app/api/funds/[id]/__tests__/route.dca.test.ts
+++ b/app/api/funds/[id]/__tests__/route.dca.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Capture the payload handed to supabase .update() and stub the auth + query chain.
+const h = vi.hoisted(() => ({
+  captured: null as Record<string, unknown> | null,
+  user: { id: 'user-1' } as { id: string } | null,
+  result: { data: { id: 'f1' }, error: null } as { data: unknown; error: unknown },
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chain: Record<string, unknown> = {
+    update: (payload: Record<string, unknown>) => { h.captured = payload; return chain },
+    select: () => chain,
+    eq: () => chain,
+    single: async () => h.result,
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: () => chain,
+    }),
+  }
+})
+
+import { PUT } from '../route'
+
+function makeReq(body: Record<string, unknown>) {
+  return { json: async () => body } as unknown as Parameters<typeof PUT>[0]
+}
+const ctx = { params: Promise.resolve({ id: 'f1' }) }
+
+const baseBody = { name: 'VFMVF1 Equity', code: 'VFMVF1', fund_type: 'equity', nav: 36120 }
+
+beforeEach(() => {
+  h.captured = null
+  h.user = { id: 'user-1' }
+  h.result = { data: { id: 'f1' }, error: null }
+})
+
+describe('PUT /api/funds/[id] — DCA fields use partial-update semantics (sibling of #411)', () => {
+  it('a name/NAV edit that omits is_dca must NOT touch the DCA columns', async () => {
+    const res = await PUT(makeReq(baseBody), ctx)
+    expect(res.status).toBe(200)
+    // The Add/Edit form sends only name/code/type/nav — DCA config must be preserved,
+    // not silently wiped by defaulting is_dca to false.
+    expect(h.captured).not.toHaveProperty('is_dca')
+    expect(h.captured).not.toHaveProperty('dca_monthly_amount_vnd')
+    expect(h.captured).not.toHaveProperty('dca_goal_id')
+    expect(h.captured!.name).toBe('VFMVF1 Equity')
+    expect(h.captured!.nav).toBe(36120)
+  })
+
+  it('an explicit is_dca:false still clears the DCA columns', async () => {
+    await PUT(makeReq({ ...baseBody, is_dca: false }), ctx)
+    expect(h.captured!.is_dca).toBe(false)
+    expect(h.captured!.dca_monthly_amount_vnd).toBeNull()
+    expect(h.captured!.dca_goal_id).toBeNull()
+  })
+
+  it('an explicit is_dca:true persists amount + goal', async () => {
+    const goal = '11111111-1111-1111-1111-111111111111'
+    await PUT(makeReq({ ...baseBody, is_dca: true, dca_monthly_amount_vnd: 2_000_000, dca_goal_id: goal }), ctx)
+    expect(h.captured!.is_dca).toBe(true)
+    expect(h.captured!.dca_monthly_amount_vnd).toBe(2_000_000)
+    expect(h.captured!.dca_goal_id).toBe(goal)
+  })
+})

--- a/app/api/funds/[id]/route.ts
+++ b/app/api/funds/[id]/route.ts
@@ -66,19 +66,27 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     return NextResponse.json({ error: 'Invalid goal' }, { status: 400 })
   }
 
+  const update: Record<string, unknown> = {
+    name: name.trim(),
+    code: code.trim().toUpperCase(),
+    fund_type,
+    nav: navNum,
+    nav_source_url: typeof nav_source_url === 'string' && nav_source_url.trim() ? nav_source_url.trim() : null,
+  }
+  // DCA fields use partial-update semantics: only written when the caller
+  // actually sends is_dca. The Add/Edit form omits them, so a name/NAV edit
+  // must preserve the existing DCA config instead of silently wiping it. The
+  // DCA toggle/amount/goal handlers always send is_dca, so they're unaffected.
+  if (is_dca !== undefined) {
+    update.is_dca = is_dca === true
+    update.dca_monthly_amount_vnd = is_dca === true && dca_monthly_amount_vnd ? Number(dca_monthly_amount_vnd) : null
+    // Goal target only applies while DCA is on; cleared otherwise.
+    update.dca_goal_id = is_dca === true && dca_goal_id ? dca_goal_id : null
+  }
+
   const { data: fund, error } = await supabase
     .from('funds')
-    .update({
-      name: name.trim(),
-      code: code.trim().toUpperCase(),
-      fund_type,
-      nav: navNum,
-      nav_source_url: typeof nav_source_url === 'string' && nav_source_url.trim() ? nav_source_url.trim() : null,
-      is_dca: is_dca === true,
-      dca_monthly_amount_vnd: is_dca === true && dca_monthly_amount_vnd ? Number(dca_monthly_amount_vnd) : null,
-      // Goal target only applies while DCA is on; cleared otherwise.
-      dca_goal_id: is_dca === true && dca_goal_id ? dca_goal_id : null,
-    })
+    .update(update)
     .eq('id', id)
     .eq('user_id', user.id)
     .select()


### PR DESCRIPTION
## What
Sibling bug of #411 (same DCA-integrity theme). Editing a fund's **name/NAV** via the Add/Edit form silently **wiped its DCA setup** (recurring-contribution toggle, monthly amount, and target goal).

## Why
The form's PUT body sends only `name/code/fund_type/nav/nav_source_url` — never `is_dca`/`dca_*`. The route read those off the body (→ `undefined`) and defaulted `is_dca` to `false` with null amount/goal, so any unrelated edit cleared the config.

## Fix
Give `PUT /api/funds/[id]` **partial-update semantics** for the DCA columns: they're written only when the caller actually sends `is_dca`.
- Edit form (omits `is_dca`) → DCA config **preserved**.
- Toggle / amount / goal handlers (always send `is_dca`) → unchanged.

This is the robust root fix (protects every caller) rather than patching the form to echo DCA fields back.

## Tests (TDD)
New route-level test (`route.dca.test.ts`) mocks the Supabase client and asserts the **update payload**:
- name/NAV edit omitting `is_dca` → touches **no** DCA column
- explicit `is_dca:false` → still clears amount + goal
- explicit `is_dca:true` → persists amount + goal

The form's `handleSave` calls `reload()` after saving (no optimistic DCA path), so a preserved server row closes the loop on the UI.

`npx vitest run app/(app)/funds app/api/funds` → 13/13 green; lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)