### PR TITLE
fix(security): guard deposit_group_id in the FK-ownership trigger (#474)

### DIFF
--- a/supabase/migrations/20260723000001_fk_ownership_deposit_group.sql
+++ b/supabase/migrations/20260723000001_fk_ownership_deposit_group.sql
@@ -57,11 +57,13 @@ begin
         using errcode = 'check_violation';
     end if;
   end loop;
-  -- deposit_group_id — same rule, but a self-grouping anchor
+  -- deposit_group_id — same rule. The self-grouping anchor
   -- (deposit_group_id = its own transaction_id) references a row that doesn't
-  -- exist yet on INSERT, so allow it.
+  -- exist yet, so bypass the lookup ONLY on INSERT. On UPDATE the anchor row
+  -- already exists, so it's checked normally against NEW.user_id — which rejects
+  -- moving an owner-changed anchor away from its still-original-owner tranches.
   if new.deposit_group_id is not null
-     and new.deposit_group_id is distinct from new.transaction_id
+     and not (tg_op = 'INSERT' and new.deposit_group_id = new.transaction_id)
      and not exists (
        select 1 from public.investment_transactions where transaction_id = new.deposit_group_id and user_id = new.user_id
      ) then

--- a/supabase/migrations/20260723000001_fk_ownership_deposit_group.sql
+++ b/supabase/migrations/20260723000001_fk_ownership_deposit_group.sql
@@ -1,0 +1,81 @@
+-- Extend the FK-ownership backstop to deposit_group_id (#474 follow-up).
+--
+-- deposit_group_id is the anchor transaction id that groups an accumulating
+-- book's tranches, and the UI groups books solely by that value. It was the one
+-- transaction-to-transaction reference the ownership trigger didn't guard, so a
+-- service-role write (or a future endpoint that sets it directly) could still
+-- point a row at another user's transaction as its book group.
+--
+-- A brand-new book anchor self-groups: deposit_group_id = its own
+-- transaction_id, which doesn't exist yet during BEFORE INSERT — so allow the
+-- self-reference explicitly and only ownership-check a group that points at a
+-- different (must be same-owner) transaction.
+
+create or replace function public.enforce_investment_tx_fk_ownership()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_ref uuid;
+begin
+  if new.fund_id is not null and not exists (
+    select 1 from public.funds where id = new.fund_id and user_id = new.user_id
+  ) then
+    raise exception 'fund_id % does not belong to the transaction owner', new.fund_id
+      using errcode = 'check_violation';
+  end if;
+  if new.plan_id is not null and not exists (
+    select 1 from public.monthly_plans where id = new.plan_id and user_id = new.user_id
+  ) then
+    raise exception 'plan_id % does not belong to the transaction owner', new.plan_id
+      using errcode = 'check_violation';
+  end if;
+  -- goal_id and merge_target_goal_id are both savings-goal references (the latter
+  -- an app-managed one, not a physical FK) that must stay within one user.
+  foreach v_ref in array array[new.goal_id, new.merge_target_goal_id] loop
+    if v_ref is not null and not exists (
+      select 1 from public.savings_goals where goal_id = v_ref and user_id = new.user_id
+    ) then
+      raise exception 'goal reference % does not belong to the transaction owner', v_ref
+        using errcode = 'check_violation';
+    end if;
+  end loop;
+  -- Transaction-to-transaction references must stay within one user too, or a
+  -- caller who knows a foreign transaction UUID could point their own row at it.
+  foreach v_ref in array array[
+    new.parent_transaction_id,
+    new.renewed_from_transaction_id,
+    new.merge_anchor_inv_id,
+    new.consumed_by_inv_id
+  ] loop
+    if v_ref is not null and not exists (
+      select 1 from public.investment_transactions where transaction_id = v_ref and user_id = new.user_id
+    ) then
+      raise exception 'referenced transaction % does not belong to the transaction owner', v_ref
+        using errcode = 'check_violation';
+    end if;
+  end loop;
+  -- deposit_group_id — same rule, but a self-grouping anchor
+  -- (deposit_group_id = its own transaction_id) references a row that doesn't
+  -- exist yet on INSERT, so allow it.
+  if new.deposit_group_id is not null
+     and new.deposit_group_id is distinct from new.transaction_id
+     and not exists (
+       select 1 from public.investment_transactions where transaction_id = new.deposit_group_id and user_id = new.user_id
+     ) then
+    raise exception 'deposit_group_id % does not belong to the transaction owner', new.deposit_group_id
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists investment_transactions_fk_ownership on public.investment_transactions;
+create trigger investment_transactions_fk_ownership
+  before insert or update of
+    fund_id, goal_id, merge_target_goal_id, plan_id, user_id,
+    parent_transaction_id, renewed_from_transaction_id, merge_anchor_inv_id, consumed_by_inv_id, deposit_group_id
+  on public.investment_transactions
+  for each row execute function public.enforce_investment_tx_fk_ownership();

--- a/supabase/tests/fk_ownership.test.sql
+++ b/supabase/tests/fk_ownership.test.sql
@@ -113,11 +113,26 @@ begin
   end;
 
   -- A self-grouping book anchor (deposit_group_id = its own transaction_id) is
-  -- allowed even though that row doesn't exist yet at INSERT time.
+  -- allowed on INSERT even though that row doesn't exist yet — but the self
+  -- bypass must NOT extend to UPDATE, or a privileged owner-change would move the
+  -- anchor to another user while its tranches keep pointing at it.
   declare v_anchor uuid := gen_random_uuid();
   begin
     insert into public.investment_transactions (transaction_id, user_id, asset_type, transaction_type, investment_date, amount_vnd, deposit_group_id)
       values (v_anchor, v_b, 'bank', 'investment', '2099-01-01', 1000000, v_anchor);
+    -- A tranche in the same book (owned by B).
+    insert into public.investment_transactions (user_id, asset_type, transaction_type, investment_date, amount_vnd, deposit_group_id)
+      values (v_b, 'bank', 'investment', '2099-02-01', 500000, v_anchor);
+    -- Moving the anchor to A must be rejected (it would orphan B's tranches onto
+    -- a now-foreign anchor).
+    v_raised := false;
+    begin update public.investment_transactions set user_id = v_a where transaction_id = v_anchor;
+    exception when others then v_raised := true; end;
+    if not v_raised then raise exception 'changing a grouped anchor owner must be rejected'; end if;
+    -- The group stays single-owner.
+    if exists (select 1 from public.investment_transactions where deposit_group_id = v_anchor and user_id <> v_b) then
+      raise exception 'grouped book must remain single-owner';
+    end if;
   end;
 
   -- 5) Legitimate same-owner references must succeed (no exception).

--- a/supabase/tests/fk_ownership.test.sql
+++ b/supabase/tests/fk_ownership.test.sql
@@ -104,6 +104,20 @@ begin
     begin update public.investment_transactions set plan_id = v_plan_a where transaction_id = v_tx2;
     exception when others then v_raised := true; end;
     if not v_raised then raise exception 'cross-user plan_id must be rejected'; end if;
+
+    -- deposit_group_id pointing at A's transaction must be rejected.
+    v_raised := false;
+    begin update public.investment_transactions set deposit_group_id = v_tx_a where transaction_id = v_tx2;
+    exception when others then v_raised := true; end;
+    if not v_raised then raise exception 'cross-user deposit_group_id must be rejected'; end if;
+  end;
+
+  -- A self-grouping book anchor (deposit_group_id = its own transaction_id) is
+  -- allowed even though that row doesn't exist yet at INSERT time.
+  declare v_anchor uuid := gen_random_uuid();
+  begin
+    insert into public.investment_transactions (transaction_id, user_id, asset_type, transaction_type, investment_date, amount_vnd, deposit_group_id)
+      values (v_anchor, v_b, 'bank', 'investment', '2099-01-01', 1000000, v_anchor);
   end;
 
   -- 5) Legitimate same-owner references must succeed (no exception).


