### PR TITLE
refactor(maturity): extract the combine held-pool sub-section (#467)

### DIFF
--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -19,9 +19,9 @@
 // (the parent wires `onWithdraw`).
 
 import { useState, useEffect } from 'react'
-import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X, Plus, Wallet, Lock, SlidersHorizontal, PiggyBank, GitMerge } from 'lucide-react'
+import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X, Plus, Wallet, Lock, SlidersHorizontal, PiggyBank } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
-import { fieldLabel, moneyInput, MoneyInputCore, MoneyField, WithdrawSection } from './maturityResolveFields'
+import { fieldLabel, moneyInput, MoneyInputCore, MoneyField, WithdrawSection, HeldPoolSection } from './maturityResolveFields'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 import { iconHit } from './iconHit'
 import { SUCCESS_FLASH_MS } from '../successFlash'
@@ -909,32 +909,8 @@ export function MaturityResolveBody({
               one just leaves it in the pool; restoring the deposit is the holdings
               chip's "Bỏ chờ gộp" action. Shown even with no live siblings. */}
           {!isBook && pooledHeld.length > 0 && (
-            <div data-testid="merge-held-pool" style={{ border: '1px solid var(--c-line)', borderRadius: 12, padding: '11px 13px', display: 'grid', gap: 9 }}>
-              <div>
-                <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
-                  <GitMerge size={14} color="var(--c-navy)" style={{ flexShrink: 0 }} />
-                  <div style={{ ...fieldLabel, marginBottom: 0 }}>{t.heldSectionTitle}</div>
-                </div>
-                <p style={{ margin: '4px 0 0', fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.45 }}>{t.heldSectionHint}</p>
-              </div>
-              <div style={{ display: 'grid', gap: 7 }}>
-                {pooledHeld.map((h) => {
-                  const sel = isHeldSelected(h.id)
-                  return (
-                    <button key={h.id} type="button" data-testid={`merge-held-${h.id}`} onClick={() => setHeldSel((prev) => ({ ...prev, [h.id]: !sel }))}
-                      style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '9px 11px', borderRadius: 10, cursor: 'pointer', textAlign: 'left',
-                        border: `1.5px solid ${sel ? 'var(--c-navy)' : 'var(--c-line)'}`, background: sel ? 'var(--c-navy-tint)' : 'var(--c-card)', fontFamily: 'inherit' }}>
-                      <span style={{ width: 18, height: 18, borderRadius: 9, flexShrink: 0, border: `1.5px solid ${sel ? 'var(--c-btn-primary)' : 'var(--c-line-strong)'}`, background: sel ? 'var(--c-btn-primary)' : 'transparent', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                        {sel && <Check size={11} color="#fff" strokeWidth={3} />}
-                      </span>
-                      <span style={{ flex: 1, minWidth: 0, fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{h.name ?? (isVi ? 'Sổ chờ gộp' : 'Held deposit')}</span>
-                      <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(h.amount)}</span>
-                    </button>
-                  )
-                })}
-              </div>
-              <p style={{ margin: 0, fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.45 }}>{t.heldUnholdHint}</p>
-            </div>
+            <HeldPoolSection pooledHeld={pooledHeld} isHeldSelected={isHeldSelected} setHeldSel={setHeldSel} isVi={isVi}
+              t={{ heldSectionTitle: t.heldSectionTitle, heldSectionHint: t.heldSectionHint, heldUnholdHint: t.heldUnholdHint }} />
           )}
 
           {/* New term + rate */}

--- a/app/assets/components/maturityResolveFields.tsx
+++ b/app/assets/components/maturityResolveFields.tsx
@@ -5,8 +5,8 @@
 // fields and the hold-vs-cash fork live in a focused module; the sheet keeps the
 // state and passes it in. The renew/combine sections still live in the sheet and
 // import the field primitives from here.
-import { PiggyBank, ArrowDownToLine, Check } from 'lucide-react'
-import { fmt } from '@/lib/formatters'
+import { PiggyBank, ArrowDownToLine, Check, GitMerge } from 'lucide-react'
+import { fmt, fmtCompact } from '@/lib/formatters'
 import AmountInput from '@/app/components/ui/AmountInput'
 
 export const fieldLabel: React.CSSProperties = {
@@ -117,5 +117,47 @@ export function WithdrawSection({
             <span style={{ fontSize: 16, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>{fmt(payout)}</span>
           </div>
         </div>
+  )
+}
+
+// The "Ví chờ gộp" held-settlement pool inside the combine flow (#467): pick which
+// parked settlements to fold into this re-deposit. Rendered only when the deposit
+// isn't a book and the pool is non-empty (the sheet guards that).
+export function HeldPoolSection({
+  pooledHeld, isHeldSelected, setHeldSel, isVi, t,
+}: {
+  pooledHeld: { id: string; name: string | null; amount: number }[]
+  isHeldSelected: (id: string) => boolean
+  setHeldSel: (updater: (prev: Record<string, boolean>) => Record<string, boolean>) => void
+  isVi: boolean
+  t: { heldSectionTitle: string; heldSectionHint: string; heldUnholdHint: string }
+}) {
+  return (
+            <div data-testid="merge-held-pool" style={{ border: '1px solid var(--c-line)', borderRadius: 12, padding: '11px 13px', display: 'grid', gap: 9 }}>
+              <div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 7 }}>
+                  <GitMerge size={14} color="var(--c-navy)" style={{ flexShrink: 0 }} />
+                  <div style={{ ...fieldLabel, marginBottom: 0 }}>{t.heldSectionTitle}</div>
+                </div>
+                <p style={{ margin: '4px 0 0', fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.45 }}>{t.heldSectionHint}</p>
+              </div>
+              <div style={{ display: 'grid', gap: 7 }}>
+                {pooledHeld.map((h) => {
+                  const sel = isHeldSelected(h.id)
+                  return (
+                    <button key={h.id} type="button" data-testid={`merge-held-${h.id}`} onClick={() => setHeldSel((prev) => ({ ...prev, [h.id]: !sel }))}
+                      style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '9px 11px', borderRadius: 10, cursor: 'pointer', textAlign: 'left',
+                        border: `1.5px solid ${sel ? 'var(--c-navy)' : 'var(--c-line)'}`, background: sel ? 'var(--c-navy-tint)' : 'var(--c-card)', fontFamily: 'inherit' }}>
+                      <span style={{ width: 18, height: 18, borderRadius: 9, flexShrink: 0, border: `1.5px solid ${sel ? 'var(--c-btn-primary)' : 'var(--c-line-strong)'}`, background: sel ? 'var(--c-btn-primary)' : 'transparent', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                        {sel && <Check size={11} color="#fff" strokeWidth={3} />}
+                      </span>
+                      <span style={{ flex: 1, minWidth: 0, fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{h.name ?? (isVi ? 'Sổ chờ gộp' : 'Held deposit')}</span>
+                      <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{fmtCompact(h.amount)}</span>
+                    </button>
+                  )
+                })}
+              </div>
+              <p style={{ margin: 0, fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.45 }}>{t.heldUnholdHint}</p>
+            </div>
   )
 }


### PR DESCRIPTION
Part of #467 — first of the **combine-workflow sub-section splits**. The combine section is a ~256-line, ~40-dependency block handling the money-merge flow, so per that risk it's being split into small, independently-verifiable sub-sections rather than one big extraction.

## What
Move the "Ví chờ gộp" held-settlement picker out of `MaturityResolveBody` into `HeldPoolSection` (in `maturityResolveFields.tsx`) — choosing which parked settlements to fold into the re-deposit. The sheet keeps the held state (`heldSel` + the derived `selectedHeld` / `heldReceivedTotal` the payload model reads) and passes the pool + selection getter/setter + the three labels down. The now-unused `GitMerge` import drops out of the sheet. **No behavior or markup change** (JSX moved verbatim).

## Parity
- The existing **MaturityResolveSheet component tests**.
- **E2E** `maturity-combine-holding` (7) — the hold → consume, "Bỏ chờ gộp" unhold, and double-count-guard flows.

## Verification
- **Full unit suite 1261 passed** · `npm run typecheck` **0 errors** · `npm run lint` **0 errors**
- E2E **7 passed**
- `MaturityResolveSheet.tsx` **1219 → 1195 lines**.

Follow-ups: the merge-sources sub-section (~15 deps) and the recurring/re-deposit fields, then the remaining renew fields — each as its own small PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)