### PR TITLE
refactor(planning): extract shared actions + derivations from mobile/desktop views (#467)

### DIFF
--- a/app/(app)/planning/__tests__/usePlanningActions.test.ts
+++ b/app/(app)/planning/__tests__/usePlanningActions.test.ts
@@ -82,6 +82,20 @@ describe('usePlanningActions (#467 shared planning actions)', () => {
     expect(onToast).toHaveBeenCalledWith('Restored Me')
   })
 
+  it('restoreInsurance fails (no success toast) when clearing the override errors', async () => {
+    const { actions, onRefresh, onToast } = setup()
+    mockFetch((url, init) => {
+      // Exclusion removal + the overrides GET succeed; the override DELETE fails.
+      if (url.includes('/insurance-overrides/') && init?.method === 'DELETE') return { ok: false }
+      if (url.includes('/insurance-overrides') && init?.method !== 'DELETE') return { ok: true, body: [{ id: 'io1', member_id: 'm1' }] }
+      return { ok: true }
+    })
+    await actions.restoreInsurance({ member_id: 'm1', member_name: 'Me' } as never)
+    expect(toastErrorMock).toHaveBeenCalled()
+    expect(onRefresh).not.toHaveBeenCalled()
+    expect(onToast).not.toHaveBeenCalled()
+  })
+
   it('saveOverride routes each type to its own endpoint and returns true', async () => {
     const { actions, onToast } = setup()
     const calls = mockFetch(() => ({ ok: true }))

--- a/app/(app)/planning/__tests__/usePlanningActions.test.ts
+++ b/app/(app)/planning/__tests__/usePlanningActions.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+const { toastErrorMock } = vi.hoisted(() => ({ toastErrorMock: vi.fn() }))
+vi.mock('sonner', () => ({ toast: Object.assign(vi.fn(), { error: toastErrorMock, success: vi.fn() }) }))
+
+import { usePlanningActions, buildBuyEdit, buildContributionPrefill } from '../usePlanningActions'
+import type { GoalItem } from '@/lib/planning'
+
+// usePlanningActions uses no React hooks internally — it returns plain async
+// functions — so it can be exercised directly. It's the single implementation
+// both planning views now call, so these cases pin mobile/desktop parity (#467).
+
+const plan = { id: 'plan-1', month: 6, year: 2026, salary_vnd: 30_000_000 }
+
+function setup(overrides: Partial<Parameters<typeof usePlanningActions>[0]> = {}) {
+  const onRefresh = vi.fn()
+  const onToast = vi.fn()
+  // usePlanningActions has no React-hook internals — it returns plain async
+  // functions — so it's safe to call outside a component in this test.
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const actions = usePlanningActions({ plan, month: 6, year: 2026, isVI: false, onRefresh, onToast, ...overrides })
+  return { actions, onRefresh, onToast }
+}
+
+function mockFetch(handler: (url: string, init?: RequestInit) => { ok: boolean; body?: unknown }) {
+  const calls: Array<{ url: string; init?: RequestInit }> = []
+  global.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url)
+    calls.push({ url: u, init })
+    const r = handler(u, init)
+    return { ok: r.ok, json: async () => r.body ?? {} } as Response
+  }) as unknown as typeof fetch
+  return calls
+}
+
+beforeEach(() => {
+  toastErrorMock.mockClear()
+  vi.restoreAllMocks()
+})
+
+describe('usePlanningActions (#467 shared planning actions)', () => {
+  it('skipFixedExpense POSTs an amount-0 override and reports success', async () => {
+    const { actions, onRefresh, onToast } = setup()
+    const calls = mockFetch(() => ({ ok: true }))
+    await actions.skipFixedExpense({ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 1_000_000 } as never)
+    expect(calls[0].url).toBe('/api/v1/monthly-plans/plan-1/fixed-expense-overrides')
+    expect(calls[0].init?.method).toBe('POST')
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({ fixed_expense_id: 'fe1', monthly_amount_override_vnd: 0 })
+    expect(onRefresh).toHaveBeenCalled()
+    expect(onToast).toHaveBeenCalledWith('Skipped Rent')
+  })
+
+  it('restoreFixedExpense deletes the matching override', async () => {
+    const { actions, onToast } = setup()
+    const calls = mockFetch((url, init) => {
+      if (init?.method === 'DELETE') return { ok: true }
+      return { ok: true, body: [{ id: 'ov1', fixed_expense_id: 'fe1' }] }
+    })
+    await actions.restoreFixedExpense({ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 1_000_000 } as never)
+    expect(calls.some(c => c.url.endsWith('/fixed-expense-overrides/ov1') && c.init?.method === 'DELETE')).toBe(true)
+    expect(onToast).toHaveBeenCalledWith('Restored Rent')
+  })
+
+  it('restoreFixedExpense still reports success when there is no override to delete (parity fix)', async () => {
+    const { actions, onRefresh, onToast } = setup()
+    const calls = mockFetch(() => ({ ok: true, body: [] }))
+    await actions.restoreFixedExpense({ expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 1 } as never)
+    expect(calls.some(c => c.init?.method === 'DELETE')).toBe(false)
+    expect(onRefresh).toHaveBeenCalled()
+    expect(onToast).toHaveBeenCalledWith('Restored Rent')
+  })
+
+  it('restoreInsurance also clears a lingering per-plan override (parity fix)', async () => {
+    const { actions, onToast } = setup()
+    const calls = mockFetch((url, init) => {
+      if (url.includes('/insurance-overrides') && init?.method !== 'DELETE') return { ok: true, body: [{ id: 'io1', member_id: 'm1' }] }
+      return { ok: true }
+    })
+    await actions.restoreInsurance({ member_id: 'm1', member_name: 'Me' } as never)
+    expect(calls.some(c => c.url.endsWith('/excluded-insurance/m1') && c.init?.method === 'DELETE')).toBe(true)
+    expect(calls.some(c => c.url.endsWith('/insurance-overrides/io1') && c.init?.method === 'DELETE')).toBe(true)
+    expect(onToast).toHaveBeenCalledWith('Restored Me')
+  })
+
+  it('saveOverride routes each type to its own endpoint and returns true', async () => {
+    const { actions, onToast } = setup()
+    const calls = mockFetch(() => ({ ok: true }))
+    expect(await actions.saveOverride({ type: 'rec', id: 'r1', amount: 500_000 })).toBe(true)
+    expect(calls[0].url).toBe('/api/v1/monthly-plans/plan-1/recurring-saving-overrides')
+    expect(JSON.parse(String(calls[0].init?.body))).toEqual({ recurring_saving_id: 'r1', monthly_amount_override_vnd: 500_000 })
+    // Regression guard: a recurring override must NOT hit the insurance endpoint.
+    expect(calls.some(c => c.url.includes('/insurance-overrides'))).toBe(false)
+    expect(onToast).toHaveBeenCalledWith('Override saved')
+  })
+
+  it('a failed write shows an error toast and does not report success', async () => {
+    const { actions, onRefresh, onToast } = setup()
+    mockFetch(() => ({ ok: false }))
+    const ok = await actions.saveOverride({ type: 'fe', id: 'fe1', amount: 100 })
+    expect(ok).toBe(false)
+    expect(toastErrorMock).toHaveBeenCalled()
+    expect(onRefresh).not.toHaveBeenCalled()
+    expect(onToast).not.toHaveBeenCalled()
+  })
+
+  describe('probeRecurringRecord', () => {
+    const item = { recurringId: 'r1', linkedDepositTxId: 'tx1', name: 'Save', amount: 1_000_000 } as GoalItem
+
+    it('returns a book top-up target for a live accumulating book', async () => {
+      setup()
+      mockFetch(() => ({ ok: true, body: { transaction_id: 'tx1', deposit_group_id: 'tx1', expiry_date: '2999-01-01', interest_rate: 6, notes: 'My book' } }))
+      const { actions } = setup()
+      const r = await actions.probeRecurringRecord(item)
+      expect(r.kind).toBe('book-topup')
+      if (r.kind === 'book-topup') {
+        expect(r.target.bookId).toBe('tx1')
+        expect(r.target.savingId).toBe('r1')
+        expect(r.target.ym).toBe('2026-06')
+      }
+    })
+
+    it('toasts and returns matured for a matured book', async () => {
+      const { actions, onToast } = setup()
+      mockFetch(() => ({ ok: true, body: { transaction_id: 'tx1', deposit_group_id: 'tx1', expiry_date: '2000-01-01' } }))
+      const r = await actions.probeRecurringRecord(item)
+      expect(r.kind).toBe('matured')
+      expect(onToast).toHaveBeenCalled()
+    })
+
+    it('falls back to a standalone contribution when there is no linked book', async () => {
+      const { actions } = setup()
+      const r = await actions.probeRecurringRecord({ recurringId: 'r1', name: 'Save', amount: 1 } as GoalItem)
+      expect(r.kind).toBe('contribution')
+    })
+  })
+
+  describe('pure builders', () => {
+    it('buildBuyEdit maps an investment row to an editable fund transaction', () => {
+      const inv = { transaction_id: 't1', investment_date: '2026-06-01', amount_vnd: 2_000_000, unit_price: 20_000, units: 100, fund_id: 'f1', goal_id: 'g1' }
+      const e = buildBuyEdit('t1', [inv] as never)
+      expect(e).toMatchObject({ transaction_id: 't1', asset_type: 'fund', amount_vnd: 2_000_000, fund_id: 'f1', goal_id: 'g1' })
+    })
+
+    it('buildBuyEdit returns null for a missing transaction', () => {
+      expect(buildBuyEdit(undefined, [] as never)).toBeNull()
+      expect(buildBuyEdit('nope', [] as never)).toBeNull()
+    })
+
+    it('buildContributionPrefill nulls the goal for Unallocated and carries the plan id', () => {
+      expect(buildContributionPrefill({ goalId: 'g1', isUnallocated: false }, 'plan-1', { asset_type: 'bank', amount_vnd: 500 }))
+        .toMatchObject({ goal_id: 'g1', plan_id: 'plan-1', asset_type: 'bank', amount_vnd: 500 })
+      expect(buildContributionPrefill({ goalId: 'unalloc', isUnallocated: true }, null).goal_id).toBeNull()
+    })
+  })
+})

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useMemo, useRef } from 'react'
+import React, { useState, useRef } from 'react'
 import {
   ChevronLeft, ChevronRight, ChevronDown, ChevronUp,
   Target, Shield, ShoppingCart,
@@ -17,7 +17,9 @@ import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction 
 import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
 import AddInsuranceMemberModal from '@/app/assets/components/AddInsuranceMemberModal'
 import { useDialogA11y, useCloseOnScroll } from './useDialogA11y'
-import { buildByGoal, resolveRecurringSavings, DEPOSIT_BACKED_FULFILLMENT_SOURCES, type GoalItem } from '@/lib/planning'
+import { type GoalItem } from '@/lib/planning'
+import { usePlanningDerivations } from '../usePlanningDerivations'
+import { usePlanningActions, buildBuyEdit, buildContributionPrefill } from '../usePlanningActions'
 import { relationshipLabel } from '@/app/assets/components/insuranceShared'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
@@ -25,20 +27,6 @@ import type {
 } from '../PlanningClient'
 
 // ─── Pure helpers ─────────────────────────────────────────────────────────────
-
-function getFixedTotal(fixedExpenses: FixedExpense[]) {
-  return fixedExpenses.reduce((s, e) => {
-    if (e.override === 0) return s
-    return s + (e.override ?? e.amount_vnd)
-  }, 0)
-}
-
-function getInsTotal(insuranceMembers: InsuranceMember[]) {
-  return insuranceMembers.reduce((s, m) => {
-    if (m.excluded) return s
-    return s + (m.monthlyOverride ?? Math.round(m.annual_payment_vnd / 12))
-  }, 0)
-}
 
 const SHORT_MONTHS_EN = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
 const SHORT_MONTHS_VI = ['Th1','Th2','Th3','Th4','Th5','Th6','Th7','Th8','Th9','Th10','Th11','Th12']
@@ -488,48 +476,17 @@ export default function DesktopPlanningView({
   const [prefillTx, setPrefillTx] = useState<PrefillTransaction | null>(null)
   const [bookTopUp, setBookTopUp] = useState<BookTopUpTarget | null>(null)
 
-  // ── Derived values ──
-  const goalsById = useMemo(() => new Map(goals.map(g => [g.goal_id, g.goal_name])), [goals])
-  const resolvedRecurring = useMemo(
-    () => resolveRecurringSavings(recurringSavings, recurringSavingOverrides),
-    [recurringSavings, recurringSavingOverrides],
-  )
-  // Skipped DCA funds are no longer seeded as rows, so synthesize struck-through
-  // lines from the fund config + the plan's skip list.
-  const skippedDcaInvestments = useMemo(() => {
-    const skipped = new Set(dcaSkips.map(s => s.fund_id))
-    return funds
-      .filter(f => f.is_dca && f.dca_monthly_amount_vnd && skipped.has(f.id))
-      .map(f => ({
-        goal_id: f.dca_goal_id ?? null,
-        amount_vnd: f.dca_monthly_amount_vnd as number,
-        is_dca_seeded: true,
-        skipped: true,
-        fund_id: f.id,
-        funds: { name: f.name },
-      }))
-  }, [funds, dcaSkips])
-  const fulfillments = useMemo(
-    () => new Map(recurringFulfillments.map(f => [f.recurring_saving_id, {
-      amount: f.amount_vnd,
-      countedAsDeposit: DEPOSIT_BACKED_FULFILLMENT_SOURCES.has(f.source),
-    }])),
-    [recurringFulfillments],
-  )
-  const byGoal = useMemo(
-    () => buildByGoal([...investments, ...skippedDcaInvestments], savings, resolvedRecurring, goalsById, {
-      unallocated: isVI ? 'Chưa phân bổ' : 'Unallocated',
-    }, fulfillments),
-    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI, fulfillments],
-  )
-  const totalGoalAmount = byGoal.reduce((s, g) => s + g.totalAllocated, 0)
-  const contributedTotal = byGoal.reduce((s, g) => s + g.contributed, 0)
-  const fixedTotal = useMemo(() => getFixedTotal(fixedExpenses), [fixedExpenses])
-  const insTotal   = useMemo(() => getInsTotal(insuranceMembers), [insuranceMembers])
-  const otherTotal = otherExpenses.reduce((s, o) => s + o.amount_vnd, 0)
-  const totalOutflow = totalGoalAmount + fixedTotal + insTotal + otherTotal
-  const remaining    = plan ? plan.salary_vnd - totalOutflow : 0
-  const savedPct     = plan && plan.salary_vnd > 0 ? Math.round(totalGoalAmount / plan.salary_vnd * 100) : 0
+  // ── Derived values ── (shared with the mobile view via usePlanningDerivations)
+  const {
+    byGoal,
+    totalGoals: totalGoalAmount, contributedTotal,
+    totalFixed: fixedTotal, totalInsurance: insTotal, totalOther: otherTotal,
+    totalOutflow, remaining,
+  } = usePlanningDerivations({
+    plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,
+    recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, isVI,
+  })
+  const savedPct = plan && plan.salary_vnd > 0 ? Math.round(totalGoalAmount / plan.salary_vnd * 100) : 0
 
   const shortMonths = isVI ? SHORT_MONTHS_VI : SHORT_MONTHS_EN
   const longMonths  = isVI ? LONG_MONTHS_VI  : LONG_MONTHS_EN
@@ -539,6 +496,9 @@ export default function DesktopPlanningView({
   const isCurrentMonth = month === todayD.getMonth() + 1 && year === todayD.getFullYear()
 
   // ── API handlers ──
+  // Skip/restore/override/record actions are shared with the mobile view via
+  // usePlanningActions so a fix lands on both surfaces (#467).
+  const actions = usePlanningActions({ plan, month, year, isVI, onRefresh, onToast })
 
   async function handleSetIncome() {
     const num = Number(incomeVal)
@@ -580,156 +540,34 @@ export default function DesktopPlanningView({
     } finally { setSaving(false) }
   }
 
-  async function handleFESkip(fe: FixedExpense) {
-    if (!plan) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ fixed_expense_id: fe.expense_id, monthly_amount_override_vnd: 0 }),
-    }).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    onRefresh(); onToast(isVI ? `Đã bỏ qua ${fe.expense_name}` : `Skipped ${fe.expense_name}`)
-  }
-
-  async function handleFERestore(fe: FixedExpense) {
-    if (!plan) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    const overrides: Array<{ id: string; fixed_expense_id: string }> = await res.json()
-    const match = overrides.find(o => o.fixed_expense_id === fe.expense_id)
-    if (match) {
-      const del = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides/${match.id}`, { method: 'DELETE' }).catch(() => null)
-      if (!del?.ok) { toast.error(failMsg); return }
-    }
-    onRefresh(); onToast(isVI ? `Đã khôi phục ${fe.expense_name}` : `Restored ${fe.expense_name}`)
-  }
-
-  async function handleInsSkip(m: InsuranceMember) {
-    if (!plan) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ member_id: m.member_id }),
-    }).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    onRefresh(); onToast(isVI ? `Đã bỏ qua ${m.member_name}` : `Skipped ${m.member_name}`)
-  }
-
-  async function handleInsRestore(m: InsuranceMember) {
-    if (!plan) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance/${m.member_id}`, { method: 'DELETE' }).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    const oRes = await fetch(`/api/v1/monthly-plans/${plan.id}/insurance-overrides`)
-    if (oRes.ok) {
-      const overrides: Array<{ id: string; member_id: string }> = await oRes.json()
-      const match = overrides.find(o => o.member_id === m.member_id)
-      if (match) await fetch(`/api/v1/monthly-plans/${plan.id}/insurance-overrides/${match.id}`, { method: 'DELETE' })
-    }
-    onRefresh(); onToast(isVI ? `Đã khôi phục ${m.member_name}` : `Restored ${m.member_name}`)
-  }
-
-  async function handleRecSkip(item: { recurringId?: string; name: string }) {
-    if (!plan || !item.recurringId) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ recurring_saving_id: item.recurringId, monthly_amount_override_vnd: 0 }),
-    }).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    onRefresh(); onToast(isVI ? `Đã bỏ qua ${item.name}` : `Skipped ${item.name}`)
-  }
-
-  async function handleRecRestore(item: { recurringId?: string; name: string }) {
-    if (!plan || !item.recurringId) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    const overrides: Array<{ id: string; recurring_saving_id: string }> = await res.json()
-    const match = overrides.find(o => o.recurring_saving_id === item.recurringId)
-    if (match) {
-      const del = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides/${match.id}`, { method: 'DELETE' }).catch(() => null)
-      if (!del?.ok) { toast.error(failMsg); return }
-    }
-    onRefresh(); onToast(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
-  }
-
-  async function handleDcaSkip(item: { fundId?: string | null; name: string }) {
-    if (!plan || !item.fundId) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ fund_id: item.fundId }),
-    }).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    onRefresh(); onToast(isVI ? `Đã bỏ qua ${item.name}` : `Skipped ${item.name}`)
-  }
-
-  async function handleDcaRestore(item: { fundId?: string | null; name: string }) {
-    if (!plan || !item.fundId) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips/${item.fundId}`, { method: 'DELETE' }).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    onRefresh(); onToast(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
-  }
+  const handleFESkip = actions.skipFixedExpense
+  const handleFERestore = actions.restoreFixedExpense
+  const handleInsSkip = actions.skipInsurance
+  const handleInsRestore = actions.restoreInsurance
+  const handleRecSkip = actions.skipRecurring
+  const handleRecRestore = actions.restoreRecurring
+  const handleDcaSkip = actions.skipDca
+  const handleDcaRestore = actions.restoreDca
 
   function openBuy(transactionId?: string) {
-    if (!transactionId) return
-    const inv = investments.find(i => i.transaction_id === transactionId)
-    if (!inv) return
-    setBuyEdit({
-      transaction_id: inv.transaction_id,
-      asset_type: 'fund',
-      investment_date: inv.investment_date ?? new Date().toISOString().slice(0, 10),
-      amount_vnd: inv.amount_vnd,
-      unit_price: inv.unit_price,
-      units: inv.units,
-      interest_rate: null,
-      expiry_date: null,
-      notes: null,
-      fund_id: inv.fund_id,
-      goal_id: inv.goal_id,
-    })
+    const edit = buildBuyEdit(transactionId, investments)
+    if (edit) setBuyEdit(edit)
   }
 
   // Open the Add-Transaction sheet in create mode, pre-filled toward a goal.
   // Used by the goal-header "+" (log any contribution) and the recurring-bank
   // "Saved" pill (record this month's deposit at the planned amount).
   function openContribution(g: { goalId: string; isUnallocated: boolean }, prefill?: Partial<PrefillTransaction>) {
-    setPrefillTx({
-      goal_id: g.isUnallocated ? null : g.goalId,
-      plan_id: plan?.id ?? null,
-      investment_date: new Date().toISOString().slice(0, 10),
-      ...prefill,
-    })
+    setPrefillTx(buildContributionPrefill(g, plan?.id ?? null, prefill))
   }
 
-  // The recurring "Saved" pill. If the recurring is linked to an accumulating
-  // book, open the prefilled top-up sheet (tranche + fulfillment). A MATURED book
-  // can't be topped up — steer the user to handle its maturity rather than silently
-  // logging an unrelated standalone deposit. Otherwise log a standalone contribution.
+  // The recurring "Saved" pill: the shared probe decides between opening the
+  // book top-up sheet, logging a standalone contribution, or (matured book) a
+  // steer-to-maturity toast.
   async function recordRecurring(g: { goalId: string; isUnallocated: boolean }, item: GoalItem) {
-    if (item.linkedDepositTxId && item.recurringId && plan) {
-      try {
-        const res = await fetch(`/api/v1/investment-transactions/${item.linkedDepositTxId}`)
-        if (res.ok) {
-          const dep = await res.json()
-          const isBookAnchor = dep.deposit_group_id && dep.deposit_group_id === dep.transaction_id
-          if (isBookAnchor) {
-            const matured = dep.expiry_date && dep.expiry_date < new Date().toISOString().slice(0, 10)
-            if (matured) {
-              onToast(isVI ? 'Sổ đã đáo hạn — hãy xử lý đáo hạn trước.' : 'This book has matured — handle its maturity first.')
-              return
-            }
-            setBookTopUp({
-              savingId: item.recurringId, bookId: dep.transaction_id,
-              bookName: dep.notes || (isVI ? 'Sổ ngân hàng' : 'Bank deposit'),
-              ym: `${year}-${String(month).padStart(2, '0')}`, planId: plan.id,
-              amount: item.amount, rate: dep.interest_rate ?? null,
-            })
-            return
-          }
-        }
-      } catch { /* fall through to the standard contribution */ }
-    }
-    openContribution(g, { asset_type: 'bank', amount_vnd: item.amount })
+    const result = await actions.probeRecurringRecord(item)
+    if (result.kind === 'book-topup') setBookTopUp(result.target)
+    else if (result.kind === 'contribution') openContribution(g, { asset_type: 'bank', amount_vnd: item.amount })
   }
 
   async function handleSaveOverride() {
@@ -738,20 +576,8 @@ export default function DesktopPlanningView({
     if (!overrideVal || isNaN(num) || num <= 0) return
     setSaving(true)
     try {
-      const url = overrideModal.type === 'fe'
-        ? `/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`
-        : overrideModal.type === 'rec'
-          ? `/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`
-          : `/api/v1/monthly-plans/${plan.id}/insurance-overrides`
-      const body = overrideModal.type === 'fe'
-        ? { fixed_expense_id: overrideModal.id, monthly_amount_override_vnd: num }
-        : overrideModal.type === 'rec'
-          ? { recurring_saving_id: overrideModal.id, monthly_amount_override_vnd: num }
-          : { member_id: overrideModal.id, monthly_amount_override_vnd: num }
-      const res = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }).catch(() => null)
-      if (!res?.ok) { toast.error(failMsg); return }
-      setOverrideModal(null)
-      onRefresh(); onToast(isVI ? 'Đã lưu' : 'Saved')
+      const ok = await actions.saveOverride({ type: overrideModal.type, id: overrideModal.id, amount: num })
+      if (ok) setOverrideModal(null)
     } finally { setSaving(false) }
   }
 

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -1,8 +1,7 @@
 'use client'
 
-import { useState, useMemo, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useLocale } from 'next-intl'
-import { toast } from 'sonner'
 import {
   Wallet, Target, Shield, ShoppingCart,
   ChevronDown, ChevronUp,
@@ -16,7 +15,9 @@ import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction 
 import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
 import AddInsuranceMemberModal from '@/app/assets/components/AddInsuranceMemberModal'
 import { useDialogA11y, useCloseOnScroll } from './useDialogA11y'
-import { buildByGoal, resolveRecurringSavings, DEPOSIT_BACKED_FULFILLMENT_SOURCES, type GoalRow, type GoalItem } from '@/lib/planning'
+import { type GoalRow, type GoalItem } from '@/lib/planning'
+import { usePlanningDerivations } from '../usePlanningDerivations'
+import { usePlanningActions, buildBuyEdit, buildContributionPrefill } from '../usePlanningActions'
 import { relationshipLabel } from '@/app/assets/components/insuranceShared'
 import { MobilePlanningSkeleton } from './PlanningSkeleton'
 import type {
@@ -69,20 +70,6 @@ const LONG_MONTHS = ['January','February','March','April','May','June','July','A
 function getMonthLabel(month: number, year: number, short = false) {
   const names = short ? SHORT_MONTHS : LONG_MONTHS
   return `${names[month - 1]} ${year}`
-}
-
-function getFixedTotal(fixedExpenses: FixedExpense[]) {
-  return fixedExpenses.reduce((s, e) => {
-    if (e.override === 0) return s
-    return s + (e.override ?? e.amount_vnd)
-  }, 0)
-}
-
-function getInsTotal(insuranceMembers: InsuranceMember[]) {
-  return insuranceMembers.reduce((s, m) => {
-    if (m.excluded) return s
-    return s + (m.monthlyOverride ?? Math.round(m.annual_payment_vnd / 12))
-  }, 0)
 }
 
 function EditIcon({ size = 16, color = 'currentColor' }: { size?: number; color?: string }) {
@@ -1075,7 +1062,6 @@ export default function MobilePlanningView({
 }: Props) {
   const locale = useLocale()
   const isVI = locale === 'vi'
-  const failMsg = isVI ? 'Có lỗi, vui lòng thử lại' : 'Something went wrong — please try again'
   const [sheet, setSheet] = useState<SheetState>(null)
   // Recording a DCA buy opens the canonical Add-Transaction sheet in edit mode,
   // pre-filled from the planned investment, so saving completes that same
@@ -1090,117 +1076,27 @@ export default function MobilePlanningView({
 
   // ─── Computed totals ────────────────────────────────────────────────────────
 
-  const goalsById = useMemo(() => new Map(goals.map(g => [g.goal_id, g.goal_name])), [goals])
-  const resolvedRecurring = useMemo(
-    () => resolveRecurringSavings(recurringSavings, recurringSavingOverrides),
-    [recurringSavings, recurringSavingOverrides],
-  )
-  // Skipped DCA funds aren't seeded as rows — synthesize struck-through lines.
-  const skippedDcaInvestments = useMemo(() => {
-    const skipped = new Set(dcaSkips.map(s => s.fund_id))
-    return funds
-      .filter(f => f.is_dca && f.dca_monthly_amount_vnd && skipped.has(f.id))
-      .map(f => ({
-        goal_id: f.dca_goal_id ?? null,
-        amount_vnd: f.dca_monthly_amount_vnd as number,
-        is_dca_seeded: true,
-        skipped: true,
-        fund_id: f.id,
-        funds: { name: f.name },
-      }))
-  }, [funds, dcaSkips])
-  const fulfillments = useMemo(
-    () => new Map(recurringFulfillments.map(f => [f.recurring_saving_id, {
-      amount: f.amount_vnd,
-      countedAsDeposit: DEPOSIT_BACKED_FULFILLMENT_SOURCES.has(f.source),
-    }])),
-    [recurringFulfillments],
-  )
-  const byGoal = useMemo(
-    () => buildByGoal([...investments, ...skippedDcaInvestments], savings, resolvedRecurring, goalsById, {
-      unallocated: isVI ? 'Chưa phân bổ' : 'Unallocated',
-    }, fulfillments),
-    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI, fulfillments],
-  )
-  const totalGoals = useMemo(() => byGoal.reduce((s, g) => s + g.totalAllocated, 0), [byGoal])
-  const contributedTotal = useMemo(() => byGoal.reduce((s, g) => s + g.contributed, 0), [byGoal])
-  const totalFixed = useMemo(() => getFixedTotal(fixedExpenses), [fixedExpenses])
-  const totalInsurance = useMemo(() => getInsTotal(insuranceMembers), [insuranceMembers])
-  const totalOther = useMemo(() => otherExpenses.reduce((s, e) => s + e.amount_vnd, 0), [otherExpenses])
-  const totalOutflow = totalGoals + totalFixed + totalInsurance + totalOther
-  const remaining = plan ? plan.salary_vnd - totalOutflow : 0
+  // Derived model shared with the desktop view via usePlanningDerivations (#467).
+  const {
+    goalsById, resolvedRecurring, skippedDcaInvestments, fulfillments, byGoal,
+    totalGoals, contributedTotal, totalFixed, totalInsurance, totalOther, totalOutflow, remaining,
+  } = usePlanningDerivations({
+    plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,
+    recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, isVI,
+  })
 
   // ─── Skip/restore handlers ─────────────────────────────────────────────────
-
-  async function handleSkipFE(expense: FixedExpense) {
-    if (!plan) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ fixed_expense_id: expense.expense_id, monthly_amount_override_vnd: 0 }),
-    }).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    onToast(isVI ? `Đã bỏ qua ${expense.expense_name}` : `Skipped ${expense.expense_name}`)
-    onRefresh()
-  }
-
-  async function handleRestoreFE(expense: FixedExpense) {
-    if (!plan) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    const overrides: Array<{ id: string; fixed_expense_id: string }> = await res.json()
-    const match = overrides.find((o) => o.fixed_expense_id === expense.expense_id)
-    if (!match) return
-    const del = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides/${match.id}`, { method: 'DELETE' }).catch(() => null)
-    if (!del?.ok) { toast.error(failMsg); return }
-    onToast(isVI ? `Đã khôi phục ${expense.expense_name}` : `Restored ${expense.expense_name}`)
-    onRefresh()
-  }
-
-  async function handleSkipIns(member: InsuranceMember) {
-    if (!plan) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ member_id: member.member_id }),
-    }).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    onToast(isVI ? `Đã bỏ qua ${member.member_name}` : `Skipped ${member.member_name}`)
-    onRefresh()
-  }
-
-  async function handleRestoreIns(member: InsuranceMember) {
-    if (!plan) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance/${member.member_id}`, { method: 'DELETE' }).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    onToast(isVI ? `Đã khôi phục ${member.member_name}` : `Restored ${member.member_name}`)
-    onRefresh()
-  }
-
-  async function handleSkipRec(item: GoalItem) {
-    if (!plan || !item.recurringId) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ recurring_saving_id: item.recurringId, monthly_amount_override_vnd: 0 }),
-    }).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    onToast(isVI ? `Đã bỏ qua ${item.name}` : `Skipped ${item.name}`)
-    onRefresh()
-  }
-
-  async function handleRestoreRec(item: GoalItem) {
-    if (!plan || !item.recurringId) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    const overrides: Array<{ id: string; recurring_saving_id: string }> = await res.json()
-    const match = overrides.find((o) => o.recurring_saving_id === item.recurringId)
-    if (!match) return
-    const del = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides/${match.id}`, { method: 'DELETE' }).catch(() => null)
-    if (!del?.ok) { toast.error(failMsg); return }
-    onToast(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
-    onRefresh()
-  }
+  // Shared with the desktop view via usePlanningActions so both surfaces stay
+  // in lock-step (#467).
+  const actions = usePlanningActions({ plan, month, year, isVI, onRefresh, onToast })
+  const handleSkipFE = actions.skipFixedExpense
+  const handleRestoreFE = actions.restoreFixedExpense
+  const handleSkipIns = actions.skipInsurance
+  const handleRestoreIns = actions.restoreInsurance
+  const handleSkipRec = actions.skipRecurring
+  const handleRestoreRec = actions.restoreRecurring
+  const handleDcaSkip = actions.skipDca
+  const handleDcaRestore = actions.restoreDca
 
   function openOverrideRec(item: GoalItem) {
     if (!item.recurringId) return
@@ -1208,87 +1104,24 @@ export default function MobilePlanningView({
     setSheet({ type: 'override-rec', item })
   }
 
-  async function handleDcaSkip(item: GoalItem) {
-    if (!plan || !item.fundId) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ fund_id: item.fundId }),
-    }).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    onToast(isVI ? `Đã bỏ qua ${item.name}` : `Skipped ${item.name}`)
-    onRefresh()
-  }
-
-  async function handleDcaRestore(item: GoalItem) {
-    if (!plan || !item.fundId) return
-    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips/${item.fundId}`, { method: 'DELETE' }).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    onToast(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
-    onRefresh()
-  }
-
   // Open the Add-Transaction sheet in create mode, pre-filled toward a goal —
   // the goal-header "+" (log any contribution) and the recurring-bank "Saved"
   // pill (record this month's deposit at the planned amount).
   function openContribution(entry: GoalRow, prefill?: Partial<PrefillTransaction>) {
-    setPrefillTx({
-      goal_id: entry.isUnallocated ? null : entry.goalId,
-      plan_id: plan?.id ?? null,
-      investment_date: new Date().toISOString().slice(0, 10),
-      ...prefill,
-    })
+    setPrefillTx(buildContributionPrefill(entry, plan?.id ?? null, prefill))
   }
 
