### PR TITLE
fix(settings): localize export-sheet control aria-labels + fix close-button casing

### DIFF
--- a/app/assets/components/DownloadReportSheet.tsx
+++ b/app/assets/components/DownloadReportSheet.tsx
@@ -67,7 +67,9 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
     sections: 'Nội dung báo cáo',
     includes: ['Tổng quan tài sản ròng', 'Chi tiết từng mục tiêu', 'Phân bổ theo loại tài sản', 'Khoản chưa phân bổ', 'Lịch sử giao dịch'],
     export: 'Xuất báo cáo',
+    exporting: 'Đang xuất',
     cancel: 'Hủy',
+    close: 'Đóng',
     done: 'Đã xuất báo cáo',
     doneSub: 'Kiểm tra thư mục tải xuống của bạn',
   } : {
@@ -80,7 +82,9 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
     sections: 'Report includes',
     includes: ['Net worth overview', 'Per-goal breakdown', 'Asset type allocation', 'Unallocated holdings', 'Transaction history'],
     export: 'Export report',
+    exporting: 'Exporting',
     cancel: 'Cancel',
+    close: 'Close',
     done: 'Report exported',
     doneSub: 'Check your downloads folder',
   }
@@ -175,7 +179,7 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
               <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
                 <button
                   onClick={onClose}
-                  aria-label="cancel"
+                  aria-label={t.cancel}
                   style={{
                     flex: 1, padding: '11px 0', fontSize: 13, fontWeight: 500,
                     minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -190,7 +194,7 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
                   onClick={handleExport}
                   disabled={exporting}
                   data-testid="export-report-btn"
-                  aria-label={exporting ? 'exporting' : t.export}
+                  aria-label={exporting ? t.exporting : t.export}
                   style={{
                     flex: 2, padding: '11px 0', fontSize: 13, fontWeight: 600,
                     minHeight: 44,
@@ -242,7 +246,7 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
         >
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0 }}>
             <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{t.title}</h3>
-            <button onClick={onClose} aria-label="Close" style={{ ...iconHit, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)' }}><X size={18} /></button>
+            <button onClick={onClose} aria-label={t.close} style={{ ...iconHit, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)' }}><X size={18} /></button>
           </div>
           <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto' }}>
             {body}
@@ -284,7 +288,7 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
             <h3 style={{ margin: 0, fontSize: 17, fontWeight: 600, color: 'var(--c-ink)' }}>{t.title}</h3>
             <button
               onClick={onClose}
-              aria-label="close"
+              aria-label={t.close}
               style={{
                 ...iconHit, background: 'transparent', border: 'none',
                 cursor: 'pointer', color: 'var(--c-muted)', borderRadius: 8,

--- a/app/assets/components/__tests__/DownloadReportSheet.i18n.test.tsx
+++ b/app/assets/components/__tests__/DownloadReportSheet.i18n.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import DownloadReportSheet from '../DownloadReportSheet'
+
+// The rest of this sheet localizes its visible text via `isVI`, but the control
+// aria-labels (close X, Cancel, Exporting) were hardcoded English — so a
+// Vietnamese screen-reader user heard "close" / "cancel" instead of the visible
+// "Đóng" / "Hủy". Render in Vietnamese and assert the control names are localized.
+vi.mock('next-intl', () => ({
+  useLocale: () => 'vi',
+}))
+
+const noop = () => Promise.resolve()
+
+describe('DownloadReportSheet — Vietnamese control aria-labels', () => {
+  it('localizes the close button (mobile variant) to "Đóng"', () => {
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
+    expect(screen.getByRole('button', { name: 'Đóng' })).toBeInTheDocument()
+  })
+
+  it('localizes the close button (desktop variant) to "Đóng"', () => {
+    render(<DownloadReportSheet open desktop data={null} onClose={noop} onExport={noop} />)
+    expect(screen.getByRole('button', { name: 'Đóng' })).toBeInTheDocument()
+  })
+
+  it('gives the Cancel button the localized name "Hủy" (no hardcoded "cancel" override)', () => {
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
+    expect(screen.getByRole('button', { name: 'Hủy' })).toBeInTheDocument()
+  })
+})

--- a/app/assets/components/__tests__/DownloadReportSheet.test.tsx
+++ b/app/assets/components/__tests__/DownloadReportSheet.test.tsx
@@ -88,6 +88,15 @@ describe('DownloadReportSheet — actions', () => {
     expect(onClose).toHaveBeenCalled()
   })
 
+  it('labels the close button "Close" consistently on both the desktop and mobile variants', () => {
+    // Regression: desktop used aria-label="Close" but mobile used "close".
+    const { unmount } = render(<DownloadReportSheet open desktop data={null} onClose={noop} onExport={noop} />)
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+    unmount()
+    render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+  })
+
   it('renders Cancel button', () => {
     render(<DownloadReportSheet open data={null} onClose={noop} onExport={noop} />)
     expect(screen.getByRole('button', { name: /^cancel$/i })).toBeInTheDocument()


### PR DESCRIPTION
## What & why

A UX re-audit of the Settings page found it in very good shape — the only concrete item was in the **export report sheet** (`DownloadReportSheet`), reached from Settings → Data → Export.

That sheet localizes all its *visible* text via `isVI`, but four **control `aria-label`s were hardcoded English**, and the close X even disagreed on casing between the two variants:

| Control | Before | Issue |
|---|---|---|
| Close X (desktop) | `aria-label="Close"` | inconsistent casing… |
| Close X (mobile) | `aria-label="close"` | …with desktop |
| Cancel | `aria-label="cancel"` | overrides the visible localized "Hủy" with English |
| Export (busy) | `aria-label="exporting"` | hardcoded English |

Net effect: a Vietnamese screen-reader user heard "close" / "cancel" / "exporting" instead of the visible **"Đóng" / "Hủy" / "Đang xuất"**.

**Fix:** route all four through the sheet's existing `t` object (added `close` + `exporting` keys) so the accessible names match the visible, localized labels — and both close buttons agree.

*(Everything else on Settings verified clean live: dialog a11y holds — profile sheet is a named `role=dialog`, read-only-email hint present; price-sync, language/appearance choosers, export flow all work. Deliberately left: the "Tùy chọn" vs "Tùy chỉnh" header/section wording (arguably intentional) and the sheet's inline-`isVI` copy — tech-debt, not a bug.)*

## Testing
- TDD: new `DownloadReportSheet.i18n.test.tsx` (VI locale) asserts the localized control names ("Đóng"/"Hủy"); the existing EN suite gains a desktop↔mobile close-label consistency check. Red → green.
- `npm test -- --run` → **1069 passed** · `npm run lint` → **0 errors** (26 pre-existing warnings, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)