### PR TITLE
chore(planning): remove unused derivation destructures in MobilePlanningView (#517)

### DIFF
--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -96,7 +96,7 @@ export default function MobilePlanningView({
 
   // Derived model shared with the desktop view via usePlanningDerivations (#467).
   const {
-    goalsById, resolvedRecurring, skippedDcaInvestments, fulfillments, byGoal,
+    byGoal,
     totalGoals, contributedTotal, totalFixed, totalInsurance, totalOther, totalOutflow, remaining,
   } = usePlanningDerivations({
     plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,


### PR DESCRIPTION
Closes #517.

Completes the second half of #517. The first half — moving `shadcn` to `devDependencies` (removing the MCP/Hono chain and its Moderate advisory from the production dependency graph) — already landed in **#519**. This PR finishes the cleanup.

## What

`MobilePlanningView` destructured four values from `usePlanningDerivations` that were never used:

- `goalsById`
- `resolvedRecurring`
- `skippedDcaInvestments`
- `fulfillments`

Each appeared exactly once in the file (the destructure itself); ESLint flagged all four as unused. `byGoal` and the totals stay — they're still referenced.

No lint suppression added — the warnings are removed by deleting the dead bindings, per the issue's acceptance criteria.

## Verification

- ✅ `npm run lint` — 0 errors; warnings drop **32 → 28** (the four unused-var warnings gone)
- ✅ `npx tsc --noEmit` — passes
- ✅ `npm test -- --run` — 1261/1261 pass (planning suite: 151/151, incl. `MobilePlanningView.test.tsx`)
- ✅ `npm audit --omit=dev` — 0 vulnerabilities (unchanged; established in #519)

## #517 acceptance criteria — now fully met
- [x] No unused CLI package in production dependencies (#519)
- [x] Production graph no longer pulls MCP/Hono via shadcn (#519)
- [x] MobilePlanningView has no unused derivation destructures (this PR)
- [x] npm audit, lint, typecheck, unit tests rerun
- [x] No new lint suppression introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)