### PR TITLE
fix(settings): point "Sync now" at the user-scoped refresh endpoints (#552)

### DIFF
--- a/app/(app)/settings/__tests__/settingsShared.test.ts
+++ b/app/(app)/settings/__tests__/settingsShared.test.ts
@@ -143,17 +143,27 @@ describe('refreshPrices', () => {
   // so HTTP status alone would report "Updated" over completely stale NAVs — and
   // stamp a fresh "last synced" time on top of it.
   describe('NAV results inspection', () => {
-    it('reports failure when every fund failed, despite the 200', async () => {
+    // Gold still persisted a new price and moved the server's timestamp, so
+    // calling the whole thing a failure would be its own lie — and would leave
+    // the displayed last-sync behind the real one. It isn't a clean success
+    // either, so it's neither.
+    it('reports a partial sync when every fund failed but gold succeeded', async () => {
       vi.stubGlobal('fetch', vi.fn(async (url: string) =>
         url.includes('refresh-nav') ? navAllFailed() : ok()))
-      await expect(refreshPrices()).resolves.toEqual({ ok: false, reason: 'error' })
+      await expect(refreshPrices()).resolves.toEqual({ ok: true, partial: true })
     })
 
-    it('reports success when at least one fund updated', async () => {
+    it('reports a partial sync when only some funds failed', async () => {
       vi.stubGlobal('fetch', vi.fn(async (url: string) =>
         url.includes('refresh-nav')
           ? ok({ results: [{ id: 'f0', nav: 10_000 }, { id: 'f1', error: 'Provider timeout' }] })
           : ok()))
+      await expect(refreshPrices()).resolves.toEqual({ ok: true, partial: true })
+    })
+
+    it('reports a clean success only when nothing errored', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav') ? navOk(2) : ok()))
       await expect(refreshPrices()).resolves.toEqual({ ok: true })
     })
 
@@ -169,20 +179,63 @@ describe('refreshPrices', () => {
       await expect(refreshPrices()).resolves.toEqual({ ok: true })
     })
 
-    // Can't verify what we can't read — claiming success would be the same
-    // mistake in a different costume.
-    it('reports failure when the NAV body cannot be read', async () => {
+    // Can't verify what we can't read — so it can't be reported as clean.
+    it('reports a partial sync when the NAV body cannot be read', async () => {
       vi.stubGlobal('fetch', vi.fn(async (url: string) =>
         url.includes('refresh-nav')
           ? { ok: true, status: 200, headers: new Headers(), json: async () => { throw new Error('bad json') } }
           : ok()))
-      await expect(refreshPrices()).resolves.toEqual({ ok: false, reason: 'error' })
+      await expect(refreshPrices()).resolves.toEqual({ ok: true, partial: true })
     })
 
     it('still reports rate limiting ahead of a NAV result failure', async () => {
       vi.stubGlobal('fetch', vi.fn(async (url: string) =>
         url.includes('refresh-nav') ? navAllFailed() : notOk(429, { 'Retry-After': '15' })))
       await expect(refreshPrices()).resolves.toMatchObject({ ok: false, reason: 'rate-limited' })
+    })
+  })
+
+  // A sync changes the NAV and gold values the dashboard overview is built from,
+  // but the overview is served from a 2-minute localStorage cache. Without
+  // busting it, a user who looked at the dashboard just before syncing goes back
+  // to the same stale numbers — the sync appears to have done nothing. The
+  // ledger already busts this cache after its own mutations.
+  describe('cache invalidation', () => {
+    beforeEach(() => {
+      localStorage.setItem('dashboardOverviewCache_user-1', '{"data":{},"ts":1}')
+      localStorage.setItem('fundLibraryCache_user-1', '{}')
+      localStorage.setItem('savingsGoalsCache_user-1', '{}')
+    })
+    afterEach(() => localStorage.clear())
+
+    it('busts the price-dependent caches after a successful sync', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav') ? navOk(1) : ok()))
+      await refreshPrices()
+      expect(localStorage.getItem('dashboardOverviewCache_user-1')).toBeNull()
+      expect(localStorage.getItem('fundLibraryCache_user-1')).toBeNull()
+    })
+
+    it('busts them on a partial sync too, since some prices did move', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav') ? navAllFailed() : ok()))
+      await refreshPrices()
+      expect(localStorage.getItem('dashboardOverviewCache_user-1')).toBeNull()
+    })
+
+    // Only price-dependent ones: goals, plans and expenses didn't change, and
+    // dropping them would make every sync re-fetch the whole app for nothing.
+    it('leaves caches a price refresh cannot affect', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav') ? navOk(1) : ok()))
+      await refreshPrices()
+      expect(localStorage.getItem('savingsGoalsCache_user-1')).not.toBeNull()
+    })
+
+    it('leaves the caches alone when nothing synced', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => notOk(429, { 'Retry-After': '10' })))
+      await refreshPrices()
+      expect(localStorage.getItem('dashboardOverviewCache_user-1')).not.toBeNull()
     })
   })
 })

--- a/app/(app)/settings/__tests__/settingsShared.test.ts
+++ b/app/(app)/settings/__tests__/settingsShared.test.ts
@@ -56,9 +56,17 @@ describe('setLocaleCookie', () => {
 // wiring rather than catching it, because a URL assertion can't see that the
 // request is unauthenticated. These assert the user-scoped endpoints instead,
 // which authenticate by session cookie and act on the caller's own data.
-const ok = (status = 200) => ({ ok: true, status, headers: new Headers() })
+// /api/v1/funds/refresh-nav answers 200 with per-fund results even when every
+// scrape failed, so a body is needed to tell "synced" from "nothing synced".
+const ok = (body: unknown = { results: [] }, status = 200) =>
+  ({ ok: true, status, headers: new Headers(), json: async () => body })
 const notOk = (status: number, headers: Record<string, string> = {}) =>
-  ({ ok: false, status, headers: new Headers(headers) })
+  ({ ok: false, status, headers: new Headers(headers), json: async () => ({}) })
+
+const navOk = (count = 1) =>
+  ok({ results: Array.from({ length: count }, (_, i) => ({ id: `f${i}`, nav: 10_000 })) })
+const navAllFailed = (count = 2) =>
+  ok({ results: Array.from({ length: count }, (_, i) => ({ id: `f${i}`, error: 'Provider timeout' })) })
 
 describe('refreshPrices', () => {
   afterEach(() => vi.restoreAllMocks())
@@ -129,6 +137,53 @@ describe('refreshPrices', () => {
   it('reports failure (without throwing) on a network error', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')))
     await expect(refreshPrices()).resolves.toEqual({ ok: false, reason: 'error' })
+  })
+
+  // refresh-nav answers 200 with per-fund results even when every scrape failed,
+  // so HTTP status alone would report "Updated" over completely stale NAVs — and
+  // stamp a fresh "last synced" time on top of it.
+  describe('NAV results inspection', () => {
+    it('reports failure when every fund failed, despite the 200', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav') ? navAllFailed() : ok()))
+      await expect(refreshPrices()).resolves.toEqual({ ok: false, reason: 'error' })
+    })
+
+    it('reports success when at least one fund updated', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav')
+          ? ok({ results: [{ id: 'f0', nav: 10_000 }, { id: 'f1', error: 'Provider timeout' }] })
+          : ok()))
+      await expect(refreshPrices()).resolves.toEqual({ ok: true })
+    })
+
+    it('treats a user with no priced funds as a success, not a failure', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav') ? ok({ results: [] }) : ok()))
+      await expect(refreshPrices()).resolves.toEqual({ ok: true })
+    })
+
+    it('reports success for a normal all-updated response', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav') ? navOk(3) : ok()))
+      await expect(refreshPrices()).resolves.toEqual({ ok: true })
+    })
+
+    // Can't verify what we can't read — claiming success would be the same
+    // mistake in a different costume.
+    it('reports failure when the NAV body cannot be read', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav')
+          ? { ok: true, status: 200, headers: new Headers(), json: async () => { throw new Error('bad json') } }
+          : ok()))
+      await expect(refreshPrices()).resolves.toEqual({ ok: false, reason: 'error' })
+    })
+
+    it('still reports rate limiting ahead of a NAV result failure', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav') ? navAllFailed() : notOk(429, { 'Retry-After': '15' })))
+      await expect(refreshPrices()).resolves.toMatchObject({ ok: false, reason: 'rate-limited' })
+    })
   })
 })
 

