### PR TITLE
perf(nav): instant tab switches via route-level loading.tsx skeletons

### DIFF
--- a/app/(app)/dashboard/__tests__/loading.test.tsx
+++ b/app/(app)/dashboard/__tests__/loading.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import DashboardLoading from '../loading'
+
+// Route-level Suspense fallback for /dashboard. The App Router paints this the
+// instant the tab is tapped — before the server component resolves getUser() —
+// so navigation feels immediate instead of dead for the auth round-trip. It
+// shows the same mobile + desktop Overview skeletons DashboardClient uses for
+// its own first-load, so there's no flash when the client component takes over.
+describe('DashboardLoading', () => {
+  it('renders both breakpoint Overview skeletons, not a spinner', () => {
+    const { container, getByTestId } = render(<DashboardLoading />)
+    expect(getByTestId('dashboard-skeleton')).toBeInTheDocument()
+    expect(getByTestId('dashboard-skeleton-desktop')).toBeInTheDocument()
+    expect(container.querySelectorAll('.sk').length).toBeGreaterThan(0)
+    expect(container.querySelector('.cairn-loader')).toBeNull()
+  })
+})

--- a/app/(app)/dashboard/loading.tsx
+++ b/app/(app)/dashboard/loading.tsx
@@ -1,0 +1,22 @@
+import { DashboardSkeleton, DesktopDashboardSkeleton } from '@/app/assets/components/Skeletons'
+
+/**
+ * Route-level Suspense fallback for /dashboard. The App Router paints this the
+ * instant the tab is tapped — before the async page component resolves its
+ * `getUser()` auth round-trip — so switching tabs feels immediate instead of
+ * dead for ~1s. It reuses the exact skeletons + breakpoint toggle DashboardClient
+ * renders for its own first-load, so the hand-off to the client component is
+ * seamless (no flash). See loading design §04. Fixes the slow tab-switch report.
+ */
+export default function DashboardLoading() {
+  return (
+    <div className="space-y-4 md:space-y-0 md:flex md:flex-col md:flex-1 md:min-h-0">
+      <div className="md:hidden">
+        <DashboardSkeleton />
+      </div>
+      <div className="hidden md:block md:flex-1 md:min-h-0">
+        <DesktopDashboardSkeleton />
+      </div>
+    </div>
+  )
+}

--- a/app/(app)/funds/__tests__/loading.test.tsx
+++ b/app/(app)/funds/__tests__/loading.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import FundsLoading from '../loading'
+
+// Route-level Suspense fallback for /funds — a fund-list shimmer for each
+// breakpoint so tapping the tab paints instantly, bridging to the view's own
+// funds-loading-skeleton once useFundsData resolves.
+describe('FundsLoading', () => {
+  it('renders mobile + desktop fund-list skeletons from the shimmer primitive', () => {
+    const { container, getByTestId } = render(<FundsLoading />)
+    expect(getByTestId('funds-loading-skeleton-mobile')).toBeInTheDocument()
+    expect(getByTestId('funds-loading-skeleton-desktop')).toBeInTheDocument()
+    expect(container.querySelectorAll('.sk').length).toBeGreaterThan(0)
+    expect(container.querySelector('.cairn-loader')).toBeNull()
+  })
+})

