### PR TITLE
fix: maturity reminder — widen window to 7 days + accurate countdown text

### DIFF
--- a/app/assets/components/MaturityActionCard.tsx
+++ b/app/assets/components/MaturityActionCard.tsx
@@ -22,7 +22,9 @@ function pillFor(inv: InvRow, isVi: boolean): { text: string; color: string; bg:
     }
   }
   return {
-    text: isVi ? (diff === 0 ? 'Đáo hạn hôm nay' : 'Đáo hạn ngày mai') : (diff === 0 ? 'Matures today' : 'Matures tomorrow'),
+    text: isVi
+      ? (diff === 0 ? 'Đáo hạn hôm nay' : diff === 1 ? 'Đáo hạn ngày mai' : `Đáo hạn sau ${diff} ngày`)
+      : (diff === 0 ? 'Matures today' : diff === 1 ? 'Matures tomorrow' : `Matures in ${diff}d`),
     color: 'var(--c-warn)', bg: 'var(--c-warn-tint)',
   }
 }

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -10,8 +10,10 @@
 // maturity date, so the new cycle's compound-interest valuation in buildInvRows
 // picks up exactly where the closed cycle ended — an overdue book does not lose
 // the days it sat past maturity, nor does its next maturity skip forward by them.
-// (An actionable deposit's old maturity is at most "tomorrow", so this never
-// trips the route's future-date guard.) The new maturity defaults to old-maturity
+// (Renewal is offered only once the deposit has matured — or is within the
+// route's +1 day tolerance — so the anchored investment_date is never rejected as
+// a future date; a still-maturing deposit surfaced by the wider reminder window
+// shows a "record at maturity" hint instead.) The new maturity defaults to old-maturity
 // + term and follows the term until the user edits it by hand. Withdrawal hands
 // off to the existing Sell/Withdraw flow rather than re-implementing the payout
 // (the parent wires `onWithdraw`).
