### PR TITLE
fix(deposits): make the hold + recurring-link cleanup atomic (#531)

### DIFF
--- a/app/api/v1/investment-transactions/__tests__/route.post.hold.test.ts
+++ b/app/api/v1/investment-transactions/__tests__/route.post.hold.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// Creating a held-for-merge settlement closes its source deposit, so a recurring
+// saving still pointing at that source has to be unlinked at the same moment.
+//
+// The route did that as a second statement after the insert, discarded its
+// result, and returned 201 either way (#531) — a failed cleanup left a dangling
+// link behind a success response. It now happens inside the insert's own
+// transaction, via an AFTER INSERT trigger
+// (supabase/migrations/20260727000003), whose rollback behaviour is pinned by
+// supabase/tests/hold_clears_recurring_link.test.sql against a real database.
+//
+// What this file guards is the route's side of that move: it must no longer
+// touch recurring_savings at all. A fire-and-forget UPDATE reappearing here
+// would silently restore the split — and, being fire-and-forget, would look like
+// it was working.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  ops: [] as { table: string; op: string }[],
+  parent: { data: { deposit_group_id: null } as unknown, error: null as unknown },
+  goal: { data: { goal_id: 'goal-1' } as unknown, error: null as unknown },
+  insertResult: { data: null as unknown, error: null as unknown },
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chain = (table: string) => {
+    let op = 'select'
+    const c: Record<string, unknown> = {
+      select: () => c,
+      insert: () => { op = 'insert'; return c },
+      update: () => { op = 'update'; return c },
+      eq: () => c,
+      is: () => c,
+      not: () => c,
+      single: async () => {
+        h.ops.push({ table, op })
+        if (op === 'insert') return h.insertResult
+        return table === 'savings_goals' ? h.goal : h.parent
+      },
+      maybeSingle: async () => {
+        h.ops.push({ table, op })
+        return table === 'savings_goals' ? h.goal : h.parent
+      },
+      then: (resolve: (v: unknown) => void) => {
+        h.ops.push({ table, op })
+        resolve({ data: null, error: null })
+      },
+    }
+    return c
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (table: string) => chain(table),
+    }),
+  }
+})
+
+const { POST } = await import('../route')
+
+const GOAL_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const SOURCE_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const NEW_TX_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc'
+
+const HELD_BODY = {
+  transaction_type: 'withdrawal',
+  asset_type: 'bank',
+  investment_date: '2026-07-01',
+  amount_vnd: 100_000_000,
+  parent_transaction_id: SOURCE_ID,
+  principal_withdrawn: 100_000_000,
+  goal_id: GOAL_ID,
+  held_for_merge: true,
+  merge_target_goal_id: GOAL_ID,
+}
+
+const call = (body: Record<string, unknown> = HELD_BODY) =>
+  POST(new NextRequest('https://app.test/api/v1/investment-transactions', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  }))
+
+describe('POST /api/v1/investment-transactions — held-for-merge settlement', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.ops = []
+    h.parent = { data: { deposit_group_id: null }, error: null }
+    h.goal = { data: { goal_id: GOAL_ID }, error: null }
+    h.insertResult = { data: { transaction_id: NEW_TX_ID, held_for_merge: true }, error: null }
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('creates the settlement', async () => {
+    const res = await call()
+    expect(res.status).toBe(201)
+    await expect(res.json()).resolves.toMatchObject({ transaction_id: NEW_TX_ID })
+  })
+
+  // The regression guard: the unlink is the database's job now.
+  it('does not touch recurring_savings from the route', async () => {
+    await call()
+    expect(h.ops.filter((o) => o.table === 'recurring_savings')).toEqual([])
+  })
+
+  it('issues exactly one write, the settlement insert', async () => {
+    await call()
+    const writes = h.ops.filter((o) => o.op === 'insert' || o.op === 'update')
+    expect(writes).toEqual([{ table: 'investment_transactions', op: 'insert' }])
+  })
+
+  // If the trigger's cleanup fails, the insert fails with it — the route must
+  // report that rather than the 201 the old fire-and-forget path returned.
+  it('returns 500 rather than 201 when the insert (and its cleanup) fails', async () => {
+    h.insertResult = { data: null, error: { message: 'forced cleanup failure' } }
+    const res = await call()
+    expect(res.status).toBe(500)
+  })
+
+  it('still rejects a held settlement with no resolvable target goal', async () => {
+    const res = await call({ ...HELD_BODY, goal_id: undefined, merge_target_goal_id: undefined })
+    expect(res.status).toBe(400)
+    expect(h.ops.filter((o) => o.op === 'insert')).toEqual([])
+  })
+
+  // A plain withdrawal never closed the source for merge, so it never had the
+  // cleanup — and must not acquire one.
+  it('does not touch recurring_savings for a plain withdrawal either', async () => {
+    await call({ ...HELD_BODY, held_for_merge: false, merge_target_goal_id: undefined })
+    expect(h.ops.filter((o) => o.table === 'recurring_savings')).toEqual([])
+  })
+})

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -292,19 +292,15 @@ export async function POST(request: NextRequest) {
 
   if (error) return NextResponse.json({ error: 'Failed to create transaction' }, { status: 500 })
 
-  // Holding a deposit for merge closes its source. If a recurring saving was
-  // linked to that source (linked_deposit_tx_id), the link now points at a closed
-  // deposit and would dangle until the merge consumes it. Clear it on hold —
-  // mirrors what the merge RPC does for its live sources (20260620000005 lines
-  // 174-178) so the recurring line never tops up a settled deposit. Scoped to the
-  // hold path; a plain withdrawal's pre-existing dangle is a separate concern.
-  if (cleanHeldForMerge && cleanParentTxId) {
-    await supabase
-      .from('recurring_savings')
-      .update({ linked_deposit_tx_id: null, updated_at: new Date().toISOString() })
-      .eq('linked_deposit_tx_id', cleanParentTxId)
-      .eq('user_id', user.id)
-  }
-
+  // Holding a deposit for merge closes its source, so a recurring saving linked
+  // to that source must be unlinked or it would keep topping up a settled
+  // deposit. That now happens inside the insert above, via the
+  // investment_transactions_hold_clears_link trigger (20260727000003).
+  //
+  // It used to be a second statement here whose result was discarded, so a
+  // failed cleanup returned 201 with a dangling link (#531). Doing it in the
+  // database makes the pair commit or roll back together — a failure surfaces as
+  // the insert's own error and is handled above — and covers every writer rather
+  // than only the code path that remembered to run it.
   return NextResponse.json(transaction, { status: 201 })
 }

