### PR TITLE
fix(landing): make the hero/plan mockups look like the app we actually ship

### DIFF
--- a/app/components/LandingAppMockup.tsx
+++ b/app/components/LandingAppMockup.tsx
@@ -1,0 +1,190 @@
+import { useTranslations } from 'next-intl'
+import { Calendar, TrendingUp, Settings } from 'lucide-react'
+import { fmtCompact } from '@/lib/formatters'
+
+// A scaled-down still of the real Overview screen, drawn in CSS for the landing hero.
+//
+// It is deliberately built from the SAME i18n keys and the same formatter the real screens
+// use (nav.*, dashboard.*, fmtCompact) rather than hardcoded English strings, so it follows
+// the page locale and cannot quietly drift into advertising an app we don't ship. The shell
+// mirrors app/components/navigation/Sidebar.tsx: a light 220px sidebar with a wordmark and
+// *labelled* nav items — not an icon-only rail. Sizes are ~0.45× the real ones to fit the
+// 540px hero frame; proportions and colours are otherwise the app's.
+
+const NAVY = '#0F2A4A'
+const LINE = '#e9e5dc'
+const CANVAS = '#faf8f4'
+const NAVY_TINT = '#eef2f8'
+const POS = '#047857'
+const POS_TINT = '#ecfdf5'
+const MUTED = '#78716c'
+const INK = '#18181b'
+
+// The production host the mockup's browser chrome shows. Kept honest on purpose: the
+// previous mockup advertised `cairn.app`, a domain we do not own.
+const APP_HOST = 'cairn-money.vercel.app/dashboard'
+
+/** Same stacked-rounded-rects mark the real Sidebar renders. */
+function CairnMark({ size = 18 }: { size?: number }) {
+  return (
+    <svg width={size} height={Math.round(size * 0.85)} viewBox="110 180 283 240" xmlns="http://www.w3.org/2000/svg" style={{ flexShrink: 0 }}>
+      <rect x="111.872" y="359.936" width="280.064" height="57.856" rx="24.3" fill="#3B5A82"/>
+      <rect x="152.064" y="293.888" width="220.16" height="50.176" rx="21.07" fill="#163A61"/>
+      <rect x="163.84" y="233.984" width="167.936" height="44.032" rx="18.49" fill="#10B981"/>
+      <rect x="208.128" y="181.76" width="103.936" height="35.84" rx="15.05" fill={NAVY}/>
+    </svg>
+  )
+}
+
+/** The Overview nav icon, same shape as Sidebar's MountainsIcon. */
+function MountainsIcon({ size = 12 }: { size?: number }) {
+  return (
+    <svg width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor"
+      strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" style={{ display: 'block', flexShrink: 0 }}>
+      <path d="M3 19h18l-6-9-3 4-2-3z" />
+      <circle cx="8" cy="7" r="1.5" />
+    </svg>
+  )
+}
+
+// Sample figures. Written as raw numbers and run through the app's own fmtCompact so the
+// mockup can never show a money format the app doesn't produce.
+const NET_WORTH = 487_500_000
+const KPI_VALUES = { invested: 446_200_000, current: 487_500_000, assets: 512_400_000, liabilities: 24_900_000 }
+const GOALS = [
+  { key: 'mockGoalRetirement', value: 215_400_000, target: 2_000_000_000, pct: 10.8 },
+  { key: 'mockGoalHouse', value: 142_800_000, target: 500_000_000, pct: 28.6 },
+  { key: 'mockGoalEmergency', value: 85_000_000, target: 100_000_000, pct: 85 },
+] as const
+
+export function LandingAppMockup() {
+  const t = useTranslations('landing')
+  const tNav = useTranslations('nav')
+  const tDash = useTranslations('dashboard')
+
+  const navItems = [
+    { label: tNav('dashboard'), icon: <MountainsIcon />, active: true },
+    { label: tNav('planning'), icon: <Calendar size={12} strokeWidth={1.8} />, active: false },
+    { label: tNav('funds'), icon: <TrendingUp size={12} strokeWidth={1.8} />, active: false },
+    { label: tNav('settings'), icon: <Settings size={12} strokeWidth={1.8} />, active: false },
+  ]
+
+  const kpis = [
+    { l: tDash('invested'), v: KPI_VALUES.invested },
+    { l: tDash('currentValue'), v: KPI_VALUES.current },
+    { l: tDash('totalAssets'), v: KPI_VALUES.assets },
+    { l: tDash('liabilities'), v: KPI_VALUES.liabilities },
+  ]
+
+  return (
+    <div className="lp-mockup" style={{ width: 540, flexShrink: 0, background: '#fff', borderRadius: '12px 12px 0 0', boxShadow: '0 -8px 64px rgba(0,0,0,0.45), 0 0 0 1px rgba(255,255,255,0.08)', overflow: 'hidden' }}>
+      {/* Browser chrome */}
+      <div className="lp-mockup-chrome" style={{ background: '#edeae2', padding: '10px 14px', display: 'flex', alignItems: 'center', gap: 10, borderBottom: '1px solid #e0dcd2' }}>
+        <div style={{ display: 'flex', gap: 5 }}>
+          <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#ff5f57', display: 'block' }}/>
+          <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#febc2e', display: 'block' }}/>
+          <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#28c840', display: 'block' }}/>
+        </div>
+        <div className="lp-chrome-url" style={{ flex: 1, textAlign: 'center', fontFamily: 'ui-monospace, monospace', fontSize: 10.5, color: MUTED, background: '#e0dcd2', borderRadius: 5, padding: '3px 10px' }}>
+          {APP_HOST}
+        </div>
+      </div>
+
+      {/* App shell */}
+      <div className="lp-mockup-app" style={{ display: 'flex', height: 400, overflow: 'hidden' }}>
+        {/* Sidebar — light, wordmark, labelled nav, user card (mirrors the real Sidebar) */}
+        <div className="lp-m-sidebar" style={{ width: 112, background: '#fff', borderRight: `1px solid ${LINE}`, flexShrink: 0, display: 'flex', flexDirection: 'column' }}>
+          <div style={{ padding: '11px 10px 10px', display: 'flex', alignItems: 'center', gap: 6, borderBottom: `1px solid ${LINE}`, flexShrink: 0 }}>
+            <CairnMark size={17} />
+            <span className="lp-m-wordmark" style={{ fontSize: 12, fontWeight: 700, color: NAVY, letterSpacing: '-0.02em' }}>Cairn</span>
+          </div>
+          <div style={{ flex: 1, padding: '8px 6px', display: 'flex', flexDirection: 'column', gap: 2 }}>
+            {navItems.map(item => (
+              <div key={item.label} className="lp-m-nav-item" style={{
+                display: 'flex', alignItems: 'center', gap: 7,
+                padding: '6px 8px', borderRadius: 6,
+                background: item.active ? NAVY_TINT : 'transparent',
+                color: item.active ? NAVY : MUTED,
+                fontSize: 10, fontWeight: item.active ? 600 : 400,
+                whiteSpace: 'nowrap',
+              }}>
+                {item.icon}
+                <span className="lp-m-nav-label">{item.label}</span>
+              </div>
+            ))}
+          </div>
+          {/* User card */}
+          <div className="lp-m-user" style={{ padding: '8px 8px 10px', borderTop: `1px solid ${LINE}`, display: 'flex', alignItems: 'center', gap: 6, flexShrink: 0 }}>
+            <span style={{ width: 20, height: 20, borderRadius: '50%', background: NAVY, color: '#fff', fontSize: 8, fontWeight: 700, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>M</span>
+            <span style={{ fontSize: 9, fontWeight: 600, color: INK, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{t('mockUserName')}</span>
+          </div>
+        </div>
+
+        {/* Main content */}
+        <div className="lp-m-content" style={{ flex: 1, background: CANVAS, padding: '13px 15px', overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
+          {/* Page header */}
+          <div className="lp-m-page-header" style={{ marginBottom: 12, borderBottom: `1px solid ${LINE}`, paddingBottom: 10 }}>
+            <div style={{ fontSize: 8.5, textTransform: 'uppercase', letterSpacing: '0.07em', color: MUTED, fontWeight: 600, marginBottom: 2 }}>{tDash('overview')}</div>
+            <div className="lp-m-page-title" style={{ fontSize: 15, fontWeight: 700, color: INK, letterSpacing: '-0.025em' }}>{tDash('greeting', { name: t('mockUserFirstName') })}</div>
+          </div>
+
+          {/* Net-worth card — label, value, P&L chip, sparkline, range pills, 2×2 KPI grid */}
+          <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 10, padding: '11px 12px', marginBottom: 12 }}>
+            <div style={{ fontSize: 8.5, fontWeight: 600, letterSpacing: '0.06em', textTransform: 'uppercase', color: MUTED, marginBottom: 4 }}>{tDash('netWorth')}</div>
+            <div className="lp-m-kpi-val" style={{ fontSize: 20, fontWeight: 700, color: INK, letterSpacing: '-0.03em', lineHeight: 1, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(NET_WORTH)}</div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 7, marginTop: 6 }}>
+              <span style={{ padding: '2px 6px', borderRadius: 999, fontSize: 9, fontWeight: 600, background: POS_TINT, color: POS }}>+9.3%</span>
+              <span style={{ fontSize: 9.5, color: POS, fontWeight: 500, fontVariantNumeric: 'tabular-nums' }}>+{fmtCompact(41_300_000)}</span>
+              <span style={{ fontSize: 9, color: MUTED }}>{tDash('overall')}</span>
+            </div>
+            {/* Sparkline */}
+            <svg style={{ height: 26, display: 'block', marginTop: 10, width: '100%' }} viewBox="0 0 380 26" preserveAspectRatio="none">
+              <polyline points="0,21 32,19 63,20 95,17 127,15 158,12 190,10 222,8 253,7 285,4 317,2 348,1 380,0" fill="none" stroke={POS} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+              <polyline points="0,21 32,19 63,20 95,17 127,15 158,12 190,10 222,8 253,7 285,4 317,2 348,1 380,0 380,26 0,26" fill={POS_TINT} stroke="none"/>
+            </svg>
+            {/* Range pills */}
+            <div style={{ display: 'flex', gap: 3, marginTop: 5 }}>
+              {['1M', '3M', '6M', '1Y', 'All'].map(r => (
+                <span key={r} style={{
+                  flex: 1, textAlign: 'center', padding: '3px 0', borderRadius: 4,
+                  fontSize: 9, fontWeight: 600,
+                  background: r === '1Y' ? NAVY_TINT : 'transparent',
+                  color: r === '1Y' ? NAVY : MUTED,
+                }}>{r}</span>
+              ))}
+            </div>
+            {/* KPI 2×2 grid */}
+            <div className="lp-m-kpi-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 1, marginTop: 11, background: LINE, borderRadius: 8, overflow: 'hidden' }}>
+              {kpis.map(k => (
+                <div key={k.l} style={{ background: '#fff', padding: '7px 9px' }}>
+                  <div style={{ fontSize: 8, color: MUTED, whiteSpace: 'nowrap' }}>{k.l}</div>
+                  <div style={{ fontSize: 10.5, fontWeight: 600, color: INK, marginTop: 1, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(k.v)}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Goals */}
+          <div style={{ fontSize: 11, fontWeight: 600, color: INK, marginBottom: 7, letterSpacing: '-0.01em' }}>{tDash('sectionGoals')}</div>
+          {GOALS.map(g => (
+            <div key={g.key} style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 9, padding: '8px 11px', marginBottom: 5 }}>
+              <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 5 }}>
+                <div style={{ fontSize: 10.5, fontWeight: 600, color: INK }}>{t(g.key)}</div>
+                <div style={{ fontSize: 9, color: MUTED, fontVariantNumeric: 'tabular-nums' }}>
+                  {t('mockGoalTarget', { amount: fmtCompact(g.target) })}
+                </div>
+              </div>
+              <div style={{ height: 4, background: LINE, borderRadius: 99, overflow: 'hidden' }}>
+                <div style={{ height: '100%', borderRadius: 99, background: g.pct >= 100 ? POS : NAVY, width: `${g.pct}%` }}/>
+              </div>
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 5 }}>
+                <span style={{ fontSize: 9, color: MUTED, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(g.value)}</span>
+                <span style={{ fontSize: 9, color: MUTED, fontVariantNumeric: 'tabular-nums' }}>{g.pct.toFixed(0)}%</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/components/LandingPlanMockup.tsx
+++ b/app/components/LandingPlanMockup.tsx
@@ -1,0 +1,65 @@
+import { useTranslations } from 'next-intl'
+import { fmt, fmtCompact } from '@/lib/formatters'
+
+// Scaled-down still of the real Monthly plan screen for the landing spotlight. Same rule as
+// LandingAppMockup: copy comes from the screen's own i18n keys (planning.*) and money from
+// the app's own formatter, so it follows the page locale and stays honest as the app moves.
+
+const NAVY = '#0F2A4A'
+const LINE = '#e9e5dc'
+const CANVAS = '#faf8f4'
+const NAVY_TINT = '#eef2f8'
+const MUTED = '#78716c'
+const INK = '#18181b'
+
+const SALARY = 45_000_000
+const ALLOCATED = 22_800_000
+const REMAINING = 12_200_000
+const ROWS = [
+  { key: 'mockGoalRetirement', sub: 'VFMVF1 + DCDS', amount: 8_000_000 },
+  { key: 'mockGoalHouse', sub: 'VESAF + VCB Save', amount: 7_500_000 },
+  { key: 'mockGoalEmergency', sub: 'VCB Flex Save + MB 6M', amount: 4_000_000 },
+  { key: 'mockGoalLaptop', sub: 'MB Term 3M', amount: 3_300_000 },
+] as const
+
+export function LandingPlanMockup() {
+  const t = useTranslations('landing')
+  const tPlan = useTranslations('planning')
+
+  return (
+    <div style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 16, boxShadow: '0 8px 24px rgba(15,42,74,0.12)', overflow: 'hidden' }}>
+      {/* Header — screen name + the month it is planning */}
+      <div style={{ background: CANVAS, borderBottom: `1px solid ${LINE}`, padding: '14px 18px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+        <div style={{ fontSize: 13, fontWeight: 700, color: INK, letterSpacing: '-0.02em' }}>{tPlan('title')}</div>
+        <div style={{ fontSize: 11, color: MUTED, fontWeight: 500 }}>{t('mockPlanMonth')}</div>
+      </div>
+
+      <div style={{ padding: '16px 18px' }}>
+        {/* Summary — the two figures the real plan header leads with */}
+        <div style={{ background: NAVY_TINT, borderRadius: 10, padding: '12px 14px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
+          <div>
+            <div style={{ fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: NAVY }}>{tPlan('rowTotal')}</div>
+            <div style={{ fontSize: 20, fontWeight: 700, color: NAVY, letterSpacing: '-0.03em', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(ALLOCATED)}</div>
+            <div style={{ fontSize: 10, color: 'rgba(15,42,74,0.6)', marginTop: 2 }}>{tPlan('salaryRow', { amount: fmt(SALARY) })}</div>
+          </div>
+          <div style={{ textAlign: 'right' }}>
+            <div style={{ fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: NAVY }}>{tPlan('rowRemaining')}</div>
+            <div style={{ fontSize: 20, fontWeight: 700, color: NAVY, letterSpacing: '-0.03em', fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(REMAINING)}</div>
+          </div>
+        </div>
+
+        {/* Per-goal allocation — the real plan's "Mục tiêu" column */}
+        <div style={{ fontSize: 9, textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, color: MUTED, marginBottom: 8 }}>{tPlan('colGoal')}</div>
+        {ROWS.map((row, i, arr) => (
+          <div key={row.key} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '9px 0', borderBottom: i < arr.length - 1 ? `1px solid ${LINE}` : 'none' }}>
+            <div>
+              <div style={{ fontSize: 12, fontWeight: 600, color: INK }}>{t(row.key)}</div>
+              <div style={{ fontSize: 10, color: MUTED, marginTop: 1 }}>{row.sub}</div>
+            </div>
+            <div style={{ fontSize: 13, fontWeight: 700, color: INK, fontVariantNumeric: 'tabular-nums', letterSpacing: '-0.02em' }}>{fmtCompact(row.amount)}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/components/__tests__/LandingMockups.test.tsx
+++ b/app/components/__tests__/LandingMockups.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { NextIntlClientProvider } from 'next-intl'
+import { LandingAppMockup } from '../LandingAppMockup'
+import { LandingPlanMockup } from '../LandingPlanMockup'
+import viMessages from '../../../messages/vi.json'
+
+// The landing mockups used to be hardcoded English markup ("Overview", "Hi, Minh",
+// "Net worth", "Total P/L") drawn against a shell the app never had — a narrow navy
+// icon-only rail, where the real app has a light 220px sidebar with text labels. On the
+// Vietnamese landing page (the default locale) that rendered a half-English picture of an
+// app nobody ships. Both mockups now read their copy from the SAME i18n keys the real
+// screens use (nav.*, dashboard.*, planning.*), so they follow the page locale and drift
+// with the app instead of away from it.
+
+function renderVi(ui: React.ReactElement) {
+  return render(
+    <NextIntlClientProvider locale="vi" messages={viMessages} timeZone="Asia/Ho_Chi_Minh">
+      {ui}
+    </NextIntlClientProvider>,
+  )
+}
+
+describe('LandingAppMockup — mirrors the real dashboard shell', () => {
+  it('draws the sidebar the app actually has: four labelled nav items', () => {
+    renderVi(<LandingAppMockup />)
+    // The real Sidebar renders nav.* labels next to icons — not an icon-only rail.
+    for (const label of ['Tổng quan', 'Kế hoạch', 'Quỹ', 'Cài đặt']) {
+      expect(screen.getAllByText(label).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('uses the real Overview copy, in the page locale', () => {
+    renderVi(<LandingAppMockup />)
+    expect(screen.getByText('Xin chào, Minh')).toBeInTheDocument()
+    expect(screen.getByText('Tài sản Ròng')).toBeInTheDocument()
+    // The 2×2 KPI grid the real DesktopNetWorthPanel renders.
+    for (const kpi of ['Đã đầu tư', 'Giá trị hiện tại', 'Tổng tài sản', 'Nợ']) {
+      expect(screen.getByText(kpi)).toBeInTheDocument()
+    }
+  })
+
+  it('leaks no hardcoded English into the Vietnamese page', () => {
+    renderVi(<LandingAppMockup />)
+    for (const stale of ['Overview', 'Hi, Minh', 'Net worth', 'Total P/L', 'Goals']) {
+      expect(screen.queryByText(stale)).not.toBeInTheDocument()
+    }
+  })
+
+  it('shows the real production URL, not a domain we do not own', () => {
+    renderVi(<LandingAppMockup />)
+    expect(screen.queryByText('cairn.app/dashboard')).not.toBeInTheDocument()
+    expect(screen.getByText('cairn-money.vercel.app/dashboard')).toBeInTheDocument()
+  })
+})
+
+describe('LandingPlanMockup — mirrors the real Monthly plan screen', () => {
+  it('uses the real planning copy, in the page locale', () => {
+    renderVi(<LandingPlanMockup />)
+    expect(screen.getByText('Kế hoạch Tháng')).toBeInTheDocument()
+    expect(screen.getByText('Tổng Phân bổ')).toBeInTheDocument()
+    expect(screen.getByText('Lương Còn lại')).toBeInTheDocument()
+  })
+
+  it('leaks no hardcoded English into the Vietnamese page', () => {
+    renderVi(<LandingPlanMockup />)
+    for (const stale of ['Monthly plan', 'Invest this month', 'Remaining', 'Contribution by goal']) {
+      expect(screen.queryByText(stale)).not.toBeInTheDocument()
+    }
+  })
+})

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,13 +4,14 @@ import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { getTranslations } from 'next-intl/server'
 import { ScrollRevealInit } from './components/ScrollRevealInit'
 import { LandingLangToggle } from './components/LandingLangToggle'
+import { LandingAppMockup } from './components/LandingAppMockup'
+import { LandingPlanMockup } from './components/LandingPlanMockup'
 
 const NAVY = '#0F2A4A'
 const LINE = '#e9e5dc'
 const CANVAS = '#faf8f4'
 const POS = '#047857'
 const POS_TINT = '#ecfdf5'
-const NAVY_TINT = '#eef2f8'
 const MUTED = '#78716c'
 const INK = '#18181b'
 const INK_2 = '#3f3f46'
@@ -121,13 +122,14 @@ html, body { overflow-x: clip; }
   .lp-mockup-chrome { padding: 8px 12px !important; }
   .lp-chrome-url { font-size: 9.5px !important; padding: 2px 8px !important; }
   .lp-mockup-app { height: 360px !important; }
-  .lp-m-sidebar { width: 44px !important; padding: 12px 0 !important; }
-  .lp-m-nav-item { width: 30px !important; height: 30px !important; }
-  .lp-m-content { padding: 14px 14px !important; }
+  /* Sidebar keeps its labels (that is the shell the app actually has); it just gets
+     narrower. Below ~380px the labels are dropped rather than wrapped — see below. */
+  .lp-m-sidebar { width: 92px !important; }
+  .lp-m-nav-item { padding: 6px !important; gap: 6px !important; }
+  .lp-m-content { padding: 12px 12px !important; }
   .lp-m-page-title { font-size: 14px !important; }
-  .lp-m-kpi-val { font-size: 15px !important; }
-  .lp-m-actions { display: none !important; }
-  .lp-m-page-header { padding-bottom: 10px !important; margin-bottom: 12px !important; }
+  .lp-m-kpi-val { font-size: 17px !important; }
+  .lp-m-page-header { padding-bottom: 10px !important; margin-bottom: 10px !important; }
 
   /* Section headers */
   .lp-features,
@@ -178,6 +180,14 @@ html, body { overflow-x: clip; }
   .lp-section-h2 { font-size: 26px !important; }
   .lp-cta-h2 { font-size: 28px !important; }
   .lp-mockup-app { height: 320px !important; }
+  /* Too narrow for the labelled sidebar — collapse it to the icon rail, which is exactly
+     what the real Sidebar does at its collapsed width. */
+  .lp-m-sidebar { width: 40px !important; }
+  .lp-m-nav-label,
+  .lp-m-wordmark,
+  .lp-m-user span:last-child { display: none !important; }
+  .lp-m-nav-item { justify-content: center !important; }
+  .lp-m-user { justify-content: center !important; }
 }
 `
 
@@ -249,7 +259,7 @@ export default async function HomePage() {
               <span className="lp-logo-wordmark" style={{ fontSize: 19, fontWeight: 700, color: '#fff', letterSpacing: '-0.03em' }}>Cairn</span>
             </Link>
             <div className="lp-nav-links" style={{ display: 'flex', gap: 28 }}>
-              {[['#features', 'Features'], ['#how', 'How it works'], ['#plan', 'Monthly plan']].map(([href, label]) => (
+              {[['#features', t('navFeatures')], ['#how', t('navHow')], ['#plan', t('navPlan')]].map(([href, label]) => (
                 <a key={href} href={href} style={{ fontSize: 13.5, fontWeight: 500, color: 'rgba(255,255,255,0.6)', textDecoration: 'none' }}
                   className="hover:!text-white transition-colors duration-150">{label}</a>
               ))}
@@ -299,86 +309,10 @@ export default async function HomePage() {
               </div>
             </div>
 
-            {/* App mockup */}
+            {/* App mockup — a still of the real Overview screen, built from the same i18n
+                keys and money formatter the app itself uses (see LandingAppMockup). */}
             <div className="lp-mockup-wrap" style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'flex-end' }}>
-              <div className="lp-mockup" style={{ width: 540, flexShrink: 0, background: '#fff', borderRadius: '12px 12px 0 0', boxShadow: '0 -8px 64px rgba(0,0,0,0.45), 0 0 0 1px rgba(255,255,255,0.08)', overflow: 'hidden' }}>
-                {/* Browser chrome */}
-                <div className="lp-mockup-chrome" style={{ background: '#edeae2', padding: '10px 14px', display: 'flex', alignItems: 'center', gap: 10, borderBottom: '1px solid #e0dcd2' }}>
-                  <div style={{ display: 'flex', gap: 5 }}>
-                    <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#ff5f57', display: 'block' }}/>
-                    <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#febc2e', display: 'block' }}/>
-                    <span style={{ width: 11, height: 11, borderRadius: '50%', background: '#28c840', display: 'block' }}/>
-                  </div>
-                  <div className="lp-chrome-url" style={{ flex: 1, textAlign: 'center', fontFamily: 'ui-monospace, monospace', fontSize: 10.5, color: '#78716c', background: '#e0dcd2', borderRadius: 5, padding: '3px 10px' }}>
-                    cairn.app/dashboard
-                  </div>
-                </div>
-                {/* App layout */}
-                <div className="lp-mockup-app" style={{ display: 'flex', height: 400, overflow: 'hidden' }}>
-                  {/* Sidebar */}
-                  <div className="lp-m-sidebar" style={{ width: 52, background: NAVY, flexShrink: 0, display: 'flex', flexDirection: 'column', alignItems: 'center', padding: '14px 0', gap: 4 }}>
-                    <div style={{ marginBottom: 12 }}>
-                      <CairnLogo width={20} height={17} />
-                    </div>
-                    <div className="lp-m-nav-item" style={{ width: 34, height: 34, borderRadius: 9, display: 'flex', alignItems: 'center', justifyContent: 'center', background: 'rgba(255,255,255,0.15)' }}>
-                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M3 12l9-9 9 9"/><path d="M5 10v10h14V10"/></svg>
-                    </div>
-                    <div className="lp-m-nav-item" style={{ width: 34, height: 34, borderRadius: 9, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.38)" strokeWidth="2" strokeLinecap="round"><rect x="3" y="5" width="18" height="16" rx="2"/><path d="M3 9h18M8 3v4M16 3v4"/></svg>
-                    </div>
-                    <div className="lp-m-nav-item" style={{ width: 34, height: 34, borderRadius: 9, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.38)" strokeWidth="2" strokeLinecap="round"><path d="M4 19V5"/><path d="M4 19h16"/><path d="M8 16v-5M12 16V9M16 16v-3"/></svg>
-                    </div>
-                    <div className="lp-m-nav-item" style={{ width: 34, height: 34, borderRadius: 9, display: 'flex', alignItems: 'center', justifyContent: 'center', marginTop: 'auto' }}>
-                      <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="rgba(255,255,255,0.38)" strokeWidth="2" strokeLinecap="round"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg>
-                    </div>
-                  </div>
-                  {/* Main content */}
-                  <div className="lp-m-content" style={{ flex: 1, background: '#faf8f4', padding: '16px 18px', overflow: 'hidden', display: 'flex', flexDirection: 'column', gap: 0 }}>
-                    <div className="lp-m-page-header" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 14, borderBottom: '1px solid #e9e5dc', paddingBottom: 12 }}>
-                      <div>
-                        <div style={{ fontSize: 8.5, textTransform: 'uppercase', letterSpacing: '0.07em', color: MUTED, fontWeight: 600, marginBottom: 2 }}>Overview</div>
-                        <div className="lp-m-page-title" style={{ fontSize: 15, fontWeight: 700, color: INK, letterSpacing: '-0.025em' }}>Hi, Minh</div>
-                      </div>
-                      <div className="lp-m-actions" style={{ display: 'flex', gap: 5 }}>
-                        <div style={{ fontSize: 9, fontWeight: 600, padding: '4px 9px', borderRadius: 7, border: `1px solid ${LINE}`, background: '#fff', color: NAVY }}>+ Transaction</div>
-                        <div style={{ fontSize: 9, fontWeight: 600, padding: '4px 9px', borderRadius: 7, border: `1px solid ${NAVY}`, background: NAVY, color: '#fff' }}>+ New goal</div>
-                      </div>
-                    </div>
-                    <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, marginBottom: 14 }}>
-                      <div style={{ background: '#fff', border: `1px solid #e9e5dc`, borderRadius: 10, padding: '9px 12px' }}>
-                        <div style={{ fontSize: 8.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: MUTED, fontWeight: 600, marginBottom: 3 }}>Net worth</div>
-                        <div className="lp-m-kpi-val" style={{ fontSize: 17, fontWeight: 700, color: INK, letterSpacing: '-0.03em', fontVariantNumeric: 'tabular-nums' }}>487.5M ₫</div>
-                      </div>
-                      <div style={{ background: '#fff', border: `1px solid #e9e5dc`, borderRadius: 10, padding: '9px 12px' }}>
-                        <div style={{ fontSize: 8.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: MUTED, fontWeight: 600, marginBottom: 3 }}>Total P/L</div>
-                        <div className="lp-m-kpi-val" style={{ fontSize: 17, fontWeight: 700, color: POS, letterSpacing: '-0.03em', fontVariantNumeric: 'tabular-nums' }}>+41.3M ₫</div>
-                      </div>
-                    </div>
-                    <svg style={{ height: 28, display: 'block', marginBottom: 14, width: '100%' }} viewBox="0 0 460 28" preserveAspectRatio="none">
-                      <polyline points="0,22 38,20 76,21 114,18 152,16 190,13 228,11 266,8 304,7 342,4 380,2 418,1 460,0" fill="none" stroke={NAVY} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
-                      <polyline points="0,22 38,20 76,21 114,18 152,16 190,13 228,11 266,8 304,7 342,4 380,2 418,1 460,0 460,28 0,28" fill={NAVY_TINT} stroke="none"/>
-                    </svg>
-                    <div style={{ fontSize: 8.5, textTransform: 'uppercase', letterSpacing: '0.07em', color: MUTED, fontWeight: 600, marginBottom: 8 }}>Goals</div>
-                    {[
-                      { name: 'Retirement', meta: '215.4M ₫ · 10.8%', pct: 10.8, done: false },
-                      { name: 'House down payment', meta: '142.8M ₫ · 28.6%', pct: 28.6, done: false },
-                      { name: 'Emergency fund', meta: '85.0M ₫ · 85%', pct: 85, done: true },
-                      { name: 'New laptop', meta: '18.1M ₫ · 51.7%', pct: 51.7, done: false },
-                    ].map(g => (
-                      <div key={g.name} style={{ background: '#fff', border: `1px solid #e9e5dc`, borderRadius: 10, padding: '9px 12px', marginBottom: 6 }}>
-                        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 6 }}>
-                          <div style={{ fontSize: 11, fontWeight: 600, color: INK }}>{g.name}</div>
-                          <div style={{ fontSize: 9.5, color: MUTED, fontVariantNumeric: 'tabular-nums' }}>{g.meta}</div>
-                        </div>
-                        <div style={{ height: 4, background: '#e9e5dc', borderRadius: 99, overflow: 'hidden' }}>
-                          <div style={{ height: '100%', borderRadius: 99, background: g.done ? POS : NAVY, width: `${g.pct}%` }}/>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              </div>
+              <LandingAppMockup />
             </div>
           </div>
         </section>
@@ -448,42 +382,9 @@ export default async function HomePage() {
               </div>
             </div>
 
-            {/* Plan mockup */}
-            <div className="reveal reveal-delay-2" style={{ background: '#fff', border: `1px solid ${LINE}`, borderRadius: 16, boxShadow: '0 8px 24px rgba(15,42,74,0.12)', overflow: 'hidden' }}>
-              <div style={{ background: CANVAS, borderBottom: `1px solid ${LINE}`, padding: '14px 18px', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-                <div style={{ fontSize: 13, fontWeight: 700, color: INK, letterSpacing: '-0.02em' }}>May 2026</div>
-                <div style={{ fontSize: 11, color: MUTED, fontWeight: 500 }}>Monthly plan</div>
-              </div>
-              <div style={{ padding: '16px 18px', display: 'flex', flexDirection: 'column', gap: 0 }}>
-                {/* Summary bar */}
-                <div style={{ background: NAVY_TINT, borderRadius: 10, padding: '12px 14px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
-                  <div>
-                    <div style={{ fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: NAVY }}>Invest this month</div>
-                    <div style={{ fontSize: 20, fontWeight: 700, color: NAVY, letterSpacing: '-0.03em', fontVariantNumeric: 'tabular-nums' }}>22.8M ₫</div>
-                    <div style={{ fontSize: 10, color: 'rgba(15,42,74,0.6)', marginTop: 2 }}>of 45M ₫ salary · 4 goals</div>
-                  </div>
-                  <div style={{ textAlign: 'right' }}>
-                    <div style={{ fontSize: 10, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.06em', color: NAVY }}>Remaining</div>
-                    <div style={{ fontSize: 20, fontWeight: 700, color: NAVY, letterSpacing: '-0.03em', fontVariantNumeric: 'tabular-nums' }}>12.2M ₫</div>
-                    <div style={{ fontSize: 10, color: 'rgba(15,42,74,0.6)', marginTop: 2 }}>after expenses</div>
-                  </div>
-                </div>
-                <div style={{ fontSize: 9, textTransform: 'uppercase', letterSpacing: '0.08em', fontWeight: 600, color: MUTED, marginBottom: 8 }}>Contribution by goal</div>
-                {[
-                  { name: 'Retirement', sub: 'VFMVF1 + DCDS', amt: '8.0M ₫' },
-                  { name: 'House down payment', sub: 'VESAF + VCB Save', amt: '7.5M ₫' },
-                  { name: 'Emergency fund', sub: 'VCB Flex Save + MB Term 6M', amt: '4.0M ₫' },
-                  { name: 'New laptop', sub: 'MB Term 3M', amt: '3.3M ₫' },
-                ].map((row, i, arr) => (
-                  <div key={row.name} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '9px 0', borderBottom: i < arr.length - 1 ? `1px solid ${LINE}` : 'none' }}>
-                    <div>
-                      <div style={{ fontSize: 12, fontWeight: 600, color: INK }}>{row.name}</div>
-                      <div style={{ fontSize: 10, color: MUTED, marginTop: 1 }}>{row.sub}</div>
-                    </div>
-                    <div style={{ fontSize: 13, fontWeight: 700, color: INK, fontVariantNumeric: 'tabular-nums', letterSpacing: '-0.02em' }}>{row.amt}</div>
-                  </div>
-                ))}
-              </div>
+            {/* Plan mockup — a still of the real Monthly plan screen (see LandingPlanMockup) */}
+            <div className="reveal reveal-delay-2">
+              <LandingPlanMockup />
             </div>
           </div>
         </section>

--- a/e2e/landing.spec.ts
+++ b/e2e/landing.spec.ts
@@ -68,7 +68,10 @@ test('hero Get started free CTA links to /auth/signup', async ({ page }) => {
 
 test('hero shows app mockup with browser chrome', async ({ page }) => {
   await page.goto('/')
-  await expect(page.locator('text=cairn.app/dashboard')).toBeVisible()
+  // The chrome shows the real production host. It used to read `cairn.app`, a domain we
+  // do not own; the shell it framed was a made-up icon rail. Both now mirror the app —
+  // the shell itself is pinned in LandingMockups.test.tsx, not here.
+  await expect(page.locator('text=cairn-money.vercel.app/dashboard')).toBeVisible()
 })
 
 // ─── Features section ────────────────────────────────────────────────────────

--- a/messages/en.json
+++ b/messages/en.json
@@ -849,6 +849,17 @@
     "ctaSub": "Join users who always know exactly where every đồng is going — and why.",
     "ctaCta1": "Get started free",
     "ctaCta2": "View the demo",
-    "footerCopy": "Cairn · © 2026"
+    "footerCopy": "Cairn · © 2026",
+    "mockUserName": "Minh Tran",
+    "mockUserFirstName": "Minh",
+    "mockGoalTarget": "Target · {amount}",
+    "mockGoalRetirement": "Retirement",
+    "mockGoalHouse": "House down payment",
+    "mockGoalEmergency": "Emergency fund",
+    "mockGoalLaptop": "New laptop",
+    "mockPlanMonth": "May 2026",
+    "navFeatures": "Features",
+    "navHow": "How it works",
+    "navPlan": "Monthly plan"
   }
 }

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -849,6 +849,17 @@
     "ctaSub": "Tham gia cùng những người dùng luôn biết chính xác mỗi đồng tiền đang đi đâu — và tại sao.",
     "ctaCta1": "Bắt đầu miễn phí",
     "ctaCta2": "Xem demo",
-    "footerCopy": "Cairn · © 2026"
+    "footerCopy": "Cairn · © 2026",
+    "mockUserName": "Minh Trần",
+    "mockUserFirstName": "Minh",
+    "mockGoalTarget": "Mục tiêu · {amount}",
+    "mockGoalRetirement": "Hưu trí",
+    "mockGoalHouse": "Mua nhà",
+    "mockGoalEmergency": "Quỹ dự phòng",
+    "mockGoalLaptop": "Laptop mới",
+    "mockPlanMonth": "Tháng 5, 2026",
+    "navFeatures": "Tính năng",
+    "navHow": "Cách hoạt động",
+    "navPlan": "Kế hoạch tháng"
   }
 }


### PR DESCRIPTION
## The bug

The landing page's "app screenshot" is not a screenshot — it's hand-drawn CSS, and it had drifted well away from the product:

| Mockup showed | The app actually has |
|---|---|
| A 52px **navy icon-only rail** | A light **220px sidebar**: Cairn wordmark, *labelled* nav items (Tổng quan / Kế hoạch / Quỹ / Cài đặt), user card |
| "Overview" / "Hi, Minh" | "Tổng quan" / "Xin chào, {name}" |
| KPIs "Net worth", "Total P/L" | Net-worth card + P&L chip + sparkline + range pills + a 2×2 KPI grid (Đã đầu tư / Giá trị hiện tại / Tổng tài sản / Nợ) |
| All copy hardcoded **English** | App + landing default to **Vietnamese** — so the page rendered half-English |
| Browser chrome: `cairn.app/dashboard` | A domain we don't own |

The same English leak affected the landing nav links (Features / How it works / Monthly plan).

## The fix

Both mockups become components (`LandingAppMockup`, `LandingPlanMockup`) that:

- draw the **real shell** (mirrors `app/components/navigation/Sidebar.tsx` and `DesktopNetWorthPanel.tsx`),
- take their copy from the **same i18n keys the real screens use** (`nav.*`, `dashboard.*`, `planning.*`) — so they follow the page locale and can't silently drift back into advertising an app we don't ship,
- format money with the app's own `fmtCompact`, so the mockup can never show a format the app doesn't produce.

Net effect on `app/page.tsx`: −147 lines of inline markup.

## Testing

- **Component test** (`LandingMockups.test.tsx`, 6 cases) — the right layer here: the shell and its copy are assertable from messages alone, no browser needed. Verified it has teeth by re-introducing both original bugs → 3 tests go red.
- `npm test -- --run`: **1090 passed**. `npm run lint`: **0 errors** (26 warnings, unchanged from main).
- `e2e/landing.spec.ts`: **21/21 pass**. Its one assertion that pinned the fake `cairn.app` domain is updated — no new E2E added.
- Eyeballed in a real browser at 1280px and 390px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)