### PR TITLE
fix(monthly-plans): fail closed when a child query fails (#514)

### DIFF
--- a/app/api/v1/monthly-plans/__tests__/route.test.ts
+++ b/app/api/v1/monthly-plans/__tests__/route.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// A `?full=true` monthly-plan read fires 14 child queries in parallel. A single
+// failed child must not be silently converted to an empty collection — that
+// makes real data look deleted behind an HTTP 200 (#514). The handler must fail
+// closed with a 500 instead.
+//
+// We drive the real GET over a mocked Supabase whose per-source result is
+// configurable. `investment_transactions` is queried twice (asset_type 'fund'
+// vs 'bank'), so the mock disambiguates on the captured eq('asset_type', …).
+// DCA seeding is an atomic RPC (`seed_and_sync_plan_dca`) that runs first with
+// its own error check, so it's mocked separately.
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  plan: { id: 'plan-1', month: 6, year: 2026, user_id: 'user-1' } as Record<string, unknown> | null,
+  planError: null as unknown,
+  seedError: null as unknown,
+  results: {} as Record<string, { data: unknown; error: unknown }>,
+}))
+
+// table name -> response key (investment_transactions handled separately)
+const TABLE_KEY: Record<string, string> = {
+  fixed_expense_overrides: 'fixed_expense_overrides',
+  fixed_expenses: 'fixed_expenses',
+  insurance_members: 'insurance_members',
+  plan_excluded_insurance_members: 'excluded_insurance',
+  plan_insurance_member_overrides: 'insurance_overrides',
+  savings_goals: 'goals',
+  funds: 'funds',
+  plan_other_expenses: 'other_expenses',
+  recurring_savings: 'recurring_savings',
+  recurring_saving_overrides: 'recurring_saving_overrides',
+  plan_dca_skips: 'dca_skips',
+  recurring_saving_fulfillments: 'recurring_fulfillments',
+}
+
+vi.mock('@/lib/supabase-server', () => {
+  const get = (key: string) => h.results[key] ?? { data: [], error: null }
+  function chainFor(name: string) {
+    const filters: Record<string, unknown> = {}
+    const resolveList = () => {
+      if (name === 'investment_transactions') {
+        return filters.asset_type === 'bank' ? get('direct_savings') : get('fund_investments')
+      }
+      return get(TABLE_KEY[name] ?? name)
+    }
+    const chain: Record<string, unknown> = {
+      select: () => chain,
+      eq: (col: string, val: unknown) => { filters[col] = val; return chain },
+      or: () => chain,
+      order: () => chain,
+      in: () => chain,
+      maybeSingle: async () => ({ data: h.plan, error: h.planError }),
+      then: (resolve: (v: unknown) => void) => resolve(resolveList()),
+    }
+    return chain
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (name: string) => chainFor(name),
+      rpc: async () => ({ error: h.seedError }),
+    }),
+  }
+})
+
+import { GET } from '../route'
+import type { NextRequest } from 'next/server'
+
+const ERR = { code: 'XX000', message: 'connection reset' }
+
+function req(full = true): NextRequest {
+  const url = `http://localhost/api/v1/monthly-plans?month=6&year=2026${full ? '&full=true' : ''}`
+  return { url } as unknown as NextRequest
+}
+
+/** All 14 child sources succeed with empty data. */
+function baseHappy() {
+  h.results = {
+    fund_investments: { data: [], error: null },
+    direct_savings: { data: [], error: null },
+    fixed_expense_overrides: { data: [], error: null },
+    fixed_expenses: { data: [], error: null },
+    insurance_members: { data: [], error: null },
+    excluded_insurance: { data: [], error: null },
+    insurance_overrides: { data: [], error: null },
+    goals: { data: [], error: null },
+    funds: { data: [], error: null },
+    other_expenses: { data: [], error: null },
+    recurring_savings: { data: [], error: null },
+    recurring_saving_overrides: { data: [], error: null },
+    dca_skips: { data: [], error: null },
+    recurring_fulfillments: { data: [], error: null },
+  }
+}
+
+beforeEach(() => {
+  h.user = { id: 'user-1' }
+  h.plan = { id: 'plan-1', month: 6, year: 2026, user_id: 'user-1' }
+  h.planError = null
+  h.seedError = null
+  baseHappy()
+})
+
+// Every child-query group; the failing source's error goes on this response key.
+const CHILD_GROUPS = [
+  'fund_investments',
+  'direct_savings',
+  'fixed_expense_overrides',
+  'fixed_expenses',
+  'insurance_members',
+  'excluded_insurance',
+  'insurance_overrides',
+  'goals',
+  'funds',
+  'other_expenses',
+  'recurring_savings',
+  'recurring_saving_overrides',
+  'dca_skips',
+  'recurring_fulfillments',
+] as const
+
+describe('GET /api/v1/monthly-plans?full=true — fail closed on child-query failure (#514)', () => {
+  it('returns 200 with all collections when every child query succeeds', async () => {
+    const res = await GET(req())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.goals).toEqual([])
+    expect(body.fund_investments).toEqual([])
+  })
+
+  for (const group of CHILD_GROUPS) {
+    it(`returns 500 (not a partial 200) when ${group} fails`, async () => {
+      h.results[group] = { data: null, error: ERR }
+      const res = await GET(req())
+      expect(res.status).toBe(500)
+      // Stable, actionable error — never leak internal details to the client.
+      const body = await res.json()
+      expect(body.error).toBeTruthy()
+      expect(JSON.stringify(body)).not.toContain('XX000')
+    })
+  }
+
+  it('returns 500 when DCA seeding (RPC) fails, before reading children', async () => {
+    h.seedError = ERR
+    const res = await GET(req())
+    expect(res.status).toBe(500)
+  })
+
+  it('still returns the bare plan (200) for a non-full request without touching children', async () => {
+    h.results.goals = { data: null, error: ERR } // would 500 if children were read
+    const res = await GET(req(false))
+    expect(res.status).toBe(200)
+  })
+
+  it('returns 404 when the plan does not exist', async () => {
+    h.plan = null
+    const res = await GET(req())
+    expect(res.status).toBe(404)
+  })
+})

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -111,6 +111,33 @@ export async function GET(request: NextRequest) {
         .select('recurring_saving_id, amount_vnd, source').eq('user_id', user.id).eq('ym', ym),
     ])
 
