### PR TITLE
fix(gold): bound the DOJI scrape and rate-limit the refresh (#530)

### DIFF
--- a/app/api/v1/gold-price/refresh/__tests__/route.test.ts
+++ b/app/api/v1/gold-price/refresh/__tests__/route.test.ts
@@ -20,8 +20,10 @@ const h = vi.hoisted(() => ({
   scrapeError: null as Error | null,
   price: 8_600_000,
   rpcResult: { data: null as unknown, error: null as unknown },
+  rateLimit: { data: [{ allowed: true, retry_after_seconds: 0 }] as unknown, error: null as unknown },
   rpcCalls: [] as { name: string; args: unknown }[],
   tableReads: [] as string[],
+  scrapeCalls: 0,
 }))
 
 vi.mock('@/lib/supabase-server', () => ({
@@ -40,15 +42,21 @@ vi.mock('@/lib/supabase-server', () => ({
       }
       return c
     },
+    // Two RPCs are involved: the rate-limit check is awaited directly, the
+    // refresh goes through .single(). One object serves both shapes.
     rpc: (name: string, args: unknown) => {
       h.rpcCalls.push({ name, args })
-      return { single: async () => h.rpcResult }
+      return {
+        single: async () => h.rpcResult,
+        then: (resolve: (v: unknown) => void) => resolve(h.rateLimit),
+      }
     },
   }),
 }))
 
 vi.mock('@/lib/scrape-gold', () => ({
   scrapeGoldPrice: async () => {
+    h.scrapeCalls++
     if (h.scrapeError) throw h.scrapeError
     return h.price
   },
@@ -65,8 +73,10 @@ describe('POST /api/v1/gold-price/refresh', () => {
     h.scrapeError = null
     h.price = 8_600_000
     h.rpcResult = { data: LATER_REFRESH, error: null }
+    h.rateLimit = { data: [{ allowed: true, retry_after_seconds: 0 }], error: null }
     h.rpcCalls = []
     h.tableReads = []
+    h.scrapeCalls = 0
     vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
@@ -85,7 +95,9 @@ describe('POST /api/v1/gold-price/refresh', () => {
     h.scrapeError = new Error('Doji: NHẪN TRÒN price row not found')
     const res = await POST()
     expect(res.status).toBe(502)
-    expect(h.rpcCalls).toEqual([])
+    // The rate-limit check runs first and legitimately spends a slot — a failed
+    // scrape still consumed an upstream request. What must not happen is a write.
+    expect(h.rpcCalls.map((c) => c.name)).toEqual(['check_gold_refresh_rate_limit'])
   })
 
   // The structural guarantee: no read-then-write gap can exist if there is no read.
@@ -96,7 +108,52 @@ describe('POST /api/v1/gold-price/refresh', () => {
 
   it('delegates the whole refresh to the atomic RPC', async () => {
     await POST()
-    expect(h.rpcCalls).toEqual([{ name: 'refresh_gold_price', args: { p_price: 8_600_000 } }])
+    expect(h.rpcCalls).toContainEqual({ name: 'refresh_gold_price', args: { p_price: 8_600_000 } })
+  })
+
+  // ── per-user rate limit (#530) ───────────────────────────────────────────────
+  it('checks the rate limit before scraping', async () => {
+    await POST()
+    expect(h.rpcCalls[0].name).toBe('check_gold_refresh_rate_limit')
+  })
+
+  it('returns 429 with Retry-After when the limit is exceeded', async () => {
+    h.rateLimit = { data: [{ allowed: false, retry_after_seconds: 42 }], error: null }
+    const res = await POST()
+    expect(res.status).toBe(429)
+    expect(res.headers.get('Retry-After')).toBe('42')
+  })
+
+  // The whole point of the limit is sparing the upstream site — a refused call
+  // that still scrapes would protect nothing.
+  it('does not scrape or write when the limit is exceeded', async () => {
+    h.rateLimit = { data: [{ allowed: false, retry_after_seconds: 42 }], error: null }
+    await POST()
+    expect(h.scrapeCalls).toBe(0)
+    expect(h.rpcCalls.map((c) => c.name)).toEqual(['check_gold_refresh_rate_limit'])
+  })
+
+  // Fail CLOSED: if the limit can't be verified, refusing is safer than letting
+  // the scrape run uncapped exactly when the database is unhealthy. Refresh is
+  // non-essential, so a retryable 503 is the right default.
+  it('returns 503 with Retry-After when the limit cannot be verified', async () => {
+    h.rateLimit = { data: null, error: { message: 'timeout' } }
+    const res = await POST()
+    expect(res.status).toBe(503)
+    expect(res.headers.get('Retry-After')).toBeTruthy()
+    expect(h.scrapeCalls).toBe(0)
+  })
+
+  it('fails closed when the limiter returns no verdict at all', async () => {
+    h.rateLimit = { data: [], error: null }
+    const res = await POST()
+    expect(res.status).toBe(503)
+    expect(h.scrapeCalls).toBe(0)
+  })
+
+  it('accepts a non-array verdict shape', async () => {
+    h.rateLimit = { data: { allowed: true, retry_after_seconds: 0 }, error: null }
+    expect((await POST()).status).toBe(200)
   })
 
   it('returns the stored pair for an existing settings row', async () => {

--- a/app/api/v1/gold-price/refresh/route.ts
+++ b/app/api/v1/gold-price/refresh/route.ts
@@ -2,10 +2,37 @@ import { NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { scrapeGoldPrice } from '@/lib/scrape-gold'
 
+// Mirrors the window hardcoded in check_gold_refresh_rate_limit; used only as
+// the Retry-After fallback when the RPC can't tell us a precise one.
+const RATE_LIMIT_WINDOW_SECONDS = 60
+
 export async function POST() {
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  // Durable per-user rate limit (atomic fixed window in Postgres), checked
+  // before the scrape so a refused call costs DOJI nothing (#530).
+  const { data: rl, error: rlError } = await supabase.rpc('check_gold_refresh_rate_limit')
+  const verdict = Array.isArray(rl) ? rl[0] : rl
+  if (rlError || !verdict) {
+    // Fail CLOSED: if the limit can't be verified (RPC error, missing verdict, or
+    // the migration not yet applied), refuse rather than let the scrape run
+    // uncapped exactly when the database is unhealthy. Refresh is non-essential,
+    // so a retryable 503 is the safe default.
+    console.error('[gold-price refresh] rate-limit check unavailable:', rlError)
+    return NextResponse.json(
+      { error: 'Rate limit check unavailable. Please try again shortly.' },
+      { status: 503, headers: { 'Retry-After': String(RATE_LIMIT_WINDOW_SECONDS) } },
+    )
+  }
+  if (verdict.allowed === false) {
+    const retryAfter = verdict.retry_after_seconds ?? RATE_LIMIT_WINDOW_SECONDS
+    return NextResponse.json(
+      { error: 'Too many refresh requests. Please wait and try again.', retryAfter },
+      { status: 429, headers: { 'Retry-After': String(retryAfter) } },
+    )
+  }
 
   let price: number
   try {

--- a/lib/__tests__/boundedFetch.test.ts
+++ b/lib/__tests__/boundedFetch.test.ts
@@ -41,14 +41,38 @@ describe('boundedFetchText', () => {
 
   // Without this, a 404/500 error page is handed to the price parser, which then
   // reports a confusing "price row not found" instead of "the site is down".
-  it('rejects a non-2xx response before reading the body', async () => {
-    const res = new Response(streamOf([enc.encode('<html>Not Found</html>')]), { status: 404 })
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue(res)
+  it('rejects a non-2xx response with the status, not a parse error', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(streamOf([enc.encode('<html>Not Found</html>')]), { status: 404 }),
+    )
+    // The error names the status, so the caller can tell an outage from a layout
+    // change — the error page is never handed to a price parser.
     await expect(boundedFetchText('https://example.test')).rejects.toThrow(/404/)
-    // `bodyUsed` is the honest signal: a stream's start/pull callbacks both run
-    // eagerly at construction, so instrumenting them would report a read that
-    // never happened. This flips only once something actually consumes the body.
-    expect(res.bodyUsed).toBe(false)
+  })
+
+  // Throwing without cancelling leaves the transfer open while the semaphore
+  // permit is already released, so a run of error responses can hold more than
+  // the cap's worth of sockets — quietly defeating the process-wide limit this
+  // helper exists to enforce.
+  it('cancels the error response body instead of leaving the transfer open', async () => {
+    let cancelled = false
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) { controller.enqueue(enc.encode('x')) }, // never ends on its own
+      cancel() { cancelled = true },
+    })
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(stream, { status: 500 }))
+    await expect(boundedFetchText('https://example.test')).rejects.toThrow(/500/)
+    expect(cancelled).toBe(true)
+  })
+
+  it('still reports the status when cancelling the body itself fails', async () => {
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) { controller.enqueue(enc.encode('x')) },
+      cancel() { throw new Error('socket already gone') },
+    })
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(stream, { status: 502 }))
+    // The cancel failure must not mask the actual problem.
+    await expect(boundedFetchText('https://example.test')).rejects.toThrow(/502/)
   })
 
   it('rejects a 500 as well as a 404', async () => {

--- a/lib/__tests__/boundedFetch.test.ts
+++ b/lib/__tests__/boundedFetch.test.ts
@@ -132,6 +132,35 @@ describe('boundedFetchText', () => {
     await expect(boundedFetchText('https://example.test', { timeoutMs: 20 })).rejects.toThrow()
   })
 
+  // The deadline must cover the wait for a permit, not just the request. One
+  // Dragon Capital scrape queues ~15 requests behind a cap of 6, so a gold
+  // refresh can sit in that queue — and a timeout that only starts on
+  // acquisition makes the real bound "queue time + 10s", not 10s.
+  it('applies the deadline to the wait for a permit, not just the fetch', async () => {
+    const { httpSemaphore } = await import('../boundedFetch')
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(streamOf([enc.encode('ok')]), { status: 200 }),
+    )
+
+    // Occupy every permit so the call below can only queue.
+    let releaseAll: () => void = () => {}
+    const blockers = Array.from({ length: 6 }, () =>
+      httpSemaphore.run(() => new Promise<void>((r) => {
+        const prev = releaseAll
+        releaseAll = () => { prev(); r() }
+      })),
+    )
+
+    await expect(
+      boundedFetchText('https://example.test', { timeoutMs: 20 }),
+    ).rejects.toThrow()
+    // Never even reached the request: it gave up while queued.
+    expect(fetchSpy).not.toHaveBeenCalled()
+
+    releaseAll()
+    await Promise.all(blockers)
+  })
+
   it('forwards caller headers to the upstream request', async () => {
     let init: RequestInit | undefined
     vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, i) => {

--- a/lib/__tests__/boundedFetch.test.ts
+++ b/lib/__tests__/boundedFetch.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { boundedFetchText } from '../boundedFetch'
+
+// Every outbound scrape must be bounded: an absolute timeout, a hard byte cap on
+// the streamed body, and a status check before anything is parsed (#530).
+//
+// This logic already existed inside lib/scrape-fund-nav.ts but was module-
+// private, so lib/scrape-gold.ts fetched completely unguarded. Extracting it
+// gives both scrapers one implementation to be correct in — and adds the status
+// check the NAV version was missing.
+
+function streamOf(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(c)
+      controller.close()
+    },
+  })
+}
+
+const enc = new TextEncoder()
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('boundedFetchText', () => {
+  it('returns the body for a normal response', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(streamOf([enc.encode('<html>ok</html>')]), { status: 200 }),
+    )
+    await expect(boundedFetchText('https://example.test')).resolves.toBe('<html>ok</html>')
+  })
+
+  it('reassembles a body split across chunks', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(streamOf([enc.encode('abc'), enc.encode('def'), enc.encode('ghi')]), { status: 200 }),
+    )
+    await expect(boundedFetchText('https://example.test')).resolves.toBe('abcdefghi')
+  })
+
+  // Without this, a 404/500 error page is handed to the price parser, which then
+  // reports a confusing "price row not found" instead of "the site is down".
+  it('rejects a non-2xx response before reading the body', async () => {
+    const res = new Response(streamOf([enc.encode('<html>Not Found</html>')]), { status: 404 })
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(res)
+    await expect(boundedFetchText('https://example.test')).rejects.toThrow(/404/)
+    // `bodyUsed` is the honest signal: a stream's start/pull callbacks both run
+    // eagerly at construction, so instrumenting them would report a read that
+    // never happened. This flips only once something actually consumes the body.
+    expect(res.bodyUsed).toBe(false)
+  })
+
+  it('rejects a 500 as well as a 404', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(streamOf([enc.encode('boom')]), { status: 500 }),
+    )
+    await expect(boundedFetchText('https://example.test')).rejects.toThrow(/500/)
+  })
+
+  it('rejects a body that exceeds the byte cap', async () => {
+    const big = new Uint8Array(1024)
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(streamOf([big, big, big]), { status: 200 }),
+    )
+    await expect(boundedFetchText('https://example.test', { maxBytes: 2048 })).rejects.toThrow(/exceeded/i)
+  })
+
+  it('accepts a body exactly at the cap', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(streamOf([new Uint8Array(2048)]), { status: 200 }),
+    )
+    await expect(boundedFetchText('https://example.test', { maxBytes: 2048 })).resolves.toHaveLength(2048)
+  })
+
+  it('stops reading as soon as the cap is passed rather than draining the body', async () => {
+    let chunksPulled = 0
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        chunksPulled++
+        if (chunksPulled > 50) return controller.close()
+        controller.enqueue(new Uint8Array(1024))
+      },
+    })
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(stream, { status: 200 }))
+    await expect(boundedFetchText('https://example.test', { maxBytes: 2048 })).rejects.toThrow(/exceeded/i)
+    // 3 pulls take it past 2048; anything close to 50 means the cap didn't stop it.
+    expect(chunksPulled).toBeLessThan(10)
+  })
+
+  it('passes an abort signal so a hung upstream cannot hold the request open', async () => {
+    let signal: AbortSignal | undefined
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, init) => {
+      signal = (init as RequestInit | undefined)?.signal as AbortSignal | undefined
+      return new Response(streamOf([enc.encode('ok')]), { status: 200 })
+    })
+    await boundedFetchText('https://example.test', { timeoutMs: 5_000 })
+    expect(signal).toBeInstanceOf(AbortSignal)
+  })
+
+  it('surfaces the abort when the upstream exceeds the timeout', async () => {
+    vi.spyOn(globalThis, 'fetch').mockImplementation((_url, init) => {
+      const s = (init as RequestInit | undefined)?.signal as AbortSignal | undefined
+      return new Promise((_resolve, reject) => {
+        s?.addEventListener('abort', () => reject(new DOMException('The operation was aborted.', 'TimeoutError')))
+      })
+    })
+    await expect(boundedFetchText('https://example.test', { timeoutMs: 20 })).rejects.toThrow()
+  })
+
+  it('forwards caller headers to the upstream request', async () => {
+    let init: RequestInit | undefined
+    vi.spyOn(globalThis, 'fetch').mockImplementation(async (_url, i) => {
+      init = i as RequestInit
+      return new Response(streamOf([enc.encode('ok')]), { status: 200 })
+    })
+    await boundedFetchText('https://example.test', { headers: { 'User-Agent': 'test-agent' } })
+    expect((init?.headers as Record<string, string>)['User-Agent']).toBe('test-agent')
+  })
+})

