### PR TITLE
docs(gold): record that previous_price_per_chi is deliberately unrendered (#548)

### DIFF
--- a/app/api/v1/gold-price/__tests__/route.test.ts
+++ b/app/api/v1/gold-price/__tests__/route.test.ts
@@ -15,6 +15,7 @@ const h = vi.hoisted(() => ({
   user: { id: 'user-1' } as { id: string } | null,
   row: null as Record<string, unknown> | null,
   dbError: null as { code?: string; message: string } | null,
+  selects: [] as string[],
 }))
 
 const PGRST116 = {
@@ -29,7 +30,10 @@ vi.mock('@/lib/supabase-server', () => {
     return { data: h.row, error: null }
   }
   const chain: Record<string, unknown> = {
-    select: () => chain,
+    select: (cols: string) => {
+      h.selects.push(cols)
+      return chain
+    },
     eq: () => chain,
     single: async () => settle('single'),
     maybeSingle: async () => settle('maybeSingle'),
@@ -55,6 +59,7 @@ describe('GET /api/v1/gold-price', () => {
     h.user = { id: 'user-1' }
     h.row = null
     h.dbError = null
+    h.selects = []
     vi.spyOn(console, 'error').mockImplementation(() => {})
   })
 
@@ -93,5 +98,22 @@ describe('GET /api/v1/gold-price', () => {
     h.dbError = { message: 'connection reset by peer' }
     const res = await GET()
     expect(JSON.stringify(await res.json())).not.toContain('connection reset')
+  })
+
+  // previous_price_per_chi has no consumer today — this route returns it and
+  // useGoalDetailData reads only price_per_chi. That absence is deliberate
+  // (#548, option 2), which is exactly what makes the field an inviting target
+  // for a "drop the unused column" cleanup.
+  //
+  // The response-body assertion above cannot protect it: the route could ask for
+  // price_per_chi alone and still pass, because it echoes back whatever the mock
+  // supplies regardless of what was requested. This pins the request instead.
+  // gold_price_previous_column.test.sql guards the column itself; this guards the
+  // only link between that column and the client.
+  it('asks the database for previous_price_per_chi even though no UI reads it yet', async () => {
+    h.row = PRICE_ROW
+    await GET()
+    expect(h.selects).toHaveLength(1)
+    expect(h.selects[0]).toContain('previous_price_per_chi')
   })
 })

--- a/app/api/v1/gold-price/refresh/route.ts
+++ b/app/api/v1/gold-price/refresh/route.ts
@@ -58,5 +58,9 @@ export async function POST() {
     return NextResponse.json({ error: 'Failed to save gold price' }, { status: 500 })
   }
 
+  // The RPC row is returned whole, so previous_price_per_chi reaches the client
+  // here too. Nothing consumes it: settingsShared's refreshPrices only inspects
+  // res.ok. Deliberate — see #548, option 2, and the column comment in
+  // 20260729000001_document_previous_price_intent.sql.
   return NextResponse.json(data)
 }

--- a/app/api/v1/gold-price/route.ts
+++ b/app/api/v1/gold-price/route.ts
@@ -11,6 +11,14 @@ export async function GET() {
   // would be indistinguishable from a real read failure the moment we start
   // failing closed on errors. With maybeSingle a missing row is `data: null,
   // error: null`, so `error` means only one thing (#533).
+  // previous_price_per_chi is returned but nothing renders it. The only client,
+  // useGoalDetailData, takes price_per_chi and drops the rest — there is no gold
+  // price card in the app; the price is a valuation input, not a displayed quote.
+  // That is a decision, not an oversight (#548, option 2): the column is kept so
+  // a change-since-last-sync indicator stays possible, and the route keeps asking
+  // for it so the field is one edit away from being usable. Removing it from this
+  // select is the cheapest way to silently break that — hence the guard in
+  // __tests__/route.test.ts pinning the request rather than the response.
   const { data, error } = await supabase
     .from('gold_price_settings')
     .select('price_per_chi, previous_price_per_chi, updated_at')

--- a/supabase/migrations/20260729000001_document_previous_price_intent.sql
+++ b/supabase/migrations/20260729000001_document_previous_price_intent.sql
@@ -1,0 +1,32 @@
+-- Record that previous_price_per_chi is deliberately unrendered (#548, option 2).
+--
+-- The column has no consumer. Both endpoints return it — GET /api/v1/gold-price
+-- selects it, POST /api/v1/gold-price/refresh returns the RPC row whole — but
+-- useGoalDetailData reads only price_per_chi, and settingsShared inspects only
+-- res.ok. There is no gold price card anywhere in the app: the price is a
+-- valuation input (dashboard overview, goal detail rows) and an editable prefill
+-- on the sell form, never a displayed quote.
+--
+-- That makes the column look like dead weight, and three separate pieces of work
+-- already hang off it (#528/#546 atomic carry-over, #547 the cron, #542/#543 the
+-- missing migration). This comment exists so the next person reads the absence
+-- of a display as a decision rather than a bug.
+--
+-- Option 2 was chosen over dropping it because keeping it costs nothing — the
+-- two RPCs maintain the pair atomically and are covered by DB tests — while
+-- dropping it would mean a migration plus reverting merged work, to recover an
+-- effort that has already been spent.
+--
+-- The superseded comment from 20260727000001 said the column exists "to show the
+-- change since last sync". No such display was ever built; that phrasing is what
+-- this migration corrects. The original file is left untouched because it has
+-- already run everywhere.
+--
+-- Before any delta UI is built, note that the two writers disagree about what
+-- this value means. The cron runs daily, so it reads as "yesterday's price". The
+-- manual refresh is rate-limited at 10 per 60s, so it reads as "the price before
+-- my last tap" — pressing Sync now twice collapses the day-over-day baseline to
+-- a 0% change. Settle that first.
+
+comment on column public.gold_price_settings.previous_price_per_chi is
+  'Price per chi immediately before the most recent refresh; null on a user''s first refresh. Returned by GET /api/v1/gold-price and POST /api/v1/gold-price/refresh but deliberately not rendered by any UI (#548, option 2) — kept so a change-since-last-sync indicator remains possible. Maintained atomically by refresh_gold_price (per user) and refresh_gold_price_all (cron). Do not drop it as unused without reopening #548.';


### PR DESCRIPTION
Closes #548. Implements **option 2** — decision recorded [here](https://github.com/mphuongth/allocate/issues/548#issuecomment-5111237078).

## Why option 2

Re-checked against `main`. The column still has no consumer: `GET /api/v1/gold-price` selects it and `POST /api/v1/gold-price/refresh` returns the RPC row whole, while `useGoalDetailData.ts:100` takes only `price_per_chi` and `settingsShared.ts:114` inspects only `res.ok`.

Two things in the original issue turned out to be stale, and both pointed away from the other options:

- **#547 is already done** (#562, merged 2026-07-28). The issue argued that deciding now would size #547, but the cron work landed first. Option 3 is no longer "drop the column and #547 goes away" — it now means reverting #562, #546/#528 and #543, four migrations and three DB tests.
- **Option 1's premise was wrong.** There is no gold price card. The price is a valuation input (`dashboard/overview/route.ts:180`, `goalDetailRows.ts:113`) and an editable prefill on the sell form (`addTransactionForms.tsx:319`); the only gold mention in Settings is a legend row on the *Price sync* card showing the last sync **time**. Option 1 means building a new surface.

Keeping the column costs nothing — two RPCs already maintain the pair atomically under DB test — so option 2 is the cheapest correct outcome.

## What changed

**Documentation**, in the three places someone would look before deleting the field:

- `20260729000001_document_previous_price_intent.sql` — a new column comment stating the field is deliberately unrendered, who maintains it, and not to drop it without reopening #548.
- `app/api/v1/gold-price/route.ts` — why the select keeps asking for a field nothing reads.
- `app/api/v1/gold-price/refresh/route.ts` — why the RPC row is returned whole.

The superseded comment from `20260727000001` said the column exists "to show the change since last sync". No such display was ever built. The new comment corrects that; the original file is left untouched because it has already run everywhere.

**A regression guard**, which is the part that actually protects the column and was not in the original acceptance criteria.

`gold_price_previous_column.test.sql` guards the column's existence, so the select was the one unguarded link — and it was genuinely unguarded. The existing GET test mocks `select: () => chain`, discarding its argument, so its `toEqual(PRICE_ROW)` assertion only proves the route echoes back whatever the mock supplies. The route could ask for `price_per_chi` alone and still pass.

The new test captures the select string and asserts the field is requested. I proved it works rather than assuming: removing `previous_price_per_chi` from the route's select turned **only** the new test red —

```
× asks the database for previous_price_per_chi even though no UI reads it yet
  AssertionError: expected 'price_per_chi, updated_at' to contain 'previous_price_per_chi'
  Tests  1 failed | 5 passed (6)
```

— confirming both that the guard bites and that the other five tests never protected the field.

## Deliberately not done

No test asserts the *text* of the column comment. It would pin prose, break on any rewording, and prove nothing about behaviour.

## Left open for whoever builds the delta UI

Recorded in the migration and in the #562 review, not fixed here because it is a product decision: **the two writers disagree about what the value means.** The cron runs daily, so it reads as "yesterday's price". The manual refresh is rate-limited at 10 per 60s, so it reads as "the price before my last tap" — pressing *Sync now* twice collapses the day-over-day baseline to a 0% change.

## Checks

Vitest **1601 passed** (148 files) · `tsc --noEmit` clean · ESLint exit 0 · full DB suite green, including the new migration applied locally and the comment verified via `col_description`.

Full E2E (a migration is in scope, so the broad gate applies): **252 passed, 1 failed** — `assign-goal-desktop.spec.ts:112`, the known flake, 11/11 passing on three isolated re-runs. This PR changes comments and one test file; that spec touches neither.

First E2E attempt failed to start at all: the new worktree had no `.env.e2e` (gitignored), so the dev server came up without Supabase credentials and every page 500'd. Copied the local-stack env in and re-ran — worth noting because the failure looked like a product break rather than a missing file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)