### PR TITLE
fix(transactions): tell the user why a delete was refused (#550)

### DIFF
--- a/app/api/v1/investment-transactions/[id]/__tests__/route.delete.test.ts
+++ b/app/api/v1/investment-transactions/[id]/__tests__/route.delete.test.ts
@@ -142,8 +142,10 @@ describe('DELETE /api/v1/investment-transactions/[id]', () => {
 
   // The mirror image of the guard. Two columns reference this table with no
   // ON DELETE action, so deleting a deposit that either points at raises 23503 —
-  // a conflict the user can resolve, not a server fault. But the two need
-  // DIFFERENT remedies, so one catch-all message would misdirect half of them.
+  // a conflict the caller has to resolve differently in each case, so one
+  // catch-all message would misdirect half of them. The wording says what IS the
+  // case rather than prescribing an undo — there is no unmerge route or UI, so
+  // "undo the merge first" pointed at an action nobody can perform (#550).
   it('returns 409 naming the merge when a consumed settlement references the row', async () => {
     h.deleteResult = {
       data: null,
@@ -151,7 +153,12 @@ describe('DELETE /api/v1/investment-transactions/[id]', () => {
     }
     const res = await call()
     expect(res.status).toBe(409)
-    expect((await res.json()).error).toMatch(/undo the merge/i)
+    const body = await res.json()
+    expect(body.code).toBe('merge_target')
+    expect(body.error).toMatch(/merged into this deposit/i)
+    // Must not converge with the pending-settlement wording, which is a
+    // different situation with a different (and actually available) remedy.
+    expect(body.error).not.toMatch(/waiting|pending/i)
   })
 
   // merge_anchor_inv_id is stamped when a settlement is HELD — before any merge

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -248,7 +248,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
       const violation = `${error.message ?? ''} ${error.details ?? ''}`
       if (violation.includes('consumed_by_inv_id')) {
         return NextResponse.json(
-          { error: 'Another settlement has been merged into this deposit. Undo the merge before removing it.', code: 'merge_target' },
+          { error: 'Another settlement has been merged into this deposit, so it cannot be removed.', code: 'merge_target' },
           { status: 409 },
         )
       }
@@ -290,7 +290,7 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
 
   // The row is still there, so the guard is what stopped the delete.
   return NextResponse.json(
-    { error: 'This settlement has already been merged into another deposit. Undo the merge before removing it.', code: 'settlement_consumed' },
+    { error: 'This settlement is part of a completed merge, so it cannot be removed.', code: 'settlement_consumed' },
     { status: 409 },
   )
 }

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -248,23 +248,23 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
       const violation = `${error.message ?? ''} ${error.details ?? ''}`
       if (violation.includes('consumed_by_inv_id')) {
         return NextResponse.json(
-          { error: 'Another settlement has been merged into this deposit. Undo the merge before removing it.' },
+          { error: 'Another settlement has been merged into this deposit. Undo the merge before removing it.', code: 'merge_target' },
           { status: 409 },
         )
       }
       if (violation.includes('merge_anchor_inv_id')) {
         return NextResponse.json(
-          { error: 'A settlement is waiting to be merged into this deposit. Cancel that pending settlement before removing it.' },
+          { error: 'A settlement is waiting to be merged into this deposit. Cancel that pending settlement before removing it.', code: 'settlement_pending' },
           { status: 409 },
         )
       }
       return NextResponse.json(
-        { error: 'Another record still references this transaction. Remove that reference before deleting it.' },
+        { error: 'Another record still references this transaction. Remove that reference before deleting it.', code: 'referenced' },
         { status: 409 },
       )
     }
     console.error('investment-transactions delete: statement failed', error.message)
-    return NextResponse.json({ error: 'Failed to delete transaction' }, { status: 500 })
+    return NextResponse.json({ error: 'Failed to delete transaction', code: 'delete_failed' }, { status: 500 })
   }
   if (deleted && deleted.length > 0) {
     return NextResponse.json({ message: 'Transaction deleted.' })
@@ -284,13 +284,13 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
     // Don't guess: 404 would claim the settlement is gone when it may still be
     // there, and 409 would block a delete that legitimately found nothing.
     console.error('investment-transactions delete: could not classify a no-op delete', lookupErr.message)
-    return NextResponse.json({ error: 'Failed to delete transaction' }, { status: 500 })
+    return NextResponse.json({ error: 'Failed to delete transaction', code: 'delete_failed' }, { status: 500 })
   }
-  if (!surviving) return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
+  if (!surviving) return NextResponse.json({ error: 'Transaction not found', code: 'not_found' }, { status: 404 })
 
   // The row is still there, so the guard is what stopped the delete.
   return NextResponse.json(
-    { error: 'This settlement has already been merged into another deposit. Undo the merge before removing it.' },
+    { error: 'This settlement has already been merged into another deposit. Undo the merge before removing it.', code: 'settlement_consumed' },
     { status: 409 },
   )
 }

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -138,10 +138,15 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
     setUnholdingId(heldTxId)
     const result = await unholdTransaction(heldTxId)
     setUnholdingId(null)
-    // Each refusal has its own remedy — "undo the merge" vs "cancel the pending
-    // settlement" send the user to different places, so one generic message
-    // isn't enough (#550).
-    if (!result.ok) { toast.error(td(result.code)); return }
+    // Each refusal reads differently — a completed merge can't be undone, while a
+    // pending settlement can be cancelled — so one generic message isn't enough
+    // (#550). not_found is the exception: the row really is gone, so refresh
+    // rather than leave it on screen for another doomed attempt.
+    if (!result.ok) {
+      toast.error(td(result.code))
+      if (result.code === 'not_found') onDataChanged()
+      return
+    }
     onDataChanged()
   }
 

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -19,6 +19,7 @@ import { useGoalDetailData } from './useGoalDetailData'
 import { deleteGoal, unholdTransaction, unassignInvestment, updateGoal } from './goalActions'
 import { SellWithdrawSheet } from './SellWithdrawSheet'
 import { invToSellItem } from './invToSellItem'
