### PR TITLE
fix(db): add the gold previous-price column the migrations never created (#542)

### DIFF
--- a/supabase/migrations/20260727000001_add_gold_previous_price_column.sql
+++ b/supabase/migrations/20260727000001_add_gold_previous_price_column.sql
@@ -1,0 +1,27 @@
+-- Add gold_price_settings.previous_price_per_chi, which the app has always read
+-- but no migration ever created.
+--
+-- 20260325000001 defines the table as (user_id, price_per_chi, updated_at). The
+-- gold-price GET selects previous_price_per_chi, and the refresh POST both
+-- writes and selects it — so the column exists on the hosted project, added out
+-- of band rather than through a migration. That drift stayed invisible there
+-- while every environment rebuilt from the migration set (a fresh local stack, a
+-- new preview database, a restore) got a gold price feature that could not work.
+--
+-- The write path already failed loudly on such a database; the read path used to
+-- swallow the error and return null, so it merely looked like "no price set"
+-- until #533 made it fail closed and the 500 surfaced the real cause.
+--
+-- `if not exists` so this is a no-op wherever the column was already added by
+-- hand — the point is to make the migration set reproduce the real schema, not
+-- to change any environment that already matches it.
+--
+-- Deliberately nullable with no default: null means "no prior price to compare
+-- against", which is exactly the state of a user's first refresh, and the
+-- endpoint already renders that as "no change" rather than a 0% move.
+
+alter table public.gold_price_settings
+  add column if not exists previous_price_per_chi numeric;
+
+comment on column public.gold_price_settings.previous_price_per_chi is
+  'Price per chi before the most recent refresh; null on a user''s first refresh. Read by GET /api/v1/gold-price and written by POST /api/v1/gold-price/refresh to show the change since last sync.';

--- a/supabase/tests/gold_price_previous_column.test.sql
+++ b/supabase/tests/gold_price_previous_column.test.sql
@@ -1,0 +1,76 @@
+-- gold_price_settings.previous_price_per_chi must exist in the migration set.
+--
+-- The column was never created by any migration — 20260325000001 defines only
+-- (user_id, price_per_chi, updated_at) — yet three code paths depend on it:
+-- the gold-price GET selects it, and the refresh POST both writes and selects
+-- it. It exists on the hosted project (added out of band), so the drift stayed
+-- invisible there while every environment rebuilt from migrations — a fresh
+-- local stack, a new preview database, a restore — got a broken gold price.
+--
+-- The write path already failed loudly on such a database ("Failed to save gold
+-- price"); the read path used to swallow the error and return null, so it looked
+-- like "no price set" instead. Failing closed (#533) turned that into a visible
+-- 500, which is what surfaced the drift.
+--
+-- This test asserts the schema contract those three code paths actually rely on:
+-- the column exists, is numeric, and is nullable (the first refresh for a user
+-- writes previous = null). Exercised the way the app uses it — insert, then
+-- read back — rather than by inspecting the catalog alone, so it fails for the
+-- same reason the endpoint would.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_user uuid;
+  v_prev numeric;
+  v_is_nullable text;
+  v_type text;
+begin
+  select data_type, is_nullable into v_type, v_is_nullable
+  from information_schema.columns
+  where table_schema = 'public'
+    and table_name = 'gold_price_settings'
+    and column_name = 'previous_price_per_chi';
+
+  if v_type is null then
+    raise exception 'gold_price_settings.previous_price_per_chi is missing — the migrations do not match what the gold-price endpoints read';
+  end if;
+  if v_type <> 'numeric' then
+    raise exception 'previous_price_per_chi must be numeric, got %', v_type;
+  end if;
+  -- The very first refresh for a user has no prior price to carry over.
+  if v_is_nullable <> 'YES' then
+    raise exception 'previous_price_per_chi must be nullable so a first refresh can store a null previous price';
+  end if;
+
+  insert into auth.users (id, email) values (gen_random_uuid(), 'gold-prev@test.invalid') returning id into v_user;
+
+  -- First refresh: no previous price yet.
+  insert into public.gold_price_settings (user_id, price_per_chi, previous_price_per_chi, updated_at)
+  values (v_user, 8500000, null, now());
+
+  select previous_price_per_chi into v_prev
+  from public.gold_price_settings where user_id = v_user;
+  if v_prev is not null then
+    raise exception 'a first refresh must store a null previous price, got %', v_prev;
+  end if;
+
+  -- Second refresh: the old current price becomes the previous one.
+  update public.gold_price_settings
+  set previous_price_per_chi = price_per_chi, price_per_chi = 8600000, updated_at = now()
+  where user_id = v_user;
+
+  select previous_price_per_chi into v_prev
+  from public.gold_price_settings where user_id = v_user;
+  if v_prev <> 8500000 then
+    raise exception 'the prior price must carry over to previous_price_per_chi, got %', v_prev;
+  end if;
+
+  raise notice 'gold_price_previous_column.test.sql: OK';
+end $$;
+
+rollback;


### PR DESCRIPTION
Closes #542.

## Problem

`20260325000001_create_gold_price_settings.sql` defines the table as `(user_id, price_per_chi, updated_at)`. No migration ever adds `previous_price_per_chi` — yet three code paths depend on it:

- `app/api/v1/gold-price/route.ts:16` selects it
- `app/api/v1/gold-price/refresh/route.ts:30` writes it
- `app/api/v1/gold-price/refresh/route.ts:33` selects it

The feature works in production, so the column was added out of band rather than through a migration. Verified on a local stack built from the migration set — only the three original columns are there.

**Impact:** any environment rebuilt from migrations (fresh local stack, new preview database, restore) gets a gold-price feature that cannot work. The migration set stopped reproducing the real schema, which is the one property the migration workflow exists to guarantee.

**How it surfaced:** the write path already checked its error and failed loudly. The read path swallowed the error and returned `null`, so a broken schema merely looked like "no gold price set" — until #533 made it fail closed. The E2E run then logged, on every goal-detail render:

```
gold-price: failed to read settings column gold_price_settings.previous_price_per_chi does not exist
```

## Fix

```sql
alter table public.gold_price_settings
  add column if not exists previous_price_per_chi numeric;
```

`if not exists` so this is a **no-op wherever the column already exists** — the goal is to make the migration set reproduce the real schema, not to change an environment that already matches it. Nullable with no default: null means "no prior price to compare against", which is exactly a user's first refresh, and the endpoint already renders that as "no change".

Plus a `comment on column` documenting what reads and writes it.

## Tests

`supabase/tests/gold_price_previous_column.test.sql` asserts the schema contract the endpoints rely on — the column exists, is `numeric`, and is nullable — then exercises it the way the app does: insert a first refresh with a null previous price, then carry the prior price over on the second. Catalog inspection alone would be tautological; this fails for the same reason the endpoint would.

Verified red against the pre-migration local stack:

```
ERROR: gold_price_settings.previous_price_per_chi is missing — the migrations do not match what the gold-price endpoints read
```

## Checks

| Check | Result |
|---|---|
| `npm run test:db` | **6/6 OK** (including the new test) |
| Migration idempotency | re-applied to an already-migrated DB — clean no-op |
| Full E2E (`npx playwright test`) | **239 passed, 1 failed** — see below |
| `gold-price: failed to read settings` in the E2E server log | **0 occurrences** (was firing on every goal-detail render) |

Full E2E was run because this is a DB migration, per the repo's own guidance. The single failure is `assign-goal-desktop.spec.ts › confirming shows "Assigned to" success state` — unrelated to gold price, and it **passes isolated** (11/11). It's the same serial-run state flake that hit #539's branch, which I confirmed there by reverting to `origin/main` route code and watching it fail identically.

## ⚠️ Note for merging

Unlike the recent PRs, this one **contains a migration**, so the `Apply DB migrations (production)` workflow will actually run on merge instead of being skipped. It's an `add column if not exists`, so it should be a no-op against production — but worth being aware that this merge does touch the production schema path.

## Follow-up

Nothing currently compares the migration set against the deployed schema, which is why this went unnoticed. A `supabase db diff` check — even run manually before a release — would catch the next one. Noted in #542.

🤖 Generated with [Claude Code](https://claude.com/claude-code)