### PR TITLE
fix(transactions): make the merged-settlement delete guard atomic (#526)

### DIFF
--- a/app/api/v1/investment-transactions/[id]/__tests__/route.delete.test.ts
+++ b/app/api/v1/investment-transactions/[id]/__tests__/route.delete.test.ts
@@ -140,18 +140,43 @@ describe('DELETE /api/v1/investment-transactions/[id]', () => {
     expect((await call()).status).toBe(500)
   })
 
-  // The mirror image of the guard. consumed_by_inv_id has no ON DELETE action,
-  // so deleting the ANCHOR while a consumed source still points at it raises a
-  // foreign-key violation. That is a conflict with existing data the user can
-  // resolve (undo the merge first), not a server fault — it must not read as a
-  // generic 500.
-  it('returns 409 when the row is still referenced by a merged settlement', async () => {
+  // The mirror image of the guard. Two columns reference this table with no
+  // ON DELETE action, so deleting a deposit that either points at raises 23503 —
+  // a conflict the user can resolve, not a server fault. But the two need
+  // DIFFERENT remedies, so one catch-all message would misdirect half of them.
+  it('returns 409 naming the merge when a consumed settlement references the row', async () => {
     h.deleteResult = {
       data: null,
       error: { code: '23503', message: 'violates foreign key constraint "investment_transactions_consumed_by_inv_id_fkey"' },
     }
     const res = await call()
     expect(res.status).toBe(409)
+    expect((await res.json()).error).toMatch(/undo the merge/i)
+  })
+
+  // merge_anchor_inv_id is stamped when a settlement is HELD — before any merge
+  // happens. Telling this caller to undo a merge sends them looking for
+  // something that doesn't exist; the fix is to cancel the pending settlement.
+  it('returns 409 naming the pending settlement when only a held one references the row', async () => {
+    h.deleteResult = {
+      data: null,
+      error: { code: '23503', message: 'violates foreign key constraint "investment_transactions_merge_anchor_inv_id_fkey"' },
+    }
+    const res = await call()
+    expect(res.status).toBe(409)
+    const { error } = await res.json()
+    expect(error).toMatch(/pending|waiting/i)
+    expect(error).not.toMatch(/undo the merge/i)
+  })
+
+  it('returns a generic 409 for an unrecognised foreign-key reference', async () => {
+    h.deleteResult = {
+      data: null,
+      error: { code: '23503', message: 'violates foreign key constraint "some_future_fkey"' },
+    }
+    const res = await call()
+    expect(res.status).toBe(409)
+    expect((await res.json()).error).toBeTruthy()
   })
 
   it('does not leak the database message to the client', async () => {

--- a/app/api/v1/investment-transactions/[id]/__tests__/route.delete.test.ts
+++ b/app/api/v1/investment-transactions/[id]/__tests__/route.delete.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// A merge folds a source deposit's cash into an anchor and closes the source
+// with a withdrawal stamped consumed_by_inv_id. Deleting that withdrawal
+// re-opens the source at full value while its cash still sits in the anchor —
+// the money is then counted twice in net worth.
+//
+// The guard existed, but as a SELECT followed by a separate DELETE (#526):
+//
+//   • the SELECT's error was discarded, so a failed guard read fell straight
+//     through to the DELETE — the one path where the guard mattered most;
+//   • a merge committing between the two statements was not seen by the DELETE,
+//     so the check passed against a row that was consumed a moment later.
+//
+// The fix folds the condition into the DELETE's own WHERE clause, so there is no
+// window at all: Postgres re-evaluates the predicate against the committed row.
+// These tests assert that structurally — the delete must be the FIRST database
+// operation, carrying the guard with it — not just that the status codes match.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  ops: [] as { op: string; filters: Record<string, unknown> }[],
+  deleteResult: { data: [] as unknown[] | null, error: null as unknown },
+  classifyResult: { data: null as unknown, error: null as unknown },
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chain = () => {
+    const filters: Record<string, unknown> = {}
+    let op = 'select'
+    const c: Record<string, unknown> = {
+      select: () => c,
+      delete: () => { op = 'delete'; return c },
+      eq: (col: string, val: unknown) => { filters[col] = val; return c },
+      is: (col: string, val: unknown) => { filters[`${col}:is`] = val; return c },
+      not: (col: string, o: string, val: unknown) => { filters[`${col}:not.${o}`] = val; return c },
+      maybeSingle: async () => {
+        h.ops.push({ op, filters })
+        return h.classifyResult
+      },
+      single: async () => {
+        h.ops.push({ op, filters })
+        return h.classifyResult
+      },
+      then: (resolve: (v: unknown) => void) => {
+        h.ops.push({ op, filters })
+        resolve(op === 'delete' ? h.deleteResult : h.classifyResult)
+      },
+    }
+    return c
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: () => chain(),
+    }),
+  }
+})
+
+const { DELETE } = await import('../route')
+
+const TX_ID = '88888888-8888-4888-8888-888888888888'
+const ANCHOR_ID = '99999999-9999-4999-8999-999999999999'
+
+const call = (id = TX_ID) =>
+  DELETE(new Request(`https://app.test/api/v1/investment-transactions/${id}`) as unknown as NextRequest, {
+    params: Promise.resolve({ id }),
+  })
+
+describe('DELETE /api/v1/investment-transactions/[id]', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.ops = []
+    h.deleteResult = { data: [{ transaction_id: TX_ID }], error: null }
+    h.classifyResult = { data: null, error: null }
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    h.user = null
+    expect((await call()).status).toBe(401)
+    expect(h.ops).toEqual([])
+  })
+
+  it('returns 400 for a malformed transaction id', async () => {
+    expect((await call('not-a-uuid')).status).toBe(400)
+    expect(h.ops).toEqual([])
+  })
+
+  it('deletes an unconsumed transaction', async () => {
+    const res = await call()
+    expect(res.status).toBe(200)
+  })
+
+  // ── the atomicity guarantee ──────────────────────────────────────────────────
+  it('makes the delete the first database operation, with no guard read before it', async () => {
+    await call()
+    expect(h.ops[0].op).toBe('delete')
+  })
+
+  it('carries the consumed guard inside the delete statement', async () => {
+    await call()
+    const del = h.ops.find((o) => o.op === 'delete')!
+    expect(del.filters['consumed_by_inv_id:is']).toBeNull()
+    expect(del.filters.transaction_id).toBe(TX_ID)
+    expect(del.filters.user_id).toBe('user-1')
+  })
+
+  // ── classifying a delete that matched nothing ────────────────────────────────
+  it('returns 409 when the row survives because it was already merged', async () => {
+    h.deleteResult = { data: [], error: null }
+    h.classifyResult = { data: { consumed_by_inv_id: ANCHOR_ID }, error: null }
+    const res = await call()
+    expect(res.status).toBe(409)
+  })
+
+  it('returns 404 when the transaction does not exist', async () => {
+    h.deleteResult = { data: [], error: null }
+    h.classifyResult = { data: null, error: null }
+    expect((await call()).status).toBe(404)
+  })
+
+  // ── failing closed ───────────────────────────────────────────────────────────
+  it('returns 500 when the delete itself errors, never a success', async () => {
+    h.deleteResult = { data: null, error: { message: 'deadlock detected' } }
+    const res = await call()
+    expect(res.status).toBe(500)
+  })
+
+  // Guessing 404 here would tell the client the settlement is gone when it may
+  // still be there; guessing 409 would block a legitimate delete.
+  it('returns 500 when the follow-up classification read errors', async () => {
+    h.deleteResult = { data: [], error: null }
+    h.classifyResult = { data: null, error: { message: 'timeout' } }
+    expect((await call()).status).toBe(500)
+  })
+
+  // The mirror image of the guard. consumed_by_inv_id has no ON DELETE action,
+  // so deleting the ANCHOR while a consumed source still points at it raises a
+  // foreign-key violation. That is a conflict with existing data the user can
+  // resolve (undo the merge first), not a server fault — it must not read as a
+  // generic 500.
+  it('returns 409 when the row is still referenced by a merged settlement', async () => {
+    h.deleteResult = {
+      data: null,
+      error: { code: '23503', message: 'violates foreign key constraint "investment_transactions_consumed_by_inv_id_fkey"' },
+    }
+    const res = await call()
+    expect(res.status).toBe(409)
+  })
+
+  it('does not leak the database message to the client', async () => {
+    h.deleteResult = { data: null, error: { message: 'relation "x" does not exist' } }
+    const res = await call()
+    expect(JSON.stringify(await res.json())).not.toContain('does not exist')
+  })
+})

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -216,28 +216,61 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   //   • live: the plain withdrawal the merge RPC opens for a sibling source.
   // Both carry consumed_by_inv_id, so the guard keys on that marker alone (not on
   // held_for_merge). The UI hides the affordances once consumed, but a stale tab or