+import { useTranslations } from 'next-intl'
 
 interface Props {
   goal: GoalData
@@ -47,6 +48,7 @@ interface Props {
 
 export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged, onRenewed, refreshKey, onAddToGoal }: Props) {
   const isVi = locale === 'vi'
+  const td = useTranslations('deleteTransaction')
   const [tab, setTab] = useState<'investments' | 'calculator' | 'history'>('investments')
   // Bumped by the retry button to re-run the transactions fetch.
   const [txReload, setTxReload] = useState(0)
@@ -134,9 +136,12 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
   const [unholdingId, setUnholdingId] = useState<string | null>(null)
   async function handleUnhold(heldTxId: string) {
     setUnholdingId(heldTxId)
-    const ok = await unholdTransaction(heldTxId)
+    const result = await unholdTransaction(heldTxId)
     setUnholdingId(null)
-    if (!ok) { toast.error(isVi ? 'Không thể bỏ chờ gộp' : "Couldn't cancel the merge hold"); return }
+    // Each refusal has its own remedy — "undo the merge" vs "cancel the pending
+    // settlement" send the user to different places, so one generic message
+    // isn't enough (#550).
+    if (!result.ok) { toast.error(td(result.code)); return }
     onDataChanged()
   }
 

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -6,7 +6,7 @@ import {
   Target, PiggyBank, Plus,
 } from 'lucide-react'
 import { iconHit } from './iconHit'
-import { useLocale } from 'next-intl'
+import { useLocale, useTranslations } from 'next-intl'
 import { toast } from 'sonner'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import { formatIntVN, parseIntVN } from '@/lib/numberFormat'
@@ -44,6 +44,7 @@ interface Props {
 
 export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, refreshKey, onAddToGoal }: Props) {
   const isVI = useLocale() === 'vi'
+  const td = useTranslations('deleteTransaction')
   const [mounted, setMounted] = useState(false)
   const [activeTab, setActiveTab] = useState<'investments' | 'calculator' | 'history'>('investments')
   // Bumped by the retry button to re-run the transactions fetch.
@@ -106,9 +107,12 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   const [unholdingId, setUnholdingId] = useState<string | null>(null)
   async function handleUnhold(heldTxId: string) {
     setUnholdingId(heldTxId)
-    const ok = await unholdTransaction(heldTxId)
+    const result = await unholdTransaction(heldTxId)
     setUnholdingId(null)
-    if (!ok) { toast.error(isVI ? 'Không thể bỏ chờ gộp' : "Couldn't cancel the merge hold"); return }
+    // Each refusal has its own remedy — "undo the merge" vs "cancel the pending
+    // settlement" send the user to different places, so one generic message
+    // isn't enough (#550).
+    if (!result.ok) { toast.error(td(result.code)); return }
     onDataChanged()
   }
 

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -109,10 +109,15 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
     setUnholdingId(heldTxId)
     const result = await unholdTransaction(heldTxId)
     setUnholdingId(null)
-    // Each refusal has its own remedy — "undo the merge" vs "cancel the pending
-    // settlement" send the user to different places, so one generic message
-    // isn't enough (#550).
-    if (!result.ok) { toast.error(td(result.code)); return }
+    // Each refusal reads differently — a completed merge can't be undone, while a
+    // pending settlement can be cancelled — so one generic message isn't enough
+    // (#550). not_found is the exception: the row really is gone, so refresh
+    // rather than leave it on screen for another doomed attempt.
+    if (!result.ok) {
+      toast.error(td(result.code))
+      if (result.code === 'not_found') onDataChanged()
+      return
+    }
     onDataChanged()
   }
 

