### PR TITLE
refactor(goal-detail): extract shared transactions/gold-price load hook (#467)

### DIFF
--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -12,29 +12,8 @@ import { MaturityResolveModal } from './MaturityResolveSheet'
 import { fmtTxDate, txKind } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 import LoadError from './LoadError'
+import { useGoalDetailData } from './useGoalDetailData'
 import { todayIso } from '@/lib/dates'
-
-interface InvestmentTx {
-  transaction_id: string
-  transaction_type: string
-  asset_type: string
-  fund_id: string | null
-  fund_name: string | null
-  parent_transaction_id: string | null
-  investment_date: string
-  amount_vnd: number
-  units: number | null
-  interest_rate: number | null
-  expiry_date: string | null
-  notes: string | null
-  principal_withdrawn: number | null
-  units_withdrawn: number | null
-  renewed_from_transaction_id?: string | null
-  interest_earned_vnd?: number | null
-  is_recurring?: boolean
-  held_for_merge?: boolean | null
-  consumed_by_inv_id?: string | null
-}
 
 interface Props {
   goal: GoalData
@@ -64,10 +43,6 @@ interface Props {
 export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged, onRenewed, refreshKey, onAddToGoal }: Props) {
   const isVi = locale === 'vi'
   const [tab, setTab] = useState<'investments' | 'calculator' | 'history'>('investments')
-  const [transactions, setTransactions] = useState<InvestmentTx[]>([])
-  const [goldPricePerChi, setGoldPricePerChi] = useState<number | null>(null)
-  const [txLoading, setTxLoading] = useState(false)
-  const [txError, setTxError] = useState(false)
   // Bumped by the retry button to re-run the transactions fetch.
   const [txReload, setTxReload] = useState(0)
   const [actionsOpen, setActionsOpen] = useState(false)
@@ -85,41 +60,16 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
   const [unassigning, setUnassigning] = useState(false)
   const [unassignedIds, setUnassignedIds] = useState<string[]>([])
 
-  useEffect(() => {
-    setTxLoading(true)
-    setTxError(false)
-    // The new server response is the source of truth — drop any locally
-    // hidden tx IDs from the unassign flow so a re-assigned tx isn't stuck
-    // behind the optimistic filter on subsequent refreshes.
-    setUnassignedIds([])
-    // cache: 'no-store' — same reason as GoalDetailSheet: prevent the browser
-    // from serving a stale list after an assign-from-Unallocated.
-    // Recurring savings are plan-only (no investment_transactions row), so fetch
-    // their realized contributions separately and merge into the history list.
-    Promise.all([
-      // The investments list is built from these rows — a failed fetch must
-      // surface a retry, not render as "No investments yet".
-      fetch(`/api/v1/investment-transactions?goal_id=${goal.goalId}&limit=200&include_history=true`, { cache: 'no-store' })
-        .then((r) => { if (!r.ok) throw new Error('load failed'); return r.json() }),
-      // Recurring contributions are supplementary — degrade to empty on failure.
-      fetch(`/api/v1/savings-goals/${goal.goalId}/recurring-contributions`, { cache: 'no-store' })
-        .then((r) => r.ok ? r.json() : { contributions: [] })
-        .catch(() => ({ contributions: [] })),
-    ])
-      .then(([txRes, recRes]) => {
-        const merged: InvestmentTx[] = [...(txRes.transactions ?? []), ...(recRes.contributions ?? [])]
-        merged.sort((a, b) => (a.investment_date < b.investment_date ? 1 : a.investment_date > b.investment_date ? -1 : 0))
-        setTransactions(merged)
-      })
-      .catch(() => { setTransactions([]); setTxError(true) })
-      .finally(() => setTxLoading(false))
-    // Gold is valued at the live market price per chỉ, not its purchase cost —
-    // without this the sell modal would prefill the stale buy price (issue #251).
-    fetch('/api/v1/gold-price', { cache: 'no-store' })
-      .then((r) => r.ok ? r.json() : null)
-      .then((res) => setGoldPricePerChi(res?.price_per_chi ?? null))
-      .catch(() => setGoldPricePerChi(null))
-  }, [goal.goalId, refreshKey, txReload])
+  // Transactions + gold price load (shared with GoalDetailSheet, #467). The
+  // panel is always mounted, so it always loads; each load clears the optimistic
+  // unassign filter.
+  const { transactions, txLoading, txError, goldPricePerChi } = useGoalDetailData({
+    goalId: goal.goalId,
+    enabled: true,
+    refreshKey,
+    txReload,
+    onLoadStart: () => setUnassignedIds([]),
+  })
 
   // Reset tab when the selected goal itself changes.
   useEffect(() => {

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -18,30 +18,7 @@ import { GD_COLORS, buildCompositionSegments, calcDeadlineMonths, TypeIcon, Unli
 import { fmtTxDate, txKind } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 import LoadError from './LoadError'
-
-interface InvestmentTx {
-  transaction_id: string
-  transaction_type: string
-  asset_type: string
-  fund_id: string | null
-  fund_name: string | null
-  fund_code: string | null
-  parent_transaction_id: string | null
-  investment_date: string
-  amount_vnd: number
-  units: number | null
-  unit_price: number | null
-  interest_rate: number | null
-  expiry_date: string | null
-  notes: string | null
-  principal_withdrawn: number | null
-  units_withdrawn: number | null
-  renewed_from_transaction_id?: string | null
-  interest_earned_vnd?: number | null
-  is_recurring?: boolean
-  held_for_merge?: boolean | null
-  consumed_by_inv_id?: string | null
-}
+import { useGoalDetailData } from './useGoalDetailData'
 
 interface Props {
   goal: GoalData | null
@@ -771,10 +748,6 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   const isVI = useLocale() === 'vi'
   const [mounted, setMounted] = useState(false)
   const [activeTab, setActiveTab] = useState<'investments' | 'calculator' | 'history'>('investments')
-  const [transactions, setTransactions] = useState<InvestmentTx[]>([])
-  const [goldPricePerChi, setGoldPricePerChi] = useState<number | null>(null)
-  const [txLoading, setTxLoading] = useState(false)
-  const [txError, setTxError] = useState(false)
   // Bumped by the retry button to re-run the transactions fetch.
   const [txReload, setTxReload] = useState(0)
   const [actionsOpen, setActionsOpen] = useState(false)
@@ -788,6 +761,15 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   const [unassignConfirmOpen, setUnassignConfirmOpen] = useState(false)
   const [unassigning, setUnassigning] = useState(false)
   const [unassignedIds, setUnassignedIds] = useState<string[]>([])
+  // Transactions + gold price load (shared with DesktopGoalDetail, #467). The
+  // sheet only loads while open; each load clears the optimistic unassign filter.
+  const { transactions, txLoading, txError, goldPricePerChi } = useGoalDetailData({
+    goalId: goal?.goalId,
+    enabled: open && !!goal,
+    refreshKey,
+    txReload,
+    onLoadStart: () => setUnassignedIds([]),
+  })
   const [fundDetailId, setFundDetailId] = useState<string | null>(null)
   const [purchaseHistory, setPurchaseHistory] = useState<PurchaseHistoryRow[]>([])
   const [historyLoading, setHistoryLoading] = useState(false)
@@ -804,43 +786,6 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
       return () => clearTimeout(t)
     }
   }, [open])
-
-  useEffect(() => {
-    if (!open || !goal) return
-    setTxLoading(true)
-    setTxError(false)
-    // The new server response is the source of truth — drop any locally
-    // hidden tx IDs from the unassign flow so a re-assigned tx isn't stuck
-    // behind the optimistic filter on subsequent refreshes.
-    setUnassignedIds([])
-    // cache: 'no-store' — without it the browser can serve a stale list when
-    // an investment was just (re)assigned to this goal in the same session.
-    // Recurring savings are plan-only (no investment_transactions row), so fetch
-    // their realized contributions separately and merge into the history list.
-    Promise.all([
-      // The investments list is built from these rows — a failed fetch must
-      // surface a retry, not render as "No investments yet".
-      fetch(`/api/v1/investment-transactions?goal_id=${goal.goalId}&limit=200&include_history=true`, { cache: 'no-store' })
-        .then((r) => { if (!r.ok) throw new Error('load failed'); return r.json() }),
-      // Recurring contributions are supplementary — degrade to empty on failure.
-      fetch(`/api/v1/savings-goals/${goal.goalId}/recurring-contributions`, { cache: 'no-store' })
-        .then((r) => r.ok ? r.json() : { contributions: [] })
-        .catch(() => ({ contributions: [] })),
-    ])
-      .then(([txRes, recRes]) => {
-        const merged: InvestmentTx[] = [...(txRes.transactions ?? []), ...(recRes.contributions ?? [])]
-        merged.sort((a, b) => (a.investment_date < b.investment_date ? 1 : a.investment_date > b.investment_date ? -1 : 0))
-        setTransactions(merged)
-      })
-      .catch(() => { setTransactions([]); setTxError(true) })
-      .finally(() => setTxLoading(false))
-    // Gold is valued at the live market price per chỉ, not its purchase cost —
-    // without this the sell sheet would prefill the stale buy price (issue #251).
-    fetch('/api/v1/gold-price', { cache: 'no-store' })
-      .then((r) => r.ok ? r.json() : null)
-      .then((res) => setGoldPricePerChi(res?.price_per_chi ?? null))
-      .catch(() => setGoldPricePerChi(null))
-  }, [open, goal, refreshKey, txReload])
 
   async function handleDelete() {
     if (!goal) return

--- a/app/assets/components/__tests__/useGoalDetailData.test.tsx
+++ b/app/assets/components/__tests__/useGoalDetailData.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useGoalDetailData } from '../useGoalDetailData'
+
+// The goal-detail load effect, shared by GoalDetailSheet (mobile) and
+// DesktopGoalDetail (#467). Both surfaces now rely on this, so these cases pin
+// the parity: merge tx + recurring contributions, sort newest-first, load gold.
+
+function mockFetch(map: (url: string) => { ok: boolean; body?: unknown }) {
+  global.fetch = vi.fn(async (url: string | URL | Request) => {
+    const r = map(String(url))
+    return { ok: r.ok, json: async () => r.body ?? {} } as Response
+  }) as unknown as typeof fetch
+}
+
+beforeEach(() => vi.restoreAllMocks())
+
+describe('useGoalDetailData (#467)', () => {
+  it('merges transactions + recurring contributions newest-first and loads the gold price', async () => {
+    mockFetch((url) => {
+      if (url.includes('/investment-transactions')) return { ok: true, body: { transactions: [{ transaction_id: 't1', investment_date: '2026-01-01' }] } }
+      if (url.includes('/recurring-contributions')) return { ok: true, body: { contributions: [{ transaction_id: 'r1', investment_date: '2026-03-01' }] } }
+      if (url.includes('/gold-price')) return { ok: true, body: { price_per_chi: 7_500_000 } }
+      return { ok: false }
+    })
+    const { result } = renderHook(() => useGoalDetailData({ goalId: 'g1', enabled: true, refreshKey: 0, txReload: 0 }))
+    await waitFor(() => expect(result.current.txLoading).toBe(false))
+    // Newest first: the March recurring contribution precedes the January tx.
+    expect(result.current.transactions.map(t => t.transaction_id)).toEqual(['r1', 't1'])
+    expect(result.current.goldPricePerChi).toBe(7_500_000)
+    expect(result.current.txError).toBe(false)
+  })
+
+  it('does not fetch while disabled', async () => {
+    const fetchSpy = vi.fn()
+    global.fetch = fetchSpy as unknown as typeof fetch
+    renderHook(() => useGoalDetailData({ goalId: 'g1', enabled: false, refreshKey: 0, txReload: 0 }))
+    await new Promise(r => setTimeout(r, 10))
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('sets txError and empties the list when the transactions fetch fails', async () => {
+    mockFetch((url) => {
+      if (url.includes('/investment-transactions')) return { ok: false }
+      return { ok: true, body: {} }
+    })
+    const { result } = renderHook(() => useGoalDetailData({ goalId: 'g1', enabled: true, refreshKey: 0, txReload: 0 }))
+    await waitFor(() => expect(result.current.txError).toBe(true))
+    expect(result.current.transactions).toEqual([])
+  })
+
+  it('degrades to just the transactions when recurring contributions fail', async () => {
+    mockFetch((url) => {
+      if (url.includes('/investment-transactions')) return { ok: true, body: { transactions: [{ transaction_id: 't1', investment_date: '2026-01-01' }] } }
+      if (url.includes('/recurring-contributions')) return { ok: false }
+      return { ok: true, body: {} }
+    })
+    const { result } = renderHook(() => useGoalDetailData({ goalId: 'g1', enabled: true, refreshKey: 0, txReload: 0 }))
+    await waitFor(() => expect(result.current.txLoading).toBe(false))
+    expect(result.current.transactions.map(t => t.transaction_id)).toEqual(['t1'])
+    expect(result.current.txError).toBe(false)
+  })
+
+  it('fires onLoadStart at the beginning of each load', async () => {
+    mockFetch(() => ({ ok: true, body: {} }))
+    const onLoadStart = vi.fn()
+    renderHook(() => useGoalDetailData({ goalId: 'g1', enabled: true, refreshKey: 0, txReload: 0, onLoadStart }))
+    await waitFor(() => expect(onLoadStart).toHaveBeenCalled())
+  })
+})

--- a/app/assets/components/useGoalDetailData.ts
+++ b/app/assets/components/useGoalDetailData.ts
@@ -1,0 +1,100 @@
+import { useState, useEffect, useRef } from 'react'
+
+// The transaction shape both goal-detail surfaces render. Superset of what each
+// used locally (the mobile sheet also reads fund_code / unit_price); the desktop
+// panel simply ignores the extra fields.
+export interface InvestmentTx {
+  transaction_id: string
+  transaction_type: string
+  asset_type: string
+  fund_id: string | null
+  fund_name: string | null
+  fund_code?: string | null
+  parent_transaction_id: string | null
+  investment_date: string
+  amount_vnd: number
+  units: number | null
+  unit_price?: number | null
+  interest_rate: number | null
+  expiry_date: string | null
+  notes: string | null
+  principal_withdrawn: number | null
+  units_withdrawn: number | null
+  renewed_from_transaction_id?: string | null
+  interest_earned_vnd?: number | null
+  is_recurring?: boolean
+  held_for_merge?: boolean | null
+  consumed_by_inv_id?: string | null
+}
+
+export interface UseGoalDetailData {
+  transactions: InvestmentTx[]
+  txLoading: boolean
+  txError: boolean
+  goldPricePerChi: number | null
+}
+
+// The goal-detail transactions + gold-price load, shared by GoalDetailSheet
+// (mobile) and DesktopGoalDetail so the two can't drift (#467). The effect was
+// previously copy-pasted verbatim into both.
+//
+// `enabled` gates the load (the mobile sheet only loads while open; the desktop
+// panel is always mounted). `onLoadStart` fires at the start of every load so
+// the caller can reset its own optimistic state (e.g. the unassigned-id filter).
+export function useGoalDetailData(opts: {
+  goalId: string | undefined
+  enabled: boolean
+  refreshKey: unknown
+  txReload: unknown
+  onLoadStart?: () => void
+}): UseGoalDetailData {
+  const { goalId, enabled, refreshKey, txReload } = opts
+  const [transactions, setTransactions] = useState<InvestmentTx[]>([])
+  const [goldPricePerChi, setGoldPricePerChi] = useState<number | null>(null)
+  const [txLoading, setTxLoading] = useState(false)
+  const [txError, setTxError] = useState(false)
+
+  // Keep the latest onLoadStart without making it a load dependency (callers
+  // pass an inline arrow, so it changes identity every render).
+  const onLoadStartRef = useRef(opts.onLoadStart)
+  useEffect(() => { onLoadStartRef.current = opts.onLoadStart })
+
+  useEffect(() => {
+    if (!enabled || !goalId) return
+    setTxLoading(true)
+    setTxError(false)
+    // The new server response is the source of truth — let the caller drop any
+    // locally hidden tx IDs from the unassign flow so a re-assigned tx isn't
+    // stuck behind the optimistic filter on subsequent refreshes.
+    onLoadStartRef.current?.()
+    // cache: 'no-store' — without it the browser can serve a stale list when an
+    // investment was just (re)assigned to this goal in the same session.
+    // Recurring savings are plan-only (no investment_transactions row), so fetch
+    // their realized contributions separately and merge into the history list.
+    Promise.all([
+      // The investments list is built from these rows — a failed fetch must
+      // surface a retry, not render as "No investments yet".
+      fetch(`/api/v1/investment-transactions?goal_id=${goalId}&limit=200&include_history=true`, { cache: 'no-store' })
+        .then((r) => { if (!r.ok) throw new Error('load failed'); return r.json() }),
+      // Recurring contributions are supplementary — degrade to empty on failure.
+      fetch(`/api/v1/savings-goals/${goalId}/recurring-contributions`, { cache: 'no-store' })
+        .then((r) => r.ok ? r.json() : { contributions: [] })
+        .catch(() => ({ contributions: [] })),
+    ])
+      .then(([txRes, recRes]) => {
+        const merged: InvestmentTx[] = [...(txRes.transactions ?? []), ...(recRes.contributions ?? [])]
+        merged.sort((a, b) => (a.investment_date < b.investment_date ? 1 : a.investment_date > b.investment_date ? -1 : 0))
+        setTransactions(merged)
+      })
+      .catch(() => { setTransactions([]); setTxError(true) })
+      .finally(() => setTxLoading(false))
+    // Gold is valued at the live market price per chỉ, not its purchase cost —
+    // without this the sell UI would prefill the stale buy price (issue #251).
+    fetch('/api/v1/gold-price', { cache: 'no-store' })
+      .then((r) => r.ok ? r.json() : null)
+      .then((res) => setGoldPricePerChi(res?.price_per_chi ?? null))
+      .catch(() => setGoldPricePerChi(null))
+  }, [enabled, goalId, refreshKey, txReload])
+
+  return { transactions, txLoading, txError, goldPricePerChi }
+}


### PR DESCRIPTION
Continues #467 (follow-up to #480).

## What & why
`GoalDetailSheet` (mobile) and `DesktopGoalDetail` duplicated the goal-detail **data-load effect** — a byte-identical `Promise.all` over `investment-transactions` + `recurring-contributions` (merge + newest-first sort) plus the `gold-price` fetch — and each declared its own copy of the `InvestmentTx` type.

Extracted both into **`useGoalDetailData`**:
- owns the `transactions` / `txLoading` / `txError` / `goldPricePerChi` state (all only ever set by that effect);
- takes an `enabled` gate — the mobile sheet loads only while `open`, the desktop panel always;
- takes an `onLoadStart` hook so each surface still resets its own optimistic unassign filter;
- the shared `InvestmentTx` type moves to the hook module (superset — the sheet also reads `fund_code` / `unit_price`).

Both components shed the effect + four `useState` + the local type; **behaviour is unchanged**.

## Testing
- **`useGoalDetailData.test.tsx`** (5 cases) — merge/newest-first sort, the disabled gate, the tx-failure and recurring-degrade paths, and `onLoadStart`. Since both surfaces now call this, it *is* the parity test.
- Existing `GoalDetailSheet` / `DesktopGoalDetail` component tests unchanged and green.
- Full unit **1183 passed**, lint **0 errors**, full E2E **237 passed**.

> The one E2E failure (`assign-goal-desktop` success-state) is the known timing flake — the full spec passes in isolation.

## Scope / follow-ups
- The **salary / delete-plan / other-expense** planning writes (originally noted as follow-up 2) were assessed and **left as-is**: those handlers genuinely diverge per surface (inline error vs toast, different success copy) and share only a trivial `fetch`, so folding them in would trade little dedup for added indirection.
- Remaining goal-detail follow-ups: **`useGoalActions`** (delete / unassign / unhold / edit-goal — identical handlers) and unifying `DesktopGoalDetail`'s **inline** sell/withdraw onto the shared `SellWithdrawSheet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)