### PR TITLE
fix(settings): mobile Language row opens a chooser sheet (honest chevron)

### DIFF
--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -279,6 +279,78 @@ function AppearanceSheet({ open, onClose, onApply }: {
   )
 }
 
+// ─── Language sheet ────────────────────────────────────────────────────────────
+// Mirrors AppearanceSheet so the Language row's chevron is honest: it opens a
+// chooser (explicit select + Apply) rather than silently flipping en↔vi on tap.
+
+function LanguageSheet({ open, onClose, onApply, currentLocale }: {
+  open: boolean
+  onClose: () => void
+  onApply: (next: string) => void
+  currentLocale: string
+}) {
+  const t = useTranslations('settings')
+  const [selected, setSelected] = useState(currentLocale)
+
+  useEffect(() => {
+    if (open) setSelected(currentLocale)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  const options = [
+    { v: 'en', label: t('languageEnglish') },
+    { v: 'vi', label: t('languageVietnamese') },
+  ]
+
+  function handleApply() {
+    onApply(selected)
+    onClose()
+  }
+
+  return (
+    <BottomSheet open={open} onClose={onClose} title={t('language')}>
+      <div style={{ display: 'grid', gap: 8, marginBottom: 14 }}>
+        {options.map(opt => (
+          <button
+            key={opt.v}
+            onClick={() => setSelected(opt.v)}
+            style={{
+              width: '100%', textAlign: 'left', padding: '14px 16px', minHeight: 44,
+              background: selected === opt.v ? 'var(--c-navy-tint)' : 'var(--c-card)',
+              border: `1.5px solid ${selected === opt.v ? 'var(--c-navy)' : 'var(--c-line)'}`,
+              borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit',
+              display: 'flex', alignItems: 'center', gap: 12, transition: 'all 120ms',
+            }}
+          >
+            <span style={{ color: selected === opt.v ? 'var(--c-navy)' : 'var(--c-muted)' }}><Globe size={18} /></span>
+            <span style={{ fontSize: 13, fontWeight: 600, color: selected === opt.v ? 'var(--c-navy)' : 'var(--c-ink)', flex: 1 }}>
+              {opt.label}
+            </span>
+            {selected === opt.v && (
+              <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-btn-primary)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                <Check size={12} strokeWidth={2.5} color="#fff" />
+              </div>
+            )}
+          </button>
+        ))}
+      </div>
+      <button
+        onClick={handleApply}
+        aria-label={t('apply')}
+        style={{
+          width: '100%', padding: '11px 0', fontSize: 13, fontWeight: 600,
+          minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center',
+          background: 'var(--c-btn-primary)', border: 'none',
+          borderRadius: 10, cursor: 'pointer', fontFamily: 'inherit',
+          color: '#fff',
+        }}
+      >
+        {t('apply')}
+      </button>
+    </BottomSheet>
+  )
+}
+
 // ─── Settings row ──────────────────────────────────────────────────────────────
 
 function SettingsRow({ icon, label, value, onClick, last = false }: {
@@ -342,6 +414,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
     .join('') || initials
 
   const [showProfile, setShowProfile] = useState(false)
+  const [showLanguage, setShowLanguage] = useState(false)
   const [showAppearance, setShowAppearance] = useState(false)
   const [showReport, setShowReport] = useState(false)
   const [overviewCache, setOverviewCache] = useState<DashboardData | null>(null)
@@ -470,7 +543,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
               icon={<Globe size={16} />}
               label={t('language')}
               value={localeLabel}
-              onClick={() => switchLocale(locale === 'vi' ? 'en' : 'vi')}
+              onClick={() => setShowLanguage(true)}
             />
             <SettingsRow
               icon={<Sun size={16} />}
@@ -605,6 +678,12 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
         onSave={handleSaveProfile}
         displayName={localDisplayName}
         email={email}
+      />
+      <LanguageSheet
+        open={showLanguage}
+        onClose={() => setShowLanguage(false)}
+        onApply={switchLocale}
+        currentLocale={locale}
       />
       <AppearanceSheet
         open={showAppearance}

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -493,3 +493,46 @@ describe('MobileSettingsView — export sheet touch targets (≥44px)', () => {
       .toHaveStyle({ minWidth: '44px', minHeight: '44px' })
   })
 })
+
+// ─── Language chooser (honest chevron) ───────────────────────────────────────────
+// The Language row carries a chevron — the same affordance as Appearance, which
+// opens a chooser. It must actually open a chooser sheet (explicit select +
+// Apply), not silently flip en↔vi on tap. Tapping a row that looks like it opens
+// a picker but instead mutates state is a dishonest affordance.
+
+describe('MobileSettingsView — language chooser', () => {
+  it('opens a labelled chooser sheet with both languages instead of toggling', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /language/i }))
+    // Same pattern as Appearance: a labelled dialog with the options + Apply.
+    expect(screen.getByRole('dialog')).toHaveAccessibleName(/language/i)
+    expect(screen.getByRole('button', { name: 'English' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Tiếng Việt' })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /apply/i })).toBeInTheDocument()
+  })
+
+  it('persists the chosen locale only after Apply (not on row tap or select)', async () => {
+    // Clear any locale cookie left by a prior test so the assertions are clean.
+    document.cookie = 'locale=;path=/;max-age=0'
+    render(<MobileSettingsView {...defaultProps} />)
+
+    // Opening the row alone must not switch the locale…
+    await userEvent.click(screen.getByRole('button', { name: /language/i }))
+    expect(document.cookie).not.toContain('locale=vi')
+
+    // …nor does merely selecting an option…
+    await userEvent.click(screen.getByRole('button', { name: 'Tiếng Việt' }))
+    expect(document.cookie).not.toContain('locale=vi')
+
+    // …only Apply persists the chosen locale.
+    await userEvent.click(screen.getByRole('button', { name: /apply/i }))
+    expect(document.cookie).toContain('locale=vi')
+  })
+
+  it('gives the chooser options and Apply a ≥44px touch target', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /language/i }))
+    expect(screen.getByRole('button', { name: 'English' })).toHaveStyle({ minHeight: '44px' })
+    expect(screen.getByRole('button', { name: /apply/i })).toHaveStyle({ minHeight: '44px' })
+  })
+})