--- a/app/(app)/funds/loading.tsx
+++ b/app/(app)/funds/loading.tsx
@@ -1,0 +1,54 @@
+import { Skeleton } from '@/app/components/ui/Skeleton'
+
+const card: React.CSSProperties = {
+  background: 'var(--c-card)',
+  border: '1px solid var(--c-line)',
+  borderRadius: 16,
+}
+
+/**
+ * Route-level Suspense fallback for /funds. Paints instantly on tab tap, then
+ * hands off to each view's own `funds-loading-skeleton` once useFundsData
+ * resolves — so a fund-row shimmer is on screen the whole time instead of a
+ * dead tap. Each breakpoint gets its own shape (mobile card stack vs desktop
+ * single-card row list), mirroring the Mobile/DesktopFundLibraryView skeletons.
+ */
+export default function FundsLoading() {
+  return (
+    <>
+      {/* Mobile — stacked fund cards */}
+      <div className="md:hidden" data-testid="funds-loading-skeleton-mobile" style={{ display: 'grid', gap: 8 }} aria-hidden="true">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} style={{ ...card, padding: '12px 14px', display: 'flex', gap: 10, alignItems: 'center' }}>
+            <Skeleton width={36} height={36} style={{ borderRadius: 8 }} />
+            <div style={{ flex: 1, display: 'grid', gap: 6 }}>
+              <Skeleton width="55%" height={13} />
+              <Skeleton width="75%" height={10} />
+            </div>
+            <Skeleton width={56} height={13} />
+          </div>
+        ))}
+      </div>
+
+      {/* Desktop — single card, row list */}
+      <div className="hidden md:block" data-testid="funds-loading-skeleton-desktop" aria-hidden="true">
+        <div style={{ ...card, overflow: 'hidden' }}>
+          {[0, 1, 2, 3, 4].map((i) => (
+            <div
+              key={i}
+              style={{ display: 'flex', alignItems: 'center', gap: 12, padding: '14px 16px', borderBottom: i < 4 ? '1px solid var(--c-line)' : 'none' }}
+            >
+              <Skeleton width={32} height={32} style={{ borderRadius: 8, flexShrink: 0 }} />
+              <div style={{ flex: 1, display: 'grid', gap: 6 }}>
+                <Skeleton width="35%" height={13} />
+                <Skeleton width="22%" height={10} />
+              </div>
+              <Skeleton width={72} height={13} />
+              <Skeleton width={56} height={13} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  )
+}

--- a/app/(app)/planning/__tests__/loading.test.tsx
+++ b/app/(app)/planning/__tests__/loading.test.tsx
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import PlanningLoading from '../loading'
+
+// Route-level Suspense fallback for /planning — mirrors PlanningClient's own
+// first-load state (mobile stack + desktop tables) so tapping the tab paints a
+// skeleton instantly and hands off to the client component with no flash.
+describe('PlanningLoading', () => {
+  it('renders both breakpoint planning skeletons, not a spinner', () => {
+    const { container, getByTestId } = render(<PlanningLoading />)
+    expect(getByTestId('mobile-planning-skeleton')).toBeInTheDocument()
+    expect(getByTestId('planning-skeleton')).toBeInTheDocument()
+    expect(container.querySelectorAll('.sk').length).toBeGreaterThan(0)
+    expect(container.querySelector('.cairn-loader')).toBeNull()
+  })
+})

--- a/app/(app)/planning/loading.tsx
+++ b/app/(app)/planning/loading.tsx
@@ -1,0 +1,23 @@
+import { MobilePlanningSkeleton, DesktopPlanningSkeleton } from './components/PlanningSkeleton'
+
+/**
+ * Route-level Suspense fallback for /planning. Paints instantly on tab tap and
+ * mirrors the mobile stack / desktop tables that PlanningClient shows on its own
+ * first load, so the client component takes over without a flash. The wrappers
+ * match each view's outer padding/background (MobilePlanningView `md:hidden`
+ * canvas stack; DesktopPlanningView scroll padding). See loading design §04.
+ */
+export default function PlanningLoading() {
+  return (
+    <>
+      <div className="md:hidden" style={{ background: 'var(--c-canvas)', minHeight: '100%' }}>
+        <div style={{ padding: '4px 16px 100px', display: 'grid', gap: 10 }}>
+          <MobilePlanningSkeleton />
+        </div>
+      </div>
+      <div className="hidden md:block" style={{ padding: '20px 24px 40px' }}>
+        <DesktopPlanningSkeleton />
+      </div>
+    </>
+  )
+}

--- a/app/(app)/settings/__tests__/loading.test.tsx
+++ b/app/(app)/settings/__tests__/loading.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import SettingsLoading from '../loading'
+
+// Route-level Suspense fallback for /settings. Settings renders synchronously
+// from server props (no client fetch), so the only navigation delay is the
+// server getUser() round-trip — this skeleton fills exactly that gap with a
+// profile card + preference rows for each breakpoint.
+describe('SettingsLoading', () => {
+  it('renders mobile + desktop settings skeletons, not a spinner', () => {
+    const { container, getByTestId } = render(<SettingsLoading />)
+    expect(getByTestId('settings-loading-skeleton-mobile')).toBeInTheDocument()
+    expect(getByTestId('settings-loading-skeleton-desktop')).toBeInTheDocument()
+    expect(container.querySelectorAll('.sk').length).toBeGreaterThan(0)
+    expect(container.querySelector('.cairn-loader')).toBeNull()
+  })
+})

--- a/app/(app)/settings/loading.tsx
+++ b/app/(app)/settings/loading.tsx
@@ -1,0 +1,70 @@
+import { Skeleton } from '@/app/components/ui/Skeleton'
+
+const card: React.CSSProperties = {
+  background: 'var(--c-card)',
+  border: '1px solid var(--c-line)',
+  borderRadius: 'var(--r-card)',
+}
+
+/** Profile card placeholder — avatar + name/email lines. */
+function ProfileSk() {
+  return (
+    <div style={{ ...card, padding: 18, display: 'flex', alignItems: 'center', gap: 14 }}>
+      <Skeleton width={48} height={48} round />
+      <div style={{ flex: 1, display: 'grid', gap: 8 }}>
+        <Skeleton width="45%" height={15} />
+        <Skeleton width="60%" height={11} />
+      </div>
+    </div>
+  )
+}
+
+/** A settings section card — heading + a few preference rows. */
+function SectionSk({ rows = 3 }: { rows?: number }) {
+  return (
+    <div style={{ ...card, overflow: 'hidden' }}>
+      <div style={{ padding: '14px 18px', borderBottom: '1px solid var(--c-line)' }}>
+        <Skeleton width={110} height={13} />
+      </div>
+      {Array.from({ length: rows }, (_, i) => (
+        <div
+          key={i}
+          style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '14px 18px', borderBottom: i < rows - 1 ? '1px solid var(--c-line)' : 'none' }}
+        >
+          <Skeleton width="40%" height={12} />
+          <Skeleton width={44} height={20} round />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * Route-level Suspense fallback for /settings. Settings renders synchronously
+ * from server props (no client data fetch), so the only tab-switch delay is the
+ * server `getUser()` round-trip — this skeleton fills exactly that gap with a
+ * profile card + preference sections instead of a dead tap. Mobile and desktop
+ * both get a variant. See loading design §04.
+ */
+export default function SettingsLoading() {
+  return (
+    <>
+      {/* Mobile */}
+      <div className="md:hidden" data-testid="settings-loading-skeleton-mobile" style={{ padding: '4px 16px 100px', display: 'grid', gap: 12 }} aria-hidden="true">
+        <ProfileSk />
+        <SectionSk rows={3} />
+        <SectionSk rows={2} />
+      </div>
+
+      {/* Desktop */}
+      <div className="hidden md:block" data-testid="settings-loading-skeleton-desktop" aria-hidden="true">
+        <div style={{ padding: '20px 28px 40px', maxWidth: 720, display: 'grid', gap: 16 }}>
+          <Skeleton width={140} height={20} />
+          <ProfileSk />
+          <SectionSk rows={3} />
+          <SectionSk rows={2} />
+        </div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Vấn đề
Chuyển tab (nhất là trên mobile) bị **đứng ~1s không phản hồi** rồi mới hiện trang mới.

**Nguyên nhân:** không có `loading.tsx` ở bất kỳ route nào. Mỗi trang tab `(app)` là async Server Component có `await supabase.auth.getUser()` (một round-trip mạng). Không có loading boundary → App Router **chặn cho tới khi server render xong** mới đổi màn hình, và route động không thể được prefetch tới boundary. Tap → màn hình chết cho tới hết server render.

## Fix
Thêm `loading.tsx` cho **dashboard, planning, funds, settings**. Giờ:
- Tap tab → skeleton hiện **ngay lập tức** (Suspense fallback)
- Next prefetch được shell của route → cảm giác tức thì
- Mỗi loading **tái dùng** (dashboard, planning) hoặc **bám sát** (funds, settings) skeleton first-load của chính view đó, cùng cách toggle mobile/desktop bằng CSS → không nháy khi client component tiếp quản

## Phạm vi & rủi ro
- **Chỉ thêm mới, không sửa file nào đang có** → gần như không có nguy cơ hồi quy
- Có unit test cho cả 4 fallback
- `npm test -- --run`: **1051 passed** ✓ · `npm run lint`: **0 errors** ✓

## Lưu ý
Đây là bản "quick win" tập trung vào *cảm giác phản hồi tức thì*. Vẫn còn 2 hướng tối ưu sâu hơn (chưa làm trong PR này):
1. Cắt round-trip `getUser()` thừa ở dashboard/settings page (layout đã verify rồi)
2. Fetch data ban đầu ở server thay vì waterfall client-side

🤖 Generated with [Claude Code](https://claude.com/claude-code)