--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -11,6 +11,8 @@ import { fmtCompact, fmtNav, fmtUnits } from '@/lib/formatters'
 import { parseExcelPaste, type ParsedRow } from '@/lib/parseExcelPaste'
 import AddTransactionSheet from './AddTransactionSheet'
 import { ASSET_TYPES, type AssetType, type LedgerTransaction, isWithdrawal, txKind, txPrimaryName, fmtTxDate } from './transactionUtils'
+import { toast } from 'sonner'
+import { deleteTransaction } from './deleteTransaction'
 
 interface Goal { goal_id: string; goal_name: string }
 interface Fund { id: string; name: string; code: string; nav: number }
@@ -134,6 +136,7 @@ interface Props {
 export default function TransactionLedgerSheet({ open, desktop, locale, onClose, onChanged }: Props) {
   const t = useTranslations('transactions')
   const tc = useTranslations('common')
+  const td = useTranslations('deleteTransaction')
 
   const [transactions, setTransactions] = useState<LedgerTransaction[]>([])
   const [goals, setGoals] = useState<Goal[]>([])
@@ -326,11 +329,17 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
 
   async function handleDelete(tx: LedgerTransaction) {
     setDeletingId(tx.transaction_id)
-    const res = await fetch(`/api/v1/investment-transactions/${tx.transaction_id}`, { method: 'DELETE' })
-    if (res.ok) {
+    const result = await deleteTransaction(tx.transaction_id)
+    if (result.ok) {
       setConfirmTx(null)
       await fetchTransactions()
       notifyChanged()
+    } else {
+      // Close the dialog and let the toast carry the explanation. Leaving it
+      // open would sit there unchanged with no indication of what happened —
+      // which is what it did before, for every refusal (#550).
+      setConfirmTx(null)
+      toast.error(td(result.code))
     }
     setDeletingId(null)
   }

--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -340,6 +340,14 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
       // which is what it did before, for every refusal (#550).
       setConfirmTx(null)
       toast.error(td(result.code))
+      // not_found isn't a refusal: the row really is gone (a stale tab, or
+      // another surface removed it). Keeping it on screen would leave the user
+      // retrying a delete against something that only exists in this render, so
+      // adopt the server's view instead.
+      if (result.code === 'not_found') {
+        await fetchTransactions()
+        notifyChanged()
+      }
     }
     setDeletingId(null)
   }

--- a/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
+++ b/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
@@ -127,3 +127,45 @@ describe('TransactionLedgerSheet — a refused delete says why', () => {
     expect(toastError).not.toHaveBeenCalled()
   })
 })