### PR DESCRIPTION
## What & why

The mobile Language row carried a `ChevronRight` — the **same affordance as the Appearance row, which opens a chooser sheet** — but tapping it *silently flipped* en↔vi instead. A row that looks like it opens a picker but quietly mutates state is a dishonest affordance, and it was the only preferences row that behaved that way (Appearance opens a sheet; desktop shows both languages as inline pills).

This is **PR-3** from the Settings UX audit (PR-1 dialog a11y #424, PR-2 touch targets #425).

## Change

Add a `LanguageSheet` that mirrors `AppearanceSheet` (explicit select + Apply), and point the Language row at it. The chevron now tells the truth, and the two preference rows behave identically. The options + Apply carry the ≥44px touch-target floor from PR-2.

Desktop is untouched — it already renders English / Tiếng Việt as inline pills (no chevron).

> Note on apply-model: the sheet uses select-then-Apply to match Appearance exactly. Unifying *all* mobile preferences to instant-apply (and aligning desktop) is the separate, already-planned **PR-4**.

## Tests (TDD)

Failing tests first, asserting the **user-visible outcome**:
- the row opens a labelled chooser dialog with both options + Apply (not a silent toggle)
- the locale is persisted (cookie) **only after Apply** — not on row tap or on select
- the options + Apply meet the ≥44px touch target

then implemented until green.

- ✅ 50 mobile-settings tests pass (incl. 3 new)
- ✅ Full unit suite: 957 passing
- ✅ Lint baseline unchanged (54 problems before & after)
- E2E checked: the settings specs only set the locale cookie directly; nothing depends on the old mobile toggle, so no spec breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)