### PR TITLE
chore(deps): move shadcn to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "recharts": "^3.8.1",
-        "shadcn": "^4.1.2",
         "sharp": "^0.35.3",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
@@ -42,6 +41,7 @@
         "eslint-config-next": "16.1.7",
         "jsdom": "^29.1.0",
         "prettier": "^3.8.1",
+        "shadcn": "^4.1.2",
         "tailwindcss": "^4",
         "typescript": "^5.9.3",
         "vitest": "^4.1.5"
@@ -110,6 +110,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
       "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.29.7",
@@ -124,6 +125,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
       "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -133,6 +135,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -163,6 +166,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
       "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.7",
@@ -177,6 +181,7 @@
     },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.27.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.27.3"
@@ -189,6 +194,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
       "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.29.7",
@@ -203,6 +209,7 @@
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
       "version": "7.28.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -224,6 +231,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
       "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -231,6 +239,7 @@
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.28.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.5",
@@ -244,6 +253,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
       "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.29.7",
@@ -257,6 +267,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
       "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.29.7",
@@ -272,6 +283,7 @@
     },
     "node_modules/@babel/helper-optimise-call-expression": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.27.1"
@@ -282,6 +294,7 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.28.6",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -289,6 +302,7 @@
     },
     "node_modules/@babel/helper-replace-supers": {
       "version": "7.28.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.28.5",
@@ -304,6 +318,7 @@
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.27.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.27.1",
@@ -317,6 +332,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
       "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -326,6 +342,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -335,6 +352,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
       "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -344,6 +362,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
       "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.29.7",
@@ -357,6 +376,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
       "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.7"
@@ -370,6 +390,7 @@
     },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.28.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -383,6 +404,7 @@
     },
     "node_modules/@babel/plugin-syntax-typescript": {
       "version": "7.28.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -396,6 +418,7 @@
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
       "version": "7.28.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.28.6",
@@ -410,6 +433,7 @@
     },
     "node_modules/@babel/plugin-transform-typescript": {
       "version": "7.28.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
@@ -427,6 +451,7 @@
     },
     "node_modules/@babel/preset-typescript": {
       "version": "7.28.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1",
@@ -453,6 +478,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
       "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -467,6 +493,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
       "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
@@ -485,6 +512,7 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
       "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -692,6 +720,7 @@
     },
     "node_modules/@dotenvx/dotenvx": {
       "version": "1.60.0",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "commander": "^11.1.0",
@@ -714,6 +743,7 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/commander": {
       "version": "11.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16"
@@ -721,6 +751,7 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/execa": {
       "version": "5.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cross-spawn": "^7.0.3",
@@ -742,6 +773,7 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/fdir": {
       "version": "6.5.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -757,6 +789,7 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/get-stream": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -767,6 +800,7 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/human-signals": {
       "version": "2.1.0",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
@@ -774,6 +808,7 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/is-stream": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -784,6 +819,7 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/isexe": {
       "version": "3.1.5",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
@@ -791,6 +827,7 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/npm-run-path": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.0.0"
@@ -801,6 +838,7 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/onetime": {
       "version": "5.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-fn": "^2.1.0"
@@ -814,6 +852,7 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/picomatch": {
       "version": "4.0.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -824,10 +863,12 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/signal-exit": {
       "version": "3.0.7",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/@dotenvx/dotenvx/node_modules/strip-final-newline": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -835,6 +876,7 @@
     },
     "node_modules/@dotenvx/dotenvx/node_modules/which": {
       "version": "4.0.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^3.1.1"
@@ -848,6 +890,7 @@
     },
     "node_modules/@ecies/ciphers": {
       "version": "0.2.6",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "bun": ">=1",
@@ -1095,6 +1138,7 @@
       "version": "1.19.14",
       "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
       "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -1695,6 +1739,7 @@
     },
     "node_modules/@inquirer/ansi": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1702,6 +1747,7 @@
     },
     "node_modules/@inquirer/confirm": {
       "version": "5.1.21",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/core": "^10.3.2",
@@ -1721,6 +1767,7 @@
     },
     "node_modules/@inquirer/core": {
       "version": "10.3.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@inquirer/ansi": "^1.0.2",
@@ -1746,6 +1793,7 @@
     },
     "node_modules/@inquirer/figures": {
       "version": "1.0.15",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1753,6 +1801,7 @@
     },
     "node_modules/@inquirer/type": {
       "version": "3.0.10",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -1768,6 +1817,7 @@
     },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1776,6 +1826,7 @@
     },
     "node_modules/@jridgewell/remapping": {
       "version": "2.3.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -1784,6 +1835,7 @@
     },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1791,10 +1843,12 @@
     },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1803,6 +1857,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.29.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -1841,6 +1896,7 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
       "version": "8.18.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1855,10 +1911,12 @@
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@mswjs/interceptors": {
       "version": "0.41.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@open-draft/deferred-promise": "^2.2.0",
