### PR TITLE
fix(dashboard): prevent partial overview reads from corrupting net-worth snapshots (#513)

### DIFF
--- a/app/api/v1/dashboard/overview/__tests__/route.test.ts
+++ b/app/api/v1/dashboard/overview/__tests__/route.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// A partial dashboard read must never (a) return an understated 200 nor
+// (b) overwrite today's net-worth snapshot with the incomplete value (#513).
+// We drive the real GET handler over a mocked Supabase whose per-table result
+// is configurable, and assert the error gate + snapshot-write guard.
+//
+// The handler issues, roughly:
+//   from(table).select(...).eq(...)                    -> awaited (thenable)
+//   from('gold_price_settings').select().eq().single() -> .single()
+//   from('net_worth_snapshots').select().eq().eq().maybeSingle()
+//   from('plan_*').select().in(...)                    -> awaited (only if planIds)
+//   from('net_worth_snapshots').upsert(row).then(...)  -> the snapshot write
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  tables: {} as Record<string, { data: unknown; error: unknown }>,
+  upsertCalls: [] as unknown[],
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  function chainFor(name: string) {
+    const result = () => h.tables[name] ?? { data: [], error: null }
+    const chain: Record<string, unknown> = {
+      select: () => chain,
+      eq: () => chain,
+      in: () => chain,
+      single: async () => result(),
+      maybeSingle: async () => result(),
+      then: (resolve: (v: unknown) => void) => resolve(result()),
+      upsert: (row: unknown) => {
+        if (name === 'net_worth_snapshots') h.upsertCalls.push(row)
+        return { then: (r: (v: unknown) => void) => r({ error: null }) }
+      },
+    }
+    return chain
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (name: string) => chainFor(name),
+    }),
+  }
+})
+
+import { GET } from '../route'
+
+const ERR = { code: 'XX000', message: 'connection reset' }
+
+/** Reset every table to a valid, empty-but-successful result. */
+function baseHappy() {
+  h.tables = {
+    monthly_plans: { data: [], error: null },
+    savings_goals: { data: [], error: null },
+    active_investment_transactions: { data: [], error: null },
+    insurance_members: { data: [], error: null },
+    insurance_savings: { data: [], error: null },
+    recurring_savings: { data: [], error: null },
+    gold_price_settings: { data: null, error: null },
+    net_worth_snapshots: { data: null, error: null },
+    plan_excluded_insurance_members: { data: [], error: null },
+    plan_insurance_member_overrides: { data: [], error: null },
+    recurring_saving_overrides: { data: [], error: null },
+    recurring_saving_fulfillments: { data: [], error: null },
+  }
+}
+
+/** A single monthly plan so the plan-scoped override queries actually run. */
+function withOnePlan() {
+  const now = new Date()
+  h.tables.monthly_plans = {
+    data: [{ id: 'p1', month: now.getMonth() + 1, year: now.getFullYear() }],
+    error: null,
+  }
+}
+
+beforeEach(() => {
+  h.user = { id: 'user-1' }
+  h.upsertCalls = []
+  baseHappy()
+})
+
+describe('GET /api/v1/dashboard/overview — partial reads never corrupt snapshots (#513)', () => {
+  it('returns 200 and writes a snapshot when every source loads', async () => {
+    const res = await GET()
+    expect(res.status).toBe(200)
+    expect(h.upsertCalls).toHaveLength(1)
+  })
+
+  // Each required source, when it fails, must 500 AND leave the snapshot alone.
+  const requiredAlwaysRun = [
+    'monthly_plans',
+    'savings_goals',
+    'active_investment_transactions',
+    'insurance_members',
+    'insurance_savings',
+    'recurring_savings',
+    'recurring_saving_fulfillments',
+    'net_worth_snapshots',
+  ] as const
+
+  for (const table of requiredAlwaysRun) {
+    it(`returns 500 and writes no snapshot when ${table} fails`, async () => {
+      h.tables[table] = { data: null, error: ERR }
+      const res = await GET()
+      expect(res.status).toBe(500)
+      expect(h.upsertCalls).toHaveLength(0)
+    })
+  }
+
+  // The plan-scoped queries only run when at least one plan exists.
+  const requiredPlanScoped = [
+    'plan_excluded_insurance_members',
+    'plan_insurance_member_overrides',
+    'recurring_saving_overrides',
+  ] as const
+
+  for (const table of requiredPlanScoped) {
+    it(`returns 500 and writes no snapshot when ${table} fails`, async () => {
+      withOnePlan()
+      h.tables[table] = { data: null, error: ERR }
+      const res = await GET()
+      expect(res.status).toBe(500)
+      expect(h.upsertCalls).toHaveLength(0)
+    })
+  }
+})
+
+describe('GET /api/v1/dashboard/overview — optional gold price (#513)', () => {
+  it('still returns 200 when gold_price_settings has no row (PGRST116)', async () => {
+    h.tables.gold_price_settings = { data: null, error: { code: 'PGRST116' } }
+    const res = await GET()
+    expect(res.status).toBe(200)
+    expect(h.upsertCalls).toHaveLength(1)
+  })
+
+  it('returns 500 for a real gold_price_settings error (not a missing row)', async () => {
+    h.tables.gold_price_settings = { data: null, error: ERR }
+    const res = await GET()
+    expect(res.status).toBe(500)
+    expect(h.upsertCalls).toHaveLength(0)
+  })
+})

