### PR TITLE
fix(funds): steady NAV-age label — Date.now() out of render

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -11,6 +11,7 @@ import { SyncPill } from '@/app/components/ui/SyncPill'
 // the Plan feature today; reused here so Funds dialogs behave the same.
 import { useDialogA11y } from '@/app/(app)/planning/components/useDialogA11y'
 import { FundsEmptyState } from './FundsEmptyState'
+import { FundNavAge } from './FundNavAge'
 import type { Fund, Goal, FundType, FundsData } from './useFundsData'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -348,16 +349,6 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
     setToasts(p => [...p, { id, msg, ok }])
     setTimeout(() => setToasts(p => p.filter(t => t.id !== id)), 3000)
   }, [])
-
-  // Relative NAV age per fund (#9) — same buckets as the mobile card.
-  const relDate = (str: string) => {
-    const mins = Math.floor((Date.now() - new Date(str).getTime()) / 60000)
-    if (mins < 1) return t('relJustNow')
-    if (mins < 60) return t('relMinutes', { m: mins })
-    const h = Math.floor(mins / 60)
-    if (h < 24) return t('relHours', { h })
-    return t('relDays', { d: Math.floor(h / 24) })
-  }
 
   // Sorting
   const handleSort = (key: SortKey) => {
@@ -713,9 +704,7 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
                           {fmtNav(fund.nav)}
                         </span>
                         {fund.nav_source_url && fund.updated_at && (
-                          <div style={{ fontSize: 10, color: 'var(--c-muted)', marginTop: 2 }}>
-                            {t('updatedAgo', { time: relDate(fund.updated_at) })}
-                          </div>
+                          <FundNavAge isoStr={fund.updated_at} style={{ fontSize: 10, color: 'var(--c-muted)', marginTop: 2 }} />
                         )}
                       </td>
 

--- a/app/(app)/funds/components/FundNavAge.tsx
+++ b/app/(app)/funds/components/FundNavAge.tsx
@@ -21,15 +21,6 @@ type Bucket =
   | { kind: 'hour'; h: number }
   | { kind: 'day'; d: number }
 
-function format(b: Bucket, t: (k: string, p?: Record<string, unknown>) => string): string {
-  switch (b.kind) {
-    case 'justNow': return t('relJustNow')
-    case 'min': return t('relMinutes', { m: b.m })
-    case 'hour': return t('relHours', { h: b.h })
-    case 'day': return t('relDays', { d: b.d })
-  }
-}
-
 export function FundNavAge({ isoStr, style }: { isoStr: string; style?: React.CSSProperties }) {
   const t = useTranslations('funds')
   const [bucket, setBucket] = useState<Bucket | null>(null)
@@ -54,5 +45,14 @@ export function FundNavAge({ isoStr, style }: { isoStr: string; style?: React.CS
     setBucket(next)
   }, [isoStr])
   if (!bucket) return null
-  return <div style={style}>{t('updatedAgo', { time: format(bucket, t) })}</div>
+  // Translation is applied in render from the stored bucket (so `t`'s changing
+  // identity isn't an effect dependency); `format` is inlined here rather than
+  // typed separately to keep next-intl's Translator type inferred.
+  const time =
+    bucket.kind === 'justNow' ? t('relJustNow')
+      : bucket.kind === 'min' ? t('relMinutes', { m: bucket.m })
+        : bucket.kind === 'hour' ? t('relHours', { h: bucket.h })
+          : t('relDays', { d: bucket.d })
+  return <div style={style}>{t('updatedAgo', { time })}</div>
 }
+

--- a/app/(app)/funds/components/FundNavAge.tsx
+++ b/app/(app)/funds/components/FundNavAge.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useTranslations } from 'next-intl'
+
+// "Updated {time} ago" line shown under a fund's NAV. The relative bucket is
+// computed ONCE per `isoStr`, inside an effect — never during render — so:
+//   • Date.now() is read after paint, satisfying react-hooks/purity (the old
+//     relDate() called it in the render body → lint error + non-deterministic).
+//   • the label stays steady across parent re-renders: previously every render
+//     recomputed the bucket with a newer Date.now(), so the "Updated Xm ago"
+//     line drifted even though updated_at was unchanged.
+// `isoStr` is required (callers gate on `fund.updated_at` before rendering).
+// Translation (t) is applied in render from the stored bucket, so the effect's
+// only dependency is `isoStr` — `t`'s identity is NOT in the dep list (next-intl
+// and the test mock both return a fresh function per render, which would otherwise
+// re-run the effect on every parent re-render and re-read Date.now()).
+type Bucket =
+  | { kind: 'justNow' }
+  | { kind: 'min'; m: number }
+  | { kind: 'hour'; h: number }
+  | { kind: 'day'; d: number }
+
+function format(b: Bucket, t: (k: string, p?: Record<string, unknown>) => string): string {
+  switch (b.kind) {
+    case 'justNow': return t('relJustNow')
+    case 'min': return t('relMinutes', { m: b.m })
+    case 'hour': return t('relHours', { h: b.h })
+    case 'day': return t('relDays', { d: b.d })
+  }
+}
+
+export function FundNavAge({ isoStr, style }: { isoStr: string; style?: React.CSSProperties }) {
+  const t = useTranslations('funds')
+  const [bucket, setBucket] = useState<Bucket | null>(null)
+  useEffect(() => {
+    const diff = Date.now() - new Date(isoStr).getTime()
+    const mins = Math.floor(diff / 60000)
+    let next: Bucket
+    if (mins < 1) next = { kind: 'justNow' }
+    else if (mins < 60) next = { kind: 'min', m: mins }
+    else {
+      const h = Math.floor(mins / 60)
+      next = h < 24 ? { kind: 'hour', h } : { kind: 'day', d: Math.floor(h / 24) }
+    }
+    /* Canonical "subscribe to an external system" effect (React docs):
+       the relative-age bucket is derived from Date.now() (an external mutable
+       value) and written to state once per `isoStr` change, memoizing the label
+       so it stays steady across parent re-renders (the drift bug this fixes).
+       The rule's heuristic can't distinguish this from the cascading-render
+       anti-pattern, so it's suppressed here only — unlike the mounted-animation
+       cases elsewhere, there is no CSS-only refactor for "current time". */
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- see block comment above
+    setBucket(next)
+  }, [isoStr])
+  if (!bucket) return null
+  return <div style={style}>{t('updatedAgo', { time: format(bucket, t) })}</div>
+}

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -11,6 +11,7 @@ import { fmtNav, fmtCompact } from '@/lib/formatters'
 // the Plan feature today; reused here so Funds sheets behave the same.
 import { useDialogA11y } from '@/app/(app)/planning/components/useDialogA11y'
 import { FundsEmptyState } from './FundsEmptyState'
