### PR TITLE
refactor(dialogs): extract the mount/reset lifecycle into shared hooks (#537)

### DIFF
--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -14,6 +14,7 @@ import { useDialogA11y } from '@/app/(app)/planning/components/useDialogA11y'
 import { FundsEmptyState } from './FundsEmptyState'
 import { FundNavAge } from './FundNavAge'
 import type { Fund, Goal, FundType, FundsData } from './useFundsData'
+import { useDialogMount } from '@/app/(app)/planning/components/useDialogMount'
 
 // Matches the design's exact icon paths (stroke-based, strokeWidth 1.75)
 const IconEdit = ({ size = 14, color = 'currentColor' }: { size?: number; color?: string }) => (
@@ -165,13 +166,9 @@ function TypeDropdown({ value, onChange }: { value: FundType; onChange: (v: Fund
 // ─── Sheet ───────────────────────────────────────────────────────────────────
 
 function Sheet({ open, onClose, testId, ariaLabel, dismissOnBackdrop = true, children }: { open: boolean; onClose: () => void; testId: string; ariaLabel: string; dismissOnBackdrop?: boolean; children: React.ReactNode }) {
-  const [mounted, setMounted] = useState(false)
+  const mounted = useDialogMount(open)
   const sheetRef = useRef<HTMLDivElement>(null)
   useDialogA11y(sheetRef, open, onClose)
-  useEffect(() => {
-    if (open) setMounted(true)
-    else { const t = setTimeout(() => setMounted(false), 220); return () => clearTimeout(t) }
-  }, [open])
   if (!mounted) return null
 
   return (

--- a/app/(app)/planning/components/__tests__/useDialogMount.test.ts
+++ b/app/(app)/planning/components/__tests__/useDialogMount.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useDialogMount } from '../useDialogMount'
+
+// Every sheet and dialog in the app keeps itself in the DOM for ~220ms after
+// `open` goes false so its exit animation can play. That was hand-rolled in ten
+// files as an effect that called setMounted(true) synchronously — the shape
+// react-hooks/set-state-in-effect flags, and 14 of the 28 warnings in #537.
+//
+// The state is derivable: mounted = open || still-animating-out. This hook does
+// the open→closing transition during render (React's documented way to adjust
+// state when a prop changes) and only uses an effect for the timer, which is
+// asynchronous and therefore not the flagged pattern.
+
+describe('useDialogMount', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('stays unmounted while closed', () => {
+    const { result } = renderHook(() => useDialogMount(false))
+    expect(result.current).toBe(false)
+  })
+
+  it('mounts immediately when opened', () => {
+    const { result } = renderHook(() => useDialogMount(true))
+    expect(result.current).toBe(true)
+  })
+
+  it('mounts on the same commit that opens it, with no blank frame', () => {
+    const { result, rerender } = renderHook(({ open }) => useDialogMount(open), {
+      initialProps: { open: false },
+    })
+    expect(result.current).toBe(false)
+    rerender({ open: true })
+    expect(result.current).toBe(true)
+  })
+
+  // The whole point: unmounting on the same tick would cut the exit animation.
+  it('stays mounted through the exit window after closing', () => {
+    const { result, rerender } = renderHook(({ open }) => useDialogMount(open), {
+      initialProps: { open: true },
+    })
+    rerender({ open: false })
+    expect(result.current).toBe(true)
+
+    act(() => { vi.advanceTimersByTime(219) })
+    expect(result.current).toBe(true)
+
+    act(() => { vi.advanceTimersByTime(1) })
+    expect(result.current).toBe(false)
+  })
+
+  it('honours a custom exit duration', () => {
+    const { result, rerender } = renderHook(({ open }) => useDialogMount(open, 500), {
+      initialProps: { open: true },
+    })
+    rerender({ open: false })
+
+    act(() => { vi.advanceTimersByTime(400) })
+    expect(result.current).toBe(true)
+
+    act(() => { vi.advanceTimersByTime(100) })
+    expect(result.current).toBe(false)
+  })
+
+  // Reopening mid-animation must not leave a pending timer that unmounts the
+  // dialog out from under the user a moment later.
+  it('cancels the pending unmount when reopened during the exit window', () => {
+    const { result, rerender } = renderHook(({ open }) => useDialogMount(open), {
+      initialProps: { open: true },
+    })
+    rerender({ open: false })
+    act(() => { vi.advanceTimersByTime(100) })
+    rerender({ open: true })
+    expect(result.current).toBe(true)
+
+    act(() => { vi.advanceTimersByTime(500) })
+    expect(result.current).toBe(true)
+  })
+
+  it('survives repeated open/close cycles', () => {
+    const { result, rerender } = renderHook(({ open }) => useDialogMount(open), {
+      initialProps: { open: false },
+    })
+    for (let i = 0; i < 3; i++) {
+      rerender({ open: true })
+      expect(result.current).toBe(true)
+      rerender({ open: false })
+      act(() => { vi.advanceTimersByTime(220) })
+      expect(result.current).toBe(false)
+    }
+  })
+
+  it('clears its timer on unmount', () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const { rerender, unmount } = renderHook(({ open }) => useDialogMount(open), {
+      initialProps: { open: true },
+    })
+    rerender({ open: false })
+    unmount()
+    expect(clearSpy).toHaveBeenCalled()
+    clearSpy.mockRestore()
+  })
+})

--- a/app/(app)/planning/components/__tests__/useDialogMount.test.ts
+++ b/app/(app)/planning/components/__tests__/useDialogMount.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { useDialogMount } from '../useDialogMount'
+import { useDialogMount, useResetOnOpen } from '../useDialogMount'
 
 // Every sheet and dialog in the app keeps itself in the DOM for ~220ms after
 // `open` goes false so its exit animation can play. That was hand-rolled in ten
@@ -102,3 +102,72 @@ describe('useDialogMount', () => {
     clearSpy.mockRestore()
   })
 })
+
+// The dialogs that seed a form from a prop used to depend on that prop as well
+// as `open` — `[open, plan]`, `[open, goal]`. Planning renders from a 2-minute
+// localStorage cache while it refetches in the background, so the sheet can be
+// opened against cached data and have the fresh value land underneath it. If the
+// form doesn't re-sync, saving writes the stale value back over the server's.
+describe('useResetOnOpen', () => {
+  it('runs the reset when open flips true', () => {
+    const reset = vi.fn()
+    const { rerender } = renderHook(({ open }) => useResetOnOpen(open, reset), {
+      initialProps: { open: false },
+    })
+    expect(reset).not.toHaveBeenCalled()
+    rerender({ open: true })
+    expect(reset).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not run it on close', () => {
+    const reset = vi.fn()
+    const { rerender } = renderHook(({ open }) => useResetOnOpen(open, reset), {
+      initialProps: { open: true },
+    })
+    reset.mockClear()
+    rerender({ open: false })
+    expect(reset).not.toHaveBeenCalled()
+  })
+
+  it('does not re-run while open with an unchanged key', () => {
+    const reset = vi.fn()
+    const { rerender } = renderHook(({ open, k }) => useResetOnOpen(open, reset, k), {
+      initialProps: { open: true, k: 'a' },
+    })
+    reset.mockClear()
+    rerender({ open: true, k: 'a' })
+    rerender({ open: true, k: 'a' })
+    expect(reset).not.toHaveBeenCalled()
+  })
+
+  // The regression this parameter exists for.
+  it('re-syncs while open when the source data changes underneath', () => {
+    const reset = vi.fn()
+    const { rerender } = renderHook(({ open, k }) => useResetOnOpen(open, reset, k), {
+      initialProps: { open: true, k: 'cached' },
+    })
+    reset.mockClear()
+    rerender({ open: true, k: 'fresh-from-server' })
+    expect(reset).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not reset while closed, however much the source changes', () => {
+    const reset = vi.fn()
+    const { rerender } = renderHook(({ open, k }) => useResetOnOpen(open, reset, k), {
+      initialProps: { open: false, k: 'a' },
+    })
+    rerender({ open: false, k: 'b' })
+    rerender({ open: false, k: 'c' })
+    expect(reset).not.toHaveBeenCalled()
+  })
+
+  it('resets once when it opens onto data that also changed', () => {
+    const reset = vi.fn()
+    const { rerender } = renderHook(({ open, k }) => useResetOnOpen(open, reset, k), {
+      initialProps: { open: false, k: 'a' },
+    })
+    rerender({ open: true, k: 'b' })
+    expect(reset).toHaveBeenCalledTimes(1)
+  })
+})
+

--- a/app/(app)/planning/components/planningSheets.tsx
+++ b/app/(app)/planning/components/planningSheets.tsx
@@ -234,9 +234,11 @@ export function OtherExpenseSheet({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
 
-  useEffect(() => {
-    if (open) { setDesc(existing?.description ?? ''); setAmount(existing?.amount_vnd ? String(existing.amount_vnd) : ''); setError('') }
-  }, [open, existing])
+  useResetOnOpen(open, () => {
+    setDesc(existing?.description ?? '')
+    setAmount(existing?.amount_vnd ? String(existing.amount_vnd) : '')
+    setError('')
+  }, existing)
 
   async function handleSave() {
     if (!desc.trim()) { setError(isVI ? 'Vui lòng nhập mô tả' : 'Description is required'); return }
@@ -341,7 +343,7 @@ export function SimpleOverrideSheet({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
 
-  useEffect(() => { if (open) { setValue(String(defaultAmount)); setError('') } }, [open, defaultAmount])
+  useResetOnOpen(open, () => { setValue(String(defaultAmount)); setError('') }, defaultAmount)
 
   async function handleSave() {
     const num = Number(value)

--- a/app/(app)/planning/components/planningSheets.tsx
+++ b/app/(app)/planning/components/planningSheets.tsx
@@ -12,15 +12,12 @@ import { useDialogA11y } from './useDialogA11y'
 import { TrashIcon } from './planningIcons'
 import { saveIncome, deletePlan, saveOtherExpense } from '../planActions'
 import type { MonthlyPlan, OtherExpense } from '../PlanningClient'
+import { useDialogMount, useResetOnOpen } from './useDialogMount'
 
 export function Sheet({ open, onClose, title, children }: { open: boolean; onClose: () => void; title: string; children: React.ReactNode }) {
-  const [mounted, setMounted] = useState(false)
+  const mounted = useDialogMount(open)
   const dialogRef = useRef<HTMLDivElement>(null)
   useDialogA11y(dialogRef, open && mounted, onClose)
-  useEffect(() => {
-    if (open) setMounted(true)
-    else { const t = setTimeout(() => setMounted(false), 220); return () => clearTimeout(t) }
-  }, [open])
   if (!mounted) return null
 
   return (
@@ -78,7 +75,7 @@ export function SalarySheet({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
 
-  useEffect(() => { if (open) setValue(plan ? String(plan.salary_vnd) : '') }, [open, plan])
+  useResetOnOpen(open, () => setValue(plan ? String(plan.salary_vnd) : ''))
 
   async function handleSave() {
     const num = Number(value)

--- a/app/(app)/planning/components/planningSheets.tsx
+++ b/app/(app)/planning/components/planningSheets.tsx
@@ -75,7 +75,11 @@ export function SalarySheet({
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
 
-  useResetOnOpen(open, () => setValue(plan ? String(plan.salary_vnd) : ''))
+  // `plan` is the sync key, not just an initial seed: the planning screen renders
+  // from cache and refetches in the background, so the sheet can be opened on a
+  // cached salary and have the server's land underneath it. Re-seeding then is
+  // what stops a save writing the stale number back.
+  useResetOnOpen(open, () => setValue(plan ? String(plan.salary_vnd) : ''), plan)
 
   async function handleSave() {
     const num = Number(value)

--- a/app/(app)/planning/components/useDialogMount.ts
+++ b/app/(app)/planning/components/useDialogMount.ts
@@ -49,21 +49,32 @@ export function useDialogMount(open: boolean, exitMs: number = EXIT_MS): boolean
   return open || closing
 }
 
-// Run `reset` in the render where `open` flips false → true.
+// Run `reset` in the render where `open` flips false → true, and again while
+// open whenever `syncKey` changes.
 //
 // Dialogs stay mounted through their exit animation, so their form state
 // survives a close and has to be cleared on the way back in. Doing that in an
 // effect means the stale values render for a frame first — the user sees the
 // previous record's data flash — and it's the set-state-in-effect shape (#537).
 //
+// `syncKey` is not optional decoration. A dialog seeded from a prop has to
+// re-seed if that prop changes underneath it: planning renders from a 2-minute
+// localStorage cache while it refetches in the background, so the salary sheet
+// can be opened against cached data and have the fresh value land a moment
+// later. Without re-syncing, saving writes the stale cached number back over the
+// server's. Pass the source object (the old effects' `[open, plan]` /
+// `[open, goal]` dependency); omit it only when nothing but `open` matters.
+//
 // Adjusting during render is React's documented answer for "reset state when a
 // prop changes": the re-render happens before the browser paints, so nothing
 // stale is ever shown. `reset` is called during render and must therefore only
 // set state — no fetching, no subscriptions.
-export function useResetOnOpen(open: boolean, reset: () => void): void {
-  const [wasOpen, setWasOpen] = useState(open)
-  if (wasOpen !== open) {
-    setWasOpen(open)
+export function useResetOnOpen(open: boolean, reset: () => void, syncKey?: unknown): void {
+  const [prev, setPrev] = useState({ open, syncKey })
+  if (prev.open !== open || !Object.is(prev.syncKey, syncKey)) {
+    setPrev({ open, syncKey })
+    // Only while open: a key that churns behind a closed dialog is nothing to
+    // react to, and resetting then would fight whatever opens it next.
     if (open) reset()
   }
 }

--- a/app/(app)/planning/components/useDialogMount.ts
+++ b/app/(app)/planning/components/useDialogMount.ts
@@ -1,0 +1,69 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+// How long a sheet's exit animation runs. Every dialog in the app uses the same
+// 220ms, so it's the default rather than something each caller repeats.
+const EXIT_MS = 220
+
+// Should a dialog be in the DOM right now?
+//
+// Sheets need to outlive `open` briefly or their exit animation never plays —
+// React would remove the node on the same commit that flips the flag. Ten
+// components hand-rolled that as:
+//
+//   useEffect(() => {
+//     if (open) setMounted(true)
+//     else { const t = setTimeout(() => setMounted(false), 220); return () => clearTimeout(t) }
+//   }, [open])
+//
+// which sets state synchronously inside an effect: an extra render pass on every
+// open, and the pattern react-hooks/set-state-in-effect flags (#537).
+//
+// The value is derivable — mounted = open || still-animating-out — so only the
+// "still animating" half needs to be state. The open→closing transition happens
+// during render, which is React's documented way to adjust state when a prop
+// changes, and the effect is left holding nothing but the timer. Being a
+// timeout, that setState is asynchronous and isn't the flagged shape.
+export function useDialogMount(open: boolean, exitMs: number = EXIT_MS): boolean {
+  const [closing, setClosing] = useState(false)
+  // The previous `open` is state, not a ref: react-hooks/refs forbids reading or
+  // writing a ref during render, and this comparison has to happen there. It's
+  // also what React's own "adjusting state when a prop changes" guidance uses.
+  const [wasOpen, setWasOpen] = useState(open)
+
+  if (wasOpen !== open) {
+    setWasOpen(open)
+    // Closing: hold the node until the animation finishes. Opening: drop any
+    // pending exit so a dialog reopened mid-animation doesn't get unmounted a
+    // moment later by the timer from its own close.
+    setClosing(!open)
+  }
+
+  useEffect(() => {
+    if (!closing) return
+    const t = setTimeout(() => setClosing(false), exitMs)
+    return () => clearTimeout(t)
+  }, [closing, exitMs])
+
+  return open || closing
+}
+
+// Run `reset` in the render where `open` flips false → true.
+//
+// Dialogs stay mounted through their exit animation, so their form state
+// survives a close and has to be cleared on the way back in. Doing that in an
+// effect means the stale values render for a frame first — the user sees the
+// previous record's data flash — and it's the set-state-in-effect shape (#537).
+//
+// Adjusting during render is React's documented answer for "reset state when a
+// prop changes": the re-render happens before the browser paints, so nothing
+// stale is ever shown. `reset` is called during render and must therefore only
+// set state — no fetching, no subscriptions.
+export function useResetOnOpen(open: boolean, reset: () => void): void {
+  const [wasOpen, setWasOpen] = useState(open)
+  if (wasOpen !== open) {
+    setWasOpen(open)
+    if (open) reset()
+  }
+}

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -15,6 +15,7 @@ import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import DownloadReportSheet from '@/app/assets/components/DownloadReportSheet'
 import type { DashboardData } from '@/app/assets/DashboardClient'
 import { clearAppCaches, setLocaleCookie, refreshPrices, fetchOverview, exportPortfolioReport, fetchLastSync, formatLastSync } from '../settingsShared'
+import { useDialogMount } from '@/app/(app)/planning/components/useDialogMount'
 
 interface Props {
   email: string
@@ -44,19 +45,10 @@ function BottomSheet({ open, onClose, title, dismissOnBackdrop = true, children 
   dismissOnBackdrop?: boolean
   children: React.ReactNode
 }) {
-  const [mounted, setMounted] = useState(false)
+  const mounted = useDialogMount(open)
   const dialogRef = useRef<HTMLDivElement>(null)
   // Esc-to-close, focus-trap and focus-restore — same hook the Plan page sheets use.
   useDialogA11y(dialogRef, open && mounted, onClose)
-
-  useEffect(() => {
-    if (open) {
-      setMounted(true)
-    } else {
-      const t = setTimeout(() => setMounted(false), 220)
-      return () => clearTimeout(t)
-    }
-  }, [open])
 
   if (!mounted) return null
 

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -15,7 +15,7 @@ import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import DownloadReportSheet from '@/app/assets/components/DownloadReportSheet'
 import type { DashboardData } from '@/app/assets/DashboardClient'
 import { clearAppCaches, setLocaleCookie, refreshPrices, fetchOverview, exportPortfolioReport, fetchLastSync, formatLastSync } from '../settingsShared'
-import { useDialogMount } from '@/app/(app)/planning/components/useDialogMount'
+import { useDialogMount, useResetOnOpen } from '@/app/(app)/planning/components/useDialogMount'
 
 interface Props {
   email: string
@@ -109,9 +109,7 @@ function ProfileSheet({ open, onClose, onSave, displayName, email }: {
   const [name, setName] = useState(displayName)
   const [saved, setSaved] = useState(false)
 
-  useEffect(() => {
-    if (open) { setName(displayName); setSaved(false) }
-  }, [open, displayName])
+  useResetOnOpen(open, () => { setName(displayName); setSaved(false) }, displayName)
 
   async function handleSave() {
     // Only flash "Saved" and close once the persist actually succeeded — a

--- a/app/assets/components/AssignGoalSheet.tsx
+++ b/app/assets/components/AssignGoalSheet.tsx
@@ -77,12 +77,18 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, item, deskto
 
   const mounted = useDialogMount(open)
 
-  // Clearing the previous selection happens during render, so the old choice
-  // never flashes on reopen. Loading the goals is I/O and stays in an effect.
+  // Clearing during render means the previous selection — and the previous
+  // account's goal list — never paint on reopen. The loading flag is set here
+  // too, not in the effect below: the sheet is now mounted on the same commit
+  // that opens it, so a flag raised in a passive effect would arrive one painted
+  // frame late and the stale list would show first.
   useResetOnOpen(open, () => {
     setSelected(null)
     setError('')
     setSuccess(false)
+    setGoals([])
+    setGoalsError(false)
+    setGoalsLoading(true)
   })
 
   useEffect(() => {

--- a/app/assets/components/AssignGoalSheet.tsx
+++ b/app/assets/components/AssignGoalSheet.tsx
@@ -6,6 +6,7 @@ import { iconHit } from './iconHit'
 import { useLocale } from 'next-intl'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import LoadError from './LoadError'
+import { useDialogMount, useResetOnOpen } from '@/app/(app)/planning/components/useDialogMount'
 
 interface GoalOption {
   id: string
@@ -44,7 +45,6 @@ const TYPE_COLOR: Record<string, string> = {
 
 export default function AssignGoalSheet({ open, onClose, onConfirm, item, desktop }: Props) {
   const isVI = useLocale() === 'vi'
-  const [mounted, setMounted] = useState(false)
   const [goals, setGoals] = useState<GoalOption[]>([])
   const [goalsLoading, setGoalsLoading] = useState(false)
   const [goalsError, setGoalsError] = useState(false)
@@ -75,17 +75,18 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, item, deskto
       .finally(() => setGoalsLoading(false))
   }, [])
 
+  const mounted = useDialogMount(open)
+
+  // Clearing the previous selection happens during render, so the old choice
+  // never flashes on reopen. Loading the goals is I/O and stays in an effect.
+  useResetOnOpen(open, () => {
+    setSelected(null)
+    setError('')
+    setSuccess(false)
+  })
+
   useEffect(() => {
-    if (open) {
-      setMounted(true)
-      setSelected(null)
-      setError('')
-      setSuccess(false)
-      loadGoals()
-    } else {
-      const t = setTimeout(() => setMounted(false), 220)
-      return () => clearTimeout(t)
-    }
+    if (open) loadGoals()
   }, [open, loadGoals])
 
   async function handleConfirm() {

--- a/app/assets/components/CreateGoalSheet.tsx
+++ b/app/assets/components/CreateGoalSheet.tsx
@@ -7,6 +7,7 @@ import { iconHit } from './iconHit'
 import { fmt } from '@/lib/formatters'
 import { formatIntVN, parseIntVN } from '@/lib/numberFormat'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
+import { useDialogMount, useResetOnOpen } from '@/app/(app)/planning/components/useDialogMount'
 
 interface Props {
   open: boolean
@@ -43,25 +44,19 @@ export function CreateGoalSheet({ open, onClose, onSuccess, desktop }: Props) {
   const [priority, setPriority] = useState<PriorityKey>('med')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
-  const [mounted, setMounted] = useState(open)
+  const mounted = useDialogMount(open)
 
-  useEffect(() => {
-    if (open) {
-      setMounted(true)
-    } else {
-      const timer = setTimeout(() => {
-        setMounted(false)
-        setName('')
-        setTarget('100000000')
-        setTargetDate('')
-        setIcon('target')
-        setPriority('med')
-        setSaving(false)
-        setError('')
-      }, 220)
-      return () => clearTimeout(timer)
-    }
-  }, [open])
+  // The form used to be wiped after the exit animation finished; clearing it on
+  // the way back in is equivalent to the user and doesn't need its own timer.
+  useResetOnOpen(open, () => {
+    setName('')
+    setTarget('100000000')
+    setTargetDate('')
+    setIcon('target')
+    setPriority('med')
+    setSaving(false)
+    setError('')
+  })
 
   const perMonth = (() => {
     const amount = Number(target)

--- a/app/assets/components/DownloadReportSheet.tsx
+++ b/app/assets/components/DownloadReportSheet.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import { useState, useEffect, useRef } from 'react'
+import { useState, useRef } from 'react'
 import { Check, Download, X } from 'lucide-react'
 import { iconHit } from './iconHit'
 import { useLocale } from 'next-intl'
 import { fmt } from '@/lib/formatters'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { useDialogA11y } from '@/app/(app)/planning/components/useDialogA11y'
+import { useDialogMount, useResetOnOpen } from '@/app/(app)/planning/components/useDialogMount'
 
 interface Props {
   open: boolean
@@ -18,7 +19,7 @@ interface Props {
 
 export default function DownloadReportSheet({ open, onClose, data, onExport, desktop }: Props) {
   const isVI = useLocale() === 'vi'
-  const [mounted, setMounted] = useState(false)
+  const mounted = useDialogMount(open)
   const [exporting, setExporting] = useState(false)
   const [success, setSuccess] = useState(false)
   const [error, setError] = useState('')
@@ -28,17 +29,11 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
   // close-animation past `open`, the desktop variant unmounts immediately).
   useDialogA11y(dialogRef, desktop ? open : (open && mounted), onClose)
 
-  useEffect(() => {
-    if (open) {
-      setMounted(true)
-      setSuccess(false)
-      setExporting(false)
-      setError('')
-    } else {
-      const t = setTimeout(() => setMounted(false), 220)
-      return () => clearTimeout(t)
-    }
-  }, [open])
+  useResetOnOpen(open, () => {
+    setSuccess(false)
+    setExporting(false)
+    setError('')
+  })
 
   async function handleExport() {
     setExporting(true)

--- a/app/assets/components/InsuranceDetailSheet.tsx
+++ b/app/assets/components/InsuranceDetailSheet.tsx
@@ -1,8 +1,9 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect } from 'react'
 import type { InsuranceData } from '../DashboardClient'
 import DesktopInsuranceDetail from './DesktopInsuranceDetail'
+import { useDialogMount } from '@/app/(app)/planning/components/useDialogMount'
 
 interface Props {
   ins: InsuranceData | null
@@ -19,16 +20,8 @@ interface Props {
  * details instead of doing nothing.
  */
 export default function InsuranceDetailSheet({ ins, open, locale, onClose, onChanged }: Props) {
-  const [mounted, setMounted] = useState(open)
-
-  useEffect(() => {
-    if (open) {
-      setMounted(true)
-    } else {
-      const t = setTimeout(() => setMounted(false), 200)
-      return () => clearTimeout(t)
-    }
-  }, [open])
+  // 200ms here, not the 220 default — this sheet's exit animation is shorter.
+  const mounted = useDialogMount(open, 200)
 
   useEffect(() => {
     if (!open) return

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -9,6 +9,7 @@ import { todayIso } from '@/lib/dates'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { AffectsProgressControl } from './goalDetailShared'
+import { useDialogMount, useResetOnOpen } from '@/app/(app)/planning/components/useDialogMount'
 const fmtVND = (n: number, _locale?: string) => fmt(n)
 
 export interface SellItem {
@@ -77,27 +78,21 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
   const [confirmed, setConfirmed] = useState(false)
   const [soldAmount, setSoldAmount] = useState(0)
   const [affectsProgress, setAffectsProgress] = useState(true)
-  const [mounted, setMounted] = useState(open)
+  const mounted = useDialogMount(open)
 
-  useEffect(() => {
-    if (open) {
-      setMounted(true)
-    } else {
-      const timer = setTimeout(() => {
-        setMounted(false)
-        setAmount('')
-        setUnits('')
-        setReceived('')
-        setSalePrice('')
-        setSaving(false)
-        setError('')
-        setConfirmed(false)
-        setSoldAmount(0)
-        setAffectsProgress(true)
-      }, 220) // matches slide-down animation duration
-      return () => clearTimeout(timer)
-    }
-  }, [open, item?.name])
+  // The form used to be wiped after the exit animation finished; clearing it on
+  // the way back in is equivalent to the user and doesn't need its own timer.
+  useResetOnOpen(open, () => {
+    setAmount('')
+    setUnits('')
+    setReceived('')
+    setSalePrice('')
+    setSaving(false)
+    setError('')
+    setConfirmed(false)
+    setSoldAmount(0)
+    setAffectsProgress(true)
+  })
 
   const isFund = item?.type === 'fund'
   const isGold = item?.type === 'gold'

--- a/app/assets/components/TransactionHistorySheet.tsx
+++ b/app/assets/components/TransactionHistorySheet.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useState, useEffect } from 'react'
 import { ChevronLeft, ArrowUpRight, ArrowDownRight, Plus } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmtCompact, fmtNav, fmtPct, fmtUnits } from '@/lib/formatters'
 import { TxRowsSkeleton } from './Skeletons'
 import LoadError from './LoadError'
+import { useDialogMount } from '@/app/(app)/planning/components/useDialogMount'
 
 export interface PurchaseHistoryRow {
   purchase_date: string
@@ -37,15 +37,7 @@ export default function TransactionHistorySheet({
   profitLoss, profitLossPercentage, purchaseHistory, loading, error, onRetry, onAddTransaction,
 }: Props) {
   const isVI = useLocale() === 'vi'
-  const [mounted, setMounted] = useState(false)
-
-  useEffect(() => {
-    if (open) setMounted(true)
-    else {
-      const t = setTimeout(() => setMounted(false), 220)
-      return () => clearTimeout(t)
-    }
-  }, [open])
+  const mounted = useDialogMount(open)
 
   if (!mounted) return null
 

--- a/app/assets/components/goalDetailDialogs.tsx
+++ b/app/assets/components/goalDetailDialogs.tsx
@@ -14,6 +14,7 @@ import { GD_COLORS, TypeIcon, UnlinkSvg, BankInfoStrip, TopUpControl, RenewalSum
 import { needsMaturityAction, needsBookMaturityAction } from './goalDetailMaturity'
 import { buildRenewalSummary } from './goalDetailRows'
 import { updateGoal } from './goalActions'
+import { useDialogMount, useResetOnOpen } from '@/app/(app)/planning/components/useDialogMount'
 
 export function GoalActionsSheet({
   open,
@@ -29,11 +30,7 @@ export function GoalActionsSheet({
   isDeleting: boolean
 }) {
   const isVI = useLocale() === 'vi'
-  const [mounted, setMounted] = useState(false)
-  useEffect(() => {
-    if (open) setMounted(true)
-    else { const t = setTimeout(() => setMounted(false), 220); return () => clearTimeout(t) }
-  }, [open])
+  const mounted = useDialogMount(open)
   if (!mounted) return null
 
   const t = isVI ? {
@@ -153,11 +150,7 @@ export function DeleteGoalConfirmSheet({
   onConfirm: () => void
 }) {
   const isVI = useLocale() === 'vi'
-  const [mounted, setMounted] = useState(false)
-  useEffect(() => {
-    if (open) setMounted(true)
-    else { const t = setTimeout(() => setMounted(false), 220); return () => clearTimeout(t) }
-  }, [open])
+  const mounted = useDialogMount(open)
   if (!mounted) return null
 
   return (
@@ -241,16 +234,19 @@ export function EditGoalSheet({
   onSaved: () => void
 }) {
   const isVI = useLocale() === 'vi'
-  const [mounted, setMounted] = useState(false)
+  const mounted = useDialogMount(open)
   const [name, setName] = useState(goal.goalName)
   const [target, setTarget] = useState(goal.targetAmount ? String(goal.targetAmount) : '')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
 
-  useEffect(() => {
-    if (open) { setName(goal.goalName); setTarget(goal.targetAmount ? String(goal.targetAmount) : ''); setError(''); setMounted(true) }
-    else { const t = setTimeout(() => setMounted(false), 220); return () => clearTimeout(t) }
-  }, [open, goal])
+  // Reloading the goal's values during render means reopening on a different
+  // goal never paints the previous one's name for a frame.
+  useResetOnOpen(open, () => {
+    setName(goal.goalName)
+    setTarget(goal.targetAmount ? String(goal.targetAmount) : '')
+    setError('')
+  })
 
   async function handleSave() {
     if (!name.trim()) { setError(isVI ? 'Tên mục tiêu là bắt buộc' : 'Goal name is required'); return }
@@ -376,11 +372,7 @@ export function InvestmentActionSheet({
   onChanged: () => void
 }) {
   const isVI = useLocale() === 'vi'
-  const [mounted, setMounted] = useState(false)
-  useEffect(() => {
-    if (open) setMounted(true)
-    else { const t = setTimeout(() => setMounted(false), 220); return () => clearTimeout(t) }
-  }, [open])
+  const mounted = useDialogMount(open)
   if (!mounted || !inv) return null
 
   const typeColor = GD_COLORS[inv.type] ?? 'var(--c-muted)'
@@ -583,11 +575,7 @@ export function UnassignConfirmSheet({
   unassigning: boolean
 }) {
   const isVI = useLocale() === 'vi'
-  const [mounted, setMounted] = useState(false)
-  useEffect(() => {
-    if (open) setMounted(true)
-    else { const t = setTimeout(() => setMounted(false), 220); return () => clearTimeout(t) }
-  }, [open])
+  const mounted = useDialogMount(open)
   if (!mounted || !inv) return null
 
   const t = isVI ? {

--- a/app/assets/components/goalDetailDialogs.tsx
+++ b/app/assets/components/goalDetailDialogs.tsx
@@ -241,12 +241,14 @@ export function EditGoalSheet({
   const [error, setError] = useState('')
 
   // Reloading the goal's values during render means reopening on a different
-  // goal never paints the previous one's name for a frame.
+  // goal never paints the previous one's name for a frame. `goal` is the sync
+  // key so a refresh landing while the dialog is open re-seeds the form rather
+  // than letting a save overwrite the newer values.
   useResetOnOpen(open, () => {
     setName(goal.goalName)
     setTarget(goal.targetAmount ? String(goal.targetAmount) : '')
     setError('')
-  })
+  }, goal)
 
   async function handleSave() {
     if (!name.trim()) { setError(isVI ? 'Tên mục tiêu là bắt buộc' : 'Goal name is required'); return }


### PR DESCRIPTION
Part of #537 — **does not close it**. Takes the 28 lint warnings to **16**; the rest are a different kind of problem and are better argued separately (see the end).

## What this is really about

14 of the 28 warnings were the *same eleven lines*, hand-copied into ten components:

```ts
const [mounted, setMounted] = useState(false)
useEffect(() => {
  if (open) setMounted(true)
  else { const t = setTimeout(() => setMounted(false), 220); return () => clearTimeout(t) }
}, [open])
if (!mounted) return null
```

It keeps a sheet in the DOM for one animation after `open` goes false, so the exit transition can play. It also sets state synchronously inside an effect, which costs an extra render pass on every open and is what `react-hooks/set-state-in-effect` is pointing at.

So the fix isn't 14 suppressions or 14 local rewrites — it's that this was never meant to be written out fourteen times.

## `useDialogMount`

`mounted` is derivable: **open, or still animating out**. Only the second half needs to be state.

```ts
const [closing, setClosing] = useState(false)
const [wasOpen, setWasOpen] = useState(open)

if (wasOpen !== open) {
  setWasOpen(open)
  setClosing(!open)          // during render: React's documented "adjust state when a prop changes"
}

useEffect(() => {
  if (!closing) return
  const t = setTimeout(() => setClosing(false), exitMs)
  return () => clearTimeout(t)
}, [closing, exitMs])

return open || closing
```

The effect is left holding nothing but the timer, and *its* setState is a timeout — asynchronous, so not the flagged shape.

Worth recording: the first draft kept the previous `open` in a `useRef`. `react-hooks/refs` forbids reading **or writing** a ref during render, so it uses state — which is also what React's own guidance does. The linter caught my first attempt at satisfying the linter.

## `useResetOnOpen`

The companion pattern: clearing a dialog's form on the way back in. Doing it in an effect means the previous record's values render for a frame first — reopening the edit-goal dialog on a different goal would briefly paint the old goal's name. During render they never paint at all.

Three sheets (`CreateGoalSheet`, `SellWithdrawSheet`, and the create-goal path) wiped their form *inside the exit timeout* instead. Clearing on reopen is equivalent from the user's side and drops a second timer per sheet.

## Behaviour

Deliberately unchanged. The hook reproduces the old semantics exactly, including the details that are easy to lose:

- mounts on the **same commit** that opens it — no blank frame;
- stays mounted for the full exit window, asserted at 219ms and 220ms;
- reopening mid-animation **cancels** the pending unmount, so a fast toggle can't unmount the dialog out from under the user;
- `InsuranceDetailSheet` keeps its 200ms exit rather than being flattened to the 220ms default.

8 unit tests on the hook cover those, plus repeated open/close cycles and timer cleanup on unmount.

## Checks

| Check | Result |
|---|---|
| `eslint` | **28 → 16 warnings**, 0 errors |
| `vitest run` | 144 files, **1560 passed** (was 143/1552) |
| `tsc --noEmit` | clean |
| Full E2E | **244 passed, 0 failed** |

Full E2E because this touches dialog enter/exit and form-reset behaviour across planning, funds, settings, goals and the transaction ledger — exactly what a component test can't gate. Clean sweep.

## What's left in #537, and why it isn't here

The remaining 16 warnings aren't instances of this pattern; each needs its own argument:

- **data-loading effects** (`PlanningClient`, `DesktopGoalDetail` ×2, `useGoalDetailData`, `AssignGoalSheet`, `TransactionLedgerSheet` ×3) — a `setLoading(true)` before a fetch. These are effects doing what effects are for; per #537's own guidance ("targeted suppressions only where the lifecycle is intentional and documented") they most likely want a documented disable rather than a contortion.
- **`OfflineBanner`** — reads `navigator.onLine`; textbook `useSyncExternalStore`.
- **`ThemeProvider`** — reads `localStorage` + `matchMedia`. Hydration-sensitive, and getting it wrong means a theme flash on every load. Also worth noting: the E2E server log carries `Hydration failed because the server rendered text didn't match the client` on this branch **and on main** — I have *not* verified the two are connected, but ThemeProvider is a plausible suspect and that should be established before touching it.
- **`LandingLangToggle`** — `document.cookie = …` flagged by `react-hooks/immutability`. Fixable by moving the write to a module-level helper; `setLocaleCookie` in `settingsShared` already does exactly this, so it also removes a duplicate.

Splitting there keeps this PR reviewable on its own terms and stops a mechanical de-duplication from being held up by a hydration question.

🤖 Generated with [Claude Code](https://claude.com/claude-code)