-  // The recurring "Saved" pill. If the recurring is linked to an accumulating
-  // book, open the prefilled top-up sheet (adds a tranche + marks the month
-  // fulfilled). A MATURED book can't be topped up — steer the user to handle its
-  // maturity rather than silently logging an unrelated standalone deposit.
-  // Otherwise (term-deposit link, or no link) log a standalone contribution.
+  // The recurring "Saved" pill: the shared probe decides between the book top-up
+  // sheet, a standalone contribution, or a matured-book steer.
   async function recordRecurring(entry: GoalRow, item: GoalItem) {
-    if (item.linkedDepositTxId && item.recurringId && plan) {
-      try {
-        const res = await fetch(`/api/v1/investment-transactions/${item.linkedDepositTxId}`)
-        if (res.ok) {
-          const dep = await res.json()
-          const isBookAnchor = dep.deposit_group_id && dep.deposit_group_id === dep.transaction_id
-          if (isBookAnchor) {
-            const matured = dep.expiry_date && dep.expiry_date < new Date().toISOString().slice(0, 10)
-            if (matured) {
-              onToast(isVI ? 'Sổ đã đáo hạn — hãy xử lý đáo hạn trước.' : 'This book has matured — handle its maturity first.')
-              return
-            }
-            setBookTopUp({
-              savingId: item.recurringId, bookId: dep.transaction_id,
-              bookName: dep.notes || (isVI ? 'Sổ ngân hàng' : 'Bank deposit'),
-              ym: `${year}-${String(month).padStart(2, '0')}`, planId: plan.id,
-              amount: item.amount, rate: dep.interest_rate ?? null,
-            })
-            return
-          }
-        }
-      } catch { /* fall through to the standard contribution */ }
-    }
-    openContribution(entry, { asset_type: 'bank', amount_vnd: item.amount })
+    const result = await actions.probeRecurringRecord(item)
+    if (result.kind === 'book-topup') setBookTopUp(result.target)
+    else if (result.kind === 'contribution') openContribution(entry, { asset_type: 'bank', amount_vnd: item.amount })
   }
 
   function openBuy(item: GoalItem) {
-    if (!item.transactionId) return
-    const inv = investments.find(i => i.transaction_id === item.transactionId)
-    if (!inv) return
-    setBuyEdit({
-      transaction_id: inv.transaction_id,
-      asset_type: 'fund',
-      investment_date: inv.investment_date ?? new Date().toISOString().slice(0, 10),
-      amount_vnd: inv.amount_vnd,
-      unit_price: inv.unit_price,
-      units: inv.units,
-      interest_rate: null,
-      expiry_date: null,
-      notes: null,
-      fund_id: inv.fund_id,
-      goal_id: inv.goal_id,
-    })
+    const edit = buildBuyEdit(item.transactionId, investments)
+    if (edit) setBuyEdit(edit)
   }
 
   // ─── Override sheet helpers ────────────────────────────────────────────────
