### PR TITLE
fix(api): fail closed when read queries error instead of returning empty data (#533)

### DIFF
--- a/app/api/v1/dashboard/history/__tests__/route.test.ts
+++ b/app/api/v1/dashboard/history/__tests__/route.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// With fewer than two usable net-worth snapshots the chart falls back to
+// synthesizing history from investment transactions. That fallback query dropped
+// its error and the `!txData` branch treats the failure exactly like "this user
+// has no transactions" — returning the 0-or-1 snapshots as the whole history
+// (#533).
+//
+// So a transient read failure renders as a flat or empty net-worth chart on an
+// account that actually holds money. Genuinely having no transactions must stay
+// a 200; a failed read must not.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  results: {} as Record<string, { data: unknown; error: unknown }>,
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chainFor = (table: string) => {
+    const chain: Record<string, unknown> = {
+      select: () => chain,
+      eq: () => chain,
+      gte: () => chain,
+      order: () => chain,
+      then: (resolve: (v: unknown) => void) =>
+        resolve(h.results[table] ?? { data: [], error: null }),
+    }
+    return chain
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (table: string) => chainFor(table),
+    }),
+  }
+})
+
+const { GET } = await import('../route')
+
+const req = () => new Request('https://app.test/api/v1/dashboard/history?range=all')
+
+describe('GET /api/v1/dashboard/history', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.results = {}
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    h.user = null
+    const res = await GET(req())
+    expect(res.status).toBe(401)
+  })
+
+  it('returns real snapshots when there are at least two', async () => {
+    h.results.net_worth_snapshots = {
+      data: [
+        { snapshot_date: '2026-06-01', total_assets: 100 },
+        { snapshot_date: '2026-07-01', total_assets: 150 },
+      ],
+      error: null,
+    }
+    const res = await GET(req())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveLength(2)
+    expect(body[1].value).toBe(150)
+  })
+
+  it('fails closed with 500 when the snapshot read errors', async () => {
+    h.results.net_worth_snapshots = { data: null, error: { message: 'timeout' } }
+    const res = await GET(req())
+    expect(res.status).toBe(500)
+  })
+
+  it('synthesizes history from transactions when snapshots are insufficient', async () => {
+    h.results.net_worth_snapshots = { data: [], error: null }
+    h.results.active_investment_transactions = {
+      data: [
+        { investment_date: '2026-05-10', amount_vnd: 100 },
+        { investment_date: '2026-06-10', amount_vnd: 50 },
+      ],
+      error: null,
+    }
+    const res = await GET(req())
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body).toHaveLength(2)
+    expect(body[1].value).toBe(150) // running cumulative
+  })
+
+  it('returns an empty history for an account with no snapshots and no transactions', async () => {
+    h.results.net_worth_snapshots = { data: [], error: null }
+    h.results.active_investment_transactions = { data: [], error: null }
+    const res = await GET(req())
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual([])
+  })
+
+  // The dangerous shape: the account holds money, but the fallback read failed.
+  // Silently returning the lone snapshot renders a flat chart that looks real.
+  it('fails closed with 500 when the transaction fallback read errors', async () => {
+    h.results.net_worth_snapshots = {
+      data: [{ snapshot_date: '2026-07-01', total_assets: 150 }],
+      error: null,
+    }
+    h.results.active_investment_transactions = { data: null, error: { message: 'timeout' } }
+    const res = await GET(req())
+    expect(res.status).toBe(500)
+  })
+
+  it('does not leak the database message to the client', async () => {
+    h.results.net_worth_snapshots = { data: [], error: null }
+    h.results.active_investment_transactions = {
+      data: null,
+      error: { message: 'relation "active_investment_transactions" does not exist' },
+    }
+    const res = await GET(req())
+    expect(JSON.stringify(await res.json())).not.toContain('does not exist')
+  })
+})

