### PR TITLE
fix(cron): build the service-role client lazily instead of at module scope (#536)

### DIFF
--- a/app/api/cron/__tests__/route.test.ts
+++ b/app/api/cron/__tests__/route.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// Both cron routes used to build their service-role Supabase client at module
+// scope. Next evaluates every route module while collecting page data, so
+// `npm run build` failed with `supabaseKey is required.` on any machine without
+// the production secret — a build-time dependency on a runtime capability
+// (#536).
+//
+// These tests pin the three properties the fix needs. The first one is the real
+// regression test: importing the route module must not touch the secret at all.
+// The rest keep the route failing closed once the client is built lazily.
+
+const h = vi.hoisted(() => ({
+  clients: [] as { url: string; key: string }[],
+  results: {} as Record<string, { data: unknown; error: unknown }>,
+  goldCalls: 0,
+  navCalls: 0,
+}))
+
+vi.mock('@supabase/supabase-js', () => ({
+  // Mirrors the real library: supabase-js throws on a falsy key, which is
+  // exactly the `supabaseKey is required.` that broke the build. Without this
+  // the "imports without the secret" test would pass vacuously.
+  createClient: (url: string, key: string) => {
+    if (!url) throw new Error('supabaseUrl is required.')
+    if (!key) throw new Error('supabaseKey is required.')
+    h.clients.push({ url, key })
+    return {
+      // Minimal PostgREST chain. `funds` is both read and written by the NAV
+      // cron, so results are keyed by table *and* operation.
+      from: (table: string) => {
+        let op = 'select'
+        const chain: Record<string, unknown> = {
+          select: () => chain,
+          update: () => { op = 'update'; return chain },
+          not: () => chain,
+          in: () => chain,
+          then: (resolve: (v: unknown) => void) =>
+            resolve(h.results[`${table}:${op}`] ?? { data: [], error: null }),
+        }
+        return chain
+      },
+    }
+  },
+}))
+
+vi.mock('@/lib/scrape-gold', () => ({
+  scrapeGoldPrice: async () => { h.goldCalls++; return 8_500_000 },
+}))
+
+vi.mock('@/lib/scrape-fund-nav', () => ({
+  scrapeFundNav: async () => { h.navCalls++; return { nav: 12_345 } },
+}))
+
+const ORIGINAL_ENV = process.env
+const CRON_SECRET = 'cron-secret'
+
+const ROUTES = [
+  {
+    name: 'refresh-gold',
+    load: () => import('../refresh-gold/route'),
+    seedSuccess: () => {
+      h.results['gold_price_settings:update'] = { data: [{ user_id: 'user-1' }], error: null }
+    },
+    scraperCalls: () => h.goldCalls,
+  },
+  {
+    name: 'refresh-navs',
+    load: () => import('../refresh-navs/route'),
+    seedSuccess: () => {
+      h.results['funds:select'] = {
+        data: [{ id: 'fund-1', nav_source_url: 'https://www.vcbf.com/fund' }],
+        error: null,
+      }
+      h.results['funds:update'] = { data: null, error: null }
+    },
+    scraperCalls: () => h.navCalls,
+  },
+]
+
+describe.each(ROUTES)('GET /api/cron/$name', (route) => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+    h.clients.length = 0
+    h.results = {}
+    h.goldCalls = 0
+    h.navCalls = 0
+    process.env = {
+      ...ORIGINAL_ENV,
+      NEXT_PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
+      SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+      CRON_SECRET,
+    }
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+    vi.restoreAllMocks()
+  })
+
+  const authorized = () =>
+    new Request(`https://app.test/api/cron/${route.name}`, {
+      headers: { Authorization: `Bearer ${CRON_SECRET}` },
+    })
+
+  it('imports without SUPABASE_SERVICE_ROLE_KEY set', async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    await expect(route.load()).resolves.toHaveProperty('GET')
+  })
+
+  it('creates no service-role client at import time', async () => {
+    await route.load()
+    expect(h.clients).toEqual([])
+  })
+
+  it('rejects an unauthorized request without creating a client', async () => {
+    const { GET } = await route.load()
+    const res = await GET(
+      new Request(`https://app.test/api/cron/${route.name}`, {
+        headers: { Authorization: 'Bearer wrong-secret' },
+      }),
+    )
+    expect(res.status).toBe(401)
+    expect(h.clients).toEqual([])
+    expect(route.scraperCalls()).toBe(0)
+  })
+
+  it('fails closed with 500 when the service-role key is missing', async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    const { GET } = await route.load()
+    const res = await GET(authorized())
+    expect(res.status).toBe(500)
+    expect(h.clients).toEqual([])
+    // Missing config is terminal — don't hit the upstream site first.
+    expect(route.scraperCalls()).toBe(0)
+  })
+
+  it('fails closed with 500 when the Supabase URL is missing', async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    const { GET } = await route.load()
+    const res = await GET(authorized())
+    expect(res.status).toBe(500)
+    expect(h.clients).toEqual([])
+  })
+
+  it('builds the client from the runtime env once the request is authorized', async () => {
+    route.seedSuccess()
+    const { GET } = await route.load()
+    const res = await GET(authorized())
+    expect(res.status).toBe(200)
+    expect(h.clients).toEqual([{ url: 'https://test.supabase.co', key: 'service-role-key' }])
+    expect(route.scraperCalls()).toBe(1)
+  })
+})

