### PR TITLE
fix(security): close SSRF in NAV refresh + hardening (TLS, signup enum, .env)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
+.env
 .env.local
 .env.*.local
 

--- a/app/api/funds/[id]/route.ts
+++ b/app/api/funds/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { validateNavSourceUrl } from '@/lib/scrape-fund-nav'
+import { ValidationError } from '@/lib/validation'
 
 const FUND_TYPES = ['balanced', 'equity', 'debt', 'gold'] as const
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -66,12 +68,22 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     return NextResponse.json({ error: 'Invalid goal' }, { status: 400 })
   }
 
+  // Validate the NAV source URL (https + exact vendor-host allowlist) before it
+  // is stored and later fetched server-side — prevents SSRF.
+  let cleanNavUrl: string | null
+  try {
+    cleanNavUrl = validateNavSourceUrl(nav_source_url)
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const update: Record<string, unknown> = {
     name: name.trim(),
     code: code.trim().toUpperCase(),
     fund_type,
     nav: navNum,
-    nav_source_url: typeof nav_source_url === 'string' && nav_source_url.trim() ? nav_source_url.trim() : null,
+    nav_source_url: cleanNavUrl,
   }
   // DCA fields use partial-update semantics: only written when the caller
   // actually sends is_dca. The Add/Edit form omits them, so a name/NAV edit

--- a/app/api/funds/route.ts
+++ b/app/api/funds/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { validateNavSourceUrl } from '@/lib/scrape-fund-nav'
+import { ValidationError } from '@/lib/validation'
 
 const FUND_TYPES = ['balanced', 'equity', 'debt', 'gold'] as const
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -63,6 +65,15 @@ export async function POST(request: NextRequest) {
   if (dca_goal_id != null && dca_goal_id !== '' && (typeof dca_goal_id !== 'string' || !UUID_RE.test(dca_goal_id))) {
     return NextResponse.json({ error: 'Invalid goal' }, { status: 400 })
   }
+  // Validate the NAV source URL (https + exact vendor-host allowlist) before it
+  // is stored and later fetched server-side — prevents SSRF.
+  let cleanNavUrl: string | null
+  try {
+    cleanNavUrl = validateNavSourceUrl(nav_source_url)
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
 
   const { data: fund, error } = await supabase
     .from('funds')
@@ -72,7 +83,7 @@ export async function POST(request: NextRequest) {
       code: code.trim().toUpperCase(),
       fund_type,
       nav: navNum,
-      nav_source_url: typeof nav_source_url === 'string' && nav_source_url.trim() ? nav_source_url.trim() : null,
+      nav_source_url: cleanNavUrl,
       is_dca: is_dca === true,
       dca_monthly_amount_vnd: is_dca === true && dca_monthly_amount_vnd ? Number(dca_monthly_amount_vnd) : null,
       // Goal target only applies while DCA is on; cleared otherwise.

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -61,11 +61,11 @@ export default function SignupPage() {
       })
 
       if (error) {
-        if (error.message.toLowerCase().includes('already') || error.status === 422) {
-          setFormError(t('emailInUse'))
-        } else {
-          setFormError(t('cannotCreateAccount'))
-        }
+        // One neutral message for every signup failure so an attacker can't
+        // tell "email already registered" apart from other errors (user
+        // enumeration). Supabase project-level "email enumeration protection"
+        // is the server-side complement.
+        setFormError(t('cannotCreateAccount'))
         return
       }
 

--- a/lib/__tests__/scrape-fund-nav.test.ts
+++ b/lib/__tests__/scrape-fund-nav.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest'
+import { isAllowedNavHost, validateNavSourceUrl, scrapeFundNav } from '../scrape-fund-nav'
+import { ValidationError } from '../validation'
+
+// SSRF guard: nav_source_url is user-supplied and later fetched server-side (by
+// the refresh-nav route + the daily cron). The host gate must be an EXACT match
+// on the vendor domains — the old `hostname.includes('vcbf.com')` substring gate
+// let attacker-controlled hosts like evilvcbf.com / vcbf.com.attacker.com through.
+
+describe('isAllowedNavHost — exact vendor-host match', () => {
+  it('accepts the exact vendor domains and their subdomains', () => {
+    for (const h of ['vcbf.com', 'www.vcbf.com', 'ssiam.com.vn', 'www.ssiam.com.vn',
+                     'dragoncapital.com.vn', 'www.dragoncapital.com.vn', 'vinacapital.com', 'www.vinacapital.com']) {
+      expect(isAllowedNavHost(h)).toBe(true)
+    }
+  })
+
+  it('rejects substring-bypass hosts the old gate would have allowed', () => {
+    for (const h of ['evilvcbf.com', 'vcbf.com.attacker.com', 'ssiam.com.vn.evil.com',
+                     'notvcbf.com', 'vcbf.com.evil', 'dragoncapital.com.vn.attacker.net']) {
+      expect(isAllowedNavHost(h)).toBe(false)
+    }
+  })
+
+  it('rejects internal / unrelated hosts', () => {
+    for (const h of ['127.0.0.1', 'localhost', '169.254.169.254', 'metadata.google.internal', 'example.com']) {
+      expect(isAllowedNavHost(h)).toBe(false)
+    }
+  })
+})
+
+describe('validateNavSourceUrl — write-time SSRF validation', () => {
+  it('returns null for empty / absent input (nav_source_url is optional)', () => {
+    expect(validateNavSourceUrl(null)).toBeNull()
+    expect(validateNavSourceUrl(undefined)).toBeNull()
+    expect(validateNavSourceUrl('')).toBeNull()
+    expect(validateNavSourceUrl('   ')).toBeNull()
+  })
+
+  it('accepts a valid https vendor URL and returns it', () => {
+    const url = 'https://www.vcbf.com/quy-mo/quy-trai-phieu'
+    expect(validateNavSourceUrl(url)).toBe(url)
+  })
+
+  it('rejects a non-https scheme', () => {
+    expect(() => validateNavSourceUrl('http://www.vcbf.com/x')).toThrow(ValidationError)
+  })
+
+  it('rejects the substring-bypass hosts (SSRF)', () => {
+    expect(() => validateNavSourceUrl('https://evilvcbf.com/x')).toThrow(ValidationError)
+    expect(() => validateNavSourceUrl('https://vcbf.com.attacker.com/x')).toThrow(ValidationError)
+  })
+
+  it('rejects the userinfo trick where the real host is attacker-controlled', () => {
+    // new URL('https://vcbf.com@evil.com').hostname === 'evil.com'
+    expect(() => validateNavSourceUrl('https://vcbf.com@evil.com/x')).toThrow(ValidationError)
+  })
+
+  it('rejects internal targets and malformed URLs', () => {
+    expect(() => validateNavSourceUrl('https://127.0.0.1/x')).toThrow(ValidationError)
+    expect(() => validateNavSourceUrl('https://169.254.169.254/latest/meta-data/')).toThrow(ValidationError)
+    expect(() => validateNavSourceUrl('not a url')).toThrow(ValidationError)
+    expect(() => validateNavSourceUrl(42)).toThrow(ValidationError)
+  })
+})
+
+describe('scrapeFundNav — rejects disallowed hosts before any fetch', () => {
+  it('returns an Unsupported-domain error for a substring-bypass host (no network hit)', async () => {
+    const res = await scrapeFundNav('https://evilvcbf.com/x')
+    expect(res).toEqual({ error: expect.stringMatching(/unsupported domain/i) })
+  })
+})

--- a/lib/scrape-fund-nav.ts
+++ b/lib/scrape-fund-nav.ts
@@ -1,4 +1,39 @@
 import https from 'https'
+import { ValidationError } from './validation'
+
+// The only hosts the NAV scraper is allowed to fetch. `nav_source_url` is
+// user-supplied and later fetched server-side (refresh-nav route + daily cron),
+// so this doubles as the SSRF allowlist.
+export const ALLOWED_NAV_HOSTS = ['vcbf.com', 'ssiam.com.vn', 'dragoncapital.com.vn', 'vinacapital.com'] as const
+
+// Exact host match (or a subdomain of an allowed host). Deliberately NOT a
+// substring check: `'evilvcbf.com'.includes('vcbf.com')` is true, which let an
+// attacker point an owned domain (with a private-IP DNS record) at the scraper.
+export function isAllowedNavHost(hostname: string): boolean {
+  const h = hostname.toLowerCase()
+  return ALLOWED_NAV_HOSTS.some((d) => h === d || h.endsWith('.' + d))
+}
+
+// Validate a user-supplied fund NAV source URL before storing it. Requires an
+// absolute https URL whose host is an allowed fund provider; empty → null.
+// Throws ValidationError (the write routes map that to HTTP 400).
+export function validateNavSourceUrl(raw: unknown): string | null {
+  if (raw == null) return null
+  if (typeof raw !== 'string') throw new ValidationError('nav_source_url must be a string')
+  const trimmed = raw.trim()
+  if (trimmed === '') return null
+  let u: URL
+  try {
+    u = new URL(trimmed)
+  } catch {
+    throw new ValidationError('nav_source_url must be a valid URL')
+  }
+  if (u.protocol !== 'https:') throw new ValidationError('nav_source_url must use https')
+  if (!isAllowedNavHost(u.hostname)) {
+    throw new ValidationError('nav_source_url must point to a supported fund provider')
+  }
+  return trimmed
+}
 
 export function parseVietnameseNumber(raw: string): number {
   const cleaned = raw.replace(/[^\d.,]/g, '').trim()
@@ -92,7 +127,6 @@ async function scrapeDragonCapital(url: string): Promise<number> {
     const apiUrl = `https://www.dragoncapital.com.vn/individual/vi/webruntime/api/apex/execute?${qs}`
     try {
       const text = await fetchWithNodeHttps(apiUrl, {
-        rejectUnauthorized: false,
         headers: {
           'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
           'Accept': 'application/json, text/plain, */*',
@@ -152,15 +186,18 @@ async function scrapeVinaCapital(url: string): Promise<number> {
 export async function scrapeFundNav(url: string): Promise<{ nav: number } | { error: string }> {
   try {
     const hostname = new URL(url).hostname.toLowerCase()
+    if (!isAllowedNavHost(hostname)) return { error: `Unsupported domain: ${hostname}` }
+
+    const matches = (d: string) => hostname === d || hostname.endsWith('.' + d)
     let nav: number
 
-    if (hostname.includes('vcbf.com')) {
+    if (matches('vcbf.com')) {
       nav = await scrapeVCBF(url)
-    } else if (hostname.includes('ssiam.com.vn')) {
+    } else if (matches('ssiam.com.vn')) {
       nav = await scrapeSSIAM(url)
-    } else if (hostname.includes('dragoncapital.com.vn')) {
+    } else if (matches('dragoncapital.com.vn')) {
       nav = await scrapeDragonCapital(url)
-    } else if (hostname.includes('vinacapital.com')) {
+    } else if (matches('vinacapital.com')) {
       nav = await scrapeVinaCapital(url)
     } else {
       return { error: `Unsupported domain: ${hostname}` }


### PR DESCRIPTION
## Context

From a whole-app security review. The review found the app **well-secured overall** — RLS is correct on every user table, all 51 API routes authenticate + scope by `user_id`, sessions are httpOnly, the service-role key is server-only, and security headers are strong. This PR fixes the one **HIGH** finding and folds in three quick low-severity hardening items. (The MEDIUM CSP `unsafe-inline`/`unsafe-eval` item is left as a separate follow-up — it needs a nonce migration.)

## Fixes

### #1 — SSRF via `funds.nav_source_url` (HIGH)
`nav_source_url` is user-set and later fetched server-side (the `refresh-nav` route + the daily cron). It was stored with only `.trim()`, and `scrapeFundNav` gated hosts with a **substring** match — `'evilvcbf.com'.includes('vcbf.com') === true` — so `evilvcbf.com` / `vcbf.com.attacker.com` (pointed via DNS at `169.254.169.254`, `127.0.0.1`, an RFC-1918 host, …) sailed through. Blind SSRF (only a parsed number returns), but real.

- New `validateNavSourceUrl` + `isAllowedNavHost` (`lib/scrape-fund-nav.ts`): require an absolute **https** URL whose host **exactly** matches (or is a subdomain of) an allowed provider. Also rejects the `https://vcbf.com@evil.com` userinfo trick (real host = `evil.com`). Wired into the funds **POST/PUT** write path → bad URL rejected with 400, never stored.
- `scrapeFundNav`'s gate switched from `.includes()` to the same exact-host check → any already-stored bad URL is refused before fetch.

### #3 — TLS verification bypass (LOW)
Removed `rejectUnauthorized: false` on the Dragon Capital fetch (fixed trusted host → verification should be on).

### #5 — Signup user enumeration (LOW)
Signup no longer shows a distinct "email already registered" message — one neutral error for all failures. (Supabase project-level "email enumeration protection" is the server-side complement.)

### #9 — `.gitignore` (housekeeping)
Add bare `.env` (only `.env.local` / `.env.*.local` were listed).

## Testing
- TDD: new `lib/__tests__/scrape-fund-nav.test.ts` — exact-host allowlist; substring-bypass, userinfo-trick, non-https, and internal-IP rejections; and that `scrapeFundNav` refuses a disallowed host **before any network call**.
- `npm test -- --run` → **1079 passed** · `npm run lint` → **0 errors** (26 pre-existing warnings).
- No existing test/E2E creates a fund with a `nav_source_url`, so the new write-time validation breaks nothing.

## Note
`scrapeFundNav`'s exact-host allowlist assumes the vendor domains are `vcbf.com`, `ssiam.com.vn`, `dragoncapital.com.vn`, `vinacapital.com` (+ subdomains). If any real fund URL lives on a different apex domain, add it to `ALLOWED_NAV_HOSTS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)