-  // the ledger's per-row delete (shown on every row) must not get through — guard
-  // server-side with a 409 rather than trusting the UI. (One cheap SELECT.)
-  const { data: folded } = await supabase
-    .from('investment_transactions')
-    .select('consumed_by_inv_id')
-    .eq('transaction_id', txId)
-    .eq('user_id', user.id)
-    .not('consumed_by_inv_id', 'is', null)
-    .maybeSingle()
-  if (folded) {
-    return NextResponse.json(
-      { error: 'This settlement has already been merged into another deposit. Undo the merge before removing it.' },
-      { status: 409 },
-    )
-  }
-
-  const { error } = await supabase
+  // the ledger's per-row delete (shown on every row) must not get through.
+  //
+  // The guard is the DELETE's own WHERE clause, not a SELECT before it (#526).
+  // As two statements there was a window a merge could commit into, and the
+  // SELECT's dropped error fell through to an unguarded DELETE. As one statement
+  // there is nothing to race: a concurrent merge either commits first — Postgres
+  // re-evaluates the predicate against the updated row and deletes nothing — or
+  // finds the row already gone.
+  const { data: deleted, error } = await supabase
     .from('investment_transactions')
     .delete()
     .eq('transaction_id', txId)
     .eq('user_id', user.id)
+    .is('consumed_by_inv_id', null)
+    .select('transaction_id')
 
