### PR TITLE
fix(plan): align desktop/mobile empty-state copy + standardize amount unit label

### DIFF
--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -959,7 +959,7 @@ export default function DesktopPlanningView({
                 <THead col1={isVI ? 'Mục tiêu / Khoản' : 'Goal / Allocation'} col2={isVI ? 'Tháng này' : 'This month'} />
                 <tbody>
                   {byGoal.length === 0 ? (
-                    <tr><td colSpan={3} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có khoản đầu tư nào' : 'No investments yet'}</td></tr>
+                    <tr><td colSpan={3} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có phân bổ nào' : 'No allocations yet'}</td></tr>
                   ) : byGoal.map(g => {
                     const pct = g.totalAllocated > 0 ? Math.min(100, Math.round(g.contributed / g.totalAllocated * 100)) : (g.contributed > 0 ? 100 : 0)
                     const met = g.totalAllocated > 0 && g.contributed >= g.totalAllocated
@@ -1044,7 +1044,7 @@ export default function DesktopPlanningView({
                 <THead col1={isVI ? 'Chi phí' : 'Expense'} col2={isVI ? 'Số tiền' : 'Amount'} />
                 <tbody>
                   {fixedExpenses.length === 0 ? (
-                    <tr><td colSpan={3} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có chi phí cố định' : 'No fixed expenses'}</td></tr>
+                    <tr><td colSpan={3} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có chi phí cố định nào' : 'No fixed expenses yet'}</td></tr>
                   ) : fixedExpenses.map((fe, i) => {
                     const skipped    = fe.override === 0
                     const isOverridden = !skipped && fe.override != null && fe.override !== fe.amount_vnd
@@ -1092,7 +1092,7 @@ export default function DesktopPlanningView({
                 />
                 <tbody>
                   {insuranceMembers.length === 0 ? (
-                    <tr><td colSpan={5} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có bảo hiểm' : 'No insurance members'}</td></tr>
+                    <tr><td colSpan={5} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có thành viên bảo hiểm nào' : 'No insurance members yet'}</td></tr>
                   ) : insuranceMembers.map((m, i) => {
                     const defaultMonthly = Math.round(m.annual_payment_vnd / 12)
                     const monthly    = m.monthlyOverride ?? defaultMonthly
@@ -1173,7 +1173,7 @@ export default function DesktopPlanningView({
         >
           <div style={{ display: 'grid', gap: 14 }}>
             <label style={{ display: 'grid', gap: 6 }}>
-              <span style={labelStyle}>{isVI ? 'Thu nhập tháng (₫)' : 'Monthly income (₫)'}</span>
+              <span style={labelStyle}>{isVI ? 'Thu nhập tháng (VND)' : 'Monthly income (VND)'}</span>
               <input
                 type="text"
                 inputMode="numeric"
@@ -1224,7 +1224,7 @@ export default function DesktopPlanningView({
           <div style={{ display: 'grid', gap: 14 }}>
             <div style={{ fontSize: 13, color: 'var(--c-muted)', fontWeight: 500 }}>{overrideModal.name}</div>
             <label style={{ display: 'grid', gap: 6 }}>
-              <span style={labelStyle}>{isVI ? 'Số tiền tháng này (₫)' : 'Amount this month (₫)'}</span>
+              <span style={labelStyle}>{isVI ? 'Số tiền tháng này (VND)' : 'Amount this month (VND)'}</span>
               <input type="text" inputMode="numeric" value={formatIntVN(overrideVal)} onChange={e => setOverrideVal(parseIntVN(e.target.value))} autoFocus className="cn-input tabular" />
             </label>
             {overrideVal && Number(overrideVal) > 0 && (
@@ -1257,7 +1257,7 @@ export default function DesktopPlanningView({
               <input value={otherDesc} onChange={e => setOtherDesc(e.target.value)} autoFocus placeholder={isVI ? 'VD. Mua laptop...' : 'e.g. Buy laptop...'} className="cn-input" />
             </label>
             <label style={{ display: 'grid', gap: 6 }}>
-              <span style={labelStyle}>{isVI ? 'Số tiền (₫)' : 'Amount (₫)'}</span>
+              <span style={labelStyle}>{isVI ? 'Số tiền (VND)' : 'Amount (VND)'}</span>
               <input type="text" inputMode="numeric" value={formatIntVN(otherAmt)} onChange={e => setOtherAmt(parseIntVN(e.target.value))} placeholder="0" className="cn-input tabular" />
             </label>
             {otherAmt && Number(otherAmt) > 0 && (

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -198,7 +198,7 @@ function SalarySheet({
     <Sheet open={open} onClose={onClose} title={label}>
       <div style={{ display: 'grid', gap: 14 }}>
         <label style={{ fontSize: 13, color: 'var(--c-muted)', display: 'block' }}>
-          {isVI ? 'Thu nhập tháng (₫)' : 'Monthly income (₫)'}
+          {isVI ? 'Thu nhập tháng (VND)' : 'Monthly income (VND)'}
         </label>
         {error && <p style={{ color: 'var(--c-neg)', fontSize: 13 }}>{error}</p>}
         <input
@@ -376,7 +376,7 @@ function OtherExpenseSheet({
         </div>
         <div>
           <label style={{ fontSize: 13, color: 'var(--c-muted)', display: 'block', marginBottom: 4 }}>
-            {isVI ? 'Số tiền (₫)' : 'Amount (₫)'}
+            {isVI ? 'Số tiền (VND)' : 'Amount (VND)'}
           </label>
           <input
             type="text"
@@ -1402,7 +1402,7 @@ export default function MobilePlanningView({
             >
               {byGoal.length === 0 ? (
                 <div style={{ padding: '12px 14px', fontSize: 13, color: 'var(--c-muted)' }}>
-                  {isVI ? 'Chưa có phân bổ' : 'No allocations yet'}
+                  {isVI ? 'Chưa có phân bổ nào' : 'No allocations yet'}
                 </div>
               ) : (
                 byGoal.map((entry) => (
@@ -1446,7 +1446,7 @@ export default function MobilePlanningView({
               >
                 {fixedExpenses.length === 0 && (
                   <div style={{ padding: '14px', fontSize: 13, color: 'var(--c-muted)' }}>
-                    {isVI ? 'Chưa có chi phí cố định.' : 'No fixed expenses yet.'}
+                    {isVI ? 'Chưa có chi phí cố định nào' : 'No fixed expenses yet'}
                   </div>
                 )}
                 {fixedExpenses.map((fe, i) => {
@@ -1499,7 +1499,7 @@ export default function MobilePlanningView({
               >
                 {insuranceMembers.length === 0 && (
                   <div style={{ padding: '14px', fontSize: 13, color: 'var(--c-muted)' }}>
-                    {isVI ? 'Chưa có thành viên bảo hiểm.' : 'No insurance members yet.'}
+                    {isVI ? 'Chưa có thành viên bảo hiểm nào' : 'No insurance members yet'}
                   </div>
                 )}
                 {insuranceMembers.map((m, i) => {

--- a/app/(app)/planning/components/RecurringSavingManager.tsx
+++ b/app/(app)/planning/components/RecurringSavingManager.tsx
@@ -303,7 +303,7 @@ export default function RecurringSavingManager({ goals, onChange, onToast, varia
         </div>
 
         <div>
-          <label htmlFor="rs-amount" style={labelStyle}>{isVI ? 'Số tiền hàng tháng (₫)' : 'Monthly amount (₫)'}</label>
+          <label htmlFor="rs-amount" style={labelStyle}>{isVI ? 'Số tiền hàng tháng (VND)' : 'Monthly amount (VND)'}</label>
           <input
             id="rs-amount"
             data-testid="rs-amount"

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -480,3 +480,33 @@ describe('DesktopPlanningView — summary strip & sections', () => {
     expect(screen.getByText('Insurance')).toBeInTheDocument()
   })
 })
+
+// Copy parity: the desktop and mobile views hardcode their own empty-state
+// strings, and they had drifted (e.g. goals said "No investments yet" on desktop
+// but "No allocations yet" on mobile). These lock the shared wording — the mobile
+// suite asserts the identical strings.
+describe('DesktopPlanningView — empty-state copy parity', () => {
+  it('goals empty state reads "No allocations yet"', () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getByText('No allocations yet')).toBeInTheDocument()
+  })
+
+  it('fixed-expenses empty state reads "No fixed expenses yet"', () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getByText('No fixed expenses yet')).toBeInTheDocument()
+  })
+
+  it('insurance empty state reads "No insurance members yet"', () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getByText('No insurance members yet')).toBeInTheDocument()
+  })
+})
+
+describe('DesktopPlanningView — amount unit label uses (VND)', () => {
+  it('income modal labels the amount "(VND)", matching the app-wide form convention', async () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Edit income' }))
+    expect(await screen.findByText('Monthly income (VND)')).toBeInTheDocument()
+    expect(screen.queryByText('Monthly income (₫)')).not.toBeInTheDocument()
+  })
+})

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -734,3 +734,32 @@ describe('MobilePlanningView — overridden-item restore parity + recurring deep
     }
   })
 })
+
+// Copy parity: these must match the DesktopPlanningView suite's empty-state
+// strings byte-for-byte — the two views previously drifted (goals "No allocations
+// yet" vs "No investments yet"; a stray trailing period on the mobile ones).
+describe('MobilePlanningView — empty-state copy parity', () => {
+  it('goals empty state reads "No allocations yet"', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getByText('No allocations yet')).toBeInTheDocument()
+  })
+
+  it('fixed-expenses empty state reads "No fixed expenses yet"', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getByText('No fixed expenses yet')).toBeInTheDocument()
+  })
+
+  it('insurance empty state reads "No insurance members yet"', () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    expect(screen.getByText('No insurance members yet')).toBeInTheDocument()
+  })
+})
+
+describe('MobilePlanningView — amount unit label uses (VND)', () => {
+  it('salary sheet labels the amount "(VND)", matching the app-wide form convention', async () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} />)
+    await userEvent.click(screen.getByRole('button', { name: 'Edit income' }))
+    expect(await screen.findByText('Monthly income (VND)')).toBeInTheDocument()
+    expect(screen.queryByText('Monthly income (₫)')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What & why

A UX re-audit of the Plan page (`/planning`) surfaced two small copy inconsistencies. The page's prior deep audit is fully closed — these are the only fresh, user-facing polish items. **Copy-only change.**

### 1. Desktop/mobile empty-state copy had drifted
The two views hardcode their own inline empty-state strings, and they'd diverged:

| Section | Desktop (before) | Mobile (before) |
|---|---|---|
| By goal | `No investments yet` | `No allocations yet` |
| Fixed expenses | `No fixed expenses` | `No fixed expenses yet.` |
| Insurance | `No insurance members` | `No insurance members yet.` |

Normalized **both** views to identical strings:
- Goals — `Chưa có phân bổ nào` / `No allocations yet` (matches the section = allocations grouped by goal, not just investments)
- Fixed — `Chưa có chi phí cố định nào` / `No fixed expenses yet`
- Insurance — `Chưa có thành viên bảo hiểm nào` / `No insurance members yet`

### 2. Amount-input unit label mixed `(₫)` and `(VND)` on the same page
The income / override / other-expense / recurring inline labels used `(₫)`, while every `t()`-based form label in `messages/*.json` (goals, salary, insurance, override…) uses `(VND)`. Standardized the **6 inline Plan-view labels** to `(VND)` to match the app-wide convention. No shared i18n keys touched → no other pages affected, no E2E selectors reference these strings.

## Testing
- TDD: added component tests (Vitest + RTL) asserting the rendered empty-state strings — desktop **and** mobile assert the *identical* text so the drift can't recur — plus the `(VND)` label. Red → green.
- `npm test -- --run` → **1059 passed**
- `npm run lint` → **0 errors** (26 pre-existing repo-wide `set-state-in-effect` warnings, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)