--- a/supabase/migrations/20260727000003_hold_clears_recurring_link.sql
+++ b/supabase/migrations/20260727000003_hold_clears_recurring_link.sql
@@ -1,0 +1,53 @@
+-- Clear a recurring saving's deposit link when its source is held for merge (#531).
+--
+-- Creating a held-for-merge settlement closes the source deposit. A recurring
+-- saving still pointing at that source via linked_deposit_tx_id would go on
+-- trying to top up a settled deposit, so the link has to go at the same moment.
+--
+-- The route did this as a second statement after the insert, discarded its
+-- result, and returned 201 either way. A failed cleanup therefore left a
+-- dangling link behind a success response, and there was no transaction boundary
+-- around the pair at all.
+--
+-- A trigger is the smaller fix than an RPC here. The insert has ~20 columns, so
+-- an RPC would mean threading every one of them through a parameter list purely
+-- to gain a transaction — while AFTER INSERT already runs inside the insert's
+-- own transaction. The pair commits or rolls back together by construction, and
+-- the guarantee now covers every writer (this route, a future endpoint, a
+-- service-role script), not just the one code path that remembered to do it.
+--
+-- Scope is deliberately narrow: held_for_merge with a parent. A plain withdrawal
+-- does not close the source for merge and must leave the link intact. The merge
+-- RPC's own live-source cleanup (20260620000005) is untouched — it inserts plain
+-- withdrawals, not held ones, so this trigger never fires for it and there is no
+-- double work.
+--
+-- SECURITY DEFINER with an explicit user_id filter, matching the FK-ownership
+-- triggers: the cleanup is authoritative regardless of the caller's RLS
+-- visibility, and can only ever touch the inserting row's own owner.
+
+create or replace function public.clear_recurring_link_on_hold()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  update public.recurring_savings
+     set linked_deposit_tx_id = null,
+         updated_at = now()
+   where linked_deposit_tx_id = new.parent_transaction_id
+     and user_id = new.user_id;
+  return null; -- AFTER trigger: the return value is ignored
+end;
+$$;
+
+drop trigger if exists investment_transactions_hold_clears_link on public.investment_transactions;
+create trigger investment_transactions_hold_clears_link
+  after insert on public.investment_transactions
+  for each row
+  when (new.held_for_merge and new.parent_transaction_id is not null)
+  execute function public.clear_recurring_link_on_hold();
+
+comment on function public.clear_recurring_link_on_hold() is
+  'Unlinks any recurring saving feeding a deposit that has just been held for merge, inside the settlement insert''s own transaction (#531).';

