### PR TITLE
fix(settings): ≥44px touch targets for mobile action buttons

### DIFF
--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -179,6 +179,7 @@ function ProfileSheet({ open, onClose, onSave, displayName, email }: {
               aria-label={t('cancel')}
               style={{
                 flex: 1, padding: '10px 0', fontSize: 13, fontWeight: 500,
+                minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center',
                 background: 'var(--c-card)', border: '1px solid var(--c-line)',
                 borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
                 color: 'var(--c-ink)',
@@ -190,6 +191,7 @@ function ProfileSheet({ open, onClose, onSave, displayName, email }: {
               onClick={handleSave}
               style={{
                 flex: 2, padding: '10px 0', fontSize: 13, fontWeight: 600,
+                minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center',
                 background: 'var(--c-btn-primary)', border: 'none',
                 borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
                 color: '#fff',
@@ -265,6 +267,7 @@ function AppearanceSheet({ open, onClose, onApply }: {
         aria-label={t('apply')}
         style={{
           width: '100%', padding: '11px 0', fontSize: 13, fontWeight: 600,
+          minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center',
           background: 'var(--c-btn-primary)', border: 'none',
           borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
           color: '#fff',
@@ -528,6 +531,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
                 aria-label={t('syncNow')}
                 style={{
                   padding: '7px 14px', fontSize: 12, fontWeight: 600,
+                  minHeight: 44, display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
                   background: 'var(--c-btn-primary)', border: 'none', borderRadius: 8,
                   color: '#fff', cursor: syncing ? 'not-allowed' : 'pointer',
                   fontFamily: 'inherit', opacity: syncing ? 0.6 : 1,
@@ -576,7 +580,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
           onClick={handleSignOut}
           aria-label={t('signOut')}
           style={{
-            width: '100%', marginTop: 22, padding: '13px 14px',
+            width: '100%', marginTop: 22, padding: '13px 14px', minHeight: 44,
             background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 10,
             color: 'var(--c-neg)', fontSize: 13, fontWeight: 600,
             display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 8,

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -439,3 +439,57 @@ describe('MobileSettingsView — dialog a11y', () => {
     expect(screen.getByRole('dialog')).toHaveAccessibleName(/profile/i)
   })
 })
+
+// ─── Mobile touch targets (≥44px — WCAG 2.5.5, parity with #410/#413/#416) ───────
+// On a phone these are the primary actions. They previously sat at ~31–42px
+// (small padding + 12–13px text), below the 44px minimum hit area. Assert the
+// inline minHeight floor (jsdom does no layout, so the style is the contract).
+
+describe('MobileSettingsView — touch targets (≥44px)', () => {
+  it('gives the Sync now button a ≥44px touch target', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByRole('button', { name: /sync now/i })).toHaveStyle({ minHeight: '44px' })
+  })
+
+  it('gives the Sign out button a ≥44px touch target', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    expect(screen.getByRole('button', { name: /sign out/i })).toHaveStyle({ minHeight: '44px' })
+  })
+
+  it('gives the profile sheet Save and Cancel buttons a ≥44px touch target', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /profile/i }))
+    expect(screen.getByRole('button', { name: /save/i })).toHaveStyle({ minHeight: '44px' })
+    expect(screen.getByRole('button', { name: /cancel/i })).toHaveStyle({ minHeight: '44px' })
+  })
+
+  it('gives the appearance sheet Apply button a ≥44px touch target', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /appearance/i }))
+    expect(screen.getByRole('button', { name: /apply/i })).toHaveStyle({ minHeight: '44px' })
+  })
+})
+
+describe('MobileSettingsView — export sheet touch targets (≥44px)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      async () => new Response(JSON.stringify(mockOverviewResponse), { status: 200 })
+    )
+  })
+  afterEach(() => fetchSpy.mockRestore())
+
+  it('gives the Export and Cancel buttons a ≥44px touch target', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /export data/i }))
+    expect(screen.getByTestId('export-report-btn')).toHaveStyle({ minHeight: '44px' })
+    expect(screen.getByRole('button', { name: /^cancel$/i })).toHaveStyle({ minHeight: '44px' })
+  })
+
+  it('gives the close button a ≥44px square touch target', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /export data/i }))
+    expect(screen.getByRole('button', { name: /^close$/i }))
+      .toHaveStyle({ minWidth: '44px', minHeight: '44px' })
+  })
+})

--- a/app/assets/components/DownloadReportSheet.tsx
+++ b/app/assets/components/DownloadReportSheet.tsx
@@ -160,6 +160,7 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
                   aria-label="cancel"
                   style={{
                     flex: 1, padding: '11px 0', fontSize: 13, fontWeight: 500,
+                    minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center',
                     background: 'var(--c-card)', border: '1px solid var(--c-line)',
                     borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
                     color: 'var(--c-ink)',
@@ -174,6 +175,7 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
                   aria-label={exporting ? 'exporting' : t.export}
                   style={{
                     flex: 2, padding: '11px 0', fontSize: 13, fontWeight: 600,
+                    minHeight: 44,
                     background: 'var(--c-btn-primary)', border: 'none',
                     borderRadius: 10, color: '#fff',
                     cursor: exporting ? 'default' : 'pointer',
@@ -266,9 +268,8 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
               onClick={onClose}
               aria-label="close"
               style={{
-                padding: 6, background: 'transparent', border: 'none',
+                ...iconHit, background: 'transparent', border: 'none',
                 cursor: 'pointer', color: 'var(--c-muted)', borderRadius: 8,
-                display: 'flex', alignItems: 'center', justifyContent: 'center',
               }}
             >
               <X size={18} />


### PR DESCRIPTION
## What & why

On a phone, the Settings page's primary actions sat **below the WCAG 2.5.5 ≥44×44px** minimum hit area:

- **Sync now** — ~31px tall (`7px` padding + `12px` text)
- **Sign out**, profile **Save/Cancel**, appearance **Apply**, export **Export/Cancel** — ~38–42px
- the export sheet's mobile **close‑X** — an icon‑only ~30px tap target

This is **PR‑2** from the Settings UX audit (PR‑1 was the dialog a11y wire‑up, #424).

## Change

Add a `minHeight: 44` floor (with flex centering so the label stays vertically centered) to the text buttons, and apply the shared `iconHit` helper to the icon‑only close button — the same ≥44px pattern the Plan/Overview a11y passes adopted (#410 / #413 / #416). Purely additive styling; no behaviour, role, or selector changes.

Files:
- `MobileSettingsView.tsx` — Sync now, Sign out, profile Save/Cancel, appearance Apply
- `DownloadReportSheet.tsx` — Export/Cancel buttons + mobile close‑X (shared sheet; 44px is a safe floor on desktop too)

## Tests (TDD)

Wrote failing tests first asserting the inline `minHeight`/`iconHit` floor on each control (jsdom does no layout, so the inline style is the contract), then implemented until green.

- ✅ 47 mobile-settings tests pass (incl. 6 new touch-target tests)
- ✅ Full unit suite: 954 passing
- ✅ Lint baseline unchanged (54 problems before & after — all pre-existing `set-state-in-effect`)
- E2E intentionally **not** run: additive styling only, no selector/DOM-attribute changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)