### PR TITLE
refactor(maturity): extract the combine new-cycle fields (#467)

### DIFF
--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -21,9 +21,10 @@
 import { useState, useEffect } from 'react'
 import { RefreshCw, Pencil, ArrowDownToLine, AlertTriangle, Check, Building2, X, Plus, PiggyBank } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
-import { fieldLabel, moneyInput, MoneyField, WithdrawSection, HeldPoolSection } from './maturityResolveFields'
+import { fieldLabel, moneyInput, dateInput, MoneyField, WithdrawSection, HeldPoolSection } from './maturityResolveFields'
 import { MergeSourcesSection } from './maturityResolveMergeSources'
 import { RecurringRedepositSection } from './maturityResolveRecurring'
+import { CombineNewCycleSection } from './maturityResolveNewCycle'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 import { iconHit } from './iconHit'
 import { SUCCESS_FLASH_MS } from '../successFlash'
@@ -47,11 +48,6 @@ type Mode = RenewMode | 'withdraw' | 'combine'
 // wider than the viewport — letting it be dragged sideways (#439). Clamp it like
 // the ledger's date filters (#362): appearance:none trims the intrinsic width,
 // maxWidth:100% + minWidth:0 pin it to its cell.
-const dateInput: React.CSSProperties = {
-  ...moneyInput, maxWidth: '100%', minWidth: 0,
-  WebkitAppearance: 'none', appearance: 'none',
-}
-
 // Money entry core: a digit-grouped amount field (₫ suffix). Reused by every
 // money input in the maturity flow so large VND amounts stay readable
 // (e.g. "37,030,000" rather than "37030000"). `AmountInput` keeps the value raw
@@ -782,61 +778,18 @@ export function MaturityResolveBody({
               t={{ heldSectionTitle: t.heldSectionTitle, heldSectionHint: t.heldSectionHint, heldUnholdHint: t.heldUnholdHint }} />
           )}
 
-          {/* New term + rate */}
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
-            <div>
-              <div style={fieldLabel}>{t.newTerm}</div>
-              <div style={{ position: 'relative' }}>
-                <input type="text" inputMode="numeric" value={formatIntVN(term)} onChange={(e) => setTerm(parseIntVN(e.target.value))} style={moneyInput} />
-                <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>{t.mo}</span>
-              </div>
-            </div>
-            <div>
-              <div style={fieldLabel}>{t.newRate}</div>
-              <div style={{ position: 'relative' }}>
-                <input type="text" inputMode="decimal" value={formatDecimalVN(rate)} onChange={(e) => setRate(parseDecimalVN(e.target.value))} style={moneyInput} />
-                <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>%/{t.perYr}</span>
-              </div>
-            </div>
-          </div>
-
-          {/* New maturity date — same anchor (old maturity + term) as a renewal */}
-          <div>
-            <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 6 }}>
-              <span style={{ ...fieldLabel, marginBottom: 0 }}>{t.newMaturityLabel}</span>
-              {dateTouched && (
-                <button type="button" onClick={() => setMaturityOverride(null)}
-                  style={{ fontSize: 11, fontWeight: 600, color: 'var(--c-navy)', background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'inherit', padding: 0 }}>
-                  {t.resetDate}
-                </button>
-              )}
-            </div>
-            <input data-testid="maturity-combine-date" type="date" value={newMaturity} min={baseDate} onChange={(e) => setMaturityOverride(e.target.value)} style={dateInput} />
-            {!maturityValid && <p style={{ margin: '6px 0 0', fontSize: 11, color: 'var(--c-neg)', lineHeight: 1.4 }}>{t.maturityTooEarly}</p>}
-          </div>
-
-          {/* Mark this month's recurring as deposited (prevents double-count) */}
-          {linkedAmt > 0 && pickedCand && (
-            <label style={{ display: 'flex', alignItems: 'center', gap: 9, padding: '10px 12px', background: 'var(--c-pos-tint)', borderRadius: 10, fontSize: 12.5, color: 'var(--c-ink)', lineHeight: 1.4, cursor: 'pointer' }}>
-              <input data-testid="maturity-mark-fulfilled" type="checkbox" checked={markFulfilled} onChange={(e) => setMarkFulfilled(e.target.checked)} style={{ accentColor: 'var(--c-pos)', width: 16, height: 16, flexShrink: 0 }} />
-              <span>{t.markDeposited(fmtCompact(linkedAmt))}</span>
-            </label>
-          )}
-
-          {/* Preview */}
-          <div style={{ border: '1px solid var(--c-line)', borderRadius: 12, overflow: 'hidden' }}>
-            <div style={{ padding: '10px 14px', background: 'var(--c-navy-tint)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-              <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--c-navy)' }}>{t.newCycle}</span>
-              <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                <span data-testid="maturity-new-principal" style={{ fontSize: 16, fontWeight: 700, color: 'var(--c-navy)', fontVariantNumeric: 'tabular-nums' }}>{fmt(newPrincipal)}</span>
-                {rate !== '' && <span style={{ fontSize: 11, fontWeight: 600, padding: '2px 8px', borderRadius: 999, background: 'var(--c-card)', color: 'var(--c-navy)' }}>{rate}%/{t.perYr}</span>}
-              </span>
-            </div>
-            <div style={{ background: 'var(--c-card)', padding: '9px 12px' }}>
-              <div style={{ fontSize: 10, color: 'var(--c-muted)' }}>{t.newMaturityLabel}</div>
-              <div data-testid="maturity-new-date" style={{ fontSize: 13, fontWeight: 600, marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>{newMaturityFmt}</div>
-            </div>
-          </div>
+          <CombineNewCycleSection
+            term={term} setTerm={setTerm} rate={rate} setRate={setRate}
+            newMaturity={newMaturity} newMaturityFmt={newMaturityFmt} baseDate={baseDate}
+            setMaturityOverride={setMaturityOverride} dateTouched={dateTouched} maturityValid={maturityValid}
+            linkedAmt={linkedAmt} pickedCand={pickedCand} markFulfilled={markFulfilled} setMarkFulfilled={setMarkFulfilled}
+            newPrincipal={newPrincipal}
+            t={{
+              newTerm: t.newTerm, newRate: t.newRate, mo: t.mo, perYr: t.perYr,
+              newMaturityLabel: t.newMaturityLabel, resetDate: t.resetDate, maturityTooEarly: t.maturityTooEarly,
+              markDeposited: t.markDeposited, newCycle: t.newCycle,
+            }}
+          />
         </div>
       )}
 

