### PR TITLE
fix(maturity): clamp date inputs so mobile merge sheet can't overflow (#439)

### DIFF
--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -50,6 +50,15 @@ const moneyInput: React.CSSProperties = {
   background: 'var(--c-canvas,#faf9f7)', border: '1.5px solid var(--c-line)',
   borderRadius: 10, color: 'var(--c-ink)', outline: 'none',
 }
+// A native <input type=date> on iOS Safari sizes to its intrinsic content width
+// and ignores width:100%, so an un-clamped date field pushes the whole sheet
+// wider than the viewport — letting it be dragged sideways (#439). Clamp it like
+// the ledger's date filters (#362): appearance:none trims the intrinsic width,
+// maxWidth:100% + minWidth:0 pin it to its cell.
+const dateInput: React.CSSProperties = {
+  ...moneyInput, maxWidth: '100%', minWidth: 0,
+  WebkitAppearance: 'none', appearance: 'none',
+}
 
 // Money entry core: a digit-grouped amount field (₫ suffix). Reused by every
 // money input in the maturity flow so large VND amounts stay readable
@@ -1029,7 +1038,7 @@ export function MaturityResolveBody({
                 </button>
               )}
             </div>
-            <input type="date" value={newMaturity} min={baseDate} onChange={(e) => setMaturityOverride(e.target.value)} style={moneyInput} />
+            <input data-testid="maturity-combine-date" type="date" value={newMaturity} min={baseDate} onChange={(e) => setMaturityOverride(e.target.value)} style={dateInput} />
             {!maturityValid && <p style={{ margin: '6px 0 0', fontSize: 11, color: 'var(--c-neg)', lineHeight: 1.4 }}>{t.maturityTooEarly}</p>}
           </div>
 
@@ -1106,7 +1115,7 @@ export function MaturityResolveBody({
               value={newMaturity}
               min={baseDate}
               onChange={(e) => setMaturityOverride(e.target.value)}
-              style={moneyInput}
+              style={dateInput}
             />
             {maturityValid
               ? <p style={{ margin: '6px 0 0', fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.4 }}>{t.maturityHint}</p>

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -703,6 +703,54 @@ describe('MaturityResolveBody', () => {
     })
   })
 
+  // ── Mobile sheet-overflow guard (#439) ──────────────────────────────────────
+  // On iOS Safari a native <input type=date> sizes to its intrinsic content width
+  // and ignores width:100%, so an un-clamped date field pushes the whole sheet
+  // wider than the viewport — letting it be dragged sideways. Each date input must
+  // carry the same clamp as the ledger's date filters (#362): appearance:none to
+  // trim the intrinsic width, maxWidth:100% + minWidth:0 to pin it to its cell.
+  describe('date inputs are clamped so the sheet can’t overflow (#439)', () => {
+    function stubEmptyRecurring() {
+      const fetchMock = vi.fn().mockImplementation((url: string) => {
+        if (typeof url === 'string' && url.startsWith('/api/v1/recurring-savings')) {
+          return Promise.resolve({ ok: true, json: async () => ({ savings: [] }) })
+        }
+        return Promise.resolve({ ok: true, json: async () => [] })
+      })
+      vi.stubGlobal('fetch', fetchMock)
+      return fetchMock
+    }
+    function expectClamped(el: Element) {
+      const s = (el as HTMLElement).style
+      expect(s.maxWidth).toBe('100%')
+      expect(s.minWidth).toBe('0px')
+      expect(s.appearance).toBe('none')
+    }
+
+    it('clamps the renew-mode new-maturity date input', () => {
+      render(
+        <MaturityResolveBody inv={maturedDeposit} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      expectClamped(screen.getByTestId('maturity-date-input'))
+    })
+
+    it('clamps the combine/merge sheet new-maturity date input', async () => {
+      const user = userEvent.setup()
+      stubEmptyRecurring()
+      const sibBank: InvRow = {
+        id: 'sib-bank', name: 'Vikki sibling', type: 'bank', value: 8_000_000, gainPct: null,
+        units: null, principal: 8_000_000, interestRate: 6, expiryDate: daysFromNow(40),
+        investmentDate: daysFromNow(-150), fund: null,
+      }
+      render(
+        <MaturityResolveBody inv={maturedDeposit} goalId="goal-1" siblingDeposits={[sibBank]}
+          isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+      )
+      await user.click(await screen.findByRole('button', { name: /Settle & re-deposit/i }))
+      expectClamped(screen.getByTestId('maturity-combine-date'))
+    })
+  })
+
   // ── Success-flash timing ────────────────────────────────────────────────────
   // After a successful renew the sheet shows a "done" confirmation, then closes
   // and tells the parent to refresh. That hand-off was a 1.7s wait that read as


### PR DESCRIPTION
## Vấn đề (#439)

Trên **mobile Safari (iOS)**, ô `<input type=date>` (ngày đáo hạn mới) trong sheet xử lý đáo hạn / **Gộp sổ** tự dãn theo chiều rộng nội tại của control và **bỏ qua `width:100%`**, khiến ô date đẩy cả sheet rộng vượt viewport → sheet **kéo/trượt ngang được**.

Đây là biến thể của lỗi iOS date-input đã xử lý ở #362 (PR #367) cho date filter, lần này chưa vá trong `MaturityResolveSheet`.

## Fix

- Thêm style `dateInput = { ...moneyInput, maxWidth:'100%', minWidth:0, WebkitAppearance:'none', appearance:'none' }` — đúng clamp mà date filter của ledger đang dùng (#362): `appearance:none` cắt chiều rộng nội tại, `maxWidth/minWidth` ghim ô vào cell.
- Áp cho **cả 2** ô date trong sheet (mode tái tục + mode combine/gộp).

## Test

Chromium **không tái hiện** được cách iOS size native date control, nên bug này nằm ở tầng **component test** (không phải E2E — memory #362):
- `MaturityResolveSheet.test.tsx` thêm describe "date inputs are clamped… (#439)" assert cả ô date renew lẫn ô date combine mang `maxWidth:100%` / `minWidth:0` / `appearance:none`.

## Kiểm tra local

- `npm test -- --run` → **1016 passed** (93 files), gồm 2 test mới (đỏ trước khi fix).
- `npm run lint` → file thay đổi sạch; 26 lỗi còn lại là pre-existing repo-wide (rule React 19, ở ThemeProvider.tsx v.v.), không liên quan PR này.
- Không thêm E2E (Chromium không repro; đúng "pick the right layer").

🤖 Generated with [Claude Code](https://claude.com/claude-code)