### PR TITLE
fix(insurance): fail closed when savings-history sources error (#529)

### DIFF
--- a/app/api/v1/insurance-members/[id]/savings/__tests__/route.test.ts
+++ b/app/api/v1/insurance-members/[id]/savings/__tests__/route.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// The savings history for an insurance member is built from five sources. Only
+// the member and the manual-savings queries were error-checked; monthly plans,
+// plan exclusions and per-plan overrides were each collapsed to `?? []` (#529).
+//
+// Every one of them feeds `entries` and `totalSaved`, so a failure silently
+// removes real contributions and understates the total behind an HTTP 200 —
+// indistinguishable from a member who genuinely has no planning data. And this
+// total is supposed to reconcile with the dashboard's "Saved" amount, so a
+// partial answer here reads as a discrepancy between two screens rather than as
+// the outage it is.
+//
+// Plan months are fixed in the past (2026-01) so `isPlanMonthRealized` stays
+// true as the calendar moves — these tests must not rot.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  results: {} as Record<string, { data: unknown; error: unknown }>,
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const get = (table: string) => h.results[table] ?? { data: [], error: null }
+  const chainFor = (table: string) => {
+    const chain: Record<string, unknown> = {
+      select: () => chain,
+      eq: () => chain,
+      in: () => chain,
+      single: async () => get(table),
+      then: (resolve: (v: unknown) => void) => resolve(get(table)),
+    }
+    return chain
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (table: string) => chainFor(table),
+    }),
+  }
+})
+
+const { GET } = await import('../route')
+
+const MEMBER_ID = '11111111-1111-4111-8111-111111111111'
+const PLAN_ID = '22222222-2222-4222-8222-222222222222'
+
+const call = () =>
+  GET(new Request(`https://app.test/api/v1/insurance-members/${MEMBER_ID}/savings`) as unknown as NextRequest, {
+    params: Promise.resolve({ id: MEMBER_ID }),
+  })
+
+// Annual 12,000,000 → default monthly 1,000,000.
+const member = { annual_payment_vnd: 12_000_000, user_id: 'user-1', last_payment_date: null }
+
+function seedHappyPath() {
+  h.results.insurance_members = { data: member, error: null }
+  h.results.insurance_savings = {
+    data: [{ id: 'saving-1', amount_saved_vnd: 500_000, saved_date: '2026-01-15', created_at: null }],
+    error: null,
+  }
+  h.results.monthly_plans = { data: [{ id: PLAN_ID, month: 1, year: 2026 }], error: null }
+  h.results.plan_excluded_insurance_members = { data: [], error: null }
+  h.results.plan_insurance_member_overrides = { data: [], error: null }
+}
+
+describe('GET /api/v1/insurance-members/[id]/savings', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.results = {}
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    h.user = null
+    expect((await call()).status).toBe(401)
+  })
+
+  it('returns 404 when the member does not exist', async () => {
+    h.results.insurance_members = { data: null, error: { message: 'no rows' } }
+    expect((await call()).status).toBe(404)
+  })
+
+  it('returns 403 when the member belongs to another user', async () => {
+    h.results.insurance_members = { data: { ...member, user_id: 'user-2' }, error: null }
+    expect((await call()).status).toBe(403)
+  })
+
+  it('sums manual savings and realized plan accruals', async () => {
+    seedHappyPath()
+    const res = await call()
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.entries).toHaveLength(2)
+    expect(body.totalSaved).toBe(1_500_000) // 500k logged + 1M plan accrual
+  })
+
+  it('applies a per-plan override instead of the default monthly amount', async () => {
+    seedHappyPath()
+    h.results.plan_insurance_member_overrides = {
+      data: [{ plan_id: PLAN_ID, member_id: MEMBER_ID, monthly_amount_override_vnd: 250_000 }],
+      error: null,
+    }
+    const body = await (await call()).json()
+    expect(body.totalSaved).toBe(750_000) // 500k logged + 250k override
+  })
+
+  it('skips a plan that excludes this member', async () => {
+    seedHappyPath()
+    h.results.plan_excluded_insurance_members = {
+      data: [{ plan_id: PLAN_ID, member_id: MEMBER_ID }],
+      error: null,
+    }
+    const body = await (await call()).json()
+    expect(body.totalSaved).toBe(500_000) // logged only
+  })
+
+  it('returns a valid empty history for a member with no savings and no plans', async () => {
+    h.results.insurance_members = { data: member, error: null }
+    h.results.insurance_savings = { data: [], error: null }
+    h.results.monthly_plans = { data: [], error: null }
+    const res = await call()
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ entries: [], totalSaved: 0 })
+  })
+
+  it('fails closed with 500 when the manual-savings read errors', async () => {
+    seedHappyPath()
+    h.results.insurance_savings = { data: null, error: { message: 'timeout' } }
+    expect((await call()).status).toBe(500)
+  })
+
+  it('fails closed with 500 when the monthly-plans read errors', async () => {
+    seedHappyPath()
+    h.results.monthly_plans = { data: null, error: { message: 'timeout' } }
+    expect((await call()).status).toBe(500)
+  })
+
+  it('fails closed with 500 when the plan-exclusions read errors', async () => {
+    seedHappyPath()
+    h.results.plan_excluded_insurance_members = { data: null, error: { message: 'timeout' } }
+    expect((await call()).status).toBe(500)
+  })
+
+  it('fails closed with 500 when the insurance-overrides read errors', async () => {
+    seedHappyPath()
+    h.results.plan_insurance_member_overrides = { data: null, error: { message: 'timeout' } }
+    expect((await call()).status).toBe(500)
+  })
+
+  it('never returns a partial total alongside a 200', async () => {
+    seedHappyPath()
+    h.results.monthly_plans = { data: null, error: { message: 'timeout' } }
+    const res = await call()
+    const body = await res.json()
+    // The pre-fix behaviour: 200 with only the 500k logged entry, plan accrual lost.
+    expect(body.totalSaved).toBeUndefined()
+    expect(body.entries).toBeUndefined()
+  })
+
+  it('does not leak the database message to the client', async () => {
+    seedHappyPath()
+    h.results.monthly_plans = { data: null, error: { message: 'relation "monthly_plans" does not exist' } }
+    const res = await call()
+    expect(JSON.stringify(await res.json())).not.toContain('does not exist')
+  })
+})

