### PR TITLE
fix(hooks): clear the remaining React hook lint warnings (#537)

### DIFF
--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -255,6 +255,12 @@ export default function PlanningClient() {
     setLoading(false)
   }, [month, year])
 
+  // fetchPlan raises its own loading flag before awaiting, which is what the
+  // rule sees. Fetching on mount is the effect's job, and there is nothing to
+  // derive from: the answer only exists after the request. Hoisting the flag to
+  // render time would mean rendering a loading state for a fetch that hasn't
+  // been issued.
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- data load; see above
   useEffect(() => { fetchPlan() }, [fetchPlan])
 
   const refetch = useCallback(() => fetchPlan({ force: true }), [fetchPlan])

--- a/app/(app)/planning/components/planningSheets.tsx
+++ b/app/(app)/planning/components/planningSheets.tsx
@@ -4,7 +4,7 @@
 // wrapper and the salary / delete-plan / other-expense / simple-override sheets.
 // The income/delete/other-expense writes go through planActions; the override sheet
 // hands its amount up to the parent. Layout + local form state only.
-import { useState, useEffect, useRef } from 'react'
+import { useState, useRef } from 'react'
 import { useLocale } from 'next-intl'
 import { formatIntVN, parseIntVN } from '@/lib/numberFormat'
 import { fmtCompact } from '@/lib/formatters'

--- a/app/(app)/planning/components/useDialogMount.ts
+++ b/app/(app)/planning/components/useDialogMount.ts
@@ -69,6 +69,17 @@ export function useDialogMount(open: boolean, exitMs: number = EXIT_MS): boolean
 // prop changes": the re-render happens before the browser paints, so nothing
 // stale is ever shown. `reset` is called during render and must therefore only
 // set state — no fetching, no subscriptions.
+// Run `reset` in the render where `key` changes — the same adjustment as
+// useResetOnOpen, for state that tracks a prop on an always-visible surface
+// (the desktop goal panel has no `open`; switching goals is the whole event).
+export function useResetOnChange(key: unknown, reset: () => void): void {
+  const [prev, setPrev] = useState(key)
+  if (!Object.is(prev, key)) {
+    setPrev(key)
+    reset()
+  }
+}
+
 export function useResetOnOpen(open: boolean, reset: () => void, syncKey?: unknown): void {
   const [prev, setPrev] = useState({ open, syncKey })
   if (prev.open !== open || !Object.is(prev.syncKey, syncKey)) {

--- a/app/(app)/settings/settingsShared.ts
+++ b/app/(app)/settings/settingsShared.ts
@@ -22,10 +22,9 @@ export function clearAppCaches(): void {
     .forEach((k) => localStorage.removeItem(k))
 }
 
-// Persist the chosen locale for a year; callers refresh the router afterward.
-export function setLocaleCookie(next: string): void {
-  document.cookie = `locale=${next};path=/;max-age=31536000;SameSite=Lax`
-}
+// Moved to lib/locale so the landing page's toggle can share it; re-exported
+// here because both settings views already import it from this module.
+export { setLocaleCookie } from '@/lib/locale'
 
 // `partial` means something synced but not everything — gold updated while some
 // or all fund NAVs failed. It stays `ok: true` deliberately: prices did move, so

--- a/app/assets/components/AssignGoalSheet.tsx
+++ b/app/assets/components/AssignGoalSheet.tsx
@@ -91,7 +91,11 @@ export default function AssignGoalSheet({ open, onClose, onConfirm, item, deskto
     setGoalsLoading(true)
   })
 
+  // The loading flag itself is already raised during render by the reset above,
+  // so the first frame shows "Loading…". This effect only issues the request —
+  // loadGoals re-raises the flag for a retry, which is what the rule sees.
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- data load; see above
     if (open) loadGoals()
   }, [open, loadGoals])
 

