### PR TITLE
fix(a11y): ≥44px touch targets for icon-only buttons in overview sheets

### DIFF
--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { X, TrendingUp, Building2, Coins, ArrowUpRight, ArrowDownRight, ArrowDownToLine, Wallet, Shield } from 'lucide-react'
+import { iconHit } from './iconHit'
 import { useLocale, useTranslations } from 'next-intl'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { todayIso } from '@/lib/dates'
@@ -1336,7 +1337,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
         >
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0 }}>
             <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{existing ? t('editTitle') : t('title')}</h3>
-            <button onClick={onClose} style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }} aria-label="Close"><X size={18} /></button>
+            <button onClick={onClose} style={{ ...iconHit, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)' }} aria-label="Close"><X size={18} /></button>
           </div>
           <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto', overflowX: 'hidden', overscrollBehavior: 'contain' }}>
             {formBody}
@@ -1379,7 +1380,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
           </h3>
           <button
             onClick={onClose}
-            style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }}
+            style={{ ...iconHit, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)' }}
             aria-label="Close"
           >
             <X size={18} />

--- a/app/assets/components/AssignGoalSheet.tsx
+++ b/app/assets/components/AssignGoalSheet.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { Check, X, TrendingUp, Building2, Coins, ArrowRight } from 'lucide-react'
+import { iconHit } from './iconHit'
 import { useLocale } from 'next-intl'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import LoadError from './LoadError'
@@ -277,7 +278,7 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, item, deskto
         >
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0 }}>
             <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{title}</h3>
-            <button onClick={onClose} aria-label="Close" style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }}><X size={18} /></button>
+            <button onClick={onClose} aria-label="Close" style={{ ...iconHit, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)' }}><X size={18} /></button>
           </div>
           <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto' }}>
             {body}

--- a/app/assets/components/CreateGoalSheet.tsx
+++ b/app/assets/components/CreateGoalSheet.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useTranslations } from 'next-intl'
 import { X, Mountain, Home, Shield, ShoppingCart, Target } from 'lucide-react'
+import { iconHit } from './iconHit'
 import { fmt } from '@/lib/formatters'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 
@@ -316,7 +317,7 @@ export function CreateGoalSheet({ open, onClose, onSuccess, desktop }: Props) {
         >
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0 }}>
             <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{tg('newGoalTitle')}</h3>
-            <button onClick={onClose} style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }} aria-label="Close"><X size={18} /></button>
+            <button onClick={onClose} style={{ ...iconHit, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)' }} aria-label="Close"><X size={18} /></button>
           </div>
           <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto' }}>
             {formContent}
@@ -359,7 +360,7 @@ export function CreateGoalSheet({ open, onClose, onSuccess, desktop }: Props) {
           <h3 style={{ margin: 0, fontSize: 17, fontWeight: 600, color: 'var(--c-ink)' }}>{tg('newGoalTitle')}</h3>
           <button
             onClick={onClose}
-            style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }}
+            style={{ ...iconHit, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)' }}
             aria-label={tc('cancel')}
           >
             <X size={18} />

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo } from 'react'
 import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, Check, ArrowDownToLine, Wallet, Shield, RefreshCw, PiggyBank, GitMerge, Plus } from 'lucide-react'
+import { iconHit } from './iconHit'
 import { toast } from 'sonner'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import type { GoalData } from '../DashboardClient'
@@ -257,7 +258,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
               <button
                 onClick={() => setActionsOpen(true)}
                 className="cn-btn ghost"
-                style={{ padding: 5 }}
+                style={{ ...iconHit }}
                 aria-label="Goal options"
               >
                 <MoreHorizontal size={15} color="var(--c-muted)" />
@@ -429,7 +430,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                   <button
                     onClick={() => { setActionInv(inv); setShowInvOptions(true) }}
                     className="cn-btn ghost"
-                    style={{ padding: 5, flexShrink: 0 }}
+                    style={{ ...iconHit, flexShrink: 0 }}
                     aria-label="Options"
                   >
                     <MoreHorizontal size={14} color="var(--c-muted)" />
@@ -1289,7 +1290,7 @@ function DModal({ onClose, title, width = 380, children }: {
       >
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0 }}>
           <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{title}</h3>
-          <button onClick={onClose} className="cn-btn ghost" style={{ padding: 6 }} aria-label="Close"><X size={18} /></button>
+          <button onClick={onClose} className="cn-btn ghost" style={{ ...iconHit }} aria-label="Close"><X size={18} /></button>
         </div>
         <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto' }}>{children}</div>
       </div>

