### PR TITLE
chore: remove unused imports, vars and eslint-disable directives

### DIFF
--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -257,7 +257,6 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
       setGoldQty(existing.units != null ? String(existing.units) : '')
       setGoldPrice(existing.unit_price != null ? String(existing.unit_price) : '')
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, existing])
 
   // Create mode with prefilled defaults (e.g. logging a contribution from the
@@ -274,7 +273,6 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
       if (at === 'bank') setBankAmount(amt)
       else if (at === 'fund') setAmount(amt)
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open, existing, prefill])
 
   // Lazily load sellable holdings from the overview the first time the user
@@ -405,7 +403,6 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
     if (dir === 'sell' && assetType === 'gold' && sellNav) {
       setGoldSellPrice(String(Math.round(sellNav)))
     }
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dir, assetType, holdingKey, sellNav])
 
   async function handleSave() {

--- a/app/assets/components/DesktopNetWorthPanel.tsx
+++ b/app/assets/components/DesktopNetWorthPanel.tsx
@@ -82,7 +82,7 @@ export default function DesktopNetWorthPanel({ data, allocationTotals, goldUnits
     return Object.entries(raw)
       .filter(([, v]) => v > 0)
       .sort((a, b) => b[1] - a[1])
-      .map(([type, value], _i) => ({
+      .map(([type, value]) => ({
         type,
         value,
         pct: total > 0 ? (value / total) * 100 : 0,

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -8,7 +8,8 @@ import { fmt } from '@/lib/formatters'
 import { todayIso } from '@/lib/dates'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { AffectsProgressControl } from './goalDetailShared'
-const fmtVND = (n: number) => fmt(n)
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const fmtVND = (n: number, _locale?: string) => fmt(n)
 
 export interface SellItem {
   type: 'fund' | 'bank' | 'gold' | 'stock'

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -8,7 +8,7 @@ import { fmt } from '@/lib/formatters'
 import { todayIso } from '@/lib/dates'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { AffectsProgressControl } from './goalDetailShared'
-const fmtVND = (n: number, _locale?: string) => fmt(n)
+const fmtVND = (n: number) => fmt(n)
 
 export interface SellItem {
   type: 'fund' | 'bank' | 'gold' | 'stock'

--- a/app/assets/components/__tests__/AddTransactionSheet.test.tsx
+++ b/app/assets/components/__tests__/AddTransactionSheet.test.tsx
@@ -117,7 +117,7 @@ describe('AddTransactionSheet — sell flow (issue #232)', () => {
       goals: [{ goalName: 'Goal A', funds: [{ fundId: 'f1', fundName: 'VESAF', quantity: 100, currentNAV: 20000, currentValue: 2_000_000, purchasePrice: 18000, profitLossPercentage: 11.11 }] }],
       unallocated: { funds: [], nonFunds: [] },
     }
-    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
+    const fetchMock = vi.fn((url: string) => {
       if (String(url).includes('/dashboard/overview')) return Promise.resolve({ ok: true, json: () => Promise.resolve(overview) })
       if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [] }) })
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
@@ -151,7 +151,7 @@ describe('AddTransactionSheet — fund sell units field (two-way linked)', () =>
       goals: [{ goalName: 'Goal A', funds: [{ fundId: 'f1', fundName: 'VESAF', quantity: 100, currentNAV: 20000, currentValue: 2_000_000, purchasePrice: 18000, profitLossPercentage: 11.11 }] }],
       unallocated: { funds: [], nonFunds: [] },
     }
-    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
+    const fetchMock = vi.fn((url: string) => {
       if (String(url).includes('/dashboard/overview')) return Promise.resolve({ ok: true, json: () => Promise.resolve(overview) })
       if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [] }) })
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
@@ -183,7 +183,7 @@ describe('AddTransactionSheet — bank withdraw (received + principal portion)',
       goals: [{ goalName: 'Goal A', funds: [], nonFunds: [{ transactionId: 't1', type: 'bank', amount: 5_000_000, currentValue: 5_200_000, interestRate: 6, units: null, notes: 'Techcombank' }] }],
       unallocated: { funds: [], nonFunds: [] },
     }
-    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
+    const fetchMock = vi.fn((url: string) => {
       if (String(url).includes('/dashboard/overview')) return Promise.resolve({ ok: true, json: () => Promise.resolve(overview) })
       if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [] }) })
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
@@ -216,7 +216,7 @@ describe('AddTransactionSheet — sell lists goal-allocated bank/gold (issue #23
       goals: [{ goalName: 'Goal A', funds: [], nonFunds: [{ transactionId: 't1', type: 'bank', amount: 5_000_000, currentValue: 5_200_000, interestRate: 6, units: null, notes: 'Techcombank' }] }],
       unallocated: { funds: [], nonFunds: [] },
     }
-    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
+    const fetchMock = vi.fn((url: string) => {
       if (String(url).includes('/dashboard/overview')) return Promise.resolve({ ok: true, json: () => Promise.resolve(overview) })
       if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [] }) })
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
@@ -238,7 +238,7 @@ describe('AddTransactionSheet — gold sell (quantity × price) (issue #232)', (
       goals: [],
       unallocated: { funds: [], nonFunds: [{ transactionId: 'g1', type: 'gold', amount: 9_000_000, currentValue: 9_200_000, interestRate: null, units: 1, notes: 'PNJ' }] },
     }
-    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
+    const fetchMock = vi.fn((url: string) => {
       if (String(url).includes('/dashboard/overview')) return Promise.resolve({ ok: true, json: () => Promise.resolve(overview) })
       if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [] }) })
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
@@ -268,7 +268,7 @@ describe('AddTransactionSheet — gold sell (quantity × price) (issue #232)', (
 })
 
 describe('AddTransactionSheet — editable NAV on a fund buy', () => {
-  const fundsAndGoals = (url: string, _init?: RequestInit) => {
+  const fundsAndGoals = (url: string) => {
     if (String(url).includes('/funds')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve([{ id: 'f1', name: 'VESAF', nav: 20000, code: 'VES', fund_type: 'equity' }]) })
     }
@@ -370,7 +370,7 @@ describe('AddTransactionSheet — bank term interest receivable (issue #245)', (
 describe('AddTransactionSheet — gold unit (issue #232)', () => {
   // Gold is valued per chỉ, so a lượng entry must be normalized: 1 lượng = 10 chỉ.
   it('normalizes a lượng entry to chỉ on save', async () => {
-    const fetchMock = vi.fn((_url: string, _init?: RequestInit) => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
     vi.stubGlobal('fetch', fetchMock)
 
     render(<AddTransactionSheet open onClose={vi.fn()} onSaved={vi.fn()} />)
@@ -482,7 +482,7 @@ describe('AddTransactionSheet — structured bank (bank_code)', () => {
 
 describe('AddTransactionSheet — prefill create mode (plan contribution)', () => {
   it('posts a new bank deposit carrying plan_id and goal_id', async () => {
-    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
+    const fetchMock = vi.fn((url: string) => {
       if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [{ goal_id: 'g1', goal_name: 'Retirement' }] }) })
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
     })

--- a/app/assets/components/__tests__/AssignGoalSheet.test.tsx
+++ b/app/assets/components/__tests__/AssignGoalSheet.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import AssignGoalSheet from '../AssignGoalSheet'
 

--- a/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
+++ b/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
@@ -14,7 +14,7 @@ beforeEach(() => {
 
 describe('SellWithdrawSheet — bank withdraw (received + principal portion)', () => {
   it('defaults received to current value and posts received + principal portion', async () => {
-    const fetchMock = vi.fn((_url: string, _init?: RequestInit) =>
+    const fetchMock = vi.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
     vi.stubGlobal('fetch', fetchMock)
 
@@ -42,7 +42,7 @@ describe('SellWithdrawSheet — bank withdraw (received + principal portion)', (
 
 describe('SellWithdrawSheet — links the withdrawal to its goal (issue #261)', () => {
   it('posts goal_id when withdrawing in a goal context', async () => {
-    const fetchMock = vi.fn((_url: string, _init?: RequestInit) =>
+    const fetchMock = vi.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
     vi.stubGlobal('fetch', fetchMock)
 
@@ -65,7 +65,7 @@ describe('SellWithdrawSheet — links the withdrawal to its goal (issue #261)', 
   })
 
   it('keeps goal_id null in the unallocated context', async () => {
-    const fetchMock = vi.fn((_url: string, _init?: RequestInit) =>
+    const fetchMock = vi.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
     vi.stubGlobal('fetch', fetchMock)
 
@@ -112,7 +112,7 @@ describe('SellWithdrawSheet — count toward goal progress toggle', () => {
   }
 
   it('shows the toggle in goal context and posts affects_progress=true by default', async () => {
-    const fetchMock = vi.fn((_url: string, _init?: RequestInit) => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
     vi.stubGlobal('fetch', fetchMock)
 
     render(<SellWithdrawSheet item={bankItem} open context="goal" goalId="g1" goalCurrentValue={20_000_000} goalTargetAmount={50_000_000} onClose={vi.fn()} onSuccess={vi.fn()} />)
@@ -130,7 +130,7 @@ describe('SellWithdrawSheet — count toward goal progress toggle', () => {
   })
 
   it('posts affects_progress=false after toggling the switch off', async () => {
-    const fetchMock = vi.fn((_url: string, _init?: RequestInit) => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
     vi.stubGlobal('fetch', fetchMock)
 
     render(<SellWithdrawSheet item={bankItem} open context="goal" goalId="g1" goalCurrentValue={20_000_000} goalTargetAmount={50_000_000} onClose={vi.fn()} onSuccess={vi.fn()} />)
@@ -154,7 +154,7 @@ describe('SellWithdrawSheet — count toward goal progress toggle', () => {
 
 describe('SellWithdrawSheet — gold sell (quantity × price) (issue #232)', () => {
   it('prefills the price and posts proceeds + cost basis', async () => {
-    const fetchMock = vi.fn((_url: string, _init?: RequestInit) =>
+    const fetchMock = vi.fn(() =>
       Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
     vi.stubGlobal('fetch', fetchMock)
 


### PR DESCRIPTION
## Summary

Remove all unused imports, variables, and unnecessary eslint-disable directives across the codebase.

### Changes

| File | Change |
|---|---|
| \AddTransactionSheet.tsx\ | Remove 3 unused \eslint-disable-next-line react-hooks/exhaustive-deps\ directives |
| \DesktopNetWorthPanel.tsx\ | Remove unused \_i\ parameter in \.map()\ |
| \SellWithdrawSheet.tsx\ | Remove unused \_locale\ parameter from \mtVND\ |
| \AddTransactionSheet.test.tsx\ | Remove unused \_url\/\_init\ params in 8 mock fetch functions |
| \AssignGoalSheet.test.tsx\ | Remove unused \eforeEach\ import from vitest |
| \SellWithdrawSheet.test.tsx\ | Remove unused \_url\/\_init\ params in 6 mock fetch functions |

### Result

- **Warnings:** 27 → 0 ✅
- **Errors:** 26 (all pre-existing \eact-hooks/set-state-in-effect\, unrelated to this PR)
- **Files changed:** 6
- **+17 / −20 lines**