+
+// not_found isn't an ordinary refusal — the row really is gone (a stale tab, or
+// another surface deleted it). Toasting and leaving it on screen means every
+// retry hits the same 404 against a row that only exists in this render.
+describe('TransactionLedgerSheet — a not_found delete reconciles the list', () => {
+  const tx = {
+    transaction_id: 'x1', asset_type: 'bank', investment_date: '2026-06-01',
+    amount_vnd: 10_000_000, transaction_type: 'investment',
+    savings_goals: { goal_name: 'House' },
+  }
+
+  it('refetches and notifies the parent, so the stale row disappears', async () => {
+    let listCalls = 0
+    global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        return Promise.resolve({ ok: false, status: 404, json: async () => ({ error: 'gone', code: 'not_found' }) })
+      }
+      if (url.includes('savings-goals')) return Promise.resolve({ ok: true, json: async () => ({ goals: [] }) })
+      if (url.includes('/api/funds')) return Promise.resolve({ ok: true, json: async () => ({ funds: [] }) })
+      if (url.includes('investment-transactions')) {
+        listCalls++
+        // Gone on the refetch — the server's view, which the UI must adopt.
+        const list = listCalls === 1 ? [tx] : []
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: list, total: list.length }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+
+    const onChanged = vi.fn()
+    render(<TransactionLedgerSheet open desktop locale="en" onClose={() => {}} onChanged={onChanged} />)
+
+    const del = await screen.findByTestId('tx-ledger-delete')
+    del.click()
+    const confirm = await screen.findByTestId('tx-ledger-delete-confirm')
+    confirm.click()
+
+    await vi.waitFor(() => expect(onChanged).toHaveBeenCalled())
+    expect(listCalls).toBeGreaterThan(1)
+    await vi.waitFor(() => expect(screen.queryByTestId('tx-ledger-delete')).toBeNull())
+  })
+})
+

--- a/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
+++ b/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
@@ -8,6 +8,8 @@ vi.mock('next-intl', () => ({
 // Nested sheets fetch/render on their own; stub them so this test only exercises
 // the ledger rows.
 vi.mock('../AddTransactionSheet', () => ({ default: () => null }))
+const toastError = vi.fn()
+vi.mock('sonner', () => ({ toast: { error: (m: string) => toastError(m) } }))
 
 // The ledger ("Xem tất cả") shares txKind with the Recent activity card and the
 // goal-detail History tab. A held-for-merge settlement is parked cash, not a spend,
@@ -63,5 +65,65 @@ describe('TransactionLedgerSheet — held-for-merge rows read neutrally', () => 
     const edit = screen.getByRole('button', { name: 'edit' })
     expect(parseFloat(edit.style.minWidth)).toBeGreaterThanOrEqual(44)
     expect(parseFloat(edit.style.minHeight)).toBeGreaterThanOrEqual(44)
+  })
+})
+
+// A refused delete used to do nothing at all: handleDelete checked res.ok with
+// no else, so the dialog sat there and the row stayed put with no explanation
+// (#550). The message is looked up by the server's `code`, which the mocked
+// translator echoes back — so asserting on the code proves the right reason was
+// chosen, not merely that *some* toast fired.
+describe('TransactionLedgerSheet — a refused delete says why', () => {
+  const tx = {
+    transaction_id: 'x1', asset_type: 'bank', investment_date: '2026-06-01',
+    amount_vnd: 10_000_000, transaction_type: 'investment',
+    savings_goals: { goal_name: 'House' },
+  }
+
+  function mockWithDelete(deleteResponse: { ok: boolean; status?: number; body?: unknown }) {
+    global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'DELETE') {
+        return Promise.resolve({
+          ok: deleteResponse.ok,
+          status: deleteResponse.status ?? 200,
+          json: async () => deleteResponse.body ?? {},
+        })
+      }
+      if (url.includes('savings-goals')) return Promise.resolve({ ok: true, json: async () => ({ goals: [] }) })
+      if (url.includes('/api/funds')) return Promise.resolve({ ok: true, json: async () => ({ funds: [] }) })
+      if (url.includes('investment-transactions')) return Promise.resolve({ ok: true, json: async () => ({ transactions: [tx], total: 1 }) })
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+  }
+
+  beforeEach(() => { toastError.mockClear() })
+
+  it.each([
+    ['settlement_consumed'],
+    ['settlement_pending'],
+    ['merge_target'],
+  ])('surfaces the %s refusal', async (code) => {
+    mockWithDelete({ ok: false, status: 409, body: { error: 'nope', code } })
+    render(<TransactionLedgerSheet open desktop locale="en" onClose={() => {}} />)
+
+    const del = await screen.findByTestId('tx-ledger-delete')
+    del.click()
+    const confirm = await screen.findByTestId('tx-ledger-delete-confirm')
+    confirm.click()
+
+    await vi.waitFor(() => expect(toastError).toHaveBeenCalledWith(code))
+  })
+
+  it('says nothing when the delete succeeds', async () => {
+    mockWithDelete({ ok: true, body: { message: 'Transaction deleted.' } })
+    render(<TransactionLedgerSheet open desktop locale="en" onClose={() => {}} />)
+
+    const del = await screen.findByTestId('tx-ledger-delete')
+    del.click()
+    const confirm = await screen.findByTestId('tx-ledger-delete-confirm')
+    confirm.click()
+
+    await vi.waitFor(() => expect(global.fetch).toHaveBeenCalled())
+    expect(toastError).not.toHaveBeenCalled()
   })
 })

