### PR TITLE
fix(api): validate month/year before building PostgREST filters (#534)

### DIFF
--- a/app/api/v1/fixed-expenses/__tests__/route.test.ts
+++ b/app/api/v1/fixed-expenses/__tests__/route.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// The list endpoint optionally narrows to the expenses active in a plan month by
+// interpolating ?month= and ?year= into a PostgREST `.or(...)` filter STRING,
+// where a comma starts a new term. Unvalidated, a value could rewrite the
+// expression rather than be compared against it, and a malformed one produced an
+// opaque database error instead of a clear 400 (#534).
+//
+// The filter itself is asserted here too: validation that quietly stopped the
+// narrowing from happening would be its own bug.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  result: { data: [] as unknown[], error: null as unknown },
+  orFilters: [] as string[],
+  eqFilters: [] as [string, unknown][],
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chain = () => {
+    const c: Record<string, unknown> = {
+      select: () => c,
+      eq: (col: string, val: unknown) => { h.eqFilters.push([col, val]); return c },
+      or: (expr: string) => { h.orFilters.push(expr); return c },
+      order: () => c,
+      then: (resolve: (v: unknown) => void) => resolve(h.result),
+    }
+    return c
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: () => chain(),
+    }),
+  }
+})
+
+const { GET } = await import('../route')
+
+const req = (query = '') =>
+  new Request(`https://app.test/api/v1/fixed-expenses${query}`) as unknown as NextRequest
+
+describe('GET /api/v1/fixed-expenses', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.result = { data: [], error: null }
+    h.orFilters = []
+    h.eqFilters = []
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    h.user = null
+    expect((await GET(req())).status).toBe(401)
+  })
+
+  it('serves the unfiltered list when no month is supplied', async () => {
+    const res = await GET(req())
+    expect(res.status).toBe(200)
+    expect(h.orFilters).toEqual([])
+  })
+
+  it('applies the plan-month filter for a valid month and year', async () => {
+    const res = await GET(req('?month=6&year=2026'))
+    expect(res.status).toBe(200)
+    expect(h.orFilters).toEqual([
+      'effective_from.is.null,effective_from.lte.2026-06-01',
+      'effective_to.is.null,effective_to.gte.2026-06-01',
+    ])
+  })
+
+  it('zero-pads a single-digit month in the filter', async () => {
+    await GET(req('?month=9&year=2026'))
+    expect(h.orFilters[0]).toContain('2026-09-01')
+  })
+
+  it('still applies the category filter alongside the plan month', async () => {
+    await GET(req('?category=housing&month=6&year=2026'))
+    expect(h.eqFilters).toContainEqual(['category', 'housing'])
+    expect(h.orFilters).toHaveLength(2)
+  })
+
+  it('rejects a malformed month before querying', async () => {
+    const res = await GET(req('?month=6abc&year=2026'))
+    expect(res.status).toBe(400)
+    expect(h.orFilters).toEqual([])
+  })
+
+  it('rejects a month outside 1-12', async () => {
+    expect((await GET(req('?month=0&year=2026'))).status).toBe(400)
+    expect((await GET(req('?month=13&year=2026'))).status).toBe(400)
+  })
+
+  it('rejects a year outside the supported range', async () => {
+    expect((await GET(req('?month=6&year=1999'))).status).toBe(400)
+    expect((await GET(req('?month=6&year=10000'))).status).toBe(400)
+  })
+
+  // The value would otherwise be spliced into the .or(...) expression verbatim.
+  it('rejects a value carrying PostgREST filter syntax', async () => {
+    const res = await GET(req('?month=6&year=' + encodeURIComponent('2026,effective_from.gte.1900-01-01')))
+    expect(res.status).toBe(400)
+    expect(h.orFilters).toEqual([])
+  })
+
+  it('rejects month without year rather than silently dropping the filter', async () => {
+    const res = await GET(req('?month=6'))
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects year without month', async () => {
+    expect((await GET(req('?year=2026'))).status).toBe(400)
+  })
+
+  it('fails closed with 500 when the read errors', async () => {
+    h.result = { data: [], error: { message: 'timeout' } }
+    expect((await GET(req())).status).toBe(500)
+  })
+})

