### PR TITLE
refactor(goal-detail): share the transaction-history row classifier (#467)

### DIFF
--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -1,15 +1,15 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, ArrowUpRight, Target, CalendarDays, RefreshCw, PiggyBank, GitMerge, Plus } from 'lucide-react'
+import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, Target, CalendarDays, RefreshCw, PiggyBank, Plus } from 'lucide-react'
 import { iconHit } from './iconHit'
 import { toast } from 'sonner'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import { formatIntVN, parseIntVN } from '@/lib/numberFormat'
 import type { GoalData } from '../DashboardClient'
-import { GD_COLORS, buildCompositionSegments, computeGoalCalculator, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
+import { GD_COLORS, buildCompositionSegments, computeGoalCalculator, describeHistoryRow, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { MaturityResolveModal } from './MaturityResolveSheet'
-import { fmtTxDate, txKind } from './transactionUtils'
+import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 import LoadError from './LoadError'
 import { useGoalDetailData } from './useGoalDetailData'
@@ -470,16 +470,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
               )}
               {!txLoading && transactions.map((tx, i) => {
                 const isRenewed = !!tx.renewed_from_transaction_id
-                // Held/merged settlements parked their cash — render neutral (like a
-                // snapshot), never the red "−" of a real withdrawal.
-                const kind = txKind(tx)
-                const isWithdraw = kind === 'withdrawal'
-                const neutral = isRenewed || kind === 'held' || kind === 'consumed'
-                const ink = neutral ? 'var(--c-muted)' : isWithdraw ? 'var(--c-neg)' : 'var(--c-pos)'
-                const fill = neutral ? 'var(--c-card-2)' : isWithdraw ? 'var(--c-neg-tint)' : 'var(--c-pos-tint)'
-                const DirIcon = isRenewed ? RefreshCw : kind === 'held' ? PiggyBank : kind === 'consumed' ? GitMerge : isWithdraw ? ArrowDownRight : ArrowUpRight
-                const sign = isWithdraw ? '-' : kind === 'investment' ? '+' : ''
-                const name = tx.fund_name ?? tx.notes ?? (isVi ? 'Khoản đầu tư' : 'Investment')
+                const { kind, ink, fill, Icon, sign, name } = describeHistoryRow(tx, isRenewed, isVi)
                 return (
                   <div key={tx.transaction_id} data-testid={isRenewed ? 'history-renewed-row' : undefined} style={{
                     display: 'flex', alignItems: 'center', gap: 10,
@@ -492,7 +483,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                       background: fill, color: ink,
                       display: 'flex', alignItems: 'center', justifyContent: 'center',
                     }}>
-                      <DirIcon size={13} strokeWidth={2.2} />
+                      <Icon size={13} strokeWidth={2.2} />
                     </div>
                     <div style={{ flex: 1, minWidth: 0 }}>
                       <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 6 }}>

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import {
   ChevronLeft, ChevronRight, MoreHorizontal,
-  Edit2, Trash2, Calendar, Download, ArrowDownRight, ArrowUpRight, Target, RefreshCw, PiggyBank, GitMerge, Plus,
+  Edit2, Trash2, Calendar, Download, ArrowDownRight, Target, RefreshCw, PiggyBank, Plus,
 } from 'lucide-react'
 import { iconHit } from './iconHit'
 import { useLocale } from 'next-intl'
@@ -14,8 +14,8 @@ import type { GoalData, FundBreakdownItem } from '../DashboardClient'
 import TransactionHistorySheet, { type PurchaseHistoryRow } from './TransactionHistorySheet'
 import { SellWithdrawSheet } from './SellWithdrawSheet'
 import { MaturityResolveSheet } from './MaturityResolveSheet'
-import { GD_COLORS, buildCompositionSegments, computeGoalCalculator, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
-import { fmtTxDate, txKind } from './transactionUtils'
+import { GD_COLORS, buildCompositionSegments, computeGoalCalculator, describeHistoryRow, TypeIcon, UnlinkSvg, buildInvRows, buildRenewalSummary, BankInfoStrip, TopUpControl, RenewalSummaryLine, needsMaturityAction, needsBookMaturityAction, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
+import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 import LoadError from './LoadError'
 import { useGoalDetailData } from './useGoalDetailData'
@@ -1262,16 +1262,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
               )}
               {!txLoading && transactions.map((tx, i) => {
                 const isRenewed = !!tx.renewed_from_transaction_id
-                // Held/merged settlements parked their cash — render neutral (like a
-                // snapshot), never the red "−" of a real withdrawal.
-                const kind = txKind(tx)
-                const isWithdraw = kind === 'withdrawal'
-                const neutral = isRenewed || kind === 'held' || kind === 'consumed'
-                const ink = neutral ? 'var(--c-muted)' : isWithdraw ? 'var(--c-neg)' : 'var(--c-pos)'
-                const fill = neutral ? 'var(--c-card-2)' : isWithdraw ? 'var(--c-neg-tint)' : 'var(--c-pos-tint)'
-                const DirIcon = isRenewed ? RefreshCw : kind === 'held' ? PiggyBank : kind === 'consumed' ? GitMerge : isWithdraw ? ArrowDownRight : ArrowUpRight
-                const sign = isWithdraw ? '-' : kind === 'investment' ? '+' : ''
-                const name = tx.fund_name ?? tx.notes ?? (isVI ? 'Khoản đầu tư' : 'Investment')
+                const { kind, ink, fill, Icon, sign, name } = describeHistoryRow(tx, isRenewed, isVI)
                 return (
                   <div
                     key={tx.transaction_id}
@@ -1288,7 +1279,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
                       background: fill, color: ink,
                       display: 'flex', alignItems: 'center', justifyContent: 'center',
                     }}>
-                      <DirIcon size={14} strokeWidth={2.2} />
+                      <Icon size={14} strokeWidth={2.2} />
                     </div>
                     <div style={{ flex: 1, minWidth: 0 }}>
                       <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--c-ink)', display: 'flex', alignItems: 'center', gap: 6 }}>

--- a/app/assets/components/__tests__/goalDetailShared.test.tsx
+++ b/app/assets/components/__tests__/goalDetailShared.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { buildInvRows, buildRenewalSummary, calcDeadlineMonths, computeGoalCalculator, fmtMaturity, type GoalDetailTx } from '../goalDetailShared'
+import { buildInvRows, buildRenewalSummary, calcDeadlineMonths, computeGoalCalculator, describeHistoryRow, fmtMaturity, type GoalDetailTx } from '../goalDetailShared'
 import type { FundBreakdownItem } from '../../DashboardClient'
+import { ArrowUpRight, ArrowDownRight, PiggyBank, GitMerge, RefreshCw } from 'lucide-react'
 
 // A YYYY-MM-DD string `n` days from today (deterministic regardless of run date).
 function daysFromNow(n: number): string {
@@ -342,5 +343,61 @@ describe('computeGoalCalculator', () => {
     const c = computeGoalCalculator({ targetAmount: null, targetDate: null, currentValue: 10_000_000 }, 1_000_000)
     expect(c.remaining).toBe(0)
     expect(c.neededPerMonth).toBe(0)
+  })
+})
+
+
+// The transaction-history row's classifier (#467): kind → colour tokens, icon,
+// amount sign and display name. Was byte-identical inline in GoalDetailSheet and
+// DesktopGoalDetail; both now call this so the two surfaces can't drift.
+describe('describeHistoryRow', () => {
+  it('an investment reads positive (green, up-arrow, +)', () => {
+    const d = describeHistoryRow({ transaction_type: 'investment', fund_name: 'VESAF' }, false, false)
+    expect(d.kind).toBe('investment')
+    expect(d.ink).toBe('var(--c-pos)')
+    expect(d.fill).toBe('var(--c-pos-tint)')
+    expect(d.Icon).toBe(ArrowUpRight)
+    expect(d.sign).toBe('+')
+    expect(d.name).toBe('VESAF')
+  })
+
+  it('a real withdrawal reads negative (red, down-arrow, -)', () => {
+    const d = describeHistoryRow({ transaction_type: 'withdrawal', notes: 'Sell' }, false, false)
+    expect(d.kind).toBe('withdrawal')
+    expect(d.ink).toBe('var(--c-neg)')
+    expect(d.fill).toBe('var(--c-neg-tint)')
+    expect(d.Icon).toBe(ArrowDownRight)
+    expect(d.sign).toBe('-')
+    expect(d.name).toBe('Sell')
+  })
+
+  it('a held-for-merge settlement reads neutral (muted, piggy-bank, no sign)', () => {
+    const d = describeHistoryRow({ transaction_type: 'withdrawal', held_for_merge: true }, false, false)
+    expect(d.kind).toBe('held')
+    expect(d.ink).toBe('var(--c-muted)')
+    expect(d.fill).toBe('var(--c-card-2)')
+    expect(d.Icon).toBe(PiggyBank)
+    expect(d.sign).toBe('')
+  })
+
+  it('a consumed (merged) settlement uses the merge icon, still neutral', () => {
+    const d = describeHistoryRow({ transaction_type: 'withdrawal', held_for_merge: true, consumed_by_inv_id: 'x' }, false, false)
+    expect(d.kind).toBe('consumed')
+    expect(d.Icon).toBe(GitMerge)
+    expect(d.ink).toBe('var(--c-muted)')
+    expect(d.sign).toBe('')
+  })
+
+  it('a renewed row reads neutral with the renew icon but keeps its + sign', () => {
+    const d = describeHistoryRow({ transaction_type: 'investment', fund_name: 'VESAF' }, true, false)
+    expect(d.Icon).toBe(RefreshCw)
+    expect(d.ink).toBe('var(--c-muted)')   // renewed → neutral
+    expect(d.sign).toBe('+')               // still an investment
+  })
+
+  it('falls back name to notes then a localized default', () => {
+    expect(describeHistoryRow({ transaction_type: 'investment', notes: 'Cash' }, false, false).name).toBe('Cash')
+    expect(describeHistoryRow({ transaction_type: 'investment' }, false, false).name).toBe('Investment')
+    expect(describeHistoryRow({ transaction_type: 'investment' }, false, true).name).toBe('Khoản đầu tư')
   })
 })

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -4,12 +4,12 @@
 // investment-row valuation live here to stay in sync.
 
 import { useState, type CSSProperties } from 'react'
-import { TrendingUp, Building, Coins, BarChart2, Target, RefreshCw, Plus } from 'lucide-react'
+import { TrendingUp, Building, Coins, BarChart2, Target, RefreshCw, Plus, PiggyBank, GitMerge, ArrowDownRight, ArrowUpRight, type LucideIcon } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 import { calcProjectedInterest } from '@/lib/finance'
 import { blendedRate } from '@/lib/accumulating'
-import { fmtTxDate } from './transactionUtils'
+import { fmtTxDate, txKind, type TxKind, type TxKindFields } from './transactionUtils'
 import { isTermDeposit, depositMaturityState, isMaturityActionable, isActionableAccumulatingBook } from '@/lib/maturity'
 import type { FundBreakdownItem } from '../DashboardClient'
 
@@ -41,6 +41,36 @@ export function buildCompositionSegments(
     segs.push({ label: isVi ? 'Chờ gộp' : 'For merge', value: heldValue, color: 'var(--c-muted)' })
   }
   return segs
+}
+
+export interface HistoryRowDescriptor {
+  kind: TxKind
+  ink: string
+  fill: string
+  Icon: LucideIcon
+  sign: string
+  name: string
+}
+
+// How a transaction-history row presents (#467): its kind → colour tokens, icon,
+// amount sign and display name. A held/merged settlement or a renewed row reads
+// NEUTRALLY (muted, no red "−") because the cash was parked/rolled forward, not
+// spent. Byte-identical inline in both goal-detail surfaces before this; each now
+// calls it and only maps the icon size + chrome in its own JSX.
+export function describeHistoryRow(
+  tx: TxKindFields & { fund_name?: string | null; notes?: string | null },
+  isRenewed: boolean,
+  isVi: boolean,
+): HistoryRowDescriptor {
+  const kind = txKind(tx)
+  const isWithdraw = kind === 'withdrawal'
+  const neutral = isRenewed || kind === 'held' || kind === 'consumed'
+  const ink = neutral ? 'var(--c-muted)' : isWithdraw ? 'var(--c-neg)' : 'var(--c-pos)'
+  const fill = neutral ? 'var(--c-card-2)' : isWithdraw ? 'var(--c-neg-tint)' : 'var(--c-pos-tint)'
+  const Icon = isRenewed ? RefreshCw : kind === 'held' ? PiggyBank : kind === 'consumed' ? GitMerge : isWithdraw ? ArrowDownRight : ArrowUpRight
+  const sign = isWithdraw ? '-' : kind === 'investment' ? '+' : ''
+  const name = tx.fund_name ?? tx.notes ?? (isVi ? 'Khoản đầu tư' : 'Investment')
+  return { kind, ink, fill, Icon, sign, name }
 }
 
 export function calcDeadlineMonths(targetDate: string | null): number {


### PR DESCRIPTION
Part of #467. Branched off latest `main`.

## What
The transaction-history row's presentation logic was **byte-identical inline** in `GoalDetailSheet` (mobile) and `DesktopGoalDetail` (desktop):

```ts
const kind = txKind(tx)
const isWithdraw = kind === 'withdrawal'
const neutral = isRenewed || kind === 'held' || kind === 'consumed'
const ink  = neutral ? 'var(--c-muted)' : isWithdraw ? 'var(--c-neg)'      : 'var(--c-pos)'
const fill = neutral ? 'var(--c-card-2)' : isWithdraw ? 'var(--c-neg-tint)' : 'var(--c-pos-tint)'
const DirIcon = isRenewed ? RefreshCw : kind === 'held' ? PiggyBank : kind === 'consumed' ? GitMerge : isWithdraw ? ArrowDownRight : ArrowUpRight
const sign = isWithdraw ? '-' : kind === 'investment' ? '+' : ''
const name = tx.fund_name ?? tx.notes ?? (isVi ? 'Khoản đầu tư' : 'Investment')
```

A held/merged/renewed row must read **neutrally** (muted, no red "−") on both surfaces — exactly the kind of "fix one, forget the other" hazard #467 targets.

## How
Extract `describeHistoryRow(tx, isRenewed, isVi) → { kind, ink, fill, Icon, sign, name }` into `goalDetailShared.tsx`. Each surface now calls it and only maps the icon **size** + its own row chrome in JSX. The now-unused `txKind` / `ArrowUpRight` / `GitMerge` imports drop out of both components. No rendered change.

## TDD
`goalDetailShared.test.tsx` pins the mapping **first** — investment / withdrawal / held / consumed / renewed → the right tone, icon and sign, plus the name fallback (`fund_name → notes → localized default`) — then both surfaces switch over. The `GoalDetailSheet` / `DesktopGoalDetail` component tests are the rendered-parity guard.

## Verification
- `goalDetailShared` 41 tests (6 new) + **full unit suite 1250 passed**
- `npm run typecheck` **0 errors** · `npm run lint` **0 errors**
- Net: −15 lines in each component; the classifier lives once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)