@@ -408,7 +410,16 @@ export function MaturityResolveBody({
   const rateValid = rate.trim() !== '' && Number(rate) > 0
   const amountValid = mode !== 'change' || (newAmount.trim() !== '' && Number(newAmount) > 0)
   const maturityValid = newMaturity > baseDate
-  const canRenew = tNum > 0 && rateValid && amountValid && newPrincipal > 0 && maturityValid
+  // A not-yet-matured deposit's new cycle would start on its (future) old maturity
+  // date, which the renew route + RPC reject as a future investment_date (they
+  // tolerate only +1 day of skew). The bank money isn't freed before maturity
+  // anyway, so recording a roll-over early isn't meaningful — the wider reminder
+  // window just surfaces it early; the user records the renewal once it matures.
+  // Early WITHDRAW (breaking the term) stays allowed — it posts via onWithdraw,
+  // not the date-anchored renew path.
+  const daysLeft = m?.diffDays ?? 0
+  const tooEarlyToRenew = !matured && daysLeft > 1
+  const canRenew = tNum > 0 && rateValid && amountValid && newPrincipal > 0 && maturityValid && !tooEarlyToRenew
 
   const t = isVi ? {
     summarySuffix: 'năm', perYr: 'năm', mo: 'tháng',
@@ -623,10 +634,11 @@ export function MaturityResolveBody({
           expiry_date: newMaturity,
           // Anchor the new cycle's accrual to the OLD maturity date (baseDate) so
           // the value calc restarts where the closed cycle ended — overdue days
-          // are not lost. An actionable deposit's old maturity is ≤ tomorrow, so
-          // this stays within the route's future-date tolerance. The route rolls
-          // the active row forward in place and appends a history snapshot of the
-          // cycle that just closed.
+          // are not lost. Renewal is gated to matured (or ≤ tomorrow) deposits
+          // (see tooEarlyToRenew), so baseDate is in the past or within the
+          // route's +1 day future-date tolerance and is never rejected. The route
+          // rolls the active row forward in place and appends a history snapshot
+          // of the cycle that just closed.
           investment_date: baseDate,
           // Realized interest for the cycle that just closed — recorded
           // permanently on the snapshot for the renewal-history summary. A book's
@@ -713,7 +725,12 @@ export function MaturityResolveBody({
       return { text: isVi ? (n === 0 ? 'Đã đáo hạn' : `Quá hạn ${n} ngày`) : (n === 0 ? 'Matured' : `${n}d overdue`), color: 'var(--c-neg)', bg: 'var(--c-neg-tint)' }
     }
     const n = m?.diffDays ?? 0
-    return { text: isVi ? (n === 0 ? 'Đáo hạn hôm nay' : 'Đáo hạn ngày mai') : (n === 0 ? 'Matures today' : 'Matures tomorrow'), color: 'var(--c-warn)', bg: 'var(--c-warn-tint)' }
+    return {
+      text: isVi
+        ? (n === 0 ? 'Đáo hạn hôm nay' : n === 1 ? 'Đáo hạn ngày mai' : `Đáo hạn sau ${n} ngày`)
+        : (n === 0 ? 'Matures today' : n === 1 ? 'Matures tomorrow' : `Matures in ${n}d`),
+      color: 'var(--c-warn)', bg: 'var(--c-warn-tint)',
+    }
   })()
 
   return (
@@ -1172,6 +1189,13 @@ export function MaturityResolveBody({
       {error && <p style={{ margin: 0, fontSize: 13, color: 'var(--c-neg)' }}>{error}</p>}
 
       {/* Actions */}
+      {tooEarlyToRenew && mode !== 'withdraw' && (
+        <p data-testid="maturity-too-early-hint" style={{ margin: 0, fontSize: 12.5, lineHeight: 1.45, color: 'var(--c-muted)' }}>
+          {isVi
+            ? `Sổ chưa tới hạn (còn ${daysLeft} ngày) — ghi nhận tái tục khi đáo hạn. Bạn vẫn có thể rút trước hạn.`
+            : `Not matured yet (${daysLeft} days left) — record the renewal at maturity. You can still withdraw early.`}
+        </p>
+      )}
       <div style={{ display: 'flex', gap: 8 }}>
         <button type="button" onClick={onClose} className="cn-btn ghost" style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}>{t.cancel}</button>
         {(() => {

--- a/app/assets/components/__tests__/MaturityActionCard.test.tsx
+++ b/app/assets/components/__tests__/MaturityActionCard.test.tsx
@@ -50,6 +50,24 @@ describe('MaturityActionCard', () => {
     expect(screen.queryByText(/overdue|Matured|Matures/i)).not.toBeInTheDocument()
   })
 
+  it('shows an accurate maturity pill for each lead time (not a hardcoded "tomorrow")', () => {
+    const { rerender } = render(
+      <MaturityActionCard items={[mk({ expiryDate: daysFromNow(0) })]} isVi onResolve={() => {}} />,
+    )
+    expect(screen.getByText('Đáo hạn hôm nay')).toBeInTheDocument()
+
+    rerender(<MaturityActionCard items={[mk({ expiryDate: daysFromNow(1) })]} isVi onResolve={() => {}} />)
+    expect(screen.getByText('Đáo hạn ngày mai')).toBeInTheDocument()
+
+    // Within the 7-day window but more than a day out — must NOT say "ngày mai".
+    rerender(<MaturityActionCard items={[mk({ expiryDate: daysFromNow(5) })]} isVi onResolve={() => {}} />)
+    expect(screen.getByText('Đáo hạn sau 5 ngày')).toBeInTheDocument()
+    expect(screen.queryByText('Đáo hạn ngày mai')).not.toBeInTheDocument()
+
+    rerender(<MaturityActionCard items={[mk({ expiryDate: daysFromNow(5) })]} isVi={false} onResolve={() => {}} />)
+    expect(screen.getByText('Matures in 5d')).toBeInTheDocument()
+  })
+
   it('shows no merge banner when there are no clusters', () => {
     render(<MaturityActionCard items={[mk({ id: 'a' }), mk({ id: 'b' })]} isVi={false} onResolve={() => {}} />)
     expect(screen.queryByTestId(/^merge-cluster-banner-/)).not.toBeInTheDocument()

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -71,6 +71,34 @@ describe('MaturityResolveBody', () => {
     })
   })
 
+  it('blocks renewal for a not-yet-matured deposit (wider reminder window) and shows a hint', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    vi.stubGlobal('fetch', fetchMock)
+    // Maturing in 5 days: surfaced by the 7-day reminder window, but its new cycle
+    // would start on that future date — which the renew route/RPC reject. Renewal
+    // is gated; the user records it at maturity.
+    const earlyDeposit: InvRow = { ...maturedDeposit, id: 'tx-early', expiryDate: daysFromNow(5) }
+    const user = userEvent.setup()
+    render(
+      <MaturityResolveBody inv={earlyDeposit} isVi onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+
+    expect(screen.getByTestId('maturity-too-early-hint').textContent).toContain('còn 5 ngày')
+    const confirm = screen.getByRole('button', { name: /Xác nhận tái tục|Confirm renewal/i })
+    expect(confirm).toBeDisabled()
+    await user.click(confirm)
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('still allows renewal for a deposit maturing tomorrow (within the route tolerance)', () => {
+    const tomorrowDeposit: InvRow = { ...maturedDeposit, id: 'tx-tmrw', expiryDate: daysFromNow(1) }
+    render(
+      <MaturityResolveBody inv={tomorrowDeposit} isVi onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+    expect(screen.queryByTestId('maturity-too-early-hint')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Xác nhận tái tục|Confirm renewal/i })).not.toBeDisabled()
+  })
+
   it('lets the user override the new maturity date and freezes it from the term', async () => {
     const user = userEvent.setup()
     render(

--- a/lib/__tests__/maturity.test.ts
+++ b/lib/__tests__/maturity.test.ts
@@ -52,13 +52,14 @@ describe('depositMaturityState', () => {
     expect(depositMaturityState(-1)).toBe('matured')
     expect(depositMaturityState(-30)).toBe('matured')
   })
-  it('classifies today and tomorrow as maturing (REMINDER_DAYS = 1)', () => {
-    expect(MATURITY_REMINDER_DAYS).toBe(1)
+  it('classifies today through the reminder window as maturing (REMINDER_DAYS = 7)', () => {
+    expect(MATURITY_REMINDER_DAYS).toBe(7)
     expect(depositMaturityState(0)).toBe('maturing')
     expect(depositMaturityState(1)).toBe('maturing')
+    expect(depositMaturityState(7)).toBe('maturing') // last day inside the window
   })
-  it('classifies the day after tomorrow onward as active', () => {
-    expect(depositMaturityState(2)).toBe('active')
+  it('classifies past the reminder window as active', () => {
+    expect(depositMaturityState(8)).toBe('active') // first day outside the window
     expect(depositMaturityState(30)).toBe('active')
   })
 })

--- a/lib/maturity.ts
+++ b/lib/maturity.ts
@@ -9,8 +9,9 @@
 // goalDetailShared.tsx for the display formatting.
 
 // Surface a deposit as "needs attention" once it is within this many days of
-// maturity (in addition to already-matured ones).
-export const MATURITY_REMINDER_DAYS = 1
+// maturity (in addition to already-matured ones). A week of lead time lets the
+// user decide (renew / withdraw) before the deposit actually matures.
+export const MATURITY_REMINDER_DAYS = 7
 
 // Window event the dashboard dispatches (detail = number) with the live count of
 // maturing deposits, so the nav badge updates the instant the dashboard's data


### PR DESCRIPTION
## Vấn đề

1. Mục **"cần xử lý"** (Overview card + badge nav) chỉ báo tiền gửi khi **còn ≤ 1 ngày** tới hạn → thực tế gần như chỉ nhắc **sau khi đã tới/quá hạn**.
2. Text pill **fix cứng "Đáo hạn ngày mai"** cho *mọi* khoản chưa tới hạn — sai khi còn 2+ ngày.

## Thay đổi

**1. Mở rộng cửa sổ nhắc: `MATURITY_REMINDER_DAYS` 1 → 7** (`lib/maturity.ts`)
Khoản tiền gửi nổi lên "cần xử lý" **trước 1 tuần**. Đây là nguồn duy nhất điều khiển `depositMaturityState` + card + số đếm nav.

**2. Text đếm ngược chính xác** (`MaturityActionCard.tsx`, `MaturityResolveSheet.tsx`)
`hôm nay` / `ngày mai` / `sau N ngày` (EN: `today` / `tomorrow` / `in Nd`) — mirror phía quá hạn `Quá hạn N ngày` / `Nd overdue`.

**3. Khóa tái tục sớm** (`MaturityResolveSheet.tsx`)
Khoản CHƯA tới hạn (còn >1 ngày) neo kỳ mới vào ngày đáo hạn cũ (tương lai) → route `/renew` **và** RPC `renew_term_deposit` từ chối `investment_date` tương lai (chỉ dung sai +1 ngày). Tiền chưa về trước đáo hạn nên ghi tái tục sớm không có ý nghĩa → **vô hiệu hóa nút tái tục/gộp + hiện gợi ý "ghi nhận khi đáo hạn"**. **Rút trước hạn vẫn cho phép** (đi qua `onWithdraw`, không dính guard ngày). Không cần đổi DB.

> Lựa chọn thay thế nếu anh muốn **cho phép tái tục sớm** thật: nới guard ở route + migration cho các hàm renew (renew_term_deposit + biến thể merge) — nhiều SQL hơn, cần E2E qua WSL2. Có thể làm follow-up nếu cần.

## Test (TDD)

- `lib/__tests__/maturity.test.ts`: biên mới `diffDays=7`→maturing, `8`→active.
- `MaturityActionCard.test.tsx`: pill đúng cho 0/1/5 ngày (không còn "ngày mai" cứng).
- `MaturityResolveSheet.test.tsx`: khoản còn 5 ngày → nút tái tục disabled + hint; khoản còn 1 ngày → vẫn tái tục được.
- Toàn bộ unit suite: **1013 passed**.

Lint: 26 lỗi `react-hooks/set-state-in-effect` đều **có sẵn** ở component không liên quan; PR không thêm lỗi mới.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
