### PR TITLE
fix(plan): jump-to-today + close kebabs on scroll (UX audit P3 polish)

### DIFF
--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect, useCallback } from 'react'
-import { ChevronLeft, ChevronRight } from 'lucide-react'
+import { ChevronLeft, ChevronRight, RotateCcw } from 'lucide-react'
 import { toast } from 'sonner'
 import { useTranslations, useLocale } from 'next-intl'
 import { useNavigation } from '@/app/components/navigation/NavigationContext'
@@ -282,6 +282,17 @@ export default function PlanningClient() {
       title: isVI ? 'Kế hoạch Tháng' : 'Monthly Plan',
       subtitle: isVI ? 'Kế hoạch' : 'Planning',
       trailing: (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        {!(month === initialMonth && year === initialYear) && (
+          <button
+            onClick={navigateToday}
+            data-testid="mobile-today"
+            aria-label={isVI ? 'Về tháng hiện tại' : 'Jump to current month'}
+            style={{ minWidth: 36, minHeight: 36, border: '1px solid var(--c-line)', background: 'var(--c-card)', cursor: 'pointer', borderRadius: 8, color: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          >
+            <RotateCcw size={15} />
+          </button>
+        )}
         <div style={{ display: 'flex', alignItems: 'center', gap: 4, padding: 3, background: 'var(--c-card-2)', border: '1px solid var(--c-line)', borderRadius: 10 }}>
           <button
             onClick={navigatePrev}
@@ -303,10 +314,11 @@ export default function PlanningClient() {
             <ChevronRight size={16} color="var(--c-ink)" />
           </button>
         </div>
+        </div>
       ),
     })
     return () => setMobileTopBar({ title: '' })
-  }, [month, year, isVI, navigatePrev, navigateNext, setMobileTopBar])
+  }, [month, year, isVI, initialMonth, initialYear, navigatePrev, navigateNext, navigateToday, setMobileTopBar])
 
   return (
     <>

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -15,7 +15,7 @@ import RecurringSavingManager from './RecurringSavingManager'
 import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
 import AddInsuranceMemberModal from '@/app/assets/components/AddInsuranceMemberModal'
-import { useDialogA11y } from './useDialogA11y'
+import { useDialogA11y, useCloseOnScroll } from './useDialogA11y'
 import { buildByGoal, resolveRecurringSavings, DEPOSIT_BACKED_FULFILLMENT_SOURCES, type GoalItem } from '@/lib/planning'
 import { relationshipLabel } from '@/app/assets/components/insuranceShared'
 import type {
@@ -156,6 +156,7 @@ function DPlanRow({ primary, secondary, amount, relationship, defaultAmount, mut
   const [open, setOpen] = useState(false)
   const [menuPos, setMenuPos] = useState({ top: 0, right: 0 })
   const btnRef = useRef<HTMLButtonElement>(null)
+  useCloseOnScroll(open, () => setOpen(false))
 
   function openMenu() {
     if (btnRef.current) {
@@ -221,6 +222,7 @@ function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onRec
   const [open, setOpen] = useState(false)
   const [menuPos, setMenuPos] = useState({ top: 0, right: 0 })
   const btnRef = useRef<HTMLButtonElement>(null)
+  useCloseOnScroll(open, () => setOpen(false))
   const skipped = !!item.skipped
   const recorded = !!item.recorded
 
@@ -532,6 +534,8 @@ export default function DesktopPlanningView({
   const longMonths  = isVI ? LONG_MONTHS_VI  : LONG_MONTHS_EN
   const monthLabel  = `${longMonths[month - 1]} ${year}`
   const shortLabel  = `${shortMonths[month - 1]} ${year}`
+  const todayD      = new Date()
+  const isCurrentMonth = month === todayD.getMonth() + 1 && year === todayD.getFullYear()
 
   // ── API handlers ──
 
@@ -796,6 +800,16 @@ export default function DesktopPlanningView({
         </div>
 
         {/* Month picker */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        {!isCurrentMonth && (
+          <button
+            onClick={onToday}
+            style={{ padding: '6px 12px', border: '1px solid var(--c-line)', background: 'var(--c-card)', cursor: 'pointer', borderRadius: 8, fontSize: 12, fontWeight: 600, color: 'var(--c-navy)', fontFamily: 'inherit', display: 'flex', alignItems: 'center', gap: 5 }}
+          >
+            <RefreshCw size={13} />
+            {isVI ? 'Hôm nay' : 'Today'}
+          </button>
+        )}
         <div
           data-testid="desktop-month-picker"
           style={{ display: 'flex', alignItems: 'center', gap: 4, padding: 3, background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 10 }}
@@ -823,6 +837,7 @@ export default function DesktopPlanningView({
           >
             <ChevronRight size={15} />
           </button>
+        </div>
         </div>
       </header>
 

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -14,7 +14,7 @@ import RecurringSavingManager from './RecurringSavingManager'
 import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
 import AddInsuranceMemberModal from '@/app/assets/components/AddInsuranceMemberModal'
-import { useDialogA11y } from './useDialogA11y'
+import { useDialogA11y, useCloseOnScroll } from './useDialogA11y'
 import { buildByGoal, resolveRecurringSavings, DEPOSIT_BACKED_FULFILLMENT_SOURCES, type GoalRow, type GoalItem } from '@/lib/planning'
 import { relationshipLabel } from '@/app/assets/components/insuranceShared'
 import { MobilePlanningSkeleton } from './PlanningSkeleton'
@@ -818,6 +818,7 @@ function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onReco
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPos, setMenuPos] = useState({ top: 0, right: 0 })
   const btnRef = useRef<HTMLButtonElement>(null)
+  useCloseOnScroll(menuOpen, () => setMenuOpen(false))
   const skipped = !!item.skipped
   const recorded = !!item.recorded
 
@@ -942,6 +943,7 @@ function PlanLineItem({
   const [menuOpen, setMenuOpen] = useState(false)
   const [menuPos, setMenuPos] = useState({ top: 0, right: 0 })
   const btnRef = useRef<HTMLButtonElement>(null)
+  useCloseOnScroll(menuOpen, () => setMenuOpen(false))
 
   function openMenu() {
     if (btnRef.current) {

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, within, waitFor } from '@testing-library/react'
+import { render, screen, within, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DesktopPlanningView from '../DesktopPlanningView'
 import type { MonthlyPlan, FundInvestment, DirectSaving, RecurringSaving, RecurringFulfillment, InsuranceMember, FixedExpense } from '../../PlanningClient'
@@ -240,6 +240,32 @@ describe('DesktopPlanningView — allocation card amounts never wrap', () => {
     expect(within(card).getByText('+43.0M ₫')).toHaveStyle({ whiteSpace: 'nowrap' })
     // Per-row percentage chip.
     expect(within(card).getByText('4%', { exact: true })).toHaveStyle({ whiteSpace: 'nowrap' })
+  })
+})
+
+describe('DesktopPlanningView — jump-to-today affordance', () => {
+  it('shows a Today button when viewing a non-current month and calls onToday', async () => {
+    const onToday = vi.fn()
+    // defaultProps month/year = 5/2026 — not the current month.
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} onToday={onToday} />)
+    await userEvent.click(screen.getByRole('button', { name: /^(Today|Hôm nay)$/i }))
+    expect(onToday).toHaveBeenCalled()
+  })
+
+  it('hides the Today button when already on the current month', () => {
+    const now = new Date()
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} month={now.getMonth() + 1} year={now.getFullYear()} />)
+    expect(screen.queryByRole('button', { name: /^(Today|Hôm nay)$/i })).not.toBeInTheDocument()
+  })
+})
+
+describe('DesktopPlanningView — kebab closes on scroll', () => {
+  it('closes an open kebab menu when the page scrolls', async () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} fixedExpenses={[{ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000 }]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'More options' }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    fireEvent.scroll(window)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
   })
 })
 

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen, within, waitFor } from '@testing-library/react'
+import { render, screen, within, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MobilePlanningView from '../MobilePlanningView'
 import type { MonthlyPlan, FixedExpense, InsuranceMember, OtherExpense, FundInvestment, DirectSaving, RecurringFulfillment } from '../../PlanningClient'
@@ -592,6 +592,16 @@ describe('MobilePlanningView — save error feedback (no false success)', () => 
     } finally {
       vi.unstubAllGlobals()
     }
+  })
+})
+
+describe('MobilePlanningView — kebab closes on scroll', () => {
+  it('closes an open plan-line kebab when the page scrolls', async () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} fixedExpenses={[{ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 8_500_000 }]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'More options' }))
+    expect(screen.getByRole('menu')).toBeInTheDocument()
+    fireEvent.scroll(window)
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument()
   })
 })
 

