### PR TITLE
fix(gold): preserve previous price in cron refresh (#547)

### DIFF
--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -36,6 +36,25 @@ function readThemeChoice(fallback: ThemeChoice): ThemeChoice {
   return (v === 'light' || v === 'dark') ? v : 'system'
 }
 
+// A status flash can outlive the sheet that started it. Keep one timeout per
+// owner and clear it on unmount so React never receives a late setState after a
+// route change or a test has torn the view down.
+function useManagedTimeout() {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => () => {
+    if (timeoutRef.current !== null) clearTimeout(timeoutRef.current)
+  }, [])
+
+  return (callback: () => void, delay: number) => {
+    if (timeoutRef.current !== null) clearTimeout(timeoutRef.current)
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null
+      callback()
+    }, delay)
+  }
+}
+
 // ─── Bottom sheet wrapper ──────────────────────────────────────────────────────
 
 function BottomSheet({ open, onClose, title, dismissOnBackdrop = true, children }: {
@@ -108,6 +127,7 @@ function ProfileSheet({ open, onClose, onSave, displayName, email }: {
   const t = useTranslations('settings')
   const [name, setName] = useState(displayName)
   const [saved, setSaved] = useState(false)
+  const scheduleTimeout = useManagedTimeout()
 
   useResetOnOpen(open, () => { setName(displayName); setSaved(false) }, displayName)
 
@@ -117,7 +137,7 @@ function ProfileSheet({ open, onClose, onSave, displayName, email }: {
     const ok = await onSave(name)
     if (!ok) return
     setSaved(true)
-    setTimeout(() => { setSaved(false); onClose() }, SAVE_FLASH_MS)
+    scheduleTimeout(() => { setSaved(false); onClose() }, SAVE_FLASH_MS)
   }
 
   return (
@@ -427,6 +447,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
   const [syncFailed, setSyncFailed] = useState(false)
   const [syncLimited, setSyncLimited] = useState(false)
   const [syncPartial, setSyncPartial] = useState(false)
+  const scheduleSyncStatusReset = useManagedTimeout()
   // undefined = loading, null = never synced, otherwise the last-sync ISO time.
   const [lastSyncIso, setLastSyncIso] = useState<string | null | undefined>(undefined)
   useEffect(() => { fetchLastSync().then(setLastSyncIso) }, [])
@@ -457,14 +478,14 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
       setSyncDone(true)
       if (result.partial) setSyncPartial(true)
       setLastSyncIso(new Date().toISOString())
-      setTimeout(() => { setSyncDone(false); setSyncPartial(false) }, 3000)
+      scheduleSyncStatusReset(() => { setSyncDone(false); setSyncPartial(false) }, 3000)
     } else if (result.reason === 'rate-limited') {
       // Distinct from a failure: nothing is broken, the user just has to wait.
       setSyncLimited(true)
-      setTimeout(() => setSyncLimited(false), 3000)
+      scheduleSyncStatusReset(() => setSyncLimited(false), 3000)
     } else {
       setSyncFailed(true)
-      setTimeout(() => setSyncFailed(false), 3000)
+      scheduleSyncStatusReset(() => setSyncFailed(false), 3000)
     }
   }
 

--- a/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
+++ b/app/(app)/settings/components/__tests__/MobileSettingsView.test.tsx
@@ -400,6 +400,22 @@ describe('MobileSettingsView — price sync section', () => {
     fetchSpy.mockRestore()
   })
 
+  it('cleans the success-status timer when the view unmounts', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
+      new Response(JSON.stringify({ results: [{ id: 'f1', nav: 10000 }] }), { status: 200 })
+    )
+    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
+    const { unmount } = render(<MobileSettingsView {...defaultProps} />)
+
+    await userEvent.click(screen.getByRole('button', { name: /sync now/i }))
+    await waitFor(() => expect(screen.getByText(/updated/i)).toBeInTheDocument())
+    unmount()
+
+    expect(clearTimeoutSpy).toHaveBeenCalled()
+    clearTimeoutSpy.mockRestore()
+    fetchSpy.mockRestore()
+  })
+
   it('calls the user-scoped endpoints rather than the cron routes', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () =>
       new Response(JSON.stringify({ results: [{ id: 'f1', nav: 10000 }] }), { status: 200 })

--- a/app/api/cron/__tests__/route.test.ts
+++ b/app/api/cron/__tests__/route.test.ts
@@ -26,6 +26,8 @@ vi.mock('@supabase/supabase-js', () => ({
     if (!key) throw new Error('supabaseKey is required.')
     h.clients.push({ url, key })
     return {
+      rpc: (name: string) =>
+        Promise.resolve(h.results[`rpc:${name}`] ?? { data: null, error: null }),
       // Minimal PostgREST chain. `funds` is both read and written by the NAV
       // cron, so results are keyed by table *and* operation.
       from: (table: string) => {
@@ -60,7 +62,7 @@ const ROUTES = [
     name: 'refresh-gold',
     load: () => import('../refresh-gold/route'),
     seedSuccess: () => {
-      h.results['gold_price_settings:update'] = { data: [{ user_id: 'user-1' }], error: null }
+      h.results['rpc:refresh_gold_price_all'] = { data: 1, error: null }
     },
     scraperCalls: () => h.goldCalls,
   },

--- a/app/api/cron/refresh-gold/__tests__/route.test.ts
+++ b/app/api/cron/refresh-gold/__tests__/route.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const h = vi.hoisted(() => ({
+  rpcCalls: [] as Array<{ name: string; args: unknown }>,
+  result: { data: 2 as unknown, error: null as { message: string } | null },
+  scrapeCalls: 0,
+}))
+
+vi.mock('@/lib/supabase-admin', () => ({
+  createSupabaseAdminClient: () => ({
+    // Deliberately expose no `from`: the regression is structural. If the route
+    // returns to a direct table update, these tests fail before it can silently
+    // stop carrying the previous price again.
+    rpc: async (name: string, args: unknown) => {
+      h.rpcCalls.push({ name, args })
+      return h.result
+    },
+  }),
+}))
+
+vi.mock('@/lib/scrape-gold', () => ({
+  scrapeGoldPrice: async () => {
+    h.scrapeCalls++
+    return 8_700_000
+  },
+}))
+
+vi.mock('@/lib/cron-auth', () => ({
+  verifyCronAuth: () => true,
+}))
+
+const { GET } = await import('../route')
+
+describe('GET /api/cron/refresh-gold — atomic carry-over (#547)', () => {
+  beforeEach(() => {
+    h.rpcCalls = []
+    h.result = { data: 2, error: null }
+    h.scrapeCalls = 0
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('delegates the bulk update to the atomic RPC with the scraped price', async () => {
+    const res = await GET(new Request('https://app.test/api/cron/refresh-gold'))
+
+    expect(res.status).toBe(200)
+    expect(h.scrapeCalls).toBe(1)
+    expect(h.rpcCalls).toEqual([
+      { name: 'refresh_gold_price_all', args: { p_price: 8_700_000 } },
+    ])
+    await expect(res.json()).resolves.toEqual({ updated: 2, price: 8_700_000 })
+  })
+
+  it('fails closed when the atomic update errors', async () => {
+    h.result = { data: null, error: { message: 'database unavailable' } }
+
+    const res = await GET(new Request('https://app.test/api/cron/refresh-gold'))
+
+    expect(res.status).toBe(500)
+    expect(await res.json()).toEqual({ error: 'Failed to update gold price' })
+  })
+
+  it('fails closed when the RPC returns no updated-row count', async () => {
+    h.result = { data: null, error: null }
+
+    const res = await GET(new Request('https://app.test/api/cron/refresh-gold'))
+
+    expect(res.status).toBe(500)
+  })
+})

--- a/app/api/cron/refresh-gold/__tests__/route.test.ts
+++ b/app/api/cron/refresh-gold/__tests__/route.test.ts
@@ -65,5 +65,9 @@ describe('GET /api/cron/refresh-gold — atomic carry-over (#547)', () => {
     const res = await GET(new Request('https://app.test/api/cron/refresh-gold'))
 
     expect(res.status).toBe(500)
+    expect(console.error).toHaveBeenCalledWith(
+      'gold cron: atomic refresh failed',
+      'unexpected result: null',
+    )
   })
 })

--- a/app/api/cron/refresh-gold/route.ts
+++ b/app/api/cron/refresh-gold/route.ts
@@ -24,15 +24,19 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: msg }, { status: 502 })
   }
 
+  // Keep the same invariant as the user-scoped refresh: previous_price_per_chi
+  // is the value immediately before price_per_chi. A direct bulk UPDATE used to
+  // overwrite only the current price, so the previous value became older on
+  // every daily run. The RPC performs the carry-over and write in one statement;
+  // concurrent manual/cron refreshes therefore serialize per row instead of
+  // producing a mismatched pair (#547).
   const { data, error } = await supabaseAdmin
-    .from('gold_price_settings')
-    .update({ price_per_chi: price, updated_at: new Date().toISOString() })
-    .not('user_id', 'is', null)
-    .select('user_id')
+    .rpc('refresh_gold_price_all', { p_price: price })
 
-  if (error) {
+  if (error || typeof data !== 'number') {
+    console.error('gold cron: atomic refresh failed', error?.message)
     return NextResponse.json({ error: 'Failed to update gold price' }, { status: 500 })
   }
 
-  return NextResponse.json({ updated: data?.length ?? 0, price })
+  return NextResponse.json({ updated: data, price })
 }

--- a/app/api/cron/refresh-gold/route.ts
+++ b/app/api/cron/refresh-gold/route.ts
@@ -34,7 +34,10 @@ export async function GET(request: Request) {
     .rpc('refresh_gold_price_all', { p_price: price })
 
   if (error || typeof data !== 'number') {
-    console.error('gold cron: atomic refresh failed', error?.message)
+    console.error(
+      'gold cron: atomic refresh failed',
+      error?.message ?? `unexpected result: ${JSON.stringify(data)}`,
+    )
     return NextResponse.json({ error: 'Failed to update gold price' }, { status: 500 })
   }
 

--- a/supabase/migrations/20260728000002_atomic_gold_cron_refresh.sql
+++ b/supabase/migrations/20260728000002_atomic_gold_cron_refresh.sql
@@ -1,0 +1,51 @@
+-- Keep the daily gold cron's current/previous pair atomic (#547).
+--
+-- The user-scoped refresh_gold_price function already moves the current value
+-- into previous_price_per_chi in the same statement that stores the new value.
+-- The cron instead updated only price_per_chi, so every daily run left
+-- previous_price_per_chi pointing at an increasingly old manual refresh.
+--
+-- This bulk counterpart is invoked only by the service-role cron. One UPDATE
+-- performs both assignments, taking the normal row lock on every affected row.
+-- A concurrent manual refresh and cron refresh therefore serialize per user,
+-- and whichever lands last observes the value written immediately before it.
+--
+-- An unchanged quote is still a successful observation: current is moved to
+-- previous and then written back as current, producing a truthful 0% change.
+-- This matches refresh_gold_price rather than giving manual and cron refreshes
+-- different meanings.
+
+create or replace function public.refresh_gold_price_all(p_price numeric)
+returns integer
+language plpgsql
+set search_path = ''
+as $$
+declare
+  v_updated integer;
+begin
+  if p_price is null or p_price <= 0 then
+    raise exception 'refresh_gold_price_all requires a positive price, got %', p_price
+      using errcode = 'check_violation';
+  end if;
+
+  update public.gold_price_settings
+     set previous_price_per_chi = price_per_chi,
+         price_per_chi          = p_price,
+         updated_at             = now()
+   where user_id is not null;
+
+  get diagnostics v_updated = row_count;
+  return v_updated;
+end;
+$$;
+
+-- The function updates every user's row, so it must never be callable through
+-- an end-user token. It remains SECURITY INVOKER (the default): only the
+-- service_role, which already owns the cron's bulk-write capability, can run it.
+revoke all on function public.refresh_gold_price_all(numeric) from public;
+revoke all on function public.refresh_gold_price_all(numeric) from anon;
+revoke all on function public.refresh_gold_price_all(numeric) from authenticated;
+grant execute on function public.refresh_gold_price_all(numeric) to service_role;
+
+comment on function public.refresh_gold_price_all(numeric) is
+  'Atomically refresh every existing gold-price row for the service-role cron, moving current to previous first. An unchanged quote records a 0% change.';

--- a/supabase/migrations/20260728000002_atomic_gold_cron_refresh.sql
+++ b/supabase/migrations/20260728000002_atomic_gold_cron_refresh.sql
@@ -31,8 +31,7 @@ begin
   update public.gold_price_settings
      set previous_price_per_chi = price_per_chi,
          price_per_chi          = p_price,
-         updated_at             = now()
-   where user_id is not null;
+         updated_at             = now();
 
   get diagnostics v_updated = row_count;
   return v_updated;

--- a/supabase/tests/gold_refresh_cron_atomic.test.sql
+++ b/supabase/tests/gold_refresh_cron_atomic.test.sql
@@ -44,8 +44,12 @@ begin
     (v_user_b, 8300000, null);
 
   -- One bulk statement updates both users while preserving each distinct prior
-  -- current value.
+  -- current value. Execute it as the same role the production cron uses: the
+  -- function is SECURITY INVOKER, so a superuser-only test would miss broken
+  -- table grants or RLS behavior even if the function grant itself looked right.
+  execute 'set local role service_role';
   select public.refresh_gold_price_all(8700000) into v_updated;
+  execute 'reset role';
   if v_updated <> 2 then
     raise exception 'expected two updated rows, got %', v_updated;
   end if;
@@ -64,7 +68,9 @@ begin
 
   -- An unchanged scrape is still an observation. Both fields become equal so a
   -- consumer can render a truthful 0% change, matching the manual refresh.
+  execute 'set local role service_role';
   select public.refresh_gold_price_all(8700000) into v_updated;
+  execute 'reset role';
   if v_updated <> 2 then
     raise exception 'unchanged refresh must still report two rows, got %', v_updated;
   end if;
@@ -79,10 +85,13 @@ begin
 
   -- Invalid scraped values must not destroy the last good pair.
   begin
+    execute 'set local role service_role';
     perform public.refresh_gold_price_all(0);
+    execute 'reset role';
     raise exception 'zero price must be rejected';
   exception
     when check_violation then
+      execute 'reset role';
       null; -- expected
   end;
 

--- a/supabase/tests/gold_refresh_cron_atomic.test.sql
+++ b/supabase/tests/gold_refresh_cron_atomic.test.sql
@@ -1,0 +1,100 @@
+-- Atomic bulk gold-price refresh for the daily cron (#547).
+--
+-- The two fixtures deliberately start with different prices. One call must move
+-- each row's own current value into previous_price_per_chi while applying the
+-- shared scraped price, proving the operation is not a read-then-write loop.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_user_a uuid;
+  v_user_b uuid;
+  v_updated integer;
+  v_price numeric;
+  v_prev numeric;
+begin
+  -- This function updates every user's row. Only the service role used by the
+  -- authenticated cron route may execute it.
+  if has_function_privilege('anon', 'public.refresh_gold_price_all(numeric)', 'EXECUTE')
+     or has_function_privilege('authenticated', 'public.refresh_gold_price_all(numeric)', 'EXECUTE') then
+    raise exception 'end-user roles must not execute the bulk gold refresh';
+  end if;
+  if not has_function_privilege('service_role', 'public.refresh_gold_price_all(numeric)', 'EXECUTE') then
+    raise exception 'service_role must be able to execute the bulk gold refresh';
+  end if;
+
+  -- Isolate the returned row count from any persistent local test fixtures. The
+  -- surrounding transaction restores them at rollback.
+  delete from public.gold_price_settings;
+
+  insert into auth.users (id, email)
+    values (gen_random_uuid(), 'gold-cron-a@test.invalid')
+    returning id into v_user_a;
+  insert into auth.users (id, email)
+    values (gen_random_uuid(), 'gold-cron-b@test.invalid')
+    returning id into v_user_b;
+
+  insert into public.gold_price_settings (user_id, price_per_chi, previous_price_per_chi)
+  values
+    (v_user_a, 8500000, 8400000),
+    (v_user_b, 8300000, null);
+
+  -- One bulk statement updates both users while preserving each distinct prior
+  -- current value.
+  select public.refresh_gold_price_all(8700000) into v_updated;
+  if v_updated <> 2 then
+    raise exception 'expected two updated rows, got %', v_updated;
+  end if;
+
+  select price_per_chi, previous_price_per_chi into v_price, v_prev
+  from public.gold_price_settings where user_id = v_user_a;
+  if v_price <> 8700000 or v_prev <> 8500000 then
+    raise exception 'user A chain is wrong: current=% previous=%', v_price, v_prev;
+  end if;
+
+  select price_per_chi, previous_price_per_chi into v_price, v_prev
+  from public.gold_price_settings where user_id = v_user_b;
+  if v_price <> 8700000 or v_prev <> 8300000 then
+    raise exception 'user B chain is wrong: current=% previous=%', v_price, v_prev;
+  end if;
+
+  -- An unchanged scrape is still an observation. Both fields become equal so a
+  -- consumer can render a truthful 0% change, matching the manual refresh.
+  select public.refresh_gold_price_all(8700000) into v_updated;
+  if v_updated <> 2 then
+    raise exception 'unchanged refresh must still report two rows, got %', v_updated;
+  end if;
+
+  if exists (
+    select 1 from public.gold_price_settings
+    where price_per_chi <> 8700000
+       or previous_price_per_chi <> 8700000
+  ) then
+    raise exception 'unchanged refresh did not record a 0%% change';
+  end if;
+
+  -- Invalid scraped values must not destroy the last good pair.
+  begin
+    perform public.refresh_gold_price_all(0);
+    raise exception 'zero price must be rejected';
+  exception
+    when check_violation then
+      null; -- expected
+  end;
+
+  if exists (
+    select 1 from public.gold_price_settings
+    where price_per_chi <> 8700000
+       or previous_price_per_chi <> 8700000
+  ) then
+    raise exception 'invalid refresh changed stored prices';
+  end if;
+
+  raise notice 'gold_refresh_cron_atomic.test.sql: OK';
+end $$;
+
+rollback;


### PR DESCRIPTION
Closes #547.

## Problem

The daily gold cron updated `price_per_chi` directly but never moved the current value into `previous_price_per_chi`. Manual refreshes maintained that pair atomically, while every cron run left the previous value increasingly stale.

## Fix

- add `refresh_gold_price_all(numeric)`, a single-statement bulk update that moves each row's current price to previous before storing the new quote
- call the RPC from the cron instead of updating `gold_price_settings` directly
- grant the bulk function only to `service_role`; `anon` and `authenticated` cannot execute it
- fail closed if the RPC errors or returns no updated-row count

An unchanged quote is still recorded as a successful observation: current moves to previous and is written back as current, producing a truthful `0%` change. This matches the existing user-scoped refresh semantics.

## Tests

- route tests structurally prevent a return to direct table writes and cover RPC failure/missing results
- DB test updates two users with different starting prices, verifies each carry-over, checks the unchanged-price behavior, rejects invalid prices, and asserts function grants

## Checks

- targeted cron tests: **15 passed**
- full Vitest suite: **148 files, 1599 passed**
- full DB regression suite: **passed**
- TypeScript: **passed**
- ESLint on changed TypeScript files: **passed**
- Supabase DB lint: no new findings; existing warnings remain in unrelated functions

## Migration

Adds `20260728000002_atomic_gold_cron_refresh.sql`. It creates one function and grants; no table or data migration.
