### PR TITLE
fix(ledger): sửa tràn ngang sheet giao dịch trên mobile

### DIFF
--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -394,7 +394,7 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
   return (
     <>
       <Shell open={open} onClose={onClose} title={t('ledgerTitle')} desktop={desktop} width={880} testId="tx-ledger">
-        <div style={{ display: 'grid', gap: 14 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr)', gap: 14 }}>
           {/* Toolbar */}
           {desktop ? (
             /* Desktop: filters left, actions right */
@@ -431,7 +431,7 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
             </div>
           ) : (
             /* Mobile: actions on top, filters below */
-            <div style={{ display: 'grid', gap: 12 }}>
+            <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr)', gap: 12 }}>
               <div style={{ display: 'flex', gap: 8 }}>
                 <button data-testid="tx-ledger-import" onClick={() => { setShowImport(true); setImportRaw(''); setImportRows([]); setImportFundId('') }} className="cn-btn" style={{ flex: 1, minWidth: 0, justifyContent: 'center', fontSize: 12, gap: 5 }}>
                   <Download size={14} />{t('import')}
@@ -441,7 +441,7 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
                 </button>
               </div>
               {(total > 0 || hasFilters) && (
-                <div style={{ display: 'grid', gap: 8 }}>
+                <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr)', gap: 8 }}>
                   <div style={{ display: 'flex', gap: 8 }}>
                     <select value={filters.asset_type} onChange={(e) => setSelectFilter('asset_type', e.target.value)} className="cn-input" style={{ flex: 1, minWidth: 0, cursor: 'pointer' }}>
                       <option value="">{t('filterAllAssets')}</option>
@@ -532,7 +532,7 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
                 </div>
               ) : (
                 /* Mobile list */
-                <div style={{ display: 'grid', gap: 8 }}>
+                <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0, 1fr)', gap: 8 }}>
                   {transactions.map((tx) => {
                     const m = dirMeta(tx)
                     return (

--- a/e2e/recent-activity.spec.ts
+++ b/e2e/recent-activity.spec.ts
@@ -59,13 +59,22 @@ test.describe('Recent activity — mobile', () => {
   // "mm/dd/yyyy" placeholder like Chrome), so the date filters looked like two
   // empty boxes "off UI". They must carry visible From/To labels like desktop.
   test('mobile date filters show visible From/To labels', async ({ page }) => {
-    const tx = await api.createTransaction({
-      asset_type: 'bank',
-      amount_vnd: 5_000_000,
-      investment_date: new Date().toISOString().slice(0, 10),
-      interest_rate: 5,
-      notes: 'E2E 362 filter',
-    })
+    // Several rows, with names long enough to be worth eliding. The overflow this test
+    // guards is driven by the ROWS' min-content, so a single short-named transaction does
+    // not reproduce it — the assertion below used to pass or fail purely on how much data
+    // earlier specs happened to leave behind on the shared user. Seeding the condition
+    // makes it deterministic.
+    const txs = await Promise.all(
+      Array.from({ length: 6 }, (_, i) =>
+        api.createTransaction({
+          asset_type: 'bank',
+          amount_vnd: 5_000_000 + i,
+          investment_date: new Date().toISOString().slice(0, 10),
+          interest_rate: 5,
+          notes: `E2E 362 filter — long transaction label ${i}`,
+        }),
+      ),
+    )
     try {
       await page.goto('/dashboard')
       await page.waitForLoadState('networkidle')
@@ -84,16 +93,29 @@ test.describe('Recent activity — mobile', () => {
       await expect(ledger.getByText('dd/mm/yyyy')).toHaveCount(2)
       await dateInputs.first().fill('2026-06-19')
       await expect(ledger.getByText('dd/mm/yyyy')).toHaveCount(1)
-      // …and neither overflows the ledger to the right (the clipped 2nd field
-      // in the bug report). Chromium can't reproduce the iOS intrinsic-width
-      // overflow, but this guards the grid layout from gross breakage.
+      // …and nothing in the sheet overflows to the right.
+      //
+      // Widened past the two date fields on purpose. The regression this caught clipped
+      // the Add button and the goal select too: the sheet's grids had no explicit column,
+      // so the implicit `auto` track was floored at the ledger rows' min-content (~445px
+      // against a 358px sheet) and every sibling inherited that width. Measuring only the
+      // date fields understated it, and would miss the same class of break next time.
       const ledgerBox = await ledger.boundingBox()
-      for (let i = 0; i < 2; i++) {
-        const box = await dateInputs.nth(i).boundingBox()
-        expect(box!.x + box!.width).toBeLessThanOrEqual(ledgerBox!.x + ledgerBox!.width + 1)
+      const rightEdge = ledgerBox!.x + ledgerBox!.width + 1
+      const mustFit = [
+        ledger.getByTestId('tx-ledger-add'),
+        ledger.getByTestId('tx-ledger-import'),
+        ledger.locator('select').nth(0),
+        ledger.locator('select').nth(1),
+        dateInputs.nth(0),
+        dateInputs.nth(1),
+      ]
+      for (const el of mustFit) {
+        const box = await el.boundingBox()
+        expect(box!.x + box!.width).toBeLessThanOrEqual(rightEdge)
       }
     } finally {
-      await api.deleteTransactionCascade(tx.transaction_id)
+      for (const tx of txs) await api.deleteTransactionCascade(tx.transaction_id)
     }
   })
 })


### PR DESCRIPTION
Lỗi app thật mà PR #463 để lộ ra và cố tình để test đỏ. Giờ sửa.

Ở viewport 390px, các control của sheet giao dịch **tràn ra ngoài container**: nút **Thêm**, select **Mọi mục tiêu** và trường **ĐẾN** đều bị cắt ở mép phải. Issue #362 trước đây sửa phần trường ngày; đây là cùng triệu chứng nhưng đến từ hướng khác.

## Đo, không đoán

Lần trước mình mới khoanh vùng nghi ngờ. Lần này đi từ input date ngược lên cây cha:

```
input                     w=218.6  right=234.6
date grid (2 cột)         w=445.3  gridTemplateColumns: 218.6px 218.6px
grid                      w=445.3
grid                      w=445.3
grid                      w=358    clientWidth=358  scrollWidth=445   ← container
                                   gridTemplateColumns: 445.297px
```

Container **đúng 358px nhưng cột của nó là 445px**. Grid không khai báo `gridTemplateColumns` sẽ nhận một cột ngầm `auto`, và track `auto` bị **sàn dưới bằng `min-content` của child rộng nhất**.

Quét mọi hậu duệ để tìm node có `min-content > 358` thì lộ thủ phạm:

```
tx-ledger-row   min-content = 445.3   "E2E Overflow Probe Transaction 1..."
```

Hàng giao dịch mang tên `whiteSpace: nowrap`, nên chính nó ấn định cột dùng chung — rồi **mọi sibling trong cột đó** (hàng nút, select lọc, grid ngày) thừa hưởng chiều rộng lớn hơn sheet 87px và bị `overflow-x: hidden` của Shell cắt cụt.

## Fix

Cho 4 grid đó `gridTemplateColumns: 'minmax(0, 1fr)'` để cột không bao giờ vượt container. Đo lại đúng chuỗi cũ sau khi sửa: **mọi node 358px, `scrollWidth == clientWidth`**.

## Test guard cũng phải sửa — nó yếu ở hai chỗ

**1. Đo thiếu.** Chỉ đo 2 trường ngày, trong khi lỗi cắt cả nút Thêm và select. Giờ kiểm mọi control trong khối lọc.

**2. Không tự tái hiện được.** Chỉ seed **1** giao dịch tên ngắn, nên không đủ để kích hoạt tràn — nó xanh hay đỏ phụ thuộc vào lượng rác dữ liệu các spec khác để lại trên user E2E dùng chung. Đó chính là lý do lỗi này xuất hiện như một "full-suite-only failure" bí ẩn.

Giờ nó seed 6 hàng tên dài. **Đã xác minh cả hai chiều**: chạy riêng trên component chưa sửa thì đỏ (`498.6 > 391`), có fix thì xanh.

## Kiểm chứng

- **Full E2E 210/210** — lần đầu xanh hoàn toàn
- 1131/1131 unit test, lint 0 error
- Xác nhận bằng mắt ở 390px: Nhập Excel / Thêm / cả 2 select / cả 2 trường ngày đều hiện đủ, tên giao dịch ellipsis đúng

## Review

Đáng mở preview trên **điện thoại thật**, vào Tổng quan → Hoạt động gần đây → "Xem tất cả", và kiểm với tài khoản có nhiều giao dịch tên dài — đó là điều kiện kích hoạt lỗi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)