--- a/app/api/v1/fixed-expenses/route.ts
+++ b/app/api/v1/fixed-expenses/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { ValidationError, validateAmount, validateText, validateYearMonth } from '@/lib/validation'
+import { ValidationError, validateAmount, validatePlanMonthFilter, validateText, validateYearMonth, type PlanMonthFilter } from '@/lib/validation'
 
 function toDateCol(ym: string | undefined | null): string | null {
   if (!ym) return null
@@ -14,8 +14,15 @@ export async function GET(request: NextRequest) {
 
   const { searchParams } = new URL(request.url)
   const category = searchParams.get('category')
-  const month = searchParams.get('month')
-  const year = searchParams.get('year')
+
+  // Validate before the value can reach the `.or(...)` filter string below.
+  let planMonth: PlanMonthFilter | null
+  try {
+    planMonth = validatePlanMonthFilter(searchParams.get('month'), searchParams.get('year'))
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
 
   let query = supabase
     .from('fixed_expenses')
@@ -25,11 +32,10 @@ export async function GET(request: NextRequest) {
 
   if (category) query = query.eq('category', category)
 
-  if (month && year) {
-    const planDate = `${year}-${String(month).padStart(2, '0')}-01`
+  if (planMonth) {
     query = query
-      .or(`effective_from.is.null,effective_from.lte.${planDate}`)
-      .or(`effective_to.is.null,effective_to.gte.${planDate}`)
+      .or(`effective_from.is.null,effective_from.lte.${planMonth.planDate}`)
+      .or(`effective_to.is.null,effective_to.gte.${planMonth.planDate}`)
   }
 
   const { data: expenses, error } = await query

--- a/app/api/v1/recurring-savings/__tests__/route.test.ts
+++ b/app/api/v1/recurring-savings/__tests__/route.test.ts
@@ -119,6 +119,45 @@ describe('GET /api/v1/recurring-savings', () => {
     expect(body.savings).toBeUndefined()
   })
 
+  // ── month/year are interpolated into a PostgREST .or(...) filter (#534) ──────
+  it('rejects a malformed month before querying', async () => {
+    h.results.recurring_savings = { data: [SAVING], error: null }
+    const res = await GET(req('?month=6abc&year=2026'))
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects a month outside 1-12', async () => {
+    const res = await GET(req('?month=13&year=2026'))
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects a year outside the supported range', async () => {
+    const res = await GET(req('?month=6&year=1999'))
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects a value carrying PostgREST filter syntax', async () => {
+    const res = await GET(req('?month=6&year=2026,effective_from.gte.1900-01-01'))
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects month without year rather than silently dropping the filter', async () => {
+    h.results.recurring_savings = { data: [SAVING], error: null }
+    const res = await GET(req('?month=6'))
+    expect(res.status).toBe(400)
+  })
+
+  it('rejects year without month', async () => {
+    const res = await GET(req('?year=2026'))
+    expect(res.status).toBe(400)
+  })
+
+  it('still serves the unfiltered list when neither is supplied', async () => {
+    h.results.recurring_savings = { data: [SAVING], error: null }
+    const res = await GET(req())
+    expect(res.status).toBe(200)
+  })
+
   it('fails closed with 500 when the savings read errors', async () => {
     h.results.recurring_savings = { data: null, error: { message: 'timeout' } }
     const res = await GET(req())

--- a/app/api/v1/recurring-savings/route.ts
+++ b/app/api/v1/recurring-savings/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { ValidationError, validateAmount, validateText, validateUUID, validateYearMonth } from '@/lib/validation'
+import { ValidationError, validateAmount, validatePlanMonthFilter, validateText, validateUUID, validateYearMonth, type PlanMonthFilter } from '@/lib/validation'
 import { validateLinkedDeposit } from './linkValidation'
 
 function toDateCol(ym: string | undefined | null): string | null {
@@ -14,8 +14,15 @@ export async function GET(request: NextRequest) {
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const { searchParams } = new URL(request.url)
-  const month = searchParams.get('month')
-  const year = searchParams.get('year')
+
+  // Validate before the value can reach the `.or(...)` filter string below.
+  let planMonth: PlanMonthFilter | null
+  try {
+    planMonth = validatePlanMonthFilter(searchParams.get('month'), searchParams.get('year'))
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
 
   let query = supabase
     .from('recurring_savings')
@@ -23,11 +30,10 @@ export async function GET(request: NextRequest) {
     .eq('user_id', user.id)
     .order('created_at', { ascending: false })
 
-  if (month && year) {
-    const planDate = `${year}-${String(month).padStart(2, '0')}-01`
+  if (planMonth) {
     query = query
-      .or(`effective_from.is.null,effective_from.lte.${planDate}`)
-      .or(`effective_to.is.null,effective_to.gte.${planDate}`)
+      .or(`effective_from.is.null,effective_from.lte.${planMonth.planDate}`)
+      .or(`effective_to.is.null,effective_to.gte.${planMonth.planDate}`)
   }
 
   const { data: savings, error } = await query
@@ -36,13 +42,12 @@ export async function GET(request: NextRequest) {
   // When a specific month is requested, flag the ones already settled for it via
   // a maturity-combine renewal — the maturity "combine" picker uses this to avoid
   // offering (and double-folding) a recurring that's already been folded in.
-  if (month && year && savings && savings.length > 0) {
-    const ym = `${year}-${String(month).padStart(2, '0')}`
+  if (planMonth && savings && savings.length > 0) {
     const { data: fulfilled, error: fulfilledError } = await supabase
       .from('recurring_saving_fulfillments')
       .select('recurring_saving_id')
       .eq('user_id', user.id)
-      .eq('ym', ym)
+      .eq('ym', planMonth.ym)
     // Fail closed rather than default every saving to unfulfilled (#533). The
     // combine picker reads this flag to avoid re-folding a recurring that is
     // already folded into a renewed deposit, so the "safe-looking" fallback is

--- a/lib/__tests__/validation.test.ts
+++ b/lib/__tests__/validation.test.ts
@@ -11,6 +11,7 @@ import {
   validateBankCode,
   validateInteger,
   validatePositiveIntParam,
+  validatePlanMonthFilter,
   ValidationError,
 } from '../validation'
 
@@ -352,6 +353,69 @@ describe('validatePositiveIntParam', () => {
 
   it('does not clamp when no max is given (page can be large)', () => {
     expect(validatePositiveIntParam('999999', 'page', { fallback: 1 })).toBe(999999)
+  })
+})
+
+describe('validatePlanMonthFilter', () => {
+  it('returns null when neither param is supplied (the unfiltered list)', () => {
+    expect(validatePlanMonthFilter(null, null)).toBeNull()
+  })
+
+  it('treats blank strings as absent', () => {
+    expect(validatePlanMonthFilter('', '')).toBeNull()
+    expect(validatePlanMonthFilter('  ', '  ')).toBeNull()
+  })
+
+  it('derives both the plan date and the ym from validated integers', () => {
+    expect(validatePlanMonthFilter('6', '2026')).toEqual({
+      month: 6,
+      year: 2026,
+      ym: '2026-06',
+      planDate: '2026-06-01',
+    })
+  })
+
+  it('accepts a zero-padded month', () => {
+    expect(validatePlanMonthFilter('06', '2026')?.planDate).toBe('2026-06-01')
+  })
+
+  it('accepts numbers as well as strings', () => {
+    expect(validatePlanMonthFilter(12, 2026)?.ym).toBe('2026-12')
+  })
+
+  // Silently dropping the filter for a half-supplied pair returns every row,
+  // which looks exactly like a filter that ran and matched everything.
+  it('rejects a month without a year', () => {
+    expect(() => validatePlanMonthFilter('6', null)).toThrow(ValidationError)
+  })
+
+  it('rejects a year without a month', () => {
+    expect(() => validatePlanMonthFilter(null, '2026')).toThrow(ValidationError)
+  })
+
+  it('rejects a month outside 1-12', () => {
+    expect(() => validatePlanMonthFilter('0', '2026')).toThrow(ValidationError)
+    expect(() => validatePlanMonthFilter('13', '2026')).toThrow(ValidationError)
+    expect(() => validatePlanMonthFilter('-1', '2026')).toThrow(ValidationError)
+  })
+
+  it('rejects a year outside the supported range', () => {
+    expect(() => validatePlanMonthFilter('6', '1999')).toThrow(ValidationError)
+    expect(() => validatePlanMonthFilter('6', '10000')).toThrow(ValidationError)
+  })
+
+  it('rejects a partially numeric value rather than parsing a prefix', () => {
+    expect(() => validatePlanMonthFilter('6abc', '2026')).toThrow(ValidationError)
+    expect(() => validatePlanMonthFilter('6', '2026abc')).toThrow(ValidationError)
+    expect(() => validatePlanMonthFilter('6.5', '2026')).toThrow(ValidationError)
+  })
+
+  // The reason this validation exists: these values are interpolated into a
+  // PostgREST `.or(...)` filter string, where a comma or a dot starts a new
+  // term and could rewrite the expression.
+  it('rejects a value carrying PostgREST filter syntax', () => {
+    expect(() => validatePlanMonthFilter('6', '2026,effective_from.gte.1900-01-01')).toThrow(ValidationError)
+    expect(() => validatePlanMonthFilter('6),or=(user_id.eq.0', '2026')).toThrow(ValidationError)
   })
 })
 

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -199,3 +199,46 @@ export function validateEnum<T extends string>(
   }
   return val as T
 }
+
+export interface PlanMonthFilter {
+  month: number
+  year: number
+  ym: string       // YYYY-MM
+  planDate: string // YYYY-MM-01
+}
+
+// The optional ?month=&year= filter shared by the fixed-expenses and
+// recurring-savings list endpoints. Both narrow to the rows active in a plan
+// month by interpolating the value into a PostgREST `.or(...)` filter STRING,
+// where a comma starts a new term — so an unvalidated value can rewrite the
+// expression rather than be compared against it. RLS still scopes the rows to
+// one user, but the query must be built from values we've actually checked
+// (#534).
+//
+// Returns null when neither param is supplied (the plain unfiltered list).
+// Supplying only one is rejected rather than silently ignored: a caller asking
+// for ?month=6 and getting every row back cannot tell that the filter was
+// dropped — it looks like a filter that matched everything.
+//
+// The returned ym/planDate are rebuilt from the parsed integers, so nothing the
+// caller typed reaches the query even when it happens to be valid. Same
+// month/year bounds as the monthly-plan routes, which this deliberately mirrors.
+export function validatePlanMonthFilter(
+  month: unknown,
+  year: unknown
+): PlanMonthFilter | null {
+  const supplied = (v: unknown) =>
+    v !== null && v !== undefined && !(typeof v === 'string' && v.trim() === '')
+
+  const hasMonth = supplied(month)
+  const hasYear = supplied(year)
+  if (!hasMonth && !hasYear) return null
+  if (!hasMonth || !hasYear) {
+    throw new ValidationError('month and year must be supplied together')
+  }
+
+  const m = validateInteger(month, 'month', { min: 1, max: 12 })
+  const y = validateInteger(year, 'year', { min: 2000, max: 9999 })
+  const ym = `${y}-${String(m).padStart(2, '0')}`
+  return { month: m, year: y, ym, planDate: `${ym}-01` }
+}


### PR DESCRIPTION
Closes #534.

## Problem

`GET /api/v1/fixed-expenses` and `GET /api/v1/recurring-savings` concatenated the raw query params into a PostgREST `.or(...)` filter **string**:

```ts
if (month && year) {
  const planDate = `${year}-${String(month).padStart(2, '0')}-01`
  query = query
    .or(`effective_from.is.null,effective_from.lte.${planDate}`)
    .or(`effective_to.is.null,effective_to.gte.${planDate}`)
}
```

A comma starts a new term in that expression, so an unvalidated value can **rewrite the filter** rather than be compared against it, and a malformed one produced an opaque database error instead of a clear 400. RLS still scoped the rows to one user, but the query was built from values nobody had checked — and the monthly-plan routes already validated these exact two params, so the codebase disagreed with itself.

`month && year` also meant a **half-supplied pair silently dropped the filter**: a caller asking for `?month=6` got every row back, indistinguishable from a filter that ran and matched everything.

## Fix

`validatePlanMonthFilter` in `lib/validation.ts`, mirroring the monthly-plan bounds (month 1–12, year 2000–9999):

- returns `null` when neither param is supplied — the plain unfiltered list, unchanged;
- throws `ValidationError` → **400** when only one is supplied;
- rebuilds `ym`/`planDate` **from the parsed integers**, so nothing the caller typed reaches the query even when it happens to be valid.

A shared helper rather than two copies: divergence between these two routes is what the issue is about.

That last point also fixes a second interpolation the issue didn't list — the recurring-savings fulfillment lookup was building its `ym` key from the raw month (`?month=6abc` → `2026-6abc`).

## Tests

Per the repo's "test as low as it can meaningfully live": the parsing rules are pure logic, so **11 unit tests** on the helper carry that weight — absent/blank, valid, zero-padded, numeric-not-string, out-of-range month and year, partially-numeric (`6abc`, `6.5`), half-supplied both ways, and values carrying filter syntax.

Route tests on **both** endpoints then cover the integration: the 400s, and — importantly — that a valid month still produces the expected `.or(...)` expressions:

```ts
expect(h.orFilters).toEqual([
  'effective_from.is.null,effective_from.lte.2026-06-01',
  'effective_to.is.null,effective_to.gte.2026-06-01',
])
```

Validation that quietly stopped the narrowing from happening would be its own bug, so the filter is asserted, not just the status code. The fixed-expenses tests also pin that `?category=` still composes with the plan month.

## Checks

| Check | Result |
|---|---|
| `vitest run` | 137 files, **1440 passed** (was 136/1410) |
| `tsc --noEmit` | clean |
| `eslint` | 28 warnings, 0 errors — **unchanged baseline** (#537) |
| Targeted E2E (`planning`, `expenses`, `api-validation`, `maturity-combine`, `maturity-combine-explicit-link`) | **28/28 passed** |

The E2E slice includes `expenses.spec.ts › effective period hides expense outside date range on planning page`, which drives the month filter, and the maturity-combine specs, whose picker is the one client that calls `recurring-savings?month=&year=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)