### PR TITLE
fix(funds): Esc-to-close + focus trap for the fund dialogs (a11y)

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -7,6 +7,9 @@ import { Plus, RefreshCw, Search, X } from 'lucide-react'
 import { fmtCompact, fmtNav } from '@/lib/formatters'
 import { Skeleton } from '@/app/components/ui/Skeleton'
 import { SyncPill } from '@/app/components/ui/SyncPill'
+// Shared dialog a11y (Esc-to-close + focus trap + focus restore). Lives under
+// the Plan feature today; reused here so Funds dialogs behave the same.
+import { useDialogA11y } from '@/app/(app)/planning/components/useDialogA11y'
 import { FundsEmptyState } from './FundsEmptyState'
 import type { Fund, Goal, FundType, FundsData } from './useFundsData'
 
@@ -72,6 +75,8 @@ const FundIcon = ({ code, type, size = 32 }: { code: string; type: FundType; siz
 function DModal({ open, onClose, title, width = 460, dismissOnBackdrop = true, children }: {
   open: boolean; onClose: () => void; title: string; width?: number; dismissOnBackdrop?: boolean; children: ReactNode
 }) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+  useDialogA11y(dialogRef, open, onClose)
   if (!open) return null
   return (
     <div
@@ -81,6 +86,7 @@ function DModal({ open, onClose, title, width = 460, dismissOnBackdrop = true, c
       style={{ position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)', zIndex: 200, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24, backdropFilter: 'blur(2px)', animation: 'fade-in 150ms ease' }}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         data-testid="fund-modal"
@@ -104,6 +110,8 @@ function DeleteModal({ open, onClose, fundCode, onConfirm, deleting }: {
 }) {
   const t = useTranslations('funds')
   const tc = useTranslations('common')
+  const dialogRef = useRef<HTMLDivElement>(null)
+  useDialogA11y(dialogRef, open, onClose)
   if (!open) return null
   return (
     <div
@@ -111,6 +119,7 @@ function DeleteModal({ open, onClose, fundCode, onConfirm, deleting }: {
       style={{ position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)', zIndex: 200, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24, backdropFilter: 'blur(2px)', animation: 'fade-in 150ms ease' }}
     >
       <div
+        ref={dialogRef}
         role="dialog"
         aria-modal="true"
         data-testid="delete-fund-modal"

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -7,6 +7,9 @@ import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import { Skeleton } from '@/app/components/ui/Skeleton'
 import { SyncPill } from '@/app/components/ui/SyncPill'
 import { fmtNav, fmtCompact } from '@/lib/formatters'
+// Shared dialog a11y (Esc-to-close + focus trap + focus restore). Lives under
+// the Plan feature today; reused here so Funds sheets behave the same.
+import { useDialogA11y } from '@/app/(app)/planning/components/useDialogA11y'
 import { FundsEmptyState } from './FundsEmptyState'
 import type { Fund, Goal, FundType, FundsData } from './useFundsData'
 
@@ -161,6 +164,8 @@ function TypeDropdown({ value, onChange }: { value: FundType; onChange: (v: Fund
 
 function Sheet({ open, onClose, testId, dismissOnBackdrop = true, children }: { open: boolean; onClose: () => void; testId: string; dismissOnBackdrop?: boolean; children: React.ReactNode }) {
   const [mounted, setMounted] = useState(false)
+  const sheetRef = useRef<HTMLDivElement>(null)
+  useDialogA11y(sheetRef, open, onClose)
   useEffect(() => {
     if (open) setMounted(true)
     else { const t = setTimeout(() => setMounted(false), 220); return () => clearTimeout(t) }
@@ -175,6 +180,7 @@ function Sheet({ open, onClose, testId, dismissOnBackdrop = true, children }: { 
       onClick={dismissOnBackdrop ? onClose : undefined}
     >
       <div
+        ref={sheetRef}
         data-testid={testId}
         style={{ width: '100%', background: 'var(--c-card)', borderRadius: '16px 16px 0 0', paddingBottom: 'env(safe-area-inset-bottom,0)', animation: open ? 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' : 'slide-down 180ms ease forwards' }}
         onClick={(e) => e.stopPropagation()}

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.a11y.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.a11y.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DesktopFundLibraryView from '../DesktopFundLibraryView'
+import type { Fund } from '../useFundsData'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+vi.mock('@/lib/formatters', () => ({ fmtNav: (n: number) => String(n), fmtCompact: (n: number) => `${n}` }))
+
+function makeFund(over: Partial<Fund> = {}): Fund {
+  return {
+    id: 'f1', name: 'VFMVF1 Equity Fund', code: 'VFMVF1', fund_type: 'equity', nav: 36120,
+    nav_source_url: null, is_dca: false, dca_monthly_amount_vnd: null, dca_goal_id: null,
+    created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z', ...over,
+  }
+}
+function Harness() {
+  const [funds, setFunds] = useState([makeFund()])
+  return <DesktopFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
+}
+
+beforeEach(() => { vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))) })
+afterEach(() => vi.unstubAllGlobals())
+
+describe('DesktopFundLibraryView — dialog a11y (Esc + focus)', () => {
+  it('Escape closes the Add/Edit form modal', async () => {
+    render(<Harness />)
+    await userEvent.click(screen.getByRole('button', { name: 'add' }))
+    expect(screen.getByTestId('fund-modal')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByTestId('fund-modal')).not.toBeInTheDocument())
+  })
+
+  it('Escape closes the delete modal, and focus moves into it on open', async () => {
+    render(<Harness />)
+    await userEvent.click(screen.getByTestId('fund-delete-btn'))
+    const modal = screen.getByTestId('delete-fund-modal')
+    await waitFor(() => expect(modal.contains(document.activeElement)).toBe(true))
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByTestId('delete-fund-modal')).not.toBeInTheDocument())
+  })
+})

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.a11y.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.a11y.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import MobileFundLibraryView from '../MobileFundLibraryView'
+import type { Fund } from '../useFundsData'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+vi.mock('@/lib/formatters', () => ({ fmtNav: (n: number) => String(n), fmtCompact: (n: number) => `${n}` }))
+vi.mock('@/app/components/navigation/NavigationContext', () => ({ useNavigation: () => ({ setMobileTopBar: vi.fn() }) }))
+
+function makeFund(over: Partial<Fund> = {}): Fund {
+  return {
+    id: 'f1', name: 'VFMVF1 Equity Fund', code: 'VFMVF1', fund_type: 'equity', nav: 36120,
+    nav_source_url: null, is_dca: false, dca_monthly_amount_vnd: null, dca_goal_id: null,
+    created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z', ...over,
+  }
+}
+function Harness() {
+  const [funds, setFunds] = useState([makeFund()])
+  return <MobileFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
+}
+
+beforeEach(() => { vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))) })
+afterEach(() => vi.unstubAllGlobals())
+
+describe('MobileFundLibraryView — sheet a11y (Esc)', () => {
+  it('Escape closes the edit sheet', async () => {
+    render(<Harness />)
+    await userEvent.click(screen.getByLabelText('editFund'))
+    expect(screen.getByTestId('fund-sheet')).toBeInTheDocument()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByTestId('fund-sheet')).not.toBeInTheDocument())
+  })
+})


### PR DESCRIPTION
## What
Funds Library UX audit — **P3 (a11y)**. The Funds modal (`DModal`), delete confirm (`DeleteModal`) and mobile `Sheet` had no keyboard dismissal and no focus management: Escape did nothing and Tab could wander to the page behind the dialog.

## Fix
Wire all three to the shared **`useDialogA11y`** hook (already used by the Plan dialogs), so they:
- close on **Escape**,
- move focus into the dialog on open and **restore** it to the trigger on close,
- **trap** Tab / Shift+Tab inside.

No new hook — reuses the Plan one for consistent behaviour across the app (imported from its current home; a future refactor could relocate it to a shared dir).

Backdrop behaviour is unchanged: form dialogs still don't dismiss on a stray click (#415), delete dialogs still do.

## Tests (TDD)
- Desktop: Escape closes the Add/Edit modal; Escape closes the delete modal and focus moves into it on open.
- Mobile: Escape closes the edit sheet.

`npx vitest run app/(app)/funds` → 21/21 green. Lint: no new errors (2 pre-existing `relDate` purity warnings untouched). Built in an isolated worktree off `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)