@@ -2057,6 +2115,7 @@
     },
     "node_modules/@noble/curves": {
       "version": "1.9.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "1.8.0"
@@ -2080,6 +2139,7 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -2091,6 +2151,7 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -2098,6 +2159,7 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -2117,10 +2179,12 @@
     },
     "node_modules/@open-draft/deferred-promise": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@open-draft/logger": {
       "version": "0.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-node-process": "^1.2.0",
@@ -2129,6 +2193,7 @@
     },
     "node_modules/@open-draft/until": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@oxc-project/types": {
@@ -2978,10 +3043,12 @@
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3668,6 +3735,7 @@
     },
     "node_modules/@ts-morph/common": {
       "version": "0.27.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-glob": "^3.3.3",
@@ -3677,6 +3745,7 @@
     },
     "node_modules/@ts-morph/common/node_modules/fast-glob": {
       "version": "3.3.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -3691,6 +3760,7 @@
     },
     "node_modules/@ts-morph/common/node_modules/glob-parent": {
       "version": "5.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3701,6 +3771,7 @@
     },
     "node_modules/@ts-morph/common/node_modules/minimatch": {
       "version": "10.2.5",
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
@@ -3832,6 +3903,7 @@
     },
     "node_modules/@types/statuses": {
       "version": "2.0.6",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
@@ -3840,6 +3912,7 @@
     },
     "node_modules/@types/validate-npm-package-name": {
       "version": "4.0.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
@@ -4557,6 +4630,7 @@
     },
     "node_modules/accepts": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -4587,6 +4661,7 @@
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -4609,6 +4684,7 @@
     },
     "node_modules/ajv-formats": {
       "version": "3.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -4624,6 +4700,7 @@
     },
     "node_modules/ajv-formats/node_modules/ajv": {
       "version": "8.18.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4638,10 +4715,12 @@
     },
     "node_modules/ajv-formats/node_modules/json-schema-traverse": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -4652,6 +4731,7 @@
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4665,6 +4745,7 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -4829,6 +4910,7 @@
     },
     "node_modules/ast-types": {
       "version": "0.16.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
@@ -4899,6 +4981,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4945,6 +5028,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
       "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
@@ -4969,6 +5053,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4982,6 +5067,7 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
       "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4992,6 +5078,7 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -5020,6 +5107,7 @@
     },
     "node_modules/browserslist": {
       "version": "4.28.1",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5051,6 +5139,7 @@
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "run-applescript": "^7.0.0"
@@ -5064,6 +5153,7 @@
     },
     "node_modules/bytes": {
       "version": "3.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5088,6 +5178,7 @@
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5099,6 +5190,7 @@
     },
     "node_modules/call-bound": {
       "version": "1.0.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -5113,6 +5205,7 @@
     },
     "node_modules/callsites": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5171,6 +5264,7 @@
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "restore-cursor": "^5.0.0"
@@ -5184,6 +5278,7 @@
     },
     "node_modules/cli-spinners": {
       "version": "2.9.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5194,6 +5289,7 @@
     },
     "node_modules/cli-width": {
       "version": "4.1.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 12"
@@ -5205,6 +5301,7 @@
     },
     "node_modules/cliui": {
       "version": "8.0.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^4.2.0",
@@ -5217,6 +5314,7 @@
     },
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5224,10 +5322,12 @@
     },
     "node_modules/cliui/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cliui/node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -5240,6 +5340,7 @@
     },
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -5250,6 +5351,7 @@
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "7.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -5281,10 +5383,12 @@
     },
     "node_modules/code-block-writer": {
       "version": "13.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -5295,6 +5399,7 @@
     },
     "node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-string": {
@@ -5320,6 +5425,7 @@
     },
     "node_modules/commander": {
       "version": "14.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -5334,6 +5440,7 @@
     },
     "node_modules/content-disposition": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5345,6 +5452,7 @@
     },
     "node_modules/content-type": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -5352,6 +5460,7 @@
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cookie": {
@@ -5367,6 +5476,7 @@
     },
     "node_modules/cookie-signature": {
       "version": "1.2.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.6.0"
@@ -5374,6 +5484,7 @@
     },
     "node_modules/cors": {
       "version": "2.8.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "object-assign": "^4",
@@ -5389,6 +5500,7 @@
     },
     "node_modules/cosmiconfig": {
       "version": "9.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "env-paths": "^2.2.1",
@@ -5413,6 +5525,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5442,6 +5555,7 @@
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -5561,6 +5675,7 @@
     },
     "node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -5628,6 +5743,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5652,6 +5768,7 @@
     },
     "node_modules/dedent": {
       "version": "1.7.2",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "babel-plugin-macros": "^3.1.0"
@@ -5669,6 +5786,7 @@
     },
     "node_modules/deepmerge": {
       "version": "4.3.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5676,6 +5794,7 @@
     },
     "node_modules/default-browser": {
       "version": "5.5.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bundle-name": "^4.1.0",
@@ -5690,6 +5809,7 @@
     },
     "node_modules/default-browser-id": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -5716,6 +5836,7 @@
     },
     "node_modules/define-lazy-prop": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -5742,6 +5863,7 @@
     },
     "node_modules/depd": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5771,6 +5893,7 @@
     },
     "node_modules/diff": {
       "version": "8.0.4",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
@@ -5795,6 +5918,7 @@
     },
     "node_modules/dotenv": {
       "version": "17.4.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -5850,6 +5974,7 @@
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5862,6 +5987,7 @@
     },
     "node_modules/eciesjs": {
       "version": "0.4.18",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ecies/ciphers": "^0.2.5",
@@ -5877,10 +6003,12 @@
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.313",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -5896,6 +6024,7 @@
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -5926,6 +6055,7 @@
     },
     "node_modules/env-paths": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5933,6 +6063,7 @@
     },
     "node_modules/error-ex": {
       "version": "1.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
@@ -6007,6 +6138,7 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6014,6 +6146,7 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6053,6 +6186,7 @@
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -6112,6 +6246,7 @@
     },
     "node_modules/escalade": {
       "version": "3.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -6119,6 +6254,7 @@
     },
     "node_modules/escape-html": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
