### PR TITLE
test(planning): consolidate duplicated/calendar-coupled E2E into component tests (17→3)

### DIFF
--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -408,3 +408,75 @@ describe('DesktopPlanningView — insurance Relationship + Default columns', () 
     expect(screen.getAllByText('₫ 1166667').length).toBeGreaterThan(0)
   })
 })
+
+// Layout / header / summary presence — moved off the planning-desktop E2E spec
+// (these were "X is visible" / "shows label" checks running through a browser).
+describe('DesktopPlanningView — header & month picker', () => {
+  it('renders the Monthly Plan title', () => {
+    render(<DesktopPlanningView {...defaultProps} />)
+    expect(screen.getByRole('heading', { name: 'Monthly Plan' })).toBeInTheDocument()
+  })
+
+  it('renders the month picker showing the year, with prev/next that call their handlers', async () => {
+    const onPrev = vi.fn()
+    const onNext = vi.fn()
+    render(<DesktopPlanningView {...defaultProps} month={5} year={2026} onPrev={onPrev} onNext={onNext} />)
+    expect(screen.getByTestId('desktop-month-picker')).toHaveTextContent('2026')
+    await userEvent.click(screen.getByTestId('prev-month'))
+    expect(onPrev).toHaveBeenCalled()
+    await userEvent.click(screen.getByTestId('next-month'))
+    expect(onNext).toHaveBeenCalled()
+  })
+})
+
+describe('DesktopPlanningView — empty state', () => {
+  it('shows the empty state with a Set income button when there is no plan', () => {
+    render(<DesktopPlanningView {...defaultProps} plan={null} />)
+    expect(screen.getByTestId('planning-empty-state')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Set income' })).toBeInTheDocument()
+  })
+})
+
+describe('DesktopPlanningView — summary strip & sections', () => {
+  it('shows the Income / Outflow / Remaining / Saved % strip when a plan exists', () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} />)
+    const strip = within(screen.getByTestId('planning-summary-strip'))
+    expect(strip.getByText('Income')).toBeInTheDocument()
+    expect(strip.getByText('Outflow')).toBeInTheDocument()
+    expect(strip.getByText('Remaining')).toBeInTheDocument()
+    expect(strip.getByText('Saved %')).toBeInTheDocument()
+  })
+
+  it('computes Remaining as income minus outflow (20M − 3M = 17.0M)', () => {
+    render(
+      <DesktopPlanningView
+        {...defaultProps}
+        plan={{ id: 'plan-1', month: 5, year: 2026, salary_vnd: 20_000_000 }}
+        fixedExpenses={[{ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 3_000_000 }]}
+      />,
+    )
+    // fmtCompact mock renders millions as "<n>.0M ₫".
+    expect(within(screen.getByTestId('planning-summary-strip')).getByText('17.0M ₫')).toBeInTheDocument()
+  })
+
+  it('renders line-item amounts in full (fmt), not abbreviated (fmtCompact)', () => {
+    render(
+      <DesktopPlanningView
+        {...defaultProps}
+        plan={basePlan}
+        fixedExpenses={[{ expense_id: 'fe1', expense_name: 'E2E Full Amount Rent', amount_vnd: 7_250_000 }]}
+      />,
+    )
+    // The line item uses fmt → "₫ 7250000" (full). (The dense alloc card
+    // legitimately shows the same total compact, so we don't assert "7.3M ₫"
+    // is absent page-wide — only that the full line-item amount is rendered.)
+    expect(screen.getAllByText('₫ 7250000').length).toBeGreaterThan(0)
+  })
+
+  it('shows the By goal / Fixed expenses / Insurance section headers when a plan exists', () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getByText('By goal')).toBeInTheDocument()
+    expect(screen.getByText('Fixed expenses')).toBeInTheDocument()
+    expect(screen.getByText('Insurance')).toBeInTheDocument()
+  })
+})

--- a/e2e/planning-desktop.spec.ts
+++ b/e2e/planning-desktop.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import * as api from './helpers/api'
 import { makeCleanupStack } from './helpers/cleanup'
 
@@ -11,138 +11,17 @@ test.afterEach(() => cleanup.run())
 const today = new Date()
 const MONTH = today.getMonth() + 1
 const YEAR = today.getFullYear()
-const PREV_YEAR = MONTH === 1 ? YEAR - 1 : YEAR
 
