### PR TITLE
feat(seo): JSON-LD structured data + localize manifest

### DIFF
--- a/app/__tests__/manifest.test.ts
+++ b/app/__tests__/manifest.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest'
+import viMessages from '../../messages/vi.json'
+import enMessages from '../../messages/en.json'
+
+// The PWA install prompt is the one place the manifest's copy is user-facing, and it was
+// English-only on a Vietnamese-by-default app — so a Vietnamese user tapping "Add to home
+// screen" got an English pitch. The icons, sizes and start_url stay static; only the human
+// copy follows the locale.
+
+const mocks = vi.hoisted(() => ({ locale: 'vi' }))
+
+vi.mock('next-intl/server', () => ({
+  getLocale: async () => mocks.locale,
+  getTranslations: async () => {
+    const messages = (mocks.locale === 'vi' ? viMessages : enMessages) as Record<string, Record<string, string>>
+    return (key: string) => messages.meta[key]
+  },
+}))
+
+const { default: manifest } = await import('../manifest')
+
+describe('manifest', () => {
+  it('describes the app in Vietnamese by default', async () => {
+    mocks.locale = 'vi'
+    expect((await manifest()).description).toContain('quỹ mở')
+  })
+
+  it('describes the app in English for an English session', async () => {
+    mocks.locale = 'en'
+    expect((await manifest()).description).toMatch(/mutual funds/i)
+  })
+
+  it('keeps the install-prompt shape the PWA depends on', async () => {
+    mocks.locale = 'vi'
+    const m = await manifest()
+    // These are what make the install prompt appear at all — a locale change must not
+    // disturb them.
+    expect(m.name).toBe('Cairn')
+    expect(m.short_name).toBe('Cairn')
+    expect(m.start_url).toBe('/dashboard')
+    expect(m.display).toBe('standalone')
+    expect(m.icons).toHaveLength(3)
+    expect(m.screenshots).toHaveLength(2)
+  })
+})

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,7 +6,7 @@ import ServiceWorkerRegistration from './components/ServiceWorkerRegistration'
 import { NextIntlClientProvider } from 'next-intl'
 import { getMessages, getLocale, getTranslations } from 'next-intl/server'
 import { headers } from 'next/headers'
-import { buildSiteMetadata } from '@/lib/seo'
+import { buildSiteMetadata, buildStructuredData } from '@/lib/seo'
 import './globals.css'
 import { cn } from "@/lib/utils";
 
