### PR TITLE
fix(tooling): restore a clean, deterministic TypeScript typecheck (#468)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Typecheck
+        run: npm run typecheck
+
       - name: Run unit tests
         run: npm test -- --run
 

--- a/__tests__/tooling-ignores.test.ts
+++ b/__tests__/tooling-ignores.test.ts
@@ -11,11 +11,33 @@ const root = path.resolve(__dirname, '..')
 describe('tooling excludes local worktrees (#469)', () => {
   it('vitest.config.ts excludes .claude from test discovery', () => {
     const cfg = readFileSync(path.join(root, 'vitest.config.ts'), 'utf8')
-    expect(cfg).toMatch(/exclude:\s*\[[^\]]*\.claude/s)
+    expect(cfg).toMatch(/exclude:\s*\[[^\]]*\.claude/)
   })
 
   it('eslint.config.mjs ignores .claude', () => {
     const cfg = readFileSync(path.join(root, 'eslint.config.mjs'), 'utf8')
-    expect(cfg).toMatch(/globalIgnores\(\[[^\]]*\.claude/s)
+    expect(cfg).toMatch(/globalIgnores\(\[[^\]]*\.claude/)
+  })
+})
+
+// Regression guard for #468: the typecheck must be deterministic — its result may
+// not depend on the generated `.next` build artifact. The dedicated tsconfig drops
+// `.next` from discovery, and a `typecheck` script + CI step keep the gate wired up.
+describe('deterministic typecheck config (#468)', () => {
+  it('tsconfig.typecheck.json excludes the generated .next artifact', () => {
+    // Read as text — tsconfig is JSONC (has comments), which JSON.parse rejects.
+    const cfg = readFileSync(path.join(root, 'tsconfig.typecheck.json'), 'utf8')
+    expect(cfg).toMatch(/"exclude":\s*\[[^\]]*"\.next"/)
+    expect(cfg).not.toMatch(/"include":\s*\[[^\]]*\.next\/types/)
+  })
+
+  it('package.json exposes a typecheck script that uses that config', () => {
+    const pkg = JSON.parse(readFileSync(path.join(root, 'package.json'), 'utf8'))
+    expect(pkg.scripts.typecheck).toMatch(/tsc --noEmit .*tsconfig\.typecheck\.json/)
+  })
+
+  it('CI runs the typecheck command', () => {
+    const ci = readFileSync(path.join(root, '.github/workflows/ci.yml'), 'utf8')
+    expect(ci).toMatch(/npm run typecheck/)
   })
 })

--- a/__tests__/tooling-ignores.test.ts
+++ b/__tests__/tooling-ignores.test.ts
@@ -21,14 +21,39 @@ describe('tooling excludes local worktrees (#469)', () => {
 })
 
 // Regression guard for #468: the typecheck must be deterministic — its result may
-// not depend on the generated `.next` build artifact. The dedicated tsconfig drops
-// `.next` from discovery, and a `typecheck` script + CI step keep the gate wired up.
+// not depend on the generated `.next` build artifact. `.next` enters a normal
+// typecheck via TWO paths, and the guard must cover both, because `exclude` only
+// blocks one of them:
+//   1. Discovery — the base config globs in `.next/types/**`. `exclude` drops it.
+//   2. Import — `next-env.d.ts` ends with `import "./.next/dev/types/routes.d.ts"`.
+//      `exclude` CANNOT block an imported file, so next-env.d.ts is kept out of the
+//      program and replaced by a shim carrying only stable `next` references.
+// (The effective graph was verified manually with `tsc --listFilesOnly`: planting a
+// broken `.next/dev/types/routes.d.ts` leaves the typecheck at 0 errors and absent
+// from the file list. These fast structural assertions lock that wiring in place.)
 describe('deterministic typecheck config (#468)', () => {
-  it('tsconfig.typecheck.json excludes the generated .next artifact', () => {
-    // Read as text — tsconfig is JSONC (has comments), which JSON.parse rejects.
-    const cfg = readFileSync(path.join(root, 'tsconfig.typecheck.json'), 'utf8')
+  // Read as text — tsconfig is JSONC (has comments), which JSON.parse rejects.
+  const cfg = readFileSync(path.join(root, 'tsconfig.typecheck.json'), 'utf8')
+
+  it('drops the generated .next artifact from glob discovery', () => {
     expect(cfg).toMatch(/"exclude":\s*\[[^\]]*"\.next"/)
     expect(cfg).not.toMatch(/"include":\s*\[[^\]]*\.next\/types/)
+  })
+
+  it('keeps next-env.d.ts (which imports .next route types) out of the program', () => {
+    // Covers the import path exclude can't: next-env.d.ts must be excluded AND not
+    // re-added through include, or its `.next` route import re-enters the graph.
+    expect(cfg).toMatch(/"exclude":\s*\[[^\]]*"next-env\.d\.ts"/)
+    expect(cfg).not.toMatch(/"include":\s*\[[^\]]*next-env\.d\.ts/)
+  })
+
+  it('substitutes a shim that reintroduces no dependency on .next', () => {
+    expect(cfg).toMatch(/"include":\s*\[[^\]]*tsconfig\.typecheck\.d\.ts/)
+    const shim = readFileSync(path.join(root, 'tsconfig.typecheck.d.ts'), 'utf8')
+    // Drop `//` comment lines but keep `///` triple-slash directives (the references).
+    const directives = shim.split('\n').filter((l) => !/^\s*\/\/($|[^/])/.test(l)).join('\n')
+    expect(directives).not.toMatch(/\.next/)          // no build-dependent reference/import
+    expect(directives).toMatch(/reference types="next"/) // still supplies Next ambient types
   })
 
   it('package.json exposes a typecheck script that uses that config', () => {

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.dca.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.dca.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Mock } from 'vitest'
 import { useState } from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -50,7 +51,7 @@ function Harness({ initial, reload }: { initial: Fund[]; reload: () => Promise<v
 }
 
 let fetchMock: ReturnType<typeof vi.fn>
-let reload: ReturnType<typeof vi.fn>
+let reload: Mock<() => Promise<void>>
 
 beforeEach(() => {
   fetchMock = vi.fn(() => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) }))

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.delete.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.delete.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Mock } from 'vitest'
 import { useState } from 'react'
 import { render, screen, within, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -24,7 +25,7 @@ function Harness({ reload }: { reload: () => Promise<void> }) {
   return <DesktopFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={reload} />
 }
 
-let reload: ReturnType<typeof vi.fn>
+let reload: Mock<() => Promise<void>>
 afterEach(() => vi.unstubAllGlobals())
 beforeEach(() => { reload = vi.fn(() => Promise.resolve()) })
 

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.dca.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.dca.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Mock } from 'vitest'
 import { useState } from 'react'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -52,7 +53,7 @@ function Harness({ initial, reload }: { initial: Fund[]; reload: () => Promise<v
 }
 
 let fetchMock: ReturnType<typeof vi.fn>
-let reload: ReturnType<typeof vi.fn>
+let reload: Mock<() => Promise<void>>
 
 beforeEach(() => {
   fetchMock = vi.fn(() => Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) }))

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.delete.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.delete.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { Mock } from 'vitest'
 import { useState } from 'react'
 import { render, screen, within, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -25,7 +26,7 @@ function Harness({ reload }: { reload: () => Promise<void> }) {
   return <MobileFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={reload} />
 }
 
-let reload: ReturnType<typeof vi.fn>
+let reload: Mock<() => Promise<void>>
 afterEach(() => vi.unstubAllGlobals())
 beforeEach(() => { reload = vi.fn(() => Promise.resolve()) })
 

--- a/app/(app)/planning/__tests__/PlanningClient.test.tsx
+++ b/app/(app)/planning/__tests__/PlanningClient.test.tsx
@@ -49,7 +49,7 @@ describe('PlanningClient — error vs empty on plan fetch', () => {
   })
 
   it('shows the empty state on 404 (no plan yet), not the error state', async () => {
-    const fetchMock = vi.fn((url: string) => {
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       const u = String(url)
       if (u.includes('/api/v1/monthly-plans?')) {
         return Promise.resolve({ ok: false, status: 404, json: () => Promise.resolve({ error: 'Plan not found for this month' }) })
@@ -82,7 +82,7 @@ describe('PlanningClient — error vs empty on plan fetch', () => {
 
   it('retry refetches and renders the plan once the request succeeds', async () => {
     let call = 0
-    const fetchMock = vi.fn((url: string) => {
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       const u = String(url)
       if (u.includes('/api/v1/monthly-plans?')) {
         call += 1
@@ -107,7 +107,7 @@ describe('PlanningClient — error vs empty on plan fetch', () => {
 
 describe('PlanningClient — toast delivery', () => {
   it('surfaces a confirmation toast (via sonner) after a successful income edit', async () => {
-    const fetchMock = vi.fn((url: string) => {
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       const u = String(url)
       // GET the full monthly plan (initial load + refetch after save).
       if (u.includes('/api/v1/monthly-plans?')) {
@@ -139,7 +139,7 @@ describe('PlanningClient — toast delivery', () => {
   // failed silently with the error toast. Mobile already used PUT — this pins
   // desktop to the same method so both views hit a real handler.
   it('updates an existing plan with PUT (not PATCH → 405) from the desktop income editor', async () => {
-    const fetchMock = vi.fn((url: string) => {
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       const u = String(url)
       if (u.includes('/api/v1/monthly-plans?')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve(FULL_PLAN) })

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -54,6 +54,8 @@ const defaultProps = {
   funds: [],
   goals: [],
   loading: false,
+  error: false,
+  onRetry: vi.fn(),
   onPrev: vi.fn(),
   onNext: vi.fn(),
   onToday: vi.fn(),

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -445,7 +445,7 @@ describe('MobilePlanningView — recurring savings in By goal', () => {
 
   it('opens the full Add-Transaction sheet (not the mini popup) when Buy is clicked', async () => {
     // The canonical Add-Transaction sheet fetches funds + goals on open.
-    const fetchMock = vi.fn((url: string) =>
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) =>
       Promise.resolve({
         ok: true,
         json: () => Promise.resolve(String(url).includes('savings-goals') ? { goals: [] } : []),
@@ -478,7 +478,7 @@ describe('MobilePlanningView — recurring savings in By goal', () => {
   })
 
   it('opens the Add-Transaction sheet when the goal "+" is clicked', async () => {
-    const fetchMock = vi.fn((url: string) =>
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) =>
       Promise.resolve({
         ok: true,
         json: () => Promise.resolve(String(url).includes('savings-goals') ? { goals: [] } : []),
@@ -552,7 +552,7 @@ describe('MobilePlanningView — save error feedback (no false success)', () => 
   ]
 
   it('fixed-expense override failure shows an error toast and keeps the sheet open', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'boom' }) }))
+    const fetchMock = vi.fn((_url?: string, _init?: RequestInit) => Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'boom' }) }))
     vi.stubGlobal('fetch', fetchMock)
     toastErrorMock.mockClear()
     const onToast = vi.fn()
@@ -571,7 +571,7 @@ describe('MobilePlanningView — save error feedback (no false success)', () => 
   })
 
   it('skip failure shows an error toast and does not report success', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'boom' }) }))
+    const fetchMock = vi.fn((_url?: string, _init?: RequestInit) => Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'boom' }) }))
     vi.stubGlobal('fetch', fetchMock)
     toastErrorMock.mockClear()
     const onToast = vi.fn()
@@ -587,7 +587,7 @@ describe('MobilePlanningView — save error feedback (no false success)', () => 
   })
 
   it('recurring override writes once to the correct endpoint (not the insurance endpoint)', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
+    const fetchMock = vi.fn((_url?: string, _init?: RequestInit) => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
     vi.stubGlobal('fetch', fetchMock)
     const onToast = vi.fn()
     try {
@@ -688,7 +688,7 @@ describe('MobilePlanningView — overridden-item restore parity + recurring deep
     const recurringSavings = [
       { saving_id: 'rs1', name: 'VCB Savings', goal_id: 'g1', amount_vnd: 2_000_000, effective_from: null, effective_to: null, savings_goals: { goal_name: 'Retirement' } },
     ]
-    const fetchMock = vi.fn((url: string) => {
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       const u = String(url)
       if (u.includes('/api/v1/recurring-savings')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve({ savings: [{ saving_id: 'rs1', name: 'VCB Savings', goal_id: 'g1', amount_vnd: 2_000_000, effective_from: null, effective_to: null, linked_deposit_tx_id: null }] }) })
@@ -714,7 +714,7 @@ describe('MobilePlanningView — overridden-item restore parity + recurring deep
     const recurringSavings = [
       { saving_id: 'rs1', name: 'VCB Savings', goal_id: 'g1', amount_vnd: 2_000_000, effective_from: null, effective_to: null, savings_goals: { goal_name: 'Retirement' } },
     ]
-    const fetchMock = vi.fn((url: string) => {
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       const u = String(url)
       if (u.includes('/api/v1/recurring-savings')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve({ savings: [{ saving_id: 'rs1', name: 'VCB Savings', goal_id: 'g1', amount_vnd: 2_000_000, effective_from: null, effective_to: null, linked_deposit_tx_id: null }] }) })

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -9,7 +9,6 @@ import { todayIso } from '@/lib/dates'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { AffectsProgressControl } from './goalDetailShared'
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const fmtVND = (n: number, _locale?: string) => fmt(n)
 
 export interface SellItem {

--- a/app/assets/components/__tests__/AddTransactionSheet.test.tsx
+++ b/app/assets/components/__tests__/AddTransactionSheet.test.tsx
@@ -11,7 +11,7 @@ vi.mock('next-intl', () => ({
 beforeEach(() => {
   mockLocale = 'en'
   document.body.style.overflow = ''
-  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => Promise.resolve([]) })))
+  vi.stubGlobal('fetch', vi.fn((_url?: string, _init?: RequestInit) => Promise.resolve({ json: () => Promise.resolve([]) })))
 })
 
 describe('AddTransactionSheet — background scroll lock (issue #219)', () => {
@@ -58,7 +58,7 @@ describe('AddTransactionSheet — background scroll lock (issue #219)', () => {
 
 describe('AddTransactionSheet — sell holdings load error vs empty', () => {
   it('shows a retry state (not "no holdings") when the holdings fetch fails', async () => {
-    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) })))
+    vi.stubGlobal('fetch', vi.fn((_url?: string, _init?: RequestInit) => Promise.resolve({ ok: false, json: () => Promise.resolve({}) })))
 
     render(<AddTransactionSheet open onClose={vi.fn()} />)
     fireEvent.click(screen.getByRole('button', { name: 'sell' }))
@@ -71,7 +71,7 @@ describe('AddTransactionSheet — sell holdings load error vs empty', () => {
     // Key off the overview URL — the sheet fires other fetches on open that
     // would otherwise consume a blind call counter.
     let overviewCalls = 0
-    vi.stubGlobal('fetch', vi.fn((url: string) => {
+    vi.stubGlobal('fetch', vi.fn((url: string, _init?: RequestInit) => {
       if (String(url).includes('/dashboard/overview')) {
         overviewCalls += 1
         if (overviewCalls === 1) return Promise.resolve({ ok: false, json: () => Promise.resolve({}) })
@@ -97,7 +97,7 @@ describe('AddTransactionSheet — goal selector (issue #232)', () => {
   // /api/v1/savings-goals returns { goals: [...] }, not a bare array — the goal
   // selector must read that shape or it stays empty/hidden.
   it('populates the goal select from the { goals } API shape', async () => {
-    const fetchMock = vi.fn((url: string) => {
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       if (String(url).includes('/savings-goals')) {
         return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [{ goal_id: 'g1', goal_name: 'House Fund' }] }) })
       }
@@ -117,7 +117,7 @@ describe('AddTransactionSheet — sell flow (issue #232)', () => {
       goals: [{ goalName: 'Goal A', funds: [{ fundId: 'f1', fundName: 'VESAF', quantity: 100, currentNAV: 20000, currentValue: 2_000_000, purchasePrice: 18000, profitLossPercentage: 11.11 }] }],
       unallocated: { funds: [], nonFunds: [] },
     }
-    const fetchMock = vi.fn((url: string) => {
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       if (String(url).includes('/dashboard/overview')) return Promise.resolve({ ok: true, json: () => Promise.resolve(overview) })
       if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [] }) })
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
@@ -151,7 +151,7 @@ describe('AddTransactionSheet — fund sell units field (two-way linked)', () =>
       goals: [{ goalName: 'Goal A', funds: [{ fundId: 'f1', fundName: 'VESAF', quantity: 100, currentNAV: 20000, currentValue: 2_000_000, purchasePrice: 18000, profitLossPercentage: 11.11 }] }],
       unallocated: { funds: [], nonFunds: [] },
     }
-    const fetchMock = vi.fn((url: string) => {
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       if (String(url).includes('/dashboard/overview')) return Promise.resolve({ ok: true, json: () => Promise.resolve(overview) })
       if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [] }) })
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
@@ -183,7 +183,7 @@ describe('AddTransactionSheet — bank withdraw (received + principal portion)',
       goals: [{ goalName: 'Goal A', funds: [], nonFunds: [{ transactionId: 't1', type: 'bank', amount: 5_000_000, currentValue: 5_200_000, interestRate: 6, units: null, notes: 'Techcombank' }] }],
       unallocated: { funds: [], nonFunds: [] },
     }
-    const fetchMock = vi.fn((url: string) => {
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       if (String(url).includes('/dashboard/overview')) return Promise.resolve({ ok: true, json: () => Promise.resolve(overview) })
       if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [] }) })
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
@@ -216,7 +216,7 @@ describe('AddTransactionSheet — sell lists goal-allocated bank/gold (issue #23
       goals: [{ goalName: 'Goal A', funds: [], nonFunds: [{ transactionId: 't1', type: 'bank', amount: 5_000_000, currentValue: 5_200_000, interestRate: 6, units: null, notes: 'Techcombank' }] }],
       unallocated: { funds: [], nonFunds: [] },
     }
-    const fetchMock = vi.fn((url: string) => {
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       if (String(url).includes('/dashboard/overview')) return Promise.resolve({ ok: true, json: () => Promise.resolve(overview) })
       if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [] }) })
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
@@ -238,7 +238,7 @@ describe('AddTransactionSheet — gold sell (quantity × price) (issue #232)', (
       goals: [],
       unallocated: { funds: [], nonFunds: [{ transactionId: 'g1', type: 'gold', amount: 9_000_000, currentValue: 9_200_000, interestRate: null, units: 1, notes: 'PNJ' }] },
     }
-    const fetchMock = vi.fn((url: string) => {
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       if (String(url).includes('/dashboard/overview')) return Promise.resolve({ ok: true, json: () => Promise.resolve(overview) })
       if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [] }) })
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
@@ -268,7 +268,7 @@ describe('AddTransactionSheet — gold sell (quantity × price) (issue #232)', (
 })
 
 describe('AddTransactionSheet — editable NAV on a fund buy', () => {
-  const fundsAndGoals = (url: string) => {
+  const fundsAndGoals = (url: string, _init?: RequestInit) => {
     if (String(url).includes('/funds')) {
       return Promise.resolve({ ok: true, json: () => Promise.resolve([{ id: 'f1', name: 'VESAF', nav: 20000, code: 'VES', fund_type: 'equity' }]) })
     }
@@ -330,7 +330,7 @@ describe('AddTransactionSheet — bank term interest receivable (issue #245)', (
   // The box should show the interest the user actually receives by maturity,
   // prorated over the deposit term — not the full-year interest.
   it('prorates interest to the maturity date instead of showing interest/yr', () => {
-    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
+    const fetchMock = vi.fn((_url?: string, _init?: RequestInit) => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
     vi.stubGlobal('fetch', fetchMock)
 
     const { container } = render(<AddTransactionSheet open onClose={vi.fn()} />)
@@ -354,7 +354,7 @@ describe('AddTransactionSheet — bank term interest receivable (issue #245)', (
   })
 
   it('hides the interest box until a maturity date is set', () => {
-    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
+    const fetchMock = vi.fn((_url?: string, _init?: RequestInit) => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
     vi.stubGlobal('fetch', fetchMock)
 
     render(<AddTransactionSheet open onClose={vi.fn()} />)
@@ -370,7 +370,7 @@ describe('AddTransactionSheet — bank term interest receivable (issue #245)', (
 describe('AddTransactionSheet — gold unit (issue #232)', () => {
   // Gold is valued per chỉ, so a lượng entry must be normalized: 1 lượng = 10 chỉ.
   it('normalizes a lượng entry to chỉ on save', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
+    const fetchMock = vi.fn((_url?: string, _init?: RequestInit) => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }))
     vi.stubGlobal('fetch', fetchMock)
 
     render(<AddTransactionSheet open onClose={vi.fn()} onSaved={vi.fn()} />)
@@ -499,7 +499,7 @@ describe('AddTransactionSheet — structured bank (bank_code)', () => {
 
 describe('AddTransactionSheet — prefill create mode (plan contribution)', () => {
   it('posts a new bank deposit carrying plan_id and goal_id', async () => {
-    const fetchMock = vi.fn((url: string) => {
+    const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
       if (String(url).includes('/savings-goals')) return Promise.resolve({ ok: true, json: () => Promise.resolve({ goals: [{ goal_id: 'g1', goal_name: 'Retirement' }] }) })
       return Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
     })

--- a/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
+++ b/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
@@ -9,12 +9,12 @@ vi.mock('next-intl', () => ({
 
 beforeEach(() => {
   document.body.style.overflow = ''
-  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })))
+  vi.stubGlobal('fetch', vi.fn((_url?: string, _init?: RequestInit) => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })))
 })
 
 describe('SellWithdrawSheet — bank withdraw (received + principal portion)', () => {
   it('defaults received to current value and posts received + principal portion', async () => {
-    const fetchMock = vi.fn(() =>
+    const fetchMock = vi.fn((_url?: string, _init?: RequestInit) =>
       Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
     vi.stubGlobal('fetch', fetchMock)
 
@@ -42,7 +42,7 @@ describe('SellWithdrawSheet — bank withdraw (received + principal portion)', (
 
 describe('SellWithdrawSheet — links the withdrawal to its goal (issue #261)', () => {
   it('posts goal_id when withdrawing in a goal context', async () => {
-    const fetchMock = vi.fn(() =>
+    const fetchMock = vi.fn((_url?: string, _init?: RequestInit) =>
       Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
     vi.stubGlobal('fetch', fetchMock)
 
@@ -65,7 +65,7 @@ describe('SellWithdrawSheet — links the withdrawal to its goal (issue #261)', 
   })
 
   it('keeps goal_id null in the unallocated context', async () => {
-    const fetchMock = vi.fn(() =>
+    const fetchMock = vi.fn((_url?: string, _init?: RequestInit) =>
       Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
     vi.stubGlobal('fetch', fetchMock)
 
@@ -112,7 +112,7 @@ describe('SellWithdrawSheet — count toward goal progress toggle', () => {
   }
 
   it('shows the toggle in goal context and posts affects_progress=true by default', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
+    const fetchMock = vi.fn((_url?: string, _init?: RequestInit) => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
     vi.stubGlobal('fetch', fetchMock)
 
     render(<SellWithdrawSheet item={bankItem} open context="goal" goalId="g1" goalCurrentValue={20_000_000} goalTargetAmount={50_000_000} onClose={vi.fn()} onSuccess={vi.fn()} />)
@@ -130,7 +130,7 @@ describe('SellWithdrawSheet — count toward goal progress toggle', () => {
   })
 
   it('posts affects_progress=false after toggling the switch off', async () => {
-    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
+    const fetchMock = vi.fn((_url?: string, _init?: RequestInit) => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
     vi.stubGlobal('fetch', fetchMock)
 
     render(<SellWithdrawSheet item={bankItem} open context="goal" goalId="g1" goalCurrentValue={20_000_000} goalTargetAmount={50_000_000} onClose={vi.fn()} onSuccess={vi.fn()} />)
@@ -154,7 +154,7 @@ describe('SellWithdrawSheet — count toward goal progress toggle', () => {
 
 describe('SellWithdrawSheet — gold sell (quantity × price) (issue #232)', () => {
   it('prefills the price and posts proceeds + cost basis', async () => {
-    const fetchMock = vi.fn(() =>
+    const fetchMock = vi.fn((_url?: string, _init?: RequestInit) =>
       Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
     vi.stubGlobal('fetch', fetchMock)
 
@@ -186,7 +186,7 @@ describe('SellWithdrawSheet — error path shows a real message (not a raw i18n 
   // Regression: the catch/!res.ok paths used useTranslations('Dashboard').t('sellError'),
   // but that namespace/key never existed → the error path leaked a raw key or threw.
   it('renders a localized error when the withdrawal fails without a server message', async () => {
-    vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({}) })))
+    vi.stubGlobal('fetch', vi.fn((_url?: string, _init?: RequestInit) => Promise.resolve({ ok: false, json: () => Promise.resolve({}) })))
 
     const item = {
       type: 'bank' as const, name: 'Techcombank',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,6 +31,11 @@ const eslintConfig = defineConfig([
       // error.
       "react-hooks/set-state-in-effect": "warn",
       "react-hooks/immutability": "warn",
+      // Honor the `_`-prefix convention for intentionally-unused bindings. Test
+      // fetch mocks must declare `(url, init)` so `mock.calls[i]` is typed as the
+      // full [url, init] tuple (the assertions read `calls[i][1]`), even when the
+      // mock body ignores those args — prefixing with `_` marks that as deliberate.
+      "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
 ]);

--- a/lib/__tests__/seo.test.ts
+++ b/lib/__tests__/seo.test.ts
@@ -67,7 +67,9 @@ describe('buildSiteMetadata — social sharing', () => {
   })
 
   it('carries a Twitter summary card', () => {
-    const tw = buildSiteMetadata('vi', translator('vi')).twitter!
+    // Next's `Twitter` type is a union whose base member has no `card`; narrow to
+    // the discriminated card shape the builder actually produces.
+    const tw = buildSiteMetadata('vi', translator('vi')).twitter as { card: string; title?: unknown }
     expect(tw.card).toBe('summary_large_image')
     expect(tw.title).toBeTruthy()
   })

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "generate-icons": "node scripts/generate-icons.mjs",
     "generate-screenshots": "node scripts/generate-screenshots.mjs",
     "test": "vitest",

--- a/tsconfig.typecheck.d.ts
+++ b/tsconfig.typecheck.d.ts
@@ -1,0 +1,12 @@
+// Stable Next.js ambient types for the deterministic typecheck (#468).
+//
+// This mirrors the committed `next-env.d.ts` MINUS its one build-dependent line:
+//   import "./.next/dev/types/routes.d.ts"
+// That import pulls Next's *generated* typed-route declarations into the program.
+// `exclude` cannot keep them out — exclude only blocks glob discovery, not files
+// reached through an import/reference — so a plain `tsc` would depend on whatever
+// `.next` a prior build left behind (non-deterministic). tsconfig.typecheck.json
+// swaps `next-env.d.ts` out for this shim so the typecheck sees only the stable
+// `next` ambient types; typed-route checking still runs inside `next build`.
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,0 +1,14 @@
+{
+  // Deterministic typecheck config for `npm run typecheck` and CI (#468).
+  //
+  // The base tsconfig.json includes `.next/types/**` so the editor and `next build`
+  // pick up generated typed-route definitions. Those files are a build artifact:
+  // whether they exist, and which routes they reference, depends on the last build —
+  // a stale `.next` can inject phantom "route removed" errors into a plain `tsc` run.
+  // This config extends the base but drops `.next` from discovery entirely, so the
+  // command's result depends only on committed source. Typed-route checking still
+  // happens where it belongs — inside `next build`.
+  "extends": "./tsconfig.json",
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.mts"],
+  "exclude": ["node_modules", "e2e", ".next"]
+}

--- a/tsconfig.typecheck.json
+++ b/tsconfig.typecheck.json
@@ -1,14 +1,19 @@
 {
   // Deterministic typecheck config for `npm run typecheck` and CI (#468).
   //
-  // The base tsconfig.json includes `.next/types/**` so the editor and `next build`
-  // pick up generated typed-route definitions. Those files are a build artifact:
-  // whether they exist, and which routes they reference, depends on the last build —
-  // a stale `.next` can inject phantom "route removed" errors into a plain `tsc` run.
-  // This config extends the base but drops `.next` from discovery entirely, so the
-  // command's result depends only on committed source. Typed-route checking still
-  // happens where it belongs — inside `next build`.
+  // Goal: a `tsc` run whose result depends only on committed source, never on the
+  // generated `.next` build artifact.
+  //
+  // Two things pull `.next` into a normal typecheck, and each needs its own fix:
+  //   1. Discovery — the base tsconfig includes `.next/types/**`. `exclude` below
+  //      drops that (exclude blocks glob discovery).
+  //   2. Imports — `next-env.d.ts` ends with `import "./.next/dev/types/routes.d.ts"`,
+  //      Next's *generated* typed-route declarations. `exclude` does NOT stop a file
+  //      reached through an import, so we must keep `next-env.d.ts` out of the program
+  //      entirely and substitute `tsconfig.typecheck.d.ts` — a shim carrying only the
+  //      stable `next` ambient references. Typed-route checking still runs in
+  //      `next build`, where the generated file is guaranteed fresh.
   "extends": "./tsconfig.json",
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "**/*.mts"],
-  "exclude": ["node_modules", "e2e", ".next"]
+  "include": ["tsconfig.typecheck.d.ts", "**/*.ts", "**/*.tsx", "**/*.mts"],
+  "exclude": ["node_modules", "e2e", ".next", "next-env.d.ts"]
 }


### PR DESCRIPTION
Closes #468.

## Problem
`npx tsc --noEmit` reported ~97 errors — **all in test files** that had drifted from current TypeScript contracts. Production source was already clean; the suite passed at runtime, but the typecheck was red and non-deterministic (it also pulled in stale generated `.next` route types).

## What changed

### 1. Fixed the test-type drift (→ `tsc --noEmit` clean over tests, criterion 2)
| Group | Count | Cause → Fix |
|-------|------:|-------------|
| Fetch-mock tuples | 45 | Mocks declared `(url) => …` so `mock.calls[i]` was a 1-tuple; reading `calls[i][1]` (RequestInit) was out of range. Gave them the `(url, init)` signature; unused args prefixed `_`. |
| Planning props | 37 | `DesktopPlanningView` tests' shared `defaultProps` missed the new `error` / `onRetry` props. |
| Fund `reload` | 12 | `let reload: ReturnType<typeof vi.fn>` (a `Mock<Procedure>`) isn't assignable to the `() => Promise<void>` prop → typed as `Mock<() => Promise<void>>`. |
| seo `twitter` | 1 | `.card` read off Next's `Twitter` union whose base member has no `card` → narrowed cast. |
| Regex flag | 2 | Dropped an ES2018-only `/s` flag from the #469 guard (the char-class already spans newlines). |

No test **behavior** changed — only mock signatures / prop objects / a cast.

### 2. Deterministic command + CI gate (criteria 1, 3, 4)
- **`tsconfig.typecheck.json`** extends the base but drops the generated `.next` artifact from discovery, so a stale build can't inject phantom "route removed" errors. Typed-route checking still runs where it belongs — inside `next build`.
- **`npm run typecheck`** → `tsc --noEmit -p tsconfig.typecheck.json`.
- **CI** runs `npm run typecheck` before the unit tests.

### 3. Kept lint clean
- eslint now honors the `_`-prefix convention (`argsIgnorePattern: '^_'`) so the mock signatures add no `no-unused-vars` noise; removed a now-redundant `eslint-disable` directive this enabled.
- Extended the tooling regression guard (`__tests__/tooling-ignores.test.ts`) to assert the typecheck config excludes `.next`, the script exists, and CI wires it up.

## Verification
- `npm run typecheck` → **0 errors** (was ~97).
- **Determinism proof:** planted a bogus `.next/types/*.ts` — base `tsc` reports it, `npm run typecheck` stays at 0.
- `npm test -- --run` → **1199 passed** (118 files).
- `npm run lint` → **0 errors**, 32 warnings (baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)