--- a/app/assets/components/CreateGoalSheet.tsx
+++ b/app/assets/components/CreateGoalSheet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useTranslations } from 'next-intl'
 import { X, Mountain, Home, Shield, ShoppingCart, Target } from 'lucide-react'
 import { iconHit } from './iconHit'

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { ChevronLeft, X, MoreHorizontal, Edit2, Trash2, ChevronRight, ArrowDownRight, Target, CalendarDays, RefreshCw, PiggyBank, Plus } from 'lucide-react'
 import { iconHit } from './iconHit'
 import { toast } from 'sonner'
@@ -20,6 +20,7 @@ import { deleteGoal, unholdTransaction, unassignInvestment, updateGoal } from '.
 import { SellWithdrawSheet } from './SellWithdrawSheet'
 import { invToSellItem } from './invToSellItem'
 import { useTranslations } from 'next-intl'
+import { useResetOnOpen, useResetOnChange } from '@/app/(app)/planning/components/useDialogMount'
 
 interface Props {
   goal: GoalData
@@ -78,10 +79,9 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
     onLoadStart: () => setUnassignedIds([]),
   })
 
-  // Reset tab when the selected goal itself changes.
-  useEffect(() => {
-    setTab('investments')
-  }, [goal.goalId])
+  // Reset the tab when the selected goal changes. During render, so switching
+  // goals never paints the previous goal's tab for a frame.
+  useResetOnChange(goal.goalId, () => setTab('investments'))
 
   async function handleDelete() {
     setIsDeleting(true)
@@ -871,14 +871,12 @@ function EditGoalModal({ open, onClose, goal, onSaved, isVi }: {
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
 
-  useEffect(() => {
-    if (open) {
-      setName(goal.goalName)
-      setTarget(goal.targetAmount ? String(goal.targetAmount) : '')
-      setDate(goal.targetDate ? goal.targetDate.slice(0, 7) : '')
-      setError('')
-    }
-  }, [open, goal])
+  useResetOnOpen(open, () => {
+    setName(goal.goalName)
+    setTarget(goal.targetAmount ? String(goal.targetAmount) : '')
+    setDate(goal.targetDate ? goal.targetDate.slice(0, 7) : '')
+    setError('')
+  }, goal)
 
   const monthsTo = (() => {
     if (!date) return 1

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useMemo } from 'react'
+import { useState, useMemo } from 'react'
 import { useLocale } from 'next-intl'
 import { ArrowDownRight, ArrowDownToLine, Building, Check, Coins, Shield, TrendingUp, Wallet, X } from 'lucide-react'
 import { iconHit } from './iconHit'
@@ -72,7 +72,14 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
   const [amount, setAmount] = useState('')
   const [units, setUnits] = useState('')
   const [received, setReceived] = useState('') // bank: cash actually received
-  const [salePrice, setSalePrice] = useState('') // gold: sale price per chỉ
+  // Seeded lazily as well as synced below: useResetOnOpen fires on a *transition*
+  // into open, so a sheet that mounts already open — which is how it renders when
+  // the parent shows it in the same commit — would otherwise never get its gold
+  // prefill. Reads item directly because isGold/navPerUnit are derived further
+  // down the component.
+  const [salePrice, setSalePrice] = useState(
+    () => (item?.type === 'gold' && item?.navPerUnit ? String(Math.round(item.navPerUnit)) : ''),
+  ) // gold: sale price per chỉ
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   const [confirmed, setConfirmed] = useState(false)
@@ -148,10 +155,13 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
 
   const showUnits = isFund && item?.units != null
 
-  // Gold: prefill the sale price with the current market price when the sheet opens.
-  useEffect(() => {
-    if (open && isGold && navPerUnit) setSalePrice(String(Math.round(navPerUnit)))
-  }, [open, isGold, navPerUnit])
+  // Gold: prefill the sale price with the current market price when the sheet
+  // opens. navPerUnit is the sync key as well, so a price arriving after the
+  // sheet is already open still lands in the field — the old effect listed it as
+  // a dependency for exactly that reason.
+  useResetOnOpen(open, () => {
+    if (isGold && navPerUnit) setSalePrice(String(Math.round(navPerUnit)))
+  }, navPerUnit)
 
   function handleAmountChange(val: string) {
     const raw = parseIntVN(val)

--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -13,6 +13,7 @@ import AddTransactionSheet from './AddTransactionSheet'
 import { ASSET_TYPES, type AssetType, type LedgerTransaction, isWithdrawal, txKind, txPrimaryName, fmtTxDate } from './transactionUtils'
 import { toast } from 'sonner'
 import { deleteTransaction } from './deleteTransaction'
+import { useDialogMount } from '@/app/(app)/planning/components/useDialogMount'
 
 interface Goal { goal_id: string; goal_name: string }
 interface Fund { id: string; name: string; code: string; nav: number }
@@ -84,12 +85,7 @@ function Shell({ open, onClose, title, desktop, width = 520, testId, children }:
   testId?: string
   children: React.ReactNode
 }) {
-  const [mounted, setMounted] = useState(open)
-  useEffect(() => {
-    if (open) { setMounted(true); return }
-    const t = setTimeout(() => setMounted(false), 220)
-    return () => clearTimeout(t)
-  }, [open])
+  const mounted = useDialogMount(open)
   if (desktop ? !open : !mounted) return null
 
   const header = (
@@ -200,7 +196,13 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
   }, [page, filters])
 
   // Load only while open — avoids fetching for every dashboard render.
+  // Both fetchers set their loading flag before awaiting. Opening the ledger is
+  // the trigger for the request, and the result can't be derived from anything
+  // already rendered, so an effect is the right home even though the rule can't
+  // tell this from a state sync.
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- data load; see above
   useEffect(() => { if (open) { fetchGoals(); fetchFunds() } }, [open, fetchGoals, fetchFunds])
+  // eslint-disable-next-line react-hooks/set-state-in-effect -- data load; see above
   useEffect(() => { if (open) fetchTransactions() }, [open, fetchTransactions])
 
   // Lock background scroll while the ledger is open. Re-assert when a nested

--- a/app/assets/components/goalDetailDialogs.tsx
+++ b/app/assets/components/goalDetailDialogs.tsx
@@ -4,7 +4,7 @@
 // delete/edit-goal sheets, and the per-investment action + unassign-confirm sheets.
 // Prop-driven — GoalDetailSheet owns the data + orchestration and passes handlers
 // down. The edit-goal write goes through goalActions.updateGoal.
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useLocale } from 'next-intl'
 import { ChevronRight, RefreshCw, Trash2, Edit2, Download, Calendar, ArrowDownRight } from 'lucide-react'
 import { fmtCompact, fmtPct } from '@/lib/formatters'

--- a/app/assets/components/useGoalDetailData.ts
+++ b/app/assets/components/useGoalDetailData.ts
@@ -59,8 +59,13 @@ export function useGoalDetailData(opts: {
   const onLoadStartRef = useRef(opts.onLoadStart)
   useEffect(() => { onLoadStartRef.current = opts.onLoadStart })
 
+  // A fetch keyed on goalId/refreshKey: the flags mark a request that is about
+  // to be issued, not state derived from props, so there is nothing to move to
+  // render time. Clearing the error alongside is what keeps a retry from showing
+  // the previous failure while the new attempt is in flight.
   useEffect(() => {
     if (!enabled || !goalId) return
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- data load; see above
     setTxLoading(true)
     setTxError(false)
     // The new server response is the source of truth — let the caller drop any

--- a/app/components/LandingLangToggle.tsx
+++ b/app/components/LandingLangToggle.tsx
@@ -3,6 +3,7 @@
 import { useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { useLocale } from 'next-intl'
+import { setLocaleCookie } from '@/lib/locale'
 
 export function LandingLangToggle() {
   const locale = useLocale()
@@ -10,7 +11,7 @@ export function LandingLangToggle() {
   const router = useRouter()
 
   function switchLocale(next: string) {
-    document.cookie = `locale=${next};path=/;max-age=31536000;SameSite=Lax`
+    setLocaleCookie(next)
     startTransition(() => router.refresh())
   }
 

--- a/app/components/OfflineBanner.tsx
+++ b/app/components/OfflineBanner.tsx
@@ -1,37 +1,50 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useSyncExternalStore } from 'react'
 import { WifiOff } from 'lucide-react'
 
+const RECONNECTED_MS = 3000
+
+// navigator.onLine is browser state this component doesn't own, which is exactly
+// what useSyncExternalStore is for. Seeding it with setIsOnline(navigator.onLine)
+// inside an effect was the set-state-in-effect shape (#537) — and it also meant
+// the first paint always claimed "online", so a page loaded while offline showed
+// nothing until an effect corrected it a frame later.
+function subscribe(onChange: () => void) {
+  window.addEventListener('online', onChange)
+  window.addEventListener('offline', onChange)
+  return () => {
+    window.removeEventListener('online', onChange)
+    window.removeEventListener('offline', onChange)
+  }
+}
+
+const getSnapshot = () => navigator.onLine
+// There is no navigator during SSR. "Online" matches what the markup assumed
+// before, so hydration sees the same empty banner it always did.
+const getServerSnapshot = () => true
+
 export default function OfflineBanner() {
-  const [isOnline, setIsOnline] = useState(true)
+  const isOnline = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
   const [showReconnected, setShowReconnected] = useState(false)
   const [wasOffline, setWasOffline] = useState(false)
 
+  // The reconnected notice depends on a *transition*, which a snapshot can't
+  // express — so the previous value is tracked in state and compared during
+  // render (React's documented way to adjust state when an input changes).
+  const [prevOnline, setPrevOnline] = useState(isOnline)
+  if (prevOnline !== isOnline) {
+    setPrevOnline(isOnline)
+    if (!isOnline) setWasOffline(true)
+    // Only announce a reconnection that actually followed a drop.
+    else if (wasOffline) setShowReconnected(true)
+  }
+
   useEffect(() => {
-    setIsOnline(navigator.onLine)
-
-    const handleOffline = () => {
-      setIsOnline(false)
-      setWasOffline(true)
-    }
-
-    const handleOnline = () => {
-      setIsOnline(true)
-      if (wasOffline) {
-        setShowReconnected(true)
-        const t = setTimeout(() => setShowReconnected(false), 3000)
-        return () => clearTimeout(t)
-      }
-    }
-
-    window.addEventListener('offline', handleOffline)
-    window.addEventListener('online', handleOnline)
-    return () => {
-      window.removeEventListener('offline', handleOffline)
-      window.removeEventListener('online', handleOnline)
-    }
-  }, [wasOffline])
+    if (!showReconnected) return
+    const t = setTimeout(() => setShowReconnected(false), RECONNECTED_MS)
+    return () => clearTimeout(t)
+  }, [showReconnected])
 
   if (isOnline && !showReconnected) return null
 

--- a/app/components/ThemeProvider.tsx
+++ b/app/components/ThemeProvider.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useSyncExternalStore } from 'react'
 
 type Theme = 'light' | 'dark'
 export type ThemeChoice = Theme | 'system'
@@ -19,32 +19,65 @@ export function useTheme() {
   return ctx
 }
 
-export default function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [themeState, setThemeState] = useState<Theme>('light')
+// The resolved theme is derived from localStorage and the OS preference — state
+// this component reads rather than owns, so the store is those two and not a
+// useState. Seeding it inside an effect (#537) meant the first paint was always
+// 'light' and corrected a frame later.
+//
+// A lazy initializer isn't an option: there is no localStorage during SSR, so
+// the server and client would disagree and hydration would break.
+// useSyncExternalStore is built for that split — a client snapshot plus a
+// separate server one, which stays 'light' exactly as the markup assumed before.
+const listeners = new Set<() => void>()
+const emit = () => { for (const l of listeners) l() }
 
+function prefersDark(): boolean {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches
+}
+
+function subscribe(onChange: () => void): () => void {
+  listeners.add(onChange)
+  const mq = window.matchMedia('(prefers-color-scheme: dark)')
+  mq.addEventListener('change', onChange)
+  // Another tab changing the choice should move this one too.
+  window.addEventListener('storage', onChange)
+  return () => {
+    listeners.delete(onChange)
+    mq.removeEventListener('change', onChange)
+    window.removeEventListener('storage', onChange)
+  }
+}
+
+function getSnapshot(): Theme {
+  const stored = localStorage.getItem('theme')
+  if (stored === 'light' || stored === 'dark') return stored
+  return prefersDark() ? 'dark' : 'light'
+}
+
+const getServerSnapshot = (): Theme => 'light'
+
+export default function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const themeState = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+
+  // The <html> class mirrors the resolved theme. Doing it here rather than in
+  // each setter keeps one source of truth — and it's a DOM write, not state, so
+  // an effect is the right place for it.
   useEffect(() => {
-    const stored = localStorage.getItem('theme') as Theme | null
-    const resolved = stored ?? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-    setThemeState(resolved)
-    document.documentElement.classList.toggle('dark', resolved === 'dark')
-  }, [])
+    document.documentElement.classList.toggle('dark', themeState === 'dark')
+  }, [themeState])
 
   function toggleTheme() {
     applyTheme(themeState === 'dark' ? 'light' : 'dark')
   }
 
+  // Writing the choice IS the state change now: the snapshot reads it back, and
+  // emit() tells every subscriber to re-read. 'system' is the absence of a
+  // stored value, so the snapshot falls through to the OS — which is also why
+  // the theme now follows a later OS change instead of freezing at mount.
   function applyTheme(choice: ThemeChoice) {
-    if (choice === 'system') {
-      localStorage.removeItem('theme')
-      const isDark = window.matchMedia('(prefers-color-scheme: dark)').matches
-      const resolved: Theme = isDark ? 'dark' : 'light'
-      setThemeState(resolved)
-      document.documentElement.classList.toggle('dark', isDark)
-    } else {
-      setThemeState(choice)
-      localStorage.setItem('theme', choice)
-      document.documentElement.classList.toggle('dark', choice === 'dark')
-    }
+    if (choice === 'system') localStorage.removeItem('theme')
+    else localStorage.setItem('theme', choice)
+    emit()
   }
 
   return (

--- a/app/components/__tests__/OfflineBanner.test.tsx
+++ b/app/components/__tests__/OfflineBanner.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import OfflineBanner from '../OfflineBanner'
+
+// The banner reads navigator.onLine — browser state the component doesn't own.
+// It used to seed that with `setIsOnline(navigator.onLine)` inside an effect,
+// which is the set-state-in-effect shape (#537) and also means the first paint
+// always claims "online" regardless of the truth.
+//
+// useSyncExternalStore is what this is for: React reads the live value during
+// render and re-reads it whenever the online/offline events fire.
+
+function setOnline(value: boolean) {
+  Object.defineProperty(navigator, 'onLine', { value, configurable: true })
+}
+
+const fire = (type: 'online' | 'offline') =>
+  act(() => { window.dispatchEvent(new Event(type)) })
+
+describe('OfflineBanner', () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true })
+    setOnline(true)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    setOnline(true)
+  })
+
+  it('renders nothing while online', () => {
+    const { container } = render(<OfflineBanner />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  // The old effect-seeded version rendered "online" for a frame even here.
+  it('shows the offline state on first paint when the browser is already offline', () => {
+    setOnline(false)
+    render(<OfflineBanner />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('appears when the connection drops', () => {
+    render(<OfflineBanner />)
+    setOnline(false)
+    fire('offline')
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('shows the reconnected notice only after having been offline', () => {
+    render(<OfflineBanner />)
+    setOnline(false)
+    fire('offline')
+    setOnline(true)
+    fire('online')
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('does not announce a reconnection that never followed a drop', () => {
+    const { container } = render(<OfflineBanner />)
+    setOnline(true)
+    fire('online')
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('clears the reconnected notice after its timeout', () => {
+    render(<OfflineBanner />)
+    setOnline(false)
+    fire('offline')
+    setOnline(true)
+    fire('online')
+    expect(screen.getByRole('status')).toBeInTheDocument()
+
+    act(() => { vi.advanceTimersByTime(3000) })
+    expect(screen.queryByRole('status')).toBeNull()
+  })
+})

--- a/app/components/__tests__/ThemeProvider.test.tsx
+++ b/app/components/__tests__/ThemeProvider.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import ThemeProvider, { useTheme } from '../ThemeProvider'
+
+// The resolved theme comes from localStorage and the OS preference — state this
+// component reads rather than owns. It used to seed that with setThemeState()
+// inside an effect (#537), which meant the value was always 'light' for the
+// first paint and corrected a frame later.
+//
+// The seeding can't move into a lazy initializer: there is no localStorage
+// during SSR, so the server and client would disagree and hydration would break.
+// useSyncExternalStore is the tool that handles exactly that split — a client
+// snapshot and a separate server snapshot.
+
+let mqMatches = false
+const mqListeners = new Set<() => void>()
+
+function stubMatchMedia() {
+  vi.stubGlobal('matchMedia', (q: string) => ({
+    matches: q.includes('dark') ? mqMatches : false,
+    media: q,
+    addEventListener: (_: string, cb: () => void) => { mqListeners.add(cb) },
+    removeEventListener: (_: string, cb: () => void) => { mqListeners.delete(cb) },
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  }))
+}
+
+const setOsDark = (v: boolean) => act(() => {
+  mqMatches = v
+  mqListeners.forEach((l) => l())
+})
+
+function Probe() {
+  const { theme, toggleTheme, setTheme } = useTheme()
+  return (
+    <div>
+      <span data-testid="theme">{theme}</span>
+      <button onClick={toggleTheme}>toggle</button>
+      <button onClick={() => setTheme('system')}>system</button>
+      <button onClick={() => setTheme('dark')}>dark</button>
+    </div>
+  )
+}
+
+const renderProvider = () => render(<ThemeProvider><Probe /></ThemeProvider>)
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    mqMatches = false
+    mqListeners.clear()
+    document.documentElement.classList.remove('dark')
+    stubMatchMedia()
+  })
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('falls back to the OS preference when nothing is stored', () => {
+    mqMatches = true
+    renderProvider()
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark')
+  })
+
+  // The effect-seeded version rendered 'light' first and corrected afterwards.
+  it('resolves a stored theme on the first render, not a frame later', () => {
+    localStorage.setItem('theme', 'dark')
+    renderProvider()
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark')
+  })
+
+  it('a stored choice wins over the OS preference', () => {
+    mqMatches = true
+    localStorage.setItem('theme', 'light')
+    renderProvider()
+    expect(screen.getByTestId('theme')).toHaveTextContent('light')
+  })
+
+  it('mirrors the resolved theme onto the document element', () => {
+    localStorage.setItem('theme', 'dark')
+    renderProvider()
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('persists an explicit choice and applies it', () => {
+    renderProvider()
+    act(() => { screen.getByText('dark').click() })
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark')
+    expect(localStorage.getItem('theme')).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('toggles between the two', () => {
+    renderProvider()
+    act(() => { screen.getByText('toggle').click() })
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark')
+    act(() => { screen.getByText('toggle').click() })
+    expect(screen.getByTestId('theme')).toHaveTextContent('light')
+  })
+
+  it('"system" clears the stored choice and follows the OS', () => {
+    localStorage.setItem('theme', 'light')
+    mqMatches = true
+    renderProvider()
+    act(() => { screen.getByText('system').click() })
+    expect(localStorage.getItem('theme')).toBeNull()
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark')
+  })
+
+  // Only meaningful once the store is the source of truth: with the old effect
+  // this never updated after mount.
+  it('follows a later OS change while on "system"', () => {
+    renderProvider()
+    expect(screen.getByTestId('theme')).toHaveTextContent('light')
+    setOsDark(true)
+    expect(screen.getByTestId('theme')).toHaveTextContent('dark')
+  })
+})

--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -1,0 +1,11 @@
+// Persist the chosen locale for a year; callers refresh the router afterward.
+//
+// Lives in lib/ rather than the settings module because the landing page's
+// language toggle needs it too, and a landing component reaching into
+// app/(app)/settings/ would be the wrong direction. It was duplicated there
+// (#537) — inline in the component, where `document.cookie = …` trips
+// react-hooks/immutability: the rule can't tell a render from an event handler,
+// and a module-scope function is outside its remit either way.
+export function setLocaleCookie(next: string): void {
+  document.cookie = `locale=${next};path=/;max-age=31536000;SameSite=Lax`
+}


### PR DESCRIPTION
Closes #537. Baseline goes **15 → 0**, and `npm run lint` exits 0.

#555 took the mechanical half (the duplicated dialog mount/reset latch). This is the remainder, which needed four different answers rather than one.

## External state → `useSyncExternalStore`

`OfflineBanner` read `navigator.onLine`; `ThemeProvider` read `localStorage` + the OS preference. Both seeded that with `setState` inside an effect.

Neither can move to a lazy initializer: **there is no `navigator` or `localStorage` during SSR**, so the server and client would disagree and hydration would break. `useSyncExternalStore` is built for exactly that split — a client snapshot plus a separate server snapshot, which stays `'online'` / `'light'` to match what the markup already assumed.

Two behaviour improvements fall out of doing it properly:

- a page loaded **while offline** shows the banner on first paint instead of a frame later;
- the theme now **follows a later OS change** while set to "system". Previously it froze at whatever the mount-time effect read. There's a test for that one, and it fails against the old implementation.

## Mechanical leftovers from #555

One more mount latch (the ledger's `Shell`, a slightly different shape I'd missed), the desktop goal panel's tab reset and edit-form reset, and the gold sale-price prefill. New `useResetOnChange` covers state that tracks a prop on a surface with **no `open`** to key off — the desktop panel is always mounted, so switching goals is the whole event.

## `document.cookie`

`react-hooks/immutability` flagged the write in `LandingLangToggle` — the rule can't distinguish an event handler from render. Moved to `lib/locale`, which also removes a duplicate: `settingsShared` already had the identical function, and a landing component reaching into `app/(app)/settings/` would have been the wrong direction.

## Five genuine data-loading effects keep targeted disables

`PlanningClient`, `AssignGoalSheet`, both ledger loaders, `useGoalDetailData`. Each raises a flag for a request **about to be issued** — not state derived from anything already rendered, so there's nothing to hoist to render time. Hoisting would mean rendering a loading state for a fetch that hasn't been made.

#537 explicitly allows this ("targeted suppressions only where the lifecycle is intentional and documented"), and each disable carries its own reason rather than a shared boilerplate line.

## A test that earned its keep

Converting the gold prefill to `useResetOnOpen` broke two `SellWithdrawSheet` tests. `useResetOnOpen` fires on a **transition** into open, and that sheet can mount already open — so the prefill silently never ran. Fixed with a lazy initial value alongside the sync. The tests caught a real gap, not a mock detail; without them this would have shipped as "the gold price box is sometimes empty".

## Checks

| Check | Result |
|---|---|
| `eslint` | **0 problems** (was 15 warnings) |
| `vitest run` | 147 files, **1596 passed** (was 145/1582) |
| `tsc --noEmit` | clean |
| Full E2E | **253 passed, 0 failed** |

## On the hydration warning — still unresolved

I said in #555 that the `Hydration failed because the server rendered text didn't match the client` in the E2E server log should be established before touching `ThemeProvider`. Where that got to:

- **`ThemeProvider` is not the cause.** Its state started as `'light'` on both server and client, so at hydration time they agreed; the effect's correction was a *post*-hydration update. This PR keeps that property — `getServerSnapshot` returns `'light'`.
- **The warning is unchanged by this PR**, appearing at the same rate before and after.
- **I did not identify the actual source.** The E2E log only carries React's generic advice text; the component diff is truncated, so it can't be pinned from there.

It deserves its own issue rather than riding along unexamined — happy to open one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)