### PR TITLE
fix(funds): keyboard-operable sort headers + readable DCA goal select

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -159,16 +159,26 @@ function DeleteModal({ open, onClose, fundCode, onConfirm, deleting }: {
 const SortTh = ({ label, sortKey, active, asc, onSort, align = 'right' }: {
   label: string; sortKey: SortKey; active: boolean; asc: boolean; onSort: (k: SortKey) => void; align?: 'left' | 'right'
 }) => (
+  // The clickable sort target is a real <button> (not a bare th onClick) so it's
+  // keyboard-focusable + Enter/Space-activatable; aria-sort exposes state to AT.
   <th
-    onClick={() => onSort(sortKey)}
-    style={{
-      padding: '10px 12px', textAlign: align,
-      fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase',
-      color: active ? 'var(--c-navy)' : 'var(--c-muted)',
-      cursor: 'pointer', userSelect: 'none', whiteSpace: 'nowrap',
-    }}
+    aria-sort={active ? (asc ? 'ascending' : 'descending') : 'none'}
+    style={{ padding: 0, whiteSpace: 'nowrap' }}
   >
-    {label} {active ? (asc ? '↑' : '↓') : ''}
+    <button
+      type="button"
+      onClick={() => onSort(sortKey)}
+      style={{
+        width: '100%', textAlign: align,
+        padding: '10px 12px', background: 'none', border: 'none',
+        fontSize: 10, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase',
+        color: active ? 'var(--c-navy)' : 'var(--c-muted)',
+        cursor: 'pointer', userSelect: 'none', whiteSpace: 'nowrap',
+        fontFamily: 'inherit',
+      }}
+    >
+      {label} {active ? (asc ? '↑' : '↓') : ''}
+    </button>
   </th>
 )
 
@@ -264,7 +274,9 @@ function DcaToggle({ fund, editId, editValue, toggling, goals, goalLabel, unallo
           style={{
             fontSize: 11, fontWeight: 500, padding: '3px 6px', maxWidth: 120,
             border: '1px solid var(--c-line)', borderRadius: 6,
-            background: 'var(--c-card)', color: 'var(--c-muted)',
+            // --c-ink-2 (not --c-muted): the select holds a real chosen goal, so
+            // it needs readable contrast, not faint placeholder-grey.
+            background: 'var(--c-card)', color: 'var(--c-ink-2)',
             fontFamily: 'inherit', cursor: 'pointer', appearance: 'none', outline: 'none',
           }}
         >

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -423,7 +423,9 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
                 // and getting hard-clipped at the right edge (#363).
                 minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
                 border: '1px solid var(--c-line)', borderRadius: 6,
-                background: 'var(--c-card)', color: 'var(--c-muted)',
+                // --c-ink-2 (not --c-muted): the select holds a real chosen goal, so
+                // it needs readable contrast, not faint placeholder-grey.
+                background: 'var(--c-card)', color: 'var(--c-ink-2)',
                 fontFamily: 'inherit', cursor: 'pointer', appearance: 'none', outline: 'none',
               }}
             >

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.sortheader.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.sortheader.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useState } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DesktopFundLibraryView from '../DesktopFundLibraryView'
+import type { Fund } from '../useFundsData'
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+vi.mock('@/lib/formatters', () => ({ fmtNav: (n: number) => String(n), fmtCompact: (n: number) => `${n}` }))
+
+function makeFund(over: Partial<Fund> = {}): Fund {
+  return {
+    id: 'f1', name: 'Alpha Fund', code: 'AAA', fund_type: 'equity', nav: 100,
+    nav_source_url: null, is_dca: false, dca_monthly_amount_vnd: null, dca_goal_id: null,
+    created_at: '2026-01-01T00:00:00Z', updated_at: '2026-01-01T00:00:00Z', ...over,
+  }
+}
+function Harness() {
+  const [funds, setFunds] = useState([
+    makeFund(),
+    makeFund({ id: 'f2', code: 'BBB', name: 'Beta Fund', nav: 200 }),
+  ])
+  return <DesktopFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
+}
+
+beforeEach(() => { vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))) })
+afterEach(() => vi.unstubAllGlobals())
+
+describe('DesktopFundLibraryView — sortable column headers are keyboard-operable', () => {
+  it('renders the Fund and NAV sort controls as real buttons', () => {
+    render(<Harness />)
+    expect(screen.getByRole('button', { name: /colFund/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /colNav/i })).toBeInTheDocument()
+  })
+
+  it('activating the NAV header sorts by NAV and reflects it via aria-sort', async () => {
+    render(<Harness />)
+    const navBtn = screen.getByRole('button', { name: /colNav/i })
+    await userEvent.click(navBtn)
+    expect(navBtn.closest('th')).toHaveAttribute('aria-sort', 'ascending')
+  })
+})


### PR DESCRIPTION
## What
Final small a11y/polish nits from the Funds Library audit.

1. **Keyboard-operable sort headers (desktop).** The sortable column headers were a bare `<th onClick>` — not focusable, not Enter/Space-activatable. The sort target is now a real `<button>` inside the `th`, and the `th` exposes `aria-sort` (ascending/descending/none) so keyboard and screen-reader users can sort.
2. **Readable DCA goal `<select>` (both views).** It used `--c-muted` — too faint for a control that holds a real chosen goal. Bumped to `--c-ink-2` for proper contrast (defined in both light + dark themes).

## Tests (TDD)
The Fund/NAV headers render as buttons (`getByRole('button')`) and activating the NAV header sets `aria-sort="ascending"`. `npx vitest run app/(app)/funds` → 23/23 green; lint: no new errors.

## Intentionally NOT changed
- **manual-NAV "freshness"**: `updated_at` also moves on a name/type edit, so showing "Updated X ago" for source-less funds would conflate NAV freshness with any edit — kept gated on `nav_source_url`.
- The "two-panel area" wrapper and the "Library" eyebrow: cosmetic only, no user impact.

This closes the Funds Library UX audit (only-gold-type left as won't-fix — zero gold funds in prod and the UI can't create them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)