### PR TITLE
fix(overview): unify net-worth KPI copy across desktop & mobile (EN)

### DIFF
--- a/app/assets/components/DesktopNetWorthPanel.tsx
+++ b/app/assets/components/DesktopNetWorthPanel.tsx
@@ -93,8 +93,8 @@ export default function DesktopNetWorthPanel({ data, allocationTotals, goldUnits
 
   const kpis = [
     { l: isVi ? 'Đã đầu tư'       : 'Invested',     v: netWorth.totalInvested },
-    { l: isVi ? 'Giá trị hiện tại' : 'Current',      v: netWorth.currentValue },
-    { l: isVi ? 'Tổng tài sản'     : 'Total assets', v: netWorth.totalAssets },
+    { l: isVi ? 'Giá trị hiện tại' : 'Current value', v: netWorth.currentValue },
+    { l: isVi ? 'Tổng tài sản'     : 'Total Assets',  v: netWorth.totalAssets },
     { l: isVi ? 'Nợ'               : 'Liabilities',  v: netWorth.totalLiabilities },
   ]
 

--- a/app/assets/components/__tests__/DesktopNetWorthPanel.test.tsx
+++ b/app/assets/components/__tests__/DesktopNetWorthPanel.test.tsx
@@ -63,4 +63,13 @@ describe('DesktopNetWorthPanel', () => {
     fireEvent.click(btn)
     expect(onDownloadReport).toHaveBeenCalled()
   })
+
+  // English copy parity with the mobile NetWorthCard (which reads en.json). The
+  // desktop panel hardcodes its KPI labels and had drifted from the mobile ones:
+  // "Current" vs "Current value", "Total assets" vs "Total Assets".
+  it('uses the canonical English KPI labels (matches the mobile card)', () => {
+    renderPanel({ locale: 'en' })
+    expect(screen.getByText('Current value')).toBeInTheDocument()
+    expect(screen.getByText('Total Assets')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
Follow-up tới PR #441 (bản VN). Cùng nguyên nhân: `DesktopNetWorthPanel` hardcode nhãn KPI tiếng Anh, còn mobile `NetWorthCard` lấy từ `messages/en.json` → hai nhãn lệch nhau:

| Nhãn | Desktop (cũ) | Mobile |
|---|---|---|
| Current value | `Current` | `Current value` |
| Total Assets | `Total assets` | `Total Assets` |

## Sửa
Đưa hardcode EN của desktop về đúng bản canonical trong `en.json` để hai viewport giống nhau. Chỉ đổi 2 chuỗi trong `DesktopNetWorthPanel.tsx` (dòng 96–97), không đụng logic.

## Test (TDD)
- `DesktopNetWorthPanel.test.tsx` (locale `en`): assert render `Current value` + `Total Assets`. Red trước fix → green sau.
- Full suite: **1017 unit test pass**.

## Ghi chú
- Độc lập với #441 (đụng dòng khác nhau trong cùng file → không xung đột), branch off `origin/main`.
- E2E `dashboard.spec.ts:58` dùng regex case-insensitive chứa `Total Assets` → không ảnh hưởng; không có e2e nào assert chuỗi `Current` cũ.
- Lint 26 lỗi `set-state-in-effect` là **có sẵn trên main** ở file không liên quan; file trong PR lint sạch (`eslint` exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)