### PR TITLE
fix(gold): make the price refresh atomic and stop losing the previous price (#528)

### DIFF
--- a/app/api/v1/gold-price/refresh/__tests__/route.test.ts
+++ b/app/api/v1/gold-price/refresh/__tests__/route.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// The refresh used to read the current price, then upsert the new one in a
+// second statement, carrying the value it had just read into
+// previous_price_per_chi (#528).
+//
+// The read's error was discarded, so a transient failure wrote previous = null —
+// the comparison point erased while the endpoint still returned 200. The read
+// also used .single(), which reports a genuinely absent row as an error, so a
+// user's first refresh and a database failure looked identical. And a concurrent
+// refresh landing in the gap produced a mismatched previous/current pair.
+//
+// refresh_gold_price does the whole thing in one INSERT … ON CONFLICT DO UPDATE.
+// The carry-over semantics are pinned by supabase/tests/gold_refresh_atomic.test.sql
+// against a real database; what matters here is that the route delegates to it —
+// and, above all, that it performs no separate read that could reintroduce the gap.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  scrapeError: null as Error | null,
+  price: 8_600_000,
+  rpcResult: { data: null as unknown, error: null as unknown },
+  rpcCalls: [] as { name: string; args: unknown }[],
+  tableReads: [] as string[],
+}))
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: h.user } }) },
+    // Any table access at all is a regression: the atomic path must not need one.
+    from: (table: string) => {
+      h.tableReads.push(table)
+      const c: Record<string, unknown> = {
+        select: () => c,
+        eq: () => c,
+        upsert: () => c,
+        single: async () => ({ data: null, error: null }),
+        maybeSingle: async () => ({ data: null, error: null }),
+        then: (resolve: (v: unknown) => void) => resolve({ data: null, error: null }),
+      }
+      return c
+    },
+    rpc: (name: string, args: unknown) => {
+      h.rpcCalls.push({ name, args })
+      return { single: async () => h.rpcResult }
+    },
+  }),
+}))
+
+vi.mock('@/lib/scrape-gold', () => ({
+  scrapeGoldPrice: async () => {
+    if (h.scrapeError) throw h.scrapeError
+    return h.price
+  },
+}))
+
+const { POST } = await import('../route')
+
+const FIRST_REFRESH = { price_per_chi: 8_600_000, previous_price_per_chi: null, updated_at: '2026-07-27T00:00:00.000Z' }
+const LATER_REFRESH = { price_per_chi: 8_600_000, previous_price_per_chi: 8_500_000, updated_at: '2026-07-27T00:00:00.000Z' }
+
+describe('POST /api/v1/gold-price/refresh', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.scrapeError = null
+    h.price = 8_600_000
+    h.rpcResult = { data: LATER_REFRESH, error: null }
+    h.rpcCalls = []
+    h.tableReads = []
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    h.user = null
+    const res = await POST()
+    expect(res.status).toBe(401)
+    expect(h.rpcCalls).toEqual([])
+  })
+
+  it('returns 502 when the upstream scrape fails, without writing', async () => {
+    h.scrapeError = new Error('Doji: NHẪN TRÒN price row not found')
+    const res = await POST()
+    expect(res.status).toBe(502)
+    expect(h.rpcCalls).toEqual([])
+  })
+
+  // The structural guarantee: no read-then-write gap can exist if there is no read.
+  it('performs no separate read before writing', async () => {
+    await POST()
+    expect(h.tableReads).toEqual([])
+  })
+
+  it('delegates the whole refresh to the atomic RPC', async () => {
+    await POST()
+    expect(h.rpcCalls).toEqual([{ name: 'refresh_gold_price', args: { p_price: 8_600_000 } }])
+  })
+
+  it('returns the stored pair for an existing settings row', async () => {
+    const res = await POST()
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual(LATER_REFRESH)
+  })
+
+  it('returns a null previous price on a first refresh', async () => {
+    h.rpcResult = { data: FIRST_REFRESH, error: null }
+    const res = await POST()
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual(FIRST_REFRESH)
+  })
+
+  it('fails closed with 500 when the RPC errors', async () => {
+    h.rpcResult = { data: null, error: { message: 'deadlock detected' } }
+    expect((await POST()).status).toBe(500)
+  })
+
+  it('fails closed with 500 when the RPC returns no row', async () => {
+    h.rpcResult = { data: null, error: null }
+    expect((await POST()).status).toBe(500)
+  })
+
+  it('does not leak the database message to the client', async () => {
+    h.rpcResult = { data: null, error: { message: 'relation "gold_price_settings" does not exist' } }
+    const res = await POST()
+    expect(JSON.stringify(await res.json())).not.toContain('does not exist')
+  })
+})

