### PR TITLE
docs: point the live-app link at the new Vercel URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Plan, track, and visualize your financial journey — goals, investments, monthly budgets, insurance — all in one place. Bilingual (Vietnamese + English).
 
-**[Try the live app →](https://allocate-kohl.vercel.app/)**
+**[Try the live app →](https://cairn-money.vercel.app/)**
 
 </div>
 


### PR DESCRIPTION
## What

The Vercel project's auto-generated production URL was `allocate-kohl.vercel.app` — the `-kohl` suffix is the random word Vercel appends when the desired project name is already taken globally.

The project has been renamed to **`cairn-money`** and `cairn-money.vercel.app` is now attached to it, serving the same production deployment. This PR updates the only reference to the old URL in the repo (README.md:12).

## Notes

- The old URL (`allocate-kohl.vercel.app`) still resolves to the same deployment, so nothing breaks.
- No code change needed: nothing hardcodes the site URL, and auth is email+password with no `redirectTo`/`emailRedirectTo`, so no Supabase Auth URL config had to change.
- Docs-only, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)