@@ -6484,6 +6620,7 @@
     },
     "node_modules/esprima": {
       "version": "4.0.1",
+      "dev": true,
       "license": "BSD-2-Clause",
       "bin": {
         "esparse": "bin/esparse.js",
@@ -6541,6 +6678,7 @@
     },
     "node_modules/etag": {
       "version": "1.8.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6561,6 +6699,7 @@
     },
     "node_modules/eventsource": {
       "version": "3.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
@@ -6571,6 +6710,7 @@
     },
     "node_modules/eventsource-parser": {
       "version": "3.0.6",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -6578,6 +6718,7 @@
     },
     "node_modules/execa": {
       "version": "9.6.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
@@ -6610,6 +6751,7 @@
     },
     "node_modules/express": {
       "version": "5.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "^2.0.0",
@@ -6653,6 +6795,7 @@
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
       "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.2.0"
@@ -6669,6 +6812,7 @@
     },
     "node_modules/express/node_modules/cookie": {
       "version": "0.7.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6718,6 +6862,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
       "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6732,6 +6877,7 @@
     },
     "node_modules/fastq": {
       "version": "1.20.1",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -6739,6 +6885,7 @@
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6766,6 +6913,7 @@
     },
     "node_modules/figures": {
       "version": "6.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-unicode-supported": "^2.0.0"
@@ -6790,6 +6938,7 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6800,6 +6949,7 @@
     },
     "node_modules/finalhandler": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -6884,6 +7034,7 @@
     },
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fetch-blob": "^3.1.2"
@@ -6894,6 +7045,7 @@
     },
     "node_modules/forwarded": {
       "version": "0.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -6901,6 +7053,7 @@
     },
     "node_modules/fresh": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -6908,6 +7061,7 @@
     },
     "node_modules/fs-extra": {
       "version": "11.3.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -6932,6 +7086,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6966,6 +7121,7 @@
     },
     "node_modules/fuzzysort": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/generator-function": {