--- a/app/api/v1/gold-price/refresh/route.ts
+++ b/app/api/v1/gold-price/refresh/route.ts
@@ -15,25 +15,19 @@ export async function POST() {
     return NextResponse.json({ error: msg }, { status: 502 })
   }
 
-  // Read current price before overwriting so we can store it as previous
-  const { data: existing } = await supabase
-    .from('gold_price_settings')
-    .select('price_per_chi')
-    .eq('user_id', user.id)
-    .single()
-
+  // One statement does the read, the carry-over and the write. Reading the
+  // current price separately used to leave a gap on both sides: the read's error
+  // was discarded, so a transient failure stored previous = null and erased the
+  // comparison point behind a 200; and a concurrent refresh landing in the gap
+  // produced a mismatched previous/current pair. The RPC's INSERT … ON CONFLICT
+  // DO UPDATE has no read to fail and takes a row lock, so concurrent refreshes
+  // serialize into a valid chain (#528).
   const { data, error } = await supabase
-    .from('gold_price_settings')
-    .upsert({
-      user_id: user.id,
-      price_per_chi: price,
-      previous_price_per_chi: existing?.price_per_chi ?? null,
-      updated_at: new Date().toISOString(),
-    })
-    .select('price_per_chi, previous_price_per_chi, updated_at')
+    .rpc('refresh_gold_price', { p_price: price })
     .single()
 
   if (error || !data) {
+    console.error('gold-price refresh: atomic refresh failed', error?.message)
     return NextResponse.json({ error: 'Failed to save gold price' }, { status: 500 })
   }
 

