### PR TITLE
fix(settings): read-only email hint + export-sheet KPI loading state (P3 polish)

### DIFF
--- a/app/(app)/settings/components/DesktopSettingsView.tsx
+++ b/app/(app)/settings/components/DesktopSettingsView.tsx
@@ -496,6 +496,9 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
                   fontFamily: 'inherit', outline: 'none', boxSizing: 'border-box',
                 }}
               />
+              <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 6 }}>
+                {t('emailReadonlyHint')}
+              </div>
             </div>
             <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
               <button

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -175,6 +175,9 @@ function ProfileSheet({ open, onClose, onSave, displayName, email }: {
                 outline: 'none',
               }}
             />
+            <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 6 }}>
+              {t('emailReadonlyHint')}
+            </div>
           </div>
           <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
             <button

--- a/app/(app)/settings/components/__tests__/DesktopSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/DesktopSettingsView.test.tsx
@@ -307,3 +307,13 @@ describe('DesktopSettingsView — dialog a11y', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument()
   })
 })
+
+// ─── P3 polish ───────────────────────────────────────────────────────────────────
+
+describe('DesktopSettingsView — profile email hint', () => {
+  it('explains that the read-only email cannot be changed', async () => {
+    render(<DesktopSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /^edit$/i }))
+    expect(screen.getByText(/email can't be changed/i)).toBeInTheDocument()
+  })
+})

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -570,3 +570,27 @@ describe('MobileSettingsView — profile form backdrop (no accidental data loss)
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
   })
 })
+
+// ─── P3 polish ───────────────────────────────────────────────────────────────────
+
+describe('MobileSettingsView — profile email hint', () => {
+  it('explains that the read-only email cannot be changed', async () => {
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /profile/i }))
+    expect(screen.getByText(/email can't be changed/i)).toBeInTheDocument()
+  })
+})
+
+describe('MobileSettingsView — export KPI loading state', () => {
+  it('shows a KPI loading placeholder until the overview resolves', async () => {
+    // Never-resolving fetch: the overview (and last-sync) stay pending, so the
+    // report sheet must render a loading placeholder rather than an empty gap.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(
+      () => new Promise(() => {}) as Promise<Response>
+    )
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /export data/i }))
+    expect(await screen.findByTestId('report-kpi-loading')).toBeInTheDocument()
+    fetchSpy.mockRestore()
+  })
+})

--- a/app/assets/components/DownloadReportSheet.tsx
+++ b/app/assets/components/DownloadReportSheet.tsx
@@ -107,8 +107,9 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
                 <span style={{ fontWeight: 600, color: 'var(--c-ink)' }}>{today}</span>
               </div>
 
-              {/* KPI grid */}
-              {data && (
+              {/* KPI grid — skeleton until the overview resolves, so the sheet
+                  shows a stable placeholder instead of an empty gap. */}
+              {data ? (
                 <div style={{
                   display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)',
                   gap: 1, background: 'var(--c-line)', borderRadius: 12, overflow: 'hidden',
@@ -122,6 +123,23 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
                     <div key={label} style={{ background: 'var(--c-card)', padding: '10px 12px' }}>
                       <div style={{ fontSize: 10, color: 'var(--c-muted)' }}>{label}</div>
                       <div style={{ fontSize: 14, fontWeight: 600, marginTop: 2, color: color ?? 'var(--c-ink)' }}>{value}</div>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                <div
+                  data-testid="report-kpi-loading"
+                  aria-busy="true"
+                  aria-label={isVI ? 'Đang tải số liệu' : 'Loading figures'}
+                  style={{
+                    display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)',
+                    gap: 1, background: 'var(--c-line)', borderRadius: 12, overflow: 'hidden',
+                  }}
+                >
+                  {[0, 1, 2, 3].map((i) => (
+                    <div key={i} style={{ background: 'var(--c-card)', padding: '10px 12px' }}>
+                      <div style={{ height: 8, width: '45%', borderRadius: 4, background: 'var(--c-line)' }} />
+                      <div style={{ height: 12, width: '70%', borderRadius: 4, background: 'var(--c-line)', marginTop: 6 }} />
                     </div>
                   ))}
                 </div>

--- a/messages/en.json
+++ b/messages/en.json
@@ -129,6 +129,7 @@
     "edit": "Edit",
     "fullName": "Full name",
     "email": "Email",
+    "emailReadonlyHint": "Email can't be changed",
     "cancel": "Cancel",
     "save": "Save",
     "saved": "Saved",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -129,6 +129,7 @@
     "edit": "Sửa",
     "fullName": "Họ và tên",
     "email": "Email",
+    "emailReadonlyHint": "Không thể thay đổi email",
     "cancel": "Hủy",
     "save": "Lưu",
     "saved": "Đã lưu",


### PR DESCRIPTION
## What & why

Two small **P3 polish** items from the Settings UX audit (after #424 a11y, #425 touch targets, #426 language chooser, #427 consistency).

### 1. Read-only email hint
The profile form's email field is greyed and non-editable with no explanation. Add a small hint under it — **"Email can't be changed" / "Không thể thay đổi email"** (new `emailReadonlyHint` key) — on both desktop and mobile.

### 2. Export-sheet KPI loading state
The report sheet's net-worth / P-L KPI grid only rendered once the overview fetch resolved, leaving an empty gap until then. Render a **same-shape skeleton** (`aria-busy`) while `data` is null, so the layout stays stable and the wait reads as loading rather than missing. (`DownloadReportSheet` is shared with the dashboard — the skeleton only appears when opened before data is available.)

### Deliberately NOT done (from the P3 list)
- **Sign-out confirmation** — sign-out is *reversible* (just re-login). The principle is "confirm destructive actions"; adding a confirm here would be friction on a non-destructive action.
- **Centralizing the hardcoded version string** — pure refactor, no user-facing change; off-theme for a UX PR.

## Tests (TDD)

Failing tests first:
- the email hint renders in the profile form on **both** desktop and mobile
- the export sheet shows a **KPI loading placeholder** while the overview is pending (never-resolving fetch)

then implemented until green.

- ✅ 80 settings tests pass (incl. 3 new)
- ✅ Full unit suite: 964 passing
- ✅ Lint baseline unchanged (54 problems before & after)
- E2E checked: `report.spec.ts` keys off the generate/export/success testids (untouched) and doesn't assert on the KPI grid; the new `report-kpi-loading` testid + hint text are additive.

## Audit status
With this, the Settings audit is fully closed — 5 PRs (#424–#427 + this). Only intentional non-goals remain (sign-out confirm, version-string refactor), both explained above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)