### PR TITLE
fix(settings): align mobile section order + guard profile form from backdrop dismissal

### DIFF
--- a/app/(app)/settings/components/DesktopSettingsView.tsx
+++ b/app/(app)/settings/components/DesktopSettingsView.tsx
@@ -28,10 +28,11 @@ const SAVE_FLASH_MS = 1400
 
 // ─── Desktop Modal ─────────────────────────────────────────────────────────────
 
-function DModal({ open, onClose, title, children }: {
+function DModal({ open, onClose, title, dismissOnBackdrop = true, children }: {
   open: boolean
   onClose: () => void
   title: string
+  dismissOnBackdrop?: boolean
   children: React.ReactNode
 }) {
   const dialogRef = useRef<HTMLDivElement>(null)
@@ -40,7 +41,9 @@ function DModal({ open, onClose, title, children }: {
   if (!open) return null
   return (
     <div
-      onClick={onClose}
+      // Form modals (the profile editor) opt out of backdrop dismissal so a
+      // stray click doesn't discard a half-typed name. Esc + Cancel still close.
+      onClick={dismissOnBackdrop ? onClose : undefined}
       style={{
         position: 'fixed', inset: 0,
         background: 'rgba(15,23,42,0.4)',
@@ -450,7 +453,7 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
       </div>
 
       {/* ─── Edit profile modal ─────────────────────────────────────────────── */}
-      <DModal open={showProfile} onClose={() => { setShowProfile(false); setProfileSaved(false) }} title={t('profileModalTitle')}>
+      <DModal open={showProfile} onClose={() => { setShowProfile(false); setProfileSaved(false) }} title={t('profileModalTitle')} dismissOnBackdrop={false}>
         {profileSaved ? (
           <div style={{ padding: '28px 0', textAlign: 'center' }}>
             <div style={{ width: 52, height: 52, borderRadius: 26, background: 'var(--c-pos-tint)', color: 'var(--c-pos)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 12px' }}>

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -37,10 +37,11 @@ function readThemeChoice(fallback: ThemeChoice): ThemeChoice {
 
 // ─── Bottom sheet wrapper ──────────────────────────────────────────────────────
 
-function BottomSheet({ open, onClose, title, children }: {
+function BottomSheet({ open, onClose, title, dismissOnBackdrop = true, children }: {
   open: boolean
   onClose: () => void
   title: string
+  dismissOnBackdrop?: boolean
   children: React.ReactNode
 }) {
   const [mounted, setMounted] = useState(false)
@@ -67,7 +68,9 @@ function BottomSheet({ open, onClose, title, children }: {
         zIndex: 150,
         pointerEvents: open ? 'auto' : 'none',
       }}
-      onClick={onClose}
+      // Form sheets (the profile editor) opt out of backdrop dismissal so a
+      // stray tap doesn't discard a half-typed name. Esc + Cancel still close.
+      onClick={dismissOnBackdrop ? onClose : undefined}
     >
       <div
         ref={dialogRef}
@@ -128,7 +131,7 @@ function ProfileSheet({ open, onClose, onSave, displayName, email }: {
   }
 
   return (
-    <BottomSheet open={open} onClose={onClose} title={t('profileModalTitle')}>
+    <BottomSheet open={open} onClose={onClose} title={t('profileModalTitle')} dismissOnBackdrop={false}>
       {saved ? (
         <div style={{ padding: '28px 0', textAlign: 'center' }}>
           <div style={{
@@ -555,21 +558,6 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
           </div>
         </section>
 
-        {/* Data section */}
-        <section style={{ marginTop: 22 }}>
-          <div style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--c-muted)', marginBottom: 8, paddingLeft: 4 }}>
-            {t('data')}
-          </div>
-          <div style={{ background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 16, overflow: 'hidden', boxShadow: 'var(--shadow-card)' }}>
-            <SettingsRow
-              icon={<Download size={16} />}
-              label={t('exportData')}
-              onClick={handleOpenReport}
-              last
-            />
-          </div>
-        </section>
-
         {/* Price sync section */}
         <section style={{ marginTop: 22 }}>
           <div style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--c-muted)', marginBottom: 8, paddingLeft: 4 }}>
@@ -645,6 +633,21 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
                 </div>
               ))}
             </div>
+          </div>
+        </section>
+
+        {/* Data section — after Price sync, matching the desktop right column */}
+        <section style={{ marginTop: 22 }}>
+          <div style={{ fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: 'var(--c-muted)', marginBottom: 8, paddingLeft: 4 }}>
+            {t('data')}
+          </div>
+          <div style={{ background: 'var(--c-card)', border: '1px solid var(--c-line)', borderRadius: 16, overflow: 'hidden', boxShadow: 'var(--shadow-card)' }}>
+            <SettingsRow
+              icon={<Download size={16} />}
+              label={t('exportData')}
+              onClick={handleOpenReport}
+              last
+            />
           </div>
         </section>
 

--- a/app/(app)/settings/components/__tests__/DesktopSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/DesktopSettingsView.test.tsx
@@ -298,4 +298,12 @@ describe('DesktopSettingsView — dialog a11y', () => {
     await userEvent.click(screen.getByRole('button', { name: /^edit$/i }))
     expect(screen.getByRole('dialog')).toHaveAccessibleName(/profile/i)
   })
+
+  it('does NOT close the edit-profile modal on a backdrop click (avoids losing a typed name)', async () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /^edit$/i }))
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(dialog.parentElement as HTMLElement) // the backdrop
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
 })

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -536,3 +536,37 @@ describe('MobileSettingsView — language chooser', () => {
     expect(screen.getByRole('button', { name: /apply/i })).toHaveStyle({ minHeight: '44px' })
   })
 })
+
+// ─── Cross-surface consistency (PR-4) ────────────────────────────────────────────
+
+describe('MobileSettingsView — section order (matches desktop)', () => {
+  it('places the Price sync section before Data', () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    const priceSync = screen.getByText('Price sync')
+    const data = screen.getByText(/^data$/i)
+    // Desktop's right column is Price sync → Data; mobile should read the same.
+    expect(priceSync.compareDocumentPosition(data) & Node.DOCUMENT_POSITION_FOLLOWING)
+      .toBeTruthy()
+  })
+})
+
+describe('MobileSettingsView — profile form backdrop (no accidental data loss)', () => {
+  it('does NOT close the profile sheet on a backdrop tap (avoids losing a typed name)', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /profile/i }))
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(dialog.parentElement as HTMLElement) // the backdrop
+    // Wait past the BottomSheet's 220ms close animation: with backdrop-dismiss
+    // disabled the sheet must still be mounted, not merely mid-close.
+    await new Promise(r => setTimeout(r, 280))
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('still closes the appearance sheet on a backdrop tap (no unsaved input there)', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /appearance/i }))
+    const dialog = screen.getByRole('dialog')
+    fireEvent.click(dialog.parentElement as HTMLElement)
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+  })
+})


### PR DESCRIPTION
## What & why

Two cross-surface consistency fixes — **PR-4** (final item) of the Settings UX audit (after #424 dialog a11y, #425 touch targets, #426 language chooser).

### 1. Section order
Desktop's right column reads **Price sync → Data**, but mobile listed **Data before Price sync**. Reorder mobile to Price sync → Data, so the more-frequently-used control sits higher and the two layouts agree.

### 2. Profile form backdrop dismissal
The edit-profile **modal** (desktop `DModal`) and **sheet** (mobile `BottomSheet`) closed on a backdrop click, silently discarding a half-typed name. Add the `dismissOnBackdrop` prop (default `true`) that Funds adopted in #415, and pass `false` for the profile form on both surfaces. **Esc and Cancel still close it**; the appearance/language choosers keep backdrop-dismiss (they hold no unsaved input).

### Apply-model — deliberately not changed
The audit floated unifying the apply model toward instant. I'm **not** doing that: after PR-3, both mobile preference sheets use this app's standard **select + Apply** pattern (same as every Plan/Funds mobile sheet), so the mobile surface is already self-consistent. Desktop's inline pills are a reasonable form-factor choice (Context over Consistency). Forcing instant-apply would reverse PR-3, diverge from the rest of the app's mobile sheets, and make a mis-tap reload the whole page into another language. Shout if you'd prefer instant and I'll do it as a follow-up.

## Tests (TDD)

Failing tests first, asserting user-visible outcomes:
- mobile Price-sync section precedes Data (document order)
- the profile modal **and** sheet survive a backdrop click (the sheet test waits past the 220ms close animation so it can't false-pass on the closing frame)
- the appearance sheet still backdrop-closes (locks the intended distinction)

then implemented until green.

- ✅ 77 settings tests pass (incl. 4 new)
- ✅ Full unit suite: 961 passing
- ✅ Lint baseline unchanged (54 problems before & after)
- E2E checked: no spec asserts settings section order or clicks a settings backdrop.

## Audit status
This closes the Settings UX audit: PR-1 a11y (#424), PR-2 touch targets (#425), PR-3 language chooser (#426), PR-4 consistency (this). Remaining P3s were intentionally deferred (sign-out confirm, read-only-email hint, version string, export KPI loading state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)