### PR TITLE
fix(planning): desktop income edit uses PUT, not PATCH (405)

### DIFF
--- a/app/(app)/planning/__tests__/PlanningClient.test.tsx
+++ b/app/(app)/planning/__tests__/PlanningClient.test.tsx
@@ -113,7 +113,7 @@ describe('PlanningClient — toast delivery', () => {
       if (u.includes('/api/v1/monthly-plans?')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve(FULL_PLAN) })
       }
-      // PATCH the income update.
+      // PUT the income update.
       return Promise.resolve({ ok: true, json: () => Promise.resolve(FULL_PLAN) })
     })
     vi.stubGlobal('fetch', fetchMock)
@@ -129,6 +129,41 @@ describe('PlanningClient — toast delivery', () => {
       await userEvent.click(within(desktop).getByRole('button', { name: 'Save' }))
       // The dead-sink bug meant toast was never called; now it reaches sonner.
       await waitFor(() => expect(toastMock).toHaveBeenCalled())
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  // Regression: desktop edited income via PATCH, but /api/v1/monthly-plans/[id]
+  // only handles PUT (no PATCH export → Next.js returns 405). The save then
+  // failed silently with the error toast. Mobile already used PUT — this pins
+  // desktop to the same method so both views hit a real handler.
+  it('updates an existing plan with PUT (not PATCH → 405) from the desktop income editor', async () => {
+    const fetchMock = vi.fn((url: string) => {
+      const u = String(url)
+      if (u.includes('/api/v1/monthly-plans?')) {
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(FULL_PLAN) })
+      }
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(FULL_PLAN) })
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    try {
+      render(<PlanningClient />)
+      const desktop = screen.getByTestId('desktop-planning')
+      const editBtn = await within(desktop).findByRole('button', { name: 'Edit income' })
+      await userEvent.click(editBtn)
+      const input = await within(desktop).findByPlaceholderText('e.g. 45,000,000')
+      await userEvent.clear(input)
+      await userEvent.type(input, '50000000')
+      await userEvent.click(within(desktop).getByRole('button', { name: 'Save' }))
+
+      await waitFor(() => {
+        const updateCall = fetchMock.mock.calls.find(
+          ([u, opts]) => String(u) === `/api/v1/monthly-plans/${FULL_PLAN.id}` && opts,
+        )
+        expect(updateCall).toBeTruthy()
+        expect((updateCall![1] as RequestInit).method).toBe('PUT')
+      })
     } finally {
       vi.unstubAllGlobals()
     }

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -546,7 +546,7 @@ export default function DesktopPlanningView({
     try {
       if (plan) {
         const res = await fetch(`/api/v1/monthly-plans/${plan.id}`, {
-          method: 'PATCH',
+          method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ salary_vnd: num }),
         })


### PR DESCRIPTION
## Problem
`PATCH /api/v1/monthly-plans/[id]` returns **405 Method Not Allowed**. The route (`app/api/v1/monthly-plans/[id]/route.ts`) only exports `GET`/`PUT`/`DELETE`, so Next.js App Router auto-rejects `PATCH`.

The desktop income editor (`DesktopPlanningView.tsx`) was the only caller using `PATCH` for the income update on an **existing** plan — so saving income on desktop failed silently with the error toast. The mobile view already used `PUT` correctly; this was a desktop↔mobile parity gap.

## Fix
- `DesktopPlanningView`: `PATCH` → `PUT` on the existing-plan income update (matches the route + mobile).

## Test (TDD)
- Added a `PlanningClient` regression test asserting the desktop "Save income" click issues a **`PUT`** to `/api/v1/monthly-plans/{id}`. Confirmed **red** against the old code (`Received: "PATCH"`), **green** after the fix.
- The pre-existing toast test used a catch-all fetch mock that ignored the HTTP method, so it never caught this — the new test pins the method explicitly.

## Checks
- `npx vitest --run app/(app)/planning/__tests__/PlanningClient.test.tsx` → 6 passed
- `npm run lint` → no issues in changed files (pre-existing repo lint noise unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)