--- a/app/api/cron/refresh-gold/route.ts
+++ b/app/api/cron/refresh-gold/route.ts
@@ -1,16 +1,19 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { scrapeGoldPrice } from '@/lib/scrape-gold'
 import { verifyCronAuth } from '@/lib/cron-auth'
-
-const supabaseAdmin = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-)
+import { createSupabaseAdminClient } from '@/lib/supabase-admin'
 
 export async function GET(request: Request) {
   if (!verifyCronAuth(request.headers.get('Authorization'), process.env.CRON_SECRET)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // Built here, not at module scope, so the build never needs the service-role
+  // secret (#536). Resolved before the scrape: if we can't persist the result
+  // there's no reason to hit DOJI at all.
+  const supabaseAdmin = createSupabaseAdminClient()
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 })
   }
 
   let price: number

--- a/app/api/cron/refresh-navs/route.ts
+++ b/app/api/cron/refresh-navs/route.ts
@@ -1,16 +1,18 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@supabase/supabase-js'
 import { scrapeFundNav } from '@/lib/scrape-fund-nav'
 import { verifyCronAuth } from '@/lib/cron-auth'
-
-const supabaseAdmin = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
-)
+import { createSupabaseAdminClient } from '@/lib/supabase-admin'
 
 export async function GET(request: Request) {
   if (!verifyCronAuth(request.headers.get('Authorization'), process.env.CRON_SECRET)) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // Built here, not at module scope, so the build never needs the service-role
+  // secret (#536).
+  const supabaseAdmin = createSupabaseAdminClient()
+  if (!supabaseAdmin) {
+    return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 })
   }
 
   const { data: funds, error: fetchError } = await supabaseAdmin

--- a/lib/__tests__/supabaseAdmin.test.ts
+++ b/lib/__tests__/supabaseAdmin.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// The service-role client must be buildable only at request time, and must
+// report missing runtime configuration instead of throwing supabase-js's raw
+// `supabaseKey is required.` (#536).
+
+const h = vi.hoisted(() => ({
+  clients: [] as { url: string; key: string }[],
+}))
+
+vi.mock('@supabase/supabase-js', () => ({
+  // Mirrors the real library, which throws on a falsy url/key — the helper must
+  // pre-empt that with its own null return, never let it surface.
+  createClient: (url: string, key: string) => {
+    if (!url) throw new Error('supabaseUrl is required.')
+    if (!key) throw new Error('supabaseKey is required.')
+    h.clients.push({ url, key })
+    return { marker: 'admin-client' }
+  },
+}))
+
+const ORIGINAL_ENV = process.env
+
+describe('createSupabaseAdminClient', () => {
+  beforeEach(() => {
+    h.clients.length = 0
+    process.env = {
+      ...ORIGINAL_ENV,
+      NEXT_PUBLIC_SUPABASE_URL: 'https://test.supabase.co',
+      SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+    }
+  })
+
+  afterEach(() => {
+    process.env = ORIGINAL_ENV
+  })
+
+  it('builds a client from the runtime env', async () => {
+    const { createSupabaseAdminClient } = await import('../supabase-admin')
+    expect(createSupabaseAdminClient()).toEqual({ marker: 'admin-client' })
+    expect(h.clients).toEqual([{ url: 'https://test.supabase.co', key: 'service-role-key' }])
+  })
+
+  it('returns null instead of throwing when the service-role key is missing', async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    const { createSupabaseAdminClient } = await import('../supabase-admin')
+    expect(createSupabaseAdminClient()).toBeNull()
+    expect(h.clients).toEqual([])
+  })
+
+  it('returns null when the Supabase URL is missing', async () => {
+    delete process.env.NEXT_PUBLIC_SUPABASE_URL
+    const { createSupabaseAdminClient } = await import('../supabase-admin')
+    expect(createSupabaseAdminClient()).toBeNull()
+    expect(h.clients).toEqual([])
+  })
+
+  it('treats an empty-string secret as missing', async () => {
+    process.env.SUPABASE_SERVICE_ROLE_KEY = ''
+    const { createSupabaseAdminClient } = await import('../supabase-admin')
+    expect(createSupabaseAdminClient()).toBeNull()
+  })
+
+  it('reads the env on every call, not once at module load', async () => {
+    const { createSupabaseAdminClient } = await import('../supabase-admin')
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY
+    expect(createSupabaseAdminClient()).toBeNull()
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'late-key'
+    expect(createSupabaseAdminClient()).toEqual({ marker: 'admin-client' })
+  })
+})