@@ -6978,6 +7134,7 @@
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -6985,6 +7142,7 @@
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -6992,6 +7150,7 @@
     },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7002,6 +7161,7 @@
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7024,6 +7184,7 @@
     },
     "node_modules/get-own-enumerable-keys": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -7034,6 +7195,7 @@
     },
     "node_modules/get-proto": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -7045,6 +7207,7 @@
     },
     "node_modules/get-stream": {
       "version": "9.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
@@ -7123,6 +7286,7 @@
     },
     "node_modules/gopd": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7133,10 +7297,12 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphql": {
       "version": "16.13.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
@@ -7188,6 +7354,7 @@
     },
     "node_modules/has-symbols": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -7212,6 +7379,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7222,6 +7390,7 @@
     },
     "node_modules/headers-polyfill": {
       "version": "4.0.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/hermes-estree": {
@@ -7241,6 +7410,7 @@
       "version": "4.12.29",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.29.tgz",
       "integrity": "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -7279,6 +7449,7 @@
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "depd": "~2.0.0",
@@ -7297,6 +7468,7 @@
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -7308,6 +7480,7 @@
     },
     "node_modules/human-signals": {
       "version": "8.0.1",
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -7328,6 +7501,7 @@
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -7357,6 +7531,7 @@
     },
     "node_modules/ignore": {
       "version": "5.3.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -7372,6 +7547,7 @@
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -7438,6 +7614,7 @@
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
       "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -7445,6 +7622,7 @@
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
@@ -7468,6 +7646,7 @@
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-async-function": {
@@ -7594,6 +7773,7 @@
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "is-docker": "cli.js"
@@ -7628,6 +7808,7 @@
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7663,6 +7844,7 @@
     },
     "node_modules/is-in-ssh": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -7673,6 +7855,7 @@
     },
     "node_modules/is-inside-container": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-docker": "^3.0.0"
@@ -7689,6 +7872,7 @@
     },
     "node_modules/is-interactive": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7721,10 +7905,12 @@
     },
     "node_modules/is-node-process": {
       "version": "1.2.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -7747,6 +7933,7 @@
     },
     "node_modules/is-obj": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7757,6 +7944,7 @@
     },
     "node_modules/is-plain-obj": {
       "version": "4.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7772,6 +7960,7 @@
     },
     "node_modules/is-promise": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -7793,6 +7982,7 @@
     },
     "node_modules/is-regexp": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7828,6 +8018,7 @@
     },
     "node_modules/is-stream": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7883,6 +8074,7 @@
     },
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -7939,6 +8131,7 @@
     },
     "node_modules/is-wsl": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-inside-container": "^1.0.0"