--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -126,7 +126,34 @@ export async function GET() {
     supabase.from('recurring_saving_fulfillments').select('recurring_saving_id, ym').eq('user_id', user.id),
   ])
 
-  if (goalsRes.error || txRes.error || insuranceRes.error) {
+  // Every source below feeds the net-worth / contribution totals. A silent
+  // failure here doesn't just understate the dashboard — because the computed
+  // total is upserted into net_worth_snapshots at the end, a transient read
+  // error would overwrite today's snapshot with an incomplete value, turning a
+  // recoverable read failure into persisted financial-history corruption (#513).
+  // So any required-source error fails the whole request with a 500 (which also
+  // short-circuits before the snapshot write below).
+  const requiredErrors = [
+    plansRes.error,
+    goalsRes.error,
+    txRes.error,
+    insuranceRes.error,
+    insuranceSavingsRes.error,
+    recSavingsRes.error,
+    snapshotRes.error,
+    insExclusionsRes.error,
+    insOverridesRes.error,
+    recOverridesRes.error,
+    recFulfillmentsRes.error,
+  ]
+  // gold_price_settings uses .single(): a missing row surfaces as PGRST116 and
+  // is legitimate (the user simply hasn't set a gold price → null, valued as 0).
+  // Any other error is a real failure that would understate a gold holder's
+  // total, so it IS required.
+  if (goldPriceRes.error && goldPriceRes.error.code !== 'PGRST116') {
+    requiredErrors.push(goldPriceRes.error)
+  }
+  if (requiredErrors.some(Boolean)) {
     return NextResponse.json({ error: 'Failed to fetch dashboard data' }, { status: 500 })
   }
 


### PR DESCRIPTION
Closes #513.

## The bug

`app/api/v1/dashboard/overview/route.ts` runs **12 queries** but the error gate only checked **3** (`goalsRes`, `txRes`, `insuranceRes`). The other nine fell back to `data ?? []`, so a transient/schema failure was silently treated as *empty data*.

Because the computed total is upserted into `net_worth_snapshots` at the end, and `shouldWriteSnapshot(null, …)` returns `true` when the existing-snapshot read fails, a recoverable read error would:

- return an understated dashboard with **HTTP 200**, and
- **overwrite today's net-worth snapshot** with the incomplete value.

A recoverable read failure became persisted financial-history corruption.

## The fix

Classify every total-feeding query as **required** and 500 if any errors. Since the snapshot write already sits *after* the gate, a 500 short-circuits before it — **a partial read never writes a snapshot**.

| Required (500 on error) | Optional |
|---|---|
| monthly_plans, savings_goals, active_investment_transactions, insurance_members, insurance_savings, recurring_savings, net_worth_snapshots (read), plan_excluded_insurance_members, plan_insurance_member_overrides, recurring_saving_overrides, recurring_saving_fulfillments | **gold_price_settings** — its `.single()` `PGRST116` "no row" is legitimate (null price → valued 0). Any *other* gold error is required. |

## Tests

New `app/api/v1/dashboard/overview/__tests__/route.test.ts` (mocks Supabase per the existing `app/api/funds/[id]` route-test pattern):

- ✅ happy path → 200 **and** one snapshot upsert
- ✅ each required failure (plans, savings, insurance savings, recurring savings, fulfillments, snapshot read, + the three plan-scoped override/exclusion queries) → **500 and zero snapshot upserts**
- ✅ gold no-row (`PGRST116`) → 200; real gold error → 500

## Verification

- ✅ `npm test -- --run` — **1275/1275 pass** (122 files; +14 new). Existing `lib/__tests__/snapshots.test.ts` still green.
- ✅ `npm run lint` — 0 errors
- ✅ `npx tsc --noEmit` — passes

### E2E note
The change is **error-path only** — the happy 200 path and all totals math are byte-for-byte unchanged, so a healthy E2E DB wouldn't exercise the new guards. Behavior is fully covered by the route + unit tests above. The unchanged happy path is best re-confirmed on the Vercel preview.

## Acceptance criteria
- [x] Required query failures never return a partial successful dashboard
- [x] A partial read never writes/overwrites a net-worth snapshot
- [x] Optional missing rows still behave correctly (gold no-row)
- [x] Tests cover plans, savings, overrides, fulfillments, and snapshot query failures
- [x] Existing dashboard and snapshot tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)