### PR TITLE
fix(hydration): stop seeding state from localStorage during hydration (#560)

### DIFF
--- a/app/(app)/funds/components/__tests__/useFundsData.hydrate.test.tsx
+++ b/app/(app)/funds/components/__tests__/useFundsData.hydrate.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { act } from 'react'
+import { hydrateRoot } from 'react-dom/client'
+import { renderToString } from 'react-dom/server'
+import { useFundsData } from '../useFundsData'
+
+// Real hydration, not a client-only render.
+//
+// The client-only tests in useFundsData.hydration.test.tsx cannot see the
+// ordering that matters here: with no server HTML, useHydrated() is already
+// `true` on the first render, so the cache is adopted before any effect runs.
+// Under real hydration it starts `false`, and the follow-up render is scheduled
+// from the passive-effect flush — the same flush that runs the mount reload()
+// effect, whose first act is bustCache(). Whether the adoption or the bust wins
+// is the whole question, and only a hydrating test can answer it.
+
+const CACHE_KEY = 'fundLibraryCache'
+const CACHED = [{ id: 'cached-1', name: 'Cached Fund', code: 'CF', fund_type: 'stock', nav: 1 }]
+
+let renders: Array<{ loading: boolean; error: boolean; ids: string[] }> = []
+
+function Probe() {
+  const { funds, loading, error } = useFundsData()
+  renders.push({ loading, error, ids: funds.map((f) => (f as { id: string }).id) })
+  return <span>{funds.length}</span>
+}
+
+async function hydrateProbe() {
+  const container = document.createElement('div')
+  container.innerHTML = renderToString(<Probe />)
+  document.body.appendChild(container)
+  renders = []
+  await act(async () => {
+    hydrateRoot(container, <Probe />)
+  })
+  return container
+}
+
+describe('useFundsData — cache survives hydration ordering (#560)', () => {
+  beforeEach(() => {
+    renders = []
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    localStorage.clear()
+    document.body.innerHTML = ''
+  })
+
+  it('shows the cached funds while the refetch is still in flight', async () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ data: CACHED, ts: Date.now() }))
+    // Never settles, so the only thing that can put funds on screen is the cache.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+
+    await hydrateProbe()
+
+    expect(renders[0], 'hydration render must match the server').toEqual({
+      loading: true,
+      error: false,
+      ids: [],
+    })
+    expect(
+      renders[renders.length - 1].ids,
+      'cache was never adopted — the reload effect busted it first',
+    ).toEqual(['cached-1'])
+  })
+
+  it('falls back to the cached list when the refetch fails', async () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ data: CACHED, ts: Date.now() }))
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('nope', { status: 500 })))
+
+    await hydrateProbe()
+
+    // A hook-level contract, deliberately not a claim about the screen: the
+    // views hide the list whenever `error` is set, so the user sees the error
+    // panel either way. What matters here is that the data is still in hand for
+    // a retry or a view that chooses to show it, exactly as before this change.
+    const last = renders[renders.length - 1]
+    expect(last.error).toBe(true)
+    expect(last.ids, 'the cached list was discarded on a failed refetch').toEqual(['cached-1'])
+  })
+})

