### PR TITLE
refactor(add-transaction): extract the sheet's preview math into a pure model (#467)

### DIFF
--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -8,6 +8,7 @@ import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { todayIso } from '@/lib/dates'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 import LoadError from './LoadError'
+import { computeFundPricing, computeSellPreview } from './addTransactionModel'
 
 interface Fund { id: string; name: string; nav: number; code: string | null; fund_type?: string }
 interface Goal { goal_id: string; goal_name: string }
@@ -342,56 +343,19 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
     setError('')
   }
 
-  // Fund pricing: NAV is editable (the actual purchase price). It falls back to
-  // the fund's current NAV, and units derive from amount ÷ NAV (two-way linked).
+  // Fund buy pricing + all sell-side preview math live in addTransactionModel (#467);
+  // destructured back into the same names the summary UI and handleSave read.
   const selectedFund = funds.find(f => f.id === fundId)
-  const navNum = Number(nav) || selectedFund?.nav || 0
-  const displayNav = nav !== '' ? nav : (selectedFund ? String(selectedFund.nav) : '')
-  const navIsCurrent = !!selectedFund && (nav === '' || Number(nav) === selectedFund.nav)
-  const autoUnits = navNum > 0 && amount && !units
-    ? (Number(amount.replace(/\./g, '')) / navNum).toFixed(2)
-    : units
+  const { navNum, displayNav, navIsCurrent, autoUnits } = computeFundPricing({ nav, amount, units, currentNav: selectedFund?.nav })
 
-  // ── Sell derived state ──────────────────────────────────────────────────
   const sellHoldings = holdings.filter(h => h.type === assetType)
   const selectedHolding = sellHoldings.find(h => h.key === holdingKey) ?? sellHoldings[0] ?? null
