### PR TITLE
docs(claude): always use the mphuongth GitHub account for GitHub ops

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,16 @@ real date (e.g. planning's June-2026 fixtures), so they can fail as the calendar
 
 ## Git & PR Workflow
 
+**Always act as the `mphuongth` GitHub account for this repo.** This is a personal
+repo, but the machine may have other `gh` accounts logged in (e.g. an Agility work
+account set as the global default). Before **any** `gh` command or GitHub API call —
+commenting, closing, merging, pushing — verify the active account with
+`gh api user -q .login` and make sure it is `mphuongth`. The clean way to do this
+without changing the global default is to prefix gh commands with
+`GH_CONFIG_DIR=~/.config/gh-allocate` (a passive config dir whose active account is
+`mphuongth`; falls back to `gh auth switch --user mphuongth` if that dir is absent).
+Never comment / close / merge / push as any other account.
+
 **Never push code directly to `main`.** Every change — no matter how small — must go through a branch and PR.
 
 Rules:


### PR DESCRIPTION
## Vì sao
Trong lúc làm việc, một comment PR bị đăng nhầm dưới **account gh mặc định của máy** (account Agility) vì không kiểm tra active account trước khi gọi GitHub API. (Comment thừa đó đã được xoá.)

## Thay đổi
Thêm một rule ở đầu mục **Git & PR Workflow** trong `CLAUDE.md`:
- Luôn thao tác GitHub dưới account **`mphuongth`** cho repo này
- **Kiểm tra `gh api user -q .login` trước** mọi lệnh `gh` / GitHub API (comment, close, merge, push)
- Cách sạch: prefix `GH_CONFIG_DIR=~/.config/gh-allocate` (config phụ active = mphuongth) để **không đổi default global** của account công ty

Chỉ sửa docs (`CLAUDE.md`), không đụng code.