--- a/app/api/v1/dashboard/history/route.ts
+++ b/app/api/v1/dashboard/history/route.ts
@@ -40,7 +40,7 @@ export async function GET(request: Request) {
   // Not enough snapshots yet — synthesize monthly history from investment transactions only.
   // Withdrawals are intentionally excluded: they are recorded at market value which can exceed
   // original cost, driving the cumulative negative and causing a visual cliff.
-  const { data: txData } = await supabase
+  const { data: txData, error: txError } = await supabase
     // Snapshot-free view: a renewal history row is an `investment` carrying the
     // OLD principal, so summing it here would double-count it into the cumulative
     // invested chart. The view keeps it out.
@@ -49,6 +49,14 @@ export async function GET(request: Request) {
     .eq('user_id', user.id)
     .eq('transaction_type', 'investment')
     .order('investment_date', { ascending: true })
+
+  // The `!txData` branch below treats "no transactions" as an empty history.
+  // A failed read reaches it with the same shape, so without this check an
+  // outage renders as a flat/empty net-worth chart on a funded account (#533).
+  if (txError) {
+    console.error('dashboard/history: failed to read transactions', txError.message)
+    return NextResponse.json({ error: 'Failed to fetch history' }, { status: 500 })
+  }
 
   if (!txData || txData.length === 0) {
     // Return whatever snapshots we have (may be 0 or 1)

--- a/app/api/v1/gold-price/__tests__/route.test.ts
+++ b/app/api/v1/gold-price/__tests__/route.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// The gold-price read dropped its Supabase error and returned `data ?? null`, so
+// a database outage was indistinguishable from "this user has never set a gold
+// price" — both rendered as "no price" (#533).
+//
+// Fixing that is not just an `if (error)` away: the query used `.single()`, which
+// PostgREST answers with a PGRST116 *error* when no row matches. Bolting a 500
+// onto the error path while keeping `.single()` would turn every first-time user
+// into a server error. The mock below therefore reproduces real PostgREST
+// semantics — `single()` errors on a missing row, `maybeSingle()` does not — so
+// the missing-row test genuinely pins the `.maybeSingle()` switch.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  row: null as Record<string, unknown> | null,
+  dbError: null as { code?: string; message: string } | null,
+}))
+
+const PGRST116 = {
+  code: 'PGRST116',
+  message: 'JSON object requested, multiple (or no) rows returned',
+}
+
+vi.mock('@/lib/supabase-server', () => {
+  const settle = (kind: 'single' | 'maybeSingle') => {
+    if (h.dbError) return { data: null, error: h.dbError }
+    if (h.row === null && kind === 'single') return { data: null, error: PGRST116 }
+    return { data: h.row, error: null }
+  }
+  const chain: Record<string, unknown> = {
+    select: () => chain,
+    eq: () => chain,
+    single: async () => settle('single'),
+    maybeSingle: async () => settle('maybeSingle'),
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: () => chain,
+    }),
+  }
+})
+
+const { GET } = await import('../route')
+
+const PRICE_ROW = {
+  price_per_chi: 8_500_000,
+  previous_price_per_chi: 8_400_000,
+  updated_at: '2026-07-26T00:00:00.000Z',
+}
+
+describe('GET /api/v1/gold-price', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.row = null
+    h.dbError = null
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    h.user = null
+    const res = await GET()
+    expect(res.status).toBe(401)
+  })
+
+  it('returns the stored gold price', async () => {
+    h.row = PRICE_ROW
+    const res = await GET()
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual(PRICE_ROW)
+  })
+
+  it('returns null when the user has no gold settings yet', async () => {
+    h.row = null
+    const res = await GET()
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toBeNull()
+  })
+
+  it('fails closed with 500 when the read errors', async () => {
+    h.dbError = { message: 'connection reset by peer' }
+    const res = await GET()
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.not.toBeNull()
+  })
+
+  it('does not leak the database message to the client', async () => {
+    h.dbError = { message: 'connection reset by peer' }
+    const res = await GET()
+    expect(JSON.stringify(await res.json())).not.toContain('connection reset')
+  })
+})

--- a/app/api/v1/gold-price/route.ts
+++ b/app/api/v1/gold-price/route.ts
@@ -6,11 +6,21 @@ export async function GET() {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { data } = await supabase
+  // maybeSingle(), not single(): a user who has never set a gold price is an
+  // expected absence, and single() reports that as a PGRST116 *error* — which
+  // would be indistinguishable from a real read failure the moment we start
+  // failing closed on errors. With maybeSingle a missing row is `data: null,
+  // error: null`, so `error` means only one thing (#533).
+  const { data, error } = await supabase
     .from('gold_price_settings')
     .select('price_per_chi, previous_price_per_chi, updated_at')
     .eq('user_id', user.id)
-    .single()
+    .maybeSingle()
+
+  if (error) {
+    console.error('gold-price: failed to read settings', error.message)
+    return NextResponse.json({ error: 'Failed to fetch gold price' }, { status: 500 })
+  }
 
   return NextResponse.json(data ?? null)
 }

