### PR TITLE
fix(plans): make DCA auto-seeding atomic and idempotent (#466)

### DIFF
--- a/app/api/v1/monthly-plans/__tests__/route.seed.test.ts
+++ b/app/api/v1/monthly-plans/__tests__/route.seed.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// The full-load GET seeds DCA rows via the seed_and_sync_plan_dca RPC before it
+// reads anything. A failed seed must surface as a non-200 (#466) rather than
+// silently returning a half-seeded plan — this pins that branch down at the
+// route layer, mocking the RPC result.
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  plan: { id: 'plan-1', user_id: 'user-1', month: 11, year: 2099 } as Record<string, unknown> | null,
+  planError: null as unknown,
+  rpcError: null as unknown,
+  rpcCalls: [] as Array<{ fn: string; args: unknown }>,
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chain: Record<string, unknown> = {
+    select: () => chain,
+    eq: () => chain,
+    order: () => chain,
+    or: () => chain,
+    maybeSingle: async () => ({ data: h.plan, error: h.planError }),
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: () => chain,
+      rpc: async (fn: string, args: unknown) => {
+        h.rpcCalls.push({ fn, args })
+        return { error: h.rpcError }
+      },
+    }),
+  }
+})
+
+import { GET } from '../route'
+
+function makeReq(query: string) {
+  return { url: `http://localhost/api/v1/monthly-plans?${query}` } as unknown as Parameters<typeof GET>[0]
+}
+
+beforeEach(() => {
+  h.user = { id: 'user-1' }
+  h.plan = { id: 'plan-1', user_id: 'user-1', month: 11, year: 2099 }
+  h.planError = null
+  h.rpcError = null
+  h.rpcCalls = []
+})
+
+describe('GET /api/v1/monthly-plans — DCA seed failure handling (#466)', () => {
+  it('returns 500 when the seed RPC fails on a full load', async () => {
+    h.rpcError = { message: 'insert or update failed' }
+    const res = await GET(makeReq('month=11&year=2099&full=true'))
+    expect(res.status).toBe(500)
+    // It must fail on the seed, before doing any reads.
+    expect(h.rpcCalls).toEqual([{ fn: 'seed_and_sync_plan_dca', args: { p_plan_id: 'plan-1' } }])
+  })
+
+  it('does not seed (or fail) for a non-full load', async () => {
+    h.rpcError = { message: 'should never be reached' }
+    const res = await GET(makeReq('month=11&year=2099'))
+    expect(res.status).toBe(200)
+    expect(h.rpcCalls).toHaveLength(0)
+  })
+
+  it('still 404s a missing plan without seeding', async () => {
+    h.plan = null
+    const res = await GET(makeReq('month=11&year=2099&full=true'))
+    expect(res.status).toBe(404)
+    expect(h.rpcCalls).toHaveLength(0)
+  })
+})

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -27,6 +27,15 @@ export async function GET(request: NextRequest) {
   if (!plan) return NextResponse.json({ error: 'Plan not found for this month' }, { status: 404 })
 
   if (searchParams.get('full') === 'true') {
+    // Auto-seed this plan's DCA rows and sync pending ones to the fund's current
+    // amount/goal — atomically, before we read anything. Folding it into one RPC
+    // (insert-on-conflict + update, in a single transaction) removes the old
+    // read-then-insert race that let two concurrent loads create duplicate DCA
+    // rows, and surfaces a failed write as a 500 instead of silently returning a
+    // half-seeded plan. Because it runs first, the reads below see the result. (#466)
+    const { error: seedError } = await supabase.rpc('seed_and_sync_plan_dca', { p_plan_id: plan.id })
+    if (seedError) return NextResponse.json({ error: 'Failed to seed DCA entries' }, { status: 500 })
+
     const planDateForActive = `${plan.year}-${String(plan.month).padStart(2, '0')}-01`
     const ym = `${plan.year}-${String(plan.month).padStart(2, '0')}`
     const [invRes, savRes, overridesRes, expRes, insRes, exclRes, insOverridesRes, goalsRes, fundsRes, otherExpRes, recSavRes, recSavOverridesRes, dcaSkipsRes, recFulfillmentsRes] = await Promise.all([
@@ -89,61 +98,6 @@ export async function GET(request: NextRequest) {
         .from('recurring_saving_fulfillments')
         .select('recurring_saving_id, amount_vnd, source').eq('user_id', user.id).eq('ym', ym),
     ])
-    // Auto-seed DCA fund entries and keep pending rows in sync with current DCA amount
-    const allFunds = fundsRes.data ?? []
-    const skippedFundIds = new Set((dcaSkipsRes.data ?? []).map((s) => s.fund_id))
-    // Skipped funds are excluded from seeding this month (the skip endpoint also
-    // removes any pending row), so they drop out of the plan until restored.
-    const dcaFunds = allFunds.filter((f) => f.is_dca && f.dca_monthly_amount_vnd && !skippedFundIds.has(f.id))
-    const existingInvestments = invRes.data ?? []
-
-    // Insert rows for DCA funds that have no entry yet for this plan
-    const existingFundIds = new Set(existingInvestments.map((i) => i.fund_id))
-    const missingDca = dcaFunds.filter((f) => !existingFundIds.has(f.id))
-    if (missingDca.length > 0) {
-      const firstOfMonth = `${plan.year}-${String(plan.month).padStart(2, '0')}-01`
-      await supabase.from('investment_transactions').insert(
-        missingDca.map((f) => ({
-          user_id: user.id,
-          plan_id: plan.id,
-          fund_id: f.id,
-          goal_id: f.dca_goal_id ?? null,
-          asset_type: 'fund',
-          amount_vnd: f.dca_monthly_amount_vnd,
-          units: null,
-          unit_price: null,
-          investment_date: firstOfMonth,
-          is_dca_seeded: true,
-        }))
-      )
-    }
-
-    // Keep pending DCA rows in sync with the fund's current DCA amount and goal
-    // (amount changes when DCA is re-toggled; goal changes when dca_goal_id is set).
-    const staleRows = existingInvestments.filter((inv) => {
-      if (!inv.is_dca_seeded || inv.units !== null) return false
-      const fund = dcaFunds.find((f) => f.id === inv.fund_id)
-      return fund && (fund.dca_monthly_amount_vnd !== inv.amount_vnd || (fund.dca_goal_id ?? null) !== (inv.goal_id ?? null))
-    })
-    if (staleRows.length > 0) {
-      await Promise.all(
-        staleRows.map((inv) => {
-          const fund = dcaFunds.find((f) => f.id === inv.fund_id)!
-          return supabase
-            .from('investment_transactions')
-            .update({ amount_vnd: fund.dca_monthly_amount_vnd, goal_id: fund.dca_goal_id ?? null })
-            .eq('transaction_id', inv.transaction_id)
-        })
-      )
-    }
-
-    if (missingDca.length > 0 || staleRows.length > 0) {
-      const { data: refreshed } = await supabase
-        .from('investment_transactions')
-        .select('transaction_id, plan_id, fund_id, goal_id, amount_vnd, units, unit_price, investment_date, is_dca_seeded, funds(name, nav), savings_goals(goal_name)')
-        .eq('plan_id', plan.id).eq('asset_type', 'fund')
-      invRes.data = refreshed
-    }
 
     return NextResponse.json({
       ...plan,

--- a/e2e/dca-atomic-seeding.spec.ts
+++ b/e2e/dca-atomic-seeding.spec.ts
@@ -16,13 +16,25 @@ test.describe('atomic DCA seeding (#466)', () => {
   let planId: string
   let goalId: string
 
+  const FUND_PREFIX = 'E2E DCA Atomic Fund'
+  const PLAN_MONTH = 11
+  const PLAN_YEAR = 2099
+
   test.beforeEach(async () => {
+    // Sweep anything an interrupted prior run may have left behind, so this
+    // spec never trips over its own leftovers on the fixed plan date / a stale
+    // fund before it reaches the behavior under test.
+    await api.deleteFundsByNamePrefix(FUND_PREFIX)
+    await api.deleteMonthlyPlanByDate(PLAN_MONTH, PLAN_YEAR)
+
     const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
     const goal = await api.createGoal({ goal_name: `E2E DCA Atomic ${stamp}` })
     goalId = goal.goal_id
     const fund = await api.createFund({
-      name: `E2E DCA Atomic Fund ${stamp}`,
-      code: 'E2EDAT',
+      name: `${FUND_PREFIX} ${stamp}`,
+      // Randomized so a leftover fund from a failed teardown can't collide on
+      // the (user_id, code) uniqueness before the sweep above removes it.
+      code: `E2E${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
       fund_type: 'equity',
       nav: 20_000,
       is_dca: true,
@@ -32,7 +44,7 @@ test.describe('atomic DCA seeding (#466)', () => {
     fundId = fund.id
     // A far-future month keeps this plan clear of the shared test user's other
     // specs, which all key off 2026 dates (unique on user_id, month, year).
-    const plan = await api.createMonthlyPlan({ month: 11, year: 2099, salary_vnd: 50_000_000 })
+    const plan = await api.createMonthlyPlan({ month: PLAN_MONTH, year: PLAN_YEAR, salary_vnd: 50_000_000 })
     planId = plan.id
   })
 

--- a/e2e/dca-atomic-seeding.spec.ts
+++ b/e2e/dca-atomic-seeding.spec.ts
@@ -1,0 +1,75 @@
+import { test, expect } from '@playwright/test'
+import * as api from './helpers/api'
+
+// DB-level integration test for the atomic DCA auto-seeding RPC (#466).
+//
+// The old `GET /api/v1/monthly-plans?full=true` read existing DCA rows and
+// inserted the missing ones in *separate* operations, so two concurrent loads
+// could both see a row missing and both insert it — there was no uniqueness
+// constraint to stop them. The fix moves seeding into `seed_and_sync_plan_dca`,
+// an atomic RPC whose insert relies on a partial unique index + ON CONFLICT DO
+// NOTHING. That guarantee lives entirely in the database, so it's exercised
+// here at the DB layer (service-role client, no browser) — the lowest layer
+// that can actually catch a duplicate-row race.
+test.describe('atomic DCA seeding (#466)', () => {
+  let fundId: string
+  let planId: string
+  let goalId: string
+
+  test.beforeEach(async () => {
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
+    const goal = await api.createGoal({ goal_name: `E2E DCA Atomic ${stamp}` })
+    goalId = goal.goal_id
+    const fund = await api.createFund({
+      name: `E2E DCA Atomic Fund ${stamp}`,
+      code: 'E2EDAT',
+      fund_type: 'equity',
+      nav: 20_000,
+      is_dca: true,
+      dca_monthly_amount_vnd: 2_000_000,
+      dca_goal_id: goalId,
+    })
+    fundId = fund.id
+    // A far-future month keeps this plan clear of the shared test user's other
+    // specs, which all key off 2026 dates (unique on user_id, month, year).
+    const plan = await api.createMonthlyPlan({ month: 11, year: 2099, salary_vnd: 50_000_000 })
+    planId = plan.id
+  })
+
+  test.afterEach(async () => {
+    if (fundId) await api.deleteFund(fundId) // also deletes its investment rows
+    if (planId) await api.deleteMonthlyPlan(planId)
+    if (goalId) await api.deleteGoal(goalId)
+  })
+
+  test('concurrent seeds create exactly one DCA row', async () => {
+    // Fire many seeders at once against an empty plan. Every one observes the
+    // row missing; the unique index must let only a single insert win.
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () => api.rpcSeedPlanDca(planId)),
+    )
+    for (const r of results) expect(r.error).toBeNull()
+
+    const rows = await api.getPlanDcaRows(planId, fundId)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].amount_vnd).toBe(2_000_000)
+    expect(rows[0].goal_id).toBe(goalId)
+    expect(rows[0].is_dca_seeded).toBe(true)
+  })
+
+  test('repeated seeds stay idempotent and sync the current DCA amount', async () => {
+    const first = await api.rpcSeedPlanDca(planId)
+    expect(first.error).toBeNull()
+    expect(await api.countPlanDcaRows(planId, fundId)).toBe(1)
+
+    // The DCA amount changes (e.g. the user re-toggled DCA). A re-seed should
+    // update the pending row in place, never add a second one.
+    await api.setFundDca(fundId, { dca_monthly_amount_vnd: 3_500_000 })
+    const second = await api.rpcSeedPlanDca(planId)
+    expect(second.error).toBeNull()
+
+    const rows = await api.getPlanDcaRows(planId, fundId)
+    expect(rows).toHaveLength(1)
+    expect(rows[0].amount_vnd).toBe(3_500_000)
+  })
+})

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -379,3 +379,34 @@ export async function getFirstFund() {
   if (error) return null
   return data
 }
+
+export async function setFundDca(
+  fundId: string,
+  patch: { is_dca?: boolean; dca_monthly_amount_vnd?: number | null; dca_goal_id?: string | null },
+) {
+  await supabase.from('funds').update(patch).eq('id', fundId)
+}
+
+export async function rpcSeedPlanDca(planId: string) {
+  return await supabase.rpc('seed_and_sync_plan_dca', { p_plan_id: planId })
+}
+
+export async function getPlanDcaRows(planId: string, fundId: string) {
+  const { data } = await supabase
+    .from('investment_transactions')
+    .select('transaction_id, amount_vnd, goal_id, is_dca_seeded, units')
+    .eq('plan_id', planId)
+    .eq('fund_id', fundId)
+    .eq('asset_type', 'fund')
+  return data ?? []
+}
+
+export async function countPlanDcaRows(planId: string, fundId: string): Promise<number> {
+  const { count } = await supabase
+    .from('investment_transactions')
+    .select('transaction_id', { count: 'exact', head: true })
+    .eq('plan_id', planId)
+    .eq('fund_id', fundId)
+    .eq('asset_type', 'fund')
+  return count ?? 0
+}

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -380,6 +380,17 @@ export async function getFirstFund() {
   return data
 }
 
+export async function deleteFundsByNamePrefix(prefix: string) {
+  const userId = await getTestUserId()
+  const { data } = await supabase.from('funds').select('id').eq('user_id', userId).like('name', `${prefix}%`)
+  for (const f of data ?? []) await deleteFund(f.id)
+}
+
+export async function deleteMonthlyPlanByDate(month: number, year: number) {
+  const userId = await getTestUserId()
+  await supabase.from('monthly_plans').delete().eq('user_id', userId).eq('month', month).eq('year', year)
+}
+
 export async function setFundDca(
   fundId: string,
   patch: { is_dca?: boolean; dca_monthly_amount_vnd?: number | null; dca_goal_id?: string | null },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:headed": "playwright test --headed"
+    "test:e2e:headed": "playwright test --headed",
+    "test:db": "for f in supabase/tests/*.sql; do echo \"» $f\"; psql \"${DATABASE_URL:-postgresql://postgres:postgres@127.0.0.1:54322/postgres}\" -v ON_ERROR_STOP=1 -f \"$f\" || exit 1; done"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",

--- a/supabase/migrations/20260722000001_atomic_dca_seeding.sql
+++ b/supabase/migrations/20260722000001_atomic_dca_seeding.sql
@@ -12,11 +12,39 @@
 -- states are gone.
 
 -- ---------------------------------------------------------------------------
--- 1) Heal any pre-existing duplicates so the unique index can be created.
---    A fund can legitimately have several *manual* transactions in one plan, so
---    we only touch auto-seeded rows (is_dca_seeded). Among duplicates for a
---    (plan_id, fund_id) we keep the row a user has actually recorded units into
---    if there is one, otherwise the earliest — the extras are the corruption.
+-- 1) Heal any pre-existing duplicates so the unique index can be created,
+--    WITHOUT deleting financial history. A fund can legitimately have several
+--    *manual* transactions in one plan, so we only touch auto-seeded rows
+--    (is_dca_seeded). Within each (plan_id, fund_id) group we keep exactly one
+--    row flagged is_dca_seeded — preferring a row the user has actually recorded
+--    units into (so a real purchase stays the DCA line), else the earliest.
+--
+--    The remaining duplicates are handled by *type*, never blindly deleted:
+--      - a still-pending duplicate (units IS NULL) carries no data and no
+--        withdrawal children, so it is removed;
+--      - a recorded duplicate (units IS NOT NULL) is a real purchase — it is
+--        preserved and merely un-flagged (is_dca_seeded = false), which drops it
+--        from the partial unique index while keeping the transaction (and any
+--        withdrawal referencing it) intact.
+
+-- 1a) Preserve recorded duplicates as ordinary transactions.
+update investment_transactions it
+   set is_dca_seeded = false,
+       updated_at = now()
+  from (
+    select transaction_id,
+           row_number() over (
+             partition by plan_id, fund_id
+             order by (units is not null) desc, created_at asc, transaction_id asc
+           ) as rn
+      from investment_transactions
+     where is_dca_seeded and asset_type = 'fund' and plan_id is not null
+  ) dup
+ where it.transaction_id = dup.transaction_id
+   and dup.rn > 1
+   and it.units is not null;
+
+-- 1b) Remove the leftover pending duplicates (no data, no dependents).
 delete from investment_transactions it
 using (
   select transaction_id,
@@ -25,12 +53,11 @@ using (
            order by (units is not null) desc, created_at asc, transaction_id asc
          ) as rn
     from investment_transactions
-   where is_dca_seeded
-     and asset_type = 'fund'
-     and plan_id is not null
+   where is_dca_seeded and asset_type = 'fund' and plan_id is not null
 ) dup
 where it.transaction_id = dup.transaction_id
-  and dup.rn > 1;
+  and dup.rn > 1
+  and it.units is null;
 
 -- ---------------------------------------------------------------------------
 -- 2) At most one auto-seeded DCA row per (plan, fund). Partial so it never

--- a/supabase/migrations/20260722000001_atomic_dca_seeding.sql
+++ b/supabase/migrations/20260722000001_atomic_dca_seeding.sql
@@ -1,0 +1,138 @@
+-- Make DCA auto-seeding atomic and idempotent (#466).
+--
+-- `GET /api/v1/monthly-plans?full=true` used to read the existing DCA rows and
+-- INSERT the missing ones in separate steps, with nothing stopping two
+-- concurrent loads from both seeing a row missing and both inserting it — there
+-- was no uniqueness constraint on a pending DCA row. That produced duplicate
+-- planned allocations and inflated monthly totals, and any swallowed query error
+-- (treated as "no rows") could trigger a bogus re-seed.
+--
+-- This migration adds the missing constraint and folds the whole seed-and-sync
+-- into one transactional RPC, so the read-then-write race and the half-seeded
+-- states are gone.
+
+-- ---------------------------------------------------------------------------
+-- 1) Heal any pre-existing duplicates so the unique index can be created.
+--    A fund can legitimately have several *manual* transactions in one plan, so
+--    we only touch auto-seeded rows (is_dca_seeded). Among duplicates for a
+--    (plan_id, fund_id) we keep the row a user has actually recorded units into
+--    if there is one, otherwise the earliest — the extras are the corruption.
+delete from investment_transactions it
+using (
+  select transaction_id,
+         row_number() over (
+           partition by plan_id, fund_id
+           order by (units is not null) desc, created_at asc, transaction_id asc
+         ) as rn
+    from investment_transactions
+   where is_dca_seeded
+     and asset_type = 'fund'
+     and plan_id is not null
+) dup
+where it.transaction_id = dup.transaction_id
+  and dup.rn > 1;
+
+-- ---------------------------------------------------------------------------
+-- 2) At most one auto-seeded DCA row per (plan, fund). Partial so it never
+--    constrains manually-added fund transactions, and it's the conflict target
+--    the RPC's insert relies on to collapse a concurrent double-seed.
+create unique index if not exists investment_transactions_dca_seeded_uniq
+  on investment_transactions (plan_id, fund_id)
+  where is_dca_seeded and asset_type = 'fund';
+
+-- ---------------------------------------------------------------------------
+-- 3) Atomic seed + sync. Runs as the caller (security invoker) so RLS scopes it
+--    to their own rows; the plan's owner is resolved from the plan row, so a
+--    caller who doesn't own the plan simply sees nothing and the function
+--    no-ops. Everything below runs in one transaction: a failing statement
+--    aborts the whole thing instead of leaving a plan half-seeded, and the
+--    ON CONFLICT DO NOTHING insert makes two concurrent callers converge on a
+--    single row. Returns the number of rows inserted or updated.
+create or replace function public.seed_and_sync_plan_dca(p_plan_id uuid)
+returns integer
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_user_id uuid;
+  v_year int;
+  v_month int;
+  v_first_of_month date;
+  v_inserted int := 0;
+  v_updated int := 0;
+begin
+  select user_id, year, month
+    into v_user_id, v_year, v_month
+    from public.monthly_plans
+   where id = p_plan_id;
+
+  -- No such plan for this caller (or it doesn't exist): nothing to seed.
+  if v_user_id is null then
+    return 0;
+  end if;
+
+  v_first_of_month := make_date(v_year, v_month, 1);
+
+  -- Insert a pending row for every eligible DCA fund that has no fund
+  -- transaction yet in this plan. The NOT EXISTS is the fast path; the partial
+  -- unique index + ON CONFLICT DO NOTHING is the race backstop when two callers
+  -- clear that check at the same instant.
+  with inserted as (
+    insert into public.investment_transactions (
+      user_id, plan_id, fund_id, goal_id, asset_type, amount_vnd,
+      units, unit_price, investment_date, is_dca_seeded
+    )
+    select
+      v_user_id, p_plan_id, f.id, f.dca_goal_id, 'fund', f.dca_monthly_amount_vnd,
+      null, null, v_first_of_month, true
+    from public.funds f
+    where f.user_id = v_user_id
+      and f.is_dca
+      and f.dca_monthly_amount_vnd is not null
+      and not exists (
+        select 1 from public.plan_dca_skips s
+         where s.plan_id = p_plan_id and s.fund_id = f.id
+      )
+      and not exists (
+        select 1 from public.investment_transactions it
+         where it.plan_id = p_plan_id
+           and it.fund_id = f.id
+           and it.asset_type = 'fund'
+      )
+    on conflict (plan_id, fund_id) where is_dca_seeded and asset_type = 'fund'
+    do nothing
+    returning 1
+  )
+  select count(*) into v_inserted from inserted;
+
+  -- Keep still-pending seeded rows aligned with the fund's current DCA amount
+  -- and goal (both change when DCA is re-toggled / re-pointed). Rows the user
+  -- has recorded units into (units is not null) are left untouched.
+  with updated as (
+    update public.investment_transactions it
+       set amount_vnd = f.dca_monthly_amount_vnd,
+           goal_id    = f.dca_goal_id,
+           updated_at = now()
+      from public.funds f
+     where it.fund_id = f.id
+       and it.plan_id = p_plan_id
+       and it.asset_type = 'fund'
+       and it.is_dca_seeded
+       and it.units is null
+       and f.user_id = v_user_id
+       and f.is_dca
+       and f.dca_monthly_amount_vnd is not null
+       and not exists (
+         select 1 from public.plan_dca_skips s
+          where s.plan_id = p_plan_id and s.fund_id = f.id
+       )
+       and (it.amount_vnd is distinct from f.dca_monthly_amount_vnd
+            or it.goal_id is distinct from f.dca_goal_id)
+    returning 1
+  )
+  select count(*) into v_updated from updated;
+
+  return v_inserted + v_updated;
+end;
+$$;

--- a/supabase/tests/dca_seeding_heal.test.sql
+++ b/supabase/tests/dca_seeding_heal.test.sql
@@ -1,0 +1,146 @@
+-- Regression test for the #466 duplicate-healing step in
+-- 20260722000001_atomic_dca_seeding.sql.
+--
+-- The healing must reduce each (plan_id, fund_id) group to a single
+-- is_dca_seeded row so the partial unique index can build — but it must NEVER
+-- delete a recorded (units-bearing) purchase, and must never orphan a
+-- withdrawal that references one (the parent_transaction_id FK is ON DELETE SET
+-- NULL). This reproduces the worst case: two duplicates BOTH recorded, plus a
+-- pending duplicate, with a withdrawal hanging off one recorded row.
+--
+-- Runs against the local stack; everything happens inside a transaction that is
+-- rolled back, so it mutates nothing. Any failed assertion RAISEs and, under
+-- `psql -v ON_ERROR_STOP=1`, exits non-zero. Run via `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_user uuid;
+  v_goal uuid;
+  v_fund uuid;
+  v_plan uuid;
+  v_rec1 uuid;   -- first recorded duplicate  (keeper)
+  v_rec2 uuid;   -- second recorded duplicate (must survive as plain tx)
+  v_pend uuid;   -- pending duplicate         (must be deleted)
+  v_wd   uuid;   -- withdrawal hanging off v_rec2
+  v_recorded_left int;
+  v_seeded_left int;
+  v_pending_left int;
+  v_wd_parent uuid;
+begin
+  insert into auth.users (id, email)
+    values (gen_random_uuid(), 'heal-test@test.invalid') returning id into v_user;
+
+  insert into savings_goals (user_id, goal_name)
+    values (v_user, 'Heal Test Goal') returning goal_id into v_goal;
+
+  insert into funds (user_id, name, code, fund_type, nav, is_dca, dca_monthly_amount_vnd, dca_goal_id)
+    values (v_user, 'Heal Test Fund', 'HEALT', 'equity', 20000, true, 2000000, v_goal)
+    returning id into v_fund;
+
+  insert into monthly_plans (user_id, month, year, salary_vnd)
+    values (v_user, 11, 2099, 50000000) returning id into v_plan;
+
+  -- The corruption the old code could produce: TWO recorded seeded rows plus a
+  -- pending one, all for the same (plan, fund). Drop the guard index so we can
+  -- recreate that pre-migration state.
+  drop index if exists investment_transactions_dca_seeded_uniq;
+
+  insert into investment_transactions
+    (user_id, plan_id, fund_id, goal_id, asset_type, amount_vnd, units, unit_price, investment_date, is_dca_seeded, created_at)
+    values (v_user, v_plan, v_fund, v_goal, 'fund', 2000000, 100, 20000, '2099-11-01', true, now() - interval '2 min')
+    returning transaction_id into v_rec1;
+
+  insert into investment_transactions
+    (user_id, plan_id, fund_id, goal_id, asset_type, amount_vnd, units, unit_price, investment_date, is_dca_seeded, created_at)
+    values (v_user, v_plan, v_fund, v_goal, 'fund', 2000000, 50, 20000, '2099-11-01', true, now() - interval '1 min')
+    returning transaction_id into v_rec2;
+
+  insert into investment_transactions
+    (user_id, plan_id, fund_id, goal_id, asset_type, amount_vnd, units, unit_price, investment_date, is_dca_seeded, created_at)
+    values (v_user, v_plan, v_fund, v_goal, 'fund', 2000000, null, null, '2099-11-01', true, now())
+    returning transaction_id into v_pend;
+
+  -- A withdrawal referencing the second recorded row — this is what would be
+  -- orphaned if the healing deleted v_rec2.
+  insert into investment_transactions
+    (user_id, parent_transaction_id, transaction_type, asset_type, amount_vnd, principal_withdrawn, investment_date, affects_progress)
+    values (v_user, v_rec2, 'withdrawal', null, 500000, 500000, '2099-11-15', true)
+    returning transaction_id into v_wd;
+
+  -- ---- Run the healing exactly as the migration does -----------------------
+  update investment_transactions it
+     set is_dca_seeded = false, updated_at = now()
+    from (
+      select transaction_id,
+             row_number() over (
+               partition by plan_id, fund_id
+               order by (units is not null) desc, created_at asc, transaction_id asc
+             ) as rn
+        from investment_transactions
+       where is_dca_seeded and asset_type = 'fund' and plan_id is not null
+    ) dup
+   where it.transaction_id = dup.transaction_id and dup.rn > 1 and it.units is not null;
+
+  delete from investment_transactions it
+  using (
+    select transaction_id,
+           row_number() over (
+             partition by plan_id, fund_id
+             order by (units is not null) desc, created_at asc, transaction_id asc
+           ) as rn
+      from investment_transactions
+     where is_dca_seeded and asset_type = 'fund' and plan_id is not null
+  ) dup
+  where it.transaction_id = dup.transaction_id and dup.rn > 1 and it.units is null;
+
+  -- ---- Assertions ----------------------------------------------------------
+  -- Both recorded purchases survive (nothing financial deleted).
+  select count(*) into v_recorded_left
+    from investment_transactions
+   where plan_id = v_plan and fund_id = v_fund and asset_type = 'fund' and units is not null;
+  if v_recorded_left <> 2 then
+    raise exception 'expected 2 recorded rows to survive, found %', v_recorded_left;
+  end if;
+
+  -- Exactly one seeded row left → the partial unique index can build.
+  select count(*) into v_seeded_left
+    from investment_transactions
+   where plan_id = v_plan and fund_id = v_fund and asset_type = 'fund' and is_dca_seeded;
+  if v_seeded_left <> 1 then
+    raise exception 'expected exactly 1 is_dca_seeded row, found %', v_seeded_left;
+  end if;
+
+  -- The pending duplicate is gone.
+  select count(*) into v_pending_left
+    from investment_transactions where transaction_id = v_pend;
+  if v_pending_left <> 0 then
+    raise exception 'pending duplicate should have been deleted';
+  end if;
+
+  -- The keeper (earliest recorded) stays flagged; the other recorded row is
+  -- preserved but un-flagged.
+  if not exists (select 1 from investment_transactions where transaction_id = v_rec1 and is_dca_seeded) then
+    raise exception 'v_rec1 should remain the seeded keeper';
+  end if;
+  if not exists (select 1 from investment_transactions where transaction_id = v_rec2 and not is_dca_seeded) then
+    raise exception 'v_rec2 should survive as a plain (un-flagged) transaction';
+  end if;
+
+  -- The withdrawal is not orphaned — its parent link is intact.
+  select parent_transaction_id into v_wd_parent
+    from investment_transactions where transaction_id = v_wd;
+  if v_wd_parent is distinct from v_rec2 then
+    raise exception 'withdrawal was orphaned: parent_transaction_id = %', v_wd_parent;
+  end if;
+
+  -- Recreating the real index must now succeed (no duplicate seeded rows left).
+  create unique index investment_transactions_dca_seeded_uniq
+    on investment_transactions (plan_id, fund_id)
+    where is_dca_seeded and asset_type = 'fund';
+
+  raise notice 'dca_seeding_heal.test.sql: OK';
+end $$;
+
+rollback;


### PR DESCRIPTION
Closes #466.

## Problem
`GET /api/v1/monthly-plans?full=true` mutated data while loading a plan: it read existing DCA rows and inserted the missing ones in **separate** operations, with no uniqueness constraint on a pending DCA row.

- Two concurrent full-loads could both see a row missing and both insert it → **duplicate planned allocations, inflated monthly totals**.
- Query/insert errors were swallowed (`invRes.data ?? []`) — a failed investment query looked like "no rows" and triggered a bogus re-seed, and a failed write still returned **200**.

## Fix
Fold the whole seed-and-sync into one atomic RPC, backed by a partial unique index.

- **Migration `20260722000001_atomic_dca_seeding.sql`**
  - Heals any pre-existing duplicate seeded rows (keeps the one with recorded units, else the earliest) so the index can build.
  - Partial unique index `(plan_id, fund_id) WHERE is_dca_seeded AND asset_type='fund'` — at most one auto-seeded DCA row per fund/plan, without constraining manual fund buys.
  - `seed_and_sync_plan_dca(p_plan_id)` (security invoker): insert-missing (`ON CONFLICT DO NOTHING`) + amount/goal sync of pending rows, in a **single transaction**, scoped to the plan's owner. A failing statement aborts the whole thing — no half-seeded plans.
- **Route** now calls the RPC *before* its reads (so they reflect the result) and returns **500** on RPC error. The old JS read-then-insert seeding block is removed.

## Acceptance criteria
- [x] Concurrent plan loads cannot create duplicate DCA rows (unique index + `ON CONFLICT DO NOTHING`).
- [x] Failed prerequisite queries do not trigger seeding (the RPC's reads are inside the transaction; a failure aborts it).
- [x] Insert/update failures return a non-200 response (RPC error → 500).
- [x] Automated tests cover concurrent and repeated plan loading.

## Testing
- New `e2e/dca-atomic-seeding.spec.ts` (DB layer, service-role client — where the concurrency guarantee actually lives): 8 concurrent seeds → exactly one row; repeated seeds stay idempotent and sync the current DCA amount.
- `npm test -- --run` → 1131 passed. `npm run lint` → 0 errors.
- **Full E2E → 218 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)