--- a/lib/__tests__/concurrency.test.ts
+++ b/lib/__tests__/concurrency.test.ts
@@ -80,4 +80,60 @@ describe('Semaphore', () => {
     // If the permit leaked, this second run would hang forever.
     await expect(sem.run(async () => 'ok')).resolves.toBe('ok')
   })
+
+  // Waiting for a permit is part of an operation's elapsed time. Without an
+  // abortable wait, a caller's "absolute" deadline only starts once it reaches
+  // the front of the queue, so the real bound is queue time + deadline (#530).
+  describe('abortable acquisition', () => {
+    it('rejects a queued caller when its signal aborts, and never runs its op', async () => {
+      const sem = new Semaphore(1)
+      let ran = false
+      let releaseFirst: () => void = () => {}
+      const first = sem.run(() => new Promise<void>((r) => { releaseFirst = () => r() }))
+
+      const controller = new AbortController()
+      const queued = sem.run(async () => { ran = true }, controller.signal)
+      controller.abort(new Error('deadline exceeded'))
+
+      await expect(queued).rejects.toThrow('deadline exceeded')
+      expect(ran).toBe(false)
+
+      releaseFirst()
+      await first
+    })
+
+    it('does not run the op at all when the signal is already aborted', async () => {
+      const sem = new Semaphore(1)
+      let ran = false
+      await expect(
+        sem.run(async () => { ran = true }, AbortSignal.abort(new Error('too late'))),
+      ).rejects.toThrow('too late')
+      expect(ran).toBe(false)
+    })
+
+    it('leaves the queue usable for everyone else after an abort', async () => {
+      const sem = new Semaphore(1)
+      let releaseFirst: () => void = () => {}
+      const first = sem.run(() => new Promise<void>((r) => { releaseFirst = () => r() }))
+
+      const controller = new AbortController()
+      const abandoned = sem.run(async () => 'never', controller.signal)
+      const waiting = sem.run(async () => 'ran')
+
+      controller.abort(new Error('gone'))
+      await expect(abandoned).rejects.toThrow('gone')
+
+      releaseFirst()
+      await first
+      // The abandoned waiter must not have consumed the permit it never got.
+      await expect(waiting).resolves.toBe('ran')
+    })
+
+    it('is unaffected by a signal that never aborts', async () => {
+      const sem = new Semaphore(1)
+      const controller = new AbortController()
+      await expect(sem.run(async () => 'ok', controller.signal)).resolves.toBe('ok')
+      await expect(sem.run(async () => 'ok again')).resolves.toBe('ok again')
+    })
+  })
 })