+import { FundNavAge } from './FundNavAge'
 import type { Fund, Goal, FundType, FundsData } from './useFundsData'
 
 // Matches the design's exact icon paths (stroke-based, strokeWidth 1.75)
@@ -303,16 +304,6 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
   const isEditing = dcaEditId === fund.id
   const toggling = togglingIds.has(fund.id)
 
-  function relDate(str: string) {
-    const diff = Date.now() - new Date(str).getTime()
-    const mins = Math.floor(diff / 60000)
-    if (mins < 1) return t('relJustNow')
-    if (mins < 60) return t('relMinutes', { m: mins })
-    const h = Math.floor(mins / 60)
-    if (h < 24) return t('relHours', { h })
-    return t('relDays', { d: Math.floor(h / 24) })
-  }
-
   return (
     <div
       data-testid={`fund-card-${fund.id}`}
@@ -349,7 +340,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
             {fmtNav(fund.nav)}
           </div>
           {fund.nav_source_url && fund.updated_at && (
-            <div style={{ fontSize: 10, color: 'var(--c-muted)', marginTop: 1 }}>{t('updatedAgo', { time: relDate(fund.updated_at) })}</div>
+            <FundNavAge isoStr={fund.updated_at} style={{ fontSize: 10, color: 'var(--c-muted)', marginTop: 1 }} />
           )}
         </div>
 

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.reltime.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.reltime.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useState } from 'react'
+import { render, screen } from '@testing-library/react'
+import MobileFundLibraryView from '../MobileFundLibraryView'
+import type { Fund } from '../useFundsData'
+
+// Same translation mock as the DCA suite — params are echoed as JSON so the
+// relative-time bucket (relMinutes/relHours/…) is observable in the DOM:
+//   t('updatedAgo', { time: 'relMinutes:{"m":5}' }) → updatedAgo:{"time":"relMinutes:{"m":5}"}
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+
+vi.mock('@/lib/formatters', () => ({
+  fmtNav: (n: number) => String(n),
+  fmtCompact: (n: number) => `${n}`,
+}))
+
+vi.mock('@/app/components/navigation/NavigationContext', () => ({
+  useNavigation: () => ({ setMobileTopBar: vi.fn() }),
+}))
+
+function makeFund(over: Partial<Fund> = {}): Fund {
+  return {
+    id: 'f1',
+    name: 'VFMVF1 Equity Fund',
+    code: 'VFMVF1',
+    fund_type: 'equity',
+    nav: 36120,
+    nav_source_url: null,
+    is_dca: false,
+    dca_monthly_amount_vnd: null,
+    dca_goal_id: null,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...over,
+  }
+}
+
+function Harness({ initial, reload }: { initial: Fund[]; reload: () => Promise<void> }) {
+  const [funds, setFunds] = useState(initial)
+  return (
+    <MobileFundLibraryView
+      funds={funds}
+      setFunds={setFunds}
+      goals={[]}
+      loading={false}
+      error={false}
+      reload={reload}
+    />
+  )
+}
+
+describe('MobileFundLibraryView — relative NAV-age label must not jump across re-renders', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) })))
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  // The old implementation called Date.now() *inside render* via relDate(), so a
+  // parent re-render (with the clock advanced) recomputed the bucket with the new
+  // "now" → the "Updated Xm ago" line drifted even though updated_at was unchanged.
+  // After moving the computation into an effect memoized on updated_at, the label
+  // is pinned to the value from the first render and stays steady on re-render.
+  it('keeps the same relative-age bucket when the parent re-renders with a later clock', () => {
+    vi.useFakeTimers()
+    const base = new Date('2026-06-30T12:00:00Z').getTime()
+    vi.setSystemTime(base)
+    // 5 minutes before "now".
+    const updatedAt = new Date(base - 5 * 60_000).toISOString()
+
+    const { rerender } = render(
+      <Harness initial={[makeFund({ nav_source_url: 'http://example.test', updated_at: updatedAt })]} reload={vi.fn(() => Promise.resolve())} />,
+    )
+
+        // Sanity: the card renders the "Updated …" line at all, bucketed as 5m.
+    // (Match on the minutes digit via ":N}" so it survives the nested
+    // JSON.stringify in the translation mock — the inner quotes get escaped, so a
+    // literal '"m":5' substring is NOT present in the rendered text.)
+    const line = screen.getByText(/updatedAgo/)
+    expect(line.textContent).toContain(':5}')
+
+    // Advance the wall clock 3 minutes and force a re-render with identical props.
+    // Before the fix this recomputed with the newer Date.now() → 8m and the test
+    // below would fail. After the fix the bucket is memoized on updated_at → 5m.
+    vi.setSystemTime(base + 3 * 60_000)
+    rerender(
+      <Harness initial={[makeFund({ nav_source_url: 'http://example.test', updated_at: updatedAt })]} reload={vi.fn(() => Promise.resolve())} />,
+    )
+
+    expect(screen.getByText(/updatedAgo/).textContent).toContain(':5}')
+    expect(screen.getByText(/updatedAgo/).textContent).not.toContain(':8}')
+  })
+})