--- a/app/(app)/planning/components/useDialogA11y.ts
+++ b/app/(app)/planning/components/useDialogA11y.ts
@@ -11,6 +11,21 @@ import { useEffect, useRef, type RefObject } from 'react'
 // `onClose={() => …}` (new identity each render) doesn't re-run focus handling
 // and steal focus mid-interaction.
 
+// Close an open popover (a kebab menu) when anything scrolls. The menus are
+// position:fixed (computed once from the trigger's rect), so without this they
+// detach and float when the page or a scroll container moves. Capture phase so
+// scrolls from inner scroll containers count too.
+export function useCloseOnScroll(active: boolean, onClose: () => void) {
+  const onCloseRef = useRef(onClose)
+  useEffect(() => { onCloseRef.current = onClose })
+  useEffect(() => {
+    if (!active) return
+    const close = () => onCloseRef.current()
+    window.addEventListener('scroll', close, true)
+    return () => window.removeEventListener('scroll', close, true)
+  }, [active])
+}
+
 const FOCUSABLE = [
   'a[href]', 'button:not([disabled])', 'textarea:not([disabled])',
   'input:not([disabled])', 'select:not([disabled])', '[tabindex]:not([tabindex="-1"])',


### PR DESCRIPTION
**Plan-page UX audit — P3 polish** (the optional finishers after the 6 core PRs #403/#405/#406/#407/#408/#410).

## Items
1. **No obvious way back to the current month.** The desktop month-picker's centre label was clickable but didn't look it; the mobile top-bar month chip wasn't tappable at all. Both views now show a **"Today / Hôm nay"** button that appears **only when viewing a non-current month** and jumps back.
2. **Kebab menus floated on scroll.** The row kebabs are `position:fixed` (computed once from the trigger's rect), so scrolling with one open left it detached. A shared `useCloseOnScroll` hook closes any open kebab on scroll (capture phase → inner scroll containers count too).

## Deliberately not done
- **"% Tiết kiệm" wording** — kept as-is per your call.
- **Month/year quick-picker** — left as a larger follow-up (more feature than polish; higher UI risk).
- **Mobile "Other" default-collapsed parity** — dropped; it would change established behavior and break 3 tests for negligible value.

## Tests
- Desktop Today button: shows off-month, hidden on the current month, calls `onToday`.
- Desktop + mobile kebab menus close on scroll.

## Verification
- `npm test -- --run` → **893 passed** (107 in planning).
- `npm run lint` → no new errors (4 = the pre-existing count on `main`; new hook is clean).
- E2E checked: no spec targets the new "Today" button or relies on a kebab staying open across scroll.
- Please confirm on the Vercel preview: the Today button appears when you navigate away from the current month (desktop + mobile), and kebab menus close cleanly on scroll.