### PR TITLE
fix(security): enforce same-user ownership for goal/fund FKs (#474)

### DIFF
--- a/app/api/funds/[id]/route.ts
+++ b/app/api/funds/[id]/route.ts
@@ -112,6 +112,17 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     update.dca_monthly_amount_vnd = dcaAmount
     // Goal target only applies while DCA is on; cleared otherwise.
     update.dca_goal_id = is_dca === true && dca_goal_id ? dca_goal_id : null
+    // A valid-looking UUID isn't proof of ownership: verify the DCA goal is the
+    // caller's before linking it (#474).
+    if (update.dca_goal_id) {
+      const { data: goal } = await supabase
+        .from('savings_goals')
+        .select('goal_id')
+        .eq('goal_id', update.dca_goal_id)
+        .eq('user_id', user.id)
+        .single()
+      if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
+    }
   }
 
   // Disabling is a cross-table state change: the fund config and every pending

--- a/app/api/funds/route.ts
+++ b/app/api/funds/route.ts
@@ -90,6 +90,18 @@ export async function POST(request: NextRequest) {
     throw e
   }
 
+  // A valid-looking UUID isn't proof of ownership: verify the DCA goal is the
+  // caller's before linking it, so a known foreign goal_id can't be attached (#474).
+  if (is_dca === true && dca_goal_id) {
+    const { data: goal } = await supabase
+      .from('savings_goals')
+      .select('goal_id')
+      .eq('goal_id', dca_goal_id)
+      .eq('user_id', user.id)
+      .single()
+    if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
+  }
+
   const { data: fund, error } = await supabase
     .from('funds')
     .insert({

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -112,6 +112,18 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
   }
 
+  // Verify fund ownership if provided — a valid UUID isn't proof of ownership,
+  // so a known foreign fund_id can't be linked to this user's transaction (#474).
+  if (cleanFundId) {
+    const { data: fund } = await supabase
+      .from('funds')
+      .select('id')
+      .eq('id', cleanFundId)
+      .eq('user_id', user.id)
+      .single()
+    if (!fund) return NextResponse.json({ error: "You don't have permission to access this fund." }, { status: 403 })
+  }
+
   // An accumulating book shares goal + maturity across all tranches. Editing it
   // must update the whole group atomically — doing the row update and the cascade
   // as two separate statements risks a partial failure that splits the book across

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -145,6 +145,18 @@ export async function POST(request: NextRequest) {
     if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
   }
 
+  // Verify fund ownership if provided — a valid UUID isn't proof of ownership,
+  // so a known foreign fund_id can't be linked to this user's transaction (#474).
+  if (cleanFundId) {
+    const { data: fund } = await supabase
+      .from('funds')
+      .select('id')
+      .eq('id', cleanFundId)
+      .eq('user_id', user.id)
+      .single()
+    if (!fund) return NextResponse.json({ error: "You don't have permission to access this fund." }, { status: 403 })
+  }
+
   // Verify plan ownership if provided
   if (cleanPlanId) {
     const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', cleanPlanId).eq('user_id', user.id).single()

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -157,6 +157,21 @@ export async function POST(request: NextRequest) {
     if (!fund) return NextResponse.json({ error: "You don't have permission to access this fund." }, { status: 403 })
   }
 
+  // Same for caller-supplied transaction references — a foreign parent/merge
+  // anchor UUID must not be linkable to this user's row (#474). The DB trigger is
+  // the backstop; this returns a clean 403 instead of a constraint error.
+  for (const refId of [cleanParentTxId, cleanMergeAnchorInvId]) {
+    if (refId) {
+      const { data: ref } = await supabase
+        .from('investment_transactions')
+        .select('transaction_id')
+        .eq('transaction_id', refId)
+        .eq('user_id', user.id)
+        .single()
+      if (!ref) return NextResponse.json({ error: "You don't have permission to access this transaction." }, { status: 403 })
+    }
+  }
+
   // Verify plan ownership if provided
   if (cleanPlanId) {
     const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', cleanPlanId).eq('user_id', user.id).single()

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -243,6 +243,18 @@ export async function POST(request: NextRequest) {
   if (cleanHeldForMerge && !resolvedHeldTargetGoalId) {
     return NextResponse.json({ error: 'A held-for-merge settlement must resolve a target goal.' }, { status: 400 })
   }
+  // The held target goal is an app-managed goal reference (no physical FK), so a
+  // caller-supplied merge_target_goal_id must be verified for ownership too — a
+  // foreign target would strand the parked cash in another user's goal (#474).
+  if (cleanHeldForMerge && resolvedHeldTargetGoalId) {
+    const { data: goal } = await supabase
+      .from('savings_goals')
+      .select('goal_id')
+      .eq('goal_id', resolvedHeldTargetGoalId)
+      .eq('user_id', user.id)
+      .single()
+    if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
+  }
 
   const { data: transaction, error } = await supabase
     .from('investment_transactions')

--- a/e2e/fk-ownership.spec.ts
+++ b/e2e/fk-ownership.spec.ts
@@ -68,6 +68,13 @@ test.describe('FK ownership enforcement (#474)', () => {
     expect(res.status()).toBe(403)
   })
 
+  test('POST /api/v1/investment-transactions rejects a cross-user merge_target_goal_id (403)', async ({ request }) => {
+    const res = await request.post('/api/v1/investment-transactions', {
+      data: { transaction_type: 'withdrawal', held_for_merge: true, merge_target_goal_id: foreign.goalId, amount_vnd: 500_000, principal_withdrawn: 500_000, investment_date: '2026-01-01' },
+    })
+    expect(res.status()).toBe(403)
+  })
+
   // ---- funds: dca_goal_id ---------------------------------------------------
   test('POST /api/funds rejects a cross-user dca_goal_id (403)', async ({ request }) => {
     const res = await request.post('/api/funds', {

--- a/e2e/fk-ownership.spec.ts
+++ b/e2e/fk-ownership.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect } from '@playwright/test'
+import * as api from './helpers/api'
+
+// Ownership of foreign-key targets must be enforced, not just their UUID shape
+// (#474). RLS guarantees the row's own user_id, but not that a supplied fund_id
+// / goal_id / dca_goal_id belongs to the same user — so a caller who knows
+// another user's record UUID could otherwise forge a cross-user link. These hit
+// the routes with the authenticated test user while referencing a *second*
+// user's records, and expect a 403.
+test.describe('FK ownership enforcement (#474)', () => {
+  let foreign: { userId: string; goalId: string; fundId: string }
+  let ownGoalId: string
+  let ownFundId: string
+
+  test.beforeAll(async () => {
+    foreign = await api.createForeignOwned()
+    const goal = await api.createGoal({ goal_name: `E2E Own FK Goal ${Date.now()}` })
+    ownGoalId = goal.goal_id
+    const fund = await api.createFund({
+      name: `E2E Own FK Fund ${Date.now()}`,
+      code: `OWN${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      fund_type: 'equity',
+      nav: 20000,
+    })
+    ownFundId = fund.id
+  })
+
+  test.afterAll(async () => {
+    if (ownFundId) await api.deleteFund(ownFundId)
+    if (ownGoalId) await api.deleteGoal(ownGoalId)
+    if (foreign) await api.deleteForeignUser(foreign.userId)
+  })
+
+  // ---- investment-transactions: fund_id ------------------------------------
+  test('POST /api/v1/investment-transactions rejects a cross-user fund_id (403)', async ({ request }) => {
+    const res = await request.post('/api/v1/investment-transactions', {
+      data: { asset_type: 'fund', fund_id: foreign.fundId, amount_vnd: 1_000_000, investment_date: '2026-01-01', unit_price: 20000, units: 50 },
+    })
+    expect(res.status()).toBe(403)
+  })
+
+  test('POST /api/v1/investment-transactions accepts the caller’s own fund_id', async ({ request }) => {
+    const res = await request.post('/api/v1/investment-transactions', {
+      data: { asset_type: 'fund', fund_id: ownFundId, amount_vnd: 1_000_000, investment_date: '2026-01-01', unit_price: 20000, units: 50, notes: 'E2E own-fund FK' },
+    })
+    expect(res.status()).toBe(201)
+    await api.deleteAllTransactionsByNotes('E2E own-fund FK')
+  })
+
+  test('PUT /api/v1/investment-transactions/[id] rejects a cross-user fund_id (403)', async ({ request }) => {
+    const tx = await api.createTransaction({
+      asset_type: 'fund', fund_id: ownFundId, amount_vnd: 1_000_000, investment_date: '2026-01-01', unit_price: 20000, units: 50, notes: 'E2E fk put',
+    })
+    try {
+      const res = await request.put(`/api/v1/investment-transactions/${tx.transaction_id}`, {
+        data: { asset_type: 'fund', fund_id: foreign.fundId, amount_vnd: 1_000_000, investment_date: '2026-01-01', unit_price: 20000, units: 50 },
+      })
+      expect(res.status()).toBe(403)
+    } finally {
+      await api.deleteTransaction(tx.transaction_id)
+    }
+  })
+
+  // ---- funds: dca_goal_id ---------------------------------------------------
+  test('POST /api/funds rejects a cross-user dca_goal_id (403)', async ({ request }) => {
+    const res = await request.post('/api/funds', {
+      data: { name: 'E2E FK Fund', code: `FKX${Math.random().toString(36).slice(2, 6).toUpperCase()}`, fund_type: 'equity', nav: 20000, is_dca: true, dca_monthly_amount_vnd: 1_000_000, dca_goal_id: foreign.goalId },
+    })
+    expect(res.status()).toBe(403)
+  })
+
+  test('POST /api/funds accepts the caller’s own dca_goal_id', async ({ request }) => {
+    const code = `FKO${Math.random().toString(36).slice(2, 6).toUpperCase()}`
+    const res = await request.post('/api/funds', {
+      data: { name: 'E2E FK Own Fund', code, fund_type: 'equity', nav: 20000, is_dca: true, dca_monthly_amount_vnd: 1_000_000, dca_goal_id: ownGoalId },
+    })
+    expect(res.status()).toBe(201)
+    await api.deleteFundsByNamePrefix('E2E FK Own Fund')
+  })
+
+  test('PUT /api/funds/[id] rejects a cross-user dca_goal_id (403)', async ({ request }) => {
+    const fund = await api.createFund({
+      name: `E2E FK Put Fund ${Date.now()}`,
+      code: `FKP${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      fund_type: 'equity',
+      nav: 20000,
+    })
+    try {
+      const res = await request.put(`/api/funds/${fund.id}`, {
+        data: { name: fund.name, code: fund.code, fund_type: 'equity', nav: 20000, is_dca: true, dca_monthly_amount_vnd: 1_000_000, dca_goal_id: foreign.goalId },
+      })
+      expect(res.status()).toBe(403)
+    } finally {
+      await api.deleteFund(fund.id)
+    }
+  })
+})

--- a/e2e/fk-ownership.spec.ts
+++ b/e2e/fk-ownership.spec.ts
@@ -8,7 +8,7 @@ import * as api from './helpers/api'
 // the routes with the authenticated test user while referencing a *second*
 // user's records, and expect a 403.
 test.describe('FK ownership enforcement (#474)', () => {
-  let foreign: { userId: string; goalId: string; fundId: string }
+  let foreign: { userId: string; goalId: string; fundId: string; txId: string }
   let ownGoalId: string
   let ownFundId: string
 
@@ -59,6 +59,13 @@ test.describe('FK ownership enforcement (#474)', () => {
     } finally {
       await api.deleteTransaction(tx.transaction_id)
     }
+  })
+
+  test('POST /api/v1/investment-transactions rejects a cross-user parent_transaction_id (403)', async ({ request }) => {
+    const res = await request.post('/api/v1/investment-transactions', {
+      data: { transaction_type: 'withdrawal', parent_transaction_id: foreign.txId, amount_vnd: 500_000, principal_withdrawn: 500_000, investment_date: '2026-01-01' },
+    })
+    expect(res.status()).toBe(403)
   })
 
   // ---- funds: dca_goal_id ---------------------------------------------------

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -449,3 +449,36 @@ export async function countPlanDcaRows(planId: string, fundId: string): Promise<
     .eq('asset_type', 'fund')
   return count ?? 0
 }
+
+// Create a throwaway *second* user and a goal + fund they own, for cross-user
+// ownership tests. Deleting the user (deleteForeignUser) cascades their data.
+export async function createForeignOwned(): Promise<{ userId: string; goalId: string; fundId: string }> {
+  const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+  const { data, error } = await supabase.auth.admin.createUser({
+    email: `e2e-foreign-${stamp}@test.invalid`,
+    password: 'TestPass123!',
+    email_confirm: true,
+  })
+  if (error || !data.user) throw error ?? new Error('Failed to create foreign user')
+  const userId = data.user.id
+
+  const { data: goal, error: goalErr } = await supabase
+    .from('savings_goals')
+    .insert({ user_id: userId, goal_name: `Foreign Goal ${stamp}` })
+    .select('goal_id')
+    .single()
+  if (goalErr || !goal) throw goalErr ?? new Error('Failed to create foreign goal')
+
+  const { data: fund, error: fundErr } = await supabase
+    .from('funds')
+    .insert({ user_id: userId, name: `Foreign Fund ${stamp}`, code: `FGN${stamp.slice(-5).toUpperCase()}`, fund_type: 'equity', nav: 20000 })
+    .select('id')
+    .single()
+  if (fundErr || !fund) throw fundErr ?? new Error('Failed to create foreign fund')
+
+  return { userId, goalId: goal.goal_id, fundId: fund.id }
+}
+
+export async function deleteForeignUser(userId: string) {
+  await supabase.auth.admin.deleteUser(userId)
+}

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -452,7 +452,7 @@ export async function countPlanDcaRows(planId: string, fundId: string): Promise<
 
 // Create a throwaway *second* user and a goal + fund they own, for cross-user
 // ownership tests. Deleting the user (deleteForeignUser) cascades their data.
-export async function createForeignOwned(): Promise<{ userId: string; goalId: string; fundId: string }> {
+export async function createForeignOwned(): Promise<{ userId: string; goalId: string; fundId: string; txId: string }> {
   const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
   const { data, error } = await supabase.auth.admin.createUser({
     email: `e2e-foreign-${stamp}@test.invalid`,
@@ -476,7 +476,14 @@ export async function createForeignOwned(): Promise<{ userId: string; goalId: st
     .single()
   if (fundErr || !fund) throw fundErr ?? new Error('Failed to create foreign fund')
 
-  return { userId, goalId: goal.goal_id, fundId: fund.id }
+  const { data: tx, error: txErr } = await supabase
+    .from('investment_transactions')
+    .insert({ user_id: userId, asset_type: 'bank', transaction_type: 'investment', investment_date: '2026-01-01', amount_vnd: 5_000_000 })
+    .select('transaction_id')
+    .single()
+  if (txErr || !tx) throw txErr ?? new Error('Failed to create foreign transaction')
+
+  return { userId, goalId: goal.goal_id, fundId: fund.id, txId: tx.transaction_id }
 }
 
 export async function deleteForeignUser(userId: string) {

--- a/supabase/migrations/20260722000004_enforce_fk_ownership.sql
+++ b/supabase/migrations/20260722000004_enforce_fk_ownership.sql
@@ -28,12 +28,22 @@ begin
     raise exception 'fund_id % does not belong to the transaction owner', new.fund_id
       using errcode = 'check_violation';
   end if;
-  if new.goal_id is not null and not exists (
-    select 1 from public.savings_goals where goal_id = new.goal_id and user_id = new.user_id
+  if new.plan_id is not null and not exists (
+    select 1 from public.monthly_plans where id = new.plan_id and user_id = new.user_id
   ) then
-    raise exception 'goal_id % does not belong to the transaction owner', new.goal_id
+    raise exception 'plan_id % does not belong to the transaction owner', new.plan_id
       using errcode = 'check_violation';
   end if;
+  -- goal_id and merge_target_goal_id are both savings-goal references (the latter
+  -- an app-managed one, not a physical FK) that must stay within one user.
+  foreach v_ref in array array[new.goal_id, new.merge_target_goal_id] loop
+    if v_ref is not null and not exists (
+      select 1 from public.savings_goals where goal_id = v_ref and user_id = new.user_id
+    ) then
+      raise exception 'goal reference % does not belong to the transaction owner', v_ref
+        using errcode = 'check_violation';
+    end if;
+  end loop;
   -- Transaction-to-transaction references must stay within one user too, or a
   -- caller who knows a foreign transaction UUID could point their own row at it.
   foreach v_ref in array array[
@@ -56,7 +66,7 @@ $$;
 drop trigger if exists investment_transactions_fk_ownership on public.investment_transactions;
 create trigger investment_transactions_fk_ownership
   before insert or update of
-    fund_id, goal_id, user_id,
+    fund_id, goal_id, merge_target_goal_id, plan_id, user_id,
     parent_transaction_id, renewed_from_transaction_id, merge_anchor_inv_id, consumed_by_inv_id
   on public.investment_transactions
   for each row execute function public.enforce_investment_tx_fk_ownership();

--- a/supabase/migrations/20260722000004_enforce_fk_ownership.sql
+++ b/supabase/migrations/20260722000004_enforce_fk_ownership.sql
@@ -1,0 +1,64 @@
+-- Enforce same-user ownership of foreign-key targets at the database level (#474).
+--
+-- RLS only guarantees the *row's own* user_id matches auth.uid(); a Postgres FK
+-- only guarantees the referenced row exists. Neither stops a writer from linking
+-- a fund_id / goal_id / dca_goal_id owned by a *different* user. The API now
+-- checks ownership before writing, but these BEFORE triggers are defense in
+-- depth: any path (service role, a future endpoint that forgets the check) is
+-- still forced to keep the reference within one user.
+--
+-- SECURITY DEFINER + an explicit `user_id = new.user_id` filter so the check is
+-- authoritative regardless of the caller's RLS visibility. A composite FK
+-- (id, user_id) would be the "purer" guard but is incompatible with the existing
+-- ON DELETE SET NULL on these columns (it would try to NULL the NOT NULL
+-- user_id), so triggers are the feasible mechanism.
+
+create or replace function public.enforce_investment_tx_fk_ownership()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if new.fund_id is not null and not exists (
+    select 1 from public.funds where id = new.fund_id and user_id = new.user_id
+  ) then
+    raise exception 'fund_id % does not belong to the transaction owner', new.fund_id
+      using errcode = 'check_violation';
+  end if;
+  if new.goal_id is not null and not exists (
+    select 1 from public.savings_goals where goal_id = new.goal_id and user_id = new.user_id
+  ) then
+    raise exception 'goal_id % does not belong to the transaction owner', new.goal_id
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists investment_transactions_fk_ownership on public.investment_transactions;
+create trigger investment_transactions_fk_ownership
+  before insert or update of fund_id, goal_id, user_id on public.investment_transactions
+  for each row execute function public.enforce_investment_tx_fk_ownership();
+
+create or replace function public.enforce_funds_fk_ownership()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if new.dca_goal_id is not null and not exists (
+    select 1 from public.savings_goals where goal_id = new.dca_goal_id and user_id = new.user_id
+  ) then
+    raise exception 'dca_goal_id % does not belong to the fund owner', new.dca_goal_id
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists funds_fk_ownership on public.funds;
+create trigger funds_fk_ownership
+  before insert or update of dca_goal_id, user_id on public.funds
+  for each row execute function public.enforce_funds_fk_ownership();

--- a/supabase/migrations/20260722000004_enforce_fk_ownership.sql
+++ b/supabase/migrations/20260722000004_enforce_fk_ownership.sql
@@ -19,6 +19,8 @@ language plpgsql
 security definer
 set search_path = ''
 as $$
+declare
+  v_ref uuid;
 begin
   if new.fund_id is not null and not exists (
     select 1 from public.funds where id = new.fund_id and user_id = new.user_id
@@ -32,13 +34,31 @@ begin
     raise exception 'goal_id % does not belong to the transaction owner', new.goal_id
       using errcode = 'check_violation';
   end if;
+  -- Transaction-to-transaction references must stay within one user too, or a
+  -- caller who knows a foreign transaction UUID could point their own row at it.
+  foreach v_ref in array array[
+    new.parent_transaction_id,
+    new.renewed_from_transaction_id,
+    new.merge_anchor_inv_id,
+    new.consumed_by_inv_id
+  ] loop
+    if v_ref is not null and not exists (
+      select 1 from public.investment_transactions where transaction_id = v_ref and user_id = new.user_id
+    ) then
+      raise exception 'referenced transaction % does not belong to the transaction owner', v_ref
+        using errcode = 'check_violation';
+    end if;
+  end loop;
   return new;
 end;
 $$;
 
 drop trigger if exists investment_transactions_fk_ownership on public.investment_transactions;
 create trigger investment_transactions_fk_ownership
-  before insert or update of fund_id, goal_id, user_id on public.investment_transactions
+  before insert or update of
+    fund_id, goal_id, user_id,
+    parent_transaction_id, renewed_from_transaction_id, merge_anchor_inv_id, consumed_by_inv_id
+  on public.investment_transactions
   for each row execute function public.enforce_investment_tx_fk_ownership();
 
 create or replace function public.enforce_funds_fk_ownership()

--- a/supabase/tests/fk_ownership.test.sql
+++ b/supabase/tests/fk_ownership.test.sql
@@ -1,0 +1,75 @@
+-- Database-level defense in depth for FK ownership (#474): even a writer that
+-- bypasses the API (service role, a future endpoint that forgets the check)
+-- must not be able to link a fund_id / goal_id / dca_goal_id owned by a
+-- different user. Triggers enforce that the referenced row shares the writing
+-- row's user_id.
+--
+-- Runs against the local stack inside a rolled-back transaction. Any failed
+-- assertion RAISEs and, under `psql -v ON_ERROR_STOP=1`, exits non-zero.
+-- Run via `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_a uuid;
+  v_b uuid;
+  v_goal_a uuid;
+  v_fund_a uuid;
+  v_goal_b uuid;
+  v_fund_b uuid;
+  v_raised boolean;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'owner-a@test.invalid') returning id into v_a;
+  insert into auth.users (id, email) values (gen_random_uuid(), 'owner-b@test.invalid') returning id into v_b;
+  insert into public.savings_goals (user_id, goal_name) values (v_a, 'A goal') returning goal_id into v_goal_a;
+  insert into public.funds (user_id, name, code, fund_type, nav) values (v_a, 'A fund', 'OWNA', 'equity', 20000) returning id into v_fund_a;
+  insert into public.savings_goals (user_id, goal_name) values (v_b, 'B goal') returning goal_id into v_goal_b;
+  insert into public.funds (user_id, name, code, fund_type, nav) values (v_b, 'B fund', 'OWNB', 'equity', 20000) returning id into v_fund_b;
+
+  -- 1) B's transaction referencing A's fund must be rejected.
+  v_raised := false;
+  begin
+    insert into public.investment_transactions (user_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id)
+      values (v_b, 'fund', 'investment', '2099-01-01', 1000000, v_fund_a);
+  exception when others then v_raised := true; end;
+  if not v_raised then raise exception 'cross-user fund_id must be rejected'; end if;
+
+  -- 2) B's transaction referencing A's goal must be rejected.
+  v_raised := false;
+  begin
+    insert into public.investment_transactions (user_id, asset_type, transaction_type, investment_date, amount_vnd, goal_id)
+      values (v_b, 'bank', 'investment', '2099-01-01', 1000000, v_goal_a);
+  exception when others then v_raised := true; end;
+  if not v_raised then raise exception 'cross-user goal_id must be rejected'; end if;
+
+  -- 3) B's fund pointing dca_goal_id at A's goal must be rejected.
+  v_raised := false;
+  begin
+    insert into public.funds (user_id, name, code, fund_type, nav, is_dca, dca_monthly_amount_vnd, dca_goal_id)
+      values (v_b, 'B DCA fund', 'OWNBD', 'equity', 20000, true, 1000000, v_goal_a);
+  exception when others then v_raised := true; end;
+  if not v_raised then raise exception 'cross-user dca_goal_id must be rejected'; end if;
+
+  -- 4) Updating one of B's own rows to point at A's fund must be rejected too.
+  v_raised := false;
+  declare v_tx uuid;
+  begin
+    insert into public.investment_transactions (user_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id)
+      values (v_b, 'fund', 'investment', '2099-01-01', 1000000, v_fund_b) returning transaction_id into v_tx;
+    begin
+      update public.investment_transactions set fund_id = v_fund_a where transaction_id = v_tx;
+    exception when others then v_raised := true; end;
+    if not v_raised then raise exception 'cross-user fund_id on UPDATE must be rejected'; end if;
+  end;
+
+  -- 5) Legitimate same-owner references must succeed (no exception).
+  insert into public.investment_transactions (user_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, goal_id)
+    values (v_b, 'fund', 'investment', '2099-01-01', 1000000, v_fund_b, v_goal_b);
+  insert into public.funds (user_id, name, code, fund_type, nav, is_dca, dca_monthly_amount_vnd, dca_goal_id)
+    values (v_b, 'B DCA ok', 'OWNBOK', 'equity', 20000, true, 1000000, v_goal_b);
+
+  raise notice 'fk_ownership.test.sql: OK';
+end $$;
+
+rollback;

--- a/supabase/tests/fk_ownership.test.sql
+++ b/supabase/tests/fk_ownership.test.sql
@@ -18,6 +18,7 @@ declare
   v_fund_a uuid;
   v_goal_b uuid;
   v_fund_b uuid;
+  v_tx_a uuid;
   v_raised boolean;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'owner-a@test.invalid') returning id into v_a;
@@ -26,6 +27,9 @@ begin
   insert into public.funds (user_id, name, code, fund_type, nav) values (v_a, 'A fund', 'OWNA', 'equity', 20000) returning id into v_fund_a;
   insert into public.savings_goals (user_id, goal_name) values (v_b, 'B goal') returning goal_id into v_goal_b;
   insert into public.funds (user_id, name, code, fund_type, nav) values (v_b, 'B fund', 'OWNB', 'equity', 20000) returning id into v_fund_b;
+  -- A transaction owned by A, to try to reference from B's rows.
+  insert into public.investment_transactions (user_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id)
+    values (v_a, 'fund', 'investment', '2099-01-01', 1000000, v_fund_a) returning transaction_id into v_tx_a;
 
   -- 1) B's transaction referencing A's fund must be rejected.
   v_raised := false;
@@ -61,6 +65,27 @@ begin
       update public.investment_transactions set fund_id = v_fund_a where transaction_id = v_tx;
     exception when others then v_raised := true; end;
     if not v_raised then raise exception 'cross-user fund_id on UPDATE must be rejected'; end if;
+
+    -- Each transaction-to-transaction reference to A's row must be rejected too.
+    v_raised := false;
+    begin update public.investment_transactions set parent_transaction_id = v_tx_a where transaction_id = v_tx;
+    exception when others then v_raised := true; end;
+    if not v_raised then raise exception 'cross-user parent_transaction_id must be rejected'; end if;
+
+    v_raised := false;
+    begin update public.investment_transactions set renewed_from_transaction_id = v_tx_a where transaction_id = v_tx;
+    exception when others then v_raised := true; end;
+    if not v_raised then raise exception 'cross-user renewed_from_transaction_id must be rejected'; end if;
+
+    v_raised := false;
+    begin update public.investment_transactions set merge_anchor_inv_id = v_tx_a where transaction_id = v_tx;
+    exception when others then v_raised := true; end;
+    if not v_raised then raise exception 'cross-user merge_anchor_inv_id must be rejected'; end if;
+
+    v_raised := false;
+    begin update public.investment_transactions set consumed_by_inv_id = v_tx_a where transaction_id = v_tx;
+    exception when others then v_raised := true; end;
+    if not v_raised then raise exception 'cross-user consumed_by_inv_id must be rejected'; end if;
   end;
 
   -- 5) Legitimate same-owner references must succeed (no exception).

--- a/supabase/tests/fk_ownership.test.sql
+++ b/supabase/tests/fk_ownership.test.sql
@@ -86,6 +86,24 @@ begin
     begin update public.investment_transactions set consumed_by_inv_id = v_tx_a where transaction_id = v_tx;
     exception when others then v_raised := true; end;
     if not v_raised then raise exception 'cross-user consumed_by_inv_id must be rejected'; end if;
+
+    -- merge_target_goal_id is an app-managed goal reference; A's goal is off-limits.
+    v_raised := false;
+    begin update public.investment_transactions set merge_target_goal_id = v_goal_a where transaction_id = v_tx;
+    exception when others then v_raised := true; end;
+    if not v_raised then raise exception 'cross-user merge_target_goal_id must be rejected'; end if;
+  end;
+
+  -- plan_id references monthly_plans; B's row must not point at A's plan.
+  declare v_plan_a uuid; v_tx2 uuid;
+  begin
+    insert into public.monthly_plans (user_id, month, year, salary_vnd) values (v_a, 5, 2099, 50000000) returning id into v_plan_a;
+    insert into public.investment_transactions (user_id, asset_type, transaction_type, investment_date, amount_vnd)
+      values (v_b, 'bank', 'investment', '2099-01-01', 1000000) returning transaction_id into v_tx2;
+    v_raised := false;
+    begin update public.investment_transactions set plan_id = v_plan_a where transaction_id = v_tx2;
+    exception when others then v_raised := true; end;
+    if not v_raised then raise exception 'cross-user plan_id must be rejected'; end if;
   end;
 
   -- 5) Legitimate same-owner references must succeed (no exception).


### PR DESCRIPTION
Closes #474.

## Problem
Several endpoints validated foreign keys as UUIDs but never checked that the referenced record belonged to the caller. RLS only guarantees the row's own `user_id`, and a Postgres FK only guarantees the target exists — so a caller who knew another user's fund/goal UUID could forge a **cross-user link**.

| Endpoint | FK | Before |
| :-- | :-- | :-- |
| investment-transactions POST/PUT | `goal_id`, `plan_id` | ✅ already checked |
| investment-transactions POST/PUT | **`fund_id`** | ❌ UUID only |
| funds POST/PUT | **`dca_goal_id`** | ❌ UUID only |

## Fix
**App layer (403):** verify `fund_id` (investment-transactions POST/PUT) and `dca_goal_id` (funds POST/PUT) belong to `auth.uid()` before writing, mirroring the existing goal-ownership check.

**DB layer — defense in depth** (`20260722000004_enforce_fk_ownership.sql`): `BEFORE INSERT/UPDATE` triggers on `investment_transactions` (`fund_id`, `goal_id`) and `funds` (`dca_goal_id`) reject any write whose FK target has a different `user_id`. So a service-role path — or a future endpoint that forgets the check — still can't create a cross-user reference. `SECURITY DEFINER` + an explicit `user_id = new.user_id` filter make the check authoritative regardless of RLS visibility.

> A composite `(id, user_id)` FK would be the "purer" DB guard, but it's incompatible with the existing `ON DELETE SET NULL` on these columns (SET NULL would try to null the `NOT NULL` `user_id`). Triggers are the feasible mechanism that preserves the deletion semantics.

## Acceptance criteria
- [x] Every supplied `goal_id` and `fund_id` is verified against `auth.uid()`.
- [x] Cross-user references return **403**.
- [x] Database-level protection is added where feasible (triggers).
- [x] API tests cover valid ownership and cross-user UUIDs.

## Testing
- **`e2e/fk-ownership.spec.ts`** — hits the routes as the test user while referencing a *second* user's records: cross-user `fund_id` / `dca_goal_id` → 403 (POST + PUT); the caller's own → 201.
- **`supabase/tests/fk_ownership.test.sql`** (`npm run test:db`) — the triggers reject cross-user `fund_id` / `goal_id` / `dca_goal_id` on INSERT and UPDATE, and allow legitimate same-owner references.
- Full unit **1165 passed**, lint 0 errors, `npm run test:db` green, full E2E **234 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)