@@ -7957,6 +8150,7 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -8027,6 +8221,7 @@
     },
     "node_modules/jose": {
       "version": "6.2.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -8046,6 +8241,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
       "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8113,6 +8309,7 @@
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -8128,6 +8325,7 @@
     },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -8137,6 +8335,7 @@
     },
     "node_modules/json-schema-typed": {
       "version": "8.0.2",
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -8146,6 +8345,7 @@
     },
     "node_modules/json5": {
       "version": "2.2.3",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
@@ -8156,6 +8356,7 @@
     },
     "node_modules/jsonfile": {
       "version": "6.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -8188,6 +8389,7 @@
     },
     "node_modules/kleur": {
       "version": "4.1.5",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8511,6 +8713,7 @@
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -8534,6 +8737,7 @@
     },
     "node_modules/log-symbols": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -8548,6 +8752,7 @@
     },
     "node_modules/log-symbols/node_modules/chalk": {
       "version": "5.6.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -8558,6 +8763,7 @@
     },
     "node_modules/log-symbols/node_modules/is-unicode-supported": {
       "version": "1.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8580,6 +8786,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
@@ -8646,6 +8853,7 @@
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8664,6 +8872,7 @@
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -8671,6 +8880,7 @@
     },
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8681,10 +8891,12 @@
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -8692,6 +8904,7 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -8703,6 +8916,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -8710,6 +8924,7 @@
     },
     "node_modules/mime-types": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -8724,6 +8939,7 @@
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -8731,6 +8947,7 @@
     },
     "node_modules/mimic-function": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -8778,6 +8995,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -8785,10 +9003,12 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/msw": {
       "version": "2.12.14",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -8831,6 +9051,7 @@
     },
     "node_modules/mute-stream": {
       "version": "2.0.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
@@ -9014,6 +9235,7 @@
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9048,6 +9270,7 @@
     },
     "node_modules/node-fetch": {
       "version": "3.3.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -9064,6 +9287,7 @@
     },
     "node_modules/node-releases": {
       "version": "2.0.36",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-svg-path": {
@@ -9077,6 +9301,7 @@
     },
     "node_modules/npm-run-path": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^4.0.0",
@@ -9091,6 +9316,7 @@
     },
     "node_modules/npm-run-path/node_modules/path-key": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -9108,6 +9334,7 @@
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9126,6 +9353,7 @@
     },
     "node_modules/object-treeify": {
       "version": "1.1.33",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
@@ -9222,6 +9450,7 @@
     },
     "node_modules/on-finished": {
       "version": "2.4.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ee-first": "1.1.1"
@@ -9232,6 +9461,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -9239,6 +9469,7 @@
     },
     "node_modules/onetime": {
       "version": "7.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mimic-function": "^5.0.0"
@@ -9252,6 +9483,7 @@
     },
     "node_modules/open": {
       "version": "11.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "default-browser": "^5.4.0",
@@ -9286,6 +9518,7 @@
     },
     "node_modules/ora": {
       "version": "8.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -9307,6 +9540,7 @@
     },
     "node_modules/ora/node_modules/chalk": {
       "version": "5.6.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -9317,6 +9551,7 @@
     },
     "node_modules/outvariant": {
       "version": "1.4.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/own-keys": {
@@ -9371,6 +9606,7 @@
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -9381,6 +9617,7 @@
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
@@ -9397,6 +9634,7 @@
     },
     "node_modules/parse-ms": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -9424,6 +9662,7 @@
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -9431,6 +9670,7 @@
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-exists": {
@@ -9443,6 +9683,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -9455,6 +9696,7 @@
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pathe": {
@@ -9470,6 +9712,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -9480,6 +9723,7 @@
     },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
@@ -9581,6 +9825,7 @@
     },
     "node_modules/postcss-selector-parser": {
       "version": "7.1.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -9598,6 +9843,7 @@
     },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -9671,6 +9917,7 @@
     },
     "node_modules/pretty-ms": {
       "version": "9.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parse-ms": "^4.0.0"
@@ -9684,6 +9931,7 @@
     },
     "node_modules/prompts": {
       "version": "2.4.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^3.0.3",
@@ -9695,6 +9943,7 @@
     },
     "node_modules/prompts/node_modules/kleur": {
       "version": "3.0.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -9711,6 +9960,7 @@
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "forwarded": "0.2.0",
@@ -9732,6 +9982,7 @@
       "version": "6.15.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
       "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -9754,6 +10005,7 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9772,6 +10024,7 @@
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -9779,6 +10032,7 @@
     },
     "node_modules/raw-body": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -9834,6 +10088,7 @@
     },
     "node_modules/recast": {
       "version": "0.23.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ast-types": "^0.16.1",
@@ -9939,6 +10194,7 @@
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -9976,6 +10232,7 @@
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -9991,6 +10248,7 @@
     },
     "node_modules/restore-cursor": {
       "version": "5.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "onetime": "^7.0.0",
@@ -10011,10 +10269,12 @@
     },
     "node_modules/rettime": {
       "version": "0.10.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -10064,6 +10324,7 @@
     },
     "node_modules/router": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.0",
