### PR TITLE
fix(overview): unify net-worth copy across desktop & mobile (VN)

### DIFF
--- a/app/assets/components/DesktopNetWorthPanel.tsx
+++ b/app/assets/components/DesktopNetWorthPanel.tsx
@@ -127,7 +127,7 @@ export default function DesktopNetWorthPanel({ data, allocationTotals, goldUnits
             {isPos ? '+' : ''}{fmtCompact(netWorth.overallProfitLoss)}
           </span>
           <span style={{ fontSize: 11, color: 'var(--c-muted)' }}>
-            {isVi ? 'tổng' : 'overall'}
+            {isVi ? 'tổng thể' : 'overall'}
           </span>
         </div>
 

--- a/app/assets/components/__tests__/DesktopNetWorthPanel.test.tsx
+++ b/app/assets/components/__tests__/DesktopNetWorthPanel.test.tsx
@@ -63,4 +63,16 @@ describe('DesktopNetWorthPanel', () => {
     fireEvent.click(btn)
     expect(onDownloadReport).toHaveBeenCalled()
   })
+
+  // Desktop/mobile copy parity: the panel hardcodes its Vietnamese labels while
+  // the mobile NetWorthCard pulls the same strings from messages/vi.json. They
+  // used to drift ("tổng" vs "tổng thể"). Pin the desktop side to the canonical
+  // wording so the two viewports read identically.
+  it('uses the canonical Vietnamese labels (matches the mobile card)', () => {
+    renderPanel({ locale: 'vi' })
+    // overall-P&L suffix — must be "tổng thể", not the old "tổng"
+    expect(screen.getByText('tổng thể')).toBeInTheDocument()
+    // total-assets KPI label — correct Vietnamese casing
+    expect(screen.getByText('Tổng tài sản')).toBeInTheDocument()
+  })
 })

--- a/app/assets/components/__tests__/NetWorthCardI18n.test.tsx
+++ b/app/assets/components/__tests__/NetWorthCardI18n.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import NetWorthCard from '../NetWorthCard'
+import viMessages from '../../../../messages/vi.json'
+
+// Unlike NetWorthCard.test.tsx (which mocks next-intl to an identity function),
+// this suite wires the REAL Vietnamese messages so the actual rendered copy is
+// asserted — the layer where the desktop/mobile drift lived. The mobile card
+// reads its labels from messages/vi.json; pin the canonical wording here.
+
+global.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => [] })
+
+const baseProps = {
+  totalAssets: 500_000_000,
+  totalLiabilities: 0,
+  netWorth: 500_000_000,
+  totalInvested: 400_000_000,
+  currentValue: 450_000_000,
+  overallProfitLoss: 100_000_000,
+  overallProfitLossPercentage: 25,
+}
+
+function renderVi() {
+  return render(
+    <NextIntlClientProvider locale="vi" messages={viMessages} timeZone="Asia/Ho_Chi_Minh">
+      <NetWorthCard {...baseProps} />
+    </NextIntlClientProvider>,
+  )
+}
+
+describe('NetWorthCard — Vietnamese copy', () => {
+  it('renders the total-assets label with correct casing', () => {
+    renderVi()
+    expect(screen.getByText('Tổng tài sản')).toBeInTheDocument()
+    // The old mis-cased value must be gone.
+    expect(screen.queryByText('Tổng Tài sản')).not.toBeInTheDocument()
+  })
+
+  it('renders the overall-P&L suffix as "tổng thể"', () => {
+    renderVi()
+    expect(screen.getByText('tổng thể')).toBeInTheDocument()
+  })
+})

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -536,7 +536,7 @@
     "member": "thành viên",
     "members": "thành viên",
     "liabilities": "Nợ",
-    "totalAssets": "Tổng Tài sản",
+    "totalAssets": "Tổng tài sản",
     "totalLiabilities": "Tổng Nợ",
     "portfolioValue": "Giá trị Danh mục",
     "gainLossAll": "Lãi/Lỗ (Tất cả)",


### PR DESCRIPTION
## Vấn đề
Trên trang Overview, hai nhãn trong khối **Tài sản ròng** hiển thị khác nhau giữa desktop và mobile, vì `DesktopNetWorthPanel` **hardcode** chuỗi còn `NetWorthCard` (mobile) lấy từ `messages/vi.json`:

| Nhãn | Mobile (cũ) | Desktop (cũ) |
|---|---|---|
| Tổng tài sản | `Tổng Tài sản` (sai chính tả hoa) | `Tổng tài sản` |
| Hậu tố lãi/lỗ tổng | `tổng thể` | `tổng` |

## Sửa
Chuẩn hoá về đúng một bản (`Tổng tài sản`, `tổng thể`) để hai viewport đọc giống nhau:
- `messages/vi.json`: `totalAssets` → `"Tổng tài sản"`
- `DesktopNetWorthPanel.tsx`: hậu tố `"tổng"` → `"tổng thể"`

## Test (TDD, layer component)
- `DesktopNetWorthPanel.test.tsx`: thêm case locale `vi` assert render đúng `tổng thể` + `Tổng tài sản`.
- `NetWorthCardI18n.test.tsx` (mới): render mobile card qua `NextIntlClientProvider` với **messages vi thật** (không mock identity) — đây là layer mà bug thực sự sống — assert copy đã sửa, không còn `Tổng Tài sản`.
- Toàn bộ **1019 unit test pass**.

## Ghi chú
- E2E `dashboard.spec.ts:58` dùng regex case-insensitive đã chứa cả hai casing → không ảnh hưởng.
- `npm run lint` có 26 lỗi `react-hooks/set-state-in-effect` **có sẵn trên `main`** ở các file không liên quan (ThemeProvider, GoalDetailSheet, …); file trong PR này lint sạch.
- Còn tồn tại drift tương tự ở **tiếng Anh** (desktop `Total assets`/`Current` vs mobile `Total Assets`/`Current value`) — không sửa ở PR này để giữ phạm vi gọn; có thể xử lý sau bằng cách route desktop qua `t()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)