### PR TITLE
fix(funds): retire pending plan allocations when DCA is disabled (#473)

### DIFF
--- a/app/api/funds/[id]/__tests__/route.dca.test.ts
+++ b/app/api/funds/[id]/__tests__/route.dca.test.ts
@@ -1,29 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
-// Capture the payload handed to supabase .update() and stub the auth + query chain.
+// Capture writes and RPC calls while stubbing auth + Supabase query chains.
 const h = vi.hoisted(() => ({
   captured: null as Record<string, unknown> | null,
   user: { id: 'user-1' } as { id: string } | null,
-  result: { data: { id: 'f1' }, error: null } as { data: unknown; error: unknown },
-  // The pending-row cleanup on DCA-disable issues a separate .delete() chain;
-  // capture its filters (null until a delete happens).
-  deleteFilters: null as Record<string, unknown> | null,
-  inDelete: false,
+  updateResult: { data: { id: 'f1' }, error: null } as { data: unknown; error: unknown },
+  rpcResult: { data: { id: 'f1' }, error: null } as { data: unknown; error: unknown },
+  rpcCalls: [] as Array<{ fn: string; args: Record<string, unknown> }>,
 }))
 
 vi.mock('@/lib/supabase-server', () => {
   const chain: Record<string, unknown> = {
     update: (payload: Record<string, unknown>) => { h.captured = payload; return chain },
-    delete: () => { h.inDelete = true; h.deleteFilters = {}; return chain },
     select: () => chain,
-    eq: (col: string, val: unknown) => { if (h.inDelete) h.deleteFilters![col] = val; return chain },
-    is: (col: string, val: unknown) => { if (h.inDelete) h.deleteFilters![col] = val; return chain },
-    single: async () => h.result,
+    eq: () => chain,
+    single: async () => h.updateResult,
   }
   return {
     createSupabaseServerClient: async () => ({
       auth: { getUser: async () => ({ data: { user: h.user } }) },
       from: () => chain,
+      rpc: (fn: string, args: Record<string, unknown>) => {
+        h.rpcCalls.push({ fn, args })
+        return { single: async () => h.rpcResult }
+      },
     }),
   }
 })
@@ -40,9 +40,9 @@ const baseBody = { name: 'VFMVF1 Equity', code: 'VFMVF1', fund_type: 'equity', n
 beforeEach(() => {
   h.captured = null
   h.user = { id: 'user-1' }
-  h.result = { data: { id: 'f1' }, error: null }
-  h.deleteFilters = null
-  h.inDelete = false
+  h.updateResult = { data: { id: 'f1' }, error: null }
+  h.rpcResult = { data: { id: 'f1' }, error: null }
+  h.rpcCalls = []
 })
 
 describe('PUT /api/funds/[id] — DCA fields use partial-update semantics (sibling of #411)', () => {
@@ -56,35 +56,47 @@ describe('PUT /api/funds/[id] — DCA fields use partial-update semantics (sibli
     expect(h.captured).not.toHaveProperty('dca_goal_id')
     expect(h.captured!.name).toBe('VFMVF1 Equity')
     expect(h.captured!.nav).toBe(36120)
-    // Not a disable, so no pending-row cleanup runs.
-    expect(h.deleteFilters).toBeNull()
+    expect(h.rpcCalls).toHaveLength(0)
   })
 
-  it('an explicit is_dca:false still clears the DCA columns', async () => {
-    await PUT(makeReq({ ...baseBody, is_dca: false }), ctx)
-    expect(h.captured!.is_dca).toBe(false)
-    expect(h.captured!.dca_monthly_amount_vnd).toBeNull()
-    expect(h.captured!.dca_goal_id).toBeNull()
+  it('an explicit is_dca:false atomically clears config and pending rows via RPC', async () => {
+    const res = await PUT(makeReq({ ...baseBody, is_dca: false }), ctx)
+    expect(res.status).toBe(200)
+    expect(h.captured).toBeNull()
+    expect(h.rpcCalls).toEqual([{
+      fn: 'disable_fund_dca',
+      args: {
+        p_fund_id: 'f1',
+        p_name: 'VFMVF1 Equity',
+        p_code: 'VFMVF1',
+        p_fund_type: 'equity',
+        p_nav: 36120,
+        p_nav_source_url: null,
+      },
+    }])
   })
 
-  it('disabling DCA retires the fund\'s pending seeded rows, sparing recorded buys (#473)', async () => {
-    await PUT(makeReq({ ...baseBody, is_dca: false }), ctx)
-    // A scoped delete of only this fund's un-recorded seeded rows for this user.
-    expect(h.deleteFilters).toEqual({
-      user_id: 'user-1',
-      fund_id: 'f1',
-      asset_type: 'fund',
-      is_dca_seeded: true,
-      units: null,
-    })
+  it('returns an error instead of reporting success when the atomic disable fails', async () => {
+    h.rpcResult = { data: null, error: { code: 'XX000', message: 'cleanup failed' } }
+    const res = await PUT(makeReq({ ...baseBody, is_dca: false }), ctx)
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Failed to update fund' })
   })
 
-  it('an explicit is_dca:true persists amount + goal and does not delete rows', async () => {
+  it.each([null, 'false', 0])('rejects a non-boolean is_dca value: %j', async (isDca) => {
+    const res = await PUT(makeReq({ ...baseBody, is_dca: isDca }), ctx)
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'is_dca must be a boolean' })
+    expect(h.captured).toBeNull()
+    expect(h.rpcCalls).toHaveLength(0)
+  })
+
+  it('an explicit is_dca:true persists amount + goal without calling disable RPC', async () => {
     const goal = '11111111-1111-1111-1111-111111111111'
     await PUT(makeReq({ ...baseBody, is_dca: true, dca_monthly_amount_vnd: 2_000_000, dca_goal_id: goal }), ctx)
     expect(h.captured!.is_dca).toBe(true)
     expect(h.captured!.dca_monthly_amount_vnd).toBe(2_000_000)
     expect(h.captured!.dca_goal_id).toBe(goal)
-    expect(h.deleteFilters).toBeNull()
+    expect(h.rpcCalls).toHaveLength(0)
   })
 })

--- a/app/api/funds/[id]/__tests__/route.dca.test.ts
+++ b/app/api/funds/[id]/__tests__/route.dca.test.ts
@@ -83,6 +83,22 @@ describe('PUT /api/funds/[id] — DCA fields use partial-update semantics (sibli
     expect(await res.json()).toEqual({ error: 'Failed to update fund' })
   })
 
+  it('404s a missing/foreign fund on the regular update path (PGRST116)', async () => {
+    // A zero-row .update().single() surfaces as an error, not null data, so the
+    // route must map it to 404 rather than fall through to a generic 500.
+    h.updateResult = { data: null, error: { code: 'PGRST116', message: 'no rows' } }
+    const res = await PUT(makeReq(baseBody), ctx)
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'Fund not found' })
+  })
+
+  it('404s a missing/foreign fund on the disable path (P0002 no_data_found)', async () => {
+    h.rpcResult = { data: null, error: { code: 'P0002', message: 'Fund not found' } }
+    const res = await PUT(makeReq({ ...baseBody, is_dca: false }), ctx)
+    expect(res.status).toBe(404)
+    expect(await res.json()).toEqual({ error: 'Fund not found' })
+  })
+
   it.each([null, 'false', 0])('rejects a non-boolean is_dca value: %j', async (isDca) => {
     const res = await PUT(makeReq({ ...baseBody, is_dca: isDca }), ctx)
     expect(res.status).toBe(400)

--- a/app/api/funds/[id]/__tests__/route.dca.test.ts
+++ b/app/api/funds/[id]/__tests__/route.dca.test.ts
@@ -5,13 +5,19 @@ const h = vi.hoisted(() => ({
   captured: null as Record<string, unknown> | null,
   user: { id: 'user-1' } as { id: string } | null,
   result: { data: { id: 'f1' }, error: null } as { data: unknown; error: unknown },
+  // The pending-row cleanup on DCA-disable issues a separate .delete() chain;
+  // capture its filters (null until a delete happens).
+  deleteFilters: null as Record<string, unknown> | null,
+  inDelete: false,
 }))
 
 vi.mock('@/lib/supabase-server', () => {
   const chain: Record<string, unknown> = {
     update: (payload: Record<string, unknown>) => { h.captured = payload; return chain },
+    delete: () => { h.inDelete = true; h.deleteFilters = {}; return chain },
     select: () => chain,
-    eq: () => chain,
+    eq: (col: string, val: unknown) => { if (h.inDelete) h.deleteFilters![col] = val; return chain },
+    is: (col: string, val: unknown) => { if (h.inDelete) h.deleteFilters![col] = val; return chain },
     single: async () => h.result,
   }
   return {
@@ -35,6 +41,8 @@ beforeEach(() => {
   h.captured = null
   h.user = { id: 'user-1' }
   h.result = { data: { id: 'f1' }, error: null }
+  h.deleteFilters = null
+  h.inDelete = false
 })
 
 describe('PUT /api/funds/[id] — DCA fields use partial-update semantics (sibling of #411)', () => {
@@ -48,6 +56,8 @@ describe('PUT /api/funds/[id] — DCA fields use partial-update semantics (sibli
     expect(h.captured).not.toHaveProperty('dca_goal_id')
     expect(h.captured!.name).toBe('VFMVF1 Equity')
     expect(h.captured!.nav).toBe(36120)
+    // Not a disable, so no pending-row cleanup runs.
+    expect(h.deleteFilters).toBeNull()
   })
 
   it('an explicit is_dca:false still clears the DCA columns', async () => {
@@ -57,11 +67,24 @@ describe('PUT /api/funds/[id] — DCA fields use partial-update semantics (sibli
     expect(h.captured!.dca_goal_id).toBeNull()
   })
 
-  it('an explicit is_dca:true persists amount + goal', async () => {
+  it('disabling DCA retires the fund\'s pending seeded rows, sparing recorded buys (#473)', async () => {
+    await PUT(makeReq({ ...baseBody, is_dca: false }), ctx)
+    // A scoped delete of only this fund's un-recorded seeded rows for this user.
+    expect(h.deleteFilters).toEqual({
+      user_id: 'user-1',
+      fund_id: 'f1',
+      asset_type: 'fund',
+      is_dca_seeded: true,
+      units: null,
+    })
+  })
+
+  it('an explicit is_dca:true persists amount + goal and does not delete rows', async () => {
     const goal = '11111111-1111-1111-1111-111111111111'
     await PUT(makeReq({ ...baseBody, is_dca: true, dca_monthly_amount_vnd: 2_000_000, dca_goal_id: goal }), ctx)
     expect(h.captured!.is_dca).toBe(true)
     expect(h.captured!.dca_monthly_amount_vnd).toBe(2_000_000)
     expect(h.captured!.dca_goal_id).toBe(goal)
+    expect(h.deleteFilters).toBeNull()
   })
 })

--- a/app/api/funds/[id]/route.ts
+++ b/app/api/funds/[id]/route.ts
@@ -144,6 +144,15 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     if (error.code === '23505') {
       return NextResponse.json({ error: 'Code already exists' }, { status: 409 })
     }
+    // Zero rows matched: the regular update path surfaces this as PGRST116 (from
+    // .single()), the disable RPC as P0002 (no_data_found). Both mean the fund
+    // doesn't exist or isn't the caller's — a 404, not a generic 500, and it
+    // avoids disclosing whether a foreign fund exists. (This is why the `if
+    // (!fund)` guard below never fires for the update path — .single() reports a
+    // zero-row result as an error, not null data.)
+    if (error.code === 'P0002' || error.code === 'PGRST116') {
+      return NextResponse.json({ error: 'Fund not found' }, { status: 404 })
+    }
     return NextResponse.json({ error: 'Failed to update fund' }, { status: 500 })
   }
 

--- a/app/api/funds/[id]/route.ts
+++ b/app/api/funds/[id]/route.ts
@@ -45,6 +45,10 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const body = await request.json()
   const { name, code, fund_type, nav, nav_source_url, is_dca, dca_monthly_amount_vnd, dca_goal_id } = body
 
+  if (is_dca !== undefined && typeof is_dca !== 'boolean') {
+    return NextResponse.json({ error: 'is_dca must be a boolean' }, { status: 400 })
+  }
+
   if (!name || typeof name !== 'string' || name.trim().length === 0) {
     return NextResponse.json({ error: 'Name is required' }, { status: 400 })
   }
@@ -110,13 +114,31 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     update.dca_goal_id = is_dca === true && dca_goal_id ? dca_goal_id : null
   }
 
-  const { data: fund, error } = await supabase
-    .from('funds')
-    .update(update)
-    .eq('id', id)
-    .eq('user_id', user.id)
-    .select()
-    .single()
+  // Disabling is a cross-table state change: the fund config and every pending
+  // seeded allocation must commit (or roll back) together. The RPC also takes
+  // the same row lock used by plan seeding, so a concurrent plan load cannot
+  // commit a stale pending row after this cleanup finishes.
+  const disablingDca = is_dca === false
+  const result = disablingDca
+    ? await supabase
+        .rpc('disable_fund_dca', {
+          p_fund_id: id,
+          p_name: update.name,
+          p_code: update.code,
+          p_fund_type: update.fund_type,
+          p_nav: update.nav,
+          p_nav_source_url: update.nav_source_url,
+        })
+        .single()
+    : await supabase
+        .from('funds')
+        .update(update)
+        .eq('id', id)
+        .eq('user_id', user.id)
+        .select()
+        .single()
+
+  const { data: fund, error } = result
 
   if (error) {
     if (error.code === '23505') {
@@ -127,23 +149,6 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
   if (!fund) {
     return NextResponse.json({ error: 'Fund not found' }, { status: 404 })
-  }
-
-  // Turning DCA off must also retire the fund's pending (un-recorded) seeded
-  // allocations from every plan, or they keep counting toward planned totals
-  // even though the fund is no longer a DCA fund (#473). Recorded buys (units
-  // set) are financial history and are left intact. Mirrors the per-plan cleanup
-  // the DCA-skip endpoint does. Best-effort, like that endpoint.
-  const disablingDca = is_dca !== undefined && is_dca !== true
-  if (disablingDca) {
-    await supabase
-      .from('investment_transactions')
-      .delete()
-      .eq('user_id', user.id)
-      .eq('fund_id', id)
-      .eq('asset_type', 'fund')
-      .eq('is_dca_seeded', true)
-      .is('units', null)
   }
 
   return NextResponse.json(fund)

--- a/app/api/funds/[id]/route.ts
+++ b/app/api/funds/[id]/route.ts
@@ -129,6 +129,23 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     return NextResponse.json({ error: 'Fund not found' }, { status: 404 })
   }
 
+  // Turning DCA off must also retire the fund's pending (un-recorded) seeded
+  // allocations from every plan, or they keep counting toward planned totals
+  // even though the fund is no longer a DCA fund (#473). Recorded buys (units
+  // set) are financial history and are left intact. Mirrors the per-plan cleanup
+  // the DCA-skip endpoint does. Best-effort, like that endpoint.
+  const disablingDca = is_dca !== undefined && is_dca !== true
+  if (disablingDca) {
+    await supabase
+      .from('investment_transactions')
+      .delete()
+      .eq('user_id', user.id)
+      .eq('fund_id', id)
+      .eq('asset_type', 'fund')
+      .eq('is_dca_seeded', true)
+      .is('units', null)
+  }
+
   return NextResponse.json(fund)
 }
 

--- a/e2e/dca-disable-cleanup.spec.ts
+++ b/e2e/dca-disable-cleanup.spec.ts
@@ -85,4 +85,43 @@ test.describe('disabling DCA removes pending plan allocations (#473)', () => {
     expect(await api.countPlanDcaRows(planPendingId, fundId)).toBe(1)
     expect(await api.countPlanDcaRows(planRecordedId, fundId)).toBe(1)
   })
+
+  test('a concurrent plan seed cannot leave a stale pending row after disable', async ({ request }) => {
+    // Repeat the race with an empty plan. The database row lock makes either
+    // ordering safe: disable cleans a row seeded first, or seed observes the
+    // already-disabled fund and inserts nothing.
+    for (let attempt = 0; attempt < 5; attempt += 1) {
+      const on = await request.put(`/api/funds/${fundId}`, {
+        data: { ...fundBody, is_dca: true, dca_monthly_amount_vnd: 2_000_000, dca_goal_id: goalId },
+      })
+      expect(on.ok()).toBeTruthy()
+      await api.deletePendingDcaRows(planPendingId, fundId)
+
+      const [seed, off] = await Promise.all([
+        api.rpcSeedPlanDca(planPendingId),
+        request.put(`/api/funds/${fundId}`, { data: { ...fundBody, is_dca: false } }),
+      ])
+
+      expect(seed.error).toBeNull()
+      expect(off.ok()).toBeTruthy()
+      expect(await api.countPlanDcaRows(planPendingId, fundId)).toBe(0)
+    }
+  })
+
+  test('seeding self-heals stale pending rows created before the atomic fix', async () => {
+    // Bypass the route to emulate historical inconsistent state: disabled fund,
+    // but an old pending seeded allocation still exists.
+    await api.setFundDca(fundId, {
+      is_dca: false,
+      dca_monthly_amount_vnd: null,
+      dca_goal_id: null,
+    })
+    expect(await api.countPlanDcaRows(planPendingId, fundId)).toBe(1)
+
+    const seed = await api.rpcSeedPlanDca(planPendingId)
+    expect(seed.error).toBeNull()
+    expect(await api.countPlanDcaRows(planPendingId, fundId)).toBe(0)
+    // A recorded purchase is historical data and must never be reconciled away.
+    expect(await api.countPlanDcaRows(planRecordedId, fundId)).toBe(1)
+  })
 })

--- a/e2e/dca-disable-cleanup.spec.ts
+++ b/e2e/dca-disable-cleanup.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test'
+import * as api from './helpers/api'
+
+// Disabling DCA on a fund must drop its pending (un-recorded) seeded allocations
+// from every plan, so the fund stops counting toward planned totals — while
+// recorded purchases stay put, and re-enabling recreates only the missing rows
+// (#473). The cleanup is a DB effect driven by PUT /api/funds/[id], so this runs
+// at the route+DB boundary: the authenticated `request` fixture hits the route,
+// the service-role client asserts the resulting rows.
+test.describe('disabling DCA removes pending plan allocations (#473)', () => {
+  const FUND_PREFIX = 'E2E DCA Disable Fund'
+  let goalId: string
+  let fundId: string
+  let fundBody: { name: string; code: string; fund_type: string; nav: number }
+  let planPendingId: string // a plan whose seeded row stays pending
+  let planRecordedId: string // a plan whose seeded row gets recorded
+
+  test.beforeEach(async () => {
+    await api.deleteFundsByNamePrefix(FUND_PREFIX)
+    await api.deleteMonthlyPlanByDate(9, 2099)
+    await api.deleteMonthlyPlanByDate(10, 2099)
+
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`
+    const goal = await api.createGoal({ goal_name: `E2E DCA Disable Goal ${stamp}` })
+    goalId = goal.goal_id
+    fundBody = {
+      name: `${FUND_PREFIX} ${stamp}`,
+      code: `E2E${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      fund_type: 'equity',
+      nav: 20_000,
+    }
+    const fund = await api.createFund({
+      ...fundBody,
+      is_dca: true,
+      dca_monthly_amount_vnd: 2_000_000,
+      dca_goal_id: goalId,
+    })
+    fundId = fund.id
+
+    const planPending = await api.createMonthlyPlan({ month: 9, year: 2099, salary_vnd: 50_000_000 })
+    const planRecorded = await api.createMonthlyPlan({ month: 10, year: 2099, salary_vnd: 50_000_000 })
+    planPendingId = planPending.id
+    planRecordedId = planRecorded.id
+
+    // Seed both plans, then record the buy in one of them.
+    await api.rpcSeedPlanDca(planPendingId)
+    await api.rpcSeedPlanDca(planRecordedId)
+    await api.recordDcaBuy(planRecordedId, fundId, 100, 20_000)
+  })
+
+  test.afterEach(async () => {
+    if (fundId) await api.deleteFund(fundId)
+    if (planPendingId) await api.deleteMonthlyPlan(planPendingId)
+    if (planRecordedId) await api.deleteMonthlyPlan(planRecordedId)
+    if (goalId) await api.deleteGoal(goalId)
+  })
+
+  test('disable drops pending rows, keeps recorded, and re-enable recreates only the missing one', async ({ request }) => {
+    // Precondition: both plans have exactly one DCA row.
+    expect(await api.countPlanDcaRows(planPendingId, fundId)).toBe(1)
+    expect(await api.countPlanDcaRows(planRecordedId, fundId)).toBe(1)
+
+    // Disable DCA through the real route.
+    const off = await request.put(`/api/funds/${fundId}`, {
+      data: { ...fundBody, is_dca: false },
+    })
+    expect(off.ok()).toBeTruthy()
+
+    // The pending allocation is gone; the recorded purchase survives.
+    expect(await api.countPlanDcaRows(planPendingId, fundId)).toBe(0)
+    const recorded = await api.getPlanDcaRows(planRecordedId, fundId)
+    expect(recorded).toHaveLength(1)
+    expect(recorded[0].units).toBe(100)
+
+    // Re-enable DCA and reload both plans.
+    const on = await request.put(`/api/funds/${fundId}`, {
+      data: { ...fundBody, is_dca: true, dca_monthly_amount_vnd: 2_000_000, dca_goal_id: goalId },
+    })
+    expect(on.ok()).toBeTruthy()
+    await api.rpcSeedPlanDca(planPendingId)
+    await api.rpcSeedPlanDca(planRecordedId)
+
+    // The emptied plan gets a fresh pending row; the recorded plan is untouched
+    // (still exactly one row — no duplicate seeded next to the recorded buy).
+    expect(await api.countPlanDcaRows(planPendingId, fundId)).toBe(1)
+    expect(await api.countPlanDcaRows(planRecordedId, fundId)).toBe(1)
+  })
+})

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -402,6 +402,20 @@ export async function rpcSeedPlanDca(planId: string) {
   return await supabase.rpc('seed_and_sync_plan_dca', { p_plan_id: planId })
 }
 
+export async function deletePendingDcaRows(planId: string, fundId: string) {
+  const userId = await getTestUserId()
+  const { error } = await supabase
+    .from('investment_transactions')
+    .delete()
+    .eq('user_id', userId)
+    .eq('plan_id', planId)
+    .eq('fund_id', fundId)
+    .eq('asset_type', 'fund')
+    .eq('is_dca_seeded', true)
+    .is('units', null)
+  if (error) throw error
+}
+
 export async function getPlanDcaRows(planId: string, fundId: string) {
   const { data } = await supabase
     .from('investment_transactions')

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -412,6 +412,20 @@ export async function getPlanDcaRows(planId: string, fundId: string) {
   return data ?? []
 }
 
+// Turn a pending seeded DCA row into a recorded purchase (units + unit_price),
+// mirroring what happens when the user records that month's buy. is_dca_seeded
+// stays true, matching the app's real recorded-DCA row.
+export async function recordDcaBuy(planId: string, fundId: string, units: number, unitPrice: number) {
+  await supabase
+    .from('investment_transactions')
+    .update({ units, unit_price: unitPrice })
+    .eq('plan_id', planId)
+    .eq('fund_id', fundId)
+    .eq('asset_type', 'fund')
+    .eq('is_dca_seeded', true)
+    .is('units', null)
+}
+
 export async function countPlanDcaRows(planId: string, fundId: string): Promise<number> {
   const { count } = await supabase
     .from('investment_transactions')

--- a/supabase/migrations/20260722000002_atomic_dca_disable.sql
+++ b/supabase/migrations/20260722000002_atomic_dca_disable.sql
@@ -1,0 +1,176 @@
+-- Make disabling DCA atomic and serialize it with plan auto-seeding (#473).
+--
+-- Updating funds first and deleting pending allocations in a second PostgREST
+-- request leaves a partial state when the delete fails. It also races with
+-- seed_and_sync_plan_dca: a seed started before the disable can commit a pending
+-- row after the cleanup has already taken its snapshot. This migration:
+--   1. moves the fund update + cleanup into one transaction;
+--   2. makes plan seeding take a SHARE row lock on eligible funds, which
+--      conflicts with the disable UPDATE and gives the two paths a stable order;
+--   3. makes every plan seed self-heal stale pending rows for funds that are no
+--      longer eligible or are skipped in that plan.
+
+create or replace function public.disable_fund_dca(
+  p_fund_id uuid,
+  p_name text,
+  p_code text,
+  p_fund_type text,
+  p_nav numeric,
+  p_nav_source_url text
+)
+returns public.funds
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_fund public.funds;
+begin
+  -- UPDATE takes a row lock that conflicts with seed_and_sync_plan_dca's
+  -- FOR SHARE lock. Whichever path starts first completes before the other can
+  -- decide whether this fund is eligible for seeding.
+  update public.funds
+     set name = p_name,
+         code = p_code,
+         fund_type = p_fund_type,
+         nav = p_nav,
+         nav_source_url = p_nav_source_url,
+         is_dca = false,
+         dca_monthly_amount_vnd = null,
+         dca_goal_id = null
+   where id = p_fund_id
+     and user_id = auth.uid()
+  returning * into v_fund;
+
+  if not found then
+    raise no_data_found using message = 'Fund not found';
+  end if;
+
+  delete from public.investment_transactions
+   where user_id = v_fund.user_id
+     and fund_id = v_fund.id
+     and asset_type = 'fund'
+     and is_dca_seeded
+     and units is null;
+
+  return v_fund;
+end;
+$$;
+
+create or replace function public.seed_and_sync_plan_dca(p_plan_id uuid)
+returns integer
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_user_id uuid;
+  v_year int;
+  v_month int;
+  v_first_of_month date;
+  v_inserted int := 0;
+  v_updated int := 0;
+begin
+  select user_id, year, month
+    into v_user_id, v_year, v_month
+    from public.monthly_plans
+   where id = p_plan_id;
+
+  if v_user_id is null then
+    return 0;
+  end if;
+
+  v_first_of_month := make_date(v_year, v_month, 1);
+
+  -- Coordinate with disable_fund_dca. If seeding locks an active fund first,
+  -- disable waits and subsequently removes the new pending row. If disable owns
+  -- the row first, this statement waits, rechecks the updated row, and does not
+  -- lock/seed it as active.
+  perform f.id
+    from public.funds f
+   where f.user_id = v_user_id
+     and f.is_dca
+   order by f.id
+   for share;
+
+  -- Reconcile removals as well as insert/update. This repairs any stale state
+  -- produced before this migration and is defense in depth for future callers:
+  -- only pending seeded rows are retired; recorded purchases remain history.
+  delete from public.investment_transactions it
+   where it.user_id = v_user_id
+     and it.plan_id = p_plan_id
+     and it.asset_type = 'fund'
+     and it.is_dca_seeded
+     and it.units is null
+     and (
+       not exists (
+         select 1
+           from public.funds f
+          where f.id = it.fund_id
+            and f.user_id = v_user_id
+            and f.is_dca
+            and f.dca_monthly_amount_vnd is not null
+       )
+       or exists (
+         select 1
+           from public.plan_dca_skips s
+          where s.plan_id = p_plan_id
+            and s.fund_id = it.fund_id
+       )
+     );
+
+  with inserted as (
+    insert into public.investment_transactions (
+      user_id, plan_id, fund_id, goal_id, asset_type, amount_vnd,
+      units, unit_price, investment_date, is_dca_seeded
+    )
+    select
+      v_user_id, p_plan_id, f.id, f.dca_goal_id, 'fund', f.dca_monthly_amount_vnd,
+      null, null, v_first_of_month, true
+    from public.funds f
+    where f.user_id = v_user_id
+      and f.is_dca
+      and f.dca_monthly_amount_vnd is not null
+      and not exists (
+        select 1 from public.plan_dca_skips s
+         where s.plan_id = p_plan_id and s.fund_id = f.id
+      )
+      and not exists (
+        select 1 from public.investment_transactions it
+         where it.plan_id = p_plan_id
+           and it.fund_id = f.id
+           and it.asset_type = 'fund'
+      )
+    on conflict (plan_id, fund_id) where is_dca_seeded and asset_type = 'fund'
+    do nothing
+    returning 1
+  )
+  select count(*) into v_inserted from inserted;
+
+  with updated as (
+    update public.investment_transactions it
+       set amount_vnd = f.dca_monthly_amount_vnd,
+           goal_id = f.dca_goal_id,
+           updated_at = now()
+      from public.funds f
+     where it.fund_id = f.id
+       and it.plan_id = p_plan_id
+       and it.asset_type = 'fund'
+       and it.is_dca_seeded
+       and it.units is null
+       and f.user_id = v_user_id
+       and f.is_dca
+       and f.dca_monthly_amount_vnd is not null
+       and not exists (
+         select 1 from public.plan_dca_skips s
+          where s.plan_id = p_plan_id and s.fund_id = f.id
+       )
+       and (it.amount_vnd is distinct from f.dca_monthly_amount_vnd
+            or it.goal_id is distinct from f.dca_goal_id)
+    returning 1
+  )
+  select count(*) into v_updated from updated;
+
+  return v_inserted + v_updated;
+end;
+$$;


### PR DESCRIPTION
Closes #473.

## Problem
Disabling DCA cleared the config on the fund, but its already-seeded `investment_transactions` rows stayed in the monthly plans. The seed/sync RPC (`seed_and_sync_plan_dca`) only reconciles funds still in the active DCA set, so a pending row (`is_dca_seeded=true, units=null`) for a now-disabled fund was **never removed** — and kept counting toward planned allocation totals.

## Fix
On `PUT /api/funds/[id]` when `is_dca` is turned off, delete the fund's pending (un-recorded) seeded rows across **all** of the user's plans:

```
delete investment_transactions
where user_id = … and fund_id = … and asset_type = 'fund'
  and is_dca_seeded = true and units is null
```

- **Recorded buys** (`units` set) are financial history — left intact.
- Mirrors the per-plan cleanup the DCA-skip endpoint already does.
- **Re-enabling** DCA lets `seed_and_sync_plan_dca` recreate only the missing rows — a plan that still holds a recorded buy gets no duplicate.

## Acceptance criteria
- [x] Disabling DCA removes all unrecorded seeded rows that should no longer count.
- [x] Recorded purchases are preserved.
- [x] Re-enabling DCA recreates only the correct missing rows.
- [x] Tests cover disable, plan reload, re-enable, and recorded-purchase cases.

## Testing
- **`e2e/dca-disable-cleanup.spec.ts`** — drives the real route end-to-end: two plans (one pending, one with a recorded buy), disable via PUT → pending row dropped, recorded row (units=100) preserved; re-enable + reload both plans → only the emptied plan gets a fresh row.
- **`route.dca.test.ts`** — asserts the scoped delete fires only on disable, with the exact filters, and not on a name/NAV edit or an `is_dca:true` update.
- Full unit **1155 passed**, lint 0 errors, targeted E2E green.

> Note: the full E2E run shows `assign-goal-desktop` › success-state failing — a known pre-existing timing flake (8s success-state assert, 0 local retries). It passes in isolation and is unrelated to this change (assign uses the untouched `/assign` subroute; the success state renders on the PATCH 200 before any refetch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)