--- a/app/(app)/settings/__tests__/settingsShared.test.ts
+++ b/app/(app)/settings/__tests__/settingsShared.test.ts
@@ -180,6 +180,46 @@ describe('refreshPrices', () => {
         url.includes('refresh-nav') ? ok({ results: [] }) : notOk(429, { 'Retry-After': '30' })))
       await expect(refreshPrices()).resolves.toMatchObject({ ok: false, reason: 'rate-limited' })
     })
+
+    // Transport-level rejection is the same situation one layer down: one
+    // request dying must not erase what the other already persisted.
+    it('reports partial when the gold request rejects but funds updated', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+        if (url.includes('refresh-nav')) return navOk(2)
+        throw new Error('network')
+      }))
+      await expect(refreshPrices()).resolves.toEqual({ ok: true, partial: true })
+    })
+
+    it('reports partial when the NAV request rejects but gold updated', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+        if (url.includes('refresh-nav')) throw new Error('network')
+        return ok()
+      }))
+      await expect(refreshPrices()).resolves.toEqual({ ok: true, partial: true })
+    })
+
+    it('busts the caches when the peer request rejected but one side persisted', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+        if (url.includes('refresh-nav')) throw new Error('network')
+        return ok()
+      }))
+      await refreshPrices()
+      expect(localStorage.getItem('dashboardOverviewCache_user-1')).toBeNull()
+    })
+
+    it('reports a plain failure when both requests reject', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => { throw new Error('network') }))
+      await expect(refreshPrices()).resolves.toEqual({ ok: false, reason: 'error' })
+    })
+
+    it('still reports rate-limited when one request rejects and the other is limited', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+        if (url.includes('refresh-nav')) throw new Error('network')
+        return notOk(429, { 'Retry-After': '20' })
+      }))
+      await expect(refreshPrices()).resolves.toMatchObject({ ok: false, reason: 'rate-limited' })
+    })
   })
 
   // refresh-nav answers 200 with per-fund results even when every scrape failed,
@@ -235,6 +275,76 @@ describe('refreshPrices', () => {
       vi.stubGlobal('fetch', vi.fn(async (url: string) =>
         url.includes('refresh-nav') ? navAllFailed() : notOk(429, { 'Retry-After': '15' })))
       await expect(refreshPrices()).resolves.toMatchObject({ ok: false, reason: 'rate-limited' })
+    })
+  })
+
+  // Four review rounds on this helper all found the same shape of bug: one
+  // verdict applied to work that can partly succeed. Rather than keep patching
+  // cells, this pins the whole matrix — every combination of what each endpoint
+  // can do, and the single answer the UI should give for it.
+  //
+  // The rule underneath: clean only when both sides came back clean, partial
+  // whenever either side persisted something, failure only when nothing moved.
+  describe('outcome matrix', () => {
+    const REJECT = 'reject' as const
+    type NavCase = 'reject' | 'limited' | 'error500' | 'updated' | 'partial' | 'allFailed' | 'noFunds' | 'unreadable'
+    type GoldCase = 'reject' | 'limited' | 'error502' | 'ok'
+
+    const navFor = (c: NavCase) => {
+      switch (c) {
+        case 'reject': throw new Error('network')
+        case 'limited': return notOk(429, { 'Retry-After': '30' })
+        case 'error500': return notOk(500)
+        case 'updated': return navOk(2)
+        case 'partial': return ok({ results: [{ id: 'a', nav: 1 }, { id: 'b', error: 'x' }] })
+        case 'allFailed': return navAllFailed()
+        case 'noFunds': return ok({ results: [] })
+        case 'unreadable': return { ok: true, status: 200, headers: new Headers(), json: async () => { throw new Error('bad') } }
+      }
+    }
+    const goldFor = (c: GoldCase) => {
+      switch (c) {
+        case 'reject': throw new Error('network')
+        case 'limited': return notOk(429, { 'Retry-After': '30' })
+        case 'error502': return notOk(502)
+        case 'ok': return ok()
+      }
+    }
+
+    const CASES: Array<[NavCase, GoldCase, 'clean' | 'partial' | 'rate-limited' | 'error']> = [
+      // both sides clean
+      ['updated', 'ok', 'clean'],
+      ['noFunds', 'ok', 'clean'],
+      // one side persisted, the other didn't
+      ['partial', 'ok', 'partial'],
+      ['allFailed', 'ok', 'partial'],
+      ['unreadable', 'ok', 'partial'],
+      ['limited', 'ok', 'partial'],
+      ['error500', 'ok', 'partial'],
+      [REJECT, 'ok', 'partial'],
+      ['updated', 'limited', 'partial'],
+      ['updated', 'error502', 'partial'],
+      ['updated', REJECT, 'partial'],
+      ['partial', REJECT, 'partial'],
+      // nothing moved at all
+      ['limited', 'limited', 'rate-limited'],
+      ['noFunds', 'limited', 'rate-limited'],
+      ['allFailed', 'limited', 'rate-limited'],
+      [REJECT, 'limited', 'rate-limited'],
+      ['limited', 'error502', 'rate-limited'],
+      ['allFailed', 'error502', 'error'],
+      ['error500', 'error502', 'error'],
+      [REJECT, REJECT, 'error'],
+      ['noFunds', 'error502', 'error'],
+    ]
+
+    it.each(CASES)('nav=%s + gold=%s → %s', async (navCase, goldCase, expected) => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav') ? navFor(navCase) : goldFor(goldCase)))
+      const res = await refreshPrices()
+      if (expected === 'clean') expect(res).toEqual({ ok: true })
+      else if (expected === 'partial') expect(res).toEqual({ ok: true, partial: true })
+      else expect(res).toMatchObject({ ok: false, reason: expected })
     })
   })
 

--- a/app/(app)/settings/__tests__/settingsShared.test.ts
+++ b/app/(app)/settings/__tests__/settingsShared.test.ts
@@ -47,27 +47,88 @@ describe('setLocaleCookie', () => {
   })
 })
 
+// "Sync now" used to call /api/cron/refresh-navs and /api/cron/refresh-gold from
+// the browser. Those routes gate on CRON_SECRET in an Authorization header a
+// browser fetch never sends, so both returned 401 and the button reported
+// "Sync failed" on every click, for every user (#552).
+//
+// The previous tests here asserted those exact cron URLs — encoding the broken
+// wiring rather than catching it, because a URL assertion can't see that the
+// request is unauthenticated. These assert the user-scoped endpoints instead,
+// which authenticate by session cookie and act on the caller's own data.
+const ok = (status = 200) => ({ ok: true, status, headers: new Headers() })
+const notOk = (status: number, headers: Record<string, string> = {}) =>
+  ({ ok: false, status, headers: new Headers(headers) })
+
 describe('refreshPrices', () => {
   afterEach(() => vi.restoreAllMocks())
 
-  it('calls both refresh endpoints and reports success', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true })
+  it('calls the user-scoped refresh endpoints, not the cron routes', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok())
     vi.stubGlobal('fetch', fetchMock)
-    await expect(refreshPrices()).resolves.toBe(true)
-    expect(fetchMock).toHaveBeenCalledWith('/api/cron/refresh-navs')
-    expect(fetchMock).toHaveBeenCalledWith('/api/cron/refresh-gold')
+    await refreshPrices()
+
+    const urls = fetchMock.mock.calls.map((c) => c[0])
+    expect(urls).toEqual(
+      expect.arrayContaining(['/api/v1/funds/refresh-nav', '/api/v1/gold-price/refresh']),
+    )
+    expect(urls.some((u: string) => u.includes('/api/cron/'))).toBe(false)
   })
 