--- a/app/(app)/funds/components/__tests__/useFundsData.hydration.test.tsx
+++ b/app/(app)/funds/components/__tests__/useFundsData.hydration.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import { useFundsData } from '../useFundsData'
+
+// #560: the fund count hydrated as "1 quỹ" against server HTML that said
+// "0 quỹ", so React discarded the whole /funds subtree and re-rendered it.
+//
+// The cause was reading localStorage from a useState initialiser. Those run
+// during the *hydration* render, and the server has no localStorage — so a warm
+// cache guaranteed the two renders disagreed.
+//
+// The contract this pins: the first render must produce what the server
+// produced, whatever the cache holds. Adopting the cache one render later is
+// what makes it safe, and costs nothing that React wasn't already paying — a
+// mismatch regenerates the subtree anyway.
+
+const CACHE_KEY = 'fundLibraryCache'
+const CACHED = [{ id: 'cached-1', name: 'Cached Fund', code: 'CF', fund_type: 'stock', nav: 1 }]
+const SERVED = [
+  { id: 'served-1', name: 'Served Fund A', code: 'SFA', fund_type: 'stock', nav: 2 },
+  { id: 'served-2', name: 'Served Fund B', code: 'SFB', fund_type: 'stock', nav: 3 },
+]
+
+type Snapshot = { loading: boolean; ids: string[] }
+let renders: Snapshot[] = []
+
+function Probe() {
+  const { funds, loading } = useFundsData()
+  renders.push({ loading, ids: funds.map((f) => (f as { id: string }).id) })
+  return null
+}
+
+describe('useFundsData — hydration safety (#560)', () => {
+  beforeEach(() => {
+    renders = []
+    localStorage.clear()
+    vi.stubGlobal('fetch', vi.fn(async (url: string) => {
+      if (String(url).includes('/api/funds')) {
+        return new Response(JSON.stringify({ funds: SERVED }), { status: 200 })
+      }
+      return new Response(JSON.stringify({ goals: [] }), { status: 200 })
+    }))
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    localStorage.clear()
+  })
+
+  it('first render matches the server even when the cache is warm', () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ data: CACHED, ts: Date.now() }))
+
+    render(<Probe />)
+
+    // The server renders an empty, loading list because it cannot see the cache.
+    // If the client's first render disagrees, that is the mismatch — asserting on
+    // renders[0] rather than the settled state is the whole point of this test.
+    expect(renders[0]).toEqual({ loading: true, ids: [] })
+  })
+
+  it('still adopts the cache immediately after hydration', async () => {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({ data: CACHED, ts: Date.now() }))
+
+    render(<Probe />)
+
+    // The cache must not be abandoned — it exists to avoid a loading flash while
+    // the refetch is in flight. It just arrives one render later than before.
+    const cacheAdopted = renders.find((r) => r.ids.length === 1 && r.ids[0] === 'cached-1')
+    expect(cacheAdopted, 'expected a render showing the cached fund').toBeDefined()
+    expect(cacheAdopted!.loading).toBe(false)
+
+    await waitFor(() => {
+      expect(renders[renders.length - 1].ids).toEqual(['served-1', 'served-2'])
+    })
+  })
+
+  it('starts empty and loading when there is no cache', () => {
+    render(<Probe />)
+    expect(renders[0]).toEqual({ loading: true, ids: [] })
+  })
+
+  it('ignores a cache past its TTL', () => {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({ data: CACHED, ts: Date.now() - 5 * 60 * 1000 }),
+    )
+
+    render(<Probe />)
+
+    expect(renders.every((r) => !r.ids.includes('cached-1'))).toBe(true)
+  })
+})

--- a/app/(app)/funds/components/useFundsData.ts
+++ b/app/(app)/funds/components/useFundsData.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
-import { useHydrated } from '@/lib/useHydrated'
+import { useAdoptCacheOnce } from '@/lib/useHydrated'
 
 // ─── Shared types ─────────────────────────────────────────────────────────────
 