--- a/app/api/v1/insurance-members/[id]/savings/route.ts
+++ b/app/api/v1/insurance-members/[id]/savings/route.ts
@@ -49,6 +49,14 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
   if (memberRes.error || !memberRes.data) return NextResponse.json({ error: 'Insurance member not found' }, { status: 404 })
   if (memberRes.data.user_id !== user.id) return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
   if (savingsRes.error) return NextResponse.json({ error: 'Failed to fetch savings' }, { status: 500 })
+  // Plans drive the auto-accrued half of the history and of totalSaved, so a
+  // failed read is not "this member has no planning data" — it silently drops
+  // real contributions behind a 200 and desyncs this total from the dashboard's
+  // "Saved" amount, which is computed from the same sources (#529).
+  if (plansRes.error) {
+    console.error('insurance savings history: failed to read monthly plans', plansRes.error.message)
+    return NextResponse.json({ error: 'Failed to fetch savings' }, { status: 500 })
+  }
 
   const annualPremium = memberRes.data.annual_payment_vnd ?? 0
   const lastPaymentDate = memberRes.data.last_payment_date ?? null
@@ -59,11 +67,29 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
   const [exclRes, ovrRes] = await Promise.all([
     planIds.length > 0
       ? supabase.from('plan_excluded_insurance_members').select('plan_id, member_id').in('plan_id', planIds)
-      : Promise.resolve({ data: [] as { plan_id: string; member_id: string }[] }),
+      : Promise.resolve({ data: [] as { plan_id: string; member_id: string }[], error: null }),
     planIds.length > 0
       ? supabase.from('plan_insurance_member_overrides').select('plan_id, member_id, monthly_amount_override_vnd').in('plan_id', planIds)
-      : Promise.resolve({ data: [] as { plan_id: string; member_id: string; monthly_amount_override_vnd: number }[] }),
+      : Promise.resolve({ data: [] as { plan_id: string; member_id: string; monthly_amount_override_vnd: number }[], error: null }),
   ])
+
+  // Both refine the plan accruals: an exclusion drops a month entirely, an
+  // override changes its amount. Defaulting either to [] on failure doesn't
+  // return "less detail", it returns a different — wrong — number (#529). The
+  // no-plans short circuits above carry `error: null`, so this only fires on a
+  // real query failure.
+  if (exclRes.error || ovrRes.error) {
+    console.error(
+      'insurance savings history: failed to read plan refinements —',
+      [
+        exclRes.error && `plan_excluded_insurance_members: ${exclRes.error.message}`,
+        ovrRes.error && `plan_insurance_member_overrides: ${ovrRes.error.message}`,
+      ]
+        .filter(Boolean)
+        .join('; '),
+    )
+    return NextResponse.json({ error: 'Failed to fetch savings' }, { status: 500 })
+  }
 
   const excludedSet = new Set((exclRes.data ?? []).map((e) => `${e.plan_id}::${e.member_id}`))
   const overrideMap = new Map((ovrRes.data ?? []).map((o) => [`${o.plan_id}::${o.member_id}`, o.monthly_amount_override_vnd]))


### PR DESCRIPTION
Closes #529.

## Problem

`GET /api/v1/insurance-members/:id/savings` builds its response from five sources, but only the member and manual-savings queries were error-checked. Monthly plans, plan exclusions and per-plan overrides were each collapsed to `?? []`.

All three feed **both** `entries` and `totalSaved`:

- `monthly_plans` drives the auto-accrued half of the history — losing it drops real contributions and understates the total;
- an **exclusion** removes a month's accrual entirely and an **override** changes its amount, so defaulting either to `[]` doesn't return *less detail*, it returns a **different, wrong number**.

Each failure surfaced as an HTTP 200, indistinguishable from a member who genuinely has no planning data. This total is also meant to reconcile with the dashboard's "Saved" amount, computed from the same sources — so a partial answer here reads as a discrepancy between two screens rather than as the outage it is.

## Fix

All three now log server-side and return the same generic 500 the savings query already used.

The `planIds.length === 0` short circuits gained an explicit `error: null`, so a legitimate no-plans member keeps its 200 and the new check only fires on a real query failure.

## Tests

13 route tests. A failure is injected for **each required source separately** per the issue's AC, alongside the paths they would otherwise mask — the exclusion path, the override path, and the genuinely-empty history.

Plan months are pinned in the past (`2026-01`) so `isPlanMonthRealized` stays true as the calendar moves; these tests won't rot the way the date-sensitive specs do.

Confirmed red before the fix: exactly the 4 error-path assertions failed (plans, exclusions, overrides, and the no-partial-total guard) while all 9 behavioural assertions already passed.

## Checks

| Check | Result |
|---|---|
| `vitest run` | 135 files, **1377 passed** (was 134/1364) |
| `tsc --noEmit` | clean |
| `eslint` | 28 warnings, 0 errors — **unchanged baseline** (#537) |
| Targeted E2E (`insurance`, `insurance-override`, `dashboard`) | **18/18 passed** |

The E2E slice includes `insurance.spec.ts › delete a logged payment from the history and the saved progress drops`, which exercises this endpoint end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)