--- a/supabase/tests/hold_clears_recurring_link.test.sql
+++ b/supabase/tests/hold_clears_recurring_link.test.sql
@@ -17,10 +17,17 @@ begin;
 
 -- Used only by step 4, to force the cleanup UPDATE to fail. Rolled back with the
 -- rest of the transaction.
+--
+-- The custom SQLSTATE matters. A bare `raise exception` uses P0001
+-- (raise_exception), which is also what step 4's own sentinel raises when the
+-- insert unexpectedly SUCCEEDS — so a handler catching P0001 would swallow both.
+-- Worse, PL/pgSQL rolls the block back before entering the handler, so the
+-- "no settlement row" assertion would then pass too and the step would report
+-- success while proving nothing. A distinct code keeps the sentinel escaping.
 create or replace function public.tmp_raise_on_update() returns trigger
 language plpgsql as $fn$
 begin
-  raise exception 'forced cleanup failure';
+  raise exception 'forced cleanup failure' using errcode = 'ZZ999';
 end;
 $fn$;
 
@@ -37,6 +44,7 @@ declare
   v_osav   uuid;
   v_link   uuid;
   v_count  int;
+  v_saw_forced_failure boolean := false;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'hold-atomic@test.invalid') returning id into v_user;
   insert into auth.users (id, email) values (gen_random_uuid(), 'hold-other@test.invalid') returning id into v_other;
@@ -114,13 +122,22 @@ begin
       (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
        parent_transaction_id, held_for_merge, merge_target_goal_id)
     values (v_user, v_goal, 'bank', 'withdrawal', '2026-07-04', 100000000, v_src, true, v_goal);
-    raise exception 'the insert must fail when the recurring cleanup fails';
+    -- Reached only if the insert survived a failing cleanup. P0001, so the
+    -- ZZ999 handler below does NOT catch it: it propagates and fails the test.
+    raise exception 'the insert must survive nothing: the cleanup failure did not abort it';
   exception
-    when raise_exception then
-      null; -- expected: the cleanup blew up and took the insert with it
+    when sqlstate 'ZZ999' then
+      v_saw_forced_failure := true; -- the cleanup blew up and took the insert with it
   end;
 
   drop trigger tmp_break_recurring_update on public.recurring_savings;
+
+  -- Belt and braces: assert we actually observed the forced failure rather than
+  -- inferring it from the absence of rows, which a rolled-back block also
+  -- produces.
+  if not v_saw_forced_failure then
+    raise exception 'step 4 never observed the forced cleanup failure';
+  end if;
 
   select count(*) into v_count
   from public.investment_transactions