@@ -1305,26 +1138,12 @@ export default function MobilePlanningView({
     setSheet({ type: 'override-ins', member })
   }
 
-  // The single source of truth for an override write. SimpleOverrideSheet is now
-  // presentational (it used to POST too — double-writing, and to the wrong
-  // endpoint for recurring), so this is the only request that fires.
+  // The single source of truth for an override write lives in usePlanningActions;
+  // this closes the sheet on success. SimpleOverrideSheet stays presentational.
   async function handleOverrideSave(amount: number) {
-    if (!plan || !overrideTarget) return
-    const { url, body } = overrideTarget.type === 'fe'
-      ? { url: `/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`, body: { fixed_expense_id: overrideTarget.id, monthly_amount_override_vnd: amount } }
-      : overrideTarget.type === 'rec'
-        ? { url: `/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`, body: { recurring_saving_id: overrideTarget.id, monthly_amount_override_vnd: amount } }
-        : { url: `/api/v1/monthly-plans/${plan.id}/insurance-overrides`, body: { member_id: overrideTarget.id, monthly_amount_override_vnd: amount } }
-    const res = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body),
-    }).catch(() => null)
-    if (!res?.ok) { toast.error(failMsg); return }
-    setSheet(null)
-    setOverrideTarget(null)
-    onToast(isVI ? 'Đã ghi đè' : 'Override saved')
-    onRefresh()
+    if (!overrideTarget) return
+    const ok = await actions.saveOverride({ type: overrideTarget.type, id: overrideTarget.id, amount })
+    if (ok) { setSheet(null); setOverrideTarget(null) }
   }
 
   // ─── Render ────────────────────────────────────────────────────────────────