### PR DESCRIPTION
Follow-up to a **Codex review comment on #479 that arrived right before it merged** — so it couldn't be folded into that PR.

## Gap
`enforce_investment_tx_fk_ownership` (from #479) guards every FK on `investment_transactions` — `fund_id`, `goal_id`, `merge_target_goal_id`, `plan_id`, and the four self-referential transaction FKs — **except `deposit_group_id`**.

`deposit_group_id` is the anchor transaction id that groups an accumulating book's tranches, and the UI groups books **solely** by that value. So a service-role write (or a future endpoint that sets it directly) could still point a user's row at **another user's** transaction as its book group — one transaction-to-transaction reference left outside the DB backstop.

> Not reachable through the current API (the routes derive `deposit_group_id` from an already-ownership-checked anchor, never from raw input) — this is defense-in-depth, closing the backstop for service-role / future paths.

## Fix (`20260723000001_fk_ownership_deposit_group.sql`)
`create or replace` the trigger function to also same-owner-check `deposit_group_id`, and add it to the trigger's `UPDATE OF` list. A brand-new book anchor **self-groups** (`deposit_group_id = its own transaction_id`), and that row doesn't exist yet during `BEFORE INSERT`, so the check explicitly allows `deposit_group_id = NEW.transaction_id`.

## Testing
- **`fk_ownership.test.sql`** extended: a cross-user `deposit_group_id` is **rejected** on UPDATE, and a **self-grouping anchor INSERT is allowed**.
- `npm run test:db` green.
- **Full E2E 240 passed** — every accumulating-book flow (top-up / collapse / renew / merge / withdraw) is unaffected by the new check + self-anchor allowance.
- Lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)