### PR TITLE
fix(funds): dialog accessible names + labelled close buttons (a11y) + delete-label parity

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -91,13 +91,14 @@ function DModal({ open, onClose, title, width = 460, dismissOnBackdrop = true, c
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
+        aria-label={title}
         data-testid="fund-modal"
         onClick={e => e.stopPropagation()}
         style={{ width, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 'var(--r-card)', boxShadow: '0 20px 60px rgba(0,0,0,0.18)', animation: 'pop-in 180ms ease', overflow: 'hidden' }}
       >
         <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--c-line)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <span data-testid="fund-modal-title" style={{ fontSize: 15, fontWeight: 600 }}>{title}</span>
-          <button onClick={onClose} className="cn-btn ghost" style={{ padding: 6 }}>
+          <button onClick={onClose} aria-label="Close" className="cn-btn ghost" style={{ padding: 6 }}>
             <X size={16} />
           </button>
         </div>
@@ -124,13 +125,14 @@ function DeleteModal({ open, onClose, fundCode, onConfirm, deleting }: {
         ref={dialogRef}
         role="dialog"
         aria-modal="true"
+        aria-label={t('deleteModal', { name: fundCode })}
         data-testid="delete-fund-modal"
         onClick={e => e.stopPropagation()}
         style={{ width: 400, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 'var(--r-card)', boxShadow: '0 20px 60px rgba(0,0,0,0.18)', animation: 'pop-in 180ms ease', overflow: 'hidden' }}
       >
         <div style={{ padding: '16px 20px', borderBottom: '1px solid var(--c-line)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
           <span style={{ fontSize: 15, fontWeight: 600 }}>{t('deleteModal', { name: fundCode })}</span>
-          <button onClick={onClose} className="cn-btn ghost" style={{ padding: 6 }}>
+          <button onClick={onClose} aria-label="Close" className="cn-btn ghost" style={{ padding: 6 }}>
             <X size={16} />
           </button>
         </div>

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -164,7 +164,7 @@ function TypeDropdown({ value, onChange }: { value: FundType; onChange: (v: Fund
 
 // ─── Sheet ───────────────────────────────────────────────────────────────────
 
-function Sheet({ open, onClose, testId, dismissOnBackdrop = true, children }: { open: boolean; onClose: () => void; testId: string; dismissOnBackdrop?: boolean; children: React.ReactNode }) {
+function Sheet({ open, onClose, testId, ariaLabel, dismissOnBackdrop = true, children }: { open: boolean; onClose: () => void; testId: string; ariaLabel: string; dismissOnBackdrop?: boolean; children: React.ReactNode }) {
   const [mounted, setMounted] = useState(false)
   const sheetRef = useRef<HTMLDivElement>(null)
   useDialogA11y(sheetRef, open, onClose)
@@ -183,8 +183,12 @@ function Sheet({ open, onClose, testId, dismissOnBackdrop = true, children }: { 
     >
       <div
         ref={sheetRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel}
+        tabIndex={-1}
         data-testid={testId}
-        style={{ width: '100%', background: 'var(--c-card)', borderRadius: '16px 16px 0 0', paddingBottom: 'env(safe-area-inset-bottom,0)', animation: open ? 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' : 'slide-down 180ms ease forwards' }}
+        style={{ width: '100%', background: 'var(--c-card)', borderRadius: '16px 16px 0 0', outline: 'none', paddingBottom: 'env(safe-area-inset-bottom,0)', animation: open ? 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' : 'slide-down 180ms ease forwards' }}
         onClick={(e) => e.stopPropagation()}
       >
         <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '8px auto 0' }} />
@@ -810,7 +814,7 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
       </div>
 
       {/* Add sheet */}
-      <Sheet open={addOpen} onClose={() => { setAddOpen(false); setFormError(null) }} testId="fund-sheet" dismissOnBackdrop={false}>
+      <Sheet open={addOpen} onClose={() => { setAddOpen(false); setFormError(null) }} testId="fund-sheet" ariaLabel={t('addModal')} dismissOnBackdrop={false}>
         <FundForm
           existing={null}
           title={t('addModal')}
@@ -822,7 +826,7 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
       </Sheet>
 
       {/* Edit sheet */}
-      <Sheet open={!!editFund} onClose={() => { setEditFund(null); setFormError(null) }} testId="fund-sheet" dismissOnBackdrop={false}>
+      <Sheet open={!!editFund} onClose={() => { setEditFund(null); setFormError(null) }} testId="fund-sheet" ariaLabel={t('editModal')} dismissOnBackdrop={false}>
         {editFund && (
           <FundForm
             existing={editFund}
@@ -836,7 +840,7 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
       </Sheet>
 
       {/* Delete sheet */}
-      <Sheet open={!!deleteFund} onClose={() => { if (!deleting) setDeleteFund(null) }} testId="delete-fund-sheet">
+      <Sheet open={!!deleteFund} onClose={() => { if (!deleting) setDeleteFund(null) }} testId="delete-fund-sheet" ariaLabel={t('deleteModal', { name: deleteFund?.code ?? '' })}>
         {deleteFund && (
           <div style={{ paddingTop: 14, display: 'grid', gap: 14 }}>
             <p style={{ margin: 0, fontWeight: 700, fontSize: 16, color: 'var(--c-ink)' }}>{t('deleteModal', { name: deleteFund.code })}</p>
@@ -848,7 +852,7 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
               </button>
               <button onClick={handleDelete} disabled={deleting} style={{ flex: 2, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, padding: '10px 14px', fontSize: 13, fontWeight: 600, border: 'none', borderRadius: 10, background: 'var(--c-neg)', color: '#fff', cursor: deleting ? 'not-allowed' : 'pointer', opacity: deleting ? 0.6 : 1, fontFamily: 'inherit' }}>
                 <IconTrash size={14} color="#fff" />
-                {deleting ? tc('deleting') : tc('delete')}
+                {deleting ? tc('deleting') : t('deleteBtn')}
               </button>
             </div>
           </div>

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.a11y.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.a11y.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { useState } from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DesktopFundLibraryView from '../DesktopFundLibraryView'
 import type { Fund } from '../useFundsData'
@@ -43,5 +43,30 @@ describe('DesktopFundLibraryView — dialog a11y (Esc + focus)', () => {
     await waitFor(() => expect(modal.contains(document.activeElement)).toBe(true))
     fireEvent.keyDown(document, { key: 'Escape' })
     await waitFor(() => expect(screen.queryByTestId('delete-fund-modal')).not.toBeInTheDocument())
+  })
+})
+
+// The dialogs set role="dialog" but had no accessible name, and the icon-only
+// close (X) button had no label — a screen reader announced "dialog" / "button".
+describe('DesktopFundLibraryView — dialog accessible names', () => {
+  it('the Add/Edit form modal is a dialog named by its title', async () => {
+    render(<Harness />)
+    await userEvent.click(screen.getByRole('button', { name: 'add' }))
+    expect(screen.getByRole('dialog', { name: 'addModal' })).toBeInTheDocument()
+  })
+
+  it('the form-modal close button has an accessible name', async () => {
+    render(<Harness />)
+    await userEvent.click(screen.getByRole('button', { name: 'add' }))
+    const modal = screen.getByTestId('fund-modal')
+    expect(within(modal).getByRole('button', { name: 'Close' })).toBeInTheDocument()
+  })
+
+  it('the delete modal has an accessible name and a labelled close button', async () => {
+    render(<Harness />)
+    await userEvent.click(screen.getByTestId('fund-delete-btn'))
+    const modal = screen.getByTestId('delete-fund-modal')
+    expect(modal.getAttribute('aria-label')).toBeTruthy()
+    expect(within(modal).getByRole('button', { name: 'Close' })).toBeInTheDocument()
   })
 })

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.a11y.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.a11y.test.tsx
@@ -37,3 +37,21 @@ describe('MobileFundLibraryView — sheet a11y (Esc)', () => {
     await waitFor(() => expect(screen.queryByTestId('fund-sheet')).not.toBeInTheDocument())
   })
 })
+
+// The bottom sheets had focus-trap (useDialogA11y) but no dialog semantics — no
+// role="dialog"/aria-modal/aria-label — so AT didn't announce them as modals.
+describe('MobileFundLibraryView — sheet dialog semantics + names', () => {
+  it('the edit sheet is a role=dialog named by its title', async () => {
+    render(<Harness />)
+    await userEvent.click(screen.getByLabelText('editFund'))
+    expect(screen.getByRole('dialog', { name: 'editModal' })).toBeInTheDocument()
+  })
+
+  it('the delete sheet is a role=dialog with an accessible name', async () => {
+    render(<Harness />)
+    await userEvent.click(screen.getByLabelText('deleteBtn'))
+    const sheet = screen.getByTestId('delete-fund-sheet')
+    expect(sheet).toHaveAttribute('role', 'dialog')
+    expect(sheet.getAttribute('aria-label')).toBeTruthy()
+  })
+})

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.delete.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.delete.test.tsx
@@ -35,7 +35,7 @@ describe('MobileFundLibraryView — delete of an in-use fund is hard-blocked wit
     render(<Harness reload={reload} />)
     await userEvent.click(screen.getByLabelText('deleteBtn'))
     const sheet = screen.getByTestId('delete-fund-sheet')
-    await userEvent.click(within(sheet).getByRole('button', { name: 'delete' }))
+    await userEvent.click(within(sheet).getByRole('button', { name: 'deleteBtn' }))
 
     expect(await screen.findByText('toastDeleteInUse')).toBeInTheDocument()
     expect(screen.queryByText('toastDeleted')).not.toBeInTheDocument()
@@ -47,9 +47,22 @@ describe('MobileFundLibraryView — delete of an in-use fund is hard-blocked wit
     render(<Harness reload={reload} />)
     await userEvent.click(screen.getByLabelText('deleteBtn'))
     const sheet = screen.getByTestId('delete-fund-sheet')
-    await userEvent.click(within(sheet).getByRole('button', { name: 'delete' }))
+    await userEvent.click(within(sheet).getByRole('button', { name: 'deleteBtn' }))
 
     await waitFor(() => expect(reload).toHaveBeenCalled())
     expect(await screen.findByText('toastDeleted')).toBeInTheDocument()
+  })
+})
+
+// #B — the mobile confirm button used the generic common `delete` ("Delete")
+// while desktop uses the fund-specific `deleteBtn` ("Delete fund"). Align them.
+describe('MobileFundLibraryView — delete-confirm label parity with desktop', () => {
+  it('labels the confirm button "Delete fund" (deleteBtn), not the generic "Delete"', async () => {
+    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, status: 204, json: () => Promise.resolve({}) })))
+    render(<Harness reload={reload} />)
+    await userEvent.click(screen.getByLabelText('deleteBtn'))
+    const sheet = screen.getByTestId('delete-fund-sheet')
+    expect(within(sheet).getByRole('button', { name: 'deleteBtn' })).toBeInTheDocument()
+    expect(within(sheet).queryByRole('button', { name: 'delete' })).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## What & why

A UX re-audit of the Funds page (`/funds`) found two remaining gaps after the earlier a11y PR #419 (which added Esc-to-close + focus-trap via `useDialogA11y`, but not names/roles). **Copy/attribute-only change — no behavior change.**

### A. Accessible names & dialog semantics
- **Desktop** `DModal` (add/edit) and `DeleteModal` set `role="dialog"` but had **no `aria-label`** → a screen reader announced an anonymous "dialog". Now named from their visible title.
- Their **icon-only close (X) buttons had no `aria-label`** → announced as an empty "button". Added `aria-label="Close"` (matches the Plan page's `DModal`).
- **Mobile** `Sheet` (add / edit / delete) had focus-trap but **no `role="dialog"` / `aria-modal` / `aria-label` at all** → not announced as a modal. Added them via a new required `ariaLabel` prop wired from each call site.

### B. Delete-confirm label parity (desktop ↔ mobile)
Mobile used the generic `common.delete` ("Delete") while desktop uses the fund-specific `funds.deleteBtn` ("Delete fund" / "Xóa quỹ"). Aligned mobile to `deleteBtn`.

*(Not in scope — deliberately: the duplicated inline `TYPE_META` const across both views + unused `typeEquity/typeDebt/…` i18n keys. It's identical in both views today, so no user-facing drift — pure tech-debt.)*

## Testing
- TDD: extended `DesktopFundLibraryView.a11y` / `MobileFundLibraryView.a11y` / `MobileFundLibraryView.delete` component tests to assert the dialog `role`, accessible names, labelled close buttons, and the shared delete label. Red → green.
- No shared i18n keys added — reuses existing `funds`/`common` keys.
- `npm test -- --run` → **1065 passed** · `npm run lint` → **0 errors** (26 pre-existing `set-state-in-effect` warnings, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)