--- a/supabase/migrations/20260727000002_atomic_gold_price_refresh.sql
+++ b/supabase/migrations/20260727000002_atomic_gold_price_refresh.sql
@@ -1,0 +1,73 @@
+-- Atomic gold-price refresh (#528).
+--
+-- The route read the current price, then upserted the new one in a second
+-- statement, carrying the value it had just read into previous_price_per_chi.
+-- Two failure modes lived in that gap:
+--
+--   • the read's error was discarded, so a transient failure wrote
+--     previous_price_per_chi = null — the comparison point silently erased while
+--     the endpoint still returned 200. The read also used .single(), which
+--     reports a genuinely absent row as an error, so "first refresh" and
+--     "database failure" were indistinguishable;
+--   • a concurrent refresh landing between the two statements produced a
+--     mismatched previous/current pair (both writers carry the same stale
+--     "previous", or the later write wins with an older price).
+--
+-- One INSERT … ON CONFLICT DO UPDATE collapses both. There is no separate read
+-- left to fail, and the conflicting insert takes a row lock on the existing row,
+-- so two concurrent refreshes serialize — the second observes the first's
+-- committed price as its previous. Inside DO UPDATE, `g.price_per_chi` is the
+-- row as it stands before this statement and `excluded` is the incoming value;
+-- that is what makes the carry-over atomic rather than read-then-write.
+--
+-- SECURITY DEFINER with auth.uid() resolved inside the function: the price is
+-- the only parameter, so there is no user_id a caller could point at someone
+-- else's row. An unauthenticated caller is rejected outright rather than
+-- inserting a null-owner row.
+
+create or replace function public.refresh_gold_price(p_price numeric)
+returns table (
+  price_per_chi numeric,
+  previous_price_per_chi numeric,
+  updated_at timestamptz
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_user uuid := auth.uid();
+  v_now  timestamptz := now();
+begin
+  if v_user is null then
+    raise exception 'refresh_gold_price requires an authenticated caller'
+      using errcode = 'insufficient_privilege';
+  end if;
+
+  -- A price of zero or below is not a quote — refuse it rather than overwrite a
+  -- good price and lose the previous one to the carry-over.
+  if p_price is null or p_price <= 0 then
+    raise exception 'refresh_gold_price requires a positive price, got %', p_price
+      using errcode = 'check_violation';
+  end if;
+
+  return query
+  insert into public.gold_price_settings as g (user_id, price_per_chi, previous_price_per_chi, updated_at)
+  values (v_user, p_price, null, v_now)
+  on conflict (user_id) do update
+    set previous_price_per_chi = g.price_per_chi,
+        price_per_chi          = excluded.price_per_chi,
+        updated_at             = excluded.updated_at
+  returning g.price_per_chi, g.previous_price_per_chi, g.updated_at;
+end;
+$$;
+
+-- EXECUTE is granted to PUBLIC by default; revoke it (covering anon and
+-- authenticated) and re-grant only to authenticated. anon is revoked explicitly
+-- in case a prior grant targeted it directly.
+revoke all on function public.refresh_gold_price(numeric) from public;
+revoke all on function public.refresh_gold_price(numeric) from anon;
+grant execute on function public.refresh_gold_price(numeric) to authenticated;
+
+comment on function public.refresh_gold_price(numeric) is
+  'Atomically store a new gold price for auth.uid(), moving the prior price to previous_price_per_chi in the same statement. Backs POST /api/v1/gold-price/refresh.';

--- a/supabase/tests/gold_refresh_atomic.test.sql
+++ b/supabase/tests/gold_refresh_atomic.test.sql
@@ -1,0 +1,101 @@
+-- Atomic gold-price refresh (#528).
+--
+-- The route used to read the current price, then upsert the new one in a second
+-- statement. Two failure modes lived in that gap: the read's error was dropped,
+-- so a transient failure wrote previous_price_per_chi = null and silently erased
+-- the comparison point; and a concurrent refresh landing between the two
+-- statements produced a mismatched previous/current pair.
+--
+-- refresh_gold_price collapses both into one INSERT … ON CONFLICT DO UPDATE.
+-- There is no separate read to fail, and the conflicting insert takes a row lock
+-- on the existing row, so two concurrent refreshes serialize: the second sees
+-- the first's committed price as its previous. Inside the DO UPDATE,
+-- `gold_price_settings.price_per_chi` is the row as it stands *before* this
+-- statement and `excluded` is the incoming value — that is what makes the
+-- carry-over atomic rather than read-then-write.
+--
+-- True concurrency (two sessions racing the same row) can't be driven from a
+-- single rolled-back transaction; that guarantee comes from the row lock above.
+-- What is asserted here is the semantics the lock protects: the carry-over
+-- chain, the first-refresh null, and per-user isolation.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_user  uuid;
+  v_other uuid;
+  v_price numeric;
+  v_prev  numeric;
+  v_rows  int;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'gold-atomic@test.invalid') returning id into v_user;
+  insert into auth.users (id, email) values (gen_random_uuid(), 'gold-other@test.invalid') returning id into v_other;
+
+  -- The function is scoped to auth.uid(); make it resolve to our test user.
+  perform set_config('request.jwt.claims', json_build_object('sub', v_user::text)::text, true);
+  perform set_config('request.jwt.claim.sub', v_user::text, true);
+
+  -- 1) First refresh: creates the row, no prior price to carry over.
+  select price_per_chi, previous_price_per_chi into v_price, v_prev
+  from public.refresh_gold_price(8500000);
+  if v_price <> 8500000 then
+    raise exception 'first refresh must return the new price, got %', v_price;
+  end if;
+  if v_prev is not null then
+    raise exception 'first refresh must leave previous null, got %', v_prev;
+  end if;
+
+  -- 2) Second refresh: the old current becomes previous, atomically.
+  select price_per_chi, previous_price_per_chi into v_price, v_prev
+  from public.refresh_gold_price(8600000);
+  if v_price <> 8600000 or v_prev <> 8500000 then
+    raise exception 'second refresh must carry 8500000 over, got price=% previous=%', v_price, v_prev;
+  end if;
+
+  -- 3) The chain keeps moving — previous always tracks the immediately prior price.
+  select price_per_chi, previous_price_per_chi into v_price, v_prev
+  from public.refresh_gold_price(8400000);
+  if v_price <> 8400000 or v_prev <> 8600000 then
+    raise exception 'third refresh must carry 8600000 over, got price=% previous=%', v_price, v_prev;
+  end if;
+
+  -- 4) Still exactly one row per user — the upsert must never accumulate rows.
+  select count(*) into v_rows from public.gold_price_settings where user_id = v_user;
+  if v_rows <> 1 then
+    raise exception 'expected exactly one settings row per user, got %', v_rows;
+  end if;
+
+  -- 5) The persisted row matches what the function returned (no drift between
+  --    the RETURNING projection and the stored row).
+  select price_per_chi, previous_price_per_chi into v_price, v_prev
+  from public.gold_price_settings where user_id = v_user;
+  if v_price <> 8400000 or v_prev <> 8600000 then
+    raise exception 'stored row disagrees with the returned row: price=% previous=%', v_price, v_prev;
+  end if;
+
+  -- 6) Scoped to the caller: another user's settings are untouched. The function
+  --    takes no user_id, so there is no parameter to point at a foreign row.
+  select count(*) into v_rows from public.gold_price_settings where user_id = v_other;
+  if v_rows <> 0 then
+    raise exception 'refresh must not create a row for another user, got % rows', v_rows;
+  end if;
+
+  -- 7) An unauthenticated caller must not be able to write anything.
+  perform set_config('request.jwt.claims', '', true);
+  perform set_config('request.jwt.claim.sub', '', true);
+  begin
+    perform public.refresh_gold_price(9000000);
+    raise exception 'refresh_gold_price must reject an unauthenticated caller';
+  exception
+    when insufficient_privilege then
+      null; -- expected
+  end;
+
+  raise notice 'gold_refresh_atomic.test.sql: OK';
+end $$;
+
+rollback;


