### PR TITLE
fix(api): harden pagination, month, and DCA/NAV validation (#471)

### DIFF
--- a/app/api/funds/[id]/route.ts
+++ b/app/api/funds/[id]/route.ts
@@ -93,13 +93,13 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   // DCA toggle/amount/goal handlers always send is_dca, so they're unaffected.
   if (is_dca !== undefined) {
     update.is_dca = is_dca === true
-    // Validate the amount through the shared check (finite, safe integer, and
-    // positive) so junk is a 400, not a DB CHECK violation (500).
+    // Validate by *presence* (not truthiness) so a provided 0 is rejected rather
+    // than silently stored as null — a positive, whole (BIGINT) amount, else a
+    // 400 instead of a DB CHECK / type error (500).
     let dcaAmount: number | null = null
-    if (is_dca === true && dca_monthly_amount_vnd) {
+    if (is_dca === true && dca_monthly_amount_vnd != null && dca_monthly_amount_vnd !== '') {
       try {
-        dcaAmount = validateAmount(dca_monthly_amount_vnd, 'dca_monthly_amount_vnd')
-        if (dcaAmount <= 0) throw new ValidationError('dca_monthly_amount_vnd must be positive')
+        dcaAmount = validateAmount(dca_monthly_amount_vnd, 'dca_monthly_amount_vnd', { positive: true, integer: true })
       } catch (e) {
         if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
         throw e

--- a/app/api/funds/[id]/route.ts
+++ b/app/api/funds/[id]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { validateNavSourceUrl } from '@/lib/scrape-fund-nav'
-import { ValidationError } from '@/lib/validation'
+import { ValidationError, validateAmount } from '@/lib/validation'
 
 const FUND_TYPES = ['balanced', 'equity', 'debt', 'gold'] as const
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -61,7 +61,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     return NextResponse.json({ error: 'Fund type is required' }, { status: 400 })
   }
   const navNum = Number(nav)
-  if (!nav || isNaN(navNum) || navNum < 0.01) {
+  // Number('Infinity') is Infinity and would slip past a bare `< 0.01` check —
+  // require a finite value so it can't reach the DB numeric column.
+  if (!Number.isFinite(navNum) || navNum < 0.01) {
     return NextResponse.json({ error: 'NAV must be greater than 0' }, { status: 400 })
   }
   if (dca_goal_id != null && dca_goal_id !== '' && (typeof dca_goal_id !== 'string' || !UUID_RE.test(dca_goal_id))) {
@@ -91,7 +93,19 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   // DCA toggle/amount/goal handlers always send is_dca, so they're unaffected.
   if (is_dca !== undefined) {
     update.is_dca = is_dca === true
-    update.dca_monthly_amount_vnd = is_dca === true && dca_monthly_amount_vnd ? Number(dca_monthly_amount_vnd) : null
+    // Validate the amount through the shared check (finite, safe integer, and
+    // positive) so junk is a 400, not a DB CHECK violation (500).
+    let dcaAmount: number | null = null
+    if (is_dca === true && dca_monthly_amount_vnd) {
+      try {
+        dcaAmount = validateAmount(dca_monthly_amount_vnd, 'dca_monthly_amount_vnd')
+        if (dcaAmount <= 0) throw new ValidationError('dca_monthly_amount_vnd must be positive')
+      } catch (e) {
+        if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+        throw e
+      }
+    }
+    update.dca_monthly_amount_vnd = dcaAmount
     // Goal target only applies while DCA is on; cleared otherwise.
     update.dca_goal_id = is_dca === true && dca_goal_id ? dca_goal_id : null
   }

--- a/app/api/funds/route.ts
+++ b/app/api/funds/route.ts
@@ -67,14 +67,14 @@ export async function POST(request: NextRequest) {
   if (dca_goal_id != null && dca_goal_id !== '' && (typeof dca_goal_id !== 'string' || !UUID_RE.test(dca_goal_id))) {
     return NextResponse.json({ error: 'Invalid goal' }, { status: 400 })
   }
-  // DCA amount is only stored when DCA is on; validate it through the shared
-  // amount check (finite, safe integer) and require it positive, so a negative /
-  // Infinity / NaN value is a 400 rather than a DB CHECK violation (500).
+  // DCA amount is only stored when DCA is on. Validate by *presence* (not
+  // truthiness) so a provided 0 is rejected rather than silently stored as null
+  // — a positive, whole (BIGINT) amount, else a 400 instead of a DB CHECK / type
+  // error (500). Absent leaves it null (DCA on, amount not yet set).
   let dcaAmount: number | null = null
-  if (is_dca === true && dca_monthly_amount_vnd) {
+  if (is_dca === true && dca_monthly_amount_vnd != null && dca_monthly_amount_vnd !== '') {
     try {
-      dcaAmount = validateAmount(dca_monthly_amount_vnd, 'dca_monthly_amount_vnd')
-      if (dcaAmount <= 0) throw new ValidationError('dca_monthly_amount_vnd must be positive')
+      dcaAmount = validateAmount(dca_monthly_amount_vnd, 'dca_monthly_amount_vnd', { positive: true, integer: true })
     } catch (e) {
       if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
       throw e

--- a/app/api/funds/route.ts
+++ b/app/api/funds/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { validateNavSourceUrl } from '@/lib/scrape-fund-nav'
-import { ValidationError } from '@/lib/validation'
+import { ValidationError, validateAmount } from '@/lib/validation'
 
 const FUND_TYPES = ['balanced', 'equity', 'debt', 'gold'] as const
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -59,11 +59,26 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Fund type is required' }, { status: 400 })
   }
   const navNum = Number(nav)
-  if (!nav || isNaN(navNum) || navNum < 0.01) {
+  // Number('Infinity') is Infinity and would slip past a bare `< 0.01` check —
+  // require a finite value so it can't reach the DB numeric column.
+  if (!Number.isFinite(navNum) || navNum < 0.01) {
     return NextResponse.json({ error: 'NAV must be greater than 0' }, { status: 400 })
   }
   if (dca_goal_id != null && dca_goal_id !== '' && (typeof dca_goal_id !== 'string' || !UUID_RE.test(dca_goal_id))) {
     return NextResponse.json({ error: 'Invalid goal' }, { status: 400 })
+  }
+  // DCA amount is only stored when DCA is on; validate it through the shared
+  // amount check (finite, safe integer) and require it positive, so a negative /
+  // Infinity / NaN value is a 400 rather than a DB CHECK violation (500).
+  let dcaAmount: number | null = null
+  if (is_dca === true && dca_monthly_amount_vnd) {
+    try {
+      dcaAmount = validateAmount(dca_monthly_amount_vnd, 'dca_monthly_amount_vnd')
+      if (dcaAmount <= 0) throw new ValidationError('dca_monthly_amount_vnd must be positive')
+    } catch (e) {
+      if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+      throw e
+    }
   }
   // Validate the NAV source URL (https + exact vendor-host allowlist) before it
   // is stored and later fetched server-side — prevents SSRF.
@@ -85,7 +100,7 @@ export async function POST(request: NextRequest) {
       nav: navNum,
       nav_source_url: cleanNavUrl,
       is_dca: is_dca === true,
-      dca_monthly_amount_vnd: is_dca === true && dca_monthly_amount_vnd ? Number(dca_monthly_amount_vnd) : null,
+      dca_monthly_amount_vnd: dcaAmount,
       // Goal target only applies while DCA is on; cleared otherwise.
       dca_goal_id: is_dca === true && dca_goal_id ? dca_goal_id : null,
     })

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'crypto'
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { ValidationError, validateAmount, validateBankCode, validateDate, validateEnum, validateNotes, validateRate, validateUUID } from '@/lib/validation'
+import { ValidationError, validateAmount, validateBankCode, validateDate, validateEnum, validateNotes, validatePositiveIntParam, validateRate, validateUUID } from '@/lib/validation'
 import { isFutureInvestmentDate } from '@/lib/dates'
 
 const ASSET_TYPES = ['fund', 'bank', 'stock', 'gold'] as const
@@ -21,9 +21,17 @@ export async function GET(request: NextRequest) {
   // Renewal history snapshots are excluded by default (so Recent Activity and
   // any future consumer stay clean); the goal-detail History tab opts in.
   const includeHistory = searchParams.get('include_history') === 'true'
-  const page = Math.max(1, parseInt(searchParams.get('page') ?? '1', 10))
-  const limitParam = parseInt(searchParams.get('limit') ?? '20', 10)
-  const limit = Math.min(Math.max(1, isNaN(limitParam) ? 20 : limitParam), 1000)
+  let page: number
+  let limit: number
+  try {
+    // Only finite positive integers; garbage (page=abc) is a 400, not a NaN
+    // range call. limit is clamped to the documented ceiling of 1000.
+    page = validatePositiveIntParam(searchParams.get('page'), 'page', { fallback: 1 })
+    limit = validatePositiveIntParam(searchParams.get('limit'), 'limit', { fallback: 20, max: 1000 })
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
   const offset = (page - 1) * limit
 
   let query = supabase

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { ValidationError, validateAmount } from '@/lib/validation'
+import { ValidationError, validateAmount, validateInteger } from '@/lib/validation'
 
 export async function GET(request: NextRequest) {
   const supabase = await createSupabaseServerClient()
@@ -15,12 +15,24 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'month and year are required' }, { status: 400 })
   }
 
+  let monthNum: number
+  let yearNum: number
+  try {
+    // Require the entire value to be a valid integer — parseInt('1abc') === 1
+    // would otherwise silently match the wrong plan.
+    monthNum = validateInteger(month, 'month', { min: 1, max: 12 })
+    yearNum = validateInteger(year, 'year', { min: 2000, max: 9999 })
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
   const { data: plan, error } = await supabase
     .from('monthly_plans')
     .select('*')
     .eq('user_id', user.id)
-    .eq('month', parseInt(month))
-    .eq('year', parseInt(year))
+    .eq('month', monthNum)
+    .eq('year', yearNum)
     .maybeSingle()
 
   if (error) return NextResponse.json({ error: 'Failed to fetch plan' }, { status: 500 })
@@ -134,14 +146,9 @@ export async function POST(request: NextRequest) {
   let cleanSalary: number
 
   try {
-    monthNum = parseInt(month)
-    yearNum = parseInt(year)
-    if (!month || !Number.isFinite(monthNum) || monthNum < 1 || monthNum > 12) {
-      throw new ValidationError('Month must be between 1 and 12')
-    }
-    if (!year || !Number.isFinite(yearNum) || yearNum < 2000 || yearNum > 9999) {
-      throw new ValidationError('Invalid year')
-    }
+    // Whole-integer parse rejects '1abc' etc.; range mirrors the GET handler.
+    monthNum = validateInteger(month, 'month', { min: 1, max: 12 })
+    yearNum = validateInteger(year, 'year', { min: 2000, max: 9999 })
     cleanSalary = validateAmount(salary_vnd, 'salary_vnd')
     if (cleanSalary <= 0) throw new ValidationError('Salary must be positive')
   } catch (e) {

--- a/e2e/api-validation.spec.ts
+++ b/e2e/api-validation.spec.ts
@@ -109,6 +109,48 @@ test.describe('API input validation', () => {
     }
   })
 
+  // Pagination / month / DCA hardening (#471): junk inputs that used to reach
+  // the DB as NaN ranges, parseInt('1abc') → 1, or CHECK-violating amounts must
+  // now be a clean 400 at the route.
+  test('GET /api/v1/investment-transactions rejects non-integer page (400)', async ({ request }) => {
+    const res = await request.get('/api/v1/investment-transactions?page=abc')
+    expect(res.status()).toBe(400)
+  })
+
+  test('GET /api/v1/investment-transactions rejects a fractional limit (400)', async ({ request }) => {
+    const res = await request.get('/api/v1/investment-transactions?limit=2.5')
+    expect(res.status()).toBe(400)
+  })
+
+  test('GET /api/v1/monthly-plans rejects a mixed-string month (400)', async ({ request }) => {
+    const res = await request.get('/api/v1/monthly-plans?month=1abc&year=2026')
+    expect(res.status()).toBe(400)
+  })
+
+  test('POST /api/v1/monthly-plans rejects a mixed-string month (400)', async ({ request }) => {
+    const res = await request.post('/api/v1/monthly-plans', {
+      data: { month: '1abc', year: 2026, salary_vnd: 30_000_000 },
+    })
+    expect(res.status()).toBe(400)
+  })
+
+  test('POST /api/funds rejects an Infinity NAV (400)', async ({ request }) => {
+    const res = await request.post('/api/funds', {
+      data: { name: 'E2E Inf NAV', code: 'E2EINF', fund_type: 'equity', nav: 'Infinity' },
+    })
+    expect(res.status()).toBe(400)
+  })
+
+  test('POST /api/funds rejects a negative DCA amount (400)', async ({ request }) => {
+    const res = await request.post('/api/funds', {
+      data: {
+        name: 'E2E Neg DCA', code: 'E2ENEG', fund_type: 'equity', nav: 20_000,
+        is_dca: true, dca_monthly_amount_vnd: -5_000_000,
+      },
+    })
+    expect(res.status()).toBe(400)
+  })
+
   // The renewed cycle must have positive length: its new maturity has to fall
   // strictly after its start (investment) date. The client anchors the start to
   // the old maturity, so a hand-edited maturity on or before it must be rejected.

--- a/e2e/api-validation.spec.ts
+++ b/e2e/api-validation.spec.ts
@@ -151,6 +151,16 @@ test.describe('API input validation', () => {
     expect(res.status()).toBe(400)
   })
 
+  test('POST /api/funds rejects a fractional DCA amount — BIGINT column (400)', async ({ request }) => {
+    const res = await request.post('/api/funds', {
+      data: {
+        name: 'E2E Frac DCA', code: 'E2EFRC', fund_type: 'equity', nav: 20_000,
+        is_dca: true, dca_monthly_amount_vnd: 1.5,
+      },
+    })
+    expect(res.status()).toBe(400)
+  })
+
   // The renewed cycle must have positive length: its new maturity has to fall
   // strictly after its start (investment) date. The client anchors the start to
   // the old maturity, so a hand-edited maturity on or before it must be rejected.

--- a/lib/__tests__/validation.test.ts
+++ b/lib/__tests__/validation.test.ts
@@ -78,6 +78,24 @@ describe('validateAmount', () => {
       expect((e as ValidationError).message).toContain('salary_vnd')
     }
   })
+
+  it('with { positive: true } rejects zero and negatives but accepts positives', () => {
+    expect(validateAmount(1, 'dca', { positive: true })).toBe(1)
+    expect(() => validateAmount(0, 'dca', { positive: true })).toThrow(ValidationError)
+    expect(() => validateAmount(-5, 'dca', { positive: true })).toThrow(ValidationError)
+  })
+
+  it('with { integer: true } rejects fractional values (BIGINT columns)', () => {
+    expect(validateAmount(2_000_000, 'dca', { integer: true })).toBe(2_000_000)
+    expect(() => validateAmount(1.5, 'dca', { integer: true })).toThrow(ValidationError)
+    expect(() => validateAmount('1.5', 'dca', { integer: true })).toThrow(ValidationError)
+  })
+
+  it('combines positive + integer for DCA-style amounts', () => {
+    expect(validateAmount('3000000', 'dca', { positive: true, integer: true })).toBe(3_000_000)
+    expect(() => validateAmount(0, 'dca', { positive: true, integer: true })).toThrow(ValidationError)
+    expect(() => validateAmount(1.5, 'dca', { positive: true, integer: true })).toThrow(ValidationError)
+  })
 })
 
 describe('validateRate', () => {

--- a/lib/__tests__/validation.test.ts
+++ b/lib/__tests__/validation.test.ts
@@ -9,6 +9,8 @@ import {
   validateYearMonth,
   validateEnum,
   validateBankCode,
+  validateInteger,
+  validatePositiveIntParam,
   ValidationError,
 } from '../validation'
 
@@ -237,6 +239,101 @@ describe('validateEnum', () => {
 
   it('rejects non-string values', () => {
     expect(() => validateEnum(123, ['fund', 'bank'] as const, 'asset_type')).toThrow(ValidationError)
+  })
+})
+
+describe('validateInteger', () => {
+  it('accepts a whole number', () => {
+    expect(validateInteger(5, 'month')).toBe(5)
+  })
+
+  it('accepts a whole numeric string', () => {
+    expect(validateInteger('2026', 'year')).toBe(2026)
+  })
+
+  it('accepts a signed integer string and trims whitespace', () => {
+    expect(validateInteger(' -3 ', 'n')).toBe(-3)
+    expect(validateInteger('+7', 'n')).toBe(7)
+  })
+
+  it('rejects a mixed alphanumeric string (e.g. 1abc)', () => {
+    expect(() => validateInteger('1abc', 'month')).toThrow(ValidationError)
+    expect(() => validateInteger('abc', 'month')).toThrow(ValidationError)
+  })
+
+  it('rejects a fractional value (number or string)', () => {
+    expect(() => validateInteger(1.5, 'month')).toThrow(ValidationError)
+    expect(() => validateInteger('1.5', 'month')).toThrow(ValidationError)
+  })
+
+  it('rejects NaN and Infinity', () => {
+    expect(() => validateInteger(NaN, 'month')).toThrow(ValidationError)
+    expect(() => validateInteger(Infinity, 'month')).toThrow(ValidationError)
+    expect(() => validateInteger(-Infinity, 'month')).toThrow(ValidationError)
+    expect(() => validateInteger('Infinity', 'month')).toThrow(ValidationError)
+  })
+
+  it('rejects values beyond the safe-integer range', () => {
+    expect(() => validateInteger(Number.MAX_SAFE_INTEGER + 1, 'n')).toThrow(ValidationError)
+    expect(() => validateInteger('9007199254740993', 'n')).toThrow(ValidationError)
+  })
+
+  it('rejects null, undefined, empty string, and non-numeric types', () => {
+    expect(() => validateInteger(null, 'month')).toThrow(ValidationError)
+    expect(() => validateInteger(undefined, 'month')).toThrow(ValidationError)
+    expect(() => validateInteger('', 'month')).toThrow(ValidationError)
+    expect(() => validateInteger('  ', 'month')).toThrow(ValidationError)
+    expect(() => validateInteger(true, 'month')).toThrow(ValidationError)
+    expect(() => validateInteger({}, 'month')).toThrow(ValidationError)
+  })
+
+  it('enforces the min boundary', () => {
+    expect(validateInteger(1, 'month', { min: 1, max: 12 })).toBe(1)
+    expect(() => validateInteger(0, 'month', { min: 1, max: 12 })).toThrow(ValidationError)
+  })
+
+  it('enforces the max boundary', () => {
+    expect(validateInteger(12, 'month', { min: 1, max: 12 })).toBe(12)
+    expect(() => validateInteger(13, 'month', { min: 1, max: 12 })).toThrow(ValidationError)
+  })
+
+  it('mentions the field name in the error', () => {
+    expect(() => validateInteger('x', 'year')).toThrow(/year/)
+  })
+})
+
+describe('validatePositiveIntParam', () => {
+  it('returns the fallback when the param is absent or empty', () => {
+    expect(validatePositiveIntParam(null, 'page', { fallback: 1 })).toBe(1)
+    expect(validatePositiveIntParam(undefined, 'page', { fallback: 1 })).toBe(1)
+    expect(validatePositiveIntParam('', 'page', { fallback: 1 })).toBe(1)
+    expect(validatePositiveIntParam('   ', 'page', { fallback: 1 })).toBe(1)
+  })
+
+  it('accepts a positive integer string', () => {
+    expect(validatePositiveIntParam('3', 'page', { fallback: 1 })).toBe(3)
+  })
+
+  it('rejects non-integer garbage instead of silently defaulting', () => {
+    expect(() => validatePositiveIntParam('abc', 'page', { fallback: 1 })).toThrow(ValidationError)
+    expect(() => validatePositiveIntParam('1abc', 'page', { fallback: 1 })).toThrow(ValidationError)
+    expect(() => validatePositiveIntParam('NaN', 'page', { fallback: 1 })).toThrow(ValidationError)
+    expect(() => validatePositiveIntParam('Infinity', 'page', { fallback: 1 })).toThrow(ValidationError)
+    expect(() => validatePositiveIntParam('2.5', 'page', { fallback: 1 })).toThrow(ValidationError)
+  })
+
+  it('rejects zero and negative values (must be positive)', () => {
+    expect(() => validatePositiveIntParam('0', 'page', { fallback: 1 })).toThrow(ValidationError)
+    expect(() => validatePositiveIntParam('-5', 'page', { fallback: 1 })).toThrow(ValidationError)
+  })
+
+  it('clamps to the documented max when one is given', () => {
+    expect(validatePositiveIntParam('5000', 'limit', { fallback: 20, max: 1000 })).toBe(1000)
+    expect(validatePositiveIntParam('50', 'limit', { fallback: 20, max: 1000 })).toBe(50)
+  })
+
+  it('does not clamp when no max is given (page can be large)', () => {
+    expect(validatePositiveIntParam('999999', 'page', { fallback: 1 })).toBe(999999)
   })
 })
 

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -132,6 +132,52 @@ export function validateYearMonth(val: unknown, field: string): string {
   return val
 }
 
+// A whole integer, given as a number or a fully-integer string. Rejects
+// anything parseInt would silently accept (e.g. "1abc" → 1), plus NaN, Infinity,
+// fractional, and unsafe-magnitude values. Optional inclusive [min, max] bounds.
+const INTEGER_RE = /^[+-]?\d+$/
+
+export function validateInteger(
+  val: unknown,
+  field: string,
+  opts: { min?: number; max?: number } = {}
+): number {
+  let n: number
+  if (typeof val === 'number') {
+    n = val
+  } else if (typeof val === 'string' && INTEGER_RE.test(val.trim())) {
+    n = Number(val.trim())
+  } else {
+    throw new ValidationError(`${field} must be an integer`)
+  }
+  if (!Number.isSafeInteger(n)) {
+    throw new ValidationError(`${field} must be an integer`)
+  }
+  if (opts.min !== undefined && n < opts.min) {
+    throw new ValidationError(`${field} must be at least ${opts.min}`)
+  }
+  if (opts.max !== undefined && n > opts.max) {
+    throw new ValidationError(`${field} must be at most ${opts.max}`)
+  }
+  return n
+}
+
+// A pagination-style query param: absent (null/undefined/blank) falls back to
+// `fallback`; a present value must be a positive integer (else ValidationError,
+// so garbage returns 400 rather than silently defaulting). When `max` is given
+// the value is clamped to it — the documented ceiling — instead of rejected.
+export function validatePositiveIntParam(
+  val: unknown,
+  field: string,
+  opts: { fallback: number; max?: number }
+): number {
+  if (val === null || val === undefined || (typeof val === 'string' && val.trim() === '')) {
+    return opts.fallback
+  }
+  const n = validateInteger(val, field, { min: 1 })
+  return opts.max !== undefined ? Math.min(n, opts.max) : n
+}
+
 export function validateEnum<T extends string>(
   val: unknown,
   allowed: readonly T[],

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -26,13 +26,24 @@ function coerceNumber(val: unknown): number | null {
   return null
 }
 
-export function validateAmount(val: unknown, field: string): number {
+export function validateAmount(
+  val: unknown,
+  field: string,
+  opts: { positive?: boolean; integer?: boolean } = {}
+): number {
   const n = coerceNumber(val)
   if (n === null || !Number.isFinite(n)) {
     throw new ValidationError(`${field} must be a finite number`)
   }
-  if (n < 0) {
+  if (opts.positive) {
+    if (n <= 0) throw new ValidationError(`${field} must be positive`)
+  } else if (n < 0) {
     throw new ValidationError(`${field} must be non-negative`)
+  }
+  // For columns modeled as BIGINT (e.g. dca_monthly_amount_vnd): a fractional
+  // value would otherwise reach the DB and 500 instead of a clean 400.
+  if (opts.integer && !Number.isInteger(n)) {
+    throw new ValidationError(`${field} must be a whole number`)
   }
   if (n > Number.MAX_SAFE_INTEGER) {
     throw new ValidationError(`${field} exceeds maximum allowed value`)


### PR DESCRIPTION
Closes #471.

## Problem
Several API inputs were only partially validated, so junk reached the database and surfaced as a **500** instead of a clear **400**:

- `page=abc` → `parseInt` `NaN` → `Math.max(1, NaN)` = `NaN` → `offset` `NaN` passed straight to `.range()` (only `limit` was guarded).
- `month`/`year` used `parseInt`, so `1abc` parsed to `1` — matched the wrong plan (GET) or created one (POST).
- `dca_monthly_amount_vnd` and `nav` used bare `Number(...)`: negative / fractional / `Infinity` slipped through to the column CHECK (500). `Number('Infinity')` even passed the `< 0.01` NAV guard.

## Fix
Two shared validators in `lib/validation.ts`, wired into the four routes:

- **`validateInteger(val, field, {min, max})`** — a number or fully-integer string only; rejects `'1abc'`, fractions, `NaN`, `Infinity`, and unsafe magnitudes, with inclusive bounds.
- **`validatePositiveIntParam(val, field, {fallback, max})`** — pagination: absent → fallback, garbage → 400, clamped to the documented ceiling (1000 for `limit`).
- `month`/`year` (GET + POST) → `validateInteger`; DCA amount → shared `validateAmount` + positive check; NAV now requires a finite value.

Every invalid input now returns **400**.

## Acceptance criteria
- [x] Pagination accepts only finite positive integers and applies documented limits.
- [x] Month and year require the entire input to be a valid integer.
- [x] DCA amount uses shared amount validation and must be positive.
- [x] Invalid input consistently returns 400.
- [x] Tests cover NaN, Infinity, negative, fractional, mixed-string, and boundary values.

## Testing
- **`lib/__tests__/validation.test.ts`** — dense value matrix for both new validators (NaN, Infinity, ±, fractional, mixed-string, boundaries, unsafe int, clamp/fallback).
- **`e2e/api-validation.spec.ts`** — route-level 400 assertions for `page`, `limit`, `month` (GET + POST), Infinity NAV, and negative DCA amount — the inputs that used to 500.
- Unit **1151 passed**, lint 0 errors, targeted E2E green (funds / planning / investments / assign-goal / dashboard, 30 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)