@@ -10078,6 +10339,7 @@
     },
     "node_modules/router/node_modules/path-to-regexp": {
       "version": "8.4.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -10086,6 +10348,7 @@
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10096,6 +10359,7 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10186,6 +10450,7 @@
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {
@@ -10205,6 +10470,7 @@
     },
     "node_modules/semver": {
       "version": "6.3.1",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -10212,6 +10478,7 @@
     },
     "node_modules/send": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",
@@ -10236,6 +10503,7 @@
     },
     "node_modules/serve-static": {
       "version": "2.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -10296,10 +10564,12 @@
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/shadcn": {
       "version": "4.1.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",
@@ -10343,6 +10613,7 @@
     },
     "node_modules/shadcn/node_modules/fast-glob": {
       "version": "3.3.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -10357,6 +10628,7 @@
     },
     "node_modules/shadcn/node_modules/glob-parent": {
       "version": "5.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -10367,6 +10639,7 @@
     },
     "node_modules/shadcn/node_modules/tsconfig-paths": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json5": "^2.2.2",
@@ -10379,6 +10652,7 @@
     },
     "node_modules/shadcn/node_modules/zod": {
       "version": "3.25.76",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -10447,6 +10721,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10457,6 +10732,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10464,6 +10740,7 @@
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10481,6 +10758,7 @@
     },
     "node_modules/side-channel-list": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10495,6 +10773,7 @@
     },
     "node_modules/side-channel-map": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -10511,6 +10790,7 @@
     },
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -10533,6 +10813,7 @@
     },
     "node_modules/signal-exit": {
       "version": "4.1.0",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -10543,6 +10824,7 @@
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sonner": {
@@ -10555,6 +10837,7 @@
     },
     "node_modules/source-map": {
       "version": "0.6.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -10579,6 +10862,7 @@
     },
     "node_modules/statuses": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -10591,6 +10875,7 @@
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10613,6 +10898,7 @@
     },
     "node_modules/strict-event-emitter": {
       "version": "0.5.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string_decoder": {
@@ -10626,6 +10912,7 @@
     },
     "node_modules/string-width": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^10.3.0",
@@ -10641,6 +10928,7 @@
     },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "10.6.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/string.prototype.includes": {
@@ -10746,6 +11034,7 @@
     },
     "node_modules/stringify-object": {
       "version": "5.0.0",
+      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "get-own-enumerable-keys": "^1.0.0",
@@ -10761,6 +11050,7 @@
     },
     "node_modules/strip-ansi": {
       "version": "7.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -10774,6 +11064,7 @@
     },
     "node_modules/strip-bom": {
       "version": "3.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -10781,6 +11072,7 @@
     },
     "node_modules/strip-final-newline": {
       "version": "4.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -10871,6 +11163,7 @@
     },
     "node_modules/tagged-tag": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -10981,6 +11274,7 @@
     },
     "node_modules/tldts": {
       "version": "7.0.28",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.28"
@@ -10991,10 +11285,12 @@
     },
     "node_modules/tldts-core": {
       "version": "7.0.28",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -11005,6 +11301,7 @@
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
@@ -11012,6 +11309,7 @@
     },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -11044,6 +11342,7 @@
     },
     "node_modules/ts-morph": {
       "version": "26.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ts-morph/common": "~0.27.0",
@@ -11096,6 +11395,7 @@
     },
     "node_modules/type-fest": {
       "version": "5.5.0",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
@@ -11111,6 +11411,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
       "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "content-type": "^2.0.0",
@@ -11129,6 +11430,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
       "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -11210,7 +11512,7 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -11301,6 +11603,7 @@
     },
     "node_modules/unicorn-magic": {
       "version": "0.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -11311,6 +11614,7 @@
     },
     "node_modules/universalify": {
       "version": "2.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -11318,6 +11622,7 @@
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -11358,6 +11663,7 @@
     },
     "node_modules/until-async": {
       "version": "3.0.2",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/kettanaito"
@@ -11365,6 +11671,7 @@
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -11433,6 +11740,7 @@
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -11440,6 +11748,7 @@
     },
     "node_modules/vary": {
       "version": "1.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -11951,6 +12260,7 @@
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -11987,6 +12297,7 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -12104,6 +12415,7 @@
     },
     "node_modules/wrap-ansi": {
       "version": "6.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -12116,6 +12428,7 @@
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12123,10 +12436,12 @@
     },
     "node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi/node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -12139,6 +12454,7 @@
     },
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -12149,6 +12465,7 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -12174,6 +12491,7 @@
     },
     "node_modules/wsl-utils": {
       "version": "0.3.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-wsl": "^3.1.0",
@@ -12201,6 +12519,7 @@
     },
     "node_modules/y18n": {
       "version": "5.0.8",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=10"
@@ -12210,10 +12529,12 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cliui": "^8.0.1",
@@ -12230,6 +12551,7 @@
     },
     "node_modules/yargs-parser": {
       "version": "21.1.1",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -12237,6 +12559,7 @@
     },
     "node_modules/yargs/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -12244,10 +12567,12 @@
     },
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/yargs/node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -12260,6 +12585,7 @@
     },
     "node_modules/yargs/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -12281,6 +12607,7 @@
     },
     "node_modules/yocto-spinner": {
       "version": "1.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yoctocolors": "^2.1.1"
@@ -12294,6 +12621,7 @@
     },
     "node_modules/yoctocolors": {
       "version": "2.1.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -12304,6 +12632,7 @@
     },
     "node_modules/yoctocolors-cjs": {
       "version": "2.1.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -12320,6 +12649,7 @@
     },
     "node_modules/zod": {
       "version": "4.3.6",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -12327,6 +12657,7 @@
     },
     "node_modules/zod-to-json-schema": {
       "version": "3.25.2",
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "recharts": "^3.8.1",
-    "shadcn": "^4.1.2",
     "sharp": "^0.35.3",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
@@ -53,6 +52,7 @@
     "eslint-config-next": "16.1.7",
     "jsdom": "^29.1.0",
     "prettier": "^3.8.1",
+    "shadcn": "^4.1.2",
     "tailwindcss": "^4",
     "typescript": "^5.9.3",
     "vitest": "^4.1.5"


### PR DESCRIPTION
Follow-up to #518 (issue #512).

## What

Moves `shadcn` from `dependencies` → `devDependencies`.

`shadcn` is a scaffolding CLI (`npx shadcn add ...`) — it's never imported at runtime (no `from 'shadcn'` anywhere in `app/`, `lib/`, or `components/`; only `components.json` references its schema). Sitting in `dependencies` pulled its entire chain into the **production** tree:

```
shadcn → @modelcontextprotocol/sdk → @hono/node-server → express / body-parser
```

…which is exactly what surfaced the 3 remaining **Moderate** advisories in `npm audit --omit=dev` after the #512 security upgrade (the Windows-only `serve-static` path traversal in hono).

## Result

| | Before | After |
|---|---|---|
| `npm audit --omit=dev` | 3 moderate | **0 vulnerabilities** ✅ |

No version changes — the lockfile diff is just npm marking the shadcn subtree as `"dev": true`.

### Note on dev-tooling audit
A full `npm audit` (including dev) still lists highs in the ESLint chain (`brace-expansion` → `minimatch` → `@eslint/*`). Those are **dev-only** and the actually-installed versions are already patched (`brace-expansion` resolves to `5.0.8` / `1.1.16` via the #518 overrides) — npm audit just doesn't credit `overrides` when walking the dev tree. Unchanged by this PR and never shipped to production.

## Verification

- ✅ `npm audit --omit=dev` — **0 vulnerabilities**
- ✅ `npm test -- --run` — 1261/1261 pass (121 files)
- ✅ `npm run lint` — 0 errors
- ✅ `npx tsc --noEmit` — passes
- ✅ `next build` — compiles + generates all 33 pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)