### PR TITLE
fix(plan): clearer goal CTA + mobile touch targets + manager delete errors

### DIFF
--- a/app/(app)/planning/components/FixedExpenseManager.tsx
+++ b/app/(app)/planning/components/FixedExpenseManager.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useTranslations, useLocale } from 'next-intl'
+import { toast } from 'sonner'
 import { Plus, ChevronLeft } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
 
@@ -157,12 +158,14 @@ export default function FixedExpenseManager({ onChange, onToast, variant = 'moda
   async function handleDelete(e: Expense) {
     setDeleting(true)
     try {
-      const res = await fetch(`/api/v1/fixed-expenses/${e.expense_id}`, { method: 'DELETE' })
-      if (res.ok) {
+      const res = await fetch(`/api/v1/fixed-expenses/${e.expense_id}`, { method: 'DELETE' }).catch(() => null)
+      if (res?.ok) {
         setConfirmDelete(null)
         onToast?.(t('deleted'))
         await fetchList()
         onChange()
+      } else {
+        toast.error(isVI ? 'Không thể xoá, vui lòng thử lại' : "Couldn't delete — please try again")
       }
     } finally {
       setDeleting(false)

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -537,7 +537,7 @@ function SalaryCard({ amount, isVI, onEdit, onDelete }: { amount: number; isVI: 
         <button
           onClick={onEdit}
           aria-label="Edit income"
-          style={{ padding: 6, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          style={{ minWidth: 44, minHeight: 44, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
           onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--c-card-2)')}
           onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
         >
@@ -546,7 +546,7 @@ function SalaryCard({ amount, isVI, onEdit, onDelete }: { amount: number; isVI: 
         <button
           onClick={onDelete}
           aria-label="Delete plan"
-          style={{ padding: 6, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+          style={{ minWidth: 44, minHeight: 44, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
           onMouseEnter={(e) => (e.currentTarget.style.background = 'var(--c-card-2)')}
           onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
         >
@@ -777,9 +777,14 @@ function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride
         <button
           onClick={onLogContribution}
           aria-label={isVI ? 'Ghi nhận đóng góp' : 'Log contribution'}
-          style={{ padding: 4, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 6, color: 'var(--c-pos)', display: 'flex', flexShrink: 0 }}
+          title={isVI ? 'Ghi nhận đóng góp vào mục tiêu' : 'Log a contribution to this goal'}
+          style={{ minWidth: 44, minHeight: 44, padding: 0, border: 'none', background: 'transparent', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}
         >
-          <Plus size={16} strokeWidth={2.4} />
+          {/* Tinted chip so it reads as a discrete "add money" action (not a bare
+              "+" that could be mistaken for "add goal"), matching the Saved/Buy pills. */}
+          <span style={{ width: 28, height: 28, borderRadius: 999, background: 'var(--c-pos-tint)', color: 'var(--c-pos)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <Plus size={16} strokeWidth={2.4} />
+          </span>
         </button>
         <button
           onClick={() => setOpen((o) => !o)}
@@ -1555,7 +1560,7 @@ export default function MobilePlanningView({
                   <button
                     onClick={() => { setSheet({ type: 'other-expense', existing: o }) }}
                     aria-label="Edit expense"
-                    style={{ padding: 4, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 4, display: 'flex', alignItems: 'center' }}
+                    style={{ minWidth: 44, minHeight: 44, border: 'none', background: 'transparent', cursor: 'pointer', borderRadius: 4, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}
                   >
                     <EditIcon size={14} color="var(--c-muted)" />
                   </button>

--- a/app/(app)/planning/components/RecurringSavingManager.tsx
+++ b/app/(app)/planning/components/RecurringSavingManager.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react'
 import { useTranslations, useLocale } from 'next-intl'
+import { toast } from 'sonner'
 import { Plus, ChevronLeft } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import type { Goal } from '../PlanningClient'
@@ -203,12 +204,14 @@ export default function RecurringSavingManager({ goals, onChange, onToast, varia
   async function handleDelete(s: Saving) {
     setDeleting(true)
     try {
-      const res = await fetch(`/api/v1/recurring-savings/${s.saving_id}`, { method: 'DELETE' })
-      if (res.ok) {
+      const res = await fetch(`/api/v1/recurring-savings/${s.saving_id}`, { method: 'DELETE' }).catch(() => null)
+      if (res?.ok) {
         setConfirmDelete(null)
         onToast?.(isVI ? 'Đã xoá khoản' : 'Saving deleted')
         await fetchList()
         onChange()
+      } else {
+        toast.error(isVI ? 'Không thể xoá, vui lòng thử lại' : "Couldn't delete — please try again")
       }
     } finally {
       setDeleting(false)

--- a/app/(app)/planning/components/__tests__/FixedExpenseManager.test.tsx
+++ b/app/(app)/planning/components/__tests__/FixedExpenseManager.test.tsx
@@ -3,6 +3,9 @@ import { render, screen, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import FixedExpenseManager from '../FixedExpenseManager'
 
+const { toastErrorMock } = vi.hoisted(() => ({ toastErrorMock: vi.fn() }))
+vi.mock('sonner', () => ({ toast: Object.assign(vi.fn(), { error: toastErrorMock, success: vi.fn() }) }))
+
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
     params ? `${key}:${JSON.stringify(params)}` : key,
@@ -170,6 +173,25 @@ describe('FixedExpenseManager — delete', () => {
       expect(del).toBeTruthy()
     })
     expect(onChange).toHaveBeenCalled()
+  })
+
+  it('shows an error toast and keeps the confirmation open when delete fails', async () => {
+    mockFetch((url, init) => {
+      if (url.includes('/api/v1/fixed-expenses/fe1') && init?.method === 'DELETE') {
+        return { ok: false, json: async () => ({ error: 'boom' }) }
+      }
+      return undefined
+    })
+    toastErrorMock.mockClear()
+    const onChange = vi.fn()
+    render(<FixedExpenseManager onChange={onChange} />)
+    await screen.findByText('Rent')
+    await userEvent.click(within(screen.getByTestId('fe-row-fe1')).getByTestId('fe-delete'))
+    await userEvent.click(screen.getByTestId('fe-delete-confirm'))
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
+    // Confirmation stays open (not dismissed) and we didn't claim success.
+    expect(screen.getByTestId('fe-delete-overlay')).toBeInTheDocument()
+    expect(onChange).not.toHaveBeenCalled()
   })
 
   it('centers the delete confirmation in the default (modal) variant', async () => {

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -178,6 +178,12 @@ describe('MobilePlanningView — with plan', () => {
     expect(screen.getByLabelText(/delete/i)).toBeInTheDocument()
   })
 
+  it('gives the salary-card edit/delete buttons a ≥44px touch target', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getByLabelText('Edit income')).toHaveStyle({ minWidth: '44px', minHeight: '44px' })
+    expect(screen.getByLabelText('Delete plan')).toHaveStyle({ minWidth: '44px', minHeight: '44px' })
+  })
+
   it('opens salary edit sheet when edit button is clicked', async () => {
     render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
     await userEvent.click(screen.getByLabelText(/edit/i))
@@ -463,6 +469,12 @@ describe('MobilePlanningView — recurring savings in By goal', () => {
   it('renders a Log contribution "+" on the goal header', () => {
     render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
     expect(screen.getByRole('button', { name: /Log contribution/i })).toBeInTheDocument()
+  })
+
+  it('gives the Log contribution "+" a ≥44px touch target', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
+    const btn = screen.getByRole('button', { name: /Log contribution/i })
+    expect(btn).toHaveStyle({ minWidth: '44px', minHeight: '44px' })
   })
 
   it('opens the Add-Transaction sheet when the goal "+" is clicked', async () => {


### PR DESCRIPTION
Finishes the remaining Plan-page audit leftovers (#10 partial, #11, #18).

## What & why
- **Goal "+" was ambiguous + tiny (#11/#10).** A bare green "+" at the row's right edge read like "add goal" and was only ~24px. It's now a **tinted circular chip** (same style as the Saved/Buy pills) inside a **44×44 hit area** — clearly a "log a contribution" action. **No text label**: the goal name already truncates, so widening the control would crowd/clip on narrow phones (this was your concern — confirmed by the layout).
- **Remaining sub-44px mobile icon buttons (#10).** Salary-card edit/delete and other-expense edit now have a **≥44px hit area** (icons unchanged, just the tap zone, so rows barely move).
- **Silent manager delete failures (#18).** `FixedExpenseManager` / `RecurringSavingManager` deletes that failed left the confirm dialog sitting with no feedback. They now show an **error toast** and keep the confirmation open instead of implying success — same truthfulness as PR-1.

## Tests
- Goal "+" and salary-card edit/delete report a 44px min target.
- Manager delete failure → error toast, confirm stays open, `onChange` not called.

## Verification
- `npm test -- --run` → **902 passed** (110 in planning).
- `npm run lint` → no new errors (3 = pre-existing count on `main`).
- E2E: unaffected (the goal "+" keeps the same `aria-label`/onClick; touch-target/chip are style-only).
- Please eyeball on the Vercel preview: the goal-row "+" chip on mobile (shouldn't push the goal name into more truncation) and the bigger tap zones.

This closes out the Plan-page UX audit (only intentionally-deferred items remain: "% Tiết kiệm" wording kept, month/year quick-picker, sheet swipe-dismiss).