--- a/lib/supabase-admin.ts
+++ b/lib/supabase-admin.ts
@@ -1,0 +1,33 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
+
+// Service-role Supabase client for the cron routes — the only paths that
+// legitimately bypass RLS to write across every user's rows.
+//
+// Deliberately a function, never a module-scope constant. Next evaluates every
+// route module while collecting page data, so a top-level createClient() made
+// `npm run build` fail with supabase-js's raw `supabaseKey is required.` on any
+// machine without the production secret (#536). A build should not need a
+// runtime capability; creating the client inside the handler — after cron
+// authorization — keeps the secret a request-time concern.
+//
+// Reads process.env on every call (no caching) so the check reflects the
+// environment the request actually runs in, and returns null rather than
+// throwing so callers fail closed with a controlled 500. The missing variable is
+// logged server-side only: which secret an environment lacks is not something to
+// hand back to a caller.
+export function createSupabaseAdminClient(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!url || !serviceRoleKey) {
+    console.error(
+      'supabase-admin: missing runtime configuration —',
+      [!url && 'NEXT_PUBLIC_SUPABASE_URL', !serviceRoleKey && 'SUPABASE_SERVICE_ROLE_KEY']
+        .filter(Boolean)
+        .join(', '),
+    )
+    return null
+  }
+
+  return createClient(url, serviceRoleKey)
+}


### PR DESCRIPTION
Closes #536.

## Problem

`app/api/cron/refresh-gold/route.ts` and `app/api/cron/refresh-navs/route.ts` both called `createClient(...)` at **module scope** with `process.env.SUPABASE_SERVICE_ROLE_KEY!`. Next evaluates every route module while collecting page data, so a build without the runtime secret died before it ever finished:

```
Collecting page data using 9 workers ...
Error: supabaseKey is required.
  at Object.<anonymous> (.next/server/app/api/cron/refresh-gold/route.js:6:3)
> Build error occurred
Error: Failed to collect page data for /api/cron/refresh-gold
```

This reproduced on `main` as-is — `.env.local` has no `SUPABASE_SERVICE_ROLE_KEY`, so `npm run build` was simply broken locally. It also meant builds needed a production-capability secret for no reason.

## Fix

New `lib/supabase-admin.ts` exposing `createSupabaseAdminClient()`:

- reads `process.env` **on every call** (no module-scope capture, no caching), so the check reflects the environment the request actually runs in;
- returns `null` instead of throwing when `NEXT_PUBLIC_SUPABASE_URL` or `SUPABASE_SERVICE_ROLE_KEY` is missing, so callers fail closed with a controlled 500 rather than an unhandled `supabaseKey is required.`;
- logs *which* variable is missing server-side only — which secret an environment lacks isn't something to hand back to a caller.

Both cron routes now call it **inside the handler, after `verifyCronAuth`**. In `refresh-gold` it resolves before the scrape: if the result can't be persisted there's no reason to hit DOJI at all.

## Tests

`app/api/cron/__tests__/route.test.ts` (table-driven over both routes) and `lib/__tests__/supabaseAdmin.test.ts`.

The regression test imports each route module with no service-role key set and asserts it resolves. Worth noting: the `@supabase/supabase-js` mock **throws on a falsy url/key exactly like the real library** — without that the test passed vacuously against the broken code. With it, the test reproduces the build failure directly. Confirmed red before the fix:

```
× imports without SUPABASE_SERVICE_ROLE_KEY set
  → promise rejected "Error: supabaseKey is required." instead of resolving
```

Also covered: no client built at import time, none built on a 401, and a missing url/key returns 500 without calling the scraper.

## Acceptance criteria

- [x] `npm run build` succeeds without `SUPABASE_SERVICE_ROLE_KEY` — verified in a clean worktree with the variable absent from both the environment and `.env.local`; exit 0, both cron routes present as dynamic functions
- [x] Cron requests still fail closed when configuration is missing — 500, no scrape
- [x] Service-role client is created only after cron authorization
- [x] Tests cover missing secret/configuration

## Checks

| Check | Result |
|---|---|
| `vitest run` | 130 files, **1337 passed** |
| `tsc --noEmit` | clean |
| `eslint` | 28 warnings, 0 errors — **unchanged baseline** (that's #537), no new warnings |
| `npm run build` | exit 0 without the secret |

No E2E run: the change is server-only, confined to two cron handlers, and touches no UI, shared component, selector, or migration. There are no cron specs, so there was nothing targeted to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)