--- a/app/assets/components/maturityResolveFields.tsx
+++ b/app/assets/components/maturityResolveFields.tsx
@@ -22,6 +22,13 @@ export const moneyInput: React.CSSProperties = {
   borderRadius: 10, color: 'var(--c-ink)', outline: 'none',
 }
 
+// A native <input type=date> on iOS Safari sizes to its intrinsic content width and
+// ignores width:100%, so maxWidth:100% + minWidth:0 pin it to its cell.
+export const dateInput: React.CSSProperties = {
+  ...moneyInput, maxWidth: '100%', minWidth: 0,
+  WebkitAppearance: 'none', appearance: 'none',
+}
+
 export function MoneyInputCore({ value, onChange, testId, style, compact }: {
   value: string; onChange: (v: string) => void; testId?: string;
   style?: React.CSSProperties; compact?: boolean

--- a/app/assets/components/maturityResolveNewCycle.tsx
+++ b/app/assets/components/maturityResolveNewCycle.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+// The combine flow's "new cycle" fields (#467): the new term + rate, the new
+// maturity date (anchored to old-maturity + term, with a reset), the mark-recurring-
+// deposited guard, and the new-cycle preview. The sheet owns the state + the derived
+// newPrincipal/newMaturity (from maturityResolveModel) and passes them in.
+import { fmt, fmtCompact } from '@/lib/formatters'
+import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
+import { fieldLabel, moneyInput, dateInput } from './maturityResolveFields'
+
+export function CombineNewCycleSection({
+  term, setTerm, rate, setRate, newMaturity, newMaturityFmt, baseDate, setMaturityOverride,
+  dateTouched, maturityValid, linkedAmt, pickedCand, markFulfilled, setMarkFulfilled, newPrincipal, t,
+}: {
+  term: string
+  setTerm: (v: string) => void
+  rate: string
+  setRate: (v: string) => void
+  newMaturity: string
+  newMaturityFmt: string
+  baseDate: string
+  setMaturityOverride: (v: string | null) => void
+  dateTouched: boolean
+  maturityValid: boolean
+  linkedAmt: number
+  pickedCand: { saving_id: string } | null
+  markFulfilled: boolean
+  setMarkFulfilled: (v: boolean) => void
+  newPrincipal: number
+  t: {
+    newTerm: string; newRate: string; mo: string; perYr: string
+    newMaturityLabel: string; resetDate: string; maturityTooEarly: string
+    markDeposited: (amt: string) => string; newCycle: string
+  }
+}) {
+  return (
+    <>
+          {/* New term + rate */}
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+            <div>
+              <div style={fieldLabel}>{t.newTerm}</div>
+              <div style={{ position: 'relative' }}>
+                <input type="text" inputMode="numeric" value={formatIntVN(term)} onChange={(e) => setTerm(parseIntVN(e.target.value))} style={moneyInput} />
+                <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>{t.mo}</span>
+              </div>
+            </div>
+            <div>
+              <div style={fieldLabel}>{t.newRate}</div>
+              <div style={{ position: 'relative' }}>
+                <input type="text" inputMode="decimal" value={formatDecimalVN(rate)} onChange={(e) => setRate(parseDecimalVN(e.target.value))} style={moneyInput} />
+                <span style={{ position: 'absolute', right: 12, top: '50%', transform: 'translateY(-50%)', fontSize: 13, color: 'var(--c-muted)', pointerEvents: 'none' }}>%/{t.perYr}</span>
+              </div>
+            </div>
+          </div>
+
+          {/* New maturity date — same anchor (old maturity + term) as a renewal */}
+          <div>
+            <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: 6 }}>
+              <span style={{ ...fieldLabel, marginBottom: 0 }}>{t.newMaturityLabel}</span>
+              {dateTouched && (
+                <button type="button" onClick={() => setMaturityOverride(null)}
+                  style={{ fontSize: 11, fontWeight: 600, color: 'var(--c-navy)', background: 'none', border: 'none', cursor: 'pointer', fontFamily: 'inherit', padding: 0 }}>
+                  {t.resetDate}
+                </button>
+              )}
+            </div>
+            <input data-testid="maturity-combine-date" type="date" value={newMaturity} min={baseDate} onChange={(e) => setMaturityOverride(e.target.value)} style={dateInput} />
+            {!maturityValid && <p style={{ margin: '6px 0 0', fontSize: 11, color: 'var(--c-neg)', lineHeight: 1.4 }}>{t.maturityTooEarly}</p>}
+          </div>
+
+          {/* Mark this month's recurring as deposited (prevents double-count) */}
+          {linkedAmt > 0 && pickedCand && (
+            <label style={{ display: 'flex', alignItems: 'center', gap: 9, padding: '10px 12px', background: 'var(--c-pos-tint)', borderRadius: 10, fontSize: 12.5, color: 'var(--c-ink)', lineHeight: 1.4, cursor: 'pointer' }}>
+              <input data-testid="maturity-mark-fulfilled" type="checkbox" checked={markFulfilled} onChange={(e) => setMarkFulfilled(e.target.checked)} style={{ accentColor: 'var(--c-pos)', width: 16, height: 16, flexShrink: 0 }} />
+              <span>{t.markDeposited(fmtCompact(linkedAmt))}</span>
+            </label>
+          )}
+
+          {/* Preview */}
+          <div style={{ border: '1px solid var(--c-line)', borderRadius: 12, overflow: 'hidden' }}>
+            <div style={{ padding: '10px 14px', background: 'var(--c-navy-tint)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--c-navy)' }}>{t.newCycle}</span>
+              <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                <span data-testid="maturity-new-principal" style={{ fontSize: 16, fontWeight: 700, color: 'var(--c-navy)', fontVariantNumeric: 'tabular-nums' }}>{fmt(newPrincipal)}</span>
+                {rate !== '' && <span style={{ fontSize: 11, fontWeight: 600, padding: '2px 8px', borderRadius: 999, background: 'var(--c-card)', color: 'var(--c-navy)' }}>{rate}%/{t.perYr}</span>}
+              </span>
+            </div>
+            <div style={{ background: 'var(--c-card)', padding: '9px 12px' }}>
+              <div style={{ fontSize: 10, color: 'var(--c-muted)' }}>{t.newMaturityLabel}</div>
+              <div data-testid="maturity-new-date" style={{ fontSize: 13, fontWeight: 600, marginTop: 2, fontVariantNumeric: 'tabular-nums' }}>{newMaturityFmt}</div>
+            </div>
+          </div>
+    </>
+  )
+}


