### PR TITLE
fix(funds): hard-block deleting a fund that's used in a monthly plan

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -503,6 +503,13 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
     setDeleting(true)
     try {
       const res = await fetch(`/api/funds/${deleteTarget.id}`, { method: 'DELETE' })
+      // Hard-block: a fund used in a monthly plan can't be deleted (#1). Show a
+      // specific, actionable message instead of the generic failure toast.
+      if (res.status === 409) {
+        setDeleteTarget(null)
+        addToast(t('toastDeleteInUse'), false)
+        return
+      }
       if (!res.ok && res.status !== 204) throw new Error()
       setDeleteTarget(null)
       await reload()

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -577,6 +577,13 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
     setDeleting(true)
     try {
       const res = await fetch(`/api/funds/${deleteFund.id}`, { method: 'DELETE' })
+      // Hard-block: a fund used in a monthly plan can't be deleted (#1). Show a
+      // specific, actionable message instead of the generic failure toast.
+      if (res.status === 409) {
+        setDeleteFund(null)
+        addToast(t('toastDeleteInUse'), 'error')
+        return
+      }
       if (!res.ok && res.status !== 204) throw new Error()
       setDeleteFund(null)
       await reload()

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.delete.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.delete.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useState } from 'react'
+import { render, screen, within, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DesktopFundLibraryView from '../DesktopFundLibraryView'
+import type { Fund } from '../useFundsData'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+vi.mock('@/lib/formatters', () => ({ fmtNav: (n: number) => String(n), fmtCompact: (n: number) => `${n}` }))
+
+function makeFund(over: Partial<Fund> = {}): Fund {
+  return {
+    id: 'f1', name: 'VFMVF1 Equity Fund', code: 'VFMVF1', fund_type: 'equity', nav: 36120,
+    nav_source_url: null, is_dca: false, dca_monthly_amount_vnd: null, dca_goal_id: null,
+    created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z', ...over,
+  }
+}
+function Harness({ reload }: { reload: () => Promise<void> }) {
+  const [funds, setFunds] = useState([makeFund()])
+  return <DesktopFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={reload} />
+}
+
+let reload: ReturnType<typeof vi.fn>
+afterEach(() => vi.unstubAllGlobals())
+beforeEach(() => { reload = vi.fn(() => Promise.resolve()) })
+
+describe('DesktopFundLibraryView — delete of an in-use fund is hard-blocked with a clear message (#1)', () => {
+  it('shows the in-use message and does NOT reload when the API returns 409', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, status: 409, json: () => Promise.resolve({ code: 'fund_in_use' }) })))
+    render(<Harness reload={reload} />)
+    await userEvent.click(screen.getByTestId('fund-delete-btn'))
+    const modal = screen.getByTestId('delete-fund-modal')
+    await userEvent.click(within(modal).getByRole('button', { name: 'deleteBtn' }))
+
+    expect(await screen.findByText('toastDeleteInUse')).toBeInTheDocument()
+    expect(screen.queryByText('toastDeleted')).not.toBeInTheDocument()
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('a normal (204) delete still reloads and reports success', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve({}) })))
+    render(<Harness reload={reload} />)
+    await userEvent.click(screen.getByTestId('fund-delete-btn'))
+    const modal = screen.getByTestId('delete-fund-modal')
+    await userEvent.click(within(modal).getByRole('button', { name: 'deleteBtn' }))
+
+    await waitFor(() => expect(reload).toHaveBeenCalled())
+    expect(await screen.findByText('toastDeleted')).toBeInTheDocument()
+  })
+})

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.delete.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.delete.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useState } from 'react'
+import { render, screen, within, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MobileFundLibraryView from '../MobileFundLibraryView'
+import type { Fund } from '../useFundsData'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+vi.mock('@/lib/formatters', () => ({ fmtNav: (n: number) => String(n), fmtCompact: (n: number) => `${n}` }))
+vi.mock('@/app/components/navigation/NavigationContext', () => ({ useNavigation: () => ({ setMobileTopBar: vi.fn() }) }))
+
+function makeFund(over: Partial<Fund> = {}): Fund {
+  return {
+    id: 'f1', name: 'VFMVF1 Equity Fund', code: 'VFMVF1', fund_type: 'equity', nav: 36120,
+    nav_source_url: null, is_dca: false, dca_monthly_amount_vnd: null, dca_goal_id: null,
+    created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z', ...over,
+  }
+}
+function Harness({ reload }: { reload: () => Promise<void> }) {
+  const [funds, setFunds] = useState([makeFund()])
+  return <MobileFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={reload} />
+}
+
+let reload: ReturnType<typeof vi.fn>
+afterEach(() => vi.unstubAllGlobals())
+beforeEach(() => { reload = vi.fn(() => Promise.resolve()) })
+
+describe('MobileFundLibraryView — delete of an in-use fund is hard-blocked with a clear message (#1)', () => {
+  it('shows the in-use message and does NOT reload when the API returns 409', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, status: 409, json: () => Promise.resolve({ code: 'fund_in_use' }) })))
+    render(<Harness reload={reload} />)
+    await userEvent.click(screen.getByLabelText('deleteBtn'))
+    const sheet = screen.getByTestId('delete-fund-sheet')
+    await userEvent.click(within(sheet).getByRole('button', { name: 'delete' }))
+
+    expect(await screen.findByText('toastDeleteInUse')).toBeInTheDocument()
+    expect(screen.queryByText('toastDeleted')).not.toBeInTheDocument()
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('a normal (204) delete still reloads and reports success', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve({}) })))
+    render(<Harness reload={reload} />)
+    await userEvent.click(screen.getByLabelText('deleteBtn'))
+    const sheet = screen.getByTestId('delete-fund-sheet')
+    await userEvent.click(within(sheet).getByRole('button', { name: 'delete' }))
+
+    await waitFor(() => expect(reload).toHaveBeenCalled())
+    expect(await screen.findByText('toastDeleted')).toBeInTheDocument()
+  })
+})