--- a/app/api/v1/prices/last-sync/__tests__/route.test.ts
+++ b/app/api/v1/prices/last-sync/__tests__/route.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// "Last synced" reduces the newest updated_at across two sources (funds NAV and
+// gold settings). Both queries dropped their error, so a failed source silently
+// contributed nothing to the reduce — the card then showed the *other* source's
+// older timestamp, or "never synced", as if that were the truth (#533).
+//
+// Both queries already use maybeSingle(), so a user who simply owns no funds or
+// has no gold settings is a legitimate `data: null` with no error. That case must
+// keep returning a 200 — only a real failure may 500.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  results: {} as Record<string, { data: unknown; error: unknown }>,
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chainFor = (table: string) => {
+    const chain: Record<string, unknown> = {
+      select: () => chain,
+      eq: () => chain,
+      order: () => chain,
+      limit: () => chain,
+      maybeSingle: async () => h.results[table] ?? { data: null, error: null },
+    }
+    return chain
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (table: string) => chainFor(table),
+    }),
+  }
+})
+
+const { GET } = await import('../route')
+
+const FUNDS_SYNC = '2026-07-20T08:00:00.000Z'
+const GOLD_SYNC = '2026-07-26T09:30:00.000Z'
+
+describe('GET /api/v1/prices/last-sync', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.results = {}
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    h.user = null
+    const res = await GET()
+    expect(res.status).toBe(401)
+  })
+
+  it('returns the newest timestamp across both sources', async () => {
+    h.results.funds = { data: { updated_at: FUNDS_SYNC }, error: null }
+    h.results.gold_price_settings = { data: { updated_at: GOLD_SYNC }, error: null }
+    const res = await GET()
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ lastSync: GOLD_SYNC })
+  })
+
+  it('returns null when the user has neither funds nor gold settings', async () => {
+    h.results.funds = { data: null, error: null }
+    h.results.gold_price_settings = { data: null, error: null }
+    const res = await GET()
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ lastSync: null })
+  })
+
+  it('still returns 200 when only one source has data', async () => {
+    h.results.funds = { data: { updated_at: FUNDS_SYNC }, error: null }
+    h.results.gold_price_settings = { data: null, error: null }
+    const res = await GET()
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ lastSync: FUNDS_SYNC })
+  })
+
+  // The dangerous shape: gold is genuinely newer, but its read failed. Reducing
+  // over the survivors reports the stale funds timestamp as the last sync.
+  it('fails closed with 500 when the gold read errors', async () => {
+    h.results.funds = { data: { updated_at: FUNDS_SYNC }, error: null }
+    h.results.gold_price_settings = { data: null, error: { message: 'timeout' } }
+    const res = await GET()
+    expect(res.status).toBe(500)
+  })
+
+  it('fails closed with 500 when the funds read errors', async () => {
+    h.results.funds = { data: null, error: { message: 'timeout' } }
+    h.results.gold_price_settings = { data: { updated_at: GOLD_SYNC }, error: null }
+    const res = await GET()
+    expect(res.status).toBe(500)
+  })
+
+  it('does not leak the database message to the client', async () => {
+    h.results.funds = { data: null, error: { message: 'relation "funds" does not exist' } }
+    const res = await GET()
+    expect(JSON.stringify(await res.json())).not.toContain('does not exist')
+  })
+})

--- a/app/api/v1/prices/last-sync/route.ts
+++ b/app/api/v1/prices/last-sync/route.ts
@@ -25,6 +25,25 @@ export async function GET() {
       .maybeSingle(),
   ])
 
+  // Both sources are required to compute a truthful maximum. Skipping a failed
+  // one silently reports the surviving source's older timestamp — or "never
+  // synced" — as the answer, which reads as a stale/absent sync rather than as
+  // the outage it is (#533). Both queries use maybeSingle(), so a user who owns
+  // no funds or has no gold settings is `data: null, error: null` and still gets
+  // a legitimate 200.
+  if (funds.error || gold.error) {
+    console.error(
+      'prices/last-sync: failed to read —',
+      [
+        funds.error && `funds: ${funds.error.message}`,
+        gold.error && `gold_price_settings: ${gold.error.message}`,
+      ]
+        .filter(Boolean)
+        .join('; '),
+    )
+    return NextResponse.json({ error: 'Failed to fetch last sync time' }, { status: 500 })
+  }
+
   const times = [funds.data?.updated_at, gold.data?.updated_at].filter(Boolean) as string[]
   const lastSync = times.length
     ? times.reduce((a, b) => (new Date(a) > new Date(b) ? a : b))

