### PR TITLE
fix(overview): cut the blocking post-success waits to a brief flash

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -24,6 +24,7 @@ import { isActionableTermDeposit, MATURING_COUNT_EVENT } from '@/lib/maturity'
 import { detectMergeClusters } from '@/lib/mergeCluster'
 import { actionableBooks } from './maturityCardItems'
 import { collapseUnallocatedBooks } from './unallocatedBooks'
+import { SUCCESS_FLASH_MS } from './successFlash'
 import type { InvRow } from './components/goalDetailShared'
 import { loadOverview, overviewErrorText, getCachedOverview, setCachedOverview, computeAllocationTotals } from './overviewData'
 import { fetchNetWorthHistory, type TimeRange, type ChartPoint } from './components/netWorthHistory'
@@ -842,9 +843,10 @@ export default function DashboardClient({ userId }: { userId: string }) {
                             throw new Error(e ?? 'Failed to assign')
                           }
                         }
-                        // Delay refresh so the 1.5s success state in the modal
-                        // stays visible before UnallocatedSection unmounts
-                        setTimeout(() => fetchData({ force: true }), 2000)
+                        // Delay refresh so the success state in the modal stays
+                        // visible before UnallocatedSection unmounts — matched to
+                        // the modal's own flash so the refresh fires as it ends.
+                        setTimeout(() => fetchData({ force: true }), SUCCESS_FLASH_MS)
                       }}
                     />
                   </div>

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -21,6 +21,7 @@ import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X,
 import { fmt, fmtCompact } from '@/lib/formatters'
 import AmountInput from '@/app/components/ui/AmountInput'
 import { iconHit } from './iconHit'
+import { SUCCESS_FLASH_MS } from '../successFlash'
 import { fmtMaturity, type InvRow } from './goalDetailShared'
 import {
   depositMaturityState,
@@ -589,7 +590,7 @@ export function MaturityResolveBody({
         return
       }
       setHeldDone({ anchorName: holdAnchor.name })
-      setTimeout(() => { onRenewed(); onClose() }, 1700)
+      setTimeout(() => { onRenewed(); onClose() }, SUCCESS_FLASH_MS)
     } catch {
       setError(isVi ? 'Lỗi kết nối' : 'Connection error')
       setSaving(false)
@@ -664,7 +665,7 @@ export function MaturityResolveBody({
           ? [...selectedSources.map((s) => s.name), ...selectedHeld.map((h) => h.name ?? (isVi ? 'Sổ chờ gộp' : 'Held deposit'))]
           : [],
       })
-      setTimeout(() => { onRenewed(); onClose() }, 1700)
+      setTimeout(() => { onRenewed(); onClose() }, SUCCESS_FLASH_MS)
     } catch {
       setError(isVi ? 'Lỗi kết nối' : 'Connection error')
       setSaving(false)

--- a/app/assets/components/UnallocatedSection.tsx
+++ b/app/assets/components/UnallocatedSection.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { ChevronDown, ChevronUp, ChevronRight, Target, Building, Coins, TrendingUp, BarChart2, Clock, ArrowDownToLine, ArrowDownRight, ArrowRight, Wallet, Check, X } from 'lucide-react'
 import { iconHit } from './iconHit'
+import { SUCCESS_FLASH_MS } from '../successFlash'
 import { useTranslations } from 'next-intl'
 import { useLocale } from 'next-intl'
 import type { FundBreakdownItem, NonFundUnallocatedItem } from '../DashboardClient'
@@ -223,7 +224,7 @@ export default function UnallocatedSection({
       const goalName = assignGoals.find((g) => g.id === assignSelected)?.name ?? ''
       setAssignSuccessName(goalName)
       setAssignSuccess(true)
-      setTimeout(() => closeAction(), 1500)
+      setTimeout(() => closeAction(), SUCCESS_FLASH_MS)
     } catch (e: unknown) {
       setAssignError(e instanceof Error ? e.message : (isVI ? 'Lỗi kết nối' : 'Connection error'))
     }

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event'
 import { MaturityResolveBody } from '../MaturityResolveSheet'
 import { addMonths, monthsBetween, allocateCumulative } from '@/lib/maturity'
 import { fmt } from '@/lib/formatters'
+import { SUCCESS_FLASH_MS } from '../../successFlash'
 import type { InvRow } from '../goalDetailShared'
 
 // A YYYY-MM-DD string `n` days from today (deterministic regardless of run date).
@@ -671,6 +672,37 @@ describe('MaturityResolveBody', () => {
       await user.click(screen.getByTestId('merge-override-sib-bank'))
       // The compact per-source "received" field is the worst offender (was 13px).
       expect(fontPx(screen.getByTestId('merge-received-sib-bank'))).toBeGreaterThanOrEqual(16)
+    })
+  })
+
+  // ── Success-flash timing ────────────────────────────────────────────────────
+  // After a successful renew the sheet shows a "done" confirmation, then closes
+  // and tells the parent to refresh. That hand-off was a 1.7s wait that read as
+  // the sheet being stuck; it's now a brief SUCCESS_FLASH_MS flash.
+  describe('renew success flash is brief', () => {
+    it('keeps the flash short, then auto-closes + refreshes (was a 1.7s wait)', async () => {
+      const user = userEvent.setup()
+      const onRenewed = vi.fn()
+      const onClose = vi.fn()
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }))
+
+      render(
+        <MaturityResolveBody inv={maturedDeposit} isVi={false} onClose={onClose} onRenewed={onRenewed} onWithdraw={() => {}} />,
+      )
+      await user.click(screen.getByRole('button', { name: /Confirm renewal/i }))
+
+      // The done confirmation shows first; the parent hasn't been told yet.
+      await screen.findByTestId('maturity-renewed')
+      expect(onRenewed).not.toHaveBeenCalled()
+
+      // It closes + refreshes well within ~1s — the old 1.7s wait would still be
+      // pending at this 1.3s deadline, so this fails on a regression back to it.
+      await waitFor(() => expect(onRenewed).toHaveBeenCalledTimes(1), { timeout: 1300 })
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('uses a short, non-blocking flash duration', () => {
+      expect(SUCCESS_FLASH_MS).toBeLessThanOrEqual(1000)
     })
   })
 