--- a/app/assets/components/DesktopInsuranceDetail.tsx
+++ b/app/assets/components/DesktopInsuranceDetail.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { Check, ChevronLeft, Edit2, Plus, Trash2, Calendar, X } from 'lucide-react'
+import { iconHit } from './iconHit'
 import { toast } from 'sonner'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import { STATUS_COLOR, BAR_COLOR_DETAIL, COVERAGE_OPTIONS, insurancePaidState, insuranceStatusLabel } from './insuranceShared'
@@ -213,7 +214,7 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
             onClick={() => setEditing(true)}
             aria-label={isVi ? 'Chỉnh sửa' : 'Edit'}
             className="cn-btn ghost"
-            style={{ padding: 6 }}
+            style={{ ...iconHit }}
           >
             <Edit2 size={14} color="var(--c-muted)" />
           </button>
@@ -557,7 +558,7 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
                 onClick={() => !deleting && setShowDeleteConfirm(false)}
                 aria-label={isVi ? 'Đóng' : 'Close'}
                 className="cn-btn ghost"
-                style={{ padding: 6 }}
+                style={{ ...iconHit }}
               >
                 <X size={16} />
               </button>
@@ -625,7 +626,7 @@ export default function DesktopInsuranceDetail({ ins, locale, onClose, onChanged
                 onClick={() => !deletingEntry && setDeleteEntryId(null)}
                 aria-label={isVi ? 'Đóng' : 'Close'}
                 className="cn-btn ghost"
-                style={{ padding: 6 }}
+                style={{ ...iconHit }}
               >
                 <X size={16} />
               </button>

--- a/app/assets/components/DownloadReportSheet.tsx
+++ b/app/assets/components/DownloadReportSheet.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { Check, Download, X } from 'lucide-react'
+import { iconHit } from './iconHit'
 import { useLocale } from 'next-intl'
 import { fmt } from '@/lib/formatters'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
@@ -210,7 +211,7 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
         >
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0 }}>
             <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{t.title}</h3>
-            <button onClick={onClose} aria-label="Close" style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }}><X size={18} /></button>
+            <button onClick={onClose} aria-label="Close" style={{ ...iconHit, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)' }}><X size={18} /></button>
           </div>
           <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto' }}>
             {body}

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -5,6 +5,7 @@ import {
   ChevronLeft, ChevronRight, MoreHorizontal,
   Edit2, Trash2, Calendar, Download, ArrowDownRight, ArrowUpRight, Target, RefreshCw, PiggyBank, GitMerge, Plus,
 } from 'lucide-react'
+import { iconHit } from './iconHit'
 import { useLocale } from 'next-intl'
 import { toast } from 'sonner'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
@@ -995,7 +996,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
             <button
               data-testid="goal-back-btn"
               onClick={onClose}
-              style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 6, color: 'var(--c-ink)', display: 'flex', alignItems: 'center', flexShrink: 0 }}
+              style={{ ...iconHit, background: 'none', border: 'none', cursor: 'pointer', color: 'var(--c-ink)', flexShrink: 0 }}
             >
               <ChevronLeft size={20} />
             </button>
@@ -1011,7 +1012,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
               data-testid="goal-options-btn"
               aria-label={isVI ? 'Tùy chọn mục tiêu' : 'Goal options'}
               onClick={() => setActionsOpen(true)}
-              style={{ background: 'none', border: 'none', cursor: 'pointer', padding: 6, color: 'var(--c-ink)', display: 'flex', alignItems: 'center', flexShrink: 0 }}
+              style={{ ...iconHit, background: 'none', border: 'none', cursor: 'pointer', color: 'var(--c-ink)', flexShrink: 0 }}
             >
               <MoreHorizontal size={18} />
             </button>

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -20,6 +20,7 @@ import { useState, useEffect } from 'react'
 import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X, Plus, Wallet, Lock, SlidersHorizontal, PiggyBank, GitMerge } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import AmountInput from '@/app/components/ui/AmountInput'
+import { iconHit } from './iconHit'
 import { fmtMaturity, type InvRow } from './goalDetailShared'
 import {
   depositMaturityState,
@@ -1279,7 +1280,7 @@ export function MaturityResolveModal({
       >
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0 }}>
           <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{isVi ? 'Xử lý đáo hạn' : 'Handle maturity'}</h3>
-          <button onClick={onClose} className="cn-btn ghost" style={{ padding: 6 }} aria-label="Close"><X size={18} /></button>
+          <button onClick={onClose} className="cn-btn ghost" style={{ ...iconHit }} aria-label="Close"><X size={18} /></button>
         </div>
         <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto' }}>
           <MaturityResolveBody inv={inv} goalId={goalId} siblingDeposits={siblingDeposits} heldSiblings={heldSiblings} isVi={isVi} onClose={onClose} onRenewed={onRenewed} onWithdraw={onWithdraw} />

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useMemo } from 'react'
 import { useLocale } from 'next-intl'
 import { ArrowDownRight, ArrowDownToLine, Building, Check, Coins, Shield, TrendingUp, Wallet, X } from 'lucide-react'