--- a/supabase/tests/hold_clears_recurring_link.test.sql
+++ b/supabase/tests/hold_clears_recurring_link.test.sql
@@ -1,0 +1,141 @@
+-- Holding a deposit for merge must clear the recurring link atomically (#531).
+--
+-- Creating a held-for-merge settlement closes its source deposit. If a recurring
+-- saving still points at that source via linked_deposit_tx_id, the link now
+-- refers to a closed deposit and would try to top it up later.
+--
+-- The route used to do this as a second statement after the insert, ignore its
+-- result, and return 201 either way — so a failed cleanup left a dangling link
+-- behind a success response, with no transaction boundary around the pair. An
+-- AFTER INSERT trigger runs inside the insert's own transaction, so the two now
+-- commit or roll back together by construction.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+-- Used only by step 4, to force the cleanup UPDATE to fail. Rolled back with the
+-- rest of the transaction.
+create or replace function public.tmp_raise_on_update() returns trigger
+language plpgsql as $fn$
+begin
+  raise exception 'forced cleanup failure';
+end;
+$fn$;
+
+do $$
+declare
+  v_user   uuid;
+  v_other  uuid;
+  v_goal   uuid;
+  v_goal2  uuid;
+  v_src    uuid;
+  v_src2   uuid;
+  v_osrc   uuid;
+  v_saving uuid;
+  v_osav   uuid;
+  v_link   uuid;
+  v_count  int;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'hold-atomic@test.invalid') returning id into v_user;
+  insert into auth.users (id, email) values (gen_random_uuid(), 'hold-other@test.invalid') returning id into v_other;
+
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.savings_goals (user_id, goal_name) values (v_other, 'Their goal') returning goal_id into v_goal2;
+
+  -- The source deposit a recurring saving feeds.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_src;
+
+  insert into public.recurring_savings (user_id, name, goal_id, amount_vnd, linked_deposit_tx_id)
+  values (v_user, 'Monthly transfer', v_goal, 5000000, v_src) returning saving_id into v_saving;
+
+  -- A second user with the same shape, to prove the cleanup never reaches across.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_other, v_goal2, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_osrc;
+
+  insert into public.recurring_savings (user_id, name, goal_id, amount_vnd, linked_deposit_tx_id)
+  values (v_other, 'Theirs', v_goal2, 5000000, v_osrc) returning saving_id into v_osav;
+
+  -- 1) A held settlement on that source clears the link, within the insert itself.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, held_for_merge, merge_target_goal_id)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-07-01', 100000000, v_src, true, v_goal);
+
+  select linked_deposit_tx_id into v_link from public.recurring_savings where saving_id = v_saving;
+  if v_link is not null then
+    raise exception 'holding the source must clear linked_deposit_tx_id, still %', v_link;
+  end if;
+
+  -- The other user's identical link is untouched.
+  select linked_deposit_tx_id into v_link from public.recurring_savings where saving_id = v_osav;
+  if v_link is distinct from v_osrc then
+    raise exception 'another user''s link must survive, got %', v_link;
+  end if;
+
+  -- 2) A PLAIN withdrawal must NOT clear the link — only holding closes the
+  --    source for merge. Re-link, then withdraw normally.
+  update public.recurring_savings set linked_deposit_tx_id = v_src where saving_id = v_saving;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-07-02', 10000000, v_src);
+
+  select linked_deposit_tx_id into v_link from public.recurring_savings where saving_id = v_saving;
+  if v_link is distinct from v_src then
+    raise exception 'a plain withdrawal must leave the link intact, got %', v_link;
+  end if;
+
+  -- 3) Scoped to the held source: holding a DIFFERENT deposit leaves this alone.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-02-01', 50000000) returning transaction_id into v_src2;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, held_for_merge, merge_target_goal_id)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-07-03', 50000000, v_src2, true, v_goal);
+
+  select linked_deposit_tx_id into v_link from public.recurring_savings where saving_id = v_saving;
+  if v_link is distinct from v_src then
+    raise exception 'holding an unrelated deposit must not clear this link, got %', v_link;
+  end if;
+
+  -- 4) The rollback guarantee. Force the cleanup UPDATE to fail and assert the
+  --    settlement insert does not survive it — the exact failure the old
+  --    two-statement route turned into a dangling link behind a 201.
+  create trigger tmp_break_recurring_update
+    before update on public.recurring_savings
+    for each row execute function public.tmp_raise_on_update();
+
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+       parent_transaction_id, held_for_merge, merge_target_goal_id)
+    values (v_user, v_goal, 'bank', 'withdrawal', '2026-07-04', 100000000, v_src, true, v_goal);
+    raise exception 'the insert must fail when the recurring cleanup fails';
+  exception
+    when raise_exception then
+      null; -- expected: the cleanup blew up and took the insert with it
+  end;
+
+  drop trigger tmp_break_recurring_update on public.recurring_savings;
+
+  select count(*) into v_count
+  from public.investment_transactions
+  where user_id = v_user and investment_date = '2026-07-04';
+  if v_count <> 0 then
+    raise exception 'the settlement must roll back with its cleanup, found % row(s)', v_count;
+  end if;
+
+  -- Nothing committed, so the link is exactly as it was.
+  select linked_deposit_tx_id into v_link from public.recurring_savings where saving_id = v_saving;
+  if v_link is distinct from v_src then
+    raise exception 'a rolled-back hold must leave the link untouched, got %', v_link;
+  end if;
+
+  raise notice 'hold_clears_recurring_link.test.sql: OK';
+end $$;
+
+rollback;