@@ -73,23 +73,17 @@ export function useFundsData(): FundsData {
   const [error, setError] = useState(false)
   const [goals, setGoals] = useState<Goal[]>([])
 
-  // Adopt the cache on the first render after hydration. This keeps what the
-  // cache was for — no loading flash while the refetch is in flight — and costs
-  // nothing net: a mismatch regenerated this tree on the client anyway. Done as
-  // a render-phase adjustment rather than an effect, which is the pattern React
-  // documents for this and which the effect form trips
-  // (react-hooks/set-state-in-effect). It also runs before the reload effect
-  // below, so it still sees the cache that reload() is about to bust.
-  const hydrated = useHydrated()
-  const [cacheAdopted, setCacheAdopted] = useState(false)
-  if (hydrated && !cacheAdopted) {
-    setCacheAdopted(true)
-    const cached = getCache()
-    if (cached) {
-      setFunds(cached)
-      setLoading(false)
-    }
-  }
+  // Adopt the cached list on the first render after hydration, keeping what the
+  // cache was for — no loading flash while the refetch is in flight — without
+  // rendering from localStorage during hydration itself. The hook snapshots the
+  // cache before mount effects run, which matters here because reload()'s first
+  // act is bustCache().
+  useAdoptCacheOnce(getCache, (cached) => {
+    // Functional update: a refetch that has already landed must win over the
+    // older cached list, whichever order the two happen to settle in.
+    setFunds((current) => (current.length > 0 ? current : cached))
+    setLoading(false)
+  })
 
   const reload = useCallback(async () => {
     bustCache()

--- a/app/(app)/funds/components/useFundsData.ts
+++ b/app/(app)/funds/components/useFundsData.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
+import { useHydrated } from '@/lib/useHydrated'
 
 // ─── Shared types ─────────────────────────────────────────────────────────────
 
@@ -63,10 +64,32 @@ function bustCache() {
 // read the same shared state, so the old cross-view 'cairn:funds-updated' event
 // (and its _suppressNotify guard) is no longer needed (#10).
 export function useFundsData(): FundsData {
-  const [funds, setFunds] = useState<Fund[]>(() => getCache() ?? [])
-  const [loading, setLoading] = useState(() => !getCache())
+  // Start where the server starts. These used to seed from getCache(), but a
+  // useState initialiser runs during the *hydration* render, and the server has
+  // no localStorage — so a warm cache made the client render "1 quỹ" over server
+  // HTML that said "0 quỹ" and React threw the whole subtree away (#560).
+  const [funds, setFunds] = useState<Fund[]>([])
+  const [loading, setLoading] = useState(true)
   const [error, setError] = useState(false)
   const [goals, setGoals] = useState<Goal[]>([])
+
+  // Adopt the cache on the first render after hydration. This keeps what the
+  // cache was for — no loading flash while the refetch is in flight — and costs
+  // nothing net: a mismatch regenerated this tree on the client anyway. Done as
+  // a render-phase adjustment rather than an effect, which is the pattern React
+  // documents for this and which the effect form trips
+  // (react-hooks/set-state-in-effect). It also runs before the reload effect
+  // below, so it still sees the cache that reload() is about to bust.
+  const hydrated = useHydrated()
+  const [cacheAdopted, setCacheAdopted] = useState(false)
+  if (hydrated && !cacheAdopted) {
+    setCacheAdopted(true)
+    const cached = getCache()
+    if (cached) {
+      setFunds(cached)
+      setLoading(false)
+    }
+  }
 
   const reload = useCallback(async () => {
     bustCache()

--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -7,7 +7,7 @@ import { useTranslations, useLocale } from 'next-intl'
 import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import MobilePlanningView from './components/MobilePlanningView'
 import DesktopPlanningView from './components/DesktopPlanningView'
-import { useHydrated } from '@/lib/useHydrated'
+import { useAdoptCacheOnce } from '@/lib/useHydrated'
 
 export interface MonthlyPlan {
   id: string
@@ -153,18 +153,19 @@ export default function PlanningClient() {
   const [goals, setGoals] = useState<Goal[]>([])
   const [loading, setLoading] = useState(true)
 
-  // Adopt the cache on the first render after hydration. This preserves what the
-  // cache was for — no skeleton flash while the refetch is in flight — and costs
-  // nothing net, since a mismatch regenerated this tree anyway. Done as a
-  // render-phase adjustment rather than an effect, which is the pattern React
-  // documents for this and which the effect form trips
-  // (react-hooks/set-state-in-effect).
-  const hydrated = useHydrated()
-  const [cacheAdopted, setCacheAdopted] = useState(false)
-  if (hydrated && !cacheAdopted) {
-    setCacheAdopted(true)
-    const cached = getPlanCache(initialMonth, initialYear)
-    if (cached) {
+  // Adopt the cached month on the first render after hydration. This preserves
+  // what the cache was for — no skeleton flash while the refetch is in flight —
+  // and costs nothing net, since a mismatch regenerated this tree anyway.
+  //
+  // The `loading` guard is what keeps a settled fetch from being overwritten by
+  // the older cache. Unlike the fund library, fetchPlan() does not bust on mount,
+  // but it can still land first; and once it has settled, its answer is the right
+  // one even when that answer is "this month has no plan" (404) — showing the
+  // stale month back would be a lie.
+  useAdoptCacheOnce(
+    () => getPlanCache(initialMonth, initialYear),
+    (cached) => {
+      if (!loading) return
       setPlan(cached.plan ?? null)
       setInvestments(cached.investments ?? [])
       setSavings(cached.savings ?? [])
@@ -178,8 +179,8 @@ export default function PlanningClient() {
       setFunds(cached.funds ?? [])
       setGoals(cached.goals ?? [])
       setLoading(false)
-    }
-  }
+    },
+  )
   // A failed load (≠ 404) must not masquerade as the legit "no plan yet" empty
   // state — the API returns 404 only when the month genuinely has no plan.
   const [loadError, setLoadError] = useState(false)

--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -7,6 +7,7 @@ import { useTranslations, useLocale } from 'next-intl'
 import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import MobilePlanningView from './components/MobilePlanningView'
 import DesktopPlanningView from './components/DesktopPlanningView'
+import { useHydrated } from '@/lib/useHydrated'
 
 export interface MonthlyPlan {
   id: string
@@ -132,23 +133,53 @@ export default function PlanningClient() {
   const now = new Date()
   const initialMonth = now.getMonth() + 1
   const initialYear = now.getFullYear()
-  const [initialCache] = useState(() => getPlanCache(initialMonth, initialYear))
-
+  // Start where the server starts. These used to seed from getPlanCache(), but a
+  // useState initialiser runs during the *hydration* render and the server has no
+  // localStorage — so a warm cache made the client render the real cards over
+  // server HTML that held the skeleton, and React discarded the tree (#560).
   const [month, setMonth] = useState(initialMonth)
   const [year, setYear] = useState(initialYear)
-  const [plan, setPlan] = useState<MonthlyPlan | null>(initialCache?.plan ?? null)
-  const [investments, setInvestments] = useState<FundInvestment[]>(initialCache?.investments ?? [])
-  const [savings, setSavings] = useState<DirectSaving[]>(initialCache?.savings ?? [])
-  const [fixedExpenses, setFixedExpenses] = useState<FixedExpense[]>(initialCache?.fixedExpenses ?? [])
-  const [insuranceMembers, setInsuranceMembers] = useState<InsuranceMember[]>(initialCache?.insuranceMembers ?? [])
-  const [otherExpenses, setOtherExpenses] = useState<OtherExpense[]>(initialCache?.otherExpenses ?? [])
-  const [recurringSavings, setRecurringSavings] = useState<RecurringSaving[]>(initialCache?.recurringSavings ?? [])
-  const [recurringSavingOverrides, setRecurringSavingOverrides] = useState<RecurringSavingOverride[]>(initialCache?.recurringSavingOverrides ?? [])
-  const [dcaSkips, setDcaSkips] = useState<DcaSkip[]>(initialCache?.dcaSkips ?? [])
-  const [recurringFulfillments, setRecurringFulfillments] = useState<RecurringFulfillment[]>(initialCache?.recurringFulfillments ?? [])
-  const [funds, setFunds] = useState<Fund[]>(initialCache?.funds ?? [])
-  const [goals, setGoals] = useState<Goal[]>(initialCache?.goals ?? [])
-  const [loading, setLoading] = useState(!initialCache)
+  const [plan, setPlan] = useState<MonthlyPlan | null>(null)
+  const [investments, setInvestments] = useState<FundInvestment[]>([])
+  const [savings, setSavings] = useState<DirectSaving[]>([])
+  const [fixedExpenses, setFixedExpenses] = useState<FixedExpense[]>([])
+  const [insuranceMembers, setInsuranceMembers] = useState<InsuranceMember[]>([])
+  const [otherExpenses, setOtherExpenses] = useState<OtherExpense[]>([])
+  const [recurringSavings, setRecurringSavings] = useState<RecurringSaving[]>([])
+  const [recurringSavingOverrides, setRecurringSavingOverrides] = useState<RecurringSavingOverride[]>([])
+  const [dcaSkips, setDcaSkips] = useState<DcaSkip[]>([])
+  const [recurringFulfillments, setRecurringFulfillments] = useState<RecurringFulfillment[]>([])
+  const [funds, setFunds] = useState<Fund[]>([])
+  const [goals, setGoals] = useState<Goal[]>([])
+  const [loading, setLoading] = useState(true)
+
+  // Adopt the cache on the first render after hydration. This preserves what the
+  // cache was for — no skeleton flash while the refetch is in flight — and costs
+  // nothing net, since a mismatch regenerated this tree anyway. Done as a
+  // render-phase adjustment rather than an effect, which is the pattern React
+  // documents for this and which the effect form trips
+  // (react-hooks/set-state-in-effect).
+  const hydrated = useHydrated()
+  const [cacheAdopted, setCacheAdopted] = useState(false)
+  if (hydrated && !cacheAdopted) {
+    setCacheAdopted(true)
+    const cached = getPlanCache(initialMonth, initialYear)
+    if (cached) {
+      setPlan(cached.plan ?? null)
+      setInvestments(cached.investments ?? [])
+      setSavings(cached.savings ?? [])
+      setFixedExpenses(cached.fixedExpenses ?? [])
+      setInsuranceMembers(cached.insuranceMembers ?? [])
+      setOtherExpenses(cached.otherExpenses ?? [])
+      setRecurringSavings(cached.recurringSavings ?? [])
+      setRecurringSavingOverrides(cached.recurringSavingOverrides ?? [])
+      setDcaSkips(cached.dcaSkips ?? [])
+      setRecurringFulfillments(cached.recurringFulfillments ?? [])
+      setFunds(cached.funds ?? [])
+      setGoals(cached.goals ?? [])
+      setLoading(false)
+    }
+  }
   // A failed load (≠ 404) must not masquerade as the legit "no plan yet" empty
   // state — the API returns 404 only when the month genuinely has no plan.
   const [loadError, setLoadError] = useState(false)

--- a/e2e/hydration.spec.ts
+++ b/e2e/hydration.spec.ts
@@ -43,16 +43,26 @@ test('cached pages hydrate without a mismatch', async ({ page }) => {
     if (HYDRATION_RE.test(err.message)) errors.push(err.message)
   })
 
-  for (const path of ['/funds', '/planning']) {
+  // Each page must be checked against *its own* key. An "either key is present"
+  // check passes on /planning purely because /funds ran first and left
+  // fundLibraryCache behind — so a planning page that cached nothing would sail
+  // through the guard and the reload would prove nothing, which is precisely the
+  // failure this guard exists to prevent.
+  const CACHE_KEY: Record<string, string> = {
+    '/funds': 'fundLibraryCache',
+    '/planning': `planningCache_${MONTH}_${YEAR}`,
+  }
+
+  for (const path of Object.keys(CACHE_KEY)) {
     await page.goto(path)
     await page.waitForLoadState('networkidle')
 
-    // Nothing to hydrate against unless the first load actually cached something.
+    // Nothing to hydrate against unless this page actually cached something.
     const cached = await page.evaluate(() => Object.keys(localStorage))
     expect(
-      cached.some((k) => k.startsWith('fundLibraryCache') || k.startsWith('planningCache_')),
-      `${path} did not warm a cache, so the reload would prove nothing`,
-    ).toBe(true)
+      cached,
+      `${path} did not write ${CACHE_KEY[path]}, so the reload would prove nothing`,
+    ).toContain(CACHE_KEY[path])
 
     errors.length = 0
     await page.reload()

--- a/e2e/hydration.spec.ts
+++ b/e2e/hydration.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test'
+import * as api from './helpers/api'
+import { makeCleanupStack } from './helpers/cleanup'
+
+const cleanup = makeCleanupStack()
+test.afterEach(() => cleanup.run())
+
+// #560. This is one of the few things that genuinely cannot be pinned below E2E:
+// a hydration mismatch needs a real server render and a real browser hydrating
+// against it. The unit tests for useFundsData and useHydrated cover the cause
+// (state seeded from localStorage during the hydration render); this covers the
+// symptom, so a future mismatch anywhere on these pages is a real signal rather
+// than more of the noise that made #560 invisible for so long.
+//
+// The mismatch only shows on a *second* visit. The first load populates the
+// localStorage cache; the reload is what hydrates against it. A single goto
+// would pass even with the bug present.
+
+const today = new Date()
+const MONTH = today.getMonth() + 1
+const YEAR = today.getFullYear()
+
+const HYDRATION_RE = /hydrat|didn't match|did not match|server rendered/i
+
+test('cached pages hydrate without a mismatch', async ({ page }) => {
+  // Both pages only write their cache once there is something to cache, so seed
+  // real rows first — an empty account never warms the cache and the test would
+  // pass without exercising anything.
+  // Reuse this month's plan if an earlier spec left one — (user, month, year) is
+  // unique, so inserting unconditionally would throw. Only clean up a plan this
+  // test created, or it would delete another spec's fixture.
+  const existing = await api.findMonthlyPlan(MONTH, YEAR)
+  if (!existing) {
+    const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 50_000_000 })
+    if (plan?.id) cleanup.add(() => api.deleteMonthlyPlan(plan.id))
+  }
+
+  const errors: string[] = []
+  page.on('console', (msg) => {
+    if (msg.type() === 'error' && HYDRATION_RE.test(msg.text())) errors.push(msg.text())
+  })
+  page.on('pageerror', (err) => {
+    if (HYDRATION_RE.test(err.message)) errors.push(err.message)
+  })
+
+  for (const path of ['/funds', '/planning']) {
+    await page.goto(path)
+    await page.waitForLoadState('networkidle')
+
+    // Nothing to hydrate against unless the first load actually cached something.
+    const cached = await page.evaluate(() => Object.keys(localStorage))
+    expect(
+      cached.some((k) => k.startsWith('fundLibraryCache') || k.startsWith('planningCache_')),
+      `${path} did not warm a cache, so the reload would prove nothing`,
+    ).toBe(true)
+
+    errors.length = 0
+    await page.reload()
+    await page.waitForLoadState('networkidle')
+
+    expect(errors, `hydration mismatch on ${path}: ${errors.join(' | ')}`).toEqual([])
+  }
+})

--- a/lib/__tests__/useHydrated.test.tsx
+++ b/lib/__tests__/useHydrated.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { act } from 'react'
+import { act, useEffect, useState } from 'react'
 import { render } from '@testing-library/react'
 import { hydrateRoot } from 'react-dom/client'
 import { renderToString } from 'react-dom/server'
-import { useHydrated } from '../useHydrated'
+import { useHydrated, useAdoptCacheOnce } from '../useHydrated'
 
 // #560. The whole value of this hook is the *first* value it returns, so that is
 // what these tests assert. A hook that only ever settled on `true` would look
@@ -51,5 +51,99 @@ describe('useHydrated (#560)', () => {
     renders = []
     render(<Probe />)
     expect(renders[0]).toBe(true)
+  })
+})
+
+describe('useAdoptCacheOnce (#560)', () => {
+  it('adopts a cache that a mount effect has already cleared', async () => {
+    // The ordering that broke the first version of this fix, found in review.
+    // The adoption render is scheduled from React's passive-effect flush, and
+    // React drains the rest of that flush before processing it — so a mount
+    // effect that clears the source runs first. Reading the cache at adoption
+    // time therefore always found nothing, silently disabling it.
+    //
+    // Reading `store` inside the effect below is what makes this a real test of
+    // the ordering rather than of the return value: if the hook ever goes back
+    // to reading late, `adopted` stays null and this fails.
+    let store: string | null = 'cached-value'
+    const adopted: Array<string | null> = []
+
+    function Consumer() {
+      const [value, setValue] = useState<string | null>(null)
+      useAdoptCacheOnce(
+        () => store,
+        (cached) => setValue(cached),
+      )
+      // Stands in for the mount refetch, whose first act is to bust the cache.
+      useEffect(() => {
+        store = null
+      }, [])
+      adopted.push(value)
+      return <span>{value ?? 'none'}</span>
+    }
+
+    const container = document.createElement('div')
+    container.innerHTML = renderToString(<Consumer />)
+    document.body.appendChild(container)
+
+    await act(async () => {
+      hydrateRoot(container, <Consumer />)
+    })
+
+    expect(adopted[0], 'hydration render must not use the cache').toBeNull()
+    expect(adopted[adopted.length - 1], 'cache was cleared before adoption').toBe('cached-value')
+
+    container.remove()
+  })
+
+  it('does not call adopt when there is no cache', async () => {
+    let calls = 0
+
+    function Consumer() {
+      useAdoptCacheOnce<string>(
+        () => null,
+        () => { calls++ },
+      )
+      return <span>ok</span>
+    }
+
+    const container = document.createElement('div')
+    container.innerHTML = renderToString(<Consumer />)
+    document.body.appendChild(container)
+
+    await act(async () => {
+      hydrateRoot(container, <Consumer />)
+    })
+
+    expect(calls).toBe(0)
+    container.remove()
+  })
+
+  it('adopts exactly once even across later re-renders', async () => {
+    let calls = 0
+    let bump: (() => void) | null = null
+
+    function Consumer() {
+      const [, setTick] = useState(0)
+      bump = () => setTick((n) => n + 1)
+      useAdoptCacheOnce(
+        () => 'v',
+        () => { calls++ },
+      )
+      return <span>ok</span>
+    }
+
+    const container = document.createElement('div')
+    container.innerHTML = renderToString(<Consumer />)
+    document.body.appendChild(container)
+
+    await act(async () => {
+      hydrateRoot(container, <Consumer />)
+    })
+    await act(async () => { bump!() })
+    await act(async () => { bump!() })
+
+    expect(calls).toBe(1)
+    container.remove()
   })
 })

--- a/lib/__tests__/useHydrated.test.tsx
+++ b/lib/__tests__/useHydrated.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { act } from 'react'
+import { render } from '@testing-library/react'
+import { hydrateRoot } from 'react-dom/client'
+import { renderToString } from 'react-dom/server'
+import { useHydrated } from '../useHydrated'
+
+// #560. The whole value of this hook is the *first* value it returns, so that is
+// what these tests assert. A hook that only ever settled on `true` would look
+// identical under a naive test and would not prevent a single mismatch.
+
+let renders: boolean[] = []
+
+function Probe() {
+  const hydrated = useHydrated()
+  renders.push(hydrated)
+  return <span>{String(hydrated)}</span>
+}
+
+describe('useHydrated (#560)', () => {
+  it('renders false on the server', () => {
+    expect(renderToString(<Probe />)).toContain('false')
+  })
+
+  it('is false for the hydration render, then true', async () => {
+    // This has to hydrate for real. A plain client-side render never consults
+    // getServerSnapshot, so it would report true from the first render and prove
+    // nothing about the case the hook exists for.
+    const container = document.createElement('div')
+    container.innerHTML = renderToString(<Probe />)
+    document.body.appendChild(container)
+
+    renders = []
+    await act(async () => {
+      hydrateRoot(container, <Probe />)
+    })
+
+    expect(renders[0], 'hydration render must agree with the server').toBe(false)
+    expect(renders[renders.length - 1], 'must flip after hydration').toBe(true)
+    // A getSnapshot returning a fresh value each call would re-render forever.
+    expect(renders.slice(1).every((v) => v === true)).toBe(true)
+
+    container.remove()
+  })
+
+  it('is true from the first render on a client-only mount', () => {
+    // Documenting the asymmetry deliberately: with no server HTML to match,
+    // there is nothing to disagree with, so React uses getSnapshot immediately.
+    // Anyone reading only the test above could mistake false-first for a
+    // universal guarantee and write a component that relies on it.
+    renders = []
+    render(<Probe />)
+    expect(renders[0]).toBe(true)
+  })
+})

--- a/lib/useHydrated.ts
+++ b/lib/useHydrated.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useSyncExternalStore } from 'react'
+import { useState, useSyncExternalStore } from 'react'
 
 // The store never changes, so nothing ever needs to be notified. Defined at
 // module scope because useSyncExternalStore re-subscribes whenever `subscribe`
@@ -25,4 +25,34 @@ const onServer = () => false
  */
 export function useHydrated(): boolean {
   return useSyncExternalStore(subscribe, onClient, onServer)
+}
+
+/**
+ * Read a client-only cache without breaking hydration, then hand it to `adopt`
+ * exactly once, on the first render after hydration.
+ *
+ * Two orderings make this easy to get wrong, which is why it lives here instead
+ * of being repeated at each call site:
+ *
+ * 1. **The read must happen during the first render, not at adoption time.** The
+ *    follow-up render is scheduled from React's passive-effect flush, and React
+ *    drains the rest of that flush before processing it — so any mount effect
+ *    that clears the cache (a refetch calling bustCache()) runs first. Reading
+ *    late silently finds nothing and disables the cache entirely.
+ * 2. **`adopt` must not clobber fresher data.** It runs after mount effects have
+ *    started, so a fast refetch may already have landed. Callers should apply the
+ *    cached value with a functional update, or guard on a still-loading flag.
+ *
+ * `adopt` is called during render, so it may only adjust state — the pattern
+ * React documents for deriving state from a changed input.
+ */
+export function useAdoptCacheOnce<T>(read: () => T | null, adopt: (cached: T) => void): void {
+  const [snapshot] = useState(read)
+  const hydrated = useHydrated()
+  const [done, setDone] = useState(false)
+
+  if (hydrated && !done) {
+    setDone(true)
+    if (snapshot !== null && snapshot !== undefined) adopt(snapshot)
+  }
 }

--- a/lib/useHydrated.ts
+++ b/lib/useHydrated.ts
@@ -1,0 +1,28 @@
+'use client'
+
+import { useSyncExternalStore } from 'react'
+
+// The store never changes, so nothing ever needs to be notified. Defined at
+// module scope because useSyncExternalStore re-subscribes whenever `subscribe`
+// changes identity, and an inline arrow would change it on every render.
+const subscribe = () => () => {}
+const onClient = () => true
+const onServer = () => false
+
+/**
+ * `false` while the server renders and during the client's hydration render,
+ * `true` from the first render after hydration.
+ *
+ * This is the safe way to branch on anything the server cannot see —
+ * localStorage above all. Reading such a value from a `useState` initialiser
+ * looks equivalent but is not: initialisers run during the hydration render, so
+ * a warm cache makes the client's tree disagree with the server HTML and React
+ * throws the subtree away and rebuilds it (#560).
+ *
+ * `getServerSnapshot` returning `false` is what makes hydration match;
+ * `getSnapshot` returning `true` is what schedules the follow-up render where
+ * the client-only value can safely be adopted.
+ */
+export function useHydrated(): boolean {
+  return useSyncExternalStore(subscribe, onClient, onServer)
+}


### PR DESCRIPTION
Closes #560.

## The mismatch, with the diff the issue asked for

The issue said the dev-server log truncated the part that names the node. It doesn't — the tree is there, just buried under React's advice block. Stripping ANSI codes and reading past it gives both offenders.

**`/funds`** — `MobileFundLibraryView.tsx:729`, the fund count:

```
<div style={{fontSize:12,color:"var(--c-mu...",paddingLeft:2}}>
+   1 quỹ
-   0 quỹ
  730 |           {t('fundsCount', { count: sortedFunds.length })}
```

**`/planning`** — the skeleton, still in the server HTML while the client had already rendered the real card:

```
+   display: "flex"
-   display: "grid"
-   data-testid="mobile-planning-skeleton"
-   aria-hidden="true"
```

## One cause

Both read a localStorage cache from a `useState` initialiser:

- `useFundsData.ts:66` — `useState(() => getCache() ?? [])`, `useState(() => !getCache())`
- `PlanningClient.tsx:135` — `useState(() => getPlanCache(...))`, feeding twelve more states

Initialisers run during the **hydration** render, and the server has no localStorage. A warm cache therefore *guaranteed* disagreement. React's own advice list names this — "a server/client branch" — but the useState form doesn't look like a branch, which is presumably why it survived so long.

This also explains why `ThemeProvider` was correctly ruled out: it starts `'light'` on both sides, so its correction is post-hydration. Same class of problem, opposite outcome.

## The fix

A new `useHydrated()` hook — `useSyncExternalStore` with `getServerSnapshot() === false` — plus a render-phase adjustment at both call sites: start where the server starts, adopt the cache on the first render after hydration.

The cache still does its job, one render later. That is not a regression in practice: a mismatch made React discard and rebuild the whole subtree on every cached load, so the old code was paying more than the flash it avoided.

I first wrote the adoption as a mount effect. It worked, but tripped `react-hooks/set-state-in-effect` (a warning — the repo currently has zero, and I would rather not spend the first one here). The render-phase form is what React documents for this and matches `useDialogMount` from #555.

## Verified in a browser, not inferred

A Playwright probe logged in, seeded a fund and a monthly plan, loaded each page once to warm the cache, then reloaded — the reload is the part that matters, since a single visit passes even with the bug present.

| | `/funds` | `/planning` |
|---|---|---|
| before | 1 mismatch | 1 mismatch |
| after | 0 | 0 |

Same script, same seeding, files swapped between runs.

The first attempt at this repro reported `/planning` clean, which was wrong and worth recording: `/planning` only writes its cache on `res.ok`, and a brand-new account 404s because it has no plan for the month. An empty fixture made the page look innocent. The E2E spec below asserts a cache was actually warmed for exactly this reason.

## Tests

- `lib/__tests__/useHydrated.test.tsx` — hydrates for real via `renderToString` + `hydrateRoot`. My first version used RTL `render()` and asserted `false` first; that failed, correctly. A client-only mount never consults `getServerSnapshot`, so it reports `true` immediately and proves nothing. Both behaviours are now pinned, the asymmetry deliberately documented so nobody reads false-first as universal. Sabotaging `getServerSnapshot` to return `true` turns 2 of the 3 red.
- `useFundsData.hydration.test.tsx` — asserts on `renders[0]`, the render that has to match the server, rather than the settled state. It went red on the original code with exactly the expected diff (`{loading: false, ids: ['cached-1']}` vs `{loading: true, ids: []}`), and still pins that the cache is adopted, not abandoned.
- `e2e/hydration.spec.ts` — the acceptance criterion "an E2E run produces zero hydration warnings". This is one of the few things that genuinely cannot live lower: it needs a real server render and a real browser hydrating against it. Reverting both source files turns it red.

## Checks

Vitest **1608 passed** (150 files) · `tsc --noEmit` clean · ESLint exit 0, no warnings.

Full E2E: **253 passed, 1 failed** — `assign-goal-desktop.spec.ts:112`, the known flake, 11/11 on three isolated re-runs. And the number this PR is really about:

**Hydration warnings in the full E2E log: 6 → 0.**

## Noted, not fixed

`PlanningClient.tsx:133` calls `new Date()` during render to pick the initial month. That is the same class of hazard — server and client can disagree across a timezone or midnight boundary — but it is not what was firing here, and changing which month the page opens on deserves its own change rather than a drive-by.

🤖 Generated with [Claude Code](https://claude.com/claude-code)