--- a/app/api/funds/[id]/__tests__/route.delete.test.ts
+++ b/app/api/funds/[id]/__tests__/route.delete.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Stub auth + a thenable query chain. The DELETE handler does:
+//   from('funds').select('id').eq().eq().single()   -> existence pre-check
+//   from('funds').delete().eq().eq()                 -> awaited, returns { error }
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  existing: { id: 'f1' } as { id: string } | null,
+  deleteError: null as { code?: string } | null,
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  function makeChain(kind: 'select' | 'delete' | 'from') {
+    const chain: Record<string, unknown> = {
+      select: () => makeChain('select'),
+      delete: () => makeChain('delete'),
+      eq: () => chain,
+      single: async () => ({ data: h.existing, error: null }),
+      // The delete chain is awaited directly (no .single()).
+      then: (resolve: (v: unknown) => void) =>
+        resolve(kind === 'delete' ? { error: h.deleteError } : { data: h.existing, error: null }),
+    }
+    return chain
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: () => makeChain('from'),
+    }),
+  }
+})
+
+import { DELETE } from '../route'
+
+const ctx = { params: Promise.resolve({ id: 'f1' }) }
+const req = {} as unknown as Parameters<typeof DELETE>[0]
+
+beforeEach(() => {
+  h.user = { id: 'user-1' }
+  h.existing = { id: 'f1' }
+  h.deleteError = null
+})
+
+describe('DELETE /api/funds/[id] — hard-block deleting a fund that is in use (#1)', () => {
+  it('returns 204 on a successful delete', async () => {
+    const res = await DELETE(req, ctx)
+    expect(res.status).toBe(204)
+  })
+
+  it('maps a foreign-key violation (23503) to a 409 the UI can act on', async () => {
+    h.deleteError = { code: '23503' }
+    const res = await DELETE(req, ctx)
+    expect(res.status).toBe(409)
+    const body = await res.json()
+    expect(body.code).toBe('fund_in_use')
+  })
+
+  it('still returns 500 for an unexpected delete error', async () => {
+    h.deleteError = { code: 'XX000' }
+    const res = await DELETE(req, ctx)
+    expect(res.status).toBe(500)
+  })
+
+  it('returns 404 when the fund does not exist', async () => {
+    h.existing = null
+    const res = await DELETE(req, ctx)
+    expect(res.status).toBe(404)
+  })
+})

