### PR TITLE
fix(i18n): localise the non-fund sell-item fallback name

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -244,10 +244,12 @@ interface MaturingDep {
 }
 
 // Build the SellWithdrawSheet payload for a non-fund holding (bank/gold/stock).
-function nonFundToSellItem(item: NonFundUnallocatedItem): SellItem {
+// `isVi` localises the no-notes fallback name, mirroring nonFundToInvRow — without
+// it a Vietnamese user saw the raw English "Bank deposit" / "Gold" in the sheet.
+export function nonFundToSellItem(item: NonFundUnallocatedItem, isVi: boolean): SellItem {
   return {
     type: item.type as 'bank' | 'gold' | 'stock',
-    name: item.notes ?? (item.type === 'bank' ? 'Bank deposit' : item.type === 'gold' ? 'Gold' : item.type),
+    name: item.notes ?? (item.type === 'bank' ? (isVi ? 'Tiền gửi' : 'Bank deposit') : item.type === 'gold' ? (isVi ? 'Vàng' : 'Gold') : item.type),
     currentValue: item.currentValue,
     units: item.units ?? undefined,
     navPerUnit: item.units && item.units > 0 ? item.currentValue / item.units : undefined,
@@ -540,7 +542,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
   }
 
   function openSellNonFund(item: NonFundUnallocatedItem) {
-    setSellItem(nonFundToSellItem(item))
+    setSellItem(nonFundToSellItem(item, isVi))
     setSellSheetOpen(true)
   }
 
@@ -651,7 +653,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
     // prefills the book balance, not just the anchor tranche's value.
     const item: SellItem = dep.inv.depositGroupId
       ? { type: 'bank', name: dep.inv.name, currentValue: dep.inv.value, transactionId: dep.inv.id, purchasePrice: dep.inv.principal ?? dep.inv.value, depositGroupId: dep.inv.depositGroupId, interestRate: dep.inv.interestRate ?? undefined }
-      : nonFundToSellItem(dep.raw)
+      : nonFundToSellItem(dep.raw, isVi)
     if (dep.goalId) {
       const goal = data?.goals.find((g) => g.goalId === dep.goalId)
       setMaturityWithdraw({

--- a/app/assets/__tests__/nonFundToSellItem.test.ts
+++ b/app/assets/__tests__/nonFundToSellItem.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest'
+
+// DashboardClient pulls in next-intl at module load; stub it so importing the
+// pure helper doesn't need a provider.
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
+  useTranslations: () => (k: string) => k,
+}))
+
+import { nonFundToSellItem, type NonFundUnallocatedItem } from '../DashboardClient'
+
+// A non-fund holding with no user notes — the name then falls back to a type
+// label, which must follow the active locale (the bug: it leaked English
+// "Bank deposit" / "Gold" into the Vietnamese sell sheet).
+const noNotes = (type: string): NonFundUnallocatedItem => ({
+  transactionId: 't1', type, amount: 1_000_000, currentValue: 1_000_000,
+  interestRate: null, expiryDate: null, investmentDate: '2026-01-01',
+  notes: null, units: null, depositGroupId: null,
+})
+
+describe('nonFundToSellItem — localised fallback name', () => {
+  it('uses Vietnamese labels when isVi is true', () => {
+    expect(nonFundToSellItem(noNotes('bank'), true).name).toBe('Tiền gửi')
+    expect(nonFundToSellItem(noNotes('gold'), true).name).toBe('Vàng')
+  })
+
+  it('uses English labels when isVi is false', () => {
+    expect(nonFundToSellItem(noNotes('bank'), false).name).toBe('Bank deposit')
+    expect(nonFundToSellItem(noNotes('gold'), false).name).toBe('Gold')
+  })
+
+  it('always prefers the user-entered notes over the fallback', () => {
+    expect(nonFundToSellItem({ ...noNotes('bank'), notes: 'My TCB deposit' }, true).name).toBe('My TCB deposit')
+  })
+})


### PR DESCRIPTION
## What

`nonFundToSellItem` (which builds the SellWithdrawSheet payload for a bank/gold/stock holding) used a hardcoded **English** fallback name — `"Bank deposit"` / `"Gold"` — when the holding had no user notes. So a Vietnamese user selling/withdrawing a bank deposit or gold with no note saw raw English text in the sheet.

Its sibling `nonFundToInvRow` already localises the same fallback (`Tiền gửi` / `Bank deposit`). This brings the sell path in line: thread `isVi` through and localise (`Tiền gửi` / `Vàng`), passed from both call sites (`openSellNonFund` and the maturity-withdraw handler).

## Tests (TDD)

- `nonFundToSellItem` is now exported and unit-tested for the vi/en fallback and the notes-preferred case (red → green confirmed).
- Full unit suite green (898). `tsc --noEmit` + lint clean for changed files.

Scope: just the one leak from the Overview UX audit's notable list. The broader `isVi ? :` → `t()` migration is intentionally **not** included (it renders correctly in both languages — a maintainability nicety, not a bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)