### PR TITLE
refactor(maturity): extract the renew/collapse write model (#467)

### DIFF
--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -30,10 +30,10 @@ import {
   depositMaturityState,
   addMonths,
   monthsBetween,
-  renewalPrincipal,
   allocateCumulative,
   type RenewMode,
 } from '@/lib/maturity'
+import { computeNewPrincipal, renewEndpoint, buildRenewBody } from './maturityResolveModel'
 import { linkedSavingFor, type RecurringLinkCandidate, type RecurringLinkResult } from '@/lib/recurringLink'
 import { classifyMergeSources, type MergeBlockReason } from '@/lib/mergeEligibility'
 import { todayIso } from '@/lib/dates'
@@ -391,11 +391,7 @@ export function MaturityResolveBody({
   // recurring); the merged-in sibling cash is added ON TOP for the new principal.
   // Submit sends the BASE and the per-source received list — the RPC re-sums
   // Σ(received) server-side, so the net-worth invariant can't drift.
-  const newPrincipal = mode === 'withdraw'
-    ? principal
-    : mode === 'combine'
-      ? redepositNum + mergeReceivedTotal + heldReceivedTotal
-      : renewalPrincipal(mode, principal, iNum, newAmountNum)
+  const newPrincipal = computeNewPrincipal(mode, { principal, iNum, newAmountNum, redepositNum, mergeReceivedTotal, heldReceivedTotal })
 
   // Suggested re-deposit = principal + interest + this month's recurring, until
   // the user edits it (their bank's actual figure may differ).
@@ -631,49 +627,17 @@ export function MaturityResolveBody({
       // route; a single term deposit rolls forward via /renew. The collapse route
       // values each tranche's interest itself (one TS formula → the per-tranche
       // history snapshots), so — unlike /renew — it takes no interest_earned_vnd.
-      const endpoint = isBook ? 'collapse' : 'renew'
+      // Body construction (per-mode amount, book vs single, merge/held/fulfillment
+      // folding) lives in maturityResolveModel — see buildRenewBody's doc for the
+      // combine-sends-BASE and book-omits-interest rules.
+      const endpoint = renewEndpoint(isBook)
       const res = await fetch(`/api/v1/investment-transactions/${inv.id}/${endpoint}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          // Merge combine sends the BASE (re-deposit field), NOT base + Σreceived:
-          // the RPC adds the received cash so client and server can't disagree.
-          // Every other path sends the full new principal.
-          amount_vnd: mode === 'combine' ? Math.round(redepositNum) : Math.round(newPrincipal),
-          interest_rate: Number(rate),
-          expiry_date: newMaturity,
-          // Anchor the new cycle's accrual to the OLD maturity date (baseDate) so
-          // the value calc restarts where the closed cycle ended — overdue days
-          // are not lost. Renewal is gated to matured (or ≤ tomorrow) deposits
-          // (see tooEarlyToRenew), so baseDate is in the past or within the
-          // route's +1 day future-date tolerance and is never rejected. The route
-          // rolls the active row forward in place and appends a history snapshot
-          // of the cycle that just closed.
-          investment_date: baseDate,
-          // Realized interest for the cycle that just closed — recorded
-          // permanently on the snapshot for the renewal-history summary. A book's
-          // collapse route derives this per tranche, so only send it for /renew.
-          ...(isBook ? {} : { interest_earned_vnd: iNum }),
-          // Combine flow: mark this month's recurring saving fulfilled inside the
-          // same transaction, so its amount (now folded into the principal above)
-          // is not also counted as a separate synthesized contribution.
-          fulfill_recurring: mode === 'combine' && pickedCand && markFulfilled
-            ? { saving_id: pickedCand.saving_id, ym: fulfillYm, amount: linkedAmt }
-            : undefined,
-          // Merge combine: the sibling deposits being settled early and folded in.
-          // The route closes each (full withdrawal) and adds its received to D.
-          merge_sources: mode === 'combine' && selectedSources.length > 0
-            ? selectedSources.map((s) => ({ tx_id: s.id, received: Math.round(Number(mergeRecv[s.id]) || 0) }))
-            : undefined,
-          // Destination bank for the combined re-deposit (multi-source merge only).
-          // '' (no bank picked) → null; the RPC leaves the existing bank untouched.
-          bank_code: mode === 'combine' && selectedSources.length > 0 ? (destBank || null) : undefined,
-          // "Ví chờ gộp": pooled holdings to consume. The RPC stamps each
-          // consumed and folds its parked cash into D — no second withdrawal.
-          held_sources: mode === 'combine' && selectedHeld.length > 0
-            ? selectedHeld.map((h) => h.id)
-            : undefined,
-        }),
+        body: JSON.stringify(buildRenewBody({
+          mode, isBook, newPrincipal, redepositNum, rate, newMaturity, baseDate, iNum,
+          pickedCand, markFulfilled, fulfillYm, linkedAmt, selectedSources, mergeRecv, destBank, selectedHeld,
+        })),
       })
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))

--- a/app/assets/components/__tests__/maturityResolveModel.test.ts
+++ b/app/assets/components/__tests__/maturityResolveModel.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { computeNewPrincipal, renewEndpoint, buildRenewBody } from '../maturityResolveModel'
+
+// The maturity-resolve write model (#467): the new principal + the renew/collapse
+// request body, per resolution mode. Extracted from MaturityResolveBody so the
+// money that persists can be pinned without a full sheet render.
+
+describe('computeNewPrincipal', () => {
+  const base = { principal: 10_000_000, iNum: 600_000, newAmountNum: null, redepositNum: 0, mergeReceivedTotal: 0, heldReceivedTotal: 0 }
+
+  it('withdraw keeps the principal unchanged', () => {
+    expect(computeNewPrincipal('withdraw', base)).toBe(10_000_000)
+  })
+
+  it('combine folds the re-deposit + merged + held cash together', () => {
+    expect(computeNewPrincipal('combine', { ...base, redepositNum: 12_000_000, mergeReceivedTotal: 3_000_000, heldReceivedTotal: 1_000_000 })).toBe(16_000_000)
+  })
+
+  it('principal_interest compounds interest back in', () => {
+    expect(computeNewPrincipal('principal_interest', base)).toBe(10_600_000)
+  })
+
+  it('principal_only keeps just the principal', () => {
+    expect(computeNewPrincipal('principal_only', base)).toBe(10_000_000)
+  })
+
+  it('change uses the manual new amount (falls back to principal when empty)', () => {
+    expect(computeNewPrincipal('change', { ...base, newAmountNum: 8_000_000 })).toBe(8_000_000)
+    expect(computeNewPrincipal('change', { ...base, newAmountNum: null })).toBe(10_000_000)
+  })
+})
+
+describe('renewEndpoint', () => {
+  it('a book collapses, a single deposit renews', () => {
+    expect(renewEndpoint(true)).toBe('collapse')
+    expect(renewEndpoint(false)).toBe('renew')
+  })
+})
+
+const bodyBase = {
+  isBook: false, newPrincipal: 10_600_000, redepositNum: 0, rate: '6.5',
+  newMaturity: '2027-01-01', baseDate: '2026-07-01', iNum: 600_000,
+  pickedCand: null as { saving_id: string } | null, markFulfilled: true, fulfillYm: '2026-07', linkedAmt: 0,
+  selectedSources: [] as { id: string; name?: string | null }[], mergeRecv: {} as Record<string, string>,
+  destBank: '', selectedHeld: [] as { id: string; name?: string | null }[],
+}
+
+describe('buildRenewBody', () => {
+  it('single renew: full new principal + realized interest, no combine fields', () => {
+    const b = buildRenewBody({ mode: 'principal_interest', ...bodyBase })
+    expect(b.amount_vnd).toBe(10_600_000)
+    expect(b.interest_rate).toBe(6.5)
+    expect(b.expiry_date).toBe('2027-01-01')
+    expect(b.investment_date).toBe('2026-07-01')
+    expect(b.interest_earned_vnd).toBe(600_000)
+    expect(b.merge_sources).toBeUndefined()
+    expect(b.held_sources).toBeUndefined()
+    expect(b.bank_code).toBeUndefined()
+    expect(b.fulfill_recurring).toBeUndefined()
+  })
+
+  it('book collapse omits interest_earned_vnd (derived per tranche server-side)', () => {
+    const b = buildRenewBody({ mode: 'principal_interest', ...bodyBase, isBook: true })
+    expect('interest_earned_vnd' in b).toBe(false)
+  })
+
+  it('combine sends the BASE re-deposit and folds in merge + held sources + bank + fulfillment', () => {
+    const b = buildRenewBody({
+      mode: 'combine', ...bodyBase, newPrincipal: 16_000_000, redepositNum: 12_000_000,
+      pickedCand: { saving_id: 'sav1' }, markFulfilled: true, linkedAmt: 1_000_000,
+      selectedSources: [{ id: 'tx2', name: 'B' }], mergeRecv: { tx2: '3000000' }, destBank: 'VCB',
+      selectedHeld: [{ id: 'h1', name: 'H' }],
+    })
+    expect(b.amount_vnd).toBe(12_000_000)                                    // BASE, not 16M
+    expect(b.merge_sources).toEqual([{ tx_id: 'tx2', received: 3_000_000 }])
+    expect(b.bank_code).toBe('VCB')
+    expect(b.held_sources).toEqual(['h1'])
+    expect(b.fulfill_recurring).toEqual({ saving_id: 'sav1', ym: '2026-07', amount: 1_000_000 })
+  })
+
+  it('combine with no merge sources leaves merge_sources / bank_code undefined', () => {
+    const b = buildRenewBody({ mode: 'combine', ...bodyBase, redepositNum: 12_000_000, destBank: 'VCB' })
+    expect(b.amount_vnd).toBe(12_000_000)
+    expect(b.merge_sources).toBeUndefined()
+    expect(b.bank_code).toBeUndefined()
+  })
+
+  it('combine without a recurring pick or unchecked fulfillment omits fulfill_recurring', () => {
+    expect(buildRenewBody({ mode: 'combine', ...bodyBase, pickedCand: { saving_id: 's' }, markFulfilled: false }).fulfill_recurring).toBeUndefined()
+    expect(buildRenewBody({ mode: 'combine', ...bodyBase, pickedCand: null }).fulfill_recurring).toBeUndefined()
+  })
+})

--- a/app/assets/components/maturityResolveModel.ts
+++ b/app/assets/components/maturityResolveModel.ts
@@ -1,0 +1,78 @@
+// Write model for the maturity-resolve flow (#467): the new principal and the
+// renew/collapse request body, per resolution mode. Extracted from
+// MaturityResolveBody so the money that persists lives in one tested place; the
+// component keeps the form state, validation UI, and fetch/error handling.
+import { renewalPrincipal, type RenewMode } from '@/lib/maturity'
+
+export type Mode = RenewMode | 'withdraw' | 'combine'
+
+export interface RenewSource {
+  id: string
+  name?: string | null
+}
+
+// A matured deposit's new principal for the chosen resolution: unchanged on
+// withdraw; the re-deposit plus everything folded in on combine; else the renewal
+// rule (principal, principal+interest, or a manual new amount).
+export function computeNewPrincipal(mode: Mode, args: {
+  principal: number
+  iNum: number
+  newAmountNum: number | null
+  redepositNum: number
+  mergeReceivedTotal: number
+  heldReceivedTotal: number
+}): number {
+  if (mode === 'withdraw') return args.principal
+  if (mode === 'combine') return args.redepositNum + args.mergeReceivedTotal + args.heldReceivedTotal
+  return renewalPrincipal(mode, args.principal, args.iNum, args.newAmountNum)
+}
+
+// A book collapses all tranches into one fresh deposit via /collapse; a single
+// term deposit rolls forward via /renew.
+export function renewEndpoint(isBook: boolean): 'collapse' | 'renew' {
+  return isBook ? 'collapse' : 'renew'
+}
+
+// The renew/collapse POST body. Combine sends the BASE re-deposit (the RPC adds
+// the received cash itself, so client and server can't disagree); every other path
+// sends the full new principal. A book's collapse route derives per-tranche
+// realized interest, so interest_earned_vnd is only sent for /renew.
+export function buildRenewBody(args: {
+  mode: Mode
+  isBook: boolean
+  newPrincipal: number
+  redepositNum: number
+  rate: string
+  newMaturity: string
+  baseDate: string
+  iNum: number
+  pickedCand: { saving_id: string } | null
+  markFulfilled: boolean
+  fulfillYm: string
+  linkedAmt: number
+  selectedSources: RenewSource[]
+  mergeRecv: Record<string, string>
+  destBank: string
+  selectedHeld: RenewSource[]
+}): Record<string, unknown> {
+  const {
+    mode, isBook, newPrincipal, redepositNum, rate, newMaturity, baseDate, iNum,
+    pickedCand, markFulfilled, fulfillYm, linkedAmt, selectedSources, mergeRecv, destBank, selectedHeld,
+  } = args
+  const isCombine = mode === 'combine'
+  return {
+    amount_vnd: isCombine ? Math.round(redepositNum) : Math.round(newPrincipal),
+    interest_rate: Number(rate),
+    expiry_date: newMaturity,
+    investment_date: baseDate,
+    ...(isBook ? {} : { interest_earned_vnd: iNum }),
+    fulfill_recurring: isCombine && pickedCand && markFulfilled
+      ? { saving_id: pickedCand.saving_id, ym: fulfillYm, amount: linkedAmt }
+      : undefined,
+    merge_sources: isCombine && selectedSources.length > 0
+      ? selectedSources.map((s) => ({ tx_id: s.id, received: Math.round(Number(mergeRecv[s.id]) || 0) }))
+      : undefined,
+    bank_code: isCombine && selectedSources.length > 0 ? (destBank || null) : undefined,
+    held_sources: isCombine && selectedHeld.length > 0 ? selectedHeld.map((h) => h.id) : undefined,
+  }
+}


### PR DESCRIPTION
Part of #467 — first slice of the MaturityResolveSheet split from the [remaining-work comment](https://github.com/mphuongth/allocate/issues/467), tackling its "**keep one shared model for validation and payload construction**" point.

## What
Pull the money-write logic out of `MaturityResolveBody` into a tested `maturityResolveModel.ts`:
- `computeNewPrincipal(mode, …)` — withdraw keeps the principal, combine folds re-deposit + merged + held cash, else the renewal rule (principal / principal+interest / manual new amount).
- `renewEndpoint(isBook)` — a book `collapse`s, a single deposit `renew`s.
- `buildRenewBody(…)` — the POST body: per-mode `amount_vnd` (combine sends the **BASE** re-deposit; the RPC adds received cash so client/server can't disagree), book-omits-`interest_earned_vnd`, and the `merge_sources` / `held_sources` / `bank_code` / `fulfill_recurring` folding.

`handleConfirm` becomes a thin caller; `fetch` / error / success-flash state stay in the component. **No behavior change.**

## TDD
`maturityResolveModel.test.ts` pins each mode's principal and the **exact request body** first — single renew vs book collapse (interest omitted), combine-sends-BASE, and the merge/held/bank/fulfillment folding + their absent cases — then `handleConfirm` is switched to the model. The `MaturityResolveSheet` component tests, which drive the renew/combine flows and assert the POST body, are the parity guard.

## Verification
- `maturityResolveModel` 11 + **full unit suite 1261 passed**
- `npm run typecheck` **0 errors** · `npm run lint` **0 errors**
- Targeted E2E `maturity-combine` + `maturity-combine-merge` (6) passed — real renew / merge-sibling / cross-bank / recurring-fold / rejection round-trips.

The workflow JSX-section splits (combine, withdraw) are the natural follow-ups toward the full file split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)