-async function goto(page: Page) {
-  await page.goto('/planning')
-  await page.waitForLoadState('networkidle')
-}
-
-// ─── Layout ────────────────────────────────────────────────────────────────────
-
-test('desktop planning: DTopBar shows Monthly Plan title', async ({ page }) => {
-  await goto(page)
-  const desktop = page.getByTestId('desktop-planning')
-  await expect(desktop).toBeVisible()
-  await expect(desktop.getByText(/Monthly Plan|Kế hoạch Tháng/i).first()).toBeVisible({ timeout: 5_000 })
-})
-
-test('desktop planning: month picker is visible', async ({ page }) => {
-  await goto(page)
-  const desktop = page.getByTestId('desktop-planning')
-  await expect(desktop.getByTestId('desktop-month-picker')).toBeVisible()
-  await expect(desktop.getByTestId('prev-month')).toBeVisible()
-  await expect(desktop.getByTestId('next-month')).toBeVisible()
-  // Picker shows current year
-  await expect(desktop.getByTestId('desktop-month-picker')).toContainText(String(YEAR))
-})
-
-// ─── Navigation ───────────────────────────────────────────────────────────────
-
-test('desktop planning: prev/next month buttons update displayed month', async ({ page }) => {
-  await goto(page)
-  const picker = page.getByTestId('desktop-month-picker')
-
-  await page.getByTestId('prev-month').click()
-  await page.waitForTimeout(300)
-  // Prev-month year (may differ on January)
-  await expect(picker).toContainText(String(PREV_YEAR))
-
-  await page.getByTestId('next-month').click()
-  await page.waitForTimeout(300)
-  await expect(picker).toContainText(String(YEAR))
-})
-
-// ─── Empty state ──────────────────────────────────────────────────────────────
-
-test('desktop planning: empty state has Set-income button for month without plan', async ({ page }) => {
-  await goto(page)
-  const desktop = page.getByTestId('desktop-planning')
-
-  // Navigate far back to a month that almost certainly has no plan
-  for (let i = 0; i < 6; i++) {
-    await desktop.getByTestId('prev-month').click()
-    await page.waitForTimeout(150)
-  }
-  await page.waitForTimeout(500)
-
-  const emptyState = desktop.getByTestId('planning-empty-state')
-  if (await emptyState.isVisible({ timeout: 4_000 })) {
-    await expect(emptyState.getByRole('button', { name: /Set income|Thêm thu nhập/i })).toBeVisible()
-  }
-})
-
-// ─── With plan ────────────────────────────────────────────────────────────────
-
-test('desktop planning: summary strip shows Income / Outflow / Remaining when plan exists', async ({ page }) => {
-  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
-  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
-
-  await goto(page)
-  const desktop = page.getByTestId('desktop-planning')
-  const strip = desktop.getByTestId('planning-summary-strip')
-
-  await expect(strip).toBeVisible({ timeout: 8_000 })
-  await expect(strip.getByText(/Income|Thu nhập/i).first()).toBeVisible()
-  await expect(strip.getByText(/Outflow|Tổng chi/i).first()).toBeVisible()
-  await expect(strip.getByText(/Remaining|Còn lại/i).first()).toBeVisible()
-})
-
-test('desktop planning: line-item amounts are shown in full, not abbreviated', async ({ page }) => {
-  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
-  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
-  // A non-round amount so compact (7.3M) and full (7.250.000) are clearly distinct
-  const fe = await api.createFixedExpense({ expense_name: 'E2E Full Amount Rent', amount_vnd: 7_250_000, category: 'Housing' })
-  cleanup.add(() => api.deleteFixedExpense(fe.expense_id))
-
-  await goto(page)
-  const desktop = page.getByTestId('desktop-planning')
-  await expect(desktop.getByText('E2E Full Amount Rent')).toBeVisible({ timeout: 8_000 })
-
-  // Scope to the fixed-expense row: the line item renders the exact amount
-  // "7.250.000" (vi-VN grouping), never the shortened "7.3M". (The dense
-  // allocation card legitimately shows the same total compact, so we must not
-  // assert "7.3M" is absent page-wide.)
-  const row = desktop.getByRole('row', { name: /E2E Full Amount Rent/ })
-  await expect(row.getByText('7.250.000')).toBeVisible()
-  await expect(row.getByText(/7[.,]3M/)).toHaveCount(0)
-})
-
-test('desktop planning: allocation card is visible in right panel', async ({ page }) => {
-  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
-  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
-
-  await goto(page)
-  const desktop = page.getByTestId('desktop-planning')
-  await expect(desktop.getByTestId('planning-alloc-card')).toBeVisible({ timeout: 8_000 })
-})
-
-test('desktop planning: collapsible sections visible when plan exists', async ({ page }) => {
-  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
-  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
-
-  await goto(page)
-  await page.waitForLoadState('networkidle')
-  const desktop = page.getByTestId('desktop-planning')
-
-  await expect(desktop.getByText(/By goal|Theo mục tiêu/i).first()).toBeVisible({ timeout: 8_000 })
-  await expect(desktop.getByText(/Fixed expenses|Chi phí cố định/i).first()).toBeVisible()
-  await expect(desktop.getByText(/Insurance|Bảo hiểm/i).first()).toBeVisible()
-})
-
-test('desktop planning: Manage savings opens the recurring-saving manager', async ({ page }) => {
-  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
-  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
-
-  await goto(page)
-  const desktop = page.getByTestId('desktop-planning')
-
-  await desktop.getByTestId('desktop-manage-savings').click()
-  // Manager renders its list view (Add button) regardless of how many rules exist
-  await expect(page.getByTestId('recurring-saving-manager')).toBeVisible({ timeout: 8_000 })
-  await expect(page.getByTestId('rs-add')).toBeVisible()
-})
-
+// Presence/render coverage (DTopBar title, month picker + prev/next, empty state,
+// summary strip Income/Outflow/Remaining + the remaining = income − outflow math,
+// line-item full-vs-compact amounts, By goal / Fixed expenses / Insurance sections,
+// allocation card, Manage savings opens the manager) lives in the fast component test
+// app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx.
+//
+// Only this one stays E2E: a real DCA fund seeded under its goal (the goal_id fix)
+// must group correctly AND its Record-buy must open the canonical Add-Transaction
+// sheet — a data-driven, cross-component round-trip a single-view component test
+// can't reproduce.
 test('desktop planning: a DCA fund is grouped under its goal with a Buy action and contributed footer', async ({ page }) => {
   const goal = await api.createGoal({ goal_name: `E2E DCA Goal ${Date.now()}` })
   cleanup.add(() => api.deleteGoal(goal.goal_id))
@@ -154,7 +33,8 @@ test('desktop planning: a DCA fund is grouped under its goal with a Buy action a
   const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
   cleanup.add(() => api.deleteMonthlyPlan(plan.id))
 
-  await goto(page)
+  await page.goto('/planning')
+  await page.waitForLoadState('networkidle')
   const desktop = page.getByTestId('desktop-planning')
 
   // The DCA fund is seeded under its goal (goal_id fix) and shows a Record buy pill.

--- a/e2e/planning.spec.ts
+++ b/e2e/planning.spec.ts
@@ -5,17 +5,19 @@ import { makeCleanupStack } from './helpers/cleanup'
 const cleanup = makeCleanupStack()
 test.afterEach(() => cleanup.run())
 
+// Presence/render coverage (month heading, summary strip, allocation card, line-item
+// full vs compact amounts, sections, Manage savings, override) lives in the fast
+// component tests:
+//   app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+//   app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+// Only the two real round-trips a component test (which renders the view from given
+// props) can't prove stay here: creating a plan via the salary input (POST →
+// re-render), and month navigation that refetches a different month's data.
+
 const today = new Date()
 const MONTH = today.getMonth() + 1
 const YEAR = today.getFullYear()
 const NEXT_YEAR = MONTH === 12 ? YEAR + 1 : YEAR
-
-test('planning page shows current month and year heading', async ({ page }) => {
-  await page.goto('/planning')
-  await page.waitForLoadState('networkidle')
-  // Month heading should contain the current year (scoped to desktop view to avoid md:hidden mobile duplicate)
-  await expect(page.getByTestId('desktop-planning').locator(`text=${YEAR}`).first()).toBeVisible({ timeout: 10_000 })
-})
 
 test('create monthly plan by entering salary', async ({ page }) => {
   // Delete any existing plan for this month first
@@ -57,95 +59,4 @@ test('can navigate to previous and next month', async ({ page }) => {
   await expect(desktop.locator(`text=${NEXT_YEAR}`).or(desktop.locator(`text=${YEAR}`)).first()).toBeVisible()
 
   void initialText
-})
-
-test('allocation summary shows salary when plan exists', async ({ page }) => {
-  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
-  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
-
-  await page.goto('/planning')
-  await page.waitForLoadState('networkidle')
-
-  // AllocationSummary shows salary — look for the formatted value (scoped to desktop view)
-  await expect(page.getByTestId('desktop-planning').locator('text=/30|lương|salary/i').first()).toBeVisible({ timeout: 10_000 })
-})
-
-test('remaining amount updates when fixed expense is added', async ({ page }) => {
-  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 20_000_000 })
-  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
-
-  const expense = await api.createFixedExpense({
-    expense_name: 'E2E Planning Expense',
-    amount_vnd: 3_000_000,
-    category: 'Housing',
-  })
-  cleanup.add(() => api.deleteFixedExpense(expense.expense_id))
-
-  await page.goto('/planning')
-  await page.waitForLoadState('networkidle')
-
-  // Remaining should reflect salary minus expense
-  // 20,000,000 - 3,000,000 = 17,000,000
-  await expect(page.locator('text=/17|còn lại|remaining/i').first()).toBeVisible({ timeout: 10_000 })
-})
-
-test('remaining amount updates when fund investment is added', async ({ page }) => {
-  const fund = await api.getFirstFund()
-  if (!fund) test.skip()
-
-  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 20_000_000 })
-  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
-
-  await page.goto('/planning')
-  await page.waitForLoadState('networkidle')
-
-  // Find the fund investments section and add button
-  const addInvestBtn = page.getByRole('button', { name: /add|thêm/i }).first()
-  if (await addInvestBtn.isVisible({ timeout: 3_000 })) {
-    await addInvestBtn.click()
-    await page.waitForTimeout(500)
-    // Fill in investment details if a form/modal appeared
-    const amountInput = page.getByLabel(/amount|số tiền/i).first()
-    if (await amountInput.isVisible()) {
-      await amountInput.fill('5000000')
-      await page.getByRole('button', { name: /save|lưu/i }).first().click()
-      await page.waitForTimeout(1_500)
-    }
-  }
-  // Remaining should have decreased (or allocation summary updated)
-  await expect(page.locator('text=/15|còn lại|remaining/i').first().or(
-    page.locator('[class*="summary"]').first()
-  )).toBeVisible({ timeout: 10_000 })
-})
-
-test('override a fixed expense amount on Monthly Plan', async ({ page }) => {
-  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 20_000_000 })
-  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
-
-  const expense = await api.createFixedExpense({
-    expense_name: 'E2E Override Expense',
-    amount_vnd: 3_000_000,
-    category: 'Housing',
-  })
-  cleanup.add(() => api.deleteFixedExpense(expense.expense_id))
-
-  await page.goto('/planning')
-  await page.waitForLoadState('networkidle')
-
-  // Find the expense row and click override (scoped to desktop view)
-  const expenseRow = page.getByTestId('desktop-planning').locator('text=E2E Override Expense').first()
-  await expect(expenseRow).toBeVisible({ timeout: 10_000 })
-
-  const overrideBtn = expenseRow.locator('..').locator('..').getByRole('button', { name: /override|edit|sửa/i }).first()
-  if (await overrideBtn.isVisible({ timeout: 3_000 })) {
-    await overrideBtn.click()
-    const overrideInput = page.getByLabel(/amount|số tiền|override/i).first()
-    if (await overrideInput.isVisible()) {
-      await overrideInput.fill('4000000')
-      await page.getByRole('button', { name: /save|lưu/i }).first().click()
-      await page.waitForTimeout(1_000)
-    }
-  }
-  // Just verify the page is still functional after override
-  await expect(page.getByTestId('desktop-planning').locator('text=E2E Override Expense').first()).toBeVisible()
 })


