### PR TITLE
refactor(add-transaction): move the DB-write payload builders into the model (#467)

### DIFF
--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -8,7 +8,7 @@ import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { todayIso } from '@/lib/dates'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 import LoadError from './LoadError'
-import { computeFundPricing, computeSellPreview } from './addTransactionModel'
+import { computeFundPricing, computeSellPreview, buildBuyPayload, buildEditPayload, buildSellPayload, type TxForm } from './addTransactionModel'
 
 interface Fund { id: string; name: string; nav: number; code: string | null; fund_type?: string }
 interface Goal { goal_id: string; goal_name: string }
@@ -364,209 +364,54 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
     }
   }, [dir, assetType, holdingKey, sellNav])
 
-  async function handleSave() {
-    setError('')
-
-    // ── Edit an existing investment (PUT) ──────────────────────────────────
-    if (existing) {
-      let payload: Record<string, unknown>
-      if (assetType === 'fund') {
-        const amt = Number(amount.replace(/\./g, ''))
-        if (!fundId) { setError(t('fundRequired')); return }
-        if (!amt) { setError(t('amountRequired')); return }
-        const navV = Number(nav) || selectedFund?.nav || null
-        const u = units ? Number(units) : (navV ? amt / navV : null)
-        payload = {
-          asset_type: 'fund', fund_id: fundId, investment_date: date,
-          amount_vnd: amt, units: u,
-          unit_price: navV,
-          goal_id: goalId || null, notes: note || null,
-        }
-      } else if (assetType === 'bank') {
-        const amt = Number(bankAmount.replace(/\./g, ''))
-        if (!amt) { setError(t('amountRequired')); return }
-        payload = {
-          asset_type: 'bank', fund_id: null, investment_date: date, amount_vnd: amt,
-          interest_rate: rate ? Number(rate) : null, expiry_date: maturity || null,
-          goal_id: goalId || null, notes: selectedBankName || note || null,
-          bank_code: bankCode || null,
-        }
-      } else {
-        const qty = Number(goldQty)
-        const price = Number(goldPrice.replace(/\./g, ''))
-        if (!qty || !price) { setError(t('amountRequired')); return }
-        const unitsInChi = goldUnit === 'luong' ? qty * 10 : qty
-        const pricePerChi = goldUnit === 'luong' ? Math.round(price / 10) : price
-        payload = {
-          asset_type: 'gold', fund_id: null, investment_date: date,
-          amount_vnd: Math.round(qty * price), units: unitsInChi, unit_price: pricePerChi,
-          goal_id: goalId || null, notes: goldProvider || null,
-        }
-      }
-      setSaving(true)
-      try {
-        const res = await fetch(`/api/v1/investment-transactions/${existing.transaction_id}`, {
-          method: 'PUT', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(payload),
-        })
-        if (!res.ok) {
-          const d = await res.json()
-          setError(d.error ?? tc('error'))
-        } else {
-          onClose()
-          onSaved?.()
-        }
-      } catch {
-        setError(tc('error'))
-      } finally {
-        setSaving(false)
-      }
-      return
-    }
-
-    // ── Sell / withdraw: pull from the chosen holding ──────────────────────
-    if (dir === 'sell') {
-      if (!selectedHolding) { setError(t('holdingRequired')); return }
-
-      let sellBody: Record<string, unknown>
-      if (selectedHolding.type === 'gold' && selectedHolding.transactionId) {
-        // Gold: quantity (chỉ) × sale price. amount = proceeds, units = chỉ sold,
-        // principal = cost basis of the sold quantity.
-        if (numGoldSellQty <= 0) { setError(t('amountRequired')); return }
-        if (isOverUnits) { setError(t('exceedsBalance')); return }
-        sellBody = {
-          transaction_type: 'withdrawal', asset_type: 'gold',
-          parent_transaction_id: selectedHolding.transactionId,
-          investment_date: date, amount_vnd: goldProceeds,
-          units_withdrawn: parseFloat(numGoldSellQty.toFixed(4)),
-          principal_withdrawn: goldCost ?? goldProceeds, goal_id: null, notes: note || null,
-        }
-      } else if (selectedHolding.type === 'fund' && selectedHolding.fundId) {
-        if (!numSell) { setError(t('amountRequired')); return }
-        if (sellOverMax) { setError(t('exceedsBalance')); return }
-        const principalWithdrawn = selectedHolding.purchasePrice
-          ? Math.round((numSell / selectedHolding.currentValue) * (selectedHolding.purchasePrice * (selectedHolding.units ?? 0)))
-          : Math.round(numSell)
-        const unitsWithdrawn = sellNav ? numSell / sellNav : (selectedHolding.units ?? 0)
-        sellBody = {
-          transaction_type: 'withdrawal', asset_type: 'fund', fund_id: selectedHolding.fundId,
-          investment_date: date, amount_vnd: Math.round(numSell),
-          units_withdrawn: parseFloat(unitsWithdrawn.toFixed(4)),
-          principal_withdrawn: principalWithdrawn, goal_id: null, notes: note || null,
-        }
-      } else if (selectedHolding.transactionId) {
-        if (!numSell) { setError(t('amountRequired')); return }
-        if (sellOverMax) { setError(t('exceedsBalance')); return }
-        // Bank: cash received is what the user gets; principal portion is what leaves
-        // the deposit's principal, so the gain/loss is recorded accurately.
-        const isBankSell = selectedHolding.type === 'bank'
-        if (isBankSell && numReceived <= 0) { setError(t('amountRequired')); return }
-        sellBody = {
-          transaction_type: 'withdrawal', asset_type: selectedHolding.type,
-          parent_transaction_id: selectedHolding.transactionId,
-          investment_date: date,
-          amount_vnd: isBankSell ? Math.round(numReceived) : Math.round(numSell),
-          principal_withdrawn: isBankSell ? bankPrincipalPortion : Math.round(numSell),
-          goal_id: null, notes: note || null,
-        }
-      } else {
-        setError(t('holdingRequired')); return
-      }
-
-      setSaving(true)
-      try {
-        const res = await fetch('/api/v1/investment-transactions', {
-          method: 'POST', headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(sellBody),
-        })
-        if (!res.ok) {
-          const data = await res.json()
-          setError(data.error ?? tc('error'))
-        } else {
-          onClose()
-          onSaved?.()
-        }
-      } catch {
-        setError(tc('error'))
-      } finally {
-        setSaving(false)
-      }
-      return
-    }
-
-    let body: Record<string, unknown> = {
-      asset_type: assetType,
-      transaction_type: 'investment',
-      investment_date: date,
-      notes: note || null,
-      goal_id: goalId || null,
-      // Logging from the Plan page ties the transaction to the month's plan so
-      // the By-goal view counts it as contributed.
-      plan_id: prefill?.plan_id ?? null,
-    }
-
-    if (assetType === 'fund') {
-      const amt = Number(amount.replace(/\./g, ''))
-      if (!fundId) { setError(t('fundRequired')); return }
-      if (!amt) { setError(t('amountRequired')); return }
-      const navV = Number(nav) || selectedFund?.nav || null
-      body = {
-        ...body,
-        fund_id: fundId,
-        amount_vnd: amt,
-        units: units ? Number(units) : (navV ? amt / navV : null),
-        unit_price: navV,
-      }
-    } else if (assetType === 'bank') {
-      const amt = Number(bankAmount.replace(/\./g, ''))
-      if (!amt) { setError(t('amountRequired')); return }
-      body = {
-        ...body,
-        amount_vnd: amt,
-        notes: selectedBankName || note || null,
-        bank_code: bankCode || null,
-        interest_rate: rate ? Number(rate) : null,
-        expiry_date: maturity || null,
-        // An accumulating book: the route self-groups this anchor row so it can
-        // be topped up later. Term/flex stay ungrouped (one-off holdings).
-        ...(depositType === 'accumulating' ? { accumulating: true } : {}),
-      }
-    } else {
-      // gold — qty/price are in the selected unit; normalize to chỉ for storage
-      // since gold is valued per chỉ.
-      const qty = Number(goldQty)
-      const price = Number(goldPrice.replace(/\./g, ''))
-      if (!qty || !price) { setError(t('amountRequired')); return }
-      const unitsInChi = goldUnit === 'luong' ? qty * 10 : qty
-      const pricePerChi = goldUnit === 'luong' ? Math.round(price / 10) : price
-      body = {
-        ...body,
-        amount_vnd: Math.round(qty * price),
-        units: unitsInChi,
-        unit_price: pricePerChi,
-        notes: goldProvider || null,
-      }
-    }
-
+  async function submitTransaction(url: string, method: 'POST' | 'PUT', payload: Record<string, unknown>) {
     setSaving(true)
     try {
-      const res = await fetch('/api/v1/investment-transactions', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
+      const res = await fetch(url, {
+        method, headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
       })
-      if (!res.ok) {
-        const data = await res.json()
-        setError(data.error ?? tc('error'))
-      } else {
-        onClose()
-        onSaved?.()
-      }
+      if (!res.ok) { const d = await res.json(); setError(d.error ?? tc('error')); return }
+      onClose()
+      onSaved?.()
     } catch {
       setError(tc('error'))
     } finally {
       setSaving(false)
     }
+  }
+
+  async function handleSave() {
+    setError('')
+    const form: TxForm = {
+      assetType, date, goalId, note,
+      fundId, amount, units, nav, selectedFundNav: selectedFund?.nav,
+      bankCode, selectedBankName, depositType, bankAmount, rate, maturity,
+      goldProvider, goldUnit, goldQty, goldPrice,
+    }
+
+    // Edit an existing investment (PUT).
+    if (existing) {
+      const r = buildEditPayload(form)
+      if (!r.ok) { setError(t(r.errorKey)); return }
+      await submitTransaction(`/api/v1/investment-transactions/${existing.transaction_id}`, 'PUT', r.payload)
+      return
+    }
+
+    // Sell / withdraw from the chosen holding (POST).
+    if (dir === 'sell') {
+      const r = buildSellPayload(selectedHolding, {
+        numSell, sellOverMax, sellNav, numGoldSellQty, isOverUnits, goldProceeds, goldCost, numReceived, bankPrincipalPortion,
+      }, { date, note })
+      if (!r.ok) { setError(t(r.errorKey)); return }
+      await submitTransaction('/api/v1/investment-transactions', 'POST', r.payload)
+      return
+    }
+
+    // Buy / create a new investment (POST).
+    const r = buildBuyPayload(form, prefill?.plan_id ?? null)
+    if (!r.ok) { setError(t(r.errorKey)); return }
+    await submitTransaction('/api/v1/investment-transactions', 'POST', r.payload)
   }
 
   if (desktop ? !open : !mounted) return null

--- a/app/assets/components/__tests__/addTransactionModel.test.ts
+++ b/app/assets/components/__tests__/addTransactionModel.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { computeFundPricing, computeSellPreview, type PreviewHolding } from '../addTransactionModel'
+import {
+  computeFundPricing, computeSellPreview, buildBuyPayload, buildEditPayload, buildSellPayload,
+  type PreviewHolding, type TxForm,
+} from '../addTransactionModel'
 
 // The Add-transaction sheet's preview math (#467): pure derivations that feed the
 // summary UI (NAV prefill, sell gain/loss, bank principal split, gold profit) and
@@ -107,5 +110,98 @@ describe('computeSellPreview — gates', () => {
   it('never disables in the buy direction', () => {
     const s = computeSellPreview({ assetType: 'fund', dir: 'buy', holding: null, sellAmount: '', ...base })
     expect(s.sellDisabled).toBe(false)
+  })
+})
+
+const emptyForm: TxForm = {
+  assetType: 'fund', date: '2026-07-24', goalId: '', note: '',
+  fundId: '', amount: '', units: '', nav: '', selectedFundNav: undefined,
+  bankCode: '', selectedBankName: '', depositType: 'term', bankAmount: '', rate: '', maturity: '',
+  goldProvider: '', goldUnit: 'chi', goldQty: '', goldPrice: '',
+}
+const form = (over: Partial<TxForm>): TxForm => ({ ...emptyForm, ...over })
+const ok = (r: ReturnType<typeof buildBuyPayload>) => { if (!r.ok) throw new Error('expected ok'); return r.payload }
+
+describe('buildBuyPayload', () => {
+  it('fund: amount + units=amount÷NAV + plan envelope', () => {
+    const p = ok(buildBuyPayload(form({ assetType: 'fund', fundId: 'f1', amount: '1.000.000', nav: '20000', goalId: 'g1' }), 'plan-9'))
+    expect(p).toEqual({
+      asset_type: 'fund', transaction_type: 'investment', investment_date: '2026-07-24',
+      notes: null, goal_id: 'g1', plan_id: 'plan-9',
+      fund_id: 'f1', amount_vnd: 1_000_000, units: 50, unit_price: 20_000,
+    })
+  })
+
+  it('fund: missing fund → fundRequired; missing amount → amountRequired', () => {
+    expect(buildBuyPayload(form({ assetType: 'fund', amount: '1000000' }), null)).toEqual({ ok: false, errorKey: 'fundRequired' })
+    expect(buildBuyPayload(form({ assetType: 'fund', fundId: 'f1' }), null)).toEqual({ ok: false, errorKey: 'amountRequired' })
+  })
+
+  it('bank: accumulating flag only for an accumulating book; bank name becomes notes', () => {
+    const p = ok(buildBuyPayload(form({ assetType: 'bank', bankAmount: '5.000.000', bankCode: 'VCB', selectedBankName: 'Vietcombank', depositType: 'accumulating', rate: '6', maturity: '2027-01-01' }), null))
+    expect(p).toMatchObject({ asset_type: 'bank', amount_vnd: 5_000_000, bank_code: 'VCB', notes: 'Vietcombank', interest_rate: 6, expiry_date: '2027-01-01', accumulating: true })
+    const term = ok(buildBuyPayload(form({ assetType: 'bank', bankAmount: '5000000', depositType: 'term' }), null))
+    expect(term).not.toHaveProperty('accumulating')
+  })
+
+  it('gold: luông normalizes to chỉ (×10 units, ÷10 price)', () => {
+    const p = ok(buildBuyPayload(form({ assetType: 'gold', goldUnit: 'luong', goldQty: '1', goldPrice: '92.000.000', goldProvider: 'PNJ' }), null))
+    expect(p).toMatchObject({ asset_type: 'gold', amount_vnd: 92_000_000, units: 10, unit_price: 9_200_000, notes: 'PNJ' })
+  })
+})
+
+describe('buildEditPayload', () => {
+  it('fund: no transaction_type / plan_id', () => {
+    const p = ok(buildEditPayload(form({ assetType: 'fund', fundId: 'f1', amount: '1000000', nav: '25000' })))
+    expect(p).toEqual({
+      asset_type: 'fund', fund_id: 'f1', investment_date: '2026-07-24',
+      amount_vnd: 1_000_000, units: 40, unit_price: 25_000, goal_id: null, notes: null,
+    })
+    expect(p).not.toHaveProperty('transaction_type')
+  })
+
+  it('bank/gold carry explicit fund_id: null', () => {
+    expect(ok(buildEditPayload(form({ assetType: 'bank', bankAmount: '5000000' })))).toMatchObject({ asset_type: 'bank', fund_id: null })
+    expect(ok(buildEditPayload(form({ assetType: 'gold', goldQty: '2', goldPrice: '9000000' })))).toMatchObject({ asset_type: 'gold', fund_id: null, units: 2 })
+  })
+})
+
+describe('buildSellPayload', () => {
+  const date = '2026-07-24'
+  const zero = { numSell: 0, sellOverMax: false, sellNav: null, numGoldSellQty: 0, isOverUnits: false, goldProceeds: 0, goldCost: null, numReceived: 0, bankPrincipalPortion: 0 }
+
+  it('fund: proportional principal_withdrawn + units_withdrawn=amount÷NAV', () => {
+    const holding = { type: 'fund' as const, fundId: 'f1', purchasePrice: 18_000, currentValue: 2_000_000, units: 100 }
+    const preview = { ...zero, numSell: 1_000_000, sellNav: 20_000 }
+    const p = ok(buildSellPayload(holding, preview, { date, note: '' }))
+    expect(p).toEqual({
+      transaction_type: 'withdrawal', asset_type: 'fund', fund_id: 'f1', investment_date: date,
+      amount_vnd: 1_000_000, units_withdrawn: 50,
+      principal_withdrawn: 900_000, goal_id: null, notes: null,   // (1M/2M)×(18000×100)
+    })
+  })
+
+  it('bank: amount is received cash, principal is the split portion', () => {
+    const holding = { type: 'bank' as const, transactionId: 't1', purchasePrice: 5_000_000, currentValue: 5_000_000 }
+    const preview = { ...zero, numSell: 5_000_000, numReceived: 5_200_000, bankPrincipalPortion: 5_000_000 }
+    expect(ok(buildSellPayload(holding, preview, { date, note: '' }))).toMatchObject({
+      asset_type: 'bank', parent_transaction_id: 't1', amount_vnd: 5_200_000, principal_withdrawn: 5_000_000,
+    })
+  })
+
+  it('gold: proceeds/cost/units_withdrawn', () => {
+    const holding = { type: 'gold' as const, transactionId: 'g1', currentValue: 18_400_000, units: 2 }
+    const preview = { ...zero, numGoldSellQty: 1, goldProceeds: 9_200_000, goldCost: 9_000_000 }
+    expect(ok(buildSellPayload(holding, preview, { date, note: '' }))).toMatchObject({
+      asset_type: 'gold', parent_transaction_id: 'g1', amount_vnd: 9_200_000, units_withdrawn: 1, principal_withdrawn: 9_000_000,
+    })
+  })
+
+  it('validation: no holding → holdingRequired; over balance → exceedsBalance; bank no received → amountRequired', () => {
+    expect(buildSellPayload(null, zero, { date, note: '' })).toEqual({ ok: false, errorKey: 'holdingRequired' })
+    const fund = { type: 'fund' as const, fundId: 'f1', currentValue: 2_000_000, units: 100 }
+    expect(buildSellPayload(fund, { ...zero, numSell: 3_000_000, sellOverMax: true }, { date, note: '' })).toEqual({ ok: false, errorKey: 'exceedsBalance' })
+    const bank = { type: 'bank' as const, transactionId: 't1', currentValue: 5_000_000 }
+    expect(buildSellPayload(bank, { ...zero, numSell: 5_000_000, numReceived: 0 }, { date, note: '' })).toEqual({ ok: false, errorKey: 'amountRequired' })
   })
 })

--- a/app/assets/components/addTransactionModel.ts
+++ b/app/assets/components/addTransactionModel.ts
@@ -129,3 +129,192 @@ export function computeSellPreview(input: {
     goldProfit, goldRemUnits, isOverUnits, sellDisabled,
   }
 }
+
+// ── DB-write payload builders ────────────────────────────────────────────────
+// Pure `form → { payload } | { errorKey }` transforms for the three write paths
+// (#467). They own all the money math that persists — gold luông→chỉ normalization,
+// `units = amount ÷ NAV`, the fund sell's proportional `principal_withdrawn` split —
+// while the component keeps the fetch/`setError(t(errorKey))`. `errorKey` values are
+// the sheet's existing i18n keys.
+
+export type BuildResult =
+  | { ok: true; payload: Record<string, unknown> }
+  | { ok: false; errorKey: string }
+
+// Every form field the buy/edit builders read. The sheet keeps fund `amount` and
+// bank `bankAmount` as separate inputs, mirrored here.
+export interface TxForm {
+  assetType: AssetType
+  date: string
+  goalId: string
+  note: string
+  fundId: string
+  amount: string
+  units: string
+  nav: string
+  selectedFundNav?: number | null
+  bankCode: string
+  selectedBankName: string
+  depositType: 'term' | 'flex' | 'accumulating'
+  bankAmount: string
+  rate: string
+  maturity: string
+  goldProvider: string
+  goldUnit: 'chi' | 'luong'
+  goldQty: string
+  goldPrice: string
+}
+
+// Fund units: an explicit entry wins; otherwise derive amount ÷ NAV when NAV known.
+function fundUnits(units: string, amount: number, navV: number | null): number | null {
+  return units ? Number(units) : (navV ? amount / navV : null)
+}
+
+// Gold qty/price are in the selected unit; normalize to chỉ for storage (gold is
+// valued per chỉ). Returns null when qty or price is missing/zero.
+function normalizeGold(goldQty: string, goldPrice: string, goldUnit: 'chi' | 'luong'):
+  { amountVnd: number; unitsInChi: number; pricePerChi: number } | null {
+  const qty = Number(goldQty)
+  const price = Number(goldPrice.replace(/\./g, ''))
+  if (!qty || !price) return null
+  const unitsInChi = goldUnit === 'luong' ? qty * 10 : qty
+  const pricePerChi = goldUnit === 'luong' ? Math.round(price / 10) : price
+  return { amountVnd: Math.round(qty * price), unitsInChi, pricePerChi }
+}
+
+// Edit an existing investment (PUT). No transaction_type / plan_id; bank & gold
+// carry an explicit fund_id: null.
+export function buildEditPayload(form: TxForm): BuildResult {
+  const { assetType, date, goalId, note } = form
+  if (assetType === 'fund') {
+    const amt = Number(form.amount.replace(/\./g, ''))
+    if (!form.fundId) return { ok: false, errorKey: 'fundRequired' }
+    if (!amt) return { ok: false, errorKey: 'amountRequired' }
+    const navV = Number(form.nav) || form.selectedFundNav || null
+    return { ok: true, payload: {
+      asset_type: 'fund', fund_id: form.fundId, investment_date: date,
+      amount_vnd: amt, units: fundUnits(form.units, amt, navV), unit_price: navV,
+      goal_id: goalId || null, notes: note || null,
+    } }
+  }
+  if (assetType === 'bank') {
+    const amt = Number(form.bankAmount.replace(/\./g, ''))
+    if (!amt) return { ok: false, errorKey: 'amountRequired' }
+    return { ok: true, payload: {
+      asset_type: 'bank', fund_id: null, investment_date: date, amount_vnd: amt,
+      interest_rate: form.rate ? Number(form.rate) : null, expiry_date: form.maturity || null,
+      goal_id: goalId || null, notes: form.selectedBankName || note || null,
+      bank_code: form.bankCode || null,
+    } }
+  }
+  const gold = normalizeGold(form.goldQty, form.goldPrice, form.goldUnit)
+  if (!gold) return { ok: false, errorKey: 'amountRequired' }
+  return { ok: true, payload: {
+    asset_type: 'gold', fund_id: null, investment_date: date,
+    amount_vnd: gold.amountVnd, units: gold.unitsInChi, unit_price: gold.pricePerChi,
+    goal_id: goalId || null, notes: form.goldProvider || null,
+  } }
+}
+
+// Buy / create a new investment (POST). Adds the transaction_type + plan_id envelope
+// (logging from the Plan page ties it to the month's plan).
+export function buildBuyPayload(form: TxForm, planId: string | null): BuildResult {
+  const { assetType, date, goalId, note } = form
+  const base = {
+    asset_type: assetType, transaction_type: 'investment', investment_date: date,
+    notes: note || null, goal_id: goalId || null, plan_id: planId,
+  }
+  if (assetType === 'fund') {
+    const amt = Number(form.amount.replace(/\./g, ''))
+    if (!form.fundId) return { ok: false, errorKey: 'fundRequired' }
+    if (!amt) return { ok: false, errorKey: 'amountRequired' }
+    const navV = Number(form.nav) || form.selectedFundNav || null
+    return { ok: true, payload: {
+      ...base, fund_id: form.fundId, amount_vnd: amt,
+      units: fundUnits(form.units, amt, navV), unit_price: navV,
+    } }
+  }
+  if (assetType === 'bank') {
+    const amt = Number(form.bankAmount.replace(/\./g, ''))
+    if (!amt) return { ok: false, errorKey: 'amountRequired' }
+    return { ok: true, payload: {
+      ...base, amount_vnd: amt, notes: form.selectedBankName || note || null,
+      bank_code: form.bankCode || null, interest_rate: form.rate ? Number(form.rate) : null,
+      expiry_date: form.maturity || null,
+      // An accumulating book: the route self-groups this anchor row for later top-ups.
+      ...(form.depositType === 'accumulating' ? { accumulating: true } : {}),
+    } }
+  }
+  const gold = normalizeGold(form.goldQty, form.goldPrice, form.goldUnit)
+  if (!gold) return { ok: false, errorKey: 'amountRequired' }
+  return { ok: true, payload: {
+    ...base, amount_vnd: gold.amountVnd, units: gold.unitsInChi, unit_price: gold.pricePerChi,
+    notes: form.goldProvider || null,
+  } }
+}
+
+// The subset of a holding the sell builder needs (superset-compatible with the
+// sheet's Holding).
+export interface SellHolding {
+  type: AssetType
+  transactionId?: string
+  fundId?: string
+  purchasePrice?: number | null
+  currentValue: number
+  units?: number | null
+}
+
+// Sell / withdraw from a holding (POST). Reuses the already-computed SellPreview so
+// the derived figures (proceeds, cost basis, principal portions) aren't re-derived.
+export function buildSellPayload(
+  holding: SellHolding | null,
+  preview: Pick<SellPreview,
+    'numSell' | 'sellOverMax' | 'sellNav' | 'numGoldSellQty' | 'isOverUnits' |
+    'goldProceeds' | 'goldCost' | 'numReceived' | 'bankPrincipalPortion'>,
+  opts: { date: string; note: string },
+): BuildResult {
+  const { date, note } = opts
+  if (!holding) return { ok: false, errorKey: 'holdingRequired' }
+
+  if (holding.type === 'gold' && holding.transactionId) {
+    if (preview.numGoldSellQty <= 0) return { ok: false, errorKey: 'amountRequired' }
+    if (preview.isOverUnits) return { ok: false, errorKey: 'exceedsBalance' }
+    return { ok: true, payload: {
+      transaction_type: 'withdrawal', asset_type: 'gold',
+      parent_transaction_id: holding.transactionId,
+      investment_date: date, amount_vnd: preview.goldProceeds,
+      units_withdrawn: parseFloat(preview.numGoldSellQty.toFixed(4)),
+      principal_withdrawn: preview.goldCost ?? preview.goldProceeds, goal_id: null, notes: note || null,
+    } }
+  }
+  if (holding.type === 'fund' && holding.fundId) {
+    if (!preview.numSell) return { ok: false, errorKey: 'amountRequired' }
+    if (preview.sellOverMax) return { ok: false, errorKey: 'exceedsBalance' }
+    const principalWithdrawn = holding.purchasePrice
+      ? Math.round((preview.numSell / holding.currentValue) * (holding.purchasePrice * (holding.units ?? 0)))
+      : Math.round(preview.numSell)
+    const unitsWithdrawn = preview.sellNav ? preview.numSell / preview.sellNav : (holding.units ?? 0)
+    return { ok: true, payload: {
+      transaction_type: 'withdrawal', asset_type: 'fund', fund_id: holding.fundId,
+      investment_date: date, amount_vnd: Math.round(preview.numSell),
+      units_withdrawn: parseFloat(unitsWithdrawn.toFixed(4)),
+      principal_withdrawn: principalWithdrawn, goal_id: null, notes: note || null,
+    } }
+  }
+  if (holding.transactionId) {
+    if (!preview.numSell) return { ok: false, errorKey: 'amountRequired' }
+    if (preview.sellOverMax) return { ok: false, errorKey: 'exceedsBalance' }
+    // Bank: received cash is what the user gets; principal portion is what leaves the
+    // deposit's principal, so the gain/loss is recorded accurately.
+    const isBankSell = holding.type === 'bank'
+    if (isBankSell && preview.numReceived <= 0) return { ok: false, errorKey: 'amountRequired' }
+    return { ok: true, payload: {
+      transaction_type: 'withdrawal', asset_type: holding.type,
+      parent_transaction_id: holding.transactionId, investment_date: date,
+      amount_vnd: isBankSell ? Math.round(preview.numReceived) : Math.round(preview.numSell),
+      principal_withdrawn: isBankSell ? preview.bankPrincipalPortion : Math.round(preview.numSell),
+      goal_id: null, notes: note || null,
+    } }
+  }
+  return { ok: false, errorKey: 'holdingRequired' }
+}


### PR DESCRIPTION
Part of #467. Follow-up to #492 — same `addTransactionModel.ts` module. Branched off latest `main`.

## What
`handleSave` held ~180 lines of payload construction + validation across the three write paths — edit (PUT), sell/withdraw (POST), buy/create (POST) — each branching per asset type. The load-bearing money math was **duplicated between the buy and edit branches** (gold luông→chỉ normalization, `units = amount ÷ NAV`).

Extract it into pure builders in `addTransactionModel.ts`:
- `buildBuyPayload(form, planId)` / `buildEditPayload(form)` / `buildSellPayload(holding, preview, opts)` — each a `form → { ok, payload } | { ok:false, errorKey }` transform.
- The shared gold normalization + fund-units math now live **once** (private `normalizeGold` / `fundUnits` helpers).

`handleSave` becomes a thin dispatch (pick builder → on `!ok` `setError(t(errorKey))` → else submit), and the three identical fetch/error blocks collapse into one local `submitTransaction(url, method, payload)`. Error keys are the sheet's existing i18n keys; `fetch` / `setError` / `onClose` / `onSaved` stay in the component. **No behavior change.**

## Why safe (this is DB-write money math)
- **TDD:** `addTransactionModel.test.ts` pins the **exact JSON body** per asset type × direction first — gold luông normalization, `units = amount÷NAV`, the fund sell's proportional `principal_withdrawn` split, bank received-vs-principal, the `accumulating` flag, and every validation error key — then `handleSave` is switched over.
- The existing **AddTransactionSheet component tests assert the exact POST/PUT bodies** — the behavioral guard that the payloads are byte-identical.
- **Real E2E round-trips**: `accumulating-deposit`, `book-withdrawal`, `unallocated-book` (10 tests) drive actual buy/sell writes to the local DB.

## Verification
- `addTransactionModel` 22 + `AddTransactionSheet` 24 + **full unit suite 1244 passed**
- `npm run typecheck` **0 errors** · `npm run lint` **0 errors**
- Targeted E2E **10 passed** (real buy/sell payload round-trips)
- `AddTransactionSheet` drops **~185 lines**; the write-path money math lives once and is unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)