### PR TITLE
fix(funds): delete-warning parity, refresh hint, no backdrop-close on forms

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -69,13 +69,15 @@ const FundIcon = ({ code, type, size = 32 }: { code: string; type: FundType; siz
 
 // ─── DModal ───────────────────────────────────────────────────────────────────
 
-function DModal({ open, onClose, title, width = 460, children }: {
-  open: boolean; onClose: () => void; title: string; width?: number; children: ReactNode
+function DModal({ open, onClose, title, width = 460, dismissOnBackdrop = true, children }: {
+  open: boolean; onClose: () => void; title: string; width?: number; dismissOnBackdrop?: boolean; children: ReactNode
 }) {
   if (!open) return null
   return (
     <div
-      onClick={onClose}
+      // Form modals opt out of backdrop dismissal so a stray click doesn't
+      // discard typed input; they're closed via Cancel or the X (#2 P2).
+      onClick={dismissOnBackdrop ? onClose : undefined}
       style={{ position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)', zIndex: 200, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24, backdropFilter: 'blur(2px)', animation: 'fade-in 150ms ease' }}
     >
       <div
@@ -588,6 +590,7 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
             <button
               onClick={handleRefreshNav}
               disabled={refreshing || !funds.some(f => f.nav_source_url)}
+              title={funds.some(f => f.nav_source_url) ? undefined : t('refreshDisabledHint')}
               className="cn-btn ghost"
               style={{ padding: '7px 10px', gap: 5, fontSize: 12, display: 'flex', alignItems: 'center' }}
             >
@@ -763,6 +766,7 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
       <DModal
         open={!!modalMode}
         onClose={closeModal}
+        dismissOnBackdrop={false}
         title={modalMode === 'edit' ? t('editModal') : t('addModal')}
         width={460}
       >

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -159,7 +159,7 @@ function TypeDropdown({ value, onChange }: { value: FundType; onChange: (v: Fund
 
 // ─── Sheet ───────────────────────────────────────────────────────────────────
 
-function Sheet({ open, onClose, testId, children }: { open: boolean; onClose: () => void; testId: string; children: React.ReactNode }) {
+function Sheet({ open, onClose, testId, dismissOnBackdrop = true, children }: { open: boolean; onClose: () => void; testId: string; dismissOnBackdrop?: boolean; children: React.ReactNode }) {
   const [mounted, setMounted] = useState(false)
   useEffect(() => {
     if (open) setMounted(true)
@@ -170,7 +170,9 @@ function Sheet({ open, onClose, testId, children }: { open: boolean; onClose: ()
   return (
     <div
       style={{ position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.3)', zIndex: 200, pointerEvents: open ? 'auto' : 'none', display: 'flex', alignItems: 'flex-end' }}
-      onClick={onClose}
+      // Form sheets opt out of backdrop dismissal so a stray tap doesn't discard
+      // typed input; they're closed via the Cancel button (#2 P2).
+      onClick={dismissOnBackdrop ? onClose : undefined}
     >
       <div
         data-testid={testId}
@@ -801,7 +803,7 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
       </div>
 
       {/* Add sheet */}
-      <Sheet open={addOpen} onClose={() => { setAddOpen(false); setFormError(null) }} testId="fund-sheet">
+      <Sheet open={addOpen} onClose={() => { setAddOpen(false); setFormError(null) }} testId="fund-sheet" dismissOnBackdrop={false}>
         <FundForm
           existing={null}
           title={t('addModal')}
@@ -813,7 +815,7 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
       </Sheet>
 
       {/* Edit sheet */}
-      <Sheet open={!!editFund} onClose={() => { setEditFund(null); setFormError(null) }} testId="fund-sheet">
+      <Sheet open={!!editFund} onClose={() => { setEditFund(null); setFormError(null) }} testId="fund-sheet" dismissOnBackdrop={false}>
         {editFund && (
           <FundForm
             existing={editFund}
@@ -831,7 +833,8 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
         {deleteFund && (
           <div style={{ paddingTop: 14, display: 'grid', gap: 14 }}>
             <p style={{ margin: 0, fontWeight: 700, fontSize: 16, color: 'var(--c-ink)' }}>{t('deleteModal', { name: deleteFund.code })}</p>
-            <p style={{ margin: 0, fontSize: 13, color: 'var(--c-muted)', lineHeight: 1.5 }}>{t('deleteCannotUndo')}</p>
+            {/* Impact line — parity with desktop DeleteModal (#2 P2). */}
+            <p style={{ margin: 0, fontSize: 13, color: 'var(--c-muted)', lineHeight: 1.5 }}>{t('deleteWarning', { name: deleteFund.code })} {t('deleteCannotUndo')}</p>
             <div style={{ display: 'flex', gap: 8 }}>
               <button onClick={() => setDeleteFund(null)} disabled={deleting} style={{ flex: 1, padding: '10px 14px', fontSize: 13, fontWeight: 600, border: '1px solid var(--c-line)', borderRadius: 10, background: 'var(--c-card)', color: 'var(--c-ink)', cursor: 'pointer', fontFamily: 'inherit' }}>
                 {tc('cancel')}

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.parity.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.parity.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DesktopFundLibraryView from '../DesktopFundLibraryView'
+import type { Fund } from '../useFundsData'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+vi.mock('@/lib/formatters', () => ({ fmtNav: (n: number) => String(n), fmtCompact: (n: number) => `${n}` }))
+
+function makeFund(over: Partial<Fund> = {}): Fund {
+  return {
+    id: 'f1', name: 'VFMVF1 Equity Fund', code: 'VFMVF1', fund_type: 'equity', nav: 36120,
+    nav_source_url: null, is_dca: false, dca_monthly_amount_vnd: null, dca_goal_id: null,
+    created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z', ...over,
+  }
+}
+function Harness({ initial }: { initial: Fund[] }) {
+  const [funds, setFunds] = useState(initial)
+  return <DesktopFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
+}
+
+beforeEach(() => { vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))) })
+afterEach(() => vi.unstubAllGlobals())
+
+describe('DesktopFundLibraryView — P2 parity/feedback', () => {
+  it('Refresh button carries an explanatory title when disabled (no NAV source URL on any fund)', () => {
+    render(<Harness initial={[makeFund({ nav_source_url: null })]} />)
+    const btn = screen.getByRole('button', { name: /refresh/i })
+    expect(btn).toBeDisabled()
+    expect(btn).toHaveAttribute('title', 'refreshDisabledHint')
+  })
+
+  it('the Add/Edit form modal does NOT close on a backdrop click (avoids losing typed input)', async () => {
+    render(<Harness initial={[makeFund()]} />)
+    await userEvent.click(screen.getByRole('button', { name: 'add' }))
+    const modal = screen.getByTestId('fund-modal')
+    fireEvent.click(modal.parentElement as HTMLElement) // the backdrop
+    expect(screen.getByTestId('fund-modal')).toBeInTheDocument()
+  })
+})

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.parity.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.parity.test.tsx
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MobileFundLibraryView from '../MobileFundLibraryView'
+import type { Fund } from '../useFundsData'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+vi.mock('@/lib/formatters', () => ({ fmtNav: (n: number) => String(n), fmtCompact: (n: number) => `${n}` }))
+vi.mock('@/app/components/navigation/NavigationContext', () => ({ useNavigation: () => ({ setMobileTopBar: vi.fn() }) }))
+
+function makeFund(over: Partial<Fund> = {}): Fund {
+  return {
+    id: 'f1', name: 'VFMVF1 Equity Fund', code: 'VFMVF1', fund_type: 'equity', nav: 36120,
+    nav_source_url: null, is_dca: false, dca_monthly_amount_vnd: null, dca_goal_id: null,
+    created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z', ...over,
+  }
+}
+function Harness({ initial }: { initial: Fund[] }) {
+  const [funds, setFunds] = useState(initial)
+  return <MobileFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
+}
+
+beforeEach(() => { vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))) })
+afterEach(() => vi.unstubAllGlobals())
+
+describe('MobileFundLibraryView — P2 parity/reversibility', () => {
+  it('the delete sheet shows the permanent-delete impact line (parity with desktop)', async () => {
+    render(<Harness initial={[makeFund()]} />)
+    await userEvent.click(screen.getByLabelText('deleteBtn'))
+    const sheet = screen.getByTestId('delete-fund-sheet')
+    // Desktop shows deleteWarning + deleteCannotUndo; mobile must not drop the warning.
+    expect(sheet.textContent).toContain('deleteWarning')
+    expect(sheet.textContent).toContain('deleteCannotUndo')
+  })
+
+  it('the Add/Edit form sheet does NOT close on a backdrop tap (avoids losing typed input)', async () => {
+    render(<Harness initial={[makeFund()]} />)
+    await userEvent.click(screen.getByLabelText('editFund'))
+    const sheet = screen.getByTestId('fund-sheet')
+    fireEvent.click(sheet.parentElement as HTMLElement) // the backdrop overlay
+    expect(screen.getByTestId('fund-sheet')).toBeInTheDocument()
+  })
+})

--- a/messages/en.json
+++ b/messages/en.json
@@ -646,7 +646,8 @@
     "navUrlPlaceholder": "https://...",
     "editFund": "Edit fund",
     "enableDca": "Enable DCA",
-    "disableDca": "Disable DCA"
+    "disableDca": "Disable DCA",
+    "refreshDisabledHint": "Add a NAV source URL to a fund to enable auto-refresh."
   },
   "planning": {
     "title": "Monthly Plan",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -646,7 +646,8 @@
     "navUrlPlaceholder": "https://...",
     "editFund": "Sửa quỹ",
     "enableDca": "Bật DCA",
-    "disableDca": "Tắt DCA"
+    "disableDca": "Tắt DCA",
+    "refreshDisabledHint": "Thêm URL nguồn NAV cho một quỹ để bật làm mới tự động."
   },
   "planning": {
     "title": "Kế hoạch Tháng",


### PR DESCRIPTION
## What
Funds Library UX audit — **P2 (parity + reversibility)** batch. Three low-risk, frontend-only papercuts:

1. **Mobile delete warning parity.** The mobile delete sheet showed only "cannot be undone"; desktop's `DeleteModal` also shows "This will permanently delete X." Mobile now shows the same impact line — a stronger warning before an irreversible action.
2. **Refresh-NAV disabled hint.** When no fund has a NAV source URL the Refresh button is disabled with no explanation. It now carries a `title` (`refreshDisabledHint`) telling the user how to enable it.
3. **No backdrop-close on forms.** The Add/Edit modal (desktop `DModal`) and sheet (mobile `Sheet`) no longer dismiss on a backdrop click, so a stray tap can't discard typed input. They still close via **Cancel / X**. Delete dialogs keep backdrop dismissal (no data to lose).

## Why backdrop-guard is safe
The funds E2E specs close these dialogs via the **Cancel button** (`funds-desktop.spec.ts:245`), never the backdrop — grepped before changing behavior. New `dismissOnBackdrop` prop defaults to `true`, so only the two form usages opt out.

## Tests (TDD)
New `*.parity.test.tsx` for both views assert rendered outcomes:
- mobile delete sheet contains the warning + cannot-undo lines
- disabled refresh button has the explanatory `title`
- form modal/sheet stay mounted after a backdrop click

`npx vitest run app/(app)/funds` → 14/14 green. New i18n key added to both `en`/`vi`. Lint: no new errors in changed files (2 pre-existing `relDate` purity warnings untouched).

## Deferred (not in this PR)
- **Desktop name-sort** (mobile has it): desktop's sort model is column-headers with no Name column, and code≈name in practice — not worth the layout churn. Noted in the audit.
- Funds dialog a11y (Esc + focus-trap) → future P3, following the plan's `useDialogA11y` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)