### PR TITLE
fix(security): nonce-based CSP — drop script-src unsafe-inline/unsafe-eval (#2)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import ThemeProvider from './components/ThemeProvider'
 import ServiceWorkerRegistration from './components/ServiceWorkerRegistration'
 import { NextIntlClientProvider } from 'next-intl'
 import { getMessages, getLocale } from 'next-intl/server'
+import { headers } from 'next/headers'
 import './globals.css'
 import { cn } from "@/lib/utils";
 
@@ -46,11 +47,14 @@ export default async function RootLayout({
 }>) {
   const messages = await getMessages()
   const locale = await getLocale()
+  // Per-request CSP nonce set by middleware; undefined in dev (no CSP there), in
+  // which case React omits the attribute and the inline script runs unrestricted.
+  const nonce = (await headers()).get('x-nonce') ?? undefined
 
   return (
     <html lang={locale} suppressHydrationWarning className={cn("font-sans", beVietnamPro.variable, geist.variable)}>
       <head>
-        <script dangerouslySetInnerHTML={{ __html: `try{var t=localStorage.getItem('theme');if(t==='dark'||(!t&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}` }} />
+        <script nonce={nonce} dangerouslySetInnerHTML={{ __html: `try{var t=localStorage.getItem('theme');if(t==='dark'||(!t&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}` }} />
       </head>
       <body className={`${beVietnamPro.variable} font-sans antialiased bg-canvas dark:bg-gray-950 text-gray-900 dark:text-gray-100`}>
         <NextIntlClientProvider messages={messages} locale={locale}>

--- a/lib/__tests__/csp.test.ts
+++ b/lib/__tests__/csp.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { buildContentSecurityPolicy } from '../csp'
+
+describe('buildContentSecurityPolicy', () => {
+  const nonce = 'abc123=='
+  const csp = buildContentSecurityPolicy(nonce)
+  const directives = Object.fromEntries(
+    csp.split(';').map((d) => {
+      const [k, ...v] = d.trim().split(/\s+/)
+      return [k, v.join(' ')]
+    }),
+  )
+
+  it('uses a nonce + strict-dynamic for scripts', () => {
+    expect(directives['script-src']).toContain(`'nonce-${nonce}'`)
+    expect(directives['script-src']).toContain("'strict-dynamic'")
+  })
+
+  it("drops 'unsafe-inline' and 'unsafe-eval' from script-src (the XSS vectors)", () => {
+    expect(directives['script-src']).not.toContain("'unsafe-inline'")
+    expect(directives['script-src']).not.toContain("'unsafe-eval'")
+  })
+
+  it('locks down base-uri, form-action, object-src and framing', () => {
+    expect(directives['object-src']).toBe("'none'")
+    expect(directives['base-uri']).toBe("'self'")
+    expect(directives['form-action']).toBe("'self'")
+    expect(directives['frame-ancestors']).toBe("'none'")
+  })
+
+  it('still allows Supabase (REST + realtime websocket) in connect-src', () => {
+    expect(directives['connect-src']).toContain('https://*.supabase.co')
+    expect(directives['connect-src']).toContain('wss://*.supabase.co')
+  })
+
+  it('appends an extra connect-src origin when given (local Supabase for E2E)', () => {
+    const withLocal = buildContentSecurityPolicy(nonce, {
+      connectExtra: ' http://127.0.0.1:54321 ws://127.0.0.1:54321',
+    })
+    expect(withLocal).toContain('http://127.0.0.1:54321')
+    expect(withLocal).toContain('ws://127.0.0.1:54321')
+  })
+})

--- a/lib/csp.ts
+++ b/lib/csp.ts
@@ -1,0 +1,39 @@
+// Builds the production Content-Security-Policy.
+//
+// `script-src` uses a per-request nonce + 'strict-dynamic' instead of
+// 'unsafe-inline'/'unsafe-eval': an injected inline <script> (or eval'd string)
+// won't execute because it lacks the nonce, and 'strict-dynamic' lets the
+// nonce'd first-party scripts load the rest of the bundle. `'self'` is kept only
+// as a CSP2 fallback (CSP3 browsers that honour 'strict-dynamic' ignore it).
+//
+// `style-src` intentionally keeps 'unsafe-inline' — inline styles can't run
+// JavaScript, and nonce-ing every style block (incl. framework/font styles) is
+// impractical. The primary XSS lever is script execution, which this closes.
+export function buildContentSecurityPolicy(
+  nonce: string,
+  opts: { connectExtra?: string } = {},
+): string {
+  const connectExtra = opts.connectExtra ?? ''
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+    "font-src 'self' data: https://fonts.gstatic.com",
+    "img-src 'self' data: blob: https:",
+    `connect-src 'self' https://*.supabase.co wss://*.supabase.co${connectExtra}`,
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "object-src 'none'",
+  ].join('; ')
+}
+
+// Extra connect-src origins for a local Supabase stack (E2E against
+// `supabase start`). Only emitted for http://localhost|127.0.0.1 URLs, so the
+// production policy (https://*.supabase.co only) is unaffected.
+export function localSupabaseConnectExtra(supabaseUrl: string | undefined): string {
+  const url = supabaseUrl ?? ''
+  return /^http:\/\/(127\.0\.0\.1|localhost)/.test(url)
+    ? ` ${url} ${url.replace(/^http/, 'ws')}`
+    : ''
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -9,33 +9,9 @@ const nextConfig: NextConfig = {
     root: __dirname,
   },
   async headers() {
-    // Permissive CSP baseline that doesn't break Supabase realtime, Google
-    // Fonts, or Next.js inline runtime scripts. Tightening to a nonce-based
-    // policy is a future follow-up.
-
-    // When pointed at a local Supabase stack (E2E against `supabase start`),
-    // allow that origin in connect-src — otherwise the browser blocks all
-    // auth/data fetches. Only added for http://localhost|127.0.0.1 URLs, so
-    // the production CSP (https://*.supabase.co only) is unaffected.
-    const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? ''
-    const localSupabase = /^http:\/\/(127\.0\.0\.1|localhost)/.test(supabaseUrl)
-      ? ` ${supabaseUrl} ${supabaseUrl.replace(/^http/, 'ws')}`
-      : ''
-
-    const csp = [
-      "default-src 'self'",
-      "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
-      "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
-      "font-src 'self' data: https://fonts.gstatic.com",
-      "img-src 'self' data: blob: https:",
-      `connect-src 'self' https://*.supabase.co wss://*.supabase.co${localSupabase}`,
-      "frame-ancestors 'none'",
-      "base-uri 'self'",
-      "form-action 'self'",
-    ].join('; ')
-
+    // The Content-Security-Policy is set per-request in middleware.ts (it needs a
+    // fresh nonce each request); the static security headers live here.
     const securityHeaders = [
-      { key: 'Content-Security-Policy', value: csp },
       { key: 'Strict-Transport-Security', value: 'max-age=63072000; includeSubDomains; preload' },
       { key: 'X-Content-Type-Options', value: 'nosniff' },
       { key: 'X-Frame-Options', value: 'DENY' },

--- a/proxy.ts
+++ b/proxy.ts
@@ -1,14 +1,40 @@
 import { createServerClient } from '@supabase/ssr'
 import { NextRequest, NextResponse } from 'next/server'
+import { buildContentSecurityPolicy, localSupabaseConnectExtra } from '@/lib/csp'
 
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
 
-  if (pathname === '/' || pathname.startsWith('/auth/')) {
-    return NextResponse.next()
+  // Per-request CSP nonce, production only: `next dev`'s HMR / React Refresh uses
+  // eval + inline scripts that a nonce policy would block, so dev is left CSP-free
+  // (local-only). The nonce is stamped on the forwarded request headers so
+  // Next.js nonces the scripts it emits and the root layout can nonce its inline
+  // theme-bootstrap script (via `x-nonce`); it's set on every response too. The
+  // static security headers (HSTS, nosniff, …) live in next.config.ts.
+  const isProd = process.env.NODE_ENV === 'production'
+  const nonce = isProd ? btoa(crypto.randomUUID()) : ''
+  const csp = isProd
+    ? buildContentSecurityPolicy(nonce, {
+        connectExtra: localSupabaseConnectExtra(process.env.NEXT_PUBLIC_SUPABASE_URL),
+      })
+    : ''
+
+  const requestHeaders = new Headers(request.headers)
+  if (isProd) {
+    requestHeaders.set('x-nonce', nonce)
+    requestHeaders.set('content-security-policy', csp)
+  }
+  const withCsp = (res: NextResponse) => {
+    if (isProd) res.headers.set('content-security-policy', csp)
+    return res
   }
 
-  let response = NextResponse.next()
+  // Public routes (landing + auth): no session gate, but still nonce'd + CSP'd.
+  if (pathname === '/' || pathname.startsWith('/auth/')) {
+    return withCsp(NextResponse.next({ request: { headers: requestHeaders } }))
+  }
+
+  let response = NextResponse.next({ request: { headers: requestHeaders } })
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -20,7 +46,7 @@ export async function proxy(request: NextRequest) {
         },
         setAll(cookiesToSet) {
           cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
-          response = NextResponse.next({ request })
+          response = NextResponse.next({ request: { headers: requestHeaders } })
           cookiesToSet.forEach(({ name, value, options }) =>
             response.cookies.set(name, value, options)
           )
@@ -36,10 +62,10 @@ export async function proxy(request: NextRequest) {
   if (!user) {
     const loginUrl = request.nextUrl.clone()
     loginUrl.pathname = '/auth/login'
-    return NextResponse.redirect(loginUrl)
+    return withCsp(NextResponse.redirect(loginUrl))
   }
 
-  return response
+  return withCsp(response)
 }
 
 export const config = {


### PR DESCRIPTION
## What & why

Security-review finding **#2 (MEDIUM)**: the CSP used `script-src 'self' 'unsafe-inline' 'unsafe-eval'`, which largely defeats CSP's XSS mitigation — an injected inline `<script>` would execute. This moves to a per-request **nonce** policy: `script-src 'self' 'nonce-<n>' 'strict-dynamic'`. An injected inline script (or `eval`'d string) no longer runs because it lacks the nonce; `'strict-dynamic'` lets the nonce'd first-party bundle load the rest.

## How
- **`lib/csp.ts`** — pure `buildContentSecurityPolicy(nonce)` (unit-tested) + a local-Supabase `connect-src` helper (preserves the E2E-against-`supabase start` allowance). Adds `object-src 'none'`.
- **`proxy.ts`** (Next 16's middleware, already present for Supabase sessions) — generates a nonce per request, stamps it on the forwarded request headers (so Next.js nonces the scripts it emits) + `x-nonce` (for the layout), and sets the CSP on every HTML response — **keeping the existing session refresh + auth redirect intact**. Enforced in **production only**; `next dev`'s HMR needs eval/inline, so dev stays CSP-free (and E2E runs in dev, unaffected).
- **`next.config.ts`** — CSP moved to the proxy; the static headers (HSTS, nosniff, X-Frame-Options, Referrer/Permissions-Policy) stay.
- **`app/layout.tsx`** — nonces the inline theme-bootstrap `<script>` from `x-nonce`.

`style-src` deliberately keeps `'unsafe-inline'` (inline styles can't run JS; nonce-ing every style block, incl. framework/font styles, is impractical). The primary XSS lever — script execution — is what this closes.

## Testing
- Unit: `lib/__tests__/csp.test.ts` asserts the policy has nonce + strict-dynamic, **no** `unsafe-inline`/`unsafe-eval` in script-src, `object-src 'none'`, and still allows Supabase (REST + realtime + local).
- `npm test -- --run` → **1084 passed** · `npm run lint` → **0 errors**.
- ⚠️ **Runtime verification pending on the Vercel preview** (a nonce CSP can't be exercised by a local Turbopack build here). Please confirm the preview renders and the console shows **no CSP violations** — I'll drive it too. If any client path needs `'unsafe-eval'` (none expected — `recharts` is SVG/no-eval), it can be added back to `script-src` in `lib/csp.ts`.

## Note
This also corrects an observation from the review: the app **does** have central route-protection middleware — it's `proxy.ts` (Next 16 renamed `middleware` → `proxy`), which redirects unauthenticated users to `/auth/login`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)