### PR DESCRIPTION
Part of #467 — last of the combine-workflow sub-section splits (after held-pool #499, merge-sources #500, recurring/re-deposit #501). **The combine section is now fully componentised.**

## What
Move the combine flow's "new cycle" fields into `CombineNewCycleSection` (new `maturityResolveNewCycle.tsx`):
- the new **term + rate**,
- the new **maturity date** (anchored to old-maturity + term, with a reset),
- the **mark-recurring-deposited** guard (prevents double-count),
- the **new-cycle preview**.

Also lift the shared `dateInput` style into `maturityResolveFields` (the renew block still uses it). The sheet owns the state + the model-derived `newPrincipal` / `newMaturity` and passes them in. **No behavior or markup change** (JSX moved verbatim).

The renew **"Inputs per mode"** block is intentionally left in the sheet: it looks similar but genuinely differs (its own new-amount / interest fields, a two-column preview with interest in/out, hint-vs-error maturity copy, different test-ids), so it isn't a clean shared component.

## Parity
- The existing **MaturityResolveSheet component tests**.
- **E2E** `maturity-combine` + `maturity-combine-cluster`.
  - Note: the cluster spec flaked once under parallel DB contention in the combined run and **passes in isolation** (4/4) — unrelated to this change.

## Verification
- **Full unit suite 1261 passed** · `npm run typecheck` **0 errors** · `npm run lint` **0 errors**
- `MaturityResolveSheet.tsx` **1064 → 1017 lines** — **1326 → 1017** across the maturity split (write-model + fields/withdraw + 4 combine sub-sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)