--- a/app/assets/components/__tests__/deleteTransaction.test.ts
+++ b/app/assets/components/__tests__/deleteTransaction.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { deleteTransaction } from '../deleteTransaction'
+
+// DELETE /api/v1/investment-transactions/:id refuses for several distinct,
+// user-actionable reasons — a settlement already merged, one still waiting to
+// merge, another record referencing the row. None of them reached the screen:
+// both call sites checked `res.ok` and dropped the body, so a refused delete
+// made the button do nothing at all (#550).
+//
+// The route now returns a stable `code` alongside its English message. The code
+// is what the UI translates — rendering the server's prose would put untranslated
+// text in front of a Vietnamese user.
+
+afterEach(() => vi.restoreAllMocks())
+
+const res = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+
+describe('deleteTransaction', () => {
+  it('reports success on a 200', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(res(200, { message: 'Transaction deleted.' }))
+    await expect(deleteTransaction('tx-1')).resolves.toEqual({ ok: true })
+  })
+
+  it('carries the refusal code through', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      res(409, { error: 'This settlement has already been merged…', code: 'settlement_consumed' }),
+    )
+    await expect(deleteTransaction('tx-1')).resolves.toEqual({ ok: false, code: 'settlement_consumed' })
+  })
+
+  it.each([
+    ['merge_target'],
+    ['settlement_pending'],
+    ['referenced'],
+    ['not_found'],
+    ['delete_failed'],
+  ])('passes through the %s code unchanged', async (code) => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(res(409, { error: 'x', code }))
+    await expect(deleteTransaction('tx-1')).resolves.toEqual({ ok: false, code })
+  })
+
+  // A network failure is not a refusal — the server never got to decide, so
+  // "already merged" would be a guess. It gets its own code so the UI can say
+  // "connection problem" rather than invent a reason.
+  it('distinguishes a network failure from a server refusal', async () => {
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('offline'))
+    await expect(deleteTransaction('tx-1')).resolves.toEqual({ ok: false, code: 'network' })
+  })
+
+  it('falls back to an unknown code when the body has none', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(res(500, {}))
+    await expect(deleteTransaction('tx-1')).resolves.toEqual({ ok: false, code: 'unknown' })
+  })
+
+  it('survives a body that is not JSON at all', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('<html>502 Bad Gateway</html>', { status: 502 }),
+    )
+    await expect(deleteTransaction('tx-1')).resolves.toEqual({ ok: false, code: 'unknown' })
+  })
+})