### PR DESCRIPTION
Closes #531.

## Problem

Creating a held-for-merge settlement closes its source deposit. A recurring saving still pointing at that source via `linked_deposit_tx_id` would keep trying to top up a settled deposit, so the link has to go at the same moment.

The route did it as a second statement — and threw the result away:

```ts
if (cleanHeldForMerge && cleanParentTxId) {
  await supabase.from('recurring_savings').update({ linked_deposit_tx_id: null, ... })
}                                   // ↑ no error captured, no rows checked
return NextResponse.json(transaction, { status: 201 })
```

A failed cleanup left a dangling link **behind a 201**, and there was no transaction boundary around the pair at all.

## Fix — a trigger, not an RPC

```sql
create trigger investment_transactions_hold_clears_link
  after insert on public.investment_transactions
  for each row
  when (new.held_for_merge and new.parent_transaction_id is not null)
  execute function public.clear_recurring_link_on_hold();
```

The issue proposes "one RPC/transaction", and a trigger is the smaller way to get exactly that. The insert has ~20 columns, so an RPC would mean threading every one of them through a parameter list purely to gain a transaction — whereas `AFTER INSERT` already runs inside the insert's own. The pair commits or rolls back together by construction, and the guarantee now covers **every** writer (this route, a future endpoint, a service-role script), not just the one code path that remembered to do it.

`SECURITY DEFINER` with an explicit `user_id = new.user_id` filter, matching the existing FK-ownership triggers.

**Scope stays narrow** — `held_for_merge` with a parent:

- a **plain withdrawal** doesn't close the source for merge and must leave the link intact;
- the merge RPC's own live-source cleanup (`20260620000005`) is untouched — it inserts *plain* withdrawals, not held ones, so this trigger never fires for it and there's no double work.

## Tests

**DB** (`supabase/tests/hold_clears_recurring_link.test.sql`) — the AC asks for a forced cleanup failure, so the test installs a temporary `BEFORE UPDATE` trigger on `recurring_savings` that raises, then attempts the hold:

```sql
begin
  insert into public.investment_transactions (... held_for_merge, ...) values (...);
  raise exception 'the insert must fail when the recurring cleanup fails';
exception
  when raise_exception then null;   -- expected
end;
-- then: zero settlement rows, and the link is exactly as it was
```

That's the real rollback guarantee, not an inference from it. Alongside: the happy path, a plain withdrawal leaving the link alone, holding an unrelated deposit leaving it alone, and a second user's identical link surviving untouched.

Verified red before the migration:
```
ERROR: holding the source must clear linked_deposit_tx_id, still e42e8ff9-…
```

**Route** — guards the route's side of the move:

```ts
it('does not touch recurring_savings from the route', ...)   // ops filtered by table
it('issues exactly one write, the settlement insert', ...)   // inserts + updates
```

A fire-and-forget UPDATE reappearing here would silently restore the split *and*, being fire-and-forget, would look like it was working — so its absence is asserted directly.

## Checks

| Check | Result |
|---|---|
| `npm run test:db` | **9/9 OK** (including the new test) |
| `vitest run` | 141 files, **1468 passed** (was 140/1462) |
| `tsc --noEmit` | clean |
| `eslint` | 28 warnings, 0 errors — **unchanged baseline** (#537) |
| Full E2E (`npx playwright test`) | **240 passed, 0 failed** |

Full E2E because this carries a migration. Clean sweep — including the `assign-goal-desktop` spec that flaked on some earlier branches.

## ⚠️ Contains a migration

`Apply DB migrations (production)` will run on merge: one `create or replace function` plus a trigger on `investment_transactions`. No table or data change, and the trigger only fires on inserts that set `held_for_merge` with a parent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)