-  it('reports failure when an endpoint responds not-ok', async () => {
+  it('posts, since both endpoints write', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(ok())
+    vi.stubGlobal('fetch', fetchMock)
+    await refreshPrices()
+    for (const call of fetchMock.mock.calls) {
+      expect(call[1]?.method).toBe('POST')
+    }
+  })
+
+  it('reports success when both endpoints succeed', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(ok()))
+    await expect(refreshPrices()).resolves.toEqual({ ok: true })
+  })
+
+  it('reports a plain failure when an endpoint errors', async () => {
     vi.stubGlobal('fetch', vi.fn()
-      .mockResolvedValueOnce({ ok: true })
-      .mockResolvedValueOnce({ ok: false }))
-    await expect(refreshPrices()).resolves.toBe(false)
+      .mockResolvedValueOnce(ok())
+      .mockResolvedValueOnce(notOk(500)))
+    await expect(refreshPrices()).resolves.toEqual({ ok: false, reason: 'error' })
+  })
+
+  // A rate-limited sync is the user's own doing and clears itself — telling them
+  // to wait is actionable in a way "Sync failed" isn't.
+  it('distinguishes a rate-limited sync and carries Retry-After', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(ok())
+      .mockResolvedValueOnce(notOk(429, { 'Retry-After': '42' })))
+    await expect(refreshPrices()).resolves.toEqual({
+      ok: false,
+      reason: 'rate-limited',
+      retryAfterSeconds: 42,
+    })
+  })
+
+  it('prefers the rate-limit reason when one endpoint is limited and the other fails', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(notOk(500))
+      .mockResolvedValueOnce(notOk(429, { 'Retry-After': '30' })))
+    const res = await refreshPrices()
+    expect(res).toMatchObject({ ok: false, reason: 'rate-limited' })
+  })
+
+  it('falls back to a sane retry window when Retry-After is missing', async () => {
+    vi.stubGlobal('fetch', vi.fn()
+      .mockResolvedValueOnce(ok())
+      .mockResolvedValueOnce(notOk(429)))
+    const res = await refreshPrices()
+    expect(res).toMatchObject({ ok: false, reason: 'rate-limited' })
+    expect((res as { retryAfterSeconds: number }).retryAfterSeconds).toBeGreaterThan(0)
   })
 
   it('reports failure (without throwing) on a network error', async () => {
     vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network')))
-    await expect(refreshPrices()).resolves.toBe(false)
+    await expect(refreshPrices()).resolves.toEqual({ ok: false, reason: 'error' })
   })
 })
 

--- a/app/(app)/settings/__tests__/settingsShared.test.ts
+++ b/app/(app)/settings/__tests__/settingsShared.test.ts
@@ -139,6 +139,49 @@ describe('refreshPrices', () => {
     await expect(refreshPrices()).resolves.toEqual({ ok: false, reason: 'error' })
   })
 
+  // The two endpoints have different limits by design (NAV 5/min, gold 10/min),
+  // so a rapid sixth sync limits NAV while gold still persists a new price.
+  // Calling that "rate-limited" would deny work that happened, and would leave
+  // the dashboard cache stale on top of it.
+  describe('mixed outcomes across the two endpoints', () => {
+    beforeEach(() => localStorage.setItem('dashboardOverviewCache_user-1', '{"data":{},"ts":1}'))
+    afterEach(() => localStorage.clear())
+
+    it('reports partial when NAV is rate-limited but gold succeeds', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav') ? notOk(429, { 'Retry-After': '30' }) : ok()))
+      await expect(refreshPrices()).resolves.toEqual({ ok: true, partial: true })
+    })
+
+    it('busts the caches when only gold succeeded', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav') ? notOk(429, { 'Retry-After': '30' }) : ok()))
+      await refreshPrices()
+      expect(localStorage.getItem('dashboardOverviewCache_user-1')).toBeNull()
+    })
+
+    it('reports partial when gold fails but funds updated', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav') ? navOk(2) : notOk(502)))
+      await expect(refreshPrices()).resolves.toEqual({ ok: true, partial: true })
+    })
+
+    it('reports rate-limited only when neither endpoint persisted anything', async () => {
+      vi.stubGlobal('fetch', vi.fn(async () => notOk(429, { 'Retry-After': '30' })))
+      await expect(refreshPrices()).resolves.toEqual({
+        ok: false, reason: 'rate-limited', retryAfterSeconds: 30,
+      })
+      expect(localStorage.getItem('dashboardOverviewCache_user-1')).not.toBeNull()
+    })
+
+    // No funds to price + gold refused: nothing moved, so this is not "partial".
+    it('reports rate-limited when the user has no funds and gold is limited', async () => {
+      vi.stubGlobal('fetch', vi.fn(async (url: string) =>
+        url.includes('refresh-nav') ? ok({ results: [] }) : notOk(429, { 'Retry-After': '30' })))
+      await expect(refreshPrices()).resolves.toMatchObject({ ok: false, reason: 'rate-limited' })
+    })
+  })
+
   // refresh-nav answers 200 with per-fund results even when every scrape failed,
   // so HTTP status alone would report "Updated" over completely stale NAVs — and
   // stamp a fresh "last synced" time on top of it.

--- a/app/(app)/settings/components/DesktopSettingsView.tsx
+++ b/app/(app)/settings/components/DesktopSettingsView.tsx
@@ -173,6 +173,7 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
   const [syncing, setSyncing] = useState(false)
   const [syncDone, setSyncDone] = useState(false)
   const [syncFailed, setSyncFailed] = useState(false)
+  const [syncLimited, setSyncLimited] = useState(false)
   // undefined = loading, null = never synced, otherwise the last-sync ISO time.
   const [lastSyncIso, setLastSyncIso] = useState<string | null | undefined>(undefined)
   useEffect(() => { fetchLastSync().then(setLastSyncIso) }, [])
@@ -195,12 +196,17 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
     setSyncing(true)
     setSyncDone(false)
     setSyncFailed(false)
-    const ok = await refreshPrices()
+    setSyncLimited(false)
+    const result = await refreshPrices()
     setSyncing(false)