--- a/app/(app)/planning/usePlanningActions.ts
+++ b/app/(app)/planning/usePlanningActions.ts
@@ -1,0 +1,225 @@
+import { toast } from 'sonner'
+import type { GoalItem, GoalRow } from '@/lib/planning'
+import type { EditableTransaction, PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
+import type { BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
+import type { MonthlyPlan, FixedExpense, InsuranceMember, FundInvestment } from './PlanningClient'
+
+export type OverrideType = 'fe' | 'rec' | 'ins'
+
+export type RecordRecurringResult =
+  | { kind: 'matured' }
+  | { kind: 'book-topup'; target: BookTopUpTarget }
+  | { kind: 'contribution' }
+
+// Build the Add-Transaction edit payload for recording a planned DCA buy. Pure —
+// no state, so both views share it and drive their own editor state.
+export function buildBuyEdit(
+  transactionId: string | undefined,
+  investments: FundInvestment[],
+): EditableTransaction | null {
+  if (!transactionId) return null
+  const inv = investments.find(i => i.transaction_id === transactionId)
+  if (!inv) return null
+  return {
+    transaction_id: inv.transaction_id,
+    asset_type: 'fund',
+    investment_date: inv.investment_date ?? new Date().toISOString().slice(0, 10),
+    amount_vnd: inv.amount_vnd,
+    unit_price: inv.unit_price,
+    units: inv.units,
+    interest_rate: null,
+    expiry_date: null,
+    notes: null,
+    fund_id: inv.fund_id,
+    goal_id: inv.goal_id,
+  }
+}
+
+// Build the create-mode Add-Transaction prefill for logging a contribution toward
+// a goal (or Unallocated). Pure.
+export function buildContributionPrefill(
+  entry: Pick<GoalRow, 'goalId' | 'isUnallocated'>,
+  planId: string | null,
+  prefill?: Partial<PrefillTransaction>,
+): PrefillTransaction {
+  return {
+    goal_id: entry.isUnallocated ? null : entry.goalId,
+    plan_id: planId,
+    investment_date: new Date().toISOString().slice(0, 10),
+    ...prefill,
+  }
+}
+
+export interface PlanningActionsCtx {
+  plan: MonthlyPlan | null
+  month: number
+  year: number
+  isVI: boolean
+  onRefresh: () => void
+  onToast: (msg: string) => void
+}
+
+// The single implementation of the planning page's plan-mutation actions —
+// skip/restore for each line type, override writes, and the record-recurring
+// probe. Previously copy-pasted (and subtly diverged) across the mobile and
+// desktop views; now both call this so a fix lands on both surfaces (#467).
+//
+// Reconciled divergences vs the old duplicated handlers:
+//  - restore always reports success (toast + refresh) even when there was no
+//    override row to delete (desktop behaviour; mobile used to return silently);
+//  - restoring an insurance member also clears any per-plan insurance override
+//    (desktop behaviour; mobile used to leave a stale override behind).
+export function usePlanningActions(ctx: PlanningActionsCtx) {
+  const { plan, month, year, isVI, onRefresh, onToast } = ctx
+  const failMsg = isVI ? 'Có lỗi, vui lòng thử lại' : 'Something went wrong — please try again'
+
+  function fail() { toast.error(failMsg) }
+  function done(msg: string) { onRefresh(); onToast(msg) }
+
+  async function skipFixedExpense(expense: FixedExpense) {
+    if (!plan) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fixed_expense_id: expense.expense_id, monthly_amount_override_vnd: 0 }),
+    }).catch(() => null)
+    if (!res?.ok) return fail()
+    done(isVI ? `Đã bỏ qua ${expense.expense_name}` : `Skipped ${expense.expense_name}`)
+  }
+
+  async function restoreFixedExpense(expense: FixedExpense) {
+    if (!plan) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`).catch(() => null)
+    if (!res?.ok) return fail()
+    const overrides: Array<{ id: string; fixed_expense_id: string }> = await res.json()
+    const match = overrides.find(o => o.fixed_expense_id === expense.expense_id)
+    if (match) {
+      const del = await fetch(`/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides/${match.id}`, { method: 'DELETE' }).catch(() => null)
+      if (!del?.ok) return fail()
+    }
+    done(isVI ? `Đã khôi phục ${expense.expense_name}` : `Restored ${expense.expense_name}`)
+  }
+
+  async function skipInsurance(member: InsuranceMember) {
+    if (!plan) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ member_id: member.member_id }),
+    }).catch(() => null)
+    if (!res?.ok) return fail()
+    done(isVI ? `Đã bỏ qua ${member.member_name}` : `Skipped ${member.member_name}`)
+  }
+
+  async function restoreInsurance(member: InsuranceMember) {
+    if (!plan) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance/${member.member_id}`, { method: 'DELETE' }).catch(() => null)
+    if (!res?.ok) return fail()
+    // Also drop any per-plan override so a restored member starts from its base
+    // premium rather than a stale overridden amount.
+    const oRes = await fetch(`/api/v1/monthly-plans/${plan.id}/insurance-overrides`).catch(() => null)
+    if (oRes?.ok) {
+      const overrides: Array<{ id: string; member_id: string }> = await oRes.json()
+      const match = overrides.find(o => o.member_id === member.member_id)
+      if (match) await fetch(`/api/v1/monthly-plans/${plan.id}/insurance-overrides/${match.id}`, { method: 'DELETE' }).catch(() => null)
+    }
+    done(isVI ? `Đã khôi phục ${member.member_name}` : `Restored ${member.member_name}`)
+  }
+
+  async function skipRecurring(item: GoalItem) {
+    if (!plan || !item.recurringId) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ recurring_saving_id: item.recurringId, monthly_amount_override_vnd: 0 }),
+    }).catch(() => null)
+    if (!res?.ok) return fail()
+    done(isVI ? `Đã bỏ qua ${item.name}` : `Skipped ${item.name}`)
+  }
+
+  async function restoreRecurring(item: GoalItem) {
+    if (!plan || !item.recurringId) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`).catch(() => null)
+    if (!res?.ok) return fail()
+    const overrides: Array<{ id: string; recurring_saving_id: string }> = await res.json()
+    const match = overrides.find(o => o.recurring_saving_id === item.recurringId)
+    if (match) {
+      const del = await fetch(`/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides/${match.id}`, { method: 'DELETE' }).catch(() => null)
+      if (!del?.ok) return fail()
+    }
+    done(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
+  }
+
+  async function skipDca(item: GoalItem) {
+    if (!plan || !item.fundId) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fund_id: item.fundId }),
+    }).catch(() => null)
+    if (!res?.ok) return fail()
+    done(isVI ? `Đã bỏ qua ${item.name}` : `Skipped ${item.name}`)
+  }
+
+  async function restoreDca(item: GoalItem) {
+    if (!plan || !item.fundId) return
+    const res = await fetch(`/api/v1/monthly-plans/${plan.id}/dca-skips/${item.fundId}`, { method: 'DELETE' }).catch(() => null)
+    if (!res?.ok) return fail()
+    done(isVI ? `Đã khôi phục ${item.name}` : `Restored ${item.name}`)
+  }
+
+  // The single source of truth for an override write, keyed by line type.
+  async function saveOverride(input: { type: OverrideType; id: string; amount: number }): Promise<boolean> {
+    if (!plan) return false
+    const { url, body } = input.type === 'fe'
+      ? { url: `/api/v1/monthly-plans/${plan.id}/fixed-expense-overrides`, body: { fixed_expense_id: input.id, monthly_amount_override_vnd: input.amount } }
+      : input.type === 'rec'
+        ? { url: `/api/v1/monthly-plans/${plan.id}/recurring-saving-overrides`, body: { recurring_saving_id: input.id, monthly_amount_override_vnd: input.amount } }
+        : { url: `/api/v1/monthly-plans/${plan.id}/insurance-overrides`, body: { member_id: input.id, monthly_amount_override_vnd: input.amount } }
+    const res = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) }).catch(() => null)
+    if (!res?.ok) { fail(); return false }
+    done(isVI ? 'Đã ghi đè' : 'Override saved')
+    return true
+  }
+
+  // The recurring "Saved" pill: if the recurring is linked to an accumulating
+  // book, it must open the top-up sheet (tranche + fulfillment) — unless the book
+  // has matured, in which case steer the user to handle maturity first. Otherwise
+  // log a standalone contribution. Returns what the caller should open.
+  async function probeRecurringRecord(item: GoalItem): Promise<RecordRecurringResult> {
+    if (item.linkedDepositTxId && item.recurringId && plan) {
+      try {
+        const res = await fetch(`/api/v1/investment-transactions/${item.linkedDepositTxId}`)
+        if (res.ok) {
+          const dep = await res.json()
+          const isBookAnchor = dep.deposit_group_id && dep.deposit_group_id === dep.transaction_id
+          if (isBookAnchor) {
+            const matured = dep.expiry_date && dep.expiry_date < new Date().toISOString().slice(0, 10)
+            if (matured) {
+              onToast(isVI ? 'Sổ đã đáo hạn — hãy xử lý đáo hạn trước.' : 'This book has matured — handle its maturity first.')
+              return { kind: 'matured' }
+            }
+            return {
+              kind: 'book-topup',
+              target: {
+                savingId: item.recurringId, bookId: dep.transaction_id,
+                bookName: dep.notes || (isVI ? 'Sổ ngân hàng' : 'Bank deposit'),
+                ym: `${year}-${String(month).padStart(2, '0')}`, planId: plan.id,
+                amount: item.amount, rate: dep.interest_rate ?? null,
+              },
+            }
+          }
+        }
+      } catch { /* fall through to the standard contribution */ }
+    }
+    return { kind: 'contribution' }
+  }
+
+  return {
+    skipFixedExpense, restoreFixedExpense,
+    skipInsurance, restoreInsurance,
+    skipRecurring, restoreRecurring,
+    skipDca, restoreDca,
+    saveOverride, probeRecurringRecord,
+  }
+}

--- a/app/(app)/planning/usePlanningActions.ts
+++ b/app/(app)/planning/usePlanningActions.ts
@@ -116,12 +116,16 @@ export function usePlanningActions(ctx: PlanningActionsCtx) {
     const res = await fetch(`/api/v1/monthly-plans/${plan.id}/excluded-insurance/${member.member_id}`, { method: 'DELETE' }).catch(() => null)
     if (!res?.ok) return fail()
     // Also drop any per-plan override so a restored member starts from its base
-    // premium rather than a stale overridden amount.
+    // premium rather than a stale overridden amount. A failure here must NOT
+    // report success — otherwise the member reads as restored while still using
+    // the old override (mirrors the fixed/recurring restore paths).
     const oRes = await fetch(`/api/v1/monthly-plans/${plan.id}/insurance-overrides`).catch(() => null)
-    if (oRes?.ok) {
-      const overrides: Array<{ id: string; member_id: string }> = await oRes.json()
-      const match = overrides.find(o => o.member_id === member.member_id)
-      if (match) await fetch(`/api/v1/monthly-plans/${plan.id}/insurance-overrides/${match.id}`, { method: 'DELETE' }).catch(() => null)
+    if (!oRes?.ok) return fail()
+    const overrides: Array<{ id: string; member_id: string }> = await oRes.json()
+    const match = overrides.find(o => o.member_id === member.member_id)
+    if (match) {
+      const del = await fetch(`/api/v1/monthly-plans/${plan.id}/insurance-overrides/${match.id}`, { method: 'DELETE' }).catch(() => null)
+      if (!del?.ok) return fail()
     }
     done(isVI ? `Đã khôi phục ${member.member_name}` : `Restored ${member.member_name}`)
   }

--- a/app/(app)/planning/usePlanningDerivations.ts
+++ b/app/(app)/planning/usePlanningDerivations.ts
@@ -1,0 +1,106 @@
+import { useMemo } from 'react'
+import {
+  buildByGoal,
+  resolveRecurringSavings,
+  DEPOSIT_BACKED_FULFILLMENT_SOURCES,
+  type GoalRow,
+} from '@/lib/planning'
+import type {
+  MonthlyPlan, FundInvestment, DirectSaving, FixedExpense, InsuranceMember,
+  OtherExpense, RecurringSaving, RecurringSavingOverride, RecurringFulfillment, DcaSkip, Fund, Goal,
+} from './PlanningClient'
+
+// Effective monthly totals. A `override === 0` fixed expense is skipped for the
+// month; an `excluded` insurance member is skipped; otherwise the override (if
+// any) wins over the base amount. Shared verbatim by both planning views.
+export function getFixedTotal(fixedExpenses: FixedExpense[]) {
+  return fixedExpenses.reduce((s, e) => {
+    if (e.override === 0) return s
+    return s + (e.override ?? e.amount_vnd)
+  }, 0)
+}
+
+export function getInsTotal(insuranceMembers: InsuranceMember[]) {
+  return insuranceMembers.reduce((s, m) => {
+    if (m.excluded) return s
+    return s + (m.monthlyOverride ?? Math.round(m.annual_payment_vnd / 12))
+  }, 0)
+}
+
+export interface PlanningDerivationsInput {
+  plan: MonthlyPlan | null
+  investments: FundInvestment[]
+  savings: DirectSaving[]
+  fixedExpenses: FixedExpense[]
+  insuranceMembers: InsuranceMember[]
+  otherExpenses: OtherExpense[]
+  recurringSavings: RecurringSaving[]
+  recurringSavingOverrides: RecurringSavingOverride[]
+  recurringFulfillments: RecurringFulfillment[]
+  dcaSkips: DcaSkip[]
+  funds: Fund[]
+  goals: Goal[]
+  isVI: boolean
+}
+
+// The single source of truth for the planning page's derived model: the by-goal
+// allocation rows and the salary-vs-outflow totals. Extracted so the mobile and
+// desktop views can't drift (issue #467); the block was previously copy-pasted
+// into both, modulo local variable names.
+export function usePlanningDerivations(input: PlanningDerivationsInput) {
+  const {
+    plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,
+    recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, isVI,
+  } = input
+
+  const goalsById = useMemo(() => new Map(goals.map(g => [g.goal_id, g.goal_name])), [goals])
+
+  const resolvedRecurring = useMemo(
+    () => resolveRecurringSavings(recurringSavings, recurringSavingOverrides),
+    [recurringSavings, recurringSavingOverrides],
+  )
+
+  // Skipped DCA funds are no longer seeded as rows, so synthesize struck-through
+  // lines from the fund config + the plan's skip list.
+  const skippedDcaInvestments = useMemo(() => {
+    const skipped = new Set(dcaSkips.map(s => s.fund_id))
+    return funds
+      .filter(f => f.is_dca && f.dca_monthly_amount_vnd && skipped.has(f.id))
+      .map(f => ({
+        goal_id: f.dca_goal_id ?? null,
+        amount_vnd: f.dca_monthly_amount_vnd as number,
+        is_dca_seeded: true,
+        skipped: true,
+        fund_id: f.id,
+        funds: { name: f.name },
+      }))
+  }, [funds, dcaSkips])
+
+  const fulfillments = useMemo(
+    () => new Map(recurringFulfillments.map(f => [f.recurring_saving_id, {
+      amount: f.amount_vnd,
+      countedAsDeposit: DEPOSIT_BACKED_FULFILLMENT_SOURCES.has(f.source),
+    }])),
+    [recurringFulfillments],
+  )
+
+  const byGoal: GoalRow[] = useMemo(
+    () => buildByGoal([...investments, ...skippedDcaInvestments], savings, resolvedRecurring, goalsById, {
+      unallocated: isVI ? 'Chưa phân bổ' : 'Unallocated',
+    }, fulfillments),
+    [investments, skippedDcaInvestments, savings, resolvedRecurring, goalsById, isVI, fulfillments],
+  )
+
+  const totalGoals = useMemo(() => byGoal.reduce((s, g) => s + g.totalAllocated, 0), [byGoal])
+  const contributedTotal = useMemo(() => byGoal.reduce((s, g) => s + g.contributed, 0), [byGoal])
+  const totalFixed = useMemo(() => getFixedTotal(fixedExpenses), [fixedExpenses])
+  const totalInsurance = useMemo(() => getInsTotal(insuranceMembers), [insuranceMembers])
+  const totalOther = useMemo(() => otherExpenses.reduce((s, e) => s + e.amount_vnd, 0), [otherExpenses])
+  const totalOutflow = totalGoals + totalFixed + totalInsurance + totalOther
+  const remaining = plan ? plan.salary_vnd - totalOutflow : 0
+
+  return {
+    goalsById, resolvedRecurring, skippedDcaInvestments, fulfillments, byGoal,
+    totalGoals, contributedTotal, totalFixed, totalInsurance, totalOther, totalOutflow, remaining,
+  }
+}

--- a/app/api/v1/monthly-plans/[id]/insurance-overrides/[overrideId]/route.ts
+++ b/app/api/v1/monthly-plans/[id]/insurance-overrides/[overrideId]/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
+
+// Delete a per-plan insurance-premium override. This endpoint was missing —
+// only fixed-expense and recurring-saving overrides had a [overrideId] DELETE —
+// so "restore insurance member" could never actually clear a lingering override
+// (the request 404'd and was silently ignored). (#467)
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string; overrideId: string }> }
+) {
+  const { id, overrideId } = await params
+
+  let planId: string
+  let cleanOverrideId: string
+  try {
+    planId = validateUUID(id, 'plan_id')
+    cleanOverrideId = validateUUID(overrideId, 'override_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', planId).eq('user_id', user.id).single()
+  if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
+
+  const { error } = await supabase
+    .from('plan_insurance_member_overrides')
+    .delete()
+    .eq('id', cleanOverrideId)
+    .eq('plan_id', planId)
+
+  if (error) return NextResponse.json({ error: 'Override not found' }, { status: 404 })
+  return new NextResponse(null, { status: 204 })
+}

--- a/e2e/insurance-override.spec.ts
+++ b/e2e/insurance-override.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect } from '@playwright/test'
+import * as api from './helpers/api'
+
+// The per-plan insurance-override DELETE endpoint was missing, so "restore
+// insurance member" could never clear a lingering override (the request 404'd
+// and was silently ignored). This drives the real route end-to-end. (#467)
+test.describe('insurance override DELETE (#467)', () => {
+  let memberId: string
+  let planId: string
+
+  test.beforeEach(async () => {
+    await api.deleteMonthlyPlanByDate(8, 2099)
+    const member = await api.createInsuranceMember({
+      member_name: `E2E InsOverride ${Date.now()}`, relationship: 'self', annual_payment_vnd: 12_000_000, payment_date: '2099-08-01',
+    })
+    memberId = member.member_id
+    const plan = await api.createMonthlyPlan({ month: 8, year: 2099, salary_vnd: 50_000_000 })
+    planId = plan.id
+  })
+
+  test.afterEach(async () => {
+    if (planId) await api.deleteMonthlyPlan(planId)
+    if (memberId) await api.deleteInsuranceMember(memberId)
+  })
+
+  test('creating then deleting a per-plan insurance override removes it', async ({ request }) => {
+    const create = await request.post(`/api/v1/monthly-plans/${planId}/insurance-overrides`, {
+      data: { member_id: memberId, monthly_amount_override_vnd: 700_000 },
+    })
+    expect(create.ok()).toBeTruthy()
+
+    const listed = await (await request.get(`/api/v1/monthly-plans/${planId}/insurance-overrides`)).json()
+    const override = listed.find((o: { member_id: string }) => o.member_id === memberId)
+    expect(override).toBeTruthy()
+
+    const del = await request.delete(`/api/v1/monthly-plans/${planId}/insurance-overrides/${override.id}`)
+    expect(del.status()).toBe(204)
+
+    const after = await (await request.get(`/api/v1/monthly-plans/${planId}/insurance-overrides`)).json()
+    expect(after.some((o: { member_id: string }) => o.member_id === memberId)).toBe(false)
+  })
+
+  test('rejects a malformed override id (400)', async ({ request }) => {
+    const res = await request.delete(`/api/v1/monthly-plans/${planId}/insurance-overrides/not-a-uuid`)
+    expect(res.status()).toBe(400)
+  })
+})


### PR DESCRIPTION
Addresses #467 — **first slice**. Follow-up PRs are planned (see below).

## What & why
The mobile (`MobilePlanningView`, 1760 lines) and desktop (`DesktopPlanningView`, 1321) planning views duplicated **~450 near-identical lines** of plan-mutation handlers and derivation memos — same endpoints, same payloads, renamed variables. A fix could land on one surface but not the other (and, as it turns out, already had — see reconciled divergences).

Extracted the shared business logic into two modules both views now consume:

- **`usePlanningDerivations`** — the by-goal allocation model + salary-vs-outflow totals (`goalsById`, `resolvedRecurring`, `skippedDcaInvestments`, `fulfillments`, `byGoal`, all totals/remaining). Was copy-pasted verbatim into both.
- **`usePlanningActions`** — skip/restore for fixed expenses, insurance, recurring savings, and DCA; the override write; and the record-recurring probe (returns a discriminated result the view acts on). Plus pure `buildBuyEdit` / `buildContributionPrefill` helpers.

Each view keeps only its **layout + form-open state**; the network/toast/refresh logic lives once.

## Reconciled mobile/desktop divergences
The refactor surfaced three latent inconsistencies. Unified to a single behaviour, pinned by the hook's unit test:
1. Restoring an insurance member now **also clears any lingering per-plan override** (mobile previously left a stale override behind).
2. Restore always reports success (toast + refresh) **even with no override row to delete** (mobile previously returned silently).
3. The override-saved toast is unified (`"Override saved"` / `"Đã ghi đè"`; desktop previously said `"Saved"`).

## Testing
- **`usePlanningActions.test.ts`** — 12 cases covering each action's endpoint/payload/toast/refresh, the reconciled behaviours, failure handling, the record-recurring probe, and the pure builders. Since both views now call this, it *is* the mobile/desktop parity test.
- Existing planning component + client tests unchanged and green (**139 passed**).
- Full unit **1177 passed**, lint **0 errors**, full E2E **235 passed**.

> The one E2E failure (`assign-goal-desktop` success-state) is the known pre-existing timing flake — passes in isolation, unrelated to planning.

## Scope / follow-up PRs
This is intentionally one reviewable slice. Planned follow-ups:
- **(2)** Route the mobile salary / delete-plan / other-expense **sub-component** writes through `usePlanningActions` too (they still hold their own `fetch`; desktop's inline equivalents likewise), completing the planning-pair extraction.
- **(3)** Goal-detail pair (`GoalDetailSheet` + `DesktopGoalDetail`): extract `useGoalDetailData` (the shared load effect) + `useGoalActions` (delete / unassign / unhold / edit-goal).
- **(4)** Unify `DesktopGoalDetail`'s **inline** sell/withdraw onto the shared `SellWithdrawSheet` (a real duplication + consistency risk).

Note: `AddTransactionSheet` and `MaturityResolveSheet` from the issue's list are **already unified** (single component / shared body + thin wrappers) — no work needed; `MaturityResolveSheet` is the pattern this PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)