+import { iconHit } from './iconHit'
 import { fmt } from '@/lib/formatters'
 import { todayIso } from '@/lib/dates'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
@@ -349,7 +350,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
         {/* Header — pinned, sits outside the scrollable body */}
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: desktop ? '18px 20px 14px' : '0 16px 16px', borderBottom: desktop ? '1px solid var(--c-line)' : undefined, flexShrink: 0 }}>
           <h3 style={{ margin: 0, fontSize: 17, fontWeight: 600 }}>{titleText}</h3>
-          <button onClick={onClose} style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }}>
+          <button onClick={onClose} aria-label="Close" style={{ ...iconHit, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)' }}>
             <X size={18} />
           </button>
         </div>

--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslations } from 'next-intl'
 import { Plus, Download, Edit2, Trash, ChevronLeft, ChevronRight, X, Calendar, ArrowUpRight, ArrowDownRight, PiggyBank, GitMerge } from 'lucide-react'
+import { iconHit } from './iconHit'
 import AmountInput from '@/app/components/ui/AmountInput'
 import DecimalInput from '@/app/components/ui/DecimalInput'
 import { fmtCompact, fmtNav, fmtUnits } from '@/lib/formatters'
@@ -91,7 +92,7 @@ function Shell({ open, onClose, title, desktop, width = 520, testId, children }:
   const header = (
     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: desktop ? '18px 20px 14px' : '0 16px 16px', borderBottom: desktop ? '1px solid var(--c-line)' : 'none', flexShrink: 0 }}>
       <h3 style={{ margin: 0, fontSize: desktop ? 16 : 17, fontWeight: desktop ? 700 : 600, letterSpacing: '-0.01em', color: 'var(--c-ink)' }}>{title}</h3>
-      <button onClick={onClose} style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }} aria-label="Close"><X size={18} /></button>
+      <button onClick={onClose} style={{ ...iconHit, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)' }} aria-label="Close"><X size={18} /></button>
     </div>
   )
 
@@ -383,9 +384,9 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
   const rowActions = (tx: LedgerTransaction) => (
     <span style={{ display: 'inline-flex', gap: 2, whiteSpace: 'nowrap' }}>
       {!isWithdrawal(tx) && (
-        <button onClick={() => (tx.asset_type === 'stock' ? openEdit(tx) : setEditExisting(tx))} className="cn-btn ghost" style={{ padding: 5 }} aria-label={tc('edit')}><Edit2 size={14} color="var(--c-muted)" /></button>
+        <button onClick={() => (tx.asset_type === 'stock' ? openEdit(tx) : setEditExisting(tx))} className="cn-btn ghost" style={{ ...iconHit }} aria-label={tc('edit')}><Edit2 size={14} color="var(--c-muted)" /></button>
       )}
-      <button data-testid="tx-ledger-delete" onClick={() => setConfirmTx(tx)} className="cn-btn ghost" style={{ padding: 5 }} aria-label={tc('delete')}><Trash size={14} color="var(--c-neg)" /></button>
+      <button data-testid="tx-ledger-delete" onClick={() => setConfirmTx(tx)} className="cn-btn ghost" style={{ ...iconHit }} aria-label={tc('delete')}><Trash size={14} color="var(--c-neg)" /></button>
     </span>
   )
 

--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { ChevronDown, ChevronUp, ChevronRight, Target, Building, Coins, TrendingUp, BarChart2, Clock, ArrowDownToLine, ArrowDownRight, ArrowRight, Wallet, Check, X } from 'lucide-react'
+import { iconHit } from './iconHit'
 import { useTranslations } from 'next-intl'
 import { useLocale } from 'next-intl'
 import type { FundBreakdownItem, NonFundUnallocatedItem } from '../DashboardClient'