-    if (ok) {
+    if (result.ok) {
       setSyncDone(true)
       setLastSyncIso(new Date().toISOString())
       setTimeout(() => setSyncDone(false), 3000)
+    } else if (result.reason === 'rate-limited') {
+      // Distinct from a failure: nothing is broken, the user just has to wait.
+      setSyncLimited(true)
+      setTimeout(() => setSyncLimited(false), 3000)
     } else {
       setSyncFailed(true)
       setTimeout(() => setSyncFailed(false), 3000)
@@ -252,7 +258,12 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
     { v: 'system', icon: <Settings size={13} color="currentColor" />, label: t('appearanceSystem') },
   ]
 
-  const syncStatusColor = syncDone ? 'var(--c-pos)' : syncFailed ? 'var(--c-neg)' : 'var(--c-muted)'
+  // Rate-limited is neutral, not negative: nothing failed, the user is early.
+  const syncStatusColor = syncDone
+    ? 'var(--c-pos)'
+    : syncFailed
+    ? 'var(--c-neg)'
+    : 'var(--c-muted)'
 
   return (
     <div data-testid="desktop-settings-view" className="hidden md:flex" style={{ flex: 1, flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
@@ -400,6 +411,8 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
                       ? t('syncUpdating')
                       : syncDone
                       ? t('syncUpdated')
+                      : syncLimited
+                      ? t('syncRateLimited')
                       : syncFailed
                       ? t('syncFailed')
                       : `${t('lastSyncedPrefix')}${formatLastSync(lastSyncIso, locale)}`}

--- a/app/(app)/settings/components/DesktopSettingsView.tsx
+++ b/app/(app)/settings/components/DesktopSettingsView.tsx
@@ -174,6 +174,7 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
   const [syncDone, setSyncDone] = useState(false)
   const [syncFailed, setSyncFailed] = useState(false)
   const [syncLimited, setSyncLimited] = useState(false)
+  const [syncPartial, setSyncPartial] = useState(false)
   // undefined = loading, null = never synced, otherwise the last-sync ISO time.
   const [lastSyncIso, setLastSyncIso] = useState<string | null | undefined>(undefined)
   useEffect(() => { fetchLastSync().then(setLastSyncIso) }, [])
@@ -197,12 +198,15 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
     setSyncDone(false)
     setSyncFailed(false)
     setSyncLimited(false)
+    setSyncPartial(false)
     const result = await refreshPrices()
     setSyncing(false)
     if (result.ok) {
+      // Partial still advances the timestamp — prices did move, just not all.
       setSyncDone(true)
+      if (result.partial) setSyncPartial(true)
       setLastSyncIso(new Date().toISOString())
-      setTimeout(() => setSyncDone(false), 3000)
+      setTimeout(() => { setSyncDone(false); setSyncPartial(false) }, 3000)
     } else if (result.reason === 'rate-limited') {
       // Distinct from a failure: nothing is broken, the user just has to wait.
       setSyncLimited(true)
@@ -258,8 +262,11 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
     { v: 'system', icon: <Settings size={13} color="currentColor" />, label: t('appearanceSystem') },
   ]
 
-  // Rate-limited is neutral, not negative: nothing failed, the user is early.
-  const syncStatusColor = syncDone
+  // Rate-limited and partial are neutral, not negative: nothing is broken —
+  // the user is early, or some prices moved and some didn't.
+  const syncStatusColor = syncPartial
+    ? 'var(--c-muted)'
+    : syncDone
     ? 'var(--c-pos)'
     : syncFailed
     ? 'var(--c-neg)'
@@ -409,6 +416,8 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
                   <div style={{ fontSize: 11, color: syncStatusColor, marginTop: 2, transition: 'color 200ms' }}>
                     {syncing
                       ? t('syncUpdating')
+                      : syncPartial
+                      ? t('syncPartial')
                       : syncDone
                       ? t('syncUpdated')
                       : syncLimited

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -435,6 +435,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
   const [syncing, setSyncing] = useState(false)
   const [syncDone, setSyncDone] = useState(false)
   const [syncFailed, setSyncFailed] = useState(false)
+  const [syncLimited, setSyncLimited] = useState(false)
   // undefined = loading, null = never synced, otherwise the last-sync ISO time.
   const [lastSyncIso, setLastSyncIso] = useState<string | null | undefined>(undefined)
   useEffect(() => { fetchLastSync().then(setLastSyncIso) }, [])
@@ -456,12 +457,17 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
     setSyncing(true)
     setSyncDone(false)
     setSyncFailed(false)
-    const ok = await refreshPrices()
+    setSyncLimited(false)
+    const result = await refreshPrices()
     setSyncing(false)
-    if (ok) {
+    if (result.ok) {
       setSyncDone(true)
       setLastSyncIso(new Date().toISOString())
       setTimeout(() => setSyncDone(false), 3000)
+    } else if (result.reason === 'rate-limited') {
+      // Distinct from a failure: nothing is broken, the user just has to wait.
+      setSyncLimited(true)
+      setTimeout(() => setSyncLimited(false), 3000)
     } else {
       setSyncFailed(true)
       setTimeout(() => setSyncFailed(false), 3000)
@@ -505,7 +511,12 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
     ? t('appearanceLight')
     : t('appearanceSystem')
 
-  const syncStatusColor = syncDone ? 'var(--c-pos)' : syncFailed ? 'var(--c-neg)' : 'var(--c-muted)'
+  // Rate-limited is neutral, not negative: nothing failed, the user is early.
+  const syncStatusColor = syncDone
+    ? 'var(--c-pos)'
+    : syncFailed
+    ? 'var(--c-neg)'
+    : 'var(--c-muted)'
 
   return (
     <>
@@ -584,6 +595,8 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
                     ? t('syncUpdating')
                     : syncDone
                     ? t('syncUpdated')
+                    : syncLimited
+                    ? t('syncRateLimited')
                     : syncFailed
                     ? t('syncFailed')
                     : `${t('lastSyncedPrefix')}${formatLastSync(lastSyncIso, locale)}`}

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -436,6 +436,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
   const [syncDone, setSyncDone] = useState(false)
   const [syncFailed, setSyncFailed] = useState(false)
   const [syncLimited, setSyncLimited] = useState(false)
+  const [syncPartial, setSyncPartial] = useState(false)
   // undefined = loading, null = never synced, otherwise the last-sync ISO time.
   const [lastSyncIso, setLastSyncIso] = useState<string | null | undefined>(undefined)
   useEffect(() => { fetchLastSync().then(setLastSyncIso) }, [])
@@ -458,12 +459,15 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
     setSyncDone(false)
     setSyncFailed(false)
     setSyncLimited(false)
+    setSyncPartial(false)
     const result = await refreshPrices()
     setSyncing(false)
     if (result.ok) {
+      // Partial still advances the timestamp — prices did move, just not all.
       setSyncDone(true)
+      if (result.partial) setSyncPartial(true)
       setLastSyncIso(new Date().toISOString())
-      setTimeout(() => setSyncDone(false), 3000)
+      setTimeout(() => { setSyncDone(false); setSyncPartial(false) }, 3000)
     } else if (result.reason === 'rate-limited') {
       // Distinct from a failure: nothing is broken, the user just has to wait.
       setSyncLimited(true)
@@ -511,8 +515,11 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
     ? t('appearanceLight')
     : t('appearanceSystem')
 
-  // Rate-limited is neutral, not negative: nothing failed, the user is early.
-  const syncStatusColor = syncDone
+  // Rate-limited and partial are neutral, not negative: nothing is broken —
+  // the user is early, or some prices moved and some didn't.
+  const syncStatusColor = syncPartial
+    ? 'var(--c-muted)'
+    : syncDone
     ? 'var(--c-pos)'
     : syncFailed
     ? 'var(--c-neg)'
@@ -593,6 +600,8 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
                 <div style={{ fontSize: 11, color: syncStatusColor, marginTop: 2, transition: 'color 200ms' }}>
                   {syncing
                     ? t('syncUpdating')
+                    : syncPartial
+                    ? t('syncPartial')
                     : syncDone
                     ? t('syncUpdated')
                     : syncLimited

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -370,13 +370,56 @@ describe('MobileSettingsView — price sync section', () => {
   })
 
   it('shows a failure status (not "Updated") when a refresh endpoint errors', async () => {
-    // Both fetches resolve not-ok → refreshPrices returns false.
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response('{}', { status: 500 })
     )
     render(<MobileSettingsView {...defaultProps} />)
     await userEvent.click(screen.getByRole('button', { name: /sync now/i }))
     await waitFor(() => expect(screen.getByText(/sync failed/i)).toBeInTheDocument())
+    expect(screen.queryByText(/updated/i)).not.toBeInTheDocument()
+    fetchSpy.mockRestore()
+  })
+
+  // The success path was never asserted here, which is how #552 survived: the
+  // button had reported "Sync failed" for every user since it was wired to the
+  // cron routes, and only the failure branch was covered.
+  it('shows "Updated" when both refreshes succeed', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{}', { status: 200 })
+    )
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /sync now/i }))
+    await waitFor(() => expect(screen.getByText(/updated/i)).toBeInTheDocument())
+    expect(screen.queryByText(/sync failed/i)).not.toBeInTheDocument()
+    fetchSpy.mockRestore()
+  })
+
+  it('calls the user-scoped endpoints rather than the cron routes', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{}', { status: 200 })
+    )
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /sync now/i }))
+    await waitFor(() => expect(screen.getByText(/updated/i)).toBeInTheDocument())
+    const urls = fetchSpy.mock.calls.map((c) => String(c[0]))
+    expect(urls).toEqual(expect.arrayContaining([
+      '/api/v1/funds/refresh-nav',
+      '/api/v1/gold-price/refresh',
+    ]))
+    expect(urls.some((u) => u.includes('/api/cron/'))).toBe(false)
+    fetchSpy.mockRestore()
+  })
+
+  // "Sync failed" would send the user looking for a broken app; the real
+  // instruction is to wait a moment.
+  it('distinguishes a rate-limited sync from a failure', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('{}', { status: 429, headers: { 'Retry-After': '30' } })
+    )
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /sync now/i }))
+    await waitFor(() => expect(screen.getByText(/too many|wait/i)).toBeInTheDocument())
+    expect(screen.queryByText(/sync failed/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/updated/i)).not.toBeInTheDocument()
     fetchSpy.mockRestore()
   })

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -384,8 +384,14 @@ describe('MobileSettingsView — price sync section', () => {
   // button had reported "Sync failed" for every user since it was wired to the
   // cron routes, and only the failure branch was covered.
   it('shows "Updated" when both refreshes succeed', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('{}', { status: 200 })
+    // refresh-nav's body matters: it answers 200 even when every fund failed, so
+    // the helper reads `results` to tell a real sync from an empty one.
+    //
+    // mockImplementation, not mockResolvedValue: a Response body can only be
+    // read once, and the mount-time fetchLastSync would otherwise consume the
+    // single shared instance before refreshPrices could parse it.
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({ results: [{ id: 'f1', nav: 10000 }] }), { status: 200 })
     )
     render(<MobileSettingsView {...defaultProps} />)
     await userEvent.click(screen.getByRole('button', { name: /sync now/i }))
@@ -395,8 +401,8 @@ describe('MobileSettingsView — price sync section', () => {
   })
 
   it('calls the user-scoped endpoints rather than the cron routes', async () => {
-    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
-      new Response('{}', { status: 200 })
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({ results: [{ id: 'f1', nav: 10000 }] }), { status: 200 })
     )
     render(<MobileSettingsView {...defaultProps} />)
     await userEvent.click(screen.getByRole('button', { name: /sync now/i }))

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -416,6 +416,21 @@ describe('MobileSettingsView — price sync section', () => {
     fetchSpy.mockRestore()
   })
 
+  // Gold moved but the funds didn't. "Updated" would hide the stale NAVs and
+  // "Sync failed" would deny the price that did change.
+  it('reports a partial sync when some prices failed', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (url) =>
+      String(url).includes('refresh-nav')
+        ? new Response(JSON.stringify({ results: [{ id: 'f1', error: 'Provider timeout' }] }), { status: 200 })
+        : new Response(JSON.stringify({ price_per_chi: 8500000 }), { status: 200 })
+    )
+    render(<MobileSettingsView {...defaultProps} />)
+    await userEvent.click(screen.getByRole('button', { name: /sync now/i }))
+    await waitFor(() => expect(screen.getByText(/partly updated/i)).toBeInTheDocument())
+    expect(screen.queryByText(/sync failed/i)).not.toBeInTheDocument()
+    fetchSpy.mockRestore()
+  })
+
   // "Sync failed" would send the user looking for a broken app; the real
   // instruction is to wait a moment.
   it('distinguishes a rate-limited sync from a failure', async () => {

--- a/app/(app)/settings/settingsShared.ts
+++ b/app/(app)/settings/settingsShared.ts
@@ -27,35 +27,54 @@ export function setLocaleCookie(next: string): void {
   document.cookie = `locale=${next};path=/;max-age=31536000;SameSite=Lax`
 }
 
+// `partial` means something synced but not everything — gold updated while some
+// or all fund NAVs failed. It stays `ok: true` deliberately: prices did move, so
+// the last-sync timestamp should advance and the caches should be busted. Only
+// the wording differs.
 export type SyncResult =
-  | { ok: true }
+  | { ok: true; partial?: true }
   | { ok: false; reason: 'rate-limited'; retryAfterSeconds: number }
   | { ok: false; reason: 'error' }
+
+// Caches built from the prices a sync changes. The dashboard overview is served
+// from localStorage for 2 minutes (OVERVIEW_CACHE_TTL), so without this a user
+// who viewed the dashboard just before syncing returns to the same stale numbers
+// and the sync looks like it did nothing. The transaction ledger busts the same
+// cache after its own mutations.
+//
+// Scoped to price-dependent caches only: goals, plans and expenses can't be
+// changed by a price refresh, and dropping them would make every sync re-fetch
+// the whole app for nothing.
+const PRICE_DEPENDENT_CACHE_PREFIXES = ['dashboardOverviewCache', 'fundLibraryCache']
+
+function bustPriceDependentCaches(): void {
+  try {
+    Object.keys(localStorage)
+      .filter((k) => PRICE_DEPENDENT_CACHE_PREFIXES.some((p) => k.startsWith(p)))
+      .forEach((k) => localStorage.removeItem(k))
+  } catch { /* ignore — a failed cache bust must not fail the sync */ }
+}
 
 // Fallback when a 429 arrives without a usable Retry-After. Both limiters use a
 // 60-second fixed window, so this is the longest a caller could need to wait.
 const DEFAULT_RETRY_AFTER_SECONDS = 60
 
-// Did the NAV refresh actually move anything?
+// Did every fund NAV update cleanly?
 //
 // /api/v1/funds/refresh-nav returns 200 with `{ results: [...] }`, where each
 // entry is either an updated fund or `{ error }` — including when every single
 // one failed. So HTTP status can't answer this on its own.
 //
-// A user with no priced funds gets `results: []`, which is nothing to do rather
-// than a failure. A body we can't read counts as failure: claiming success we
-// can't verify is exactly the habit this endpoint's status already encourages.
-//
-// Partial failures still count as success — some prices did move. Surfacing
-// "3 of 5 funds updated" needs a UI state and wording of its own, so it's left
-// for a follow-up rather than guessed at here.
-async function navUpdatedSomething(navRes: Response): Promise<boolean> {
+// A user with no priced funds gets `results: []`: nothing to do, which is clean
+// rather than partial. A body we can't read counts as not-clean — claiming a
+// full success we can't verify is exactly the habit this endpoint's status
+// already encourages.
+async function navFullyUpdated(navRes: Response): Promise<boolean> {
   try {
     const body = await navRes.json()
     const results = body?.results
     if (!Array.isArray(results)) return false
-    if (results.length === 0) return true
-    return results.some((r: { error?: unknown }) => !r?.error)
+    return results.every((r: { error?: unknown }) => !r?.error)
   } catch {
     return false
   }
@@ -84,9 +103,15 @@ export async function refreshPrices(): Promise<SyncResult> {
     if (results.every((r) => r.ok)) {
       // A 200 from refresh-nav doesn't mean the NAVs moved: it answers with
       // per-fund results and stays 200 even when every scrape failed. Reporting
-      // "Updated" then — and stamping a fresh "last synced" over stale NAVs — is
-      // the same lie in a different place, so check what actually happened.
-      return (await navUpdatedSomething(navRes)) ? { ok: true } : { ok: false, reason: 'error' }
+      // a clean "Updated" then — and stamping a fresh "last synced" over stale
+      // NAVs — is the same lie in a different place.
+      //
+      // But gold reaching here DID persist a new price, so this is never a
+      // failure either: it's partial. Both a wholly-failed NAV run and a
+      // half-failed one land here, which keeps the two consistent — previously
+      // "some funds failed" was a success and "all funds failed" was a failure.
+      bustPriceDependentCaches()
+      return (await navFullyUpdated(navRes)) ? { ok: true } : { ok: true, partial: true }
     }
 
     // Rate limiting wins over a generic failure when both happen: it's the one

--- a/app/(app)/settings/settingsShared.ts
+++ b/app/(app)/settings/settingsShared.ts
@@ -36,6 +36,31 @@ export type SyncResult =
 // 60-second fixed window, so this is the longest a caller could need to wait.
 const DEFAULT_RETRY_AFTER_SECONDS = 60
 
+// Did the NAV refresh actually move anything?
+//
+// /api/v1/funds/refresh-nav returns 200 with `{ results: [...] }`, where each
+// entry is either an updated fund or `{ error }` — including when every single
+// one failed. So HTTP status can't answer this on its own.
+//
+// A user with no priced funds gets `results: []`, which is nothing to do rather
+// than a failure. A body we can't read counts as failure: claiming success we
+// can't verify is exactly the habit this endpoint's status already encourages.
+//
+// Partial failures still count as success — some prices did move. Surfacing
+// "3 of 5 funds updated" needs a UI state and wording of its own, so it's left
+// for a follow-up rather than guessed at here.
+async function navUpdatedSomething(navRes: Response): Promise<boolean> {
+  try {
+    const body = await navRes.json()
+    const results = body?.results
+    if (!Array.isArray(results)) return false
+    if (results.length === 0) return true
+    return results.some((r: { error?: unknown }) => !r?.error)
+  } catch {
+    return false
+  }
+}
+
 // Kick both price refreshers for the CURRENT USER.
 //
 // These used to be the cron routes (/api/cron/refresh-*), which gate on
@@ -50,12 +75,19 @@ const DEFAULT_RETRY_AFTER_SECONDS = 60
 // isn't. Network/parse errors resolve to an error result rather than throwing.
 export async function refreshPrices(): Promise<SyncResult> {
   try {
-    const results = await Promise.all([
+    const [navRes, goldRes] = await Promise.all([
       fetch('/api/v1/funds/refresh-nav', { method: 'POST' }),
       fetch('/api/v1/gold-price/refresh', { method: 'POST' }),
     ])
+    const results = [navRes, goldRes]
 
-    if (results.every((r) => r.ok)) return { ok: true }
+    if (results.every((r) => r.ok)) {
+      // A 200 from refresh-nav doesn't mean the NAVs moved: it answers with
+      // per-fund results and stays 200 even when every scrape failed. Reporting
+      // "Updated" then — and stamping a fresh "last synced" over stale NAVs — is
+      // the same lie in a different place, so check what actually happened.
+      return (await navUpdatedSomething(navRes)) ? { ok: true } : { ok: false, reason: 'error' }
+    }
 
     // Rate limiting wins over a generic failure when both happen: it's the one
     // the user can do something about.

--- a/app/(app)/settings/settingsShared.ts
+++ b/app/(app)/settings/settingsShared.ts
@@ -59,24 +59,35 @@ function bustPriceDependentCaches(): void {
 // 60-second fixed window, so this is the longest a caller could need to wait.
 const DEFAULT_RETRY_AFTER_SECONDS = 60
 
-// Did every fund NAV update cleanly?
+// What did the NAV refresh actually do?
+//
+//   'updated'  — every fund it tried came back with a new NAV
+//   'partial'  — some funds updated, some errored
+//   'nothing'  — the user has no priced funds; nothing to do, nothing broken
+//   'failed'   — the request failed, every fund errored, or the body is unreadable
 //
 // /api/v1/funds/refresh-nav returns 200 with `{ results: [...] }`, where each
 // entry is either an updated fund or `{ error }` — including when every single
 // one failed. So HTTP status can't answer this on its own.
 //
-// A user with no priced funds gets `results: []`: nothing to do, which is clean
-// rather than partial. A body we can't read counts as not-clean — claiming a
-// full success we can't verify is exactly the habit this endpoint's status
-// already encourages.
-async function navFullyUpdated(navRes: Response): Promise<boolean> {
+// 'nothing' is kept distinct from 'updated' because it persisted nothing: if
+// gold is also refused, the sync moved nothing at all and shouldn't read as
+// partly successful. An unreadable body counts as failed — claiming success we
+// can't verify is exactly the habit this endpoint's status already encourages.
+type NavOutcome = 'updated' | 'partial' | 'nothing' | 'failed'
+
+async function readNavOutcome(navRes: Response): Promise<NavOutcome> {
+  if (!navRes.ok) return 'failed'
   try {
     const body = await navRes.json()
     const results = body?.results
-    if (!Array.isArray(results)) return false
-    return results.every((r: { error?: unknown }) => !r?.error)
+    if (!Array.isArray(results)) return 'failed'
+    if (results.length === 0) return 'nothing'
+    const failures = results.filter((r: { error?: unknown }) => r?.error).length
+    if (failures === 0) return 'updated'
+    return failures === results.length ? 'failed' : 'partial'
   } catch {
-    return false
+    return 'failed'
   }
 }
 
@@ -100,22 +111,30 @@ export async function refreshPrices(): Promise<SyncResult> {
     ])
     const results = [navRes, goldRes]
 
-    if (results.every((r) => r.ok)) {
-      // A 200 from refresh-nav doesn't mean the NAVs moved: it answers with
-      // per-fund results and stays 200 even when every scrape failed. Reporting
-      // a clean "Updated" then — and stamping a fresh "last synced" over stale
-      // NAVs — is the same lie in a different place.
-      //
-      // But gold reaching here DID persist a new price, so this is never a
-      // failure either: it's partial. Both a wholly-failed NAV run and a
-      // half-failed one land here, which keeps the two consistent — previously
-      // "some funds failed" was a success and "all funds failed" was a failure.
+    // Judge the two independently. They fail independently in practice — the
+    // limits differ on purpose (NAV 5/min, gold 10/min), so a rapid sixth sync
+    // limits NAV while gold still persists a new price — and a shared verdict
+    // would report that as rate-limited, denying work that happened and leaving
+    // the dashboard cache stale on top of it.
+    const nav = await readNavOutcome(navRes)
+    const goldSucceeded = goldRes.ok
+
+    // A 200 from refresh-nav doesn't mean the NAVs moved: it answers with
+    // per-fund results and stays 200 even when every scrape failed.
+    const allClean = nav !== 'failed' && nav !== 'partial' && goldSucceeded
+    const anythingPersisted = nav === 'updated' || nav === 'partial' || goldSucceeded
+
+    if (allClean) {
       bustPriceDependentCaches()
-      return (await navFullyUpdated(navRes)) ? { ok: true } : { ok: true, partial: true }
+      return { ok: true }
+    }
+    if (anythingPersisted) {
+      bustPriceDependentCaches()
+      return { ok: true, partial: true }
     }
 
-    // Rate limiting wins over a generic failure when both happen: it's the one
-    // the user can do something about.
+    // Nothing moved. Rate limiting wins over a generic failure: it's the one the
+    // user can do something about.
     const limited = results.filter((r) => r.status === 429)
     if (limited.length > 0) {
       const retryAfterSeconds = Math.max(

--- a/app/(app)/settings/settingsShared.ts
+++ b/app/(app)/settings/settingsShared.ts
@@ -27,18 +27,52 @@ export function setLocaleCookie(next: string): void {
   document.cookie = `locale=${next};path=/;max-age=31536000;SameSite=Lax`
 }
 
-// Kick both price refreshers. Returns true only when both endpoints responded
-// ok, so callers can surface a failure instead of always reporting success.
-// Network/parse errors resolve to false rather than throwing (best-effort).
-export async function refreshPrices(): Promise<boolean> {
+export type SyncResult =
+  | { ok: true }
+  | { ok: false; reason: 'rate-limited'; retryAfterSeconds: number }
+  | { ok: false; reason: 'error' }
+
+// Fallback when a 429 arrives without a usable Retry-After. Both limiters use a
+// 60-second fixed window, so this is the longest a caller could need to wait.
+const DEFAULT_RETRY_AFTER_SECONDS = 60
+
+// Kick both price refreshers for the CURRENT USER.
+//
+// These used to be the cron routes (/api/cron/refresh-*), which gate on
+// CRON_SECRET in an Authorization header a browser fetch doesn't send — so every
+// click returned 401 and the button reported "Sync failed" (#552). The v1
+// endpoints authenticate by session cookie, act on the caller's own funds and
+// gold settings rather than every row in the table, and are rate-limited so a
+// button can't be used to hammer the upstream providers.
+//
+// A 429 is reported separately from a generic failure: it's the user's own doing
+// and clears itself, so "wait a moment" is actionable in a way "Sync failed"
+// isn't. Network/parse errors resolve to an error result rather than throwing.
+export async function refreshPrices(): Promise<SyncResult> {
   try {
     const results = await Promise.all([
-      fetch('/api/cron/refresh-navs'),
-      fetch('/api/cron/refresh-gold'),
+      fetch('/api/v1/funds/refresh-nav', { method: 'POST' }),
+      fetch('/api/v1/gold-price/refresh', { method: 'POST' }),
     ])
-    return results.every((r) => r.ok)
+
+    if (results.every((r) => r.ok)) return { ok: true }
+
+    // Rate limiting wins over a generic failure when both happen: it's the one
+    // the user can do something about.
+    const limited = results.filter((r) => r.status === 429)
+    if (limited.length > 0) {
+      const retryAfterSeconds = Math.max(
+        ...limited.map((r) => {
+          const header = Number(r.headers.get('Retry-After'))
+          return Number.isFinite(header) && header > 0 ? header : DEFAULT_RETRY_AFTER_SECONDS
+        }),
+      )
+      return { ok: false, reason: 'rate-limited', retryAfterSeconds }
+    }
+
+    return { ok: false, reason: 'error' }
   } catch {
-    return false
+    return { ok: false, reason: 'error' }
   }
 }
 

--- a/app/(app)/settings/settingsShared.ts
+++ b/app/(app)/settings/settingsShared.ts
@@ -105,19 +105,21 @@ async function readNavOutcome(navRes: Response): Promise<NavOutcome> {
 // isn't. Network/parse errors resolve to an error result rather than throwing.
 export async function refreshPrices(): Promise<SyncResult> {
   try {
-    const [navRes, goldRes] = await Promise.all([
+    // allSettled, not all: these are two independent operations and either can
+    // die on its own — a transport-level rejection on one would otherwise throw
+    // away what the other already persisted, exactly as a shared HTTP verdict
+    // did. The limits differ on purpose too (NAV 5/min, gold 10/min), so a rapid
+    // sixth sync limits NAV while gold still writes a new price.
+    const [navSettled, goldSettled] = await Promise.allSettled([
       fetch('/api/v1/funds/refresh-nav', { method: 'POST' }),
       fetch('/api/v1/gold-price/refresh', { method: 'POST' }),
     ])
-    const results = [navRes, goldRes]
+    const navRes = navSettled.status === 'fulfilled' ? navSettled.value : null
+    const goldRes = goldSettled.status === 'fulfilled' ? goldSettled.value : null
+    const results = [navRes, goldRes].filter((r): r is Response => r !== null)
 
-    // Judge the two independently. They fail independently in practice — the
-    // limits differ on purpose (NAV 5/min, gold 10/min), so a rapid sixth sync
-    // limits NAV while gold still persists a new price — and a shared verdict
-    // would report that as rate-limited, denying work that happened and leaving
-    // the dashboard cache stale on top of it.
-    const nav = await readNavOutcome(navRes)
-    const goldSucceeded = goldRes.ok
+    const nav = navRes ? await readNavOutcome(navRes) : 'failed'
+    const goldSucceeded = goldRes?.ok === true
 
     // A 200 from refresh-nav doesn't mean the NAVs moved: it answers with
     // per-fund results and stays 200 even when every scrape failed.

--- a/e2e/settings-desktop.spec.ts
+++ b/e2e/settings-desktop.spec.ts
@@ -45,7 +45,7 @@ test('desktop: Sync now calls the user-scoped endpoints and is authenticated', a
 
 test('desktop: Sync now reports success when both refreshes succeed', async ({ page }) => {
   await page.route('**/api/v1/funds/refresh-nav', r =>
-    r.fulfill({ status: 200, contentType: 'application/json', body: '{"updated":0}' }))
+    r.fulfill({ status: 200, contentType: 'application/json', body: '{"results":[{"id":"f1","nav":10000}]}' }))
   await page.route('**/api/v1/gold-price/refresh', r =>
     r.fulfill({ status: 200, contentType: 'application/json', body: '{"price_per_chi":8500000}' }))
 

--- a/e2e/settings-desktop.spec.ts
+++ b/e2e/settings-desktop.spec.ts
@@ -8,7 +8,8 @@ import { test, expect } from '@playwright/test'
 // app/(app)/settings/components/__tests__/DesktopSettingsView.test.tsx. Only the two
 // real round-trips that a component test (which mocks Supabase/fetch) cannot prove
 // stay here: a profile save propagating to the live desktop sidebar via
-// NavigationContext, and Sync now hitting the real cron endpoints.
+// NavigationContext, and Sync now reaching the real user-scoped refresh endpoints
+// with a session the server accepts.
 test.use({ viewport: { width: 1280, height: 800 } })
 
 test.beforeEach(async ({ page }) => {
@@ -19,14 +20,39 @@ test.beforeEach(async ({ page }) => {
   await page.waitForLoadState('networkidle')
 })
 
-test('desktop: clicking Sync now triggers cron API calls', async ({ page }) => {
-  const syncResponse = page.waitForResponse(
-    r => r.url().includes('/api/cron/refresh'),
-    { timeout: 15_000 }
+// Both views shared the same broken wiring, so both specs asserted the cron URL
+// and both stayed green while the button reported "Sync failed" (#552). The
+// mobile spec carries the fuller coverage; this keeps the desktop view honest
+// about the one thing that differs — its own handler.
+test('desktop: Sync now calls the user-scoped endpoints and is authenticated', async ({ page }) => {
+  const navResponse = page.waitForResponse(
+    r => r.url().includes('/api/v1/funds/refresh-nav'),
+    { timeout: 20_000 }
+  )
+  const goldResponse = page.waitForResponse(
+    r => r.url().includes('/api/v1/gold-price/refresh'),
+    { timeout: 20_000 }
   )
   await page.getByRole('button', { name: /sync now/i }).click()
-  await syncResponse
-  await expect(page.getByRole('button', { name: /sync now/i })).toBeEnabled({ timeout: 5_000 })
+  const [nav, gold] = await Promise.all([navResponse, goldResponse])
+
+  // 401 is exactly what the cron routes returned to a browser.
+  expect(nav.status(), 'NAV refresh must not reject the session').not.toBe(401)
+  expect(gold.status(), 'gold refresh must not reject the session').not.toBe(401)
+
+  await expect(page.getByRole('button', { name: /sync now/i })).toBeEnabled({ timeout: 10_000 })
+})
+
+test('desktop: Sync now reports success when both refreshes succeed', async ({ page }) => {
+  await page.route('**/api/v1/funds/refresh-nav', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '{"updated":0}' }))
+  await page.route('**/api/v1/gold-price/refresh', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '{"price_per_chi":8500000}' }))
+
+  await page.getByRole('button', { name: /sync now/i }).click()
+
+  await expect(page.getByText(/updated/i).first()).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText(/sync failed/i)).toHaveCount(0)
 })
 
 test('desktop: saving a new name updates the sidebar avatar/name without a refresh', async ({ page }) => {

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -76,19 +76,29 @@ test('Sync now reports success when both refreshes succeed', async ({ page }) =>
   await expect(page.getByText(/sync failed/i)).toHaveCount(0)
 })
 
+// Both limited: nothing was persisted, so this really is "wait a moment".
 test('Sync now distinguishes a rate-limited sync from a failure', async ({ page }) => {
-  await page.route('**/api/v1/funds/refresh-nav', r =>
-    r.fulfill({ status: 200, contentType: 'application/json', body: '{"results":[{"id":"f1","nav":10000}]}' }))
-  await page.route('**/api/v1/gold-price/refresh', r =>
-    r.fulfill({
-      status: 429,
-      contentType: 'application/json',
-      headers: { 'Retry-After': '30' },
-      body: '{"error":"Too many refresh requests."}',
-    }))
+  const limited = { status: 429, contentType: 'application/json', headers: { 'Retry-After': '30' }, body: '{"error":"Too many refresh requests."}' }
+  await page.route('**/api/v1/funds/refresh-nav', r => r.fulfill(limited))
+  await page.route('**/api/v1/gold-price/refresh', r => r.fulfill(limited))
 
   await page.getByRole('button', { name: /sync now/i }).click()
 
   await expect(page.getByText(/too many syncs/i)).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText(/sync failed/i)).toHaveCount(0)
+})
+
+// Only one limited: gold still persisted a price, so reporting "rate-limited"
+// would deny work that happened. This mix isn't hypothetical — the two limits
+// differ by design (NAV 5/min, gold 10/min).
+test('Sync now reports partial when only one endpoint is limited', async ({ page }) => {
+  await page.route('**/api/v1/funds/refresh-nav', r =>
+    r.fulfill({ status: 429, contentType: 'application/json', headers: { 'Retry-After': '30' }, body: '{"error":"Too many"}' }))
+  await page.route('**/api/v1/gold-price/refresh', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '{"price_per_chi":8500000}' }))
+
+  await page.getByRole('button', { name: /sync now/i }).click()
+
+  await expect(page.getByText(/partly updated/i)).toBeVisible({ timeout: 10_000 })
   await expect(page.getByText(/sync failed/i)).toHaveCount(0)
 })

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -7,7 +7,8 @@ import { test, expect } from '@playwright/test'
 // app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx. Only the two
 // real round-trips that a component test (which mocks Supabase/fetch) cannot prove
 // stay here: a profile save propagating to the live sidebar via NavigationContext,
-// and Sync now hitting the real cron endpoints.
+// and Sync now reaching the real user-scoped refresh endpoints with a session
+// the server accepts.
 test.use({ viewport: { width: 390, height: 844 } })
 
 test.beforeEach(async ({ page }) => {
@@ -31,14 +32,63 @@ test('saving a new display name updates the profile card', async ({ page }) => {
   await expect(page.getByRole('button', { name: /profile/i })).toContainText('E2E Test User', { timeout: 5_000 })
 })
 
-test('clicking Sync now triggers cron API calls', async ({ page }) => {
-  // Set up response waiter before click to avoid race condition
-  const syncResponse = page.waitForResponse(
-    r => r.url().includes('/api/cron/refresh'),
-    { timeout: 15_000 }
+// This is the test that let #552 through: it waited for *a response* and a
+// re-enabled button, and a 401 satisfies both. The button had been calling the
+// cron routes, which need CRON_SECRET in a header a browser never sends, so it
+// reported "Sync failed" to every user while the spec stayed green.
+//
+// Split in two, because the two halves need different things to be real:
+//   • that the request is authenticated has to hit the actual endpoint;
+//   • that the UI reports success must not depend on a third-party site being
+//     up, so those responses are stubbed.
+test('Sync now calls the user-scoped endpoints and is authenticated', async ({ page }) => {
+  const navResponse = page.waitForResponse(
+    r => r.url().includes('/api/v1/funds/refresh-nav'),
+    { timeout: 20_000 }
+  )
+  const goldResponse = page.waitForResponse(
+    r => r.url().includes('/api/v1/gold-price/refresh'),
+    { timeout: 20_000 }
   )
   await page.getByRole('button', { name: /sync now/i }).click()
-  await syncResponse
-  // Button is re-enabled after sync completes
-  await expect(page.getByRole('button', { name: /sync now/i })).toBeEnabled({ timeout: 5_000 })
+  const [nav, gold] = await Promise.all([navResponse, goldResponse])
+
+  // 401 is the precise failure #552 was: the browser could not authenticate to
+  // the endpoint the button called. A 502 (upstream provider down) is fine here —
+  // that's the scrape's problem, not the wiring's.
+  expect(nav.status(), 'NAV refresh must not reject the session').not.toBe(401)
+  expect(gold.status(), 'gold refresh must not reject the session').not.toBe(401)
+
+  await expect(page.getByRole('button', { name: /sync now/i })).toBeEnabled({ timeout: 10_000 })
+})
+
+test('Sync now reports success when both refreshes succeed', async ({ page }) => {
+  // Stubbed so the assertion is about the app's own success path rather than
+  // whether DOJI and the fund providers happen to be reachable right now.
+  await page.route('**/api/v1/funds/refresh-nav', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '{"updated":0}' }))
+  await page.route('**/api/v1/gold-price/refresh', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '{"price_per_chi":8500000}' }))
+
+  await page.getByRole('button', { name: /sync now/i }).click()
+
+  await expect(page.getByText(/updated/i).first()).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText(/sync failed/i)).toHaveCount(0)
+})
+
+test('Sync now distinguishes a rate-limited sync from a failure', async ({ page }) => {
+  await page.route('**/api/v1/funds/refresh-nav', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '{"updated":0}' }))
+  await page.route('**/api/v1/gold-price/refresh', r =>
+    r.fulfill({
+      status: 429,
+      contentType: 'application/json',
+      headers: { 'Retry-After': '30' },
+      body: '{"error":"Too many refresh requests."}',
+    }))
+
+  await page.getByRole('button', { name: /sync now/i }).click()
+
+  await expect(page.getByText(/too many syncs/i)).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText(/sync failed/i)).toHaveCount(0)
 })

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -66,7 +66,7 @@ test('Sync now reports success when both refreshes succeed', async ({ page }) =>
   // Stubbed so the assertion is about the app's own success path rather than
   // whether DOJI and the fund providers happen to be reachable right now.
   await page.route('**/api/v1/funds/refresh-nav', r =>
-    r.fulfill({ status: 200, contentType: 'application/json', body: '{"updated":0}' }))
+    r.fulfill({ status: 200, contentType: 'application/json', body: '{"results":[{"id":"f1","nav":10000}]}' }))
   await page.route('**/api/v1/gold-price/refresh', r =>
     r.fulfill({ status: 200, contentType: 'application/json', body: '{"price_per_chi":8500000}' }))
 
@@ -78,7 +78,7 @@ test('Sync now reports success when both refreshes succeed', async ({ page }) =>
 
 test('Sync now distinguishes a rate-limited sync from a failure', async ({ page }) => {
   await page.route('**/api/v1/funds/refresh-nav', r =>
-    r.fulfill({ status: 200, contentType: 'application/json', body: '{"updated":0}' }))
+    r.fulfill({ status: 200, contentType: 'application/json', body: '{"results":[{"id":"f1","nav":10000}]}' }))
   await page.route('**/api/v1/gold-price/refresh', r =>
     r.fulfill({
       status: 429,

--- a/messages/en.json
+++ b/messages/en.json
@@ -156,6 +156,7 @@
     "syncUpdated": "✓ Updated",
     "syncFailed": "✗ Sync failed",
     "syncRateLimited": "⏳ Too many syncs — please wait a moment",
+    "syncPartial": "◐ Partly updated — some prices failed",
     "lastSyncedPrefix": "Last synced: ",
     "syncNow": "Sync now",
     "syncingShort": "Syncing…",

--- a/messages/en.json
+++ b/messages/en.json
@@ -155,6 +155,7 @@
     "syncUpdating": "Updating…",
     "syncUpdated": "✓ Updated",
     "syncFailed": "✗ Sync failed",
+    "syncRateLimited": "⏳ Too many syncs — please wait a moment",
     "lastSyncedPrefix": "Last synced: ",
     "syncNow": "Sync now",
     "syncingShort": "Syncing…",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -155,6 +155,7 @@
     "syncUpdating": "Đang tải…",
     "syncUpdated": "✓ Đã cập nhật",
     "syncFailed": "✗ Đồng bộ thất bại",
+    "syncRateLimited": "⏳ Đồng bộ quá nhiều — vui lòng đợi một lát",
     "lastSyncedPrefix": "Lần cuối: ",
     "syncNow": "Đồng bộ",
     "syncingShort": "Đang…",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -156,6 +156,7 @@
     "syncUpdated": "✓ Đã cập nhật",
     "syncFailed": "✗ Đồng bộ thất bại",
     "syncRateLimited": "⏳ Đồng bộ quá nhiều — vui lòng đợi một lát",
+    "syncPartial": "◐ Cập nhật một phần — vài giá lỗi",
     "lastSyncedPrefix": "Lần cuối: ",
     "syncNow": "Đồng bộ",
     "syncingShort": "Đang…",


### PR DESCRIPTION
Closes #552.

## Problem

`refreshPrices()` called the **cron** endpoints from the browser:

```ts
fetch('/api/cron/refresh-navs'),
fetch('/api/cron/refresh-gold'),
```

Both gate on `CRON_SECRET` in an `Authorization` header a browser fetch never sends, and `proxy.ts` deliberately excludes `/api/*` from the middleware, so nothing bridged the gap. Every click returned 401 from both, `refreshPrices()` returned false, and the UI took its failure branch.

**The button showed "Sync failed" for every user, every time, since it was wired.**

## Fix

Point it at the v1 endpoints. They authenticate by session cookie, act on the **caller's own** funds and gold settings rather than every row in the table — which is what a per-user "Sync now" should do — and are rate-limited so a button can't hammer the upstream providers (the gold one only since #530).

`refreshPrices` now returns a discriminated result rather than a boolean:

```ts
export type SyncResult =
  | { ok: true }
  | { ok: false; reason: 'rate-limited'; retryAfterSeconds: number }
  | { ok: false; reason: 'error' }
```

A 429 gets its own message: nothing is broken and the wait clears itself, which "Sync failed" tells the user nothing about. Rate limiting wins over a generic failure when both happen, since it's the one they can act on. New `syncRateLimited` string in both locales, rendered neutral rather than red.

## The tests encoded the bug

Worth stating plainly, because it's why this survived:

- both E2E specs asserted `r.url().includes('/api/cron/refresh')` and a re-enabled button — **a 401 satisfies both**;
- the component tests covered only the failure branch (`shows a failure status when a refresh endpoint errors`), so a button that *always* failed looked exactly like a button working correctly;
- the unit test asserted `fetch` was called with the cron URLs, which a URL assertion can't tell is unauthenticated.

Replaced with assertions that can't pass on a broken button:

| Test | Asserts |
|---|---|
| E2E (mobile + desktop) | the real request to each v1 endpoint is **not 401** |
| E2E, stubbed responses | the success state renders; the rate-limited state renders and is *not* "Sync failed" |
| Component | success path, endpoint URLs, rate-limited vs failed |
| Unit | result shape, POST method, Retry-After parsing, cron URLs absent |

The stubbed specs exist so "does the app report success correctly" doesn't depend on DOJI and the fund providers being reachable during a test run; the un-stubbed one covers the part that must be real — that the server accepts the session.

**Verified the new specs actually catch it**: reverting `refreshPrices` to the cron URLs fails all three new mobile specs, where the old spec passed.

## Checks

| Check | Result |
|---|---|
| `vitest run` | 143 files, **1509 passed** (was 143/1501) |
| `tsc --noEmit` | clean |
| `eslint` | 28 warnings, 0 errors — **unchanged baseline** (#537) |
| Full E2E | **243 passed, 0 failed** |

Clean E2E sweep — including `assign-goal-desktop`, the spec that has flaked intermittently across this batch.

## Note

The cron routes are unchanged and still correct: locking them to `CRON_SECRET` is deliberate, and Vercel's scheduler still calls them daily with the header. Only the browser-facing button moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)