+    // Fail closed: every child query above feeds the plan the client renders.
+    // Without this check a transient DB failure would fall through the
+    // `data ?? []` defaults below and return HTTP 200 with real data missing —
+    // indistinguishable from a genuinely empty plan (#514). Log which source(s)
+    // failed for server-side diagnosis, but return a generic error to the client.
+    const childErrors: [string, { message?: string } | null][] = [
+      ['fund_investments', invRes.error],
+      ['direct_savings', savRes.error],
+      ['fixed_expense_overrides', overridesRes.error],
+      ['fixed_expenses', expRes.error],
+      ['insurance_members', insRes.error],
+      ['excluded_insurance', exclRes.error],
+      ['insurance_overrides', insOverridesRes.error],
+      ['goals', goalsRes.error],
+      ['funds', fundsRes.error],
+      ['other_expenses', otherExpRes.error],
+      ['recurring_savings', recSavRes.error],
+      ['recurring_saving_overrides', recSavOverridesRes.error],
+      ['dca_skips', dcaSkipsRes.error],
+      ['recurring_fulfillments', recFulfillmentsRes.error],
+    ]
+    const failedSources = childErrors.filter(([, e]) => e).map(([name]) => name)
+    if (failedSources.length > 0) {
+      console.error(`[monthly-plans] plan ${plan.id}: child query failed for ${failedSources.join(', ')}`)
+      return NextResponse.json({ error: 'Failed to fetch plan data' }, { status: 500 })
+    }
+
     return NextResponse.json({
       ...plan,
       fund_investments:        invRes.data ?? [],


### PR DESCRIPTION
Closes #514.

## The bug

`GET /api/v1/monthly-plans?full=true` fires **14 child queries** in parallel and returns their results directly through `data ?? []` fallbacks — **none** of the 14 `.error` fields were checked. A transient/schema DB failure therefore returned **HTTP 200 with real data silently missing** (investments, direct savings, fixed expenses + overrides, insurance members + overrides, goals, funds, other expenses, recurring savings, DCA skips, fulfillments), indistinguishable from a genuinely empty plan.

## The fix

Add a shared error gate right after the `Promise.all`: if any child query errored, **log which source(s) failed** (server-side, for diagnosis) and return a generic **500** to the client — no internal error detail leaked.

```
[monthly-plans] plan <id>: child query failed for insurance_members, goals
→ 500 { error: 'Failed to fetch plan data' }
```

DCA seeding already runs as an atomic RPC (`seed_and_sync_plan_dca`) *before* the reads with its own guard, so nothing is mutated on this failure path.

## Tests

New `app/api/v1/monthly-plans/__tests__/route.test.ts` (mocks Supabase per the `app/api/funds/[id]` pattern; `investment_transactions` disambiguated by its `asset_type` filter, seeding RPC mocked separately):

- ✅ happy path → 200 with all 14 collections
- ✅ **each of the 14 child groups failing → 500** (not a partial 200), and the response never contains the internal error code
- ✅ seed RPC failure → 500
- ✅ non-full request → 200 bare plan (children untouched)
- ✅ plan not found → 404

## Verification

- ✅ `npm test -- --run` — **1293/1293 pass** (123 files; +18 new). Existing monthly-plan / DCA-seeding tests green.
- ✅ `npm run lint` — 0 errors
- ✅ `npx tsc --noEmit` — passes

### E2E note
Error-path-only change; the happy 200 shape is unchanged, so a healthy E2E DB wouldn't exercise the new guard. Covered by the route + unit tests; happy path best re-confirmed on the Vercel preview.

## Acceptance criteria
- [x] No child-query failure is silently converted to an empty collection
- [x] Partial plans are never returned with HTTP 200
- [x] Client receives a stable, actionable error response
- [x] Failure-path tests cover all child-query groups
- [x] Existing monthly-plan and DCA-seeding tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)