### PR TITLE
fix(tooling): exclude .claude local worktrees from Vitest & ESLint (#469)

### DIFF
--- a/__tests__/tooling-ignores.test.ts
+++ b/__tests__/tooling-ignores.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// Regression guard for #469: the tooling configs must exclude the gitignored
+// local git worktrees under `.claude/` (stale repo copies other Claude sessions
+// check out). Without this, `npm test` / `npm run lint` discover those nested
+// *.test files and sources and report failures/errors from a different checkout.
+const root = path.resolve(__dirname, '..')
+
+describe('tooling excludes local worktrees (#469)', () => {
+  it('vitest.config.ts excludes .claude from test discovery', () => {
+    const cfg = readFileSync(path.join(root, 'vitest.config.ts'), 'utf8')
+    expect(cfg).toMatch(/exclude:\s*\[[^\]]*\.claude/s)
+  })
+
+  it('eslint.config.mjs ignores .claude', () => {
+    const cfg = readFileSync(path.join(root, 'eslint.config.mjs'), 'utf8')
+    expect(cfg).toMatch(/globalIgnores\(\[[^\]]*\.claude/s)
+  })
+})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -12,6 +12,9 @@ const eslintConfig = defineConfig([
     "out/**",
     "build/**",
     "next-env.d.ts",
+    // Gitignored local git worktrees (stale repo copies checked out by other
+    // Claude sessions) — don't lint their sources as if they were ours (#469).
+    ".claude/**",
   ]),
   {
     rules: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,11 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./vitest.setup.ts'],
     globals: true,
-    exclude: ['**/node_modules/**', '**/e2e/**'],
+    // `.claude/worktrees` holds gitignored local git worktrees (stale copies of
+    // the repo other Claude sessions check out). They contain their own *.test
+    // files, which vitest would otherwise discover and run — reporting failures
+    // from a stale checkout, not this one (#469).
+    exclude: ['**/node_modules/**', '**/e2e/**', '**/.claude/**'],
   },
   resolve: {
     alias: { '@': path.resolve(__dirname, '.') },


### PR DESCRIPTION
Closes #469.

## Problem
`.claude/worktrees` holds **gitignored local git worktrees** — stale copies of the repo that other Claude sessions check out. They carry their own `*.test` files and sources, and neither Vitest nor the default `eslint` command excluded them. So `npm test` / `npm run lint`, run from the main checkout, discovered and scanned those nested trees — a stale worktree could report a failure or lint error unrelated to the current tree (exactly the false 1131-vs-stale failure noted in the issue).

Sibling worktrees (`../allocate-*`) sit outside the repo root and were never scanned; the in-repo `.claude/worktrees` was the gap.

## Fix
- **`vitest.config.ts`** — add `**/.claude/**` to `test.exclude`.
- **`eslint.config.mjs`** — add `.claude/**` to `globalIgnores`.

Both carry an inline comment explaining why.

## Acceptance criteria
- [x] Vitest excludes `.claude/worktrees` and other nested worktree directories.
- [x] ESLint excludes the same.
- [x] `npm test` / `npm run lint` inspect only the intended checkout.
- [x] The ignore list is documented (inline) **and** covered by a regression check.

## Testing
- **`__tests__/tooling-ignores.test.ts`** — regression guard asserting each config keeps the exclusion.
- Verified end-to-end: with a **failing** `*.test.ts` and a **lint-erroring** `.ts` planted under `.claude/worktrees/dummy/`, `npm test` stays green (the nested test isn't discovered — `vitest list` shows 0 `.claude/worktrees` paths) and `npm run lint` stays at 0 errors (the nested file isn't referenced).
- Full unit **1196 passed**, lint 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)