--- a/app/api/v1/recurring-savings/__tests__/route.test.ts
+++ b/app/api/v1/recurring-savings/__tests__/route.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// When a month is requested, the GET flags each recurring saving as already
+// settled for that month via recurring_saving_fulfillments. That second query
+// dropped its error, so a failed read marked *every* saving unfulfilled (#533).
+//
+// That is the dangerous direction: the maturity "combine" picker uses this flag
+// to avoid re-folding a recurring that has already been folded into a renewed
+// deposit. Reporting a fulfilled saving as unfulfilled offers it for folding a
+// second time — the exact double-count the flag exists to prevent. A read
+// failure must fail closed, not degrade into the unsafe default.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  results: {} as Record<string, { data: unknown; error: unknown }>,
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chainFor = (table: string) => {
+    const chain: Record<string, unknown> = {
+      select: () => chain,
+      eq: () => chain,
+      or: () => chain,
+      order: () => chain,
+      then: (resolve: (v: unknown) => void) =>
+        resolve(h.results[table] ?? { data: [], error: null }),
+    }
+    return chain
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (table: string) => chainFor(table),
+    }),
+  }
+})
+
+const { GET } = await import('../route')
+
+const SAVING = {
+  saving_id: 'saving-1',
+  name: 'Monthly deposit',
+  goal_id: 'goal-1',
+  amount_vnd: 5_000_000,
+  effective_from: null,
+  effective_to: null,
+  linked_deposit_tx_id: null,
+  savings_goals: { goal_name: 'House' },
+}
+
+const req = (query = '') =>
+  new Request(`https://app.test/api/v1/recurring-savings${query}`) as unknown as NextRequest
+
+describe('GET /api/v1/recurring-savings', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.results = {}
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    h.user = null
+    const res = await GET(req())
+    expect(res.status).toBe(401)
+  })
+
+  it('returns the savings when no month is requested', async () => {
+    h.results.recurring_savings = { data: [SAVING], error: null }
+    const res = await GET(req())
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ savings: [SAVING] })
+  })
+
+  it('returns an empty list for a user with no recurring savings', async () => {
+    h.results.recurring_savings = { data: [], error: null }
+    const res = await GET(req('?month=6&year=2026'))
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ savings: [] })
+  })
+
+  it('flags a saving already fulfilled for the requested month', async () => {
+    h.results.recurring_savings = { data: [SAVING], error: null }
+    h.results.recurring_saving_fulfillments = {
+      data: [{ recurring_saving_id: 'saving-1' }],
+      error: null,
+    }
+    const res = await GET(req('?month=6&year=2026'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.savings[0].fulfilled).toBe(true)
+  })
+
+  it('leaves a saving unfulfilled when no fulfillment row exists', async () => {
+    h.results.recurring_savings = { data: [SAVING], error: null }
+    h.results.recurring_saving_fulfillments = { data: [], error: null }
+    const res = await GET(req('?month=6&year=2026'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.savings[0].fulfilled).toBe(false)
+  })
+
+  it('fails closed with 500 when the fulfillment read errors', async () => {
+    h.results.recurring_savings = { data: [SAVING], error: null }
+    h.results.recurring_saving_fulfillments = { data: null, error: { message: 'timeout' } }
+    const res = await GET(req('?month=6&year=2026'))
+    expect(res.status).toBe(500)
+  })
+
+  it('never reports a saving as unfulfilled when the fulfillment read failed', async () => {
+    h.results.recurring_savings = { data: [SAVING], error: null }
+    h.results.recurring_saving_fulfillments = { data: null, error: { message: 'timeout' } }
+    const res = await GET(req('?month=6&year=2026'))
+    const body = await res.json()
+    expect(body.savings).toBeUndefined()
+  })
+
+  it('fails closed with 500 when the savings read errors', async () => {
+    h.results.recurring_savings = { data: null, error: { message: 'timeout' } }
+    const res = await GET(req())
+    expect(res.status).toBe(500)
+  })
+})