--- a/app/api/funds/[id]/route.ts
+++ b/app/api/funds/[id]/route.ts
@@ -134,6 +134,14 @@ export async function DELETE(
   const { error } = await supabase.from('funds').delete().eq('id', id).eq('user_id', user.id)
 
   if (error) {
+    // A fund referenced by a monthly-plan allocation is protected by an
+    // ON DELETE RESTRICT foreign key (Postgres 23503). Funds drive cash-flow
+    // planning, so we hard-block the delete and return a specific, actionable
+    // 409 (code: fund_in_use) instead of a generic 500 — the UI tells the user
+    // to remove it from the plan first (#1).
+    if (error.code === '23503') {
+      return NextResponse.json({ error: 'Fund is in use', code: 'fund_in_use' }, { status: 409 })
+    }
     return NextResponse.json({ error: 'Failed to delete fund' }, { status: 500 })
   }
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -647,7 +647,8 @@
     "editFund": "Edit fund",
     "enableDca": "Enable DCA",
     "disableDca": "Disable DCA",
-    "refreshDisabledHint": "Add a NAV source URL to a fund to enable auto-refresh."
+    "refreshDisabledHint": "Add a NAV source URL to a fund to enable auto-refresh.",
+    "toastDeleteInUse": "Can't delete this fund — it's used in a monthly plan. Remove it from the plan first."
   },
   "planning": {
     "title": "Monthly Plan",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -647,7 +647,8 @@
     "editFund": "Sửa quỹ",
     "enableDca": "Bật DCA",
     "disableDca": "Tắt DCA",
-    "refreshDisabledHint": "Thêm URL nguồn NAV cho một quỹ để bật làm mới tự động."
+    "refreshDisabledHint": "Thêm URL nguồn NAV cho một quỹ để bật làm mới tự động.",
+    "toastDeleteInUse": "Không thể xóa quỹ này — nó đang được dùng trong một kế hoạch. Hãy gỡ khỏi kế hoạch trước."
   },
   "planning": {
     "title": "Kế hoạch Tháng",


### PR DESCRIPTION
## What
Funds Library UX audit — **#1 (reversibility)**. Deleting a fund that's referenced by a monthly-plan allocation hit the `monthly_planning.fund_id` **ON DELETE RESTRICT** FK and surfaced as a generic `500 "Failed to delete fund"` — even though the confirm dialog promised a permanent delete. Dead-end with no explanation.

Per the product call (funds drive cash-flow planning), the behaviour is a **hard block with a clear reason**, not a cascade.

## Fix
- **Route** (`DELETE /api/funds/[id]`): map the Postgres FK violation (`23503`) to `409 { code: 'fund_in_use' }`. Atomic and complete — any RESTRICT reference triggers it, no pre-count query / TOCTOU.
- **Both views**: on `409`, show a specific, actionable toast (`toastDeleteInUse` — "remove it from the plan first") and skip the reload, instead of the generic failure toast. Normal `204` deletes are unchanged.

## Tests (TDD)
- **Route** (`route.delete.test.ts`, mocked Supabase): `23503 → 409` (`fund_in_use`), other error → 500, success → 204, missing → 404.
- **Both views** (`*.delete.test.tsx`): a 409 shows the in-use message and does **not** reload; a 204 still reloads + reports success.

`npx vitest run app/(app)/funds app/api/funds` → 25/25 green. New i18n key in `en`/`vi`. Lint: no new errors (2 pre-existing `relDate` purity warnings untouched).

## Notes
- Built in an isolated git worktree off `main`.
- Follow-up (not here): a proactive "used in N plans" count + disabled confirm would need an extra query on dialog open; the reactive 409 message is the robust base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)