### PR DESCRIPTION
Closes #528.

## Problem

The refresh read the current price, then upserted the new one in a **second** statement, carrying the value it had just read into `previous_price_per_chi`. Two failure modes lived in that gap:

- **The read's error was discarded.** A transient failure wrote `previous_price_per_chi = null` — the comparison point silently erased while the endpoint still returned 200. That read also used `.single()`, which reports a genuinely absent row as an error, so a user's **first refresh** and a **database failure** were indistinguishable.
- **A concurrent refresh landing in the gap** produced a mismatched previous/current pair: both writers carry the same stale "previous", or the later write wins with an older price.

## Fix

`refresh_gold_price(numeric)` — one `INSERT … ON CONFLICT DO UPDATE`:

```sql
insert into public.gold_price_settings as g (user_id, price_per_chi, previous_price_per_chi, updated_at)
values (v_user, p_price, null, v_now)
on conflict (user_id) do update
  set previous_price_per_chi = g.price_per_chi,      -- the row before this statement
      price_per_chi          = excluded.price_per_chi,
      updated_at             = excluded.updated_at
returning g.price_per_chi, g.previous_price_per_chi, g.updated_at;
```

`g.price_per_chi` inside `DO UPDATE` is the row as it stands **before** this statement, and `excluded` is the incoming value — that's what makes the carry-over atomic rather than read-then-write. There is no separate read left to fail, and the conflicting insert takes a **row lock**, so concurrent refreshes serialize into a valid chain.

`SECURITY DEFINER` resolving `auth.uid()` inside the function: the price is the only parameter, so there is no `user_id` a caller could point at someone else's row. Unauthenticated callers are rejected, as are non-positive prices — overwriting a good price with a junk one would *also* destroy the previous value through the carry-over.

## Tests

**DB** (`supabase/tests/gold_refresh_atomic.test.sql`) — drives a real three-refresh chain against Postgres: first refresh leaves previous `null`, the second carries `8500000` over, the third carries `8600000`. Then asserts exactly one row per user, that the returned row matches the stored row, that another user's settings are untouched, and that an unauthenticated call is refused.

Verified red before the migration:
```
ERROR: function public.refresh_gold_price(integer) does not exist
```

**Route** — pins the delegation and, most importantly:

```ts
it('performs no separate read before writing', async () => {
  await POST()
  expect(h.tableReads).toEqual([])
})
```

The mock records *any* table access, so this is a structural guarantee rather than a behavioural one: a read-then-write gap cannot reappear if there is no read. Also covered: 401 and a failed scrape both write nothing, first-refresh vs. existing-row responses, and RPC error / empty-result → 500 without leaking the database message.

On the AC's "concurrent refresh test": true concurrency (two sessions racing one row) can't be driven from a single rolled-back transaction, which is the harness `npm run test:db` provides — the same limitation the NAV rate-limit test documents. The guarantee comes from the row lock, and what's asserted is the semantics that lock protects, plus the route-level proof that no non-atomic path remains.

## Checks

| Check | Result |
|---|---|
| `npm run test:db` | **7/7 OK** (including the new test) |
| Migration idempotency | `create or replace` — re-applied cleanly |
| `vitest run` | 139 files, **1449 passed** (was 137/1440) |
| `tsc --noEmit` | clean |
| `eslint` | 28 warnings, 0 errors — **unchanged baseline** (#537) |
| Full E2E (`npx playwright test`) | **240 passed, 0 failed** |

Full E2E because this carries a migration. Clean sweep this run — including `settings.spec.ts › clicking Sync now triggers cron API calls`, and the `assign-goal-desktop` spec that flaked on earlier branches.

## ⚠️ Contains a migration

`Apply DB migrations (production)` will run on merge. It's a `create or replace function` plus grants — no table or data change.

## Found while here — not fixed in this PR

**The daily cron breaks the same invariant this PR protects.** `app/api/cron/refresh-gold/route.ts` bulk-updates every user's `price_per_chi` but never touches `previous_price_per_chi`:

```ts
.update({ price_per_chi: price, updated_at: ... })
.not('user_id', 'is', null)
```

So after a cron run, `previous_price_per_chi` still holds whatever some earlier *manual* refresh left there, and "change since last sync" is measured against a stale reference. It needs a different function from this one (bulk, service-role, no `auth.uid()`), so it's genuinely separate work rather than something to bolt on here.

**Related:** nothing in the UI currently reads `previous_price_per_chi` — grep finds no consumer outside the API routes. That doesn't make the stored value wrong, but it does mean the impact today is on stored history rather than anything a user sees, which is worth knowing before sizing the cron fix.

Happy to open an issue for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)