### PR TITLE
test(settings): consolidate duplicated desktop+mobile E2E into component tests (52→4)

### DIFF
--- a/app/(app)/settings/components/__tests__/DesktopSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/DesktopSettingsView.test.tsx
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DesktopSettingsView from '../DesktopSettingsView'
+
+// Mirrors the MobileSettingsView test setup so both views are covered by fast
+// component tests rather than duplicated desktop+mobile E2E (see the e2e
+// consolidation: only the real round-trips — save→sidebar, Sync→cron — stay E2E).
+
+const { signOutMock, updateUserMock, setUserNameMock, toastErrorMock } = vi.hoisted(() => ({
+  signOutMock: vi.fn().mockResolvedValue({ error: null }),
+  updateUserMock: vi.fn().mockResolvedValue({ data: { user: {} }, error: null }),
+  setUserNameMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+}))
+
+// Resolve real English copy from the message catalog so assertions check the
+// rendered, localized text.
+vi.mock('next-intl', () => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const en = require('../../../../../messages/en.json')
+  const resolve = (ns: string | undefined, key: string) => {
+    const dict = ns ? en[ns] : en
+    return key.split('.').reduce((o: Record<string, unknown> | undefined, k: string) =>
+      (o == null ? undefined : o[k] as Record<string, unknown>), dict) ?? key
+  }
+  return {
+    useTranslations: (ns?: string) => (key: string) => resolve(ns, key),
+    useLocale: () => 'en',
+  }
+})
+
+vi.mock('sonner', () => ({
+  toast: { error: toastErrorMock, success: vi.fn() },
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  useTransition: () => [false, (fn: () => void) => fn()],
+}))
+
+vi.mock('@/app/components/navigation/NavigationContext', () => ({
+  useNavigation: () => ({ setMobileTopBar: vi.fn(), setUserName: setUserNameMock }),
+}))
+
+vi.mock('@/app/components/ThemeProvider', () => ({
+  useTheme: () => ({ theme: 'light', toggleTheme: vi.fn(), setTheme: vi.fn() }),
+}))
+
+vi.mock('@supabase/ssr', () => ({
+  createBrowserClient: () => ({
+    auth: { signOut: signOutMock, updateUser: updateUserMock },
+  }),
+}))
+
+const defaultProps = {
+  email: 'phuong.tran@example.com',
+  initials: 'PT',
+  displayName: 'Phuong',
+}
+
+// ─── Page header ─────────────────────────────────────────────────────────────────
+
+describe('DesktopSettingsView — page header', () => {
+  it('renders the Preferences heading', () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    expect(screen.getByRole('heading', { name: 'Preferences' })).toBeInTheDocument()
+  })
+
+  it('renders the Settings eyebrow/subtitle', () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    expect(screen.getByText('Settings')).toBeInTheDocument()
+  })
+})
+
+// ─── Profile card ────────────────────────────────────────────────────────────────
+
+describe('DesktopSettingsView — profile card', () => {
+  it('renders user display name, email and initials', () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    expect(screen.getByText('Phuong')).toBeInTheDocument()
+    expect(screen.getByText('phuong.tran@example.com')).toBeInTheDocument()
+    // 'Phuong' → single word → 'P'
+    expect(screen.getByText('P')).toBeInTheDocument()
+  })
+
+  it('renders an Edit button on the profile card', () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument()
+  })
+})
+
+// ─── Profile modal ───────────────────────────────────────────────────────────────
+
+describe('DesktopSettingsView — profile modal', () => {
+  it('opens a dialog with name and email prefilled when Edit is clicked', async () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /^edit$/i }))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('Phuong')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('phuong.tran@example.com')).toBeInTheDocument()
+  })
+
+  it('closes the dialog when Cancel is clicked', async () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /^edit$/i }))
+    await userEvent.click(screen.getByRole('button', { name: /^cancel$/i }))
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+
+  it('updates the profile card name and initials after saving', async () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /^edit$/i }))
+    const nameInput = screen.getByDisplayValue('Phuong')
+    await userEvent.clear(nameInput)
+    await userEvent.type(nameInput, 'Minh Phuong')
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+    // After the success flash + close, the card shows the new name + 'MP' initials.
+    await waitFor(() => expect(screen.getByText('Minh Phuong')).toBeInTheDocument(), { timeout: 2000 })
+    expect(screen.getByText('MP')).toBeInTheDocument()
+  })
+
+  it('persists the display name to Supabase and pushes it to NavigationContext', async () => {
+    updateUserMock.mockClear()
+    setUserNameMock.mockClear()
+    // Without the NavigationContext push the desktop sidebar avatar/name stays
+    // stale until a page refresh — this is the propagation the E2E guards too.
+    render(<DesktopSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /^edit$/i }))
+    const nameInput = screen.getByDisplayValue('Phuong')
+    await userEvent.clear(nameInput)
+    await userEvent.type(nameInput, 'Minh')
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+    await waitFor(() => expect(updateUserMock).toHaveBeenCalledWith({ data: { display_name: 'Minh' } }))
+    expect(setUserNameMock).toHaveBeenCalledWith('Minh')
+  })
+
+  it('surfaces a toast and keeps the modal open when the update fails', async () => {
+    toastErrorMock.mockClear()
+    updateUserMock.mockResolvedValueOnce({ data: { user: null }, error: { message: 'nope' } })
+    render(<DesktopSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /^edit$/i }))
+    const nameInput = screen.getByDisplayValue('Phuong')
+    await userEvent.clear(nameInput)
+    await userEvent.type(nameInput, 'Broken')
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }))
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalled())
+    expect(screen.queryByText('Saved')).not.toBeInTheDocument()
+    expect(screen.getByDisplayValue('Broken')).toBeInTheDocument()
+  })
+})
+
+// ─── Preferences — Language & Appearance ─────────────────────────────────────────
+
+describe('DesktopSettingsView — preferences', () => {
+  it('renders the Language label and English / Tiếng Việt pills', () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    expect(screen.getByText('Language')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'English' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Tiếng Việt' })).toBeInTheDocument()
+  })
+
+  it('renders the Appearance label and Light / Dark / System pills', () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    expect(screen.getByText('Appearance')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^light$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^dark$/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /^system$/i })).toBeInTheDocument()
+  })
+
+  it('does not render any Currency control (removed — it was a dead control)', () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    for (const code of ['VND', 'USD', 'EUR']) {
+      expect(screen.queryByRole('button', { name: code })).not.toBeInTheDocument()
+    }
+  })
+})
+
+// ─── Price sync section ──────────────────────────────────────────────────────────
+
+describe('DesktopSettingsView — price sync', () => {
+  it('renders the Price sync heading, Sync now button and Fund NAV / Gold price rows', () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    expect(screen.getByText('Price sync')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /sync now/i })).toBeInTheDocument()
+    expect(screen.getByText(/fund nav/i)).toBeInTheDocument()
+    expect(screen.getByText(/gold price/i)).toBeInTheDocument()
+  })
+
+  it('calls the sync API when Sync now is clicked', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 })
+    )
+    render(<DesktopSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /sync now/i }))
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled())
+    fetchSpy.mockRestore()
+  })
+
+  it('disables the Sync now button while syncing', async () => {
+    let resolve!: () => void
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () => new Promise(res => { resolve = () => res(new Response('{}', { status: 200 })) })
+    )
+    render(<DesktopSettingsView {...defaultProps} />)
+    const btn = screen.getByRole('button', { name: /sync now/i })
+    await userEvent.click(btn)
+    expect(btn).toBeDisabled()
+    resolve()
+    fetchSpy.mockRestore()
+  })
+
+  it('shows a failure status (not "Updated") when a refresh endpoint errors', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{}', { status: 500 })
+    )
+    render(<DesktopSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /sync now/i }))
+    await waitFor(() => expect(screen.getByText(/sync failed/i)).toBeInTheDocument())
+    expect(screen.queryByText(/updated/i)).not.toBeInTheDocument()
+    fetchSpy.mockRestore()
+  })
+})
+
+// ─── Data / Export section ───────────────────────────────────────────────────────
+
+const mockOverviewResponse = {
+  netWorth: { netWorth: 100_000_000, currentValue: 95_000_000, overallProfitLoss: 5_000_000 },
+  goals: [{ id: '1' }, { id: '2' }],
+  unallocated: { totalValue: 0, funds: [], nonFunds: [] },
+  byType: { bank: 0, gold: 0, stock: 0 },
+  insurance: [],
+}
+
+describe('DesktopSettingsView — data section', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () => new Response(JSON.stringify(mockOverviewResponse), { status: 200 })
+    )
+  })
+  afterEach(() => fetchSpy.mockRestore())
+
+  it('renders the Data heading and Export data row', () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    expect(screen.getByText(/^data$/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /export data/i })).toBeInTheDocument()
+  })
+
+  it('opens the download report sheet when Export data is clicked', async () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /export data/i }))
+    expect(screen.getByText(/portfolio report/i)).toBeInTheDocument()
+  })
+})
+
+// ─── Sign out ────────────────────────────────────────────────────────────────────
+
+describe('DesktopSettingsView — sign out', () => {
+  it('renders the Sign out button', () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    expect(screen.getByRole('button', { name: /sign out/i })).toBeInTheDocument()
+  })
+
+  it('calls supabase signOut when Sign out is clicked', async () => {
+    signOutMock.mockClear()
+    render(<DesktopSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /sign out/i }))
+    await waitFor(() => expect(signOutMock).toHaveBeenCalled())
+  })
+})
+
+// ─── Version text ────────────────────────────────────────────────────────────────
+
+describe('DesktopSettingsView — version text', () => {
+  it('renders version info', () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    expect(screen.getByText(/v\d/i)).toBeInTheDocument()
+  })
+})

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -212,6 +212,15 @@ describe('MobileSettingsView — appearance sheet', () => {
     expect(screen.getByRole('button', { name: /apply/i })).toBeInTheDocument()
   })
 
