### PR TITLE
fix(e2e): sửa 5 spec assert những thứ app chưa bao giờ làm

### DIFF
--- a/e2e/dashboard-desktop.spec.ts
+++ b/e2e/dashboard-desktop.spec.ts
@@ -63,7 +63,16 @@ test.describe('Desktop overview layout', () => {
 
       // Shrink to mobile, then back to desktop. Selection should have been cleared,
       // so the right panel reverts to net worth instead of restoring the goal detail.
+      //
+      // The two resizes must not be back-to-back: with nothing awaited between them the
+      // browser can coalesce both into a single frame, so the app never observes the
+      // mobile breakpoint and never runs the clearing effect — the test then fails
+      // claiming a regression that isn't there. It only showed up when the dashboard
+      // carried enough data from earlier specs to slow the re-render down, which is why
+      // this file passed in isolation and failed in the full suite. Waiting for the
+      // mobile layout to actually render makes the crossing real.
       await page.setViewportSize({ width: 390, height: 844 })
+      await expect(page.getByTestId('desktop-overview')).not.toBeVisible({ timeout: 8_000 })
       await page.setViewportSize({ width: 1280, height: 800 })
 
       await expect(page.getByTestId('desktop-net-worth-panel')).toBeVisible({ timeout: 8_000 })

--- a/e2e/investments.spec.ts
+++ b/e2e/investments.spec.ts
@@ -11,8 +11,11 @@ test('fund library page shows funds list', async ({ page }) => {
   await page.goto('/funds')
   // Wait for content — don't use networkidle which resolves before React useEffect fires the API call
   // Empty state text is Vietnamese: "Chưa có quỹ nào"
+  // Matched by role rather than by tag: the empty state's heading is an <h3>
+  // (FundsEmptyState), so the old `h2` selector could never resolve and this only ever
+  // passed when the shared E2E user happened to have funds.
   const content = page.locator('table')
-    .or(page.locator('h2').filter({ hasText: /no funds yet|chưa có quỹ/i }))
+    .or(page.getByRole('heading', { name: /no funds yet|chưa có quỹ/i }))
     .or(page.getByText(/failed to load/i))
     .first()
   await expect(content).toBeVisible({ timeout: 20_000 })

--- a/e2e/maturity-combine-cluster.spec.ts
+++ b/e2e/maturity-combine-cluster.spec.ts
@@ -87,16 +87,26 @@ test.describe('Maturity card — merge-cluster auto-detection', () => {
   test('surfaces the banner even when the close sibling is not itself due yet', async ({ page }) => {
     test.slow()
     const goal = await api.createGoal({ goal_name: 'E2E NotDue Goal', target_amount: 200_000_000 })
-    // D is matured (the only actionable deposit → the anchor). B matures in 4 days
-    // — NOT actionable (won't show its own Handle row), but within D's 7-day merge
-    // window, so it counts as a cluster sibling and the banner still fires.
+    // Two windows are in play and they are both 7 days, which is what the original
+    // fixture missed:
+    //   • actionable  — MATURITY_REMINDER_DAYS from TODAY (lib/maturity.ts)
+    //   • merge window — 7 days between the sibling's and the ANCHOR's maturity
+    // The original dates (D at -1, B at +4) made B 4 days out, i.e. inside the reminder
+    // window, so B was actionable too and the Handle count was always 2 — this test could
+    // never have passed. A matured anchor makes the case impossible: any sibling within 7
+    // days of it is also within 7 days of today. So the anchor is actionable-but-not-yet-
+    // matured instead, which pushes the sibling past the reminder window while keeping it
+    // inside the merge window.
+    //
+    // D at +6: actionable ('maturing'), the only Handle row → the anchor.
+    // B at +12: 12 > 7 so NOT actionable on its own, yet 6 days from D → cluster sibling.
     const D = await api.createTransaction({
       asset_type: 'bank', amount_vnd: 20_000_000, investment_date: iso(-380),
-      interest_rate: 6, expiry_date: iso(-1), goal_id: goal.goal_id, notes: 'E2E NotDue D',
+      interest_rate: 6, expiry_date: iso(6), goal_id: goal.goal_id, notes: 'E2E NotDue D',
     })
     const B = await api.createTransaction({
       asset_type: 'bank', amount_vnd: 7_000_000, investment_date: iso(-200),
-      interest_rate: 6, expiry_date: iso(4), goal_id: goal.goal_id, notes: 'E2E NotDue B',
+      interest_rate: 6, expiry_date: iso(12), goal_id: goal.goal_id, notes: 'E2E NotDue B',
     })
     try {
       await gotoFreshDashboard(page)

--- a/e2e/planning-desktop.spec.ts
+++ b/e2e/planning-desktop.spec.ts
@@ -46,7 +46,9 @@ test('desktop planning: a DCA fund is grouped under its goal with a Buy action a
 
   // Clicking Buy opens the canonical Add-Transaction sheet (pre-filled), not a
   // mini popup — the asset-type picker (Fund / Bank / Gold) is the giveaway.
-  // The asset-type labels are hard-coded English, so they're locale-proof in CI.
+  // The picker is localized (the app renders `isVi ? 'Vàng' : 'Gold'`), so match both;
+  // the old comment claimed these labels were hard-coded English and the assertion could
+  // not pass against the Vietnamese default locale.
   await desktop.getByRole('button', { name: /Record buy|Ghi nhận mua/i }).first().click()
-  await expect(page.getByRole('button', { name: 'Gold', exact: true })).toBeVisible({ timeout: 5_000 })
+  await expect(page.getByRole('button', { name: /^(Gold|Vàng)$/ })).toBeVisible({ timeout: 5_000 })
 })

--- a/e2e/recent-activity.spec.ts
+++ b/e2e/recent-activity.spec.ts
@@ -128,12 +128,15 @@ test.describe('Recent activity — rendered row', () => {
     const card = page.getByTestId('recent-activity')
     await expect(card).toBeVisible({ timeout: 10_000 })
 
-    // The most recent investment surfaces as a "+" signed amount (green), never
-    // a "−". fmtCompact renders 7,654,321 as "7.7M ₫".
-    const row = card.getByTestId('recent-activity-row').first()
+    // An investment surfaces as a "+" signed amount (green), never a "−".
+    // fmtCompact renders 7,654,321 as "7.7M ₫".
+    //
+    // Matched by amount rather than by taking `.first()`: this transaction is dated today,
+    // and so are several seeded by other specs, so "the top row is mine" only held when
+    // this file ran alone. The behaviour under test is the sign, not the ordering.
+    const row = card.getByTestId('recent-activity-row').filter({ hasText: /7\.7M/ })
     await expect(row).toBeVisible({ timeout: 5_000 })
     await expect(row).toContainText('+')
-    await expect(row).toContainText(/7\.7M/)
   })
 })
 


### PR DESCRIPTION
Điều tra 4 lỗi E2E có sẵn trên `main`. Kết quả: **không có lỗi app nào trong số đó — trừ đúng một cái, và cái đó là thật.**

Full suite: **204/210 → 209/210**.

## 3 lỗi tái hiện được kể cả khi chạy riêng

**`investments.spec.ts`** — tìm empty state trong `h2`, nhưng `FundsEmptyState` render `h3`. Nghĩa là locator chỉ có thể khớp qua nhánh `table`, tức là **chỉ xanh khi user E2E tình cờ có quỹ**. Đổi sang match theo role.

**`planning-desktop.spec.ts`** — assert nút tên đúng `'Gold'`, kèm comment khẳng định nhãn asset-type "hard-coded English, so locale-proof". Không đúng: app render `isVi ? 'Vàng' : 'Gold'`, và suite chạy ở locale Việt mặc định.

**`maturity-combine-cluster.spec.ts`** — seed anchor `-1` ngày và sibling `+4` ngày, rồi assert chỉ 1 khoản actionable. Nhưng `MATURITY_REMINDER_DAYS = 7`, nên sibling `+4` cũng actionable → count luôn là 2.

Sâu hơn: **kịch bản đó bất khả thi về số học** khi anchor đã đáo hạn — sibling nào nằm trong cửa sổ gộp 7 ngày thì cũng nằm trong cửa sổ nhắc 7 ngày. Đã seed lại bằng anchor `+6` (actionable nhưng chưa đáo hạn) và sibling `+12` (ngoài cửa sổ nhắc, vẫn cách anchor 6 ngày).

Test này **chưa từng xanh** kể từ khi merge ở #371 — lọt được vì E2E không chạy trong CI (#313).

## 2 lỗi phụ thuộc thứ tự (xanh khi chạy riêng)

**`dashboard-desktop.spec.ts`** — hai lệnh `setViewportSize` gọi liền nhau không chờ gì, nên browser gộp thành một frame và app không bao giờ quan sát được breakpoint mobile. Test báo "không xoá goal selection" trong khi app không hề sai. Chỉ lộ khi trang đủ nặng để render chậm — đúng lý do file này xanh khi chạy riêng.

**`recent-activity.spec.ts`** — assert giao dịch nó seed là **hàng đầu tiên**, nhưng giao dịch đó ghi ngày hôm nay và nhiều spec khác cũng vậy. Đổi sang match theo số tiền; hành vi đang test là dấu `+`, không phải thứ tự.

## ⚠️ Một lỗi cố tình để đỏ — vì đó là lỗi app thật

`recent-activity.spec.ts` › *mobile date filters show visible From/To labels*

```
expect(box.x + box.width).toBeLessThanOrEqual(ledgerBox.x + ledgerBox.width + 1)
Expected: <= 391
Received:    394.265625
```

Ở viewport 390px, các control của ledger **tràn ra ngoài container**. Ảnh chụp lúc lỗi cho thấy nút **Add**, select **All goals** và trường **To** đều bị cắt ở mép phải — không chỉ mỗi trường ngày mà test đo được.

Điểm quan trọng: **chỉ tái hiện khi tài khoản có đủ giao dịch**, tức là đúng điều kiện của người dùng thật, không phải tài khoản test rỗng. Đây là triệu chứng của issue #362 quay lại dưới dữ liệu thật.

Mình **không sửa test để nó xanh** — nó đang làm đúng việc của nó. Cần một fix ở `TransactionLedgerSheet.tsx`, và nên là PR riêng.

## Kiểm chứng

Chạy full suite trước và sau, cộng chạy riêng từng file để phân biệt lỗi thật với nhiễu thứ tự. Unit test và lint không đổi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)