### PR DESCRIPTION
## What

The "Updated Xm ago" line under each fund's NAV called `Date.now()` **inside render** (`relDate()`), so every parent re-render recomputed the bucket with a newer `now` → the label drifted (5m → 8m …) even though `updated_at` was unchanged. `eslint-config-next` 16 flags this as `react-hooks/purity`.

This existed in **both** the mobile card and the desktop table row (desktop had the same latent drift, just not lint-flagged).

## Fix

Extract a `FundNavAge` component that derives the relative-age bucket **once per `updated_at`** in an effect (memoized on `isoStr` — the translator `t` is applied in render so its changing identity isn't a dependency) and renders the translated label from the stored bucket. Used by both views.

The effect's `setState` is the canonical ["subscribe to an external system"](https://react.dev/learn/you-might-not-need-an-effect#fetching-data) pattern (the external value here is the current time), so `react-hooks/set-state-in-effect` is suppressed at that one line with a rationale comment — unlike the mounted-animation cases elsewhere, there is no CSS-only refactor for "current time".

## Test (TDD)

New regression test `MobileFundLibraryView.reltime.test.tsx`:
- render a card at 5m, advance the wall clock 3 min and re-render **identical props**
- before the fix: label recomputed with the newer `Date.now()` → `8m` (test failed)
- after the fix: bucket memoized on `updated_at` → stays `5m` (test passes)

The prior DCA tests used a catch-all fetch mock and never asserted the age line, so this drift slipped through.

## Verification

- `npx vitest run app/(app)/funds` → **49 passing** (incl. the new test)
- `npm test -- --run` → **1010 / 1010 passing** (93 files) — no regressions
- `npm run lint` → **27 → 26 errors** (`react-hooks/purity` gone; `FundNavAge` suppressed legitimately, no new error)

## Files

- `app/(app)/funds/components/FundNavAge.tsx` — new
- `app/(app)/funds/components/MobileFundLibraryView.tsx` — drop `relDate`, render `<FundNavAge/>`
- `app/(app)/funds/components/DesktopFundLibraryView.tsx` — drop `relDate`, render `<FundNavAge/>`
- `app/(app)/funds/components/__tests__/MobileFundLibraryView.reltime.test.tsx` — regression test

Follows the branch-and-PR workflow in `CLAUDE.md` — branched off `main`, not pushing directly to `main`. Awaiting review on the Vercel preview before merge.