+  it('shows Light, Dark and System options in the appearance sheet', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /appearance/i }))
+    // The current-theme value also renders these labels, so match ≥1 occurrence.
+    expect(screen.getAllByText(/^light$/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/^dark$/i).length).toBeGreaterThan(0)
+    expect(screen.getAllByText(/^system$/i).length).toBeGreaterThan(0)
+  })
+
   it('closes appearance sheet when apply is clicked', async () => {
     render(<MobileSettingsView {...defaultProps} />)
     await userEvent.click(screen.getByRole('button', { name: /appearance/i }))
@@ -280,6 +289,14 @@ describe('MobileSettingsView — data section', () => {
     render(<MobileSettingsView {...defaultProps} />)
     await userEvent.click(screen.getByRole('button', { name: /export data/i }))
     expect(screen.getByText(/portfolio report/i)).toBeInTheDocument()
+  })
+
+  it('offers a single PDF export button and no dead CSV picker', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /export data/i }))
+    expect(screen.getByRole('button', { name: /export report/i })).toBeInTheDocument()
+    // The CSV option was a dead control (always exported PDF) and was removed.
+    expect(screen.queryByRole('button', { name: /^csv$/i })).not.toBeInTheDocument()
   })
 
   it('shows KPI data in report sheet after fetch', async () => {

--- a/e2e/settings-desktop.spec.ts
+++ b/e2e/settings-desktop.spec.ts
@@ -1,6 +1,14 @@
 import { test, expect } from '@playwright/test'
 
-// Desktop viewport — tests the new two-column DesktopSettingsView
+// Desktop viewport — the two-column DesktopSettingsView.
+//
+// Presence/render coverage (headings, profile card, Edit modal prefill/close,
+// language + appearance pills, Currency-removed, Price sync / Data rows, Sign out,
+// version) lives in the fast component test
+// app/(app)/settings/components/__tests__/DesktopSettingsView.test.tsx. Only the two
+// real round-trips that a component test (which mocks Supabase/fetch) cannot prove
+// stay here: a profile save propagating to the live desktop sidebar via
+// NavigationContext, and Sync now hitting the real cron endpoints.
 test.use({ viewport: { width: 1280, height: 800 } })
 
 test.beforeEach(async ({ page }) => {
@@ -9,97 +17,6 @@ test.beforeEach(async ({ page }) => {
   await page.context().addCookies([{ name: 'locale', value: 'en', domain: hostname, path: '/' }])
   await page.goto('/settings')
   await page.waitForLoadState('networkidle')
-})
-
-// ─── Page header ───────────────────────────────────────────────────────────────
-
-test('desktop settings shows Preferences heading', async ({ page }) => {
-  await expect(page.getByRole('heading', { name: 'Preferences' })).toBeVisible()
-})
-
-test('desktop settings shows Settings subtitle', async ({ page }) => {
-  await expect(page.locator('[data-testid="desktop-settings-view"]').locator('text=Settings')).toBeVisible()
-})
-
-// ─── Profile card ──────────────────────────────────────────────────────────────
-
-test('desktop: profile card shows user email', async ({ page }) => {
-  await expect(page.locator('[data-testid="desktop-profile-card"]')).toContainText('@')
-})
-
-test('desktop: Edit button on profile card is visible', async ({ page }) => {
-  await expect(page.getByRole('button', { name: /^edit$/i })).toBeVisible()
-})
-
-test('desktop: clicking Edit opens profile modal', async ({ page }) => {
-  await page.getByRole('button', { name: /^edit$/i }).click()
-  await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5_000 })
-  await expect(page.getByRole('textbox').first()).toBeVisible()
-})
-
-test('desktop: profile modal prefills name and email', async ({ page }) => {
-  await page.getByRole('button', { name: /^edit$/i }).click()
-  await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5_000 })
-  const nameVal = await page.getByRole('textbox').first().inputValue()
-  const emailVal = await page.getByRole('textbox').nth(1).inputValue()
-  expect(nameVal.length).toBeGreaterThan(0)
-  expect(emailVal).toContain('@')
-})
-
-test('desktop: profile modal closes when Cancel is clicked', async ({ page }) => {
-  await page.getByRole('button', { name: /^edit$/i }).click()
-  await expect(page.getByRole('dialog')).toBeVisible({ timeout: 5_000 })
-  await page.getByRole('button', { name: /^cancel$/i }).click()
-  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 5_000 })
-})
-
-// ─── Preferences — Language ────────────────────────────────────────────────────
-
-test('desktop: Language label is visible', async ({ page }) => {
-  await expect(page.locator('[data-testid="desktop-settings-view"]').locator('text=Language')).toBeVisible()
-})
-
-test('desktop: English and Tiếng Việt language pills are visible', async ({ page }) => {
-  await expect(page.getByRole('button', { name: 'English' })).toBeVisible()
-  await expect(page.getByRole('button', { name: 'Tiếng Việt' })).toBeVisible()
-})
-
-// ─── Preferences — Appearance ──────────────────────────────────────────────────
-
-test('desktop: Appearance label is visible', async ({ page }) => {
-  await expect(page.locator('[data-testid="desktop-settings-view"]').locator('text=Appearance')).toBeVisible()
-})
-
-test('desktop: Light, Dark, System appearance pills are visible', async ({ page }) => {
-  await expect(page.getByRole('button', { name: /^light$/i })).toBeVisible()
-  await expect(page.getByRole('button', { name: /^dark$/i })).toBeVisible()
-  await expect(page.getByRole('button', { name: /^system$/i })).toBeVisible()
-})
-
-// ─── Preferences — Currency (removed) ──────────────────────────────────────────
-
-test('desktop: Currency control is removed (was a dead control)', async ({ page }) => {
-  await expect(page.getByRole('button', { name: 'VND' })).toHaveCount(0)
-  await expect(page.getByRole('button', { name: 'USD' })).toHaveCount(0)
-  await expect(page.getByRole('button', { name: 'EUR' })).toHaveCount(0)
-})
-
-// ─── Price sync ────────────────────────────────────────────────────────────────
-
-test('desktop: Price sync section heading is visible', async ({ page }) => {
-  await expect(page.locator('[data-testid="desktop-settings-view"]').locator('text=Price sync')).toBeVisible()
-})
-
-test('desktop: Sync now button is visible', async ({ page }) => {
-  await expect(page.getByRole('button', { name: /sync now/i })).toBeVisible()
-})
-
-test('desktop: Fund NAV row is visible', async ({ page }) => {
-  await expect(page.locator('[data-testid="desktop-settings-view"]').locator('text=Fund NAV')).toBeVisible()
-})
-
-test('desktop: Gold price row is visible', async ({ page }) => {
-  await expect(page.locator('[data-testid="desktop-settings-view"]').locator('text=/gold price/i')).toBeVisible()
 })
 
 test('desktop: clicking Sync now triggers cron API calls', async ({ page }) => {
@@ -111,23 +28,6 @@ test('desktop: clicking Sync now triggers cron API calls', async ({ page }) => {
   await syncResponse
   await expect(page.getByRole('button', { name: /sync now/i })).toBeEnabled({ timeout: 5_000 })
 })
-
-// ─── Data ─────────────────────────────────────────────────────────────────────
-
-test('desktop: Data section heading is visible', async ({ page }) => {
-  await expect(page.locator('[data-testid="desktop-settings-view"]').getByText('Data', { exact: true })).toBeVisible()
-})
-
-test('desktop: Export data row is visible', async ({ page }) => {
-  await expect(page.getByRole('button', { name: /export data/i })).toBeVisible()
-})
-
-test('desktop: clicking Export data opens download report sheet', async ({ page }) => {
-  await page.getByRole('button', { name: /export data/i }).click()
-  await expect(page.locator('text=Portfolio report').first()).toBeVisible({ timeout: 8_000 })
-})
-
-// ─── Profile save propagates to sidebar ────────────────────────────────────────
 
 test('desktop: saving a new name updates the sidebar avatar/name without a refresh', async ({ page }) => {
   const sidebar = page.locator('[data-testid="desktop-sidebar"]')
@@ -148,16 +48,4 @@ test('desktop: saving a new name updates the sidebar avatar/name without a refre
   // Avatar initials reflect the new name ("Sidebar Sync Test" → "SS").
   await expect(sidebar).toContainText('SS')
   expect(before).not.toContain('Sidebar Sync Test')
-})
-
-// ─── Sign out ──────────────────────────────────────────────────────────────────
-
-test('desktop: Sign out button is visible', async ({ page }) => {
-  await expect(page.getByRole('button', { name: /sign out/i })).toBeVisible()
-})
-
-// ─── Version ──────────────────────────────────────────────────────────────────
-
-test('desktop: version text is visible', async ({ page }) => {
-  await expect(page.locator('[data-testid="desktop-settings-view"]').locator('text=/v\\d/')).toBeVisible()
 })

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,6 +1,13 @@
 import { test, expect } from '@playwright/test'
 
-// Settings page uses md:hidden — must run at mobile viewport
+// Settings page uses md:hidden — must run at mobile viewport.
+//
+// Presence/render coverage (every "X is visible", sheet/modal open-close, prefill,
+// localized labels, Currency-removed, etc.) lives in the fast component test
+// app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx. Only the two
+// real round-trips that a component test (which mocks Supabase/fetch) cannot prove
+// stay here: a profile save propagating to the live sidebar via NavigationContext,
+// and Sync now hitting the real cron endpoints.
 test.use({ viewport: { width: 390, height: 844 } })
 
 test.beforeEach(async ({ page }) => {
@@ -10,55 +17,6 @@ test.beforeEach(async ({ page }) => {
   await page.context().addCookies([{ name: 'locale', value: 'en', domain: hostname, path: '/' }])
   await page.goto('/settings')
   await page.waitForLoadState('networkidle')
-})
-
-// ─── Page load ─────────────────────────────────────────────────────────────────
-
-test('settings page loads at /settings', async ({ page }) => {
-  await expect(page).toHaveURL(/settings/)
-})
-
-// ─── Profile card ──────────────────────────────────────────────────────────────
-
-test('profile card is visible', async ({ page }) => {
-  await expect(page.getByRole('button', { name: /profile/i })).toBeVisible()
-})
-
-test('profile card shows user email', async ({ page }) => {
-  const card = page.getByRole('button', { name: /profile/i })
-  // The test user email contains @
-  await expect(card).toContainText('@')
-})
-
-test('profile card shows avatar initials', async ({ page }) => {
-  const card = page.getByRole('button', { name: /profile/i })
-  const text = await card.innerText()
-  // Avatar initials: 1-2 uppercase letters appear somewhere in the card text
-  expect(text).toMatch(/[A-Z]{1,2}/)
-})
-
-// ─── Profile sheet ─────────────────────────────────────────────────────────────
-
-test('clicking profile card opens profile sheet', async ({ page }) => {
-  await page.getByRole('button', { name: /profile/i }).click()
-  await expect(page.getByRole('textbox').first()).toBeVisible({ timeout: 5_000 })
-})
-
-test('profile sheet prefills name and email inputs', async ({ page }) => {
-  await page.getByRole('button', { name: /profile/i }).click()
-  const nameInput = page.getByRole('textbox').first()
-  await expect(nameInput).toBeVisible({ timeout: 5_000 })
-  const nameVal = await nameInput.inputValue()
-  const emailVal = await page.getByRole('textbox').nth(1).inputValue()
-  expect(nameVal.length).toBeGreaterThan(0)
-  expect(emailVal).toContain('@')
-})
-
-test('profile sheet closes when Cancel is clicked', async ({ page }) => {
-  await page.getByRole('button', { name: /profile/i }).click()
-  await expect(page.getByRole('textbox').first()).toBeVisible({ timeout: 5_000 })
-  await page.getByRole('button', { name: /^cancel$/i }).click()
-  await expect(page.getByRole('textbox').first()).not.toBeVisible({ timeout: 5_000 })
 })
 
 test('saving a new display name updates the profile card', async ({ page }) => {
@@ -73,102 +31,6 @@ test('saving a new display name updates the profile card', async ({ page }) => {
   await expect(page.getByRole('button', { name: /profile/i })).toContainText('E2E Test User', { timeout: 5_000 })
 })
 
-// ─── Preferences section ───────────────────────────────────────────────────────
-
-test('Preferences section heading is visible', async ({ page }) => {
-  await expect(page.locator('text=Preferences').first()).toBeVisible()
-})
-
-test('Language row is visible', async ({ page }) => {
-  await expect(page.getByRole('button', { name: /^language$/i })).toBeVisible()
-})
-
-test('Appearance row is visible', async ({ page }) => {
-  await expect(page.getByRole('button', { name: /^appearance$/i })).toBeVisible()
-})
-
-test('Currency row is removed (was a dead control)', async ({ page }) => {
-  await expect(page.getByRole('button', { name: /^currency$/i })).toHaveCount(0)
-})
-
-test('Language row shows current locale', async ({ page }) => {
-  const row = page.getByRole('button', { name: /^language$/i })
-  await expect(row).toContainText('English')
-})
-
-// ─── Appearance sheet ──────────────────────────────────────────────────────────
-
-test('clicking Appearance row opens appearance sheet', async ({ page }) => {
-  await page.getByRole('button', { name: /^appearance$/i }).click()
-  await expect(page.getByRole('button', { name: /^apply$/i })).toBeVisible({ timeout: 5_000 })
-})
-
-test('appearance sheet shows Light, Dark, System options', async ({ page }) => {
-  await page.getByRole('button', { name: /^appearance$/i }).click()
-  await expect(page.locator('text=Light').first()).toBeVisible({ timeout: 5_000 })
-  await expect(page.locator('text=Dark').first()).toBeVisible({ timeout: 5_000 })
-  await expect(page.locator('text=System').first()).toBeVisible({ timeout: 5_000 })
-})
-
-test('clicking Apply closes appearance sheet', async ({ page }) => {
-  await page.getByRole('button', { name: /^appearance$/i }).click()
-  await expect(page.getByRole('button', { name: /^apply$/i })).toBeVisible({ timeout: 5_000 })
-  await page.getByRole('button', { name: /^apply$/i }).click()
-  await expect(page.getByRole('button', { name: /^apply$/i })).not.toBeVisible({ timeout: 5_000 })
-})
-
-// ─── Data / Export section ─────────────────────────────────────────────────────
-
-test('Data section heading is visible', async ({ page }) => {
-  await expect(page.locator('text=Data').first()).toBeVisible()
-})
-
-test('Export data row is visible', async ({ page }) => {
-  await expect(page.getByRole('button', { name: /export data/i })).toBeVisible()
-})
-
-test('clicking Export data opens download report sheet', async ({ page }) => {
-  await page.getByRole('button', { name: /export data/i }).click()
-  await expect(page.locator('text=Portfolio report').first()).toBeVisible({ timeout: 8_000 })
-})
-
-test('download report sheet has an export button (PDF-only, no dead CSV picker)', async ({ page }) => {
-  await page.getByRole('button', { name: /export data/i }).click()
-  await expect(page.locator('text=Portfolio report').first()).toBeVisible({ timeout: 8_000 })
-  await expect(page.getByRole('button', { name: /export report/i })).toBeVisible()
-  // The CSV option was a dead control (always exported PDF) and was removed.
-  await expect(page.getByRole('button', { name: /^csv$/i })).toHaveCount(0)
-})
-
-test('download report sheet closes when X close button is clicked', async ({ page }) => {
-  await page.getByRole('button', { name: /export data/i }).click()
-  await expect(page.locator('text=Portfolio report').first()).toBeVisible({ timeout: 8_000 })
-  await page.getByRole('button', { name: /^close$/i }).click()
-  await expect(page.locator('text=Portfolio report').first()).not.toBeVisible({ timeout: 5_000 })
-})
-
-// ─── Price sync section ────────────────────────────────────────────────────────
-
-test('Price sync section heading is visible', async ({ page }) => {
-  await expect(page.locator('text=Price sync').first()).toBeVisible()
-})
-
-test('Fund NAV row is visible', async ({ page }) => {
-  await expect(page.locator('text=Fund NAV').first()).toBeVisible()
-})
-
-test('Gold price row is visible', async ({ page }) => {
-  await expect(page.locator('text=/gold price/i').first()).toBeVisible()
-})
-
-test('Sync now button is visible', async ({ page }) => {
-  await expect(page.getByRole('button', { name: /sync now/i })).toBeVisible()
-})
-
-test('Last synced info is visible', async ({ page }) => {
-  await expect(page.locator('text=/last synced/i').first()).toBeVisible()
-})
-
 test('clicking Sync now triggers cron API calls', async ({ page }) => {
   // Set up response waiter before click to avoid race condition
   const syncResponse = page.waitForResponse(
@@ -179,16 +41,4 @@ test('clicking Sync now triggers cron API calls', async ({ page }) => {
   await syncResponse
   // Button is re-enabled after sync completes
   await expect(page.getByRole('button', { name: /sync now/i })).toBeEnabled({ timeout: 5_000 })
-})
-
-// ─── Sign out ──────────────────────────────────────────────────────────────────
-
-test('Sign out button is visible', async ({ page }) => {
-  await expect(page.getByRole('button', { name: /sign out/i })).toBeVisible()
-})
-
-// ─── Version text ──────────────────────────────────────────────────────────────
-
-test('version text is visible', async ({ page }) => {
-  await expect(page.locator('text=/v\\d/').first()).toBeVisible()
 })


### PR DESCRIPTION
## Why
Part of the E2E consolidation (follow-up to the test-layering policy in #422). The Settings page was tested twice over: **27 mobile + 21 desktop E2E**, the vast majority being `X is visible` / sheet-opens / prefill **presence checks duplicated across two viewports**. Each E2E spins a real browser and is brittle against DOM/i18n changes — pure cost for coverage a component test gives faster and more robustly.

## What
**Move presence coverage down to Vitest + RTL component tests:**
- **New** `DesktopSettingsView.test.tsx` — the desktop view had **no** component test. Covers page header, profile card + Edit modal (prefill / cancel-close / save-updates-card / persists to Supabase / pushes to NavigationContext / save-failure toast), language + appearance pills, Currency-removed, price-sync rows + sync/disabled/failure states, Data + export sheet, sign out, version text.
- **Gaps filled** in `MobileSettingsView.test.tsx` — appearance sheet Light/Dark/System options; PDF-only export button + no dead CSV picker.

**Slim both E2E specs to only the real round-trips** a mocked component test can't prove:
- profile save → **live sidebar** updates via `NavigationContext` (no refresh)
- `Sync now` → **real** `/api/cron/refresh` endpoints

`settings.spec` 27→2, `settings-desktop` 21→2 — **52→4 E2E**. The kept E2E tests are unchanged verbatim.

## Coverage / verification
- `npx vitest run` → **943 passing** (89 files); the two settings component files = 59 passing.
- `npx eslint` on all 4 changed files → clean.
- `npx playwright test e2e/settings*.spec.ts --list` → the 4 intended round-trip tests.
- Kept E2E tests are byte-identical to before, so no behavioral risk from this change.

## Net effect
~48 browser-driven tests removed from the local E2E run; equivalent coverage now runs in milliseconds at the component layer. First of the consolidation PRs (funds + dashboard to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)