-  const sellMax = selectedHolding?.currentValue ?? 0
-  const numSell = Number(sellAmount) || 0
-  const sellOverMax = numSell > sellMax && sellMax > 0
-  const sellRemaining = Math.max(0, sellMax - numSell)
-  const sellNav = selectedHolding?.navPerUnit ?? null
-  const sellGainLoss = (numSell && assetType === 'fund' && selectedHolding?.gainPct != null)
-    ? numSell * selectedHolding.gainPct / (100 + selectedHolding.gainPct) : null
-  const sellTax = assetType === 'fund' && numSell > 0 ? Math.round(numSell * 0.001) : null
-
-  // Bank withdrawal: the cash received is editable (early withdrawal can cut interest).
-  // We split the principal out of the withdrawn amount so the summary can show gain/loss.
-  const numReceived = Number(received) || 0
-  const bankPrincipal = selectedHolding?.purchasePrice ?? sellMax
-  const bankFraction = sellMax > 0 ? Math.min(1, numSell / sellMax) : 0
-  const bankPrincipalPortion = Math.round(bankPrincipal * bankFraction)
-  const bankGain = assetType === 'bank' && numReceived > 0 && numSell > 0 ? numReceived - bankPrincipalPortion : null
-
-  // Gold sells are quantity-based: enter chỉ to sell + the sale price per chỉ.
-  const goldMaxUnits = selectedHolding?.units ?? 0
-  const numGoldSellQty = Number(goldSellQty) || 0
-  const numGoldSellPrice = Number(goldSellPrice) || 0
-  const goldBuyUnit = selectedHolding?.units && selectedHolding.units > 0 && selectedHolding.purchasePrice != null
-    ? Math.round(selectedHolding.purchasePrice / selectedHolding.units) : null
-  const goldProceeds = Math.round(numGoldSellQty * numGoldSellPrice)
-  const goldCost = goldBuyUnit != null ? Math.round(numGoldSellQty * goldBuyUnit) : null
-  const goldProfit = goldProceeds > 0 && goldCost != null ? goldProceeds - goldCost : null
-  const goldRemUnits = selectedHolding?.units != null ? selectedHolding.units - numGoldSellQty : null
-  const isOverUnits = numGoldSellQty > goldMaxUnits && goldMaxUnits > 0
-
-  const sellDisabled = dir === 'sell' && (
-    !selectedHolding ||
-    (assetType === 'gold'
-      ? (numGoldSellQty <= 0 || isOverUnits)
-      : assetType === 'bank'
-        ? (numSell <= 0 || sellOverMax || numReceived <= 0)
-        : (numSell <= 0 || sellOverMax))
-  )
+  const {
+    sellMax, numSell, sellOverMax, sellRemaining, sellNav, sellGainLoss, sellTax,
+    numReceived, bankFraction, bankPrincipalPortion, bankGain,
+    goldMaxUnits, numGoldSellQty, numGoldSellPrice, goldBuyUnit, goldProceeds, goldCost,
+    goldProfit, goldRemUnits, isOverUnits, sellDisabled,
+  } = computeSellPreview({ assetType, dir, holding: selectedHolding, sellAmount, received, goldSellQty, goldSellPrice })
 
   // Prefill the gold sale price with the holding's current price per chỉ.
   useEffect(() => {

--- a/app/assets/components/__tests__/addTransactionModel.test.ts
+++ b/app/assets/components/__tests__/addTransactionModel.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { computeFundPricing, computeSellPreview, type PreviewHolding } from '../addTransactionModel'
+
+// The Add-transaction sheet's preview math (#467): pure derivations that feed the
+// summary UI (NAV prefill, sell gain/loss, bank principal split, gold profit) and
+// the confirm-button gate. Extracted from AddTransactionSheet so the numbers can
+// be pinned without a full component render.
+
+describe('computeFundPricing', () => {
+  it("falls back to the fund's current NAV and derives units from amount ÷ NAV", () => {
+    const p = computeFundPricing({ nav: '', amount: '1.000.000', units: '', currentNav: 20_000 })
+    expect(p.navNum).toBe(20_000)
+    expect(p.displayNav).toBe('20000')      // shows the current NAV when the field is empty
+    expect(p.navIsCurrent).toBe(true)
+    expect(p.autoUnits).toBe('50.00')       // 1,000,000 ÷ 20,000
+  })
+
+  it('uses an edited NAV and flags it as no longer current', () => {
+    const p = computeFundPricing({ nav: '25000', amount: '1000000', units: '', currentNav: 20_000 })
+    expect(p.navNum).toBe(25_000)
+    expect(p.displayNav).toBe('25000')
+    expect(p.navIsCurrent).toBe(false)
+    expect(p.autoUnits).toBe('40.00')       // 1,000,000 ÷ 25,000
+  })
+
+  it('leaves an explicit units entry untouched (two-way link stops overwriting it)', () => {
+    const p = computeFundPricing({ nav: '', amount: '1000000', units: '12.5', currentNav: 20_000 })
+    expect(p.autoUnits).toBe('12.5')
+  })
+
+  it('handles no selected fund (empty NAV, not current)', () => {
+    const p = computeFundPricing({ nav: '', amount: '', units: '', currentNav: undefined })
+    expect(p.navNum).toBe(0)
+    expect(p.displayNav).toBe('')
+    expect(p.navIsCurrent).toBe(false)
+  })
+})
+
+const fund: PreviewHolding = { type: 'fund', currentValue: 2_000_000, navPerUnit: 20_000, gainPct: 25, purchasePrice: 18_000, units: 100 }
+const bank: PreviewHolding = { type: 'bank', currentValue: 5_000_000, navPerUnit: null, gainPct: null, purchasePrice: 5_000_000, units: null }
+const gold: PreviewHolding = { type: 'gold', currentValue: 18_400_000, navPerUnit: 9_200_000, gainPct: null, purchasePrice: 18_000_000, units: 2 }
+
+const base = { received: '', goldSellQty: '', goldSellPrice: '' }
+
+describe('computeSellPreview — fund', () => {
+  it('derives max, tax (0.1%), gain/loss and enables the sell', () => {
+    const s = computeSellPreview({ assetType: 'fund', dir: 'sell', holding: fund, sellAmount: '1000000', ...base })
+    expect(s.sellMax).toBe(2_000_000)
+    expect(s.numSell).toBe(1_000_000)
+    expect(s.sellOverMax).toBe(false)
+    expect(s.sellRemaining).toBe(1_000_000)
+    expect(s.sellNav).toBe(20_000)
+    expect(s.sellGainLoss).toBe(200_000)     // 1,000,000 × 25 / 125
+    expect(s.sellTax).toBe(1_000)            // round(1,000,000 × 0.001)
+    expect(s.sellDisabled).toBe(false)
+  })
+
+  it('flags over-balance and disables the sell', () => {
+    const s = computeSellPreview({ assetType: 'fund', dir: 'sell', holding: fund, sellAmount: '3000000', ...base })
+    expect(s.sellOverMax).toBe(true)
+    expect(s.sellDisabled).toBe(true)
+  })
+})
+
+describe('computeSellPreview — bank', () => {
+  it('splits principal out of the received cash and shows the gain', () => {
+    const s = computeSellPreview({ assetType: 'bank', dir: 'sell', holding: bank, sellAmount: '5000000', received: '5200000', goldSellQty: '', goldSellPrice: '' })
+    expect(s.numReceived).toBe(5_200_000)
+    expect(s.bankFraction).toBe(1)
+    expect(s.bankPrincipalPortion).toBe(5_000_000)
+    expect(s.bankGain).toBe(200_000)         // received − principal portion
+    expect(s.sellDisabled).toBe(false)
+  })
+
+  it('disables when nothing received', () => {
+    const s = computeSellPreview({ assetType: 'bank', dir: 'sell', holding: bank, sellAmount: '5000000', received: '0', goldSellQty: '', goldSellPrice: '' })
+    expect(s.sellDisabled).toBe(true)
+  })
+})
+
+describe('computeSellPreview — gold', () => {
+  it('computes proceeds, cost basis (per-chi), profit and remaining units', () => {
+    const s = computeSellPreview({ assetType: 'gold', dir: 'sell', holding: gold, sellAmount: '', received: '', goldSellQty: '1', goldSellPrice: '9200000' })
+    expect(s.goldMaxUnits).toBe(2)
+    expect(s.goldBuyUnit).toBe(9_000_000)    // round(18,000,000 ÷ 2)
+    expect(s.goldProceeds).toBe(9_200_000)   // 1 × 9,200,000
+    expect(s.goldCost).toBe(9_000_000)
+    expect(s.goldProfit).toBe(200_000)
+    expect(s.goldRemUnits).toBe(1)
+    expect(s.isOverUnits).toBe(false)
+    expect(s.sellDisabled).toBe(false)
+  })
+
+  it('flags selling more chi than held', () => {
+    const s = computeSellPreview({ assetType: 'gold', dir: 'sell', holding: gold, sellAmount: '', received: '', goldSellQty: '3', goldSellPrice: '9200000' })
+    expect(s.isOverUnits).toBe(true)
+    expect(s.sellDisabled).toBe(true)
+  })
+})
+
+describe('computeSellPreview — gates', () => {
+  it('disables when no holding is selected (sell direction)', () => {
+    const s = computeSellPreview({ assetType: 'fund', dir: 'sell', holding: null, sellAmount: '1000000', ...base })
+    expect(s.sellDisabled).toBe(true)
+  })
+
+  it('never disables in the buy direction', () => {
+    const s = computeSellPreview({ assetType: 'fund', dir: 'buy', holding: null, sellAmount: '', ...base })
+    expect(s.sellDisabled).toBe(false)
+  })
+})

--- a/app/assets/components/addTransactionModel.ts
+++ b/app/assets/components/addTransactionModel.ts
@@ -1,0 +1,131 @@
+// Pure preview math for AddTransactionSheet (#467). These derivations feed the
+// sheet's summary UI and the confirm-button gate; they were computed inline in the
+// component. Keeping them here — free of React state and fetch — lets the numbers
+// (NAV prefill, sell tax/gain, bank principal split, gold profit) be unit-tested
+// directly. The DB-write payload builders inside handleSave are a separate concern
+// and stay in the component for now.
+
+export type AssetType = 'fund' | 'bank' | 'gold'
+
+// The sell-side holding fields the preview reads — a structural subset of the
+// sheet's `Holding`, so `selectedHolding` satisfies it without a cast.
+export interface PreviewHolding {
+  type: AssetType
+  currentValue: number
+  navPerUnit: number | null
+  gainPct: number | null
+  purchasePrice?: number | null
+  units?: number | null
+}
+
+export interface FundPricing {
+  navNum: number
+  displayNav: string
+  navIsCurrent: boolean
+  autoUnits: string
+}
+
+// Fund buy pricing: NAV is editable (the real purchase price) and falls back to the
+// fund's current NAV; units derive from amount ÷ NAV (two-way linked, so an explicit
+// units entry is left untouched). `currentNav` is the selected fund's NAV, or
+// null/undefined when no fund is selected.
+export function computeFundPricing(input: {
+  nav: string
+  amount: string
+  units: string
+  currentNav?: number | null
+}): FundPricing {
+  const { nav, amount, units, currentNav } = input
+  const hasFund = currentNav != null
+  const navNum = Number(nav) || currentNav || 0
+  const displayNav = nav !== '' ? nav : (hasFund ? String(currentNav) : '')
+  const navIsCurrent = hasFund && (nav === '' || Number(nav) === currentNav)
+  const autoUnits = navNum > 0 && amount && !units
+    ? (Number(amount.replace(/\./g, '')) / navNum).toFixed(2)
+    : units
+  return { navNum, displayNav, navIsCurrent, autoUnits }
+}
+
+export interface SellPreview {
+  sellMax: number
+  numSell: number
+  sellOverMax: boolean
+  sellRemaining: number
+  sellNav: number | null
+  sellGainLoss: number | null
+  sellTax: number | null
+  numReceived: number
+  bankFraction: number
+  bankPrincipalPortion: number
+  bankGain: number | null
+  goldMaxUnits: number
+  numGoldSellQty: number
+  numGoldSellPrice: number
+  goldBuyUnit: number | null
+  goldProceeds: number
+  goldCost: number | null
+  goldProfit: number | null
+  goldRemUnits: number | null
+  isOverUnits: boolean
+  sellDisabled: boolean
+}
+
+// Every sell-side derivation for the selected holding: the amount cap + tax + gain
+// for a fund, the principal-vs-received split for a bank withdrawal, the
+// quantity/cost/profit for a gold sell, and the combined confirm-disabled gate.
+export function computeSellPreview(input: {
+  assetType: AssetType
+  dir: 'buy' | 'sell'
+  holding: PreviewHolding | null
+  sellAmount: string
+  received: string
+  goldSellQty: string
+  goldSellPrice: string
+}): SellPreview {
+  const { assetType, dir, holding: h, sellAmount, received, goldSellQty, goldSellPrice } = input
+
+  const sellMax = h?.currentValue ?? 0
+  const numSell = Number(sellAmount) || 0
+  const sellOverMax = numSell > sellMax && sellMax > 0
+  const sellRemaining = Math.max(0, sellMax - numSell)
+  const sellNav = h?.navPerUnit ?? null
+  const sellGainLoss = (numSell && assetType === 'fund' && h?.gainPct != null)
+    ? numSell * h.gainPct / (100 + h.gainPct) : null
+  const sellTax = assetType === 'fund' && numSell > 0 ? Math.round(numSell * 0.001) : null
+
+  // Bank withdrawal: received cash is editable (early withdrawal can cut interest);
+  // split the principal out so the summary can show the gain/loss.
+  const numReceived = Number(received) || 0
+  const bankPrincipal = h?.purchasePrice ?? sellMax
+  const bankFraction = sellMax > 0 ? Math.min(1, numSell / sellMax) : 0
+  const bankPrincipalPortion = Math.round(bankPrincipal * bankFraction)
+  const bankGain = assetType === 'bank' && numReceived > 0 && numSell > 0 ? numReceived - bankPrincipalPortion : null
+
+  // Gold sells are quantity-based: chỉ to sell × the sale price per chỉ.
+  const goldMaxUnits = h?.units ?? 0
+  const numGoldSellQty = Number(goldSellQty) || 0
+  const numGoldSellPrice = Number(goldSellPrice) || 0
+  const goldBuyUnit = h?.units && h.units > 0 && h.purchasePrice != null
+    ? Math.round(h.purchasePrice / h.units) : null
+  const goldProceeds = Math.round(numGoldSellQty * numGoldSellPrice)
+  const goldCost = goldBuyUnit != null ? Math.round(numGoldSellQty * goldBuyUnit) : null
+  const goldProfit = goldProceeds > 0 && goldCost != null ? goldProceeds - goldCost : null
+  const goldRemUnits = h?.units != null ? h.units - numGoldSellQty : null
+  const isOverUnits = numGoldSellQty > goldMaxUnits && goldMaxUnits > 0
+
+  const sellDisabled = dir === 'sell' && (
+    !h ||
+    (assetType === 'gold'
+      ? (numGoldSellQty <= 0 || isOverUnits)
+      : assetType === 'bank'
+        ? (numSell <= 0 || sellOverMax || numReceived <= 0)
+        : (numSell <= 0 || sellOverMax))
+  )
+
+  return {
+    sellMax, numSell, sellOverMax, sellRemaining, sellNav, sellGainLoss, sellTax,
+    numReceived, bankFraction, bankPrincipalPortion, bankGain,
+    goldMaxUnits, numGoldSellQty, numGoldSellPrice, goldBuyUnit, goldProceeds, goldCost,
+    goldProfit, goldRemUnits, isOverUnits, sellDisabled,
+  }
+}


### PR DESCRIPTION
Part of #467. Branched off latest `main`; independent (new file + one component).

## What
`AddTransactionSheet` (a ~1380-line single file with no lib extraction yet) computed all its preview derivations inline — the largest clean pure-logic seam left in the #467 files. Extracted ~50 lines into a new pure module.

**New `app/assets/components/addTransactionModel.ts`:**
- `computeFundPricing({ nav, amount, units, currentNav })` → `{ navNum, displayNav, navIsCurrent, autoUnits }` — editable NAV with fallback to the fund's current NAV, and `units = amount ÷ NAV` (two-way linked).
- `computeSellPreview({ assetType, dir, holding, sellAmount, received, goldSellQty, goldSellPrice })` → every sell figure: fund cap + 0.1% tax + gain/loss, bank principal-vs-received split, gold quantity/cost/profit, and the combined `sellDisabled` gate.

The component now calls the two functions and destructures the results **back into the same variable names**, so no JSX and no DB-write payload (`handleSave`) changed.

## Why this slice
Pure scalar math, no React state / no fetch — the lowest-risk, most TDD-friendly extraction. It establishes `addTransactionModel.ts`; the heavier `handleSave` payload builders (the DB-write money math) are a natural, separately-tested follow-up.

## TDD
`addTransactionModel.test.ts` (12 cases) pins the numbers **first** — NAV fallback + unit derivation, edited-NAV, explicit-units passthrough, fund tax/gain, over-balance gate, bank principal split + gain, gold cost basis/profit/remaining, over-units and no-holding gates — then the component is switched over. The existing `AddTransactionSheet` component tests, which assert the **exact POST bodies** for fund/bank/gold buy and sell, are the behavioral guard that the derived values still flow through `handleSave` unchanged.

## Verification
- `addTransactionModel` 12 + `AddTransactionSheet` 24 + **full unit suite 1234 passed**
- `npm run typecheck` **0 errors** · `npm run lint` **0 errors**
- Net: −47 lines in the component; the preview math is unit-tested in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)