--- a/app/assets/components/__tests__/goalActions.test.ts
+++ b/app/assets/components/__tests__/goalActions.test.ts
@@ -34,9 +34,18 @@ describe('goalActions (#467)', () => {
 
   it('unholdTransaction DELETEs the held row', async () => {
     const calls = mockFetch(() => ({ ok: true }))
-    expect(await unholdTransaction('tx1')).toBe(true)
+    // Returns a result object now, not a boolean: a refused unhold has to carry
+    // *why* so the caller can say something useful (#550). Both call sites did
+    // `const ok = await unholdTransaction(...)` — with an object that is always
+    // truthy, so their error branch would silently never run.
+    expect(await unholdTransaction('tx1')).toEqual({ ok: true })
     expect(calls[0].url).toBe('/api/v1/investment-transactions/tx1')
     expect(calls[0].init?.method).toBe('DELETE')
+  })
+
+  it('unholdTransaction reports the refusal code', async () => {
+    mockFetch(() => ({ ok: false, body: { error: 'already merged', code: 'settlement_consumed' } }))
+    expect(await unholdTransaction('tx1')).toEqual({ ok: false, code: 'settlement_consumed' })
   })
 
   // GET /fund-investments returns a BARE ARRAY (matches the real route), not

--- a/app/assets/components/deleteTransaction.ts
+++ b/app/assets/components/deleteTransaction.ts
@@ -1,0 +1,52 @@
+// Every reason DELETE /api/v1/investment-transactions/:id can refuse, plus the
+// two the client decides for itself. The route returns these verbatim; the UI
+// maps them to translated strings rather than showing the server's English.
+export type DeleteFailureCode =
+  | 'settlement_consumed'   // this row is a settlement already merged elsewhere
+  | 'merge_target'          // another settlement has been merged INTO this deposit
+  | 'settlement_pending'    // a settlement is held, waiting to merge into this one
+  | 'referenced'            // some other record still points at this row
+  | 'not_found'             // already gone
+  | 'delete_failed'         // the server tried and failed
+  | 'network'               // the request never got an answer
+  | 'unknown'               // a response we don't recognise
+
+export type DeleteResult = { ok: true } | { ok: false; code: DeleteFailureCode }
+
+// Delete a transaction and report *why* if it was refused.
+//
+// Both call sites used to do `if (res.ok) { … }` with no else, so a 409 made the
+// button do nothing and say nothing — the worst rendering of "here is what to do
+// instead" (#550). Three of the refusals are user-actionable and each needs its
+// own instruction, so a boolean can't carry the answer.
+//
+// A rejected fetch is deliberately its own code: the server never got to decide,
+// so reporting a specific refusal would be inventing one.
+export async function deleteTransaction(txId: string): Promise<DeleteResult> {
+  let res: Response
+  try {
+    res = await fetch(`/api/v1/investment-transactions/${txId}`, { method: 'DELETE' })
+  } catch {
+    return { ok: false, code: 'network' }
+  }
+
+  if (res.ok) return { ok: true }
+
+  // An error body isn't guaranteed to be JSON — a gateway can answer HTML.
+  try {
+    const body = await res.json()
+    const code = body?.code
+    return { ok: false, code: isFailureCode(code) ? code : 'unknown' }
+  } catch {
+    return { ok: false, code: 'unknown' }
+  }
+}
+
+const CODES: readonly DeleteFailureCode[] = [
+  'settlement_consumed', 'merge_target', 'settlement_pending',
+  'referenced', 'not_found', 'delete_failed', 'network', 'unknown',
+]
+
+function isFailureCode(v: unknown): v is DeleteFailureCode {
+  return typeof v === 'string' && (CODES as readonly string[]).includes(v)
+}

--- a/app/assets/components/goalActions.ts
+++ b/app/assets/components/goalActions.ts
@@ -1,3 +1,4 @@
+import { deleteTransaction, type DeleteResult } from './deleteTransaction'
 // Goal-detail mutation network calls shared by GoalDetailSheet (mobile) and
 // DesktopGoalDetail (#467). These were byte-identical in both — the desktop
 // unassign even carried a "Mirror of ..." comment. Plain async functions (no
@@ -48,13 +49,13 @@ export async function deleteGoal(goalId: string): Promise<boolean> {
 }
 
 // "Bỏ chờ gộp" — delete the held settlement row, restoring the original deposit.
-export async function unholdTransaction(heldTxId: string): Promise<boolean> {
-  try {
-    const res = await fetch(`/api/v1/investment-transactions/${heldTxId}`, { method: 'DELETE' })
-    return res.ok
-  } catch {
-    return false
-  }
+//
+// Returns the same discriminated result as the ledger's delete so the caller can
+// say why it was refused. It used to return a bare `res.ok`, which threw away
+// the one thing the user needed (#550) — and a held settlement is exactly the
+// row the server refuses once a merge has consumed it.
+export async function unholdTransaction(heldTxId: string): Promise<DeleteResult> {
+  return deleteTransaction(heldTxId)
 }
 
 // Unassign an investment from a specific goal. A fund row aggregates every

--- a/messages/en.json
+++ b/messages/en.json
@@ -881,8 +881,8 @@
     "navPlan": "Monthly plan"
   },
   "deleteTransaction": {
-    "settlement_consumed": "This settlement has already been merged into another deposit. Undo the merge before removing it.",
-    "merge_target": "Another settlement has been merged into this deposit. Undo the merge before removing it.",
+    "settlement_consumed": "This settlement is part of a completed merge, so it can’t be removed.",
+    "merge_target": "Another settlement has been merged into this deposit, so it can’t be removed.",
     "settlement_pending": "A settlement is waiting to be merged into this deposit. Cancel that pending settlement first.",
     "referenced": "Another record still references this transaction. Remove that reference before deleting it.",
     "not_found": "This transaction no longer exists.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -879,5 +879,15 @@
     "navFeatures": "Features",
     "navHow": "How it works",
     "navPlan": "Monthly plan"
+  },
+  "deleteTransaction": {
+    "settlement_consumed": "This settlement has already been merged into another deposit. Undo the merge before removing it.",
+    "merge_target": "Another settlement has been merged into this deposit. Undo the merge before removing it.",
+    "settlement_pending": "A settlement is waiting to be merged into this deposit. Cancel that pending settlement first.",
+    "referenced": "Another record still references this transaction. Remove that reference before deleting it.",
+    "not_found": "This transaction no longer exists.",
+    "delete_failed": "Couldn’t delete this transaction. Please try again.",
+    "network": "Connection problem — the transaction wasn’t deleted.",
+    "unknown": "Couldn’t delete this transaction."
   }
 }

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -881,8 +881,8 @@
     "navPlan": "Kế hoạch tháng"
   },
   "deleteTransaction": {
-    "settlement_consumed": "Khoản tất toán này đã được gộp vào một sổ khác. Hãy huỷ gộp trước khi xoá.",
-    "merge_target": "Một khoản tất toán đã được gộp vào sổ này. Hãy huỷ gộp trước khi xoá.",
+    "settlement_consumed": "Khoản tất toán này thuộc một lần gộp đã hoàn tất nên không thể xoá.",
+    "merge_target": "Đã có khoản tất toán được gộp vào sổ này nên không thể xoá.",
     "settlement_pending": "Có khoản tất toán đang chờ gộp vào sổ này. Hãy huỷ khoản chờ gộp trước.",
     "referenced": "Bản ghi khác vẫn tham chiếu tới giao dịch này. Hãy gỡ tham chiếu đó trước khi xoá.",
     "not_found": "Giao dịch này không còn tồn tại.",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -879,5 +879,15 @@
     "navFeatures": "Tính năng",
     "navHow": "Cách hoạt động",
     "navPlan": "Kế hoạch tháng"
+  },
+  "deleteTransaction": {
+    "settlement_consumed": "Khoản tất toán này đã được gộp vào một sổ khác. Hãy huỷ gộp trước khi xoá.",
+    "merge_target": "Một khoản tất toán đã được gộp vào sổ này. Hãy huỷ gộp trước khi xoá.",
+    "settlement_pending": "Có khoản tất toán đang chờ gộp vào sổ này. Hãy huỷ khoản chờ gộp trước.",
+    "referenced": "Bản ghi khác vẫn tham chiếu tới giao dịch này. Hãy gỡ tham chiếu đó trước khi xoá.",
+    "not_found": "Giao dịch này không còn tồn tại.",
+    "delete_failed": "Không xoá được giao dịch. Vui lòng thử lại.",
+    "network": "Lỗi kết nối — giao dịch chưa được xoá.",
+    "unknown": "Không xoá được giao dịch."
   }
 }