-  if (error) return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
-  return NextResponse.json({ message: 'Transaction deleted.' })
+  if (error) {
+    // The mirror image of the guard above: consumed_by_inv_id has no ON DELETE
+    // action, so deleting the ANCHOR while a consumed source still references it
+    // raises a foreign-key violation. That's a conflict the user can resolve —
+    // undo the merge first — not a server fault, so it must not read as a 500.
+    if (error.code === '23503') {
+      return NextResponse.json(
+        { error: 'Another settlement has been merged into this deposit. Undo the merge before removing it.' },
+        { status: 409 },
+      )
+    }
+    console.error('investment-transactions delete: statement failed', error.message)
+    return NextResponse.json({ error: 'Failed to delete transaction' }, { status: 500 })
+  }
+  if (deleted && deleted.length > 0) {
+    return NextResponse.json({ message: 'Transaction deleted.' })
+  }
+
+  // Nothing matched: either the row is gone, or it survived the guard. Only a
+  // read can tell those apart, and it runs strictly AFTER the delete — it can no
+  // longer influence whether anything is removed.
+  const { data: surviving, error: lookupErr } = await supabase
+    .from('investment_transactions')
+    .select('transaction_id')
+    .eq('transaction_id', txId)
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (lookupErr) {
+    // Don't guess: 404 would claim the settlement is gone when it may still be
+    // there, and 409 would block a delete that legitimately found nothing.
+    console.error('investment-transactions delete: could not classify a no-op delete', lookupErr.message)
+    return NextResponse.json({ error: 'Failed to delete transaction' }, { status: 500 })
+  }
+  if (!surviving) return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
+
+  // The row is still there, so the guard is what stopped the delete.
+  return NextResponse.json(
+    { error: 'This settlement has already been merged into another deposit. Undo the merge before removing it.' },
+    { status: 409 },
+  )
 }

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -233,13 +233,33 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
     .select('transaction_id')
 
   if (error) {
-    // The mirror image of the guard above: consumed_by_inv_id has no ON DELETE
-    // action, so deleting the ANCHOR while a consumed source still references it
-    // raises a foreign-key violation. That's a conflict the user can resolve —
-    // undo the merge first — not a server fault, so it must not read as a 500.
+    // The mirror image of the guard above. Two columns reference this table with
+    // no ON DELETE action, so deleting a deposit that either one points at raises
+    // a foreign-key violation — a conflict the user can resolve, not a server
+    // fault, so it must not read as a 500.
+    //
+    // The two need different remedies, which is why this doesn't collapse into
+    // one message: consumed_by_inv_id means a merge already happened and must be
+    // undone, while merge_anchor_inv_id is stamped when a settlement is HELD —
+    // before any merge — so telling that caller to undo a merge sends them
+    // looking for something that doesn't exist. Postgres names the violated
+    // constraint in the error, which is where the distinction comes from.
     if (error.code === '23503') {
+      const violation = `${error.message ?? ''} ${error.details ?? ''}`
+      if (violation.includes('consumed_by_inv_id')) {
+        return NextResponse.json(
+          { error: 'Another settlement has been merged into this deposit. Undo the merge before removing it.' },
+          { status: 409 },
+        )
+      }
+      if (violation.includes('merge_anchor_inv_id')) {
+        return NextResponse.json(
+          { error: 'A settlement is waiting to be merged into this deposit. Cancel that pending settlement before removing it.' },
+          { status: 409 },
+        )
+      }
       return NextResponse.json(
-        { error: 'Another settlement has been merged into this deposit. Undo the merge before removing it.' },
+        { error: 'Another record still references this transaction. Remove that reference before deleting it.' },
         { status: 409 },
       )
     }


### PR DESCRIPTION
Closes #526.

## Problem

A merge folds a source deposit's cash into an anchor and closes the source with a withdrawal stamped `consumed_by_inv_id`. Deleting that withdrawal re-opens the source at full value **while its cash still sits in the anchor** — net worth then counts the money twice.

The guard existed, but as two statements:

```ts
const { data: folded } = await supabase   // error discarded
  .select('consumed_by_inv_id') ... .maybeSingle()
if (folded) return 409

const { error } = await supabase.delete()...   // separate statement
```

- **The SELECT's error was discarded**, so a failed guard read fell straight through to an unguarded DELETE — the one path where the guard mattered most.
- **A merge committing between the two statements** was invisible to the DELETE, so the check passed against a row that was consumed a moment later.

## Fix

Fold the condition into the DELETE's own `WHERE` clause:

```ts
.delete()
.eq('transaction_id', txId)
.eq('user_id', user.id)
.is('consumed_by_inv_id', null)
.select('transaction_id')
```

There is then no window. A concurrent merge either commits first — Postgres re-evaluates the predicate against the updated row under READ COMMITTED and removes nothing — or finds the row already gone. One operation safely loses, by construction rather than by timing.

When the statement matches nothing, a follow-up read decides 404 vs 409. It runs **strictly after** the delete, so it can no longer influence what is removed, and its own failure returns 500 rather than guessing (404 would claim the settlement is gone when it may still be there; 409 would block a legitimate delete).

## Two behaviour corrections that fall out

| Case | Before | After |
|---|---|---|
| Transaction doesn't exist | **200** "Transaction deleted." — a zero-row DELETE isn't an error in PostgREST | **404**, matching GET and PUT on the same route |
| Genuine database failure | **404** "Transaction not found" — a lie | **500** |
| Anchor still referenced by a consumed source | 404 | **409** with "undo the merge first" |

That last row is the mirror image of this guard. `consumed_by_inv_id` has no `ON DELETE` action, so deleting the **anchor** while a consumed source references it raises `23503`. Changing the error path from 404 to 500 would have made that *worse* — a user-resolvable conflict reading as a server fault — so it's mapped to 409 with the instruction that fixes it.

Both callers (`goalActions.unholdTransaction`, `TransactionLedgerSheet.handleDelete`) only check `res.ok`, so none of these status changes affect the UI.

## Tests

12 route tests. Beyond the status codes, they assert the **construction**, because that — not the response shape — is what closes the race:

```ts
it('makes the delete the first database operation, with no guard read before it', async () => {
  await call()
  expect(h.ops[0].op).toBe('delete')
})

it('carries the consumed guard inside the delete statement', async () => {
  await call()
  const del = h.ops.find((o) => o.op === 'delete')!
  expect(del.filters['consumed_by_inv_id:is']).toBeNull()
})
```

The mock records every database operation in order, so a future refactor that reintroduces a pre-read fails immediately. Five tests were red before the fix.

## On the AC's "concurrent merge/delete test"

True two-session concurrency isn't drivable from this repo's DB-test harness: `npm run test:db` runs each file in a single rolled-back transaction, and a second connection can't see uncommitted fixture rows. `dblink` is available locally but would require committed fixtures, breaking the rollback model every other DB test uses and leaving rows behind on failure.

The guarantee here comes from the statement being *one* statement — that's an engine property, not something route code can get wrong once the predicate is in the `WHERE`. So what's tested is the construction that earns it, which is the part this codebase can actually regress.

## Checks

| Check | Result |
|---|---|
| `vitest run` | 140 files, **1460 passed** (was 139/1449) |
| `tsc --noEmit` | clean |
| `eslint` | 28 warnings, 0 errors — **unchanged baseline** (#537) |
| Full E2E (`npx playwright test`) | **239 passed, 1 failed** — see below |

Full E2E because this changes a widely-used endpoint's status codes. The failure is the known `assign-goal-desktop.spec.ts › confirming shows "Assigned to" success state` flake — it uses PATCH, not DELETE, it passed 240/240 on the previous branch, and it passes isolated here (11/11). The DELETE-heavy specs (`maturity-combine-holding`, `maturity-combine-merge`, `investments`) are **13/13**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)