--- a/app/assets/successFlash.ts
+++ b/app/assets/successFlash.ts
@@ -1,0 +1,8 @@
+// Duration of the brief "success" confirmation flash before a maturity/assign
+// sheet auto-closes and the dashboard refreshes. Long enough to register the
+// checkmark, short enough that the UI doesn't feel blocked — the previous
+// 1.7–2s waits read as a stall (you'd sit watching a done checkmark, and the
+// dashboard took 2s to reflect an assignment). Kept in one place so the assign
+// flow's modal flash and the dashboard refresh stay coordinated: the refresh
+// fires as the flash ends, so the unallocated row never unmounts mid-animation.
+export const SUCCESS_FLASH_MS = 800


### PR DESCRIPTION
## What

Two spots in the Overview flow made you wait on a *finished* action:

- **Maturity renew / hold** (`MaturityResolveSheet`): after a successful renew the sheet sat on its "done" confirmation for **1.7s** before closing and telling the dashboard to refresh.
- **Desktop goal-assign** (`DashboardClient`): waited **2s** before refreshing the dashboard so an assigned item would update.

Both read as the UI being stuck. This replaces those long waits with a shared `SUCCESS_FLASH_MS` (**800ms**) — long enough to register the checkmark, short enough not to feel blocked.

The assign flow's modal flash (`UnallocatedSection`, was 1.5s) and the dashboard refresh now share the one constant, so the refresh fires *as* the flash ends — the unallocated row never unmounts mid-animation, so **no jank** (the "ưu tiên không giật" requirement).

### Deliberately left as-is
The standalone confirmation modals — `AssignGoalSheet`, `LogInsurancePaymentModal`, `DownloadReportSheet`, `DesktopGoalDetail` sell — keep their own short confirmation flashes; they aren't gating the dashboard, so they're out of this "cut the blocking waits" scope.

## Tests (TDD)

- New `MaturityResolveSheet` test asserts the renew success hands off (closes + refreshes) **well within ~1s** — the old 1.7s wait fails the 1.3s deadline (red → green).
- A guard test pins `SUCCESS_FLASH_MS ≤ 1000ms`.
- Full unit suite green (915). tsc + lint clean for changed files.

Best confirmed by feel on the Vercel preview (renew a deposit / assign an unallocated item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)