--- a/app/api/v1/recurring-savings/route.ts
+++ b/app/api/v1/recurring-savings/route.ts
@@ -38,11 +38,19 @@ export async function GET(request: NextRequest) {
   // offering (and double-folding) a recurring that's already been folded in.
   if (month && year && savings && savings.length > 0) {
     const ym = `${year}-${String(month).padStart(2, '0')}`
-    const { data: fulfilled } = await supabase
+    const { data: fulfilled, error: fulfilledError } = await supabase
       .from('recurring_saving_fulfillments')
       .select('recurring_saving_id')
       .eq('user_id', user.id)
       .eq('ym', ym)
+    // Fail closed rather than default every saving to unfulfilled (#533). The
+    // combine picker reads this flag to avoid re-folding a recurring that is
+    // already folded into a renewed deposit, so the "safe-looking" fallback is
+    // in fact the unsafe one: it re-offers settled savings and double-counts.
+    if (fulfilledError) {
+      console.error('recurring-savings: failed to read fulfillments', fulfilledError.message)
+      return NextResponse.json({ error: 'Failed to fetch recurring savings' }, { status: 500 })
+    }
     const fulfilledSet = new Set((fulfilled ?? []).map((f) => f.recurring_saving_id))
     return NextResponse.json({
       savings: savings.map((s) => ({ ...s, fulfilled: fulfilledSet.has(s.saving_id) })),


### PR DESCRIPTION
Closes #533.

## Problem

Four read endpoints dropped their Supabase `error` and turned the failure into a valid-looking 200. A client could not distinguish an empty account from a database outage — and in two of the four, the "empty" default was the actively unsafe one.

| Endpoint | Old behaviour on a failed read |
|---|---|
| `gold-price` | `data ?? null` → looks like "no gold price set" |
| `prices/last-sync` | failed source contributes nothing → reports the survivor's **older** timestamp, or "never synced" |
| `recurring-savings` | marks **every** saving unfulfilled |
| `dashboard/history` | `!txData` branch → flat/empty net-worth chart on a funded account |

The `recurring-savings` one is worth calling out: the maturity **combine** picker reads that `fulfilled` flag specifically to avoid re-folding a recurring that has already been folded into a renewed deposit. Defaulting to "unfulfilled" re-offers settled savings and invites the exact double-count the flag exists to prevent — the safe-looking fallback was the dangerous one.

## Fix

All four now check the error, log it server-side, and return a generic 500 (no database message reaches the client).

One subtlety beyond adding `if (error)`. `gold-price` queried with **`.single()`**, which PostgREST answers with a `PGRST116` **error** when no row matches. Bolting a 500 onto the error path while keeping `.single()` would have turned every first-time user — anyone who has never set a gold price — into a server error. Switched to `.maybeSingle()` so a missing row is `data: null, error: null` and `error` means exactly one thing.

`prices/last-sync` already used `maybeSingle()` on both sources, so "owns no funds" / "no gold settings" were already clean absences and needed only the error check.

**Legitimate absences are unchanged** and explicitly tested: no gold settings, no funds, no recurring savings, and no transactions all still return their 200 with `null`/`[]`.

## Tests

27 route tests across the four endpoints (`__tests__/route.test.ts` beside each), covering the missing-row and query-error cases **separately** per the issue's AC.

The gold-price mock reproduces real PostgREST semantics — `single()` errors on a missing row, `maybeSingle()` does not — so the missing-row test genuinely pins the `maybeSingle` switch instead of passing against either implementation. Confirmed red before the fix: exactly the 6 error-path assertions failed while every legitimate-absence assertion already passed.

## Checks

| Check | Result |
|---|---|
| `vitest run` | 134 files, **1364 passed** (was 130/1337) |
| `tsc --noEmit` | clean |
| `eslint` | 28 warnings, 0 errors — **unchanged baseline** (#537), no new warnings |
| Full E2E (`npx playwright test`) | **239 passed, 1 failed** — see below |

The one E2E failure is `assign-goal-desktop.spec.ts › confirming shows "Assigned to" success state`, which touches none of these four endpoints. It **passes on re-run in isolation** (11/11); it's serial-run state flakiness in the shared local stack. I hit the same pattern earlier with `maturity-combine.spec.ts` and checked it properly: it failed with the **route code reverted to `origin/main`** too, then passed on re-run with the change applied — so neither failure is caused by this PR.

Targeted run of the directly-affected areas (`dashboard`, `planning`, `settings`, `maturity-combine`) is **16/16 green**.

## Follow-up, not in this PR

Every client consumer already guards on `!res.ok` and falls back to `null`/`[]`, so nothing crashes — but that means the UI still degrades silently to "empty" on a 500. The server is now honest; making the dashboard chart, the planning list and the Settings sync line actually *surface* an error state is a separate UI concern worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)