### PR TITLE
fix(plans): backfill DCA rows orphaned by pre-trigger plan deletes (#472)

### DIFF
--- a/supabase/migrations/20260723000002_backfill_orphan_pending_dca.sql
+++ b/supabase/migrations/20260723000002_backfill_orphan_pending_dca.sql
@@ -1,0 +1,21 @@
+-- One-time backfill for pending seeded DCA rows orphaned by plan deletes that
+-- happened BEFORE the 20260722000003 BEFORE-DELETE trigger existed (#472 follow-up).
+--
+-- That trigger removes a plan's pending seeded rows on delete, but it can only
+-- match rows that still carry the plan id. Any plan deleted earlier already had
+-- investment_transactions.plan_id set to NULL by the ON DELETE SET NULL FK, so
+-- its pending seeded rows were left behind — planning artifacts with no plan
+-- that still leak through the transaction/history and goal-stats APIs.
+--
+-- Remove those orphans now so the invariant holds for existing data too. The
+-- filter is exactly a pending auto-seeded fund allocation with no plan:
+--   is_dca_seeded  → only ever set on rows the seeding RPC created (always with a
+--                    plan), so is_dca_seeded + plan_id IS NULL means the plan is gone
+--   units IS NULL  → never recorded; a real purchase (units set) is preserved
+-- A still-planned pending row keeps its plan_id (excluded), a recorded buy keeps
+-- its units (excluded), and a manual fund tx is not is_dca_seeded (excluded).
+delete from public.investment_transactions
+ where plan_id is null
+   and asset_type = 'fund'
+   and is_dca_seeded
+   and units is null;

--- a/supabase/tests/backfill_orphan_dca.test.sql
+++ b/supabase/tests/backfill_orphan_dca.test.sql
@@ -1,0 +1,60 @@
+-- Regression for the one-time orphan backfill in
+-- 20260723000002_backfill_orphan_pending_dca.sql (#472 follow-up).
+--
+-- The backfill must remove ONLY pending seeded DCA fund rows detached from their
+-- plan (plan_id NULL, is_dca_seeded, units NULL) and leave everything else:
+-- a still-planned pending row, a recorded (detached) buy, and a manual fund tx.
+--
+-- Runs against the local stack inside a rolled-back transaction; a failed
+-- assertion RAISEs and, under `psql -v ON_ERROR_STOP=1`, exits non-zero.
+-- Run via `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_user uuid;
+  v_fund uuid;
+  v_plan uuid;
+  v_orphan uuid;      -- pending seeded, plan gone (plan_id NULL) → must be deleted
+  v_planned uuid;     -- pending seeded, still has a plan          → survives
+  v_recorded uuid;    -- seeded but recorded (units set), detached → survives
+  v_manual uuid;      -- manual fund tx (not seeded)               → survives
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'backfill@test.invalid') returning id into v_user;
+  insert into public.funds (user_id, name, code, fund_type, nav) values (v_user, 'Fund', 'BKF', 'equity', 20000) returning id into v_fund;
+  insert into public.monthly_plans (user_id, month, year, salary_vnd) values (v_user, 11, 2099, 50000000) returning id into v_plan;
+
+  insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, is_dca_seeded, units, plan_id)
+    values (v_user, v_fund, 'fund', 'investment', '2099-11-01', 2000000, true, null, null) returning transaction_id into v_orphan;
+  insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, is_dca_seeded, units, plan_id)
+    values (v_user, v_fund, 'fund', 'investment', '2099-11-01', 2000000, true, null, v_plan) returning transaction_id into v_planned;
+  insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, is_dca_seeded, units, unit_price, plan_id)
+    values (v_user, v_fund, 'fund', 'investment', '2099-11-01', 2000000, true, 100, 20000, null) returning transaction_id into v_recorded;
+  insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, is_dca_seeded, units, plan_id)
+    values (v_user, v_fund, 'fund', 'investment', '2099-11-01', 3000000, false, null, null) returning transaction_id into v_manual;
+
+  -- The backfill statement, verbatim.
+  delete from public.investment_transactions
+   where plan_id is null
+     and asset_type = 'fund'
+     and is_dca_seeded
+     and units is null;
+
+  if exists (select 1 from public.investment_transactions where transaction_id = v_orphan) then
+    raise exception 'orphaned pending seeded row should have been deleted';
+  end if;
+  if not exists (select 1 from public.investment_transactions where transaction_id = v_planned) then
+    raise exception 'a still-planned pending row must survive';
+  end if;
+  if not exists (select 1 from public.investment_transactions where transaction_id = v_recorded) then
+    raise exception 'a recorded (units-bearing) buy must survive';
+  end if;
+  if not exists (select 1 from public.investment_transactions where transaction_id = v_manual) then
+    raise exception 'a manual (non-seeded) fund tx must survive';
+  end if;
+
+  raise notice 'backfill_orphan_dca.test.sql: OK';
+end $$;
+
+rollback;


### PR DESCRIPTION
Follow-up to a **Codex review comment on #478 that arrived ~1 min after it merged** — so it couldn't be folded into that PR.

## Gap
The `20260722000003` `BEFORE DELETE` trigger removes a plan's pending seeded DCA rows on delete, but only matches rows that still carry the plan id (`plan_id = OLD.id`). Any plan deleted **before** that migration already had its rows' `plan_id` set to `NULL` by the `ON DELETE SET NULL` FK — so those pending seeds were left behind: planning artifacts with no plan that still leak through the transaction/history and goal-stats APIs. The trigger fixes future deletes but not existing data.

## Fix (`20260723000002_backfill_orphan_pending_dca.sql`)
A one-time backfill removing orphaned pending seeded fund rows:

```sql
delete from public.investment_transactions
 where plan_id is null and asset_type = 'fund' and is_dca_seeded and units is null;
```

The filter is exactly a detached, never-recorded auto-seed:
- `is_dca_seeded` is only ever set on rows the seeding RPC created (always with a plan), so `is_dca_seeded + plan_id IS NULL` means the plan is gone;
- `units IS NULL` means never recorded — a real purchase is preserved.

A still-planned pending row (`plan_id` set), a recorded buy (`units` set), and a manual fund tx (not seeded) are all excluded.

## Testing
- **`backfill_orphan_dca.test.sql`** seeds one of each (orphan / still-planned / recorded / manual) and asserts **only the orphan** is removed.
- `npm run test:db` green (all four suites).

Migration-only change; no app/runtime behaviour changes (the #478 trigger still handles future deletes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)