@@ -576,7 +577,7 @@ export default function UnallocatedSection({
                 <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>
                   {desktopStep === 'assign' ? (isVI ? 'Gán vào mục tiêu' : 'Assign to goal') : (isVI ? 'Tùy chọn' : 'Options')}
                 </h3>
-                <button onClick={closeAction} aria-label="Close" style={{ padding: 6, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)', display: 'flex' }}>
+                <button onClick={closeAction} aria-label="Close" style={{ ...iconHit, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)' }}>
                   <X size={18} />
                 </button>
               </div>

--- a/app/assets/components/__tests__/AssignGoalSheet.test.tsx
+++ b/app/assets/components/__tests__/AssignGoalSheet.test.tsx
@@ -44,4 +44,14 @@ describe('AssignGoalSheet — goals load error vs empty', () => {
     await waitFor(() => expect(screen.getByText('House Fund')).toBeInTheDocument())
     expect(screen.queryByTestId('load-error')).not.toBeInTheDocument()
   })
+
+  it('gives the close button a ≥44px touch target', async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ goals: [] }) })
+
+    render(<AssignGoalSheet {...baseProps} />)
+
+    const close = await screen.findByRole('button', { name: 'Close' })
+    expect(parseFloat(close.style.minWidth)).toBeGreaterThanOrEqual(44)
+    expect(parseFloat(close.style.minHeight)).toBeGreaterThanOrEqual(44)
+  })
 })

--- a/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
+++ b/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
@@ -51,4 +51,17 @@ describe('TransactionLedgerSheet — held-for-merge rows read neutrally', () => 
     expect(screen.getByText('withdrawal')).toBeInTheDocument()
     expect(row.textContent).toContain('−')
   })
+
+  it('gives the row edit/delete buttons a ≥44px touch target', async () => {
+    mockTxs([{ ...base, transaction_id: 'd1', transaction_type: 'deposit' }])
+    render(<TransactionLedgerSheet {...props} />)
+
+    const del = await screen.findByTestId('tx-ledger-delete')
+    expect(parseFloat(del.style.minWidth)).toBeGreaterThanOrEqual(44)
+    expect(parseFloat(del.style.minHeight)).toBeGreaterThanOrEqual(44)
+
+    const edit = screen.getByRole('button', { name: 'edit' })
+    expect(parseFloat(edit.style.minWidth)).toBeGreaterThanOrEqual(44)
+    expect(parseFloat(edit.style.minHeight)).toBeGreaterThanOrEqual(44)
+  })
 })

--- a/app/assets/components/iconHit.ts
+++ b/app/assets/components/iconHit.ts
@@ -1,0 +1,15 @@
+import type { CSSProperties } from 'react'
+
+// Shared touch-target floor for icon-only buttons (sheet/modal close, row
+// edit/delete, kebab menus). WCAG 2.5.5 asks for a ≥44×44px hit area; these
+// buttons previously sat at ~24–30px (a small icon with 5–6px padding). Spread
+// onto a button's existing style — the icon keeps its own size, centered within
+// the padded target. Matches the inline `minWidth:44, minHeight:44` pattern the
+// Plan-page a11y pass adopted (#410), so the two audits stay consistent.
+export const iconHit: CSSProperties = {
+  minWidth: 44,
+  minHeight: 44,
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}


### PR DESCRIPTION
## What

Across the Overview/dashboard sheets and modals, the icon-only buttons — sheet/modal **close (X)**, transaction-row **edit/delete**, and the goal/insurance **kebab menus** — were small icons with 5–6px padding, giving a ~24–30px hit area. That's under the WCAG 2.5.5 44×44px minimum and fiddly to tap on mobile.

Adds a shared `iconHit` style (`minWidth/minHeight: 44`, centered) and spreads it onto each icon-only button. Values match the inline `minWidth:44,minHeight:44` pattern the Plan-page a11y pass adopted in #410, so the two UX audits stay consistent.

### Buttons covered
- **Close (X):** AddTransactionSheet, AssignGoalSheet, CreateGoalSheet, DownloadReportSheet, SellWithdrawSheet, TransactionLedgerSheet, UnallocatedSection, DesktopGoalDetail, MaturityResolveSheet, DesktopInsuranceDetail (×2 delete-confirm)
- **Row edit/delete:** TransactionLedgerSheet
- **Kebab menus:** DesktopGoalDetail (×2), GoalDetailSheet (×2), DesktopInsuranceDetail (edit)
- Also gives the SellWithdraw close button the `aria-label="Close"` it was missing.

## Safety

Pure styling/markup. Icons keep their own size (centered in the padded target); every `aria-label`, `data-testid`, and `role` is unchanged, so behaviour and E2E selectors are untouched.

## Tests

- **TDD:** new tests in `AssignGoalSheet` (close) and `TransactionLedgerSheet` (row edit/delete) assert a ≥44px hit area (red → green).
- Full unit suite green; lint + `tsc --noEmit` clean for changed files.
- E2E not run locally (shared stack in use); selectors are unchanged so no spec impact is expected — best verified by feel on the Vercel preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)