### PR TITLE
fix(mobile): date field overflows edit-transaction sheet (#447)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -325,6 +325,18 @@
 @media (max-width: 768px) {
   .cn-input { font-size: 16px; }
   input, textarea, select { font-size: 16px; }
+  /* iOS Safari renders native date/time controls at an intrinsic width and
+     ignores width/max-width until -webkit-appearance is reset — so the NGÀY
+     field spilled past the edit-transaction sheet (#447). Resetting appearance
+     lets our width:100%/box-sizing apply; iOS still shows its native picker on
+     tap. Scoped to mobile so desktop keeps the native calendar-picker icon. */
+  input[type="date"],
+  input[type="datetime-local"],
+  input[type="time"],
+  input[type="month"] {
+    -webkit-appearance: none;
+    appearance: none;
+  }
 }
 
 /* Empty <input type=date>: iOS shows nothing, Chrome shows a native "mm/dd/yyyy".


### PR DESCRIPTION
Fixes #447

## Vấn đề
Trên mobile, field **NGÀY** trong sheet *Sửa giao dịch* tràn ra khỏi mép phải modal, trong khi mọi field khác nằm gọn bên trong.

## Nguyên nhân
iOS Safari render `<input type="date">` với chiều rộng nội tại và **bỏ qua `width`/`max-width` cho tới khi reset `-webkit-appearance`**. `inputStyle` đã có `width:100%` + `box-sizing:border-box` nhưng iOS không áp dụng cho date control mặc định → tràn.

## Cách sửa (CSS-only)
Reset `appearance` cho các input date/time trong breakpoint mobile (`max-width: 768px`), để `width:100%` sẵn có được áp dụng:
```css
@media (max-width: 768px) {
  input[type="date"], input[type="datetime-local"],
  input[type="time"], input[type="month"] {
    -webkit-appearance: none; appearance: none;
  }
}
```
- iOS vẫn hiện native picker khi chạm.
- Scoped mobile → desktop **giữ nguyên** icon lịch native.
- Không ép `width:100%` để không phá hàng lọc ngày dạng flex (from/to) trong ledger.

## Kiểm thử
Đây là lỗi render native-control riêng của iOS-WebKit — **headless (jsdom/chromium/desktop-webkit) không tái hiện được** (chúng render date input như box thường, vốn đã tôn trọng width), nên một test tự động sẽ không thể "đỏ" trên bug này → không thêm test giả. **Cần verify trực tiếp trên preview iOS.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)