### PR TITLE
fix(auth): make the OAuth failure redirect CSP-compatible (#516)

### DIFF
--- a/app/auth/auth-code-error/__tests__/page.test.tsx
+++ b/app/auth/auth-code-error/__tests__/page.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// The OAuth error page must give the user a usable, no-JavaScript way forward
+// under production CSP: a plain link back to login (#516).
+vi.mock('next-intl/server', () => ({
+  getTranslations: async () => (key: string) => key,
+}))
+
+import AuthCodeErrorPage from '../page'
+
+describe('AuthCodeErrorPage (#516)', () => {
+  it('renders a plain link back to /auth/login as the recovery path', async () => {
+    render(await AuthCodeErrorPage())
+    const link = screen.getByRole('link', { name: 'goToLogin' })
+    expect(link).toHaveAttribute('href', '/auth/login')
+  })
+
+  it('shows the failure title and message', async () => {
+    render(await AuthCodeErrorPage())
+    expect(screen.getByText('oauthErrorTitle')).toBeInTheDocument()
+    expect(screen.getByText('oauthErrorMessage')).toBeInTheDocument()
+  })
+})

--- a/app/auth/auth-code-error/page.tsx
+++ b/app/auth/auth-code-error/page.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+import { getTranslations } from 'next-intl/server'
+import { AuthLayout } from '../AuthLayout'
+
+// Dedicated OAuth-failure page the callback redirects to (#516). It's a normal
+// Next.js server-rendered page under /auth/*, so it inherits the per-request CSP
+// nonce like every other auth page — no raw inline script. The link back to
+// login is a plain <a>, so recovery works even with JavaScript disabled.
+export default async function AuthCodeErrorPage() {
+  const t = await getTranslations('auth')
+  return (
+    <AuthLayout>
+      <div data-testid="auth-card" className="cn-auth-card" style={{ textAlign: 'center' }}>
+        <div style={{
+          width: 48, height: 48, borderRadius: 12,
+          background: 'var(--c-navy-tint)',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: 24, margin: '0 auto 16px',
+        }}>
+          ⚠️
+        </div>
+        <h1 className="cn-auth-title" style={{ marginBottom: 12 }}>{t('oauthErrorTitle')}</h1>
+        <p className="cn-auth-sub" style={{ marginBottom: 24 }}>{t('oauthErrorMessage')}</p>
+        <Link
+          href="/auth/login"
+          className="cn-btn primary"
+          style={{ display: 'inline-flex', padding: '11px 24px', fontSize: 14, fontWeight: 600, textDecoration: 'none' }}
+        >
+          {t('goToLogin')}
+        </Link>
+      </div>
+    </AuthLayout>
+  )
+}

--- a/app/auth/callback/__tests__/route.test.ts
+++ b/app/auth/callback/__tests__/route.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Production CSP is nonce-based (`script-src 'self' 'nonce-…' 'strict-dynamic'`,
+// no 'unsafe-inline'), so an un-nonced inline <script> returned as raw HTML is
+// blocked — the old callback error page's 2-second JS redirect never fired and
+// the user got stuck (#516). A failed code exchange must instead navigate via a
+// plain server-side redirect (no script at all).
+const h = vi.hoisted(() => ({ exchangeError: null as unknown }))
+
+vi.mock('@supabase/ssr', () => ({
+  createServerClient: () => ({
+    auth: { exchangeCodeForSession: async () => ({ error: h.exchangeError }) },
+  }),
+}))
+vi.mock('next/headers', () => ({
+  cookies: async () => ({ getAll: () => [], set: () => {} }),
+}))
+
+import { GET } from '../route'
+import type { NextRequest } from 'next/server'
+
+const req = (url: string) => ({ url } as unknown as NextRequest)
+
+beforeEach(() => {
+  h.exchangeError = null
+})
+
+describe('GET /auth/callback — CSP-safe failure navigation (#516)', () => {
+  it('redirects to /dashboard on a successful code exchange', async () => {
+    const res = await GET(req('http://localhost/auth/callback?code=good'))
+    expect(res.status).toBeGreaterThanOrEqual(300)
+    expect(res.status).toBeLessThan(400)
+    expect(res.headers.get('location')).toContain('/dashboard')
+  })
+
+  it('redirects to the dedicated error page (no inline script) when the exchange fails', async () => {
+    h.exchangeError = { message: 'invalid grant' }
+    const res = await GET(req('http://localhost/auth/callback?code=bad'))
+    expect(res.status).toBeGreaterThanOrEqual(300)
+    expect(res.status).toBeLessThan(400)
+    expect(res.headers.get('location')).toContain('/auth/auth-code-error')
+    // A redirect has no body — but assert no executable script is ever returned.
+    expect(await res.text()).not.toContain('<script')
+  })
+
+  it('redirects to the error page when no code is present at all', async () => {
+    const res = await GET(req('http://localhost/auth/callback'))
+    expect(res.headers.get('location')).toContain('/auth/auth-code-error')
+    expect(await res.text()).not.toContain('<script')
+  })
+})

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -32,29 +32,11 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  // Show error page with 2-second redirect to login
-  const html = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Authentication Failed</title>
-  <style>
-    body { margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center; background: #f9fafb; font-family: sans-serif; }
-    .card { background: white; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); padding: 2rem; text-align: center; max-width: 400px; }
-    p { color: #dc2626; font-size: 0.875rem; }
-  </style>
-  <script>setTimeout(() => { window.location.href = '/auth/login'; }, 2000);</script>
-</head>
-<body>
-  <div class="card">
-    <p>Authentication failed. Redirecting to login...</p>
-  </div>
-</body>
-</html>`
-
-  return new NextResponse(html, {
-    status: 200,
-    headers: { 'Content-Type': 'text/html' },
-  })
+  // Code exchange failed (or no code was returned). Navigate with a plain
+  // server-side redirect to a dedicated error page rather than returning raw
+  // HTML with an inline <script> redirect: production CSP is nonce-based
+  // (`script-src` has no 'unsafe-inline'), so that script was blocked and the
+  // user got stuck on the error page. The error page carries a normal link back
+  // to login, so it works with JavaScript fully disabled too (#516).
+  return NextResponse.redirect(`${origin}/auth/auth-code-error`)
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -803,6 +803,8 @@
     "checkEmailTitle": "Check your email",
     "checkEmailMessage": "We sent a confirmation link to your email. Click it to activate your account, then come back to sign in.",
     "goToLogin": "Go to sign in",
+    "oauthErrorTitle": "Authentication failed",
+    "oauthErrorMessage": "We couldn't complete your sign in. Please try again.",
     "logoutSuccess": "Signed out successfully",
     "logoutFailed": "Sign out failed. Please try again.",
     "retryLabel": "Try again",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -803,6 +803,8 @@
     "checkEmailTitle": "Kiểm tra email",
     "checkEmailMessage": "Chúng tôi đã gửi liên kết xác nhận đến email của bạn. Nhấp vào đó để kích hoạt tài khoản, sau đó quay lại đăng nhập.",
     "goToLogin": "Đi đến đăng nhập",
+    "oauthErrorTitle": "Xác thực thất bại",
+    "oauthErrorMessage": "Chúng tôi không thể hoàn tất đăng nhập của bạn. Vui lòng thử lại.",
     "logoutSuccess": "Đã đăng xuất thành công",
     "logoutFailed": "Đăng xuất thất bại. Vui lòng thử lại.",
     "retryLabel": "Thử lại",


### PR DESCRIPTION
Closes #516.

## The bug

The OAuth callback error response returned raw HTML with an inline redirect script:

```html
<script>setTimeout(() => { window.location.href = '/auth/login'; }, 2000);</script>
```

Production CSP is nonce-based — `script-src 'self' 'nonce-…' 'strict-dynamic'`, **no `'unsafe-inline'`** (see `lib/csp.ts`). That un-nonced inline script was blocked, so on a failed code exchange the page sat on "Redirecting to login..." forever and the user was **stuck**.

The callback is a Route Handler returning raw HTML, so — unlike a Next.js page — its inline script never received the per-request nonce that `proxy.ts` stamps on `/auth/*`.

## The fix

Replace the inline-script HTML with a **plain server-side redirect** to a dedicated `/auth/auth-code-error` page (the canonical Supabase pattern):

- **`app/auth/callback/route.ts`** — on a failed or absent code exchange, `return NextResponse.redirect(.../auth/auth-code-error)`. No script, no CSP surface at all.
- **`app/auth/auth-code-error/page.tsx`** — a normal Next.js server page under `/auth/*`, so it inherits the CSP nonce like every other auth page. Renders via `AuthLayout` with a failure message and a **plain `<a>` link back to login** — recovery works with JavaScript fully disabled. Bilingual via new `auth.oauthErrorTitle` / `auth.oauthErrorMessage` keys.

## Tests

- `app/auth/callback/__tests__/route.test.ts` — failed exchange → redirect to `/auth/auth-code-error` and the response **never contains `<script`**; no-code → same; successful exchange still → `/dashboard`.
- `app/auth/auth-code-error/__tests__/page.test.tsx` — the page renders the plain `/auth/login` recovery link + the failure title/message.

## Verification

- ✅ `npm test -- --run` — **1320/1320 pass** (128 files; +5 new)
- ✅ `npm run lint` — 0 errors · `npx tsc --noEmit` passes
- ✅ `next build` — compiles; `/auth/auth-code-error` route registered

## Acceptance criteria
- [x] OAuth callback failures reliably reach the login/error page under production CSP (pure HTTP redirect — no script to block)
- [x] No un-nonced executable inline script is returned
- [x] The error response includes a usable fallback link (plain `<a>` to `/auth/login`, works with JS disabled)
- [x] Tests verify the failure response and its CSP-compatible navigation behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)