### PR DESCRIPTION
Closes #550.

## Problem

`DELETE /api/v1/investment-transactions/:id` refuses for several distinct, **user-actionable** reasons — a settlement already merged elsewhere, one still waiting to merge into this deposit, another record referencing the row. None of them reached the screen:

```ts
const res = await fetch(`/api/v1/investment-transactions/${tx.transaction_id}`, { method: 'DELETE' })
if (res.ok) { … }          // ← no else
```

`goalActions.unholdTransaction` had the same shape, returning a bare `res.ok` and dropping the body. So a refused delete left the confirm dialog sitting there, the row unchanged, and nothing said. **"Nothing happened" is the worst possible rendering of "here is what to do instead."**

## Codes, not prose

The route now returns a stable `code` beside its English message, and the client translates the code.

That's the part worth arguing: shipping the server's sentence straight to the UI would put untranslated English in front of a Vietnamese user. So the **code** is the contract and the copy lives in `messages/{en,vi}.json`.

| code | meaning | what the user should do |
|---|---|---|
| `settlement_consumed` | this row was merged into another deposit | undo the merge |
| `merge_target` | another settlement was merged *into* this one | undo the merge |
| `settlement_pending` | a settlement is held, waiting to merge in | cancel the pending settlement |
| `referenced` | something else still points at it | remove that reference |
| `not_found` | already gone | — |
| `delete_failed` | the server tried and failed | retry |
| `network` | the request never got an answer | retry |
| `unknown` | unrecognised response | — |