@@ -47,10 +47,18 @@ export default async function RootLayout({
   // which case React omits the attribute and the inline script runs unrestricted.
   const nonce = (await headers()).get('x-nonce') ?? undefined
 
+  const tMeta = await getTranslations('meta')
+  // Escaped rather than interpolated raw: a `<` in the payload can terminate the <script>
+  // element early, and the strings come from a translation catalogue. Carries the nonce
+  // like the theme script above — browsers do not execute a JSON-LD data block, but the
+  // CSP applies to the element and there is no reason to make it an exception.
+  const structuredData = JSON.stringify(buildStructuredData(locale, tMeta)).replace(/</g, '\\u003c')
+
   return (
     <html lang={locale} suppressHydrationWarning className={cn("font-sans", beVietnamPro.variable, geist.variable)}>
       <head>
         <script nonce={nonce} dangerouslySetInnerHTML={{ __html: `try{var t=localStorage.getItem('theme');if(t==='dark'||(!t&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}` }} />
+        <script type="application/ld+json" nonce={nonce} dangerouslySetInnerHTML={{ __html: structuredData }} />
       </head>
       <body className={`${beVietnamPro.variable} font-sans antialiased bg-canvas dark:bg-gray-950 text-gray-900 dark:text-gray-100`}>
         <NextIntlClientProvider messages={messages} locale={locale}>

--- a/app/manifest.ts
+++ b/app/manifest.ts
@@ -1,11 +1,20 @@
 import type { MetadataRoute } from 'next'
+import { getTranslations } from 'next-intl/server'
 
-export default function manifest(): MetadataRoute.Manifest {
+// The install prompt is the only place this copy is user-facing, and it was English-only
+// on a Vietnamese-by-default app — so tapping "Add to home screen" pitched the app in a
+// language the user may not read. Reading the locale makes this route dynamic, which is
+// fine: it is excluded from the auth middleware (see proxy.ts) and is fetched once per
+// install prompt, not per page view. Everything the prompt depends on structurally —
+// name, start_url, display, icons, screenshots — stays static.
+export default async function manifest(): Promise<MetadataRoute.Manifest> {
+  const t = await getTranslations('meta')
+
   return {
     id: '/dashboard',
     name: 'Cairn',
     short_name: 'Cairn',
-    description: 'Personal finance, one stone at a time. Plan, track, and grow toward every goal.',
+    description: t('description'),
     start_url: '/dashboard',
     display: 'standalone',
     background_color: '#0F2A4A',

--- a/lib/__tests__/structuredData.test.ts
+++ b/lib/__tests__/structuredData.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest'
+import { buildStructuredData, SITE_URL } from '../seo'
+import viMessages from '../../messages/vi.json'
+import enMessages from '../../messages/en.json'
+
+// The JSON-LD block that tells search engines what this site *is*, rather than leaving them
+// to infer it from prose. Without it Cairn is just another page; with it a finance app with
+// a price, a platform and a language.
+//
+// Pure-function tests, like buildSiteMetadata: the object is the thing that has to be right.
+
+function translator(locale: 'vi' | 'en') {
+  const messages = (locale === 'vi' ? viMessages : enMessages) as Record<string, Record<string, string>>
+  return (key: string) => messages.meta[key]
+}
+
+describe('buildStructuredData', () => {
+  it('declares itself as a finance application', () => {
+    const d = buildStructuredData('vi', translator('vi'))
+    expect(d['@context']).toBe('https://schema.org')
+    expect(d['@type']).toBe('WebApplication')
+    expect(d.applicationCategory).toBe('FinanceApplication')
+  })
+
+  it('names and describes the app in the page locale', () => {
+    expect(buildStructuredData('vi', translator('vi')).description).toContain('quỹ mở')
+    expect(buildStructuredData('en', translator('en')).description).toMatch(/mutual funds/i)
+  })
+
+  it('advertises the price, because "free" is the question a visitor has', () => {
+    const offer = buildStructuredData('vi', translator('vi')).offers
+    expect(offer.price).toBe('0')
+    expect(offer.priceCurrency).toBe('VND')
+  })
+
+  it('points at the production origin, not the current deployment', () => {
+    expect(buildStructuredData('vi', translator('vi')).url).toBe(`${SITE_URL}/`)
+  })
+
+  it('reports the locale it was built for', () => {
+    expect(buildStructuredData('vi', translator('vi')).inLanguage).toBe('vi-VN')
+    expect(buildStructuredData('en', translator('en')).inLanguage).toBe('en-US')
+  })
+
+  it('serialises to JSON that cannot break out of the script tag', () => {
+    // A raw `<` in a JSON-LD payload can terminate the <script> element early. The values
+    // are ours today, but they come from a translation catalogue anyone can edit.
+    const json = JSON.stringify(buildStructuredData('vi', translator('vi')))
+    expect(json).not.toContain('</')
+  })
+})

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -33,6 +33,43 @@ export type Locale = (typeof LOCALES)[number]
 /** Open Graph wants a full locale tag, not a bare language code. */
 const OG_LOCALE: Record<Locale, string> = { vi: 'vi_VN', en: 'en_US' }
 
+/** BCP 47, which is what schema.org's inLanguage expects (OG uses underscores instead). */
+const BCP47: Record<Locale, string> = { vi: 'vi-VN', en: 'en-US' }
+
+export function normalizeLocale(locale: string): Locale {
+  return (LOCALES as readonly string[]).includes(locale) ? (locale as Locale) : 'vi'
+}
+
+/**
+ * schema.org JSON-LD for the landing page.
+ *
+ * Metadata tags say how to *display* the page; this says what it *is* — a free finance
+ * app, in this language, on these platforms — which is what earns a rich result rather
+ * than a plain blue link.
+ *
+ * `price: '0'` is deliberate and load-bearing: "is it free?" is the question a visitor has
+ * before signing up, and it is the one thing a search result can answer for them.
+ */
+export function buildStructuredData(locale: string, t: (key: string) => string) {
+  const loc = normalizeLocale(locale)
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebApplication',
+    name: 'Cairn',
+    url: `${SITE_URL}/`,
+    description: t('description'),
+    applicationCategory: 'FinanceApplication',
+    operatingSystem: 'Web, iOS, Android',
+    inLanguage: BCP47[loc],
+    image: `${SITE_URL}${OG_IMAGE}`,
+    offers: {
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'VND',
+    },
+  }
+}
+
 /**
  * Builds the site-wide metadata for a locale.
  *
@@ -40,7 +77,7 @@ const OG_LOCALE: Record<Locale, string> = { vi: 'vi_VN', en: 'en_US' }
  * the object is cheaper and catches more than booting Next and scraping its own <head>.
  */
 export function buildSiteMetadata(locale: string, t: (key: string) => string): Metadata {
-  const loc: Locale = (LOCALES as readonly string[]).includes(locale) ? (locale as Locale) : 'vi'
+  const loc = normalizeLocale(locale)
   const title = t('title')
   const description = t('description')
 


### PR DESCRIPTION
Hai việc cố tình để lại khỏi #462, giờ làm nốt.

## 1. JSON-LD (`WebApplication` / `FinanceApplication`)

Thẻ metadata ở #462 nói cho công cụ tìm kiếm biết **cách hiển thị** trang. JSON-LD nói **trang này là cái gì** — một app tài chính miễn phí, bằng ngôn ngữ này, chạy trên nền tảng này. Đây là thứ tạo ra rich result thay vì một dòng link xanh trơn.

`price: "0"` là chi tiết có trọng lượng: "có miễn phí không?" đúng là câu hỏi người dùng đặt ra trước khi đăng ký, và kết quả tìm kiếm có thể trả lời hộ.

**Vì sao trước đó mình hoãn:** app dùng CSP nonce nghiêm ngặt (#456), nên nhét một `<script>` vào `<head>` cần cân nhắc riêng, không nên gộp vào PR vốn đã chạm middleware auth.

Cách xử lý:
- Khối JSON-LD mang **nonce theo từng request**, giống script theme ngay cạnh nó. Browser không thực thi khối `ld+json`, nhưng CSP vẫn áp lên element và không có lý do gì để tạo ngoại lệ.
- Payload **escape ký tự `<`** — một dấu `<` thô có thể đóng sớm thẻ `<script>`, mà chuỗi thì đến từ file dịch ai cũng sửa được. Có test riêng cho việc này.

## 2. Localize description của manifest

Description trong manifest là tiếng Anh, trên app mặc định tiếng Việt — nên khi người dùng bấm "Thêm vào màn hình chính", họ nhận được lời giới thiệu bằng thứ tiếng có thể họ không đọc.

Đọc locale khiến route này thành dynamic. Chấp nhận được ở đây: nó vốn đã được loại khỏi middleware auth (#462), và chỉ được fetch mỗi khi hiện install prompt chứ không phải mỗi lần tải trang. Mọi thứ mà install prompt phụ thuộc về mặt cấu trúc — `name`, `start_url`, `display`, `icons`, `screenshots` — giữ nguyên tĩnh, và **có test ghim lại đúng điều đó**.

## Kiểm chứng

Chạy thật với app đang chạy:

```
<script type="application/ld+json">
  ... "inLanguage":"vi-VN", "price":"0", "priceCurrency":"VND" ...

/manifest.webmanifest        → "Theo dõi tài sản, quỹ mở, tiền gửi và vàng..."
/manifest.webmanifest (en)   → "Track your assets, mutual funds, deposits, and gold..."
```

- **1131/1131 unit test xanh** (thêm 9 test), lint 0 error
- **E2E 62/62** trên landing + auth + navigation + dashboard — chọn nhóm này vì thay đổi nằm ở `<head>` của layout dùng chung, nên hydration là rủi ro chính cần canh

## Sau khi merge

Đáng kiểm bằng [Rich Results Test](https://search.google.com/test/rich-results) của Google, và mở DevTools Console trên production để chắc CSP không chặn khối JSON-LD (local dev không bật CSP nên chỗ này chưa kiểm được).

🤖 Generated with [Claude Code](https://claude.com/claude-code)