### PR DESCRIPTION
## Why
Continuing the E2E consolidation (policy #422; settings #423, funds #428). The Plan page had **two E2E specs (7 + 10)** that were near-duplicates of each other and of the already-rich component suites (`DesktopPlanningView` 26 cases + `MobilePlanningView` 62) — mostly "X is visible" / "shows label" presence checks running through a browser. Several also keyed off the **real calendar** (current month/year), so they drift as the date moves — exactly the brittleness the policy calls out.

## What
**Add 7 cases to `DesktopPlanningView.test.tsx`** for the gaps the E2E held (all rendered from props, no browser):
- DTopBar **Monthly Plan** title
- **month picker** + prev/next call their handlers
- **empty state** + Set-income button (no plan)
- summary strip **Income / Outflow / Remaining / Saved %**
- the **remaining = income − outflow** arithmetic (20M − 3M = 17.0M)
- line-item **full (`fmt`) vs compact (`fmtCompact`)** amounts
- **By goal / Fixed expenses / Insurance** section headers

(Allocation card + Manage-savings-opens-manager were already covered.)

**Keep as E2E** only what a from-props component test can't prove:
- create a plan via the salary input (POST → re-render)
- month navigation that **refetches** a different month's data
- a real **DCA fund seeded under its goal** grouping correctly + its Record-buy opening the canonical Add-Transaction sheet (data-driven cross-component round-trip; guards the goal_id regression)

`planning.spec` 7→2, `planning-desktop` 10→1 — **17→3 E2E**. Kept tests unchanged verbatim.

## Coverage / verification
- `npx vitest run` → **996 passing** (91 files); `DesktopPlanningView.test.tsx` = 33 passing (26 + 7 new).
- `npx eslint` on the 3 changed files → clean.
- Removing the calendar-coupled presence specs also kills a class of date-drift flakes (the old `current month and year heading` etc.).

## Net effect (running total)
settings + funds + planning = **108 → 17 E2E** (~91 browser-driven tests removed), coverage moved to component/lib running in milliseconds. Dashboard remains as the last candidate (keeps genuinely viewport-specific cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)