`network` is deliberately separate from the refusals: the server never got to decide, so naming a specific reason would be inventing one. A non-JSON body (a gateway's HTML error page) resolves to `unknown` rather than throwing.

The ledger's confirm dialog now closes on refusal and lets the toast carry the explanation — leaving it open would be a dialog sitting unchanged, which is close to the original complaint.

## A silent break the compiler didn't catch

Changing `unholdTransaction`'s return type from `boolean` to a result object broke both goal-detail views:

```ts
const ok = await unholdTransaction(heldTxId)
if (!ok) { toast.error(…); return }     // an object is always truthy
```

Their error branch would simply never run again, and the success path would run on every refusal. **`tsc` accepted all of it** — `ok` is only used in a boolean context, so there's no type error to report.

I found it by grepping the call sites after changing the signature rather than trusting a clean typecheck. Both are updated, and the `goalActions` test now pins the object shape so the next change to it fails loudly.

## Tests

- **10** on `deleteTransaction` — every code, the network path, a non-JSON body
- `goalActions` parity case updated to the new shape, plus a refusal case
- **Component tests** asserting the ledger renders the *right* refusal:

```ts
it.each([['settlement_consumed'], ['settlement_pending'], ['merge_target']])(
  'surfaces the %s refusal', …
  await vi.waitFor(() => expect(toastError).toHaveBeenCalledWith(code))
)
```

The mocked translator echoes its key, so asserting on the code proves the **correct reason** was chosen — not merely that some toast fired. A success case pins that nothing is shown when the delete works.

## Checks

| Check | Result |
|---|---|
| `vitest run` | 145 files, **1581 passed** (was 144/1566) |
| `tsc --noEmit` | clean |
| `eslint` | 15 warnings, 0 errors — unchanged baseline (#537) |
| Full E2E | **253 passed, 0 failed** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)