--- a/lib/__tests__/scrape-gold.test.ts
+++ b/lib/__tests__/scrape-gold.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// The gold scraper fetched DOJI with a bare `fetch(...).then(r => r.text())`:
+// no timeout, no size cap, no status check (#530). A slow upstream could hold a
+// serverless function open for as long as it liked, an oversized body was read
+// straight into memory, and a 404/500 error page was handed to the price regex —
+// which then reported "price row not found", pointing the reader at a layout
+// change rather than an outage.
+//
+// It now goes through the same bounded fetch the NAV scraper uses. The bounds
+// themselves are covered in boundedFetch.test.ts; what this file pins is that
+// gold actually goes through it and doesn't swallow what it raises.
+
+const h = vi.hoisted(() => ({
+  calls: [] as { url: string; init: Record<string, unknown> }[],
+  html: '',
+  error: null as Error | null,
+}))
+
+vi.mock('../boundedFetch', () => ({
+  boundedFetchText: async (url: string, init: Record<string, unknown> = {}) => {
+    h.calls.push({ url, init })
+    if (h.error) throw h.error
+    return h.html
+  },
+}))
+
+const { scrapeGoldPrice } = await import('../scrape-gold')
+
+const page = (price: string) =>
+  `<table><tr><td>NHẪN TRÒN 9999</td><td>${price}</td><td>8,700</td></tr></table>`
+
+describe('scrapeGoldPrice', () => {
+  beforeEach(() => {
+    h.calls = []
+    h.html = page('8,500')
+    h.error = null
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('parses the ring price and scales it to VND per chi', async () => {
+    await expect(scrapeGoldPrice()).resolves.toBe(8_500_000)
+  })
+
+  it('handles a larger comma-grouped price', async () => {
+    h.html = page('12,345')
+    await expect(scrapeGoldPrice()).resolves.toBe(12_345_000)
+  })
+
+  // Not asserting a dot-grouped price here: parseVietnameseNumber deliberately
+  // reads '8.500' as the float 8.5 when no comma-decimal gives it thousands
+  // context — see parseVietnameseNumber.test.ts, which documents that ambiguity.
+  // DOJI sends comma groups, so this scraper never hits it.
+
+  // The structural point: gold must not reintroduce a bare fetch.
+  it('fetches through the bounded helper', async () => {
+    await scrapeGoldPrice()
+    expect(h.calls).toHaveLength(1)
+    expect(h.calls[0].url).toContain('doji.vn')
+  })
+
+  it('does not call the global fetch directly', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch')
+    await scrapeGoldPrice()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+
+  it('still sends the browser-ish headers the site expects', async () => {
+    await scrapeGoldPrice()
+    const headers = h.calls[0].init.headers as Record<string, string>
+    expect(headers['User-Agent']).toBeTruthy()
+    expect(headers['Accept-Language']).toContain('vi')
+  })
+
+  // A timeout, an oversized body and a non-2xx all surface as a throw from the
+  // bounded fetch. The scraper must let them through — the refresh routes turn a
+  // throw into a 502, whereas swallowing it would mean writing a junk price.
+  it('propagates an upstream failure instead of swallowing it', async () => {
+    h.error = new Error('Upstream responded 503 for giavang.doji.vn')
+    await expect(scrapeGoldPrice()).rejects.toThrow(/503/)
+  })
+
+  it('propagates a timeout', async () => {
+    h.error = new Error('The operation was aborted due to timeout')
+    await expect(scrapeGoldPrice()).rejects.toThrow(/timeout/i)
+  })
+
+  it('propagates an oversized response', async () => {
+    h.error = new Error('Response exceeded 2097152 bytes')
+    await expect(scrapeGoldPrice()).rejects.toThrow(/exceeded/i)
+  })
+
+  it('throws when the price row is absent', async () => {
+    h.html = '<html>maintenance</html>'
+    await expect(scrapeGoldPrice()).rejects.toThrow(/not found/i)
+  })
+
+  it('throws rather than returning a non-positive price', async () => {
+    h.html = page('0')
+    await expect(scrapeGoldPrice()).rejects.toThrow(/invalid price/i)
+  })
+})

--- a/lib/boundedFetch.ts
+++ b/lib/boundedFetch.ts
@@ -37,8 +37,17 @@ export async function boundedFetchText(
   init: RequestInit & { timeoutMs?: number; maxBytes?: number } = {},
 ): Promise<string> {
   const { timeoutMs = SCRAPE_TIMEOUT_MS, maxBytes = SCRAPE_MAX_BYTES, ...rest } = init
+
+  // The clock starts HERE, before queuing for a permit — not inside the
+  // callback. Waiting is part of the elapsed time: one Dragon Capital scrape
+  // queues ~15 requests behind a cap of 6, so a deadline that only started on
+  // acquisition made the real bound "queue time + timeoutMs" rather than the
+  // absolute one it advertises. The same signal aborts the wait, the request and
+  // the body read, so it bounds the whole operation.
+  const signal = AbortSignal.timeout(timeoutMs)
+
   return httpSemaphore.run(async () => {
-    const res = await fetch(url, { ...rest, signal: AbortSignal.timeout(timeoutMs) })
+    const res = await fetch(url, { ...rest, signal })
     if (!res.ok) {
       // Cancel before throwing. The semaphore permit is released as soon as this
       // callback returns, so an un-cancelled error body would keep its transfer
@@ -73,5 +82,5 @@ export async function boundedFetchText(
       offset += chunk.byteLength
     }
     return new TextDecoder().decode(merged)
-  })
+  }, signal)
 }

--- a/lib/boundedFetch.ts
+++ b/lib/boundedFetch.ts
@@ -40,6 +40,13 @@ export async function boundedFetchText(
   return httpSemaphore.run(async () => {
     const res = await fetch(url, { ...rest, signal: AbortSignal.timeout(timeoutMs) })
     if (!res.ok) {
+      // Cancel before throwing. The semaphore permit is released as soon as this
+      // callback returns, so an un-cancelled error body would keep its transfer
+      // open past the permit — and a run of error responses could then hold more
+      // than MAX_CONCURRENT_HTTP sockets, defeating the very cap this helper
+      // exists to enforce. Swallow a cancel failure: it isn't actionable and
+      // must not mask the status, which is the real problem.
+      await res.body?.cancel().catch(() => {})
       throw new Error(`Upstream responded ${res.status} for ${new URL(url).host}`)
     }
 

--- a/lib/boundedFetch.ts
+++ b/lib/boundedFetch.ts
@@ -1,0 +1,70 @@
+import { Semaphore } from './concurrency'
+
+// Every outbound scrape is bounded so a slow, oversized or broken upstream can't
+// hang a serverless function, exhaust its memory, or feed an error page to a
+// price parser (#515, #530).
+export const SCRAPE_TIMEOUT_MS = 10_000
+export const SCRAPE_MAX_BYTES = 2 * 1024 * 1024 // 2 MB — the pages we scrape are tens of KB
+
+// Process-wide cap on concurrent outbound provider requests. This bounds the
+// TRUE fan-out regardless of how it nests: a route may already limit how many
+// URLs scrape at once, but one Dragon Capital scrape alone issues ~15 requests
+// via Promise.all, so without a per-request cap a handful of scrapes could still
+// open hundreds of sockets. Every fetch below goes through this gate.
+// Exported because the NAV scraper's Node-https path (used for providers whose
+// TLS the fetch path can't negotiate) must share the SAME gate — two separate
+// semaphores would each allow the cap, doubling the real ceiling.
+const MAX_CONCURRENT_HTTP = 6
+export const httpSemaphore = new Semaphore(MAX_CONCURRENT_HTTP)
+
+// fetch(url).text() with an absolute timeout, a status check, and a hard byte
+// cap on the streamed body.
+//
+// Lives here rather than inside one scraper because both the NAV and the gold
+// scraper need it: gold was fetching completely unguarded, and copying the logic
+// would have left two implementations to keep correct.
+//
+// The status check is the part the original NAV version lacked. Without it a
+// 404 or 500 error page is handed to the price parser, which reports something
+// like "price row not found" — indistinguishable from a layout change, and
+// pointing the reader at the wrong problem.
+//
+// The cap is enforced while streaming, not after: reading a huge body into
+// memory first and measuring it afterwards would be the very failure being
+// guarded against, so the reader is cancelled the moment the limit is passed.
+export async function boundedFetchText(
+  url: string,
+  init: RequestInit & { timeoutMs?: number; maxBytes?: number } = {},
+): Promise<string> {
+  const { timeoutMs = SCRAPE_TIMEOUT_MS, maxBytes = SCRAPE_MAX_BYTES, ...rest } = init
+  return httpSemaphore.run(async () => {
+    const res = await fetch(url, { ...rest, signal: AbortSignal.timeout(timeoutMs) })
+    if (!res.ok) {
+      throw new Error(`Upstream responded ${res.status} for ${new URL(url).host}`)
+    }
+
+    const reader = res.body?.getReader()
+    if (!reader) return res.text()
+
+    const chunks: Uint8Array[] = []
+    let total = 0
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (done) break
+      total += value.byteLength
+      if (total > maxBytes) {
+        await reader.cancel()
+        throw new Error(`Response exceeded ${maxBytes} bytes`)
+      }
+      chunks.push(value)
+    }
+
+    const merged = new Uint8Array(total)
+    let offset = 0
+    for (const chunk of chunks) {
+      merged.set(chunk, offset)
+      offset += chunk.byteLength
+    }
+    return new TextDecoder().decode(merged)
+  })
+}

--- a/lib/concurrency.ts
+++ b/lib/concurrency.ts
@@ -37,12 +37,31 @@ export class Semaphore {
     this.available = Math.max(1, Math.floor(permits) || 1)
   }
 
-  private async acquire(): Promise<void> {
+  // Waiting for a permit is part of an operation's elapsed time, so a caller
+  // with a deadline has to be able to give up while queued. Without this, an
+  // "absolute" timeout created by the caller only starts once it reaches the
+  // front of the queue, and the real bound becomes queue time + timeout (#530).
+  private async acquire(signal?: AbortSignal): Promise<void> {
+    if (signal?.aborted) throw signal.reason
     if (this.available > 0) {
       this.available--
       return
     }
-    await new Promise<void>((resolve) => this.waiters.push(resolve))
+    await new Promise<void>((resolve, reject) => {
+      const waiter = () => {
+        signal?.removeEventListener('abort', onAbort)
+        resolve()
+      }
+      const onAbort = () => {
+        // Drop out of the queue so release() never hands a permit to a waiter
+        // that has already given up — that permit would be lost.
+        const i = this.waiters.indexOf(waiter)
+        if (i !== -1) this.waiters.splice(i, 1)
+        reject(signal!.reason)
+      }
+      this.waiters.push(waiter)
+      signal?.addEventListener('abort', onAbort, { once: true })
+    })
   }
 
   private release(): void {
@@ -51,9 +70,10 @@ export class Semaphore {
     else this.available++
   }
 
-  // Run `fn` once a permit is free, always releasing it (even on throw).
-  async run<T>(fn: () => Promise<T>): Promise<T> {
-    await this.acquire()
+  // Run `fn` once a permit is free, always releasing it (even on throw). Pass a
+  // signal to abandon the wait — `fn` then never runs and no permit is consumed.
+  async run<T>(fn: () => Promise<T>, signal?: AbortSignal): Promise<T> {
+    await this.acquire(signal)
     try {
       return await fn()
     } finally {

--- a/lib/scrape-fund-nav.ts
+++ b/lib/scrape-fund-nav.ts
@@ -1,20 +1,16 @@
 import https from 'https'
 import { ValidationError } from './validation'
-import { Semaphore } from './concurrency'
+import {
+  boundedFetchText,
+  httpSemaphore,
+  SCRAPE_MAX_BYTES,
+  SCRAPE_TIMEOUT_MS,
+} from './boundedFetch'
 
-// Every outbound provider request is bounded so a slow or oversized upstream
-// can't hang a serverless function or exhaust its memory (#515).
-const SCRAPE_TIMEOUT_MS = 10_000
-const SCRAPE_MAX_BYTES = 2 * 1024 * 1024 // 2 MB — fund pages are tens of KB
-
-// Process-wide cap on the number of concurrent outbound provider requests. This
-// bounds the TRUE fan-out regardless of how it nests: the route already limits
-// how many URLs scrape at once, but one Dragon Capital scrape alone issues ~15
-// requests via Promise.all, so without a per-request cap a handful of scrapes
-// could still open hundreds of sockets at once. Every fetch below goes through
-// this gate.
-const MAX_CONCURRENT_HTTP = 6
-const httpSemaphore = new Semaphore(MAX_CONCURRENT_HTTP)
+// The bounded fetch, its timeout/size limits and the process-wide outbound
+// semaphore moved to lib/boundedFetch so the gold scraper shares one
+// implementation instead of a second copy (#530). The Node-https path below
+// still runs through that same semaphore, so the concurrency cap stays global.
 
 // Normalize a NAV source URL for de-duplication: lowercase the host (case-
 // insensitive) but PRESERVE the path/query case — the Dragon Capital and
@@ -32,40 +28,6 @@ export function normalizeNavUrl(raw: string): string {
   } catch {
     return raw.trim()
   }
-}
-
-// fetch(url).text() with an abort timeout and a hard byte cap on the streamed
-// body. Throws on timeout or when the response exceeds the cap; scrapeFundNav's
-// try/catch turns either into a per-fund { error } instead of a hung request.
-async function boundedFetchText(
-  url: string,
-  init: RequestInit & { timeoutMs?: number; maxBytes?: number } = {},
-): Promise<string> {
-  const { timeoutMs = SCRAPE_TIMEOUT_MS, maxBytes = SCRAPE_MAX_BYTES, ...rest } = init
-  return httpSemaphore.run(async () => {
-  const res = await fetch(url, { ...rest, signal: AbortSignal.timeout(timeoutMs) })
-  const reader = res.body?.getReader()
-  if (!reader) return res.text()
-  const chunks: Uint8Array[] = []
-  let total = 0
-  for (;;) {
-    const { done, value } = await reader.read()
-    if (done) break
-    total += value.byteLength
-    if (total > maxBytes) {
-      await reader.cancel()
-      throw new Error(`Response exceeded ${maxBytes} bytes`)
-    }
-    chunks.push(value)
-  }
-  const merged = new Uint8Array(total)
-  let offset = 0
-  for (const chunk of chunks) {
-    merged.set(chunk, offset)
-    offset += chunk.byteLength
-  }
-  return new TextDecoder().decode(merged)
-  })
 }
 
 // The only hosts the NAV scraper is allowed to fetch. `nav_source_url` is

--- a/lib/scrape-gold.ts
+++ b/lib/scrape-gold.ts
@@ -1,3 +1,5 @@
+import { boundedFetchText } from './boundedFetch'
+
 function parseVietnameseNumber(raw: string): number {
   const cleaned = raw.replace(/[^\d.,]/g, '').trim()
   if (/,\d{2}$/.test(cleaned)) {
@@ -6,13 +8,22 @@ function parseVietnameseNumber(raw: string): number {
   return parseFloat(cleaned.replace(/,/g, ''))
 }
 
+// The DOJI fetch goes through the shared bounded helper (#530): an absolute
+// timeout so a slow upstream can't hold a serverless function open, a hard byte
+// cap so an oversized body can't be read into memory, and a status check so a
+// 404/500 error page never reaches the regex below — which would otherwise
+// report "price row not found" and send the reader after a layout change that
+// didn't happen.
+//
+// Failures are deliberately left to propagate: both refresh routes turn a throw
+// into a 502, whereas swallowing one would store a junk price.
 export async function scrapeGoldPrice(): Promise<number> {
-  const html = await fetch('https://giavang.doji.vn', {
+  const html = await boundedFetchText('https://giavang.doji.vn', {
     headers: {
       'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
       'Accept-Language': 'vi-VN,vi;q=0.9',
     },
-  }).then((r) => r.text())
+  })
 
   const match = html.match(/NHẪN TRÒN[\s\S]{0,300}?<td[^>]*>([\d.,]+)<\/td>/)
   if (!match) throw new Error('Doji: NHẪN TRÒN price row not found')

--- a/supabase/migrations/20260727000004_gold_refresh_rate_limit.sql
+++ b/supabase/migrations/20260727000004_gold_refresh_rate_limit.sql
@@ -1,0 +1,94 @@
+-- Per-user rate limit for the gold price refresh (#530).
+--
+-- POST /api/v1/gold-price/refresh lets any authenticated user trigger an
+-- outbound scrape of giavang.doji.vn. Nothing stopped one account from doing
+-- that in a loop, driving serverless cost and load on a third party's site.
+--
+-- This mirrors the NAV limiter (20260725000001) rather than extending it. The
+-- two protect different upstreams with very different costs — one request to
+-- DOJI versus ~15 provider requests per fund — so they keep separate counters
+-- and separate policies, and neither retune drags the other with it. The shape
+-- is deliberately identical so there is one pattern to understand, not two.
+--
+-- Durable, atomic fixed window: one row per user tracks the window start and a
+-- request count, and the whole check-and-increment happens in a single
+-- INSERT … ON CONFLICT DO UPDATE, so two concurrent calls can't both read a
+-- stale count (the row lock on conflict serializes them).
+
+create table if not exists public.gold_refresh_rate_limit (
+  user_id       uuid primary key references auth.users(id) on delete cascade,
+  window_start  timestamptz not null default now(),
+  request_count int not null default 0,
+  updated_at    timestamptz not null default now()
+);
+
+-- Only the SECURITY DEFINER function below may touch this table. RLS on, no
+-- policies, and revoked grants means a user cannot read or reset their own
+-- counter directly (which would defeat the limit) — they can only go through
+-- the RPC.
+alter table public.gold_refresh_rate_limit enable row level security;
+revoke all on public.gold_refresh_rate_limit from anon, authenticated;
+
+-- Atomically record one refresh attempt for the current caller and report
+-- whether it is allowed. Runs as owner so it can maintain the locked-down table,
+-- but scopes everything to auth.uid() — a caller can only ever affect their own
+-- row. A blocked attempt still increments the count (so hammering keeps you
+-- blocked) but never advances window_start, so the lockout stays bounded by the
+-- window length.
+--
+-- The policy is HARDCODED, not passed in: the function is granted to
+-- `authenticated` so the client's supabase-js can call it, which means an
+-- attacker could otherwise invoke it directly with a degenerate window (e.g. 0
+-- seconds) and reset their own counter before every refresh.
+--
+-- 10 per minute, vs the NAV limiter's 5: a gold refresh is a single upstream
+-- request, so the same per-minute pressure on DOJI allows more calls here.
+create or replace function public.check_gold_refresh_rate_limit()
+returns table (allowed boolean, retry_after_seconds int)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_max    constant int := 10;
+  v_window constant interval := interval '60 seconds';
+  v_user   uuid := auth.uid();
+  v_now    timestamptz := now();
+  v_start  timestamptz;
+  v_count  int;
+begin
+  if v_user is null then
+    allowed := false;
+    retry_after_seconds := 60;
+    return next;
+    return;
+  end if;
+
+  insert into public.gold_refresh_rate_limit as r (user_id, window_start, request_count, updated_at)
+  values (v_user, v_now, 1, v_now)
+  on conflict (user_id) do update
+    set window_start  = case when v_now - r.window_start >= v_window then v_now else r.window_start end,
+        request_count = case when v_now - r.window_start >= v_window then 1    else r.request_count + 1 end,
+        updated_at    = v_now
+  returning r.window_start, r.request_count into v_start, v_count;
+
+  if v_count <= v_max then
+    allowed := true;
+    retry_after_seconds := 0;
+  else
+    allowed := false;
+    retry_after_seconds := greatest(1, ceil(extract(epoch from (v_start + v_window - v_now)))::int);
+  end if;
+  return next;
+end;
+$$;
+
+-- EXECUTE is granted to PUBLIC by default, so revoke it (covering anon and
+-- authenticated) and re-grant only to authenticated. anon is revoked explicitly
+-- too, in case any prior grant targeted it directly.
+revoke all on function public.check_gold_refresh_rate_limit() from public;
+revoke all on function public.check_gold_refresh_rate_limit() from anon;
+grant execute on function public.check_gold_refresh_rate_limit() to authenticated;
+
+comment on function public.check_gold_refresh_rate_limit() is
+  'Atomically records one gold-refresh attempt for auth.uid() and reports whether it is within the fixed window (10 per 60s). Backs POST /api/v1/gold-price/refresh (#530).';

--- a/supabase/tests/gold_refresh_rate_limit.test.sql
+++ b/supabase/tests/gold_refresh_rate_limit.test.sql
@@ -1,0 +1,98 @@
+-- Per-user rate limit for the gold price refresh (#530).
+--
+-- POST /api/v1/gold-price/refresh lets any authenticated user trigger an
+-- outbound scrape of giavang.doji.vn. Nothing stopped one account from doing
+-- that in a loop, driving serverless cost and load on a third party's site.
+--
+-- Mirrors the NAV limiter (20260725000001) rather than extending it: the two
+-- protect different upstreams with different costs — one gold request versus
+-- ~15 provider requests per fund — so they get separate counters and can be
+-- tuned independently. Deliberately the same shape, so there is one pattern to
+-- understand rather than two.
+--
+-- Asserts the three properties the route tests can't reach (they mock the RPC):
+--   1) the policy is enforced server-side, hardcoded, not passed in;
+--   2) counters are per user, so one account can't exhaust another's budget;
+--   3) anon cannot execute it; only authenticated can.
+--
+-- now() is the transaction timestamp (constant here), so the window never rolls
+-- over mid-test and the count climbs monotonically. True concurrency can't be
+-- driven from a single rolled-back transaction; that guarantee comes from the
+-- atomic INSERT … ON CONFLICT DO UPDATE row lock, the same as the NAV limiter.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_user    uuid;
+  v_other   uuid;
+  v_allowed boolean;
+  v_retry   int;
+  i         int;
+begin
+  -- 1) No parameterized overload: a caller who can execute the function must not
+  --    be able to hand it a degenerate window and reset their own counter.
+  if exists (
+    select 1 from pg_proc p join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public' and p.proname = 'check_gold_refresh_rate_limit' and p.pronargs > 0
+  ) then
+    raise exception 'check_gold_refresh_rate_limit must take no arguments';
+  end if;
+
+  -- 2) anon must not be able to call it at all.
+  if has_function_privilege('anon', 'public.check_gold_refresh_rate_limit()', 'execute') then
+    raise exception 'anon must not be able to execute check_gold_refresh_rate_limit';
+  end if;
+  if not has_function_privilege('authenticated', 'public.check_gold_refresh_rate_limit()', 'execute') then
+    raise exception 'authenticated must be able to execute check_gold_refresh_rate_limit';
+  end if;
+
+  insert into auth.users (id, email) values (gen_random_uuid(), 'gold-rl@test.invalid') returning id into v_user;
+  insert into auth.users (id, email) values (gen_random_uuid(), 'gold-rl2@test.invalid') returning id into v_other;
+
+  perform set_config('request.jwt.claims', json_build_object('sub', v_user::text)::text, true);
+  perform set_config('request.jwt.claim.sub', v_user::text, true);
+
+  -- 3) The budget is spendable up to the cap.
+  for i in 1..10 loop
+    select allowed into v_allowed from public.check_gold_refresh_rate_limit();
+    if not v_allowed then
+      raise exception 'call % of 10 should be allowed within the window', i;
+    end if;
+  end loop;
+
+  -- 4) …and the next one is refused, with a usable Retry-After.
+  select allowed, retry_after_seconds into v_allowed, v_retry from public.check_gold_refresh_rate_limit();
+  if v_allowed then
+    raise exception 'the 11th call in the window must be blocked';
+  end if;
+  if v_retry <= 0 then
+    raise exception 'a blocked call must report a positive retry_after_seconds, got %', v_retry;
+  end if;
+
+  -- 5) The counter is per user: a second account starts with a full budget even
+  --    though the first is currently blocked.
+  perform set_config('request.jwt.claims', json_build_object('sub', v_other::text)::text, true);
+  perform set_config('request.jwt.claim.sub', v_other::text, true);
+
+  select allowed into v_allowed from public.check_gold_refresh_rate_limit();
+  if not v_allowed then
+    raise exception 'a different user must not inherit the first user''s exhausted budget';
+  end if;
+
+  -- 6) An unauthenticated caller is refused rather than sharing a null-owner row.
+  perform set_config('request.jwt.claims', '', true);
+  perform set_config('request.jwt.claim.sub', '', true);
+
+  select allowed into v_allowed from public.check_gold_refresh_rate_limit();
+  if v_allowed then
+    raise exception 'an unauthenticated caller must not be allowed';
+  end if;
+
+  raise notice 'gold_refresh_rate_limit.test.sql: OK';
+end $$;
+
+rollback;


### PR DESCRIPTION
Closes #530.

## Problem

`lib/scrape-gold.ts` fetched DOJI completely unguarded:

```ts
const html = await fetch('https://giavang.doji.vn', { headers: {...} }).then((r) => r.text())
```

No timeout — a slow upstream holds a serverless function open for as long as it likes. No size cap — an oversized body is read straight into memory. No status check — a 404/500 error page goes to the price regex, which then reports `NHẪN TRÒN price row not found`, sending the reader after a layout change that didn't happen.

And `POST /api/v1/gold-price/refresh` had no per-user limit, so one account could scrape a third party's site in a loop.

## Fix

**Extract, don't copy.** The bounded fetch already existed inside `scrape-fund-nav.ts` but was module-private, so gold couldn't reuse it. It moves to `lib/boundedFetch.ts` and both scrapers import it — one implementation to keep correct instead of two.

The process-wide semaphore is exported alongside it, because the NAV scraper's Node-https path (for providers whose TLS the fetch path can't negotiate) must share the **same** gate. Two semaphores would each allow the cap and quietly double the real ceiling.

**The status check is new.** The NAV version never had one, so this changes NAV behaviour too: a non-2xx now fails with the status rather than parsing an error page. Strictly more informative, and the existing NAV tests pass unchanged.

**`check_gold_refresh_rate_limit()`** mirrors the NAV limiter rather than extending it. The two protect different upstreams with very different costs — one DOJI request versus ~15 provider requests per fund — so they keep separate counters and separate policies, and retuning one doesn't drag the other. That's why gold is 10/60s against NAV's 5/60s. Same shape deliberately, so there's one pattern to understand.

The route checks it **before** scraping (a refused call must cost DOJI nothing), returns 429 with `Retry-After`, and fails closed with a retryable 503 when the limit can't be verified.

## Tests

| Layer | Covers |
|---|---|
| `boundedFetch.test.ts` (10) | timeout signal + abort surfacing, byte cap incl. exactly-at-cap, streaming cancellation, non-2xx before reading, header passthrough |
| `scrape-gold.test.ts` (10) | goes through the helper, never calls global `fetch`, propagates timeout/oversize/non-2xx instead of swallowing |
| `gold_refresh_rate_limit.test.sql` | policy hardcoded (no parameterized overload), per-user counters, anon denied / authenticated granted, positive `retry_after_seconds` |
| route tests | 429 + `Retry-After`, 503 fail-closed, and that a refused call never reaches the scraper |

Two test bugs of my own worth noting, since both would have made a test pass for the wrong reason:

- asserting "didn't read the body" by instrumenting the stream's `start`/`pull` was wrong — both run eagerly at construction. Switched to `res.bodyUsed`, which only flips when something actually consumes the body.
- I asserted `'8.500'` parses as 8,500. It doesn't: `parseVietnameseNumber` deliberately reads a dot as a decimal point without comma context, which `parseVietnameseNumber.test.ts` already documents. My assumption was wrong, not the code — replaced with a realistic comma-grouped case and a comment pointing at the documented ambiguity.

## Checks

| Check | Result |
|---|---|
| `npm run test:db` | **10/10 OK** |
| `vitest run` | 143 files, **1494 passed** (was 141/1468) |
| `tsc --noEmit` | clean |
| `eslint` | 28 warnings, 0 errors — **unchanged baseline** (#537) |
| Full E2E | **239 passed, 1 failed** — the known `assign-goal-desktop` flake, passes isolated (13/13 with `settings` + `funds`) |

## ⚠️ Contains a migration

`Apply DB migrations (production)` runs on merge: a new `gold_refresh_rate_limit` table (RLS on, no policies, grants revoked) plus the function and its grants. No change to existing tables or data.

## Found while here — #552

While tracing who actually calls the gold refresh, I found that **Settings → "Sync now" has never worked**: it calls `/api/cron/refresh-navs` and `/api/cron/refresh-gold` from the browser, which gate on `CRON_SECRET` in an `Authorization` header a browser fetch doesn't send. Both return 401, so the button shows "Sync failed" on every click. Filed as #552 with the verification.

Relevant here because the correct fix for that button is to point it at the user-scoped v1 endpoints — and this PR is what makes the gold one safe to expose to a button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)