### PR TITLE
security(pwa): isolate authenticated service-worker caches between accounts

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -11,7 +11,7 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   const displayName = (meta.display_name || meta.full_name) as string | undefined
 
   return (
-    <AuthenticatedLayout email={user.email ?? ''} displayName={displayName}>
+    <AuthenticatedLayout userId={user.id} email={user.email ?? ''} displayName={displayName}>
       {children}
     </AuthenticatedLayout>
   )

--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -1,6 +1,8 @@
 import { redirect } from 'next/navigation'
+import { headers } from 'next/headers'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import AuthenticatedLayout from '@/app/components/layouts/AuthenticatedLayout'
+import { buildCacheOwnerScript } from '@/lib/clientCache'
 
 export default async function AppLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createSupabaseServerClient()
@@ -9,10 +11,21 @@ export default async function AppLayout({ children }: { children: React.ReactNod
 
   const meta = user.user_metadata ?? {}
   const displayName = (meta.display_name || meta.full_name) as string | undefined
+  // Per-request CSP nonce set by middleware; undefined in dev, where React omits
+  // the attribute and the inline script runs unrestricted.
+  const nonce = (await headers()).get('x-nonce') ?? undefined
 
   return (
-    <AuthenticatedLayout userId={user.id} email={user.email ?? ''} displayName={displayName}>
-      {children}
-    </AuthenticatedLayout>
+    <>
+      {/* Claims the service worker's cache ownership for this account while the
+          HTML is still parsing — ahead of hydration and of any data fetch, and
+          on entries that no client code precedes, such as the email-confirmation
+          callback redirecting straight here. CacheOwnerAnnouncer below keeps
+          handling every later auth-state change. */}
+      <script nonce={nonce} dangerouslySetInnerHTML={{ __html: buildCacheOwnerScript(user.id) }} />
+      <AuthenticatedLayout userId={user.id} email={user.email ?? ''} displayName={displayName}>
+        {children}
+      </AuthenticatedLayout>
+    </>
   )
 }

--- a/app/(app)/settings/__tests__/settingsShared.test.ts
+++ b/app/(app)/settings/__tests__/settingsShared.test.ts
@@ -14,28 +14,24 @@ vi.mock('@/lib/generateReport', () => ({
   downloadPortfolioPDF: (...args: unknown[]) => downloadPortfolioPDF(...args),
 }))
 
+// The behaviour now lives in lib/clientCache (it also clears the service
+// worker's caches) and is covered by lib/__tests__/clientCache.test.ts; the two
+// settings views import it from here, so only the re-export is asserted.
 describe('clearAppCaches', () => {
   beforeEach(() => localStorage.clear())
 
-  it('removes only app cache keys and leaves unrelated keys intact', () => {
-    localStorage.setItem('dashboardOverviewCache', '1')
-    localStorage.setItem('planningCache_2026-06', '1')
+  it('is re-exported for the settings views', async () => {
+    const { clearAppCaches: fromLib } = await import('@/lib/clientCache')
+    expect(clearAppCaches).toBe(fromLib)
+  })
+
+  it('removes app cache keys', async () => {
     localStorage.setItem('savingsGoalsCache', '1')
-    localStorage.setItem('fixedExpensesCache:bills', '1')
-    localStorage.setItem('insuranceMembersCache', '1')
-    localStorage.setItem('fundLibraryCache', '1')
-    localStorage.setItem('cairn.insuranceCoachDismissed', '1') // unrelated, must survive
     localStorage.setItem('theme', 'dark') // unrelated, must survive
 
-    clearAppCaches()
+    await clearAppCaches()
 
-    expect(localStorage.getItem('dashboardOverviewCache')).toBeNull()
-    expect(localStorage.getItem('planningCache_2026-06')).toBeNull()
     expect(localStorage.getItem('savingsGoalsCache')).toBeNull()
-    expect(localStorage.getItem('fixedExpensesCache:bills')).toBeNull()
-    expect(localStorage.getItem('insuranceMembersCache')).toBeNull()
-    expect(localStorage.getItem('fundLibraryCache')).toBeNull()
-    expect(localStorage.getItem('cairn.insuranceCoachDismissed')).toBe('1')
     expect(localStorage.getItem('theme')).toBe('dark')
   })
 })

--- a/app/(app)/settings/components/DesktopSettingsView.tsx
+++ b/app/(app)/settings/components/DesktopSettingsView.tsx
@@ -251,7 +251,7 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
     if (error) {
       toast.error(t('signOutFailed'))
     } else {
-      clearAppCaches()
+      await clearAppCaches()
       router.push('/auth/login')
     }
   }

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -514,7 +514,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
     if (error) {
       toast.error(t('signOutFailed'))
     } else {
-      clearAppCaches()
+      await clearAppCaches()
       router.push('/auth/login')
     }
   }

--- a/app/(app)/settings/settingsShared.ts
+++ b/app/(app)/settings/settingsShared.ts
@@ -5,22 +5,11 @@
 
 import type { DashboardData } from '@/app/assets/DashboardClient'
 
-// localStorage cache keys cleared on sign-out so the next account never sees
-// the previous user's stale data.
-const APP_CACHE_PREFIXES = [
-  'dashboardOverviewCache',
-  'planningCache_',
-  'savingsGoalsCache',
-  'fixedExpensesCache',
-  'insuranceMembersCache',
-  'fundLibraryCache',
-]
-
-export function clearAppCaches(): void {
-  Object.keys(localStorage)
-    .filter((k) => APP_CACHE_PREFIXES.some((p) => k.startsWith(p)))
-    .forEach((k) => localStorage.removeItem(k))
-}
+// Moved to lib/clientCache so the sign-out in UserMenu shares one definition of
+// "this account's caches" — which now spans the service worker's Cache Storage,
+// not just localStorage. Re-exported here because both settings views already
+// import it from this module.
+export { clearAppCaches } from '@/lib/clientCache'
 
 // Moved to lib/locale so the landing page's toggle can share it; re-exported
 // here because both settings views already import it from this module.

--- a/app/auth/callback/__tests__/route.test.ts
+++ b/app/auth/callback/__tests__/route.test.ts
@@ -26,11 +26,17 @@ beforeEach(() => {
 })
 
 describe('GET /auth/callback — CSP-safe failure navigation (#516)', () => {
-  it('redirects to /dashboard on a successful code exchange', async () => {
+  // Not straight to /dashboard: this is a server redirect, so nothing has told
+  // the service worker that the account changed. If a previous account still
+  // owned the caches, that dashboard navigation could be answered from their
+  // cached HTML — which carries *their* ownership claim and re-asserts it (#565).
+  // /auth/complete hands ownership over first, and has no cached entry of its
+  // own to be served from.
+  it('redirects through the ownership handoff on a successful code exchange', async () => {
     const res = await GET(req('http://localhost/auth/callback?code=good'))
     expect(res.status).toBeGreaterThanOrEqual(300)
     expect(res.status).toBeLessThan(400)
-    expect(res.headers.get('location')).toContain('/dashboard')
+    expect(res.headers.get('location')).toContain('/auth/complete')
   })
 
   it('redirects to the dedicated error page (no inline script) when the exchange fails', async () => {

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -28,7 +28,13 @@ export async function GET(request: NextRequest) {
     const { error } = await supabase.auth.exchangeCodeForSession(code)
 
     if (!error) {
-      return NextResponse.redirect(`${origin}/dashboard`)
+      // Via /auth/complete, not straight to /dashboard: this is a server
+      // redirect, so nothing has told the service worker the account changed.
+      // A dashboard navigation made while a previous account still owns the
+      // caches can be answered from their cached HTML, which re-asserts their
+      // ownership before anything corrects it (#565). /auth/complete hands
+      // ownership over first and has no cached entry of its own.
+      return NextResponse.redirect(`${origin}/auth/complete`)
     }
   }
 

--- a/app/auth/complete/__tests__/page.test.tsx
+++ b/app/auth/complete/__tests__/page.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import CompletePage from '../page'
+
+const clearAppCaches = vi.fn(async () => {})
+vi.mock('@/lib/clientCache', () => ({
+  clearAppCaches: () => clearAppCaches(),
+}))
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+// The email-confirmation callback is a *server* redirect, so no client code has
+// run to tell the service worker the account changed. Landing on /dashboard
+// directly could therefore be answered from a previous account's cached page —
+// which carries that account's own ownership claim and re-asserts it. This page
+// exists to hand ownership over before any authenticated page is requested
+// (#565).
+describe('CompletePage — ownership handoff after the auth callback', () => {
+  let replaceMock: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    clearAppCaches.mockClear()
+    replaceMock = vi.fn()
+    Object.defineProperty(window, 'location', {
+      value: { ...window.location, replace: replaceMock, href: 'http://localhost/auth/complete' },
+      writable: true,
+      configurable: true,
+    })
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('drops the previous account caches before entering the app', async () => {
+    const order: string[] = []
+    clearAppCaches.mockImplementation(async () => { order.push('clear') })
+    replaceMock.mockImplementation(() => { order.push('navigate') })
+
+    render(<CompletePage />)
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith('/dashboard'))
+    expect(order).toEqual(['clear', 'navigate'])
+  })
+
+  it('still enters the app when the caches cannot be cleared', async () => {
+    clearAppCaches.mockRejectedValueOnce(new Error('storage unavailable'))
+
+    render(<CompletePage />)
+
+    await waitFor(() => expect(replaceMock).toHaveBeenCalledWith('/dashboard'))
+  })
+
+  it('tells the user something is happening rather than showing a blank page', () => {
+    render(<CompletePage />)
+
+    expect(screen.getByText(/completingSignIn/i)).toBeInTheDocument()
+  })
+})

--- a/app/auth/complete/page.tsx
+++ b/app/auth/complete/page.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useTranslations } from 'next-intl'
+import { clearAppCaches } from '@/lib/clientCache'
+import { AuthLayout } from '../AuthLayout'
+
+/**
+ * Ownership handoff between the email-confirmation callback and the app (#565).
+ *
+ * `app/auth/callback/route.ts` is a *server* redirect, so no client code has run
+ * to tell the service worker that the account changed. Landing on `/dashboard`
+ * directly means the very first authenticated navigation is made while a
+ * previous account may still own the caches — and if that request fails, the
+ * worker answers it from their cached HTML, which carries their own ownership
+ * claim and re-asserts it before anything can correct the record.
+ *
+ * So the callback lands here first. This route has no cached entry of its own to
+ * be served from: offline, it resolves to the offline fallback, which is safe.
+ * Clearing rather than announcing keeps it simple and fails closed — the new
+ * account starts with a cold cache, which is what a new account on this device
+ * should have.
+ */
+export default function CompletePage() {
+  const t = useTranslations('auth')
+
+  useEffect(() => {
+    // Never strand the user here: entering the app matters more than the purge,
+    // and a browser without Cache Storage has nothing to purge anyway.
+    clearAppCaches()
+      .catch(() => {})
+      .then(() => window.location.replace('/dashboard'))
+  }, [])
+
+  return (
+    <AuthLayout>
+      <div data-testid="auth-card" className="cn-auth-card">
+        <p className="cn-auth-sub" style={{ margin: 0 }}>{t('completingSignIn')}</p>
+      </div>
+    </AuthLayout>
+  )
+}

--- a/app/auth/login/__tests__/LoginPage.test.tsx
+++ b/app/auth/login/__tests__/LoginPage.test.tsx
@@ -3,10 +3,15 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import LoginPage from '../page'
 
-const { signInMock, pushMock, refreshMock } = vi.hoisted(() => ({
+const { signInMock, pushMock, refreshMock, announceCacheOwnerMock } = vi.hoisted(() => ({
   signInMock: vi.fn(),
   pushMock: vi.fn(),
   refreshMock: vi.fn(),
+  announceCacheOwnerMock: vi.fn(async () => {}),
+}))
+
+vi.mock('@/lib/clientCache', () => ({
+  announceCacheOwner: (...args: unknown[]) => announceCacheOwnerMock(...(args as [])),
 }))
 
 vi.mock('next-intl', () => ({
@@ -37,6 +42,8 @@ describe('LoginPage — navigation after successful sign-in', () => {
     signInMock.mockReset()
     pushMock.mockReset()
     refreshMock.mockReset()
+    announceCacheOwnerMock.mockReset()
+    announceCacheOwnerMock.mockResolvedValue(undefined)
     // jsdom does not implement navigation; replace location with a spy so we can
     // observe a full-page navigation without it throwing.
     assignMock = vi.fn()
@@ -68,6 +75,34 @@ describe('LoginPage — navigation after successful sign-in', () => {
     // A soft client-side push must NOT be the mechanism that moves the user off
     // the login route — that is the bug being fixed.
     expect(pushMock).not.toHaveBeenCalled()
+  })
+
+  // The navigation to /dashboard reaches the service worker before the
+  // authenticated layout can mount and announce this account. If the previous
+  // account's ownership were still recorded at that moment, a failed request
+  // would be answered from their cached dashboard (#565).
+  it('hands the service worker the new account before navigating', async () => {
+    signInMock.mockResolvedValue({ data: { user: { id: 'user-b' } }, error: null })
+    const order: string[] = []
+    announceCacheOwnerMock.mockImplementation(async () => { order.push('announce') })
+    assignMock.mockImplementation(() => { order.push('navigate') })
+
+    render(<LoginPage />)
+    await submitLogin()
+
+    await waitFor(() => expect(assignMock).toHaveBeenCalledWith('/dashboard'))
+    expect(announceCacheOwnerMock).toHaveBeenCalledWith('user-b')
+    expect(order).toEqual(['announce', 'navigate'])
+  })
+
+  it('still navigates when the worker cannot be told who signed in', async () => {
+    signInMock.mockResolvedValue({ data: { user: { id: 'user-b' } }, error: null })
+    announceCacheOwnerMock.mockRejectedValueOnce(new Error('no service worker'))
+
+    render(<LoginPage />)
+    await submitLogin()
+
+    await waitFor(() => expect(assignMock).toHaveBeenCalledWith('/dashboard'))
   })
 
   it('stays on the login page and shows an error when credentials are invalid', async () => {

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -7,6 +7,7 @@ import { createBrowserClient } from '@supabase/ssr'
 import { useTranslations } from 'next-intl'
 import { Eye, EyeOff } from 'lucide-react'
 import { AuthLayout } from '../AuthLayout'
+import { announceCacheOwner } from '@/lib/clientCache'
 
 const fieldLabelStyle: React.CSSProperties = {
   fontSize: 11,
@@ -39,12 +40,19 @@ function LoginForm() {
     )
 
     try {
-      const { error } = await supabase.auth.signInWithPassword({ email, password })
+      const { data, error } = await supabase.auth.signInWithPassword({ email, password })
       if (error) {
         setError(t('invalidCredentials'))
         setLoading(false)
       } else {
         setRedirecting(true)
+        // Hand the service worker this account before navigating. The navigation
+        // below reaches the worker before the authenticated layout can mount and
+        // announce, so without this a stale owner left by a session that expired
+        // while the app was closed would still be in force — and a failed
+        // request would be answered from that account's cached pages (#565).
+        // Never block the login on it: the worker is optional.
+        await announceCacheOwner(data?.user?.id ?? '').catch(() => {})
         // Full-page navigation rather than router.push(): this forces the
         // server (middleware in proxy.ts + the (app) layout) to re-read the
         // freshly-set auth cookies on a clean request. A soft client-side push

--- a/app/auth/signup/__tests__/SignupPage.test.tsx
+++ b/app/auth/signup/__tests__/SignupPage.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SignupPage from '../page'
+
+const { signUpMock, pushMock, refreshMock, announceCacheOwnerMock } = vi.hoisted(() => ({
+  signUpMock: vi.fn(),
+  pushMock: vi.fn(),
+  refreshMock: vi.fn(),
+  announceCacheOwnerMock: vi.fn(async () => {}),
+}))
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+}))
+
+vi.mock('@supabase/ssr', () => ({
+  createBrowserClient: () => ({ auth: { signUp: signUpMock } }),
+}))
+
+vi.mock('@/lib/clientCache', () => ({
+  announceCacheOwner: (...args: unknown[]) => announceCacheOwnerMock(...(args as [])),
+}))
+
+async function submitSignup() {
+  await userEvent.type(screen.getByLabelText(/fullNameLabel/i), 'Minh')
+  await userEvent.type(screen.getByLabelText(/emailLabel/i), 'user@example.com')
+  await userEvent.type(screen.getByLabelText(/^passwordLabel/i), 'secret123')
+  await userEvent.click(screen.getByRole('button', { name: /signupBtn/i }))
+}
+
+// A machine where a previous account's session expired while the app was closed
+// still has that account recorded as the service worker's cache owner. A brand
+// new account must take ownership before it reaches the dashboard, or the
+// worker can answer its first failed request from the old account's cache
+// (#565).
+describe('SignupPage — cache ownership', () => {
+  beforeEach(() => {
+    signUpMock.mockReset()
+    pushMock.mockReset()
+    refreshMock.mockReset()
+    announceCacheOwnerMock.mockReset()
+    announceCacheOwnerMock.mockResolvedValue(undefined)
+  })
+
+  it('hands the service worker the new account before routing to the dashboard', async () => {
+    signUpMock.mockResolvedValue({ data: { session: {}, user: { id: 'user-new' } }, error: null })
+    const order: string[] = []
+    announceCacheOwnerMock.mockImplementation(async () => { order.push('announce') })
+    pushMock.mockImplementation(() => { order.push('navigate') })
+
+    render(<SignupPage />)
+    await submitSignup()
+
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/dashboard'))
+    expect(announceCacheOwnerMock).toHaveBeenCalledWith('user-new')
+    expect(order).toEqual(['announce', 'navigate'])
+  })
+
+  it('does not claim ownership when signup only sends a confirmation email', async () => {
+    signUpMock.mockResolvedValue({ data: { session: null, user: { id: 'user-new' } }, error: null })
+
+    render(<SignupPage />)
+    await submitSignup()
+
+    await waitFor(() => expect(signUpMock).toHaveBeenCalled())
+    expect(announceCacheOwnerMock).not.toHaveBeenCalled()
+    expect(pushMock).not.toHaveBeenCalled()
+  })
+})

--- a/app/auth/signup/page.tsx
+++ b/app/auth/signup/page.tsx
@@ -7,6 +7,7 @@ import { createBrowserClient } from '@supabase/ssr'
 import { useTranslations } from 'next-intl'
 import { Eye, EyeOff } from 'lucide-react'
 import { AuthLayout } from '../AuthLayout'
+import { announceCacheOwner } from '@/lib/clientCache'
 
 const fieldLabelStyle: React.CSSProperties = {
   fontSize: 11,
@@ -73,6 +74,11 @@ export default function SignupPage() {
         setConfirmSent(true)
         return
       }
+
+      // Take over the service worker's cache ownership before leaving this page,
+      // so a stale owner left by an earlier account on this machine can't answer
+      // the new account's first failed request (#565). Never block signup on it.
+      await announceCacheOwner(data.user?.id ?? '').catch(() => {})
 
       router.push('/dashboard')
       router.refresh()

--- a/app/components/CacheOwnerAnnouncer.tsx
+++ b/app/components/CacheOwnerAnnouncer.tsx
@@ -2,19 +2,31 @@
 
 import { useEffect } from 'react'
 import { createBrowserClient } from '@supabase/ssr'
-import { announceCacheOwner } from '@/lib/clientCache'
+import { announceCacheOwner, clearAppCaches } from '@/lib/clientCache'
 
 /**
  * Keeps the service worker's authenticated caches attached to the account that
  * owns them (#565).
  *
- * Mounted inside the authenticated layout, so it fires on every app load
- * (`INITIAL_SESSION`) and on every later auth-state change. The worker wipes its
- * `api-v1-*` / `pages-*` caches whenever the announced id differs from the one
- * it recorded — which is what covers the flow sign-out cleanup cannot: a session
- * that expires and is replaced by a different account without any sign-out.
+ * Mounted inside the authenticated layout, so it announces on every app load and
+ * on every later auth-state change. The worker wipes its `api-v1-*` / `pages-*`
+ * caches whenever the announced id differs from the one it recorded — which is
+ * what covers the flows sign-out cleanup cannot reach:
+ *
+ *   • a session that expires and is replaced by a different account, and
+ *   • a session that simply disappears (failed token refresh, revoked token),
+ *     where no sign-out handler ever runs to clear anything.
+ *
+ * `userId` comes from the server component that already resolved the session to
+ * render this layout, so the first announcement doesn't wait on Supabase's own
+ * auth-state round trip — child effects run before this one, so the page's data
+ * fetches would otherwise start against caches still owned by the last account.
  */
-export default function CacheOwnerAnnouncer() {
+export default function CacheOwnerAnnouncer({ userId }: { userId: string }) {
+  useEffect(() => {
+    void announceCacheOwner(userId)
+  }, [userId])
+
   useEffect(() => {
     const supabase = createBrowserClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -22,10 +34,11 @@ export default function CacheOwnerAnnouncer() {
     )
 
     const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
-      const userId = session?.user?.id
-      // No session means signed out or expired; the sign-out path clears the
-      // caches, and the worker refuses to serve them with no owner recorded.
-      if (userId) void announceCacheOwner(userId)
+      const id = session?.user?.id
+      // No session: nothing here is attributable any more, so drop it all rather
+      // than leave the worker holding an owner it can still serve cache for.
+      if (id) void announceCacheOwner(id)
+      else void clearAppCaches()
     })
 
     return () => subscription.unsubscribe()

--- a/app/components/CacheOwnerAnnouncer.tsx
+++ b/app/components/CacheOwnerAnnouncer.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useEffect } from 'react'
+import { createBrowserClient } from '@supabase/ssr'
+import { announceCacheOwner } from '@/lib/clientCache'
+
+/**
+ * Keeps the service worker's authenticated caches attached to the account that
+ * owns them (#565).
+ *
+ * Mounted inside the authenticated layout, so it fires on every app load
+ * (`INITIAL_SESSION`) and on every later auth-state change. The worker wipes its
+ * `api-v1-*` / `pages-*` caches whenever the announced id differs from the one
+ * it recorded — which is what covers the flow sign-out cleanup cannot: a session
+ * that expires and is replaced by a different account without any sign-out.
+ */
+export default function CacheOwnerAnnouncer() {
+  useEffect(() => {
+    const supabase = createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    )
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      const userId = session?.user?.id
+      // No session means signed out or expired; the sign-out path clears the
+      // caches, and the worker refuses to serve them with no owner recorded.
+      if (userId) void announceCacheOwner(userId)
+    })
+
+    return () => subscription.unsubscribe()
+  }, [])
+
+  return null
+}

--- a/app/components/__tests__/CacheOwnerAnnouncer.test.tsx
+++ b/app/components/__tests__/CacheOwnerAnnouncer.test.tsx
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, waitFor } from '@testing-library/react'
 import CacheOwnerAnnouncer from '../CacheOwnerAnnouncer'
 
 const announceCacheOwner = vi.fn()
+const clearAppCaches = vi.fn()
 vi.mock('@/lib/clientCache', () => ({
   announceCacheOwner: (...args: unknown[]) => announceCacheOwner(...args),
+  clearAppCaches: (...args: unknown[]) => clearAppCaches(...args),
 }))
 
 let authCallback: ((event: string, session: unknown) => void) | null = null
@@ -25,34 +27,54 @@ describe('CacheOwnerAnnouncer', () => {
   beforeEach(() => {
     authCallback = null
     announceCacheOwner.mockClear()
+    clearAppCaches.mockClear()
     unsubscribe.mockClear()
   })
-  afterEach(() => vi.unstubAllEnvs())
 
-  it('announces the account already signed in when the app mounts', async () => {
-    render(<CacheOwnerAnnouncer />)
-    authCallback!('INITIAL_SESSION', { user: { id: 'user-a' } })
+  // The server already resolved the session to render this layout, so the id is
+  // known at mount — waiting for Supabase's own auth-state round trip would let
+  // the page's data fetches run first against caches still owned by whoever was
+  // signed in before.
+  it('announces the account the server rendered for, without waiting for an auth event', async () => {
+    render(<CacheOwnerAnnouncer userId="user-a" />)
 
     await waitFor(() => expect(announceCacheOwner).toHaveBeenCalledWith('user-a'))
   })
 
   it('announces the new account when a different user signs in on the same browser', async () => {
-    render(<CacheOwnerAnnouncer />)
-    authCallback!('INITIAL_SESSION', { user: { id: 'user-a' } })
+    render(<CacheOwnerAnnouncer userId="user-a" />)
     authCallback!('SIGNED_IN', { user: { id: 'user-b' } })
 
     await waitFor(() => expect(announceCacheOwner).toHaveBeenLastCalledWith('user-b'))
   })
 
-  it('does not announce anything when there is no session', async () => {
-    render(<CacheOwnerAnnouncer />)
+  // Token-refresh failures and expiries never run a sign-out handler, so this is
+  // the only place that notices the session is gone. Leaving the owner in place
+  // would let the worker keep serving that account's cached data offline.
+  it('clears the caches when the session disappears without a sign-out', async () => {
+    render(<CacheOwnerAnnouncer userId="user-a" />)
+    authCallback!('TOKEN_REFRESHED', null)
+
+    await waitFor(() => expect(clearAppCaches).toHaveBeenCalled())
+  })
+
+  it('clears the caches on sign-out', async () => {
+    render(<CacheOwnerAnnouncer userId="user-a" />)
     authCallback!('SIGNED_OUT', null)
 
-    await waitFor(() => expect(announceCacheOwner).not.toHaveBeenCalled())
+    await waitFor(() => expect(clearAppCaches).toHaveBeenCalled())
+  })
+
+  it('does not clear the caches while the session is healthy', async () => {
+    render(<CacheOwnerAnnouncer userId="user-a" />)
+    authCallback!('TOKEN_REFRESHED', { user: { id: 'user-a' } })
+
+    await waitFor(() => expect(announceCacheOwner).toHaveBeenLastCalledWith('user-a'))
+    expect(clearAppCaches).not.toHaveBeenCalled()
   })
 
   it('unsubscribes on unmount', () => {
-    const { unmount } = render(<CacheOwnerAnnouncer />)
+    const { unmount } = render(<CacheOwnerAnnouncer userId="user-a" />)
     unmount()
 
     expect(unsubscribe).toHaveBeenCalled()

--- a/app/components/__tests__/CacheOwnerAnnouncer.test.tsx
+++ b/app/components/__tests__/CacheOwnerAnnouncer.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, waitFor } from '@testing-library/react'
+import CacheOwnerAnnouncer from '../CacheOwnerAnnouncer'
+
+const announceCacheOwner = vi.fn()
+vi.mock('@/lib/clientCache', () => ({
+  announceCacheOwner: (...args: unknown[]) => announceCacheOwner(...args),
+}))
+
+let authCallback: ((event: string, session: unknown) => void) | null = null
+const unsubscribe = vi.fn()
+
+vi.mock('@supabase/ssr', () => ({
+  createBrowserClient: () => ({
+    auth: {
+      onAuthStateChange: (cb: (event: string, session: unknown) => void) => {
+        authCallback = cb
+        return { data: { subscription: { unsubscribe } } }
+      },
+    },
+  }),
+}))
+
+describe('CacheOwnerAnnouncer', () => {
+  beforeEach(() => {
+    authCallback = null
+    announceCacheOwner.mockClear()
+    unsubscribe.mockClear()
+  })
+  afterEach(() => vi.unstubAllEnvs())
+
+  it('announces the account already signed in when the app mounts', async () => {
+    render(<CacheOwnerAnnouncer />)
+    authCallback!('INITIAL_SESSION', { user: { id: 'user-a' } })
+
+    await waitFor(() => expect(announceCacheOwner).toHaveBeenCalledWith('user-a'))
+  })
+
+  it('announces the new account when a different user signs in on the same browser', async () => {
+    render(<CacheOwnerAnnouncer />)
+    authCallback!('INITIAL_SESSION', { user: { id: 'user-a' } })
+    authCallback!('SIGNED_IN', { user: { id: 'user-b' } })
+
+    await waitFor(() => expect(announceCacheOwner).toHaveBeenLastCalledWith('user-b'))
+  })
+
+  it('does not announce anything when there is no session', async () => {
+    render(<CacheOwnerAnnouncer />)
+    authCallback!('SIGNED_OUT', null)
+
+    await waitFor(() => expect(announceCacheOwner).not.toHaveBeenCalled())
+  })
+
+  it('unsubscribes on unmount', () => {
+    const { unmount } = render(<CacheOwnerAnnouncer />)
+    unmount()
+
+    expect(unsubscribe).toHaveBeenCalled()
+  })
+})

--- a/app/components/layouts/AuthenticatedLayout.tsx
+++ b/app/components/layouts/AuthenticatedLayout.tsx
@@ -86,7 +86,7 @@ function AuthenticatedLayoutInner({ children, email, initials }: { children: Rea
   )
 }
 
-export default function AuthenticatedLayout({ children, email, displayName }: { children: React.ReactNode; email: string; displayName?: string }) {
+export default function AuthenticatedLayout({ children, userId, email, displayName }: { children: React.ReactNode; userId: string; email: string; displayName?: string }) {
   const router = useRouter()
 
   // Watch for session expiry (e.g. token revoked or expired)
@@ -111,7 +111,7 @@ export default function AuthenticatedLayout({ children, email, displayName }: { 
 
   return (
     <NavigationProvider userName={userName}>
-      <CacheOwnerAnnouncer />
+      <CacheOwnerAnnouncer userId={userId} />
       <AuthenticatedLayoutInner email={email} initials={initials}>
         {children}
       </AuthenticatedLayoutInner>

--- a/app/components/layouts/AuthenticatedLayout.tsx
+++ b/app/components/layouts/AuthenticatedLayout.tsx
@@ -10,6 +10,7 @@ import Header from '../navigation/Header'
 import MobileBottomTabs from '../navigation/MobileBottomTabs'
 import MobileTopBar from '../navigation/MobileTopBar'
 import OfflineBanner from '@/app/components/OfflineBanner'
+import CacheOwnerAnnouncer from '@/app/components/CacheOwnerAnnouncer'
 import AddTransactionSheet from '@/app/assets/components/AddTransactionSheet'
 
 function getInitials(email: string): string {
@@ -110,6 +111,7 @@ export default function AuthenticatedLayout({ children, email, displayName }: { 
 
   return (
     <NavigationProvider userName={userName}>
+      <CacheOwnerAnnouncer />
       <AuthenticatedLayoutInner email={email} initials={initials}>
         {children}
       </AuthenticatedLayoutInner>

--- a/app/components/navigation/UserMenu.tsx
+++ b/app/components/navigation/UserMenu.tsx
@@ -5,6 +5,7 @@ import { createBrowserClient } from '@supabase/ssr'
 import { useRouter } from 'next/navigation'
 import { toast } from 'sonner'
 import { useTranslations } from 'next-intl'
+import { clearAppCaches } from '@/lib/clientCache'
 
 export default function UserMenu() {
   const t = useTranslations('auth')
@@ -21,10 +22,9 @@ export default function UserMenu() {
         action: { label: t('retryLabel'), onClick: handleLogout },
       })
     } else {
-      // Clear all page caches on logout
-      Object.keys(localStorage)
-        .filter(k => k.startsWith('dashboardOverviewCache') || k.startsWith('planningCache_') || k.startsWith('savingsGoalsCache') || k.startsWith('fixedExpensesCache') || k.startsWith('insuranceMembersCache') || k.startsWith('fundLibraryCache'))
-        .forEach(k => localStorage.removeItem(k))
+      // Drop this account's caches — localStorage snapshots and the service
+      // worker's authenticated responses — before the next account can sign in.
+      await clearAppCaches()
       toast.success(t('logoutSuccess'))
       router.push('/auth/login')
     }

--- a/lib/__tests__/clientCache.test.ts
+++ b/lib/__tests__/clientCache.test.ts
@@ -110,10 +110,38 @@ describe('clearAppCaches', () => {
 // fetch, and on flows no client code precedes, such as the email-confirmation
 // callback redirecting straight to /dashboard.
 describe('buildCacheOwnerScript', () => {
+  beforeEach(() => localStorage.clear())
+
   function run(script: string, controller: { postMessage: (v: unknown) => void } | null) {
     const nav = { serviceWorker: controller ? { controller } : undefined }
-    new Function('navigator', script)(nav)
+    new Function('navigator', 'localStorage', script)(nav, localStorage)
   }
+
+  // Not every localStorage snapshot is user-keyed — `planningCache_${month}_${year}`
+  // is not — so an account takeover that runs no sign-out handler (visiting
+  // /auth/login directly, or the old session expiring while the app was closed)
+  // would otherwise hand the new account the previous one's plan. This runs
+  // during parse, before anything reads those keys.
+  it('drops local snapshots when a different account takes over', () => {
+    localStorage.setItem('planningCache_6_2026', '1')
+    localStorage.setItem('savingsGoalsCache', '1')
+    localStorage.setItem('theme', 'dark') // unrelated, must survive
+
+    run(buildCacheOwnerScript('user-b'), null)
+
+    expect(localStorage.getItem('planningCache_6_2026')).toBeNull()
+    expect(localStorage.getItem('savingsGoalsCache')).toBeNull()
+    expect(localStorage.getItem('theme')).toBe('dark')
+  })
+
+  it('keeps local snapshots when the same account loads another page', () => {
+    run(buildCacheOwnerScript('user-a'), null)
+    localStorage.setItem('planningCache_6_2026', '1')
+
+    run(buildCacheOwnerScript('user-a'), null)
+
+    expect(localStorage.getItem('planningCache_6_2026')).toBe('1')
+  })
 
   it('claims ownership through the controlling worker', () => {
     const sent: unknown[] = []
@@ -142,8 +170,11 @@ describe('buildCacheOwnerScript', () => {
 })
 
 describe('announceCacheOwner', () => {
-  beforeEach(() => postMessage.mockClear())
-  afterEach(() => Reflect.deleteProperty(navigator, 'serviceWorker'))
+  beforeEach(() => { postMessage.mockClear(); localStorage.clear() })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    Reflect.deleteProperty(navigator, 'serviceWorker')
+  })
 
   it('announces the signed-in account to the controlling worker', async () => {
     stubServiceWorker({ controlled: true })
@@ -181,6 +212,9 @@ describe('announceCacheOwner', () => {
     expect(settled).toBe(true)
   })
 
+  // A timeout is not a completed swap. Callers navigate to the dashboard as
+  // soon as this resolves, so an unacknowledged change must leave nothing the
+  // worker could serve rather than look like success.
   it('gives up waiting rather than hanging when the worker never replies', async () => {
     vi.useFakeTimers()
     stubServiceWorker({ controlled: true, acks: false })
@@ -192,6 +226,31 @@ describe('announceCacheOwner', () => {
     vi.useRealTimers()
   })
 
+  it('deletes the authenticated caches when the swap is never acknowledged', async () => {
+    vi.useFakeTimers()
+    const deleted = stubCacheStorage(['api-v1-v8-tok', 'pages-v8-tok', 'cache-owner-v8', 'static-assets-v8'])
+    stubServiceWorker({ controlled: true, acks: false })
+
+    const pending = announceCacheOwner('user-a')
+    await vi.advanceTimersByTimeAsync(5_000)
+    await pending
+
+    expect(deleted).toContain('api-v1-v8-tok')
+    expect(deleted).toContain('pages-v8-tok')
+    expect(deleted).toContain('cache-owner-v8')
+    expect(deleted).not.toContain('static-assets-v8')
+    vi.useRealTimers()
+  })
+
+  it('leaves the caches alone when the swap is acknowledged', async () => {
+    const deleted = stubCacheStorage(['api-v1-v8-tok', 'pages-v8-tok'])
+    stubServiceWorker({ controlled: true })
+
+    await announceCacheOwner('user-a')
+
+    expect(deleted).toEqual([])
+  })
+
   // Nothing is registered in development, and nothing is registered on the very
   // first production load either. `ready` never settles in that state, so the
   // sign-in that awaits this before navigating would hang forever.
@@ -200,6 +259,25 @@ describe('announceCacheOwner', () => {
 
     await expect(announceCacheOwner('user-a')).resolves.toBeUndefined()
     expect(postMessage).not.toHaveBeenCalled()
+  })
+
+  // No reload happens when another tab swaps the account, so the parse-time
+  // script never runs and this is the only thing that notices.
+  it('drops local snapshots when the account changes without a page load', async () => {
+    localStorage.setItem('planningCache_6_2026', '1')
+
+    await announceCacheOwner('user-b')
+
+    expect(localStorage.getItem('planningCache_6_2026')).toBeNull()
+  })
+
+  it('keeps local snapshots when the same account re-announces', async () => {
+    await announceCacheOwner('user-a')
+    localStorage.setItem('planningCache_6_2026', '1')
+
+    await announceCacheOwner('user-a')
+
+    expect(localStorage.getItem('planningCache_6_2026')).toBe('1')
   })
 
   it('is a no-op without service-worker support', async () => {

--- a/lib/__tests__/clientCache.test.ts
+++ b/lib/__tests__/clientCache.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { clearAppCaches, announceCacheOwner } from '../clientCache'
+import { clearAppCaches, announceCacheOwner, buildCacheOwnerScript } from '../clientCache'
 
 const postMessage = vi.fn()
 
@@ -101,6 +101,43 @@ describe('clearAppCaches', () => {
     await expect(clearAppCaches()).resolves.toBeUndefined()
 
     expect(localStorage.getItem('savingsGoalsCache')).toBeNull()
+  })
+})
+
+// React effects can't win this race: effects run child-first, so the dashboard's
+// data fetch starts before the layout's announcement. An inline script in the
+// authenticated layout runs during HTML parsing — before hydration, before any
+// fetch, and on flows no client code precedes, such as the email-confirmation
+// callback redirecting straight to /dashboard.
+describe('buildCacheOwnerScript', () => {
+  function run(script: string, controller: { postMessage: (v: unknown) => void } | null) {
+    const nav = { serviceWorker: controller ? { controller } : undefined }
+    new Function('navigator', script)(nav)
+  }
+
+  it('claims ownership through the controlling worker', () => {
+    const sent: unknown[] = []
+    run(buildCacheOwnerScript('user-a'), { postMessage: (v) => sent.push(v) })
+
+    expect(sent).toEqual([{ type: 'SET_CACHE_OWNER', userId: 'user-a' }])
+  })
+
+  it('does nothing when the page is not controlled by a worker', () => {
+    expect(() => run(buildCacheOwnerScript('user-a'), null)).not.toThrow()
+  })
+
+  it('cannot break out of the script element', () => {
+    const script = buildCacheOwnerScript('</script><img onerror=alert(1)>')
+
+    expect(script).not.toContain('</script>')
+    expect(script).not.toContain('<')
+  })
+
+  it('embeds the id as data rather than interpolated source', () => {
+    const sent: unknown[] = []
+    run(buildCacheOwnerScript("'); alert(1); ('"), { postMessage: (v) => sent.push(v) })
+
+    expect(sent).toEqual([{ type: 'SET_CACHE_OWNER', userId: "'); alert(1); ('" }])
   })
 })
 

--- a/lib/__tests__/clientCache.test.ts
+++ b/lib/__tests__/clientCache.test.ts
@@ -16,7 +16,7 @@ function stubCacheStorage(names: string[]) {
  * @param acks whether the fake worker replies on the port it is handed, the way
  *   public/sw.js does once the purge has finished.
  */
-function stubServiceWorker({ controlled, acks = true }: { controlled: boolean; acks?: boolean }) {
+function stubServiceWorker({ controlled, acks = true, registered = true }: { controlled: boolean; acks?: boolean; registered?: boolean }) {
   const worker = {
     postMessage: (...args: [unknown, Transferable[]?]) => {
       postMessage(...args)
@@ -26,7 +26,13 @@ function stubServiceWorker({ controlled, acks = true }: { controlled: boolean; a
   }
   Object.defineProperty(navigator, 'serviceWorker', {
     configurable: true,
-    value: { controller: controlled ? worker : null, ready: Promise.resolve({ active: worker }) },
+    value: {
+      controller: controlled ? worker : null,
+      getRegistration: async () => (registered ? { active: worker } : undefined),
+      // Present but never settling, as in a browser with nothing registered —
+      // touching this must not hang the caller.
+      ready: new Promise(() => {}),
+    },
   })
 }
 
@@ -147,6 +153,16 @@ describe('announceCacheOwner', () => {
 
     await expect(pending).resolves.toBeUndefined()
     vi.useRealTimers()
+  })
+
+  // Nothing is registered in development, and nothing is registered on the very
+  // first production load either. `ready` never settles in that state, so the
+  // sign-in that awaits this before navigating would hang forever.
+  it('returns promptly when no worker is registered', async () => {
+    stubServiceWorker({ controlled: false, registered: false })
+
+    await expect(announceCacheOwner('user-a')).resolves.toBeUndefined()
+    expect(postMessage).not.toHaveBeenCalled()
   })
 
   it('is a no-op without service-worker support', async () => {

--- a/lib/__tests__/clientCache.test.ts
+++ b/lib/__tests__/clientCache.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { clearAppCaches, announceCacheOwner } from '../clientCache'
+
+const postMessage = vi.fn()
+
+function stubCacheStorage(names: string[]) {
+  const deleted: string[] = []
+  vi.stubGlobal('caches', {
+    keys: async () => names,
+    delete: async (name: string) => { deleted.push(name); return true },
+  })
+  return deleted
+}
+
+function stubServiceWorker({ controlled }: { controlled: boolean }) {
+  Object.defineProperty(navigator, 'serviceWorker', {
+    configurable: true,
+    value: {
+      controller: controlled ? { postMessage } : null,
+      ready: Promise.resolve({ active: { postMessage } }),
+    },
+  })
+}
+
+describe('clearAppCaches', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    postMessage.mockClear()
+  })
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    Reflect.deleteProperty(navigator, 'serviceWorker')
+  })
+
+  it('removes only app cache keys and leaves unrelated keys intact', async () => {
+    localStorage.setItem('dashboardOverviewCache', '1')
+    localStorage.setItem('planningCache_2026-06', '1')
+    localStorage.setItem('savingsGoalsCache', '1')
+    localStorage.setItem('fixedExpensesCache:bills', '1')
+    localStorage.setItem('insuranceMembersCache', '1')
+    localStorage.setItem('fundLibraryCache', '1')
+    localStorage.setItem('cairn.insuranceCoachDismissed', '1') // unrelated, must survive
+    localStorage.setItem('theme', 'dark') // unrelated, must survive
+
+    await clearAppCaches()
+
+    expect(localStorage.getItem('dashboardOverviewCache')).toBeNull()
+    expect(localStorage.getItem('planningCache_2026-06')).toBeNull()
+    expect(localStorage.getItem('savingsGoalsCache')).toBeNull()
+    expect(localStorage.getItem('fixedExpensesCache:bills')).toBeNull()
+    expect(localStorage.getItem('insuranceMembersCache')).toBeNull()
+    expect(localStorage.getItem('fundLibraryCache')).toBeNull()
+    expect(localStorage.getItem('cairn.insuranceCoachDismissed')).toBe('1')
+    expect(localStorage.getItem('theme')).toBe('dark')
+  })
+
+  it('deletes the authenticated service-worker caches and the owner record', async () => {
+    const deleted = stubCacheStorage(['api-v1-v8', 'pages-v8', 'cache-owner-v8', 'static-assets-v8'])
+
+    await clearAppCaches()
+
+    expect(deleted).toContain('api-v1-v8')
+    expect(deleted).toContain('pages-v8')
+    expect(deleted).toContain('cache-owner-v8')
+  })
+
+  it('leaves static assets cached — they hold no user data', async () => {
+    const deleted = stubCacheStorage(['api-v1-v8', 'static-assets-v8'])
+
+    await clearAppCaches()
+
+    expect(deleted).not.toContain('static-assets-v8')
+  })
+
+  it('tells the active worker to forget the owner', async () => {
+    stubCacheStorage([])
+    stubServiceWorker({ controlled: true })
+
+    await clearAppCaches()
+
+    expect(postMessage).toHaveBeenCalledWith({ type: 'CLEAR_CACHE_OWNER' })
+  })
+
+  it('still clears localStorage where Cache Storage is unavailable', async () => {
+    localStorage.setItem('savingsGoalsCache', '1')
+
+    await expect(clearAppCaches()).resolves.toBeUndefined()
+
+    expect(localStorage.getItem('savingsGoalsCache')).toBeNull()
+  })
+})
+
+describe('announceCacheOwner', () => {
+  beforeEach(() => postMessage.mockClear())
+  afterEach(() => Reflect.deleteProperty(navigator, 'serviceWorker'))
+
+  it('announces the signed-in account to the controlling worker', async () => {
+    stubServiceWorker({ controlled: true })
+
+    await announceCacheOwner('user-a')
+
+    expect(postMessage).toHaveBeenCalledWith({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+  })
+
+  it('waits for the registration when the page is not yet controlled', async () => {
+    stubServiceWorker({ controlled: false })
+
+    await announceCacheOwner('user-b')
+
+    expect(postMessage).toHaveBeenCalledWith({ type: 'SET_CACHE_OWNER', userId: 'user-b' })
+  })
+
+  it('is a no-op without service-worker support', async () => {
+    await expect(announceCacheOwner('user-a')).resolves.toBeUndefined()
+    expect(postMessage).not.toHaveBeenCalled()
+  })
+})

--- a/lib/__tests__/clientCache.test.ts
+++ b/lib/__tests__/clientCache.test.ts
@@ -12,13 +12,21 @@ function stubCacheStorage(names: string[]) {
   return deleted
 }
 
-function stubServiceWorker({ controlled }: { controlled: boolean }) {
+/**
+ * @param acks whether the fake worker replies on the port it is handed, the way
+ *   public/sw.js does once the purge has finished.
+ */
+function stubServiceWorker({ controlled, acks = true }: { controlled: boolean; acks?: boolean }) {
+  const worker = {
+    postMessage: (...args: [unknown, Transferable[]?]) => {
+      postMessage(...args)
+      const port = args[1]?.[0] as MessagePort | undefined
+      if (acks && port) port.postMessage({ ok: true })
+    },
+  }
   Object.defineProperty(navigator, 'serviceWorker', {
     configurable: true,
-    value: {
-      controller: controlled ? { postMessage } : null,
-      ready: Promise.resolve({ active: { postMessage } }),
-    },
+    value: { controller: controlled ? worker : null, ready: Promise.resolve({ active: worker }) },
   })
 }
 
@@ -99,7 +107,10 @@ describe('announceCacheOwner', () => {
 
     await announceCacheOwner('user-a')
 
-    expect(postMessage).toHaveBeenCalledWith({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'SET_CACHE_OWNER', userId: 'user-a' },
+      expect.any(Array),
+    )
   })
 
   it('waits for the registration when the page is not yet controlled', async () => {
@@ -107,7 +118,35 @@ describe('announceCacheOwner', () => {
 
     await announceCacheOwner('user-b')
 
-    expect(postMessage).toHaveBeenCalledWith({ type: 'SET_CACHE_OWNER', userId: 'user-b' })
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: 'SET_CACHE_OWNER', userId: 'user-b' },
+      expect.any(Array),
+    )
+  })
+
+  // The worker purges the previous account's caches while handling the message,
+  // so resolving on `postMessage` alone would let a caller believe the swap is
+  // done while the old entries are still readable.
+  it('resolves only once the worker acknowledges the swap', async () => {
+    stubServiceWorker({ controlled: true })
+    let settled = false
+
+    const pending = announceCacheOwner('user-a').then(() => { settled = true })
+    expect(settled).toBe(false)
+
+    await pending
+    expect(settled).toBe(true)
+  })
+
+  it('gives up waiting rather than hanging when the worker never replies', async () => {
+    vi.useFakeTimers()
+    stubServiceWorker({ controlled: true, acks: false })
+
+    const pending = announceCacheOwner('user-a')
+    await vi.advanceTimersByTimeAsync(5_000)
+
+    await expect(pending).resolves.toBeUndefined()
+    vi.useRealTimers()
   })
 
   it('is a no-op without service-worker support', async () => {

--- a/lib/__tests__/serviceWorker.test.ts
+++ b/lib/__tests__/serviceWorker.test.ts
@@ -46,12 +46,18 @@ type FakeRequest = { url: string; method: string; mode?: string; destination?: s
 
 const keyOf = (req: FakeRequest | string) => (typeof req === 'string' ? req : req.url)
 
+// Cache Storage writes are genuinely slow on real devices, which is what opens
+// the window between announcing an owner and that owner taking effect. Turning
+// this on makes that window real instead of relying on microtask luck.
+const slowWrites = { enabled: false }
+const storageWrite = () => (slowWrites.enabled ? new Promise((r) => setTimeout(r, 1)) : Promise.resolve())
+
 class FakeCache {
   store = new Map<string, FakeResponse>()
-  async put(req: FakeRequest | string, res: FakeResponse) { this.store.set(keyOf(req), res) }
+  async put(req: FakeRequest | string, res: FakeResponse) { await storageWrite(); this.store.set(keyOf(req), res) }
   async add(url: string) { this.store.set(url, new FakeResponse(`offline-fallback:${url}`, { status: 200 })) }
   async match(req: FakeRequest | string) { return this.store.get(keyOf(req)) }
-  async delete(req: FakeRequest | string) { return this.store.delete(keyOf(req)) }
+  async delete(req: FakeRequest | string) { await storageWrite(); return this.store.delete(keyOf(req)) }
 }
 
 class FakeCacheStorage {
@@ -172,6 +178,7 @@ describe('service worker — authenticated cache isolation', () => {
 
   beforeEach(() => {
     blobGate.promise = null
+    slowWrites.enabled = false
     net = makeNetwork()
     sw = loadWorker(net.handler)
   })
@@ -301,6 +308,24 @@ describe('service worker — authenticated cache isolation', () => {
     const offline = await sw.request({ url: DASHBOARD_URL, mode: 'navigate' })
 
     expect(await offline!.text()).not.toContain('user-a-dashboard')
+  })
+
+  // The announcement is a message; the requests that follow it are fetch events.
+  // Nothing makes the worker finish handling the first before answering the
+  // second, so the transition has to hold them itself.
+  it('holds requests behind an ownership change that is still in progress', async () => {
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+    await sw.request({ url: OVERVIEW_URL })
+
+    net.state.online = false
+    slowWrites.enabled = true
+    const swap = sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-b' }) // not awaited
+    const duringSwap = sw.request({ url: OVERVIEW_URL })
+    const [, response] = await Promise.all([swap, duringSwap])
+    slowWrites.enabled = false
+
+    expect(response!.status).toBe(503)
+    expect(await response!.text()).not.toContain('user-a')
   })
 
   // The fallback leaks in the other direction too: a request issued by user A's

--- a/lib/__tests__/serviceWorker.test.ts
+++ b/lib/__tests__/serviceWorker.test.ts
@@ -118,8 +118,8 @@ function loadWorker(networkHandler: (req: FakeRequest) => Promise<FakeResponse>)
       await Promise.all(pending.splice(0))
       return result
     },
-    async message(data: unknown) {
-      await dispatch('message', { data, waitUntil: (p: Promise<unknown>) => { pending.push(p) } })
+    async message(data: unknown, ports?: { postMessage: (v: unknown) => void }[]) {
+      await dispatch('message', { data, ports, waitUntil: (p: Promise<unknown>) => { pending.push(p) } })
     },
     async install() {
       await dispatch('install', { waitUntil: (p: Promise<unknown>) => { pending.push(p) } })
@@ -234,6 +234,24 @@ describe('service worker — authenticated cache isolation', () => {
     const offline = await sw.request({ url: OVERVIEW_URL })
 
     expect(await offline!.text()).toBe('user-a-portfolio')
+  })
+
+  // lib/clientCache.ts waits on this reply before treating the swap as done, so
+  // it must arrive only after the previous account's entries are gone.
+  it('acknowledges an ownership change on the reply port, after the purge', async () => {
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+    await sw.request({ url: OVERVIEW_URL })
+
+    const replies: unknown[] = []
+    const port = {
+      postMessage: (value: unknown) => {
+        // Snapshot at reply time: the API cache must already be gone.
+        replies.push({ value, apiCacheStillPresent: sw.cacheStorage.caches.has('api-v1-v8') })
+      },
+    }
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-b' }, [port])
+
+    expect(replies).toEqual([{ value: { ok: true }, apiCacheStillPresent: false }])
   })
 
   it('keeps static assets cached across accounts — they carry no user data', async () => {

--- a/lib/__tests__/serviceWorker.test.ts
+++ b/lib/__tests__/serviceWorker.test.ts
@@ -149,6 +149,7 @@ function makeNetwork() {
   const handler = async (req: FakeRequest) => {
     if (!state.online) throw new Error('offline')
     if (state.hold) await state.hold
+    if (!state.online) throw new Error('offline') // the network can die while held
     const isPage = req.mode === 'navigate'
     return new FakeResponse(isPage ? state.page : state.body, { status: 200 })
   }
@@ -300,6 +301,53 @@ describe('service worker — authenticated cache isolation', () => {
     const offline = await sw.request({ url: DASHBOARD_URL, mode: 'navigate' })
 
     expect(await offline!.text()).not.toContain('user-a-dashboard')
+  })
+
+  // The fallback leaks in the other direction too: a request issued by user A's
+  // still-open tab must not be answered from the partition of whoever owns the
+  // cache by the time that request gives up.
+  it('does not answer a request from the account that took over mid-request', async () => {
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+
+    const gate = deferred()
+    net.state.hold = gate.promise
+    const aInFlight = sw.request({ url: OVERVIEW_URL })   // user A's tab, held
+    await flush()
+    net.state.hold = null
+
+    // User B signs in on another tab and populates the same endpoint.
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-b' })
+    net.state.body = 'user-b-portfolio'
+    await sw.request({ url: OVERVIEW_URL })
+
+    // A's request then fails, long after ownership moved on.
+    net.state.online = false
+    gate.release()
+    const aResponse = await aInFlight
+
+    expect(aResponse!.status).toBe(503)
+    expect(await aResponse!.text()).not.toContain('user-b')
+  })
+
+  it('does not answer a navigation from the account that took over mid-request', async () => {
+    await sw.install()
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+
+    const gate = deferred()
+    net.state.hold = gate.promise
+    const aInFlight = sw.request({ url: DASHBOARD_URL, mode: 'navigate' })
+    await flush()
+    net.state.hold = null
+
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-b' })
+    net.state.page = '<html>user-b-dashboard</html>'
+    await sw.request({ url: DASHBOARD_URL, mode: 'navigate' })
+
+    net.state.online = false
+    gate.release()
+    const aResponse = await aInFlight
+
+    expect(await aResponse!.text()).not.toContain('user-b-dashboard')
   })
 
   // Checking ownership and then writing are separated by asynchronous work

--- a/lib/__tests__/serviceWorker.test.ts
+++ b/lib/__tests__/serviceWorker.test.ts
@@ -22,6 +22,10 @@ class FakeHeaders {
   set(key: string, value: string) { this.map.set(key.toLowerCase(), value) }
 }
 
+// Lets a test suspend a response mid-read, to land an owner switch inside the
+// window between the worker checking ownership and completing the cache write.
+const blobGate: { promise: Promise<void> | null } = { promise: null }
+
 class FakeResponse {
   status: number
   statusText: string
@@ -33,7 +37,7 @@ class FakeResponse {
   }
   get ok() { return this.status >= 200 && this.status < 300 }
   clone() { return new FakeResponse(this.body, { status: this.status, statusText: this.statusText, headers: this.headers }) }
-  async blob() { return this.body }
+  async blob() { if (blobGate.promise) await blobGate.promise; return this.body }
   async text() { return typeof this.body === 'string' ? this.body : JSON.stringify(this.body) }
   async json() { return typeof this.body === 'string' ? JSON.parse(this.body) : this.body }
 }
@@ -124,6 +128,9 @@ function loadWorker(networkHandler: (req: FakeRequest) => Promise<FakeResponse>)
     async install() {
       await dispatch('install', { waitUntil: (p: Promise<unknown>) => { pending.push(p) } })
     },
+    async activate() {
+      await dispatch('activate', { waitUntil: (p: Promise<unknown>) => { pending.push(p) } })
+    },
   }
 }
 
@@ -148,6 +155,10 @@ function makeNetwork() {
   return { state, handler }
 }
 
+/** Authenticated API cache partitions currently in storage. */
+const apiPartitions = (sw: ReturnType<typeof loadWorker>) =>
+  [...sw.cacheStorage.caches.keys()].filter((name) => name.startsWith('api-v1-'))
+
 function deferred() {
   let release: () => void = () => {}
   const promise = new Promise<void>((resolve) => { release = resolve })
@@ -159,9 +170,12 @@ describe('service worker — authenticated cache isolation', () => {
   let sw: ReturnType<typeof loadWorker>
 
   beforeEach(() => {
+    blobGate.promise = null
     net = makeNetwork()
     sw = loadWorker(net.handler)
   })
+
+  const flush = () => new Promise((resolve) => setTimeout(resolve, 0))
 
   it('serves user A their own cached API response while offline', async () => {
     await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
@@ -288,6 +302,30 @@ describe('service worker — authenticated cache isolation', () => {
     expect(await offline!.text()).not.toContain('user-a-dashboard')
   })
 
+  // Checking ownership and then writing are separated by asynchronous work
+  // (reading the body), so a check-then-write design still has a window where
+  // the account can change in between. Ownership must decide *where* the write
+  // goes, not merely whether it is allowed.
+  it('does not store a response under the new account when ownership changes while the write is prepared', async () => {
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+
+    const gate = deferred()
+    blobGate.promise = gate.promise
+    const inFlight = sw.request({ url: OVERVIEW_URL })
+    await flush() // let the response land and the worker reach the body read
+
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-b' })
+    gate.release()
+    blobGate.promise = null
+    await inFlight
+
+    net.state.online = false
+    const offline = await sw.request({ url: OVERVIEW_URL })
+
+    expect(offline!.status).toBe(503)
+    expect(await offline!.text()).not.toContain('user-a')
+  })
+
   // lib/clientCache.ts waits on this reply before treating the swap as done, so
   // it must arrive only after the previous account's entries are gone.
   it('acknowledges an ownership change on the reply port, after the purge', async () => {
@@ -297,13 +335,40 @@ describe('service worker — authenticated cache isolation', () => {
     const replies: unknown[] = []
     const port = {
       postMessage: (value: unknown) => {
-        // Snapshot at reply time: the API cache must already be gone.
-        replies.push({ value, apiCacheStillPresent: sw.cacheStorage.caches.has('api-v1-v8') })
+        // Snapshot at reply time: user A's partition must already be swept.
+        replies.push({ value, apiPartitionsLeft: apiPartitions(sw).length })
       },
     }
     await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-b' }, [port])
 
-    expect(replies).toEqual([{ value: { ok: true }, apiCacheStillPresent: false }])
+    expect(replies).toEqual([{ value: { ok: true }, apiPartitionsLeft: 0 }])
+  })
+
+  it('sweeps the previous account partition instead of accumulating one per switch', async () => {
+    for (const userId of ['user-a', 'user-b', 'user-c']) {
+      await sw.message({ type: 'SET_CACHE_OWNER', userId })
+      await sw.request({ url: OVERVIEW_URL })
+    }
+
+    expect(apiPartitions(sw)).toHaveLength(1)
+  })
+
+  it('names partitions opaquely, so cache names do not enumerate the accounts used here', async () => {
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+    await sw.request({ url: OVERVIEW_URL })
+
+    expect(apiPartitions(sw)).toHaveLength(1)
+    expect(apiPartitions(sw).join()).not.toContain('user-a')
+  })
+
+  it('drops the unattributed caches left by the previous worker version on activate', async () => {
+    sw.cacheStorage.caches.set('api-v1-v7', new FakeCache())
+    sw.cacheStorage.caches.set('pages-v7', new FakeCache())
+
+    await sw.activate()
+
+    expect(await sw.cacheStorage.has('api-v1-v7')).toBe(false)
+    expect(await sw.cacheStorage.has('pages-v7')).toBe(false)
   })
 
   it('keeps static assets cached across accounts — they carry no user data', async () => {

--- a/lib/__tests__/serviceWorker.test.ts
+++ b/lib/__tests__/serviceWorker.test.ts
@@ -1,0 +1,249 @@
+// Exercises the real production service worker (public/sw.js) against a fake
+// Cache Storage / fetch environment. The worker only registers in production
+// (ServiceWorkerRegistration bails out otherwise), so no browser-level test
+// covers it — but it is the layer that decides whether one account's cached
+// portfolio data can be handed to the next account on a shared browser (#565).
+
+import { describe, it, expect, beforeEach } from 'vitest'
+import { readFileSync } from 'fs'
+import path from 'path'
+
+// ── Minimal fetch-API doubles ────────────────────────────────────────────────
+// jsdom ships no Cache Storage and no Response, and the worker only needs a
+// narrow slice of each, so hand-rolled doubles keep the harness hermetic.
+
+class FakeHeaders {
+  private map = new Map<string, string>()
+  constructor(init?: FakeHeaders | Record<string, string>) {
+    if (init instanceof FakeHeaders) init.map.forEach((v, k) => this.map.set(k, v))
+    else if (init) Object.entries(init).forEach(([k, v]) => this.map.set(k.toLowerCase(), v))
+  }
+  get(key: string) { return this.map.get(key.toLowerCase()) ?? null }
+  set(key: string, value: string) { this.map.set(key.toLowerCase(), value) }
+}
+
+class FakeResponse {
+  status: number
+  statusText: string
+  headers: FakeHeaders
+  constructor(public body: unknown, init: { status?: number; statusText?: string; headers?: FakeHeaders | Record<string, string> } = {}) {
+    this.status = init.status ?? 200
+    this.statusText = init.statusText ?? ''
+    this.headers = init.headers instanceof FakeHeaders ? new FakeHeaders(init.headers) : new FakeHeaders(init.headers)
+  }
+  get ok() { return this.status >= 200 && this.status < 300 }
+  clone() { return new FakeResponse(this.body, { status: this.status, statusText: this.statusText, headers: this.headers }) }
+  async blob() { return this.body }
+  async text() { return typeof this.body === 'string' ? this.body : JSON.stringify(this.body) }
+  async json() { return typeof this.body === 'string' ? JSON.parse(this.body) : this.body }
+}
+
+type FakeRequest = { url: string; method: string; mode?: string; destination?: string }
+
+const keyOf = (req: FakeRequest | string) => (typeof req === 'string' ? req : req.url)
+
+class FakeCache {
+  store = new Map<string, FakeResponse>()
+  async put(req: FakeRequest | string, res: FakeResponse) { this.store.set(keyOf(req), res) }
+  async add(url: string) { this.store.set(url, new FakeResponse(`offline-fallback:${url}`, { status: 200 })) }
+  async match(req: FakeRequest | string) { return this.store.get(keyOf(req)) }
+  async delete(req: FakeRequest | string) { return this.store.delete(keyOf(req)) }
+}
+
+class FakeCacheStorage {
+  caches = new Map<string, FakeCache>()
+  async open(name: string) {
+    if (!this.caches.has(name)) this.caches.set(name, new FakeCache())
+    return this.caches.get(name)!
+  }
+  async keys() { return [...this.caches.keys()] }
+  async delete(name: string) { return this.caches.delete(name) }
+  async has(name: string) { return this.caches.has(name) }
+  async match(req: FakeRequest | string) {
+    for (const cache of this.caches.values()) {
+      const hit = await cache.match(req)
+      if (hit) return hit
+    }
+    return undefined
+  }
+}
+
+// ── Worker harness ───────────────────────────────────────────────────────────
+
+const SW_SOURCE = readFileSync(path.resolve(__dirname, '../../public/sw.js'), 'utf8')
+
+type Listener = (event: Record<string, unknown>) => void
+
+function loadWorker(networkHandler: (req: FakeRequest) => Promise<FakeResponse>) {
+  const listeners = new Map<string, Listener[]>()
+  const pending: Promise<unknown>[] = []
+  const cacheStorage = new FakeCacheStorage()
+
+  const self = {
+    addEventListener: (type: string, fn: Listener) => {
+      listeners.set(type, [...(listeners.get(type) ?? []), fn])
+    },
+    skipWaiting: () => {},
+    clients: { claim: async () => {} },
+  }
+
+  const fetchImpl = async (req: FakeRequest, init?: { signal?: AbortSignal }) => {
+    if (init?.signal?.aborted) throw new Error('aborted')
+    return networkHandler(req)
+  }
+
+  const factory = new Function(
+    'self', 'caches', 'fetch', 'Response', 'Headers', 'URL', 'AbortController', 'setTimeout', 'clearTimeout',
+    SW_SOURCE,
+  )
+  factory(self, cacheStorage, fetchImpl, FakeResponse, FakeHeaders, URL, AbortController, setTimeout, clearTimeout)
+
+  const dispatch = async (type: string, event: Record<string, unknown>) => {
+    for (const fn of listeners.get(type) ?? []) await fn(event)
+    await Promise.all(pending.splice(0))
+  }
+
+  return {
+    cacheStorage,
+    /** Drive a GET through the worker's fetch handler; undefined = worker passed through. */
+    async request(req: Partial<FakeRequest> & { url: string }) {
+      const request: FakeRequest = { method: 'GET', ...req }
+      let responded: Promise<FakeResponse> | undefined
+      await dispatch('fetch', {
+        request,
+        respondWith: (p: Promise<FakeResponse>) => { responded = p },
+        waitUntil: (p: Promise<unknown>) => { pending.push(p) },
+      })
+      const result = responded ? await responded : undefined
+      await Promise.all(pending.splice(0))
+      return result
+    },
+    async message(data: unknown) {
+      await dispatch('message', { data, waitUntil: (p: Promise<unknown>) => { pending.push(p) } })
+    },
+    async install() {
+      await dispatch('install', { waitUntil: (p: Promise<unknown>) => { pending.push(p) } })
+    },
+  }
+}
+
+const OVERVIEW_URL = 'https://cairn.app/api/v1/dashboard/overview'
+const DASHBOARD_URL = 'https://cairn.app/dashboard'
+
+/** Network that serves per-account payloads, and can be switched offline. */
+function makeNetwork() {
+  const state = { online: true, body: 'user-a-portfolio', page: '<html>user-a-dashboard</html>' }
+  const handler = async (req: FakeRequest) => {
+    if (!state.online) throw new Error('offline')
+    const isPage = req.mode === 'navigate'
+    return new FakeResponse(isPage ? state.page : state.body, { status: 200 })
+  }
+  return { state, handler }
+}
+
+describe('service worker — authenticated cache isolation', () => {
+  let net: ReturnType<typeof makeNetwork>
+  let sw: ReturnType<typeof loadWorker>
+
+  beforeEach(() => {
+    net = makeNetwork()
+    sw = loadWorker(net.handler)
+  })
+
+  it('serves user A their own cached API response while offline', async () => {
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+    await sw.request({ url: OVERVIEW_URL })
+
+    net.state.online = false
+    const offline = await sw.request({ url: OVERVIEW_URL })
+
+    expect(await offline!.text()).toBe('user-a-portfolio')
+  })
+
+  it('never returns user A cached API data after a logout and login as user B', async () => {
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+    await sw.request({ url: OVERVIEW_URL })
+    expect(await (await sw.request({ url: OVERVIEW_URL }))!.text()).toBe('user-a-portfolio')
+
+    // Sign out, then user B signs in on the same browser profile.
+    await sw.message({ type: 'CLEAR_CACHE_OWNER' })
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-b' })
+
+    // B goes offline before replacing the cached URL.
+    net.state.online = false
+    const offline = await sw.request({ url: OVERVIEW_URL })
+
+    expect(offline!.status).toBe(503)
+    expect(await offline!.text()).not.toContain('user-a')
+  })
+
+  it('never returns user A cached data when the session expires and user B signs in without an explicit logout', async () => {
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+    await sw.request({ url: OVERVIEW_URL })
+
+    // Session expiry leaves no logout; the next account simply announces itself.
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-b' })
+
+    net.state.online = false
+    const offline = await sw.request({ url: OVERVIEW_URL })
+
+    expect(offline!.status).toBe(503)
+    expect(await offline!.text()).not.toContain('user-a')
+  })
+
+  it('does not serve user A cached page HTML to user B offline', async () => {
+    await sw.install()
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+    await sw.request({ url: DASHBOARD_URL, mode: 'navigate' })
+
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-b' })
+    net.state.online = false
+    const offline = await sw.request({ url: DASHBOARD_URL, mode: 'navigate' })
+
+    expect(await offline!.text()).not.toContain('user-a-dashboard')
+  })
+
+  it('falls back to the offline page rather than a cached page when no account is known', async () => {
+    await sw.install()
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+    await sw.request({ url: DASHBOARD_URL, mode: 'navigate' })
+    await sw.message({ type: 'CLEAR_CACHE_OWNER' })
+
+    net.state.online = false
+    const offline = await sw.request({ url: DASHBOARD_URL, mode: 'navigate' })
+
+    expect(await offline!.text()).not.toContain('user-a-dashboard')
+  })
+
+  it('does not cache authenticated responses fetched before any account is announced', async () => {
+    await sw.request({ url: OVERVIEW_URL })
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-b' })
+
+    net.state.online = false
+    const offline = await sw.request({ url: OVERVIEW_URL })
+
+    expect(offline!.status).toBe(503)
+  })
+
+  it('keeps the cache when the same account re-announces itself', async () => {
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+    await sw.request({ url: OVERVIEW_URL })
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+
+    net.state.online = false
+    const offline = await sw.request({ url: OVERVIEW_URL })
+
+    expect(await offline!.text()).toBe('user-a-portfolio')
+  })
+
+  it('keeps static assets cached across accounts — they carry no user data', async () => {
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+    await sw.request({ url: 'https://cairn.app/_next/static/chunk.js' })
+
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-b' })
+    net.state.online = false
+    const asset = await sw.request({ url: 'https://cairn.app/_next/static/chunk.js' })
+
+    expect(asset!.status).toBe(200)
+  })
+})

--- a/lib/__tests__/serviceWorker.test.ts
+++ b/lib/__tests__/serviceWorker.test.ts
@@ -130,15 +130,28 @@ function loadWorker(networkHandler: (req: FakeRequest) => Promise<FakeResponse>)
 const OVERVIEW_URL = 'https://cairn.app/api/v1/dashboard/overview'
 const DASHBOARD_URL = 'https://cairn.app/dashboard'
 
-/** Network that serves per-account payloads, and can be switched offline. */
+/** Network that serves per-account payloads, can go offline, and can be held mid-request. */
 function makeNetwork() {
-  const state = { online: true, body: 'user-a-portfolio', page: '<html>user-a-dashboard</html>' }
+  const state = {
+    online: true,
+    body: 'user-a-portfolio',
+    page: '<html>user-a-dashboard</html>',
+    /** When set, responses wait on this — lets a test interleave a message with an in-flight fetch. */
+    hold: null as Promise<void> | null,
+  }
   const handler = async (req: FakeRequest) => {
     if (!state.online) throw new Error('offline')
+    if (state.hold) await state.hold
     const isPage = req.mode === 'navigate'
     return new FakeResponse(isPage ? state.page : state.body, { status: 200 })
   }
   return { state, handler }
+}
+
+function deferred() {
+  let release: () => void = () => {}
+  const promise = new Promise<void>((resolve) => { release = resolve })
+  return { promise, release }
 }
 
 describe('service worker — authenticated cache isolation', () => {
@@ -234,6 +247,45 @@ describe('service worker — authenticated cache isolation', () => {
     const offline = await sw.request({ url: OVERVIEW_URL })
 
     expect(await offline!.text()).toBe('user-a-portfolio')
+  })
+
+  // A request issued under user A can still be in flight when user B announces
+  // themselves. Checking only that *some* owner exists once the response lands
+  // would file A's data under B's ownership.
+  it('does not store a response fetched for the previous account when the owner changes mid-request', async () => {
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+
+    const gate = deferred()
+    net.state.hold = gate.promise
+    const inFlight = sw.request({ url: OVERVIEW_URL })       // user A's fetch, not yet resolved
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-b' })
+    gate.release()
+    await inFlight
+
+    net.state.hold = null
+    net.state.online = false
+    const offline = await sw.request({ url: OVERVIEW_URL })
+
+    expect(offline!.status).toBe(503)
+    expect(await offline!.text()).not.toContain('user-a')
+  })
+
+  it('does not store page HTML fetched for the previous account when the owner changes mid-request', async () => {
+    await sw.install()
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-a' })
+
+    const gate = deferred()
+    net.state.hold = gate.promise
+    const inFlight = sw.request({ url: DASHBOARD_URL, mode: 'navigate' })
+    await sw.message({ type: 'SET_CACHE_OWNER', userId: 'user-b' })
+    gate.release()
+    await inFlight
+
+    net.state.hold = null
+    net.state.online = false
+    const offline = await sw.request({ url: DASHBOARD_URL, mode: 'navigate' })
+
+    expect(await offline!.text()).not.toContain('user-a-dashboard')
   })
 
   // lib/clientCache.ts waits on this reply before treating the swap as done, so

--- a/lib/clientCache.ts
+++ b/lib/clientCache.ts
@@ -25,6 +25,10 @@ const APP_CACHE_PREFIXES = [
 // purpose: chunks, images and fonts are identical for every account.
 const SW_USER_CACHE_PREFIXES = ['api-v1-', 'pages-', 'cache-owner-']
 
+// Which account the localStorage snapshots above belong to. Mirrors the worker's
+// own owner record, for the half of the caching the worker can't see.
+const LOCAL_OWNER_KEY = 'cairn.cacheOwner'
+
 function getServiceWorkerContainer(): ServiceWorkerContainer | null {
   if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return null
   return navigator.serviceWorker
@@ -46,8 +50,19 @@ function getServiceWorkerContainer(): ServiceWorkerContainer | null {
 export function buildCacheOwnerScript(userId: string): string {
   // Serialised as data, with `<` escaped so the payload can't close the script
   // element — the id reaches us from the session, not from source we control.
-  const payload = JSON.stringify({ type: 'SET_CACHE_OWNER', userId }).replace(/</g, '\\u003c')
-  return `try{navigator.serviceWorker.controller.postMessage(${payload})}catch(e){}`
+  const esc = (value: unknown) => JSON.stringify(value).replace(/</g, '\\u003c')
+
+  // Not every localStorage snapshot is keyed by user — `planningCache_${month}_${year}`
+  // is not — so an account takeover that runs no sign-out handler would leave the
+  // new account reading the previous one's data. Done synchronously here, ahead
+  // of any component that reads those keys.
+  return (
+    `try{var o=${esc(LOCAL_OWNER_KEY)},u=${esc(userId)},p=${esc(APP_CACHE_PREFIXES)};` +
+    `if(localStorage.getItem(o)!==u){` +
+    `Object.keys(localStorage).forEach(function(k){if(p.some(function(x){return k.indexOf(x)===0}))localStorage.removeItem(k)});` +
+    `localStorage.setItem(o,u)}}catch(e){}` +
+    `try{navigator.serviceWorker.controller.postMessage({type:"SET_CACHE_OWNER",userId:${esc(userId)}})}catch(e){}`
+  )
 }
 
 // How long to wait for the worker to confirm an ownership change before giving
@@ -68,6 +83,11 @@ const OWNER_ACK_TIMEOUT_MS = 3_000
  * taken effect yet.
  */
 export async function announceCacheOwner(userId: string): Promise<void> {
+  // The parse-time script does this for a page load; this covers an account
+  // change while the app stays open, e.g. signing in as someone else in another
+  // tab, where nothing reloads and the snapshots would otherwise linger.
+  adoptLocalOwner(userId)
+
   const container = getServiceWorkerContainer()
   if (!container) return
 
@@ -87,10 +107,15 @@ export async function announceCacheOwner(userId: string): Promise<void> {
 
   let timer: ReturnType<typeof setTimeout> | undefined
   try {
-    await Promise.race([
-      acknowledged,
-      new Promise<void>((resolve) => { timer = setTimeout(resolve, OWNER_ACK_TIMEOUT_MS) }),
+    const acked = await Promise.race([
+      acknowledged.then(() => true),
+      new Promise<boolean>((resolve) => { timer = setTimeout(() => resolve(false), OWNER_ACK_TIMEOUT_MS) }),
     ])
+    // A timeout is not a completed swap. Callers navigate as soon as this
+    // resolves, so rather than let them proceed under an owner that may still be
+    // the previous account, delete the authenticated caches outright — with no
+    // partition and no owner record there is nothing the worker can serve.
+    if (!acked) await clearServiceWorkerCaches()
   } finally {
     clearTimeout(timer)
     channel.port1.close()
@@ -117,6 +142,18 @@ function clearLocalAppCaches(): void {
   Object.keys(localStorage)
     .filter((k) => APP_CACHE_PREFIXES.some((p) => k.startsWith(p)))
     .forEach((k) => localStorage.removeItem(k))
+}
+
+/** Drop the localStorage snapshots if they belong to a different account. */
+function adoptLocalOwner(userId: string): void {
+  if (typeof localStorage === 'undefined') return
+  try {
+    if (localStorage.getItem(LOCAL_OWNER_KEY) === userId) return
+    clearLocalAppCaches()
+    localStorage.setItem(LOCAL_OWNER_KEY, userId)
+  } catch {
+    // Storage disabled or full; nothing cached means nothing to leak.
+  }
 }
 
 async function clearServiceWorkerCaches(): Promise<void> {

--- a/lib/clientCache.ts
+++ b/lib/clientCache.ts
@@ -30,11 +30,22 @@ function getServiceWorkerContainer(): ServiceWorkerContainer | null {
   return navigator.serviceWorker
 }
 
+// How long to wait for the worker to confirm an ownership change before giving
+// up. Only a safety valve: the work is a couple of Cache Storage deletes, and a
+// worker that never replies must not leave the caller hanging.
+const OWNER_ACK_TIMEOUT_MS = 3_000
+
 /**
- * Tell the service worker which account owns the authenticated caches. Called on
- * every auth-state change; the worker wipes those caches whenever the id differs
- * from the one it recorded, which covers logging in as a different user after a
- * session expiry (no sign-out ever runs in that flow).
+ * Tell the service worker which account owns the authenticated caches. Called as
+ * soon as the authenticated layout mounts and on every later auth-state change;
+ * the worker wipes those caches whenever the id differs from the one it
+ * recorded, which covers logging in as a different user after a session expiry
+ * (no sign-out ever runs in that flow).
+ *
+ * Resolves once the worker has *finished* the swap, not merely when the message
+ * is queued — the purge of the previous account's entries happens while the
+ * message is handled, so resolving earlier would report a swap that has not
+ * taken effect yet.
  */
 export async function announceCacheOwner(userId: string): Promise<void> {
   const container = getServiceWorkerContainer()
@@ -43,7 +54,24 @@ export async function announceCacheOwner(userId: string): Promise<void> {
   // Before the first activation the page isn't controlled yet, so fall back to
   // the registration's active worker once it's ready.
   const worker = container.controller ?? (await container.ready).active
-  worker?.postMessage({ type: 'SET_CACHE_OWNER', userId })
+  if (!worker) return
+
+  const channel = new MessageChannel()
+  const acknowledged = new Promise<void>((resolve) => {
+    channel.port1.onmessage = () => resolve()
+  })
+  worker.postMessage({ type: 'SET_CACHE_OWNER', userId }, [channel.port2])
+
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      acknowledged,
+      new Promise<void>((resolve) => { timer = setTimeout(resolve, OWNER_ACK_TIMEOUT_MS) }),
+    ])
+  } finally {
+    clearTimeout(timer)
+    channel.port1.close()
+  }
 }
 
 /**

--- a/lib/clientCache.ts
+++ b/lib/clientCache.ts
@@ -1,0 +1,85 @@
+// Client-side cache lifecycle for the signed-in account.
+//
+// Two caches hold per-account data: localStorage (page-level snapshots) and the
+// service worker's Cache Storage (`api-v1-*`, `pages-*`). Both are keyed by URL
+// or page, never by user, so on a shared browser profile they have to be wiped
+// when the account changes — otherwise the worker can hand user B a cached
+// response belonging to user A (#565).
+//
+// The worker's half of the contract lives in public/sw.js.
+
+// localStorage cache keys cleared on sign-out so the next account never sees
+// the previous user's stale data.
+const APP_CACHE_PREFIXES = [
+  'dashboardOverviewCache',
+  'planningCache_',
+  'savingsGoalsCache',
+  'fixedExpensesCache',
+  'insuranceMembersCache',
+  'fundLibraryCache',
+]
+
+// Cache Storage names holding authenticated responses, plus the worker's record
+// of who they belong to. Matched by prefix so a CACHE_VERSION bump in sw.js
+// doesn't silently leave a cache behind here. `static-assets-*` is excluded on
+// purpose: chunks, images and fonts are identical for every account.
+const SW_USER_CACHE_PREFIXES = ['api-v1-', 'pages-', 'cache-owner-']
+
+function getServiceWorkerContainer(): ServiceWorkerContainer | null {
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return null
+  return navigator.serviceWorker
+}
+
+/**
+ * Tell the service worker which account owns the authenticated caches. Called on
+ * every auth-state change; the worker wipes those caches whenever the id differs
+ * from the one it recorded, which covers logging in as a different user after a
+ * session expiry (no sign-out ever runs in that flow).
+ */
+export async function announceCacheOwner(userId: string): Promise<void> {
+  const container = getServiceWorkerContainer()
+  if (!container) return
+
+  // Before the first activation the page isn't controlled yet, so fall back to
+  // the registration's active worker once it's ready.
+  const worker = container.controller ?? (await container.ready).active
+  worker?.postMessage({ type: 'SET_CACHE_OWNER', userId })
+}
+
+/**
+ * Drop every cached artefact of the current account. Awaited on sign-out before
+ * routing to the login page, so nothing survives into the next session.
+ *
+ * Cache Storage is deleted from the page rather than through the worker: the
+ * page has the same access, and a `postMessage` to a worker that may not be
+ * controlling this page yet would leave the purge unobservable. The message is
+ * still sent so a live worker forgets the owner it is holding in flight.
+ */
+export async function clearAppCaches(): Promise<void> {
+  clearLocalAppCaches()
+  getServiceWorkerContainer()?.controller?.postMessage({ type: 'CLEAR_CACHE_OWNER' })
+  await clearServiceWorkerCaches()
+}
+
+function clearLocalAppCaches(): void {
+  if (typeof localStorage === 'undefined') return
+  Object.keys(localStorage)
+    .filter((k) => APP_CACHE_PREFIXES.some((p) => k.startsWith(p)))
+    .forEach((k) => localStorage.removeItem(k))
+}
+
+async function clearServiceWorkerCaches(): Promise<void> {
+  if (typeof caches === 'undefined') return
+  try {
+    const names = await caches.keys()
+    await Promise.all(
+      names
+        .filter((name) => SW_USER_CACHE_PREFIXES.some((p) => name.startsWith(p)))
+        .map((name) => caches.delete(name)),
+    )
+  } catch {
+    // Cache Storage is unavailable (private mode, http origin). The localStorage
+    // clear above still happened, and without Cache Storage the worker has no
+    // cached responses to leak.
+  }
+}

--- a/lib/clientCache.ts
+++ b/lib/clientCache.ts
@@ -30,6 +30,26 @@ function getServiceWorkerContainer(): ServiceWorkerContainer | null {
   return navigator.serviceWorker
 }
 
+/**
+ * Source for an inline script that claims cache ownership during HTML parsing.
+ *
+ * React effects cannot win this race: effects run child-first, so a page's data
+ * fetch starts before the layout's announcement. Running it as an inline script
+ * puts ownership in place before hydration and before any fetch — and covers
+ * entries no client code precedes, such as the email-confirmation callback
+ * redirecting straight to /dashboard (#565).
+ *
+ * Fire-and-forget: with no controller there is no worker holding a partition,
+ * so there is nothing to correct. The effect in CacheOwnerAnnouncer still runs
+ * and handles every later auth-state change.
+ */
+export function buildCacheOwnerScript(userId: string): string {
+  // Serialised as data, with `<` escaped so the payload can't close the script
+  // element — the id reaches us from the session, not from source we control.
+  const payload = JSON.stringify({ type: 'SET_CACHE_OWNER', userId }).replace(/</g, '\\u003c')
+  return `try{navigator.serviceWorker.controller.postMessage(${payload})}catch(e){}`
+}
+
 // How long to wait for the worker to confirm an ownership change before giving
 // up. Only a safety valve: the work is a couple of Cache Storage deletes, and a
 // worker that never replies must not leave the caller hanging.

--- a/lib/clientCache.ts
+++ b/lib/clientCache.ts
@@ -52,8 +52,11 @@ export async function announceCacheOwner(userId: string): Promise<void> {
   if (!container) return
 
   // Before the first activation the page isn't controlled yet, so fall back to
-  // the registration's active worker once it's ready.
-  const worker = container.controller ?? (await container.ready).active
+  // the registration's active worker. Deliberately `getRegistration()` and not
+  // `ready`: `ready` never settles when nothing is registered, which is every
+  // page load in development and the first one in production — awaiting it
+  // would hang the sign-in that calls this before navigating.
+  const worker = container.controller ?? (await container.getRegistration())?.active
   if (!worker) return
 
   const channel = new MessageChannel()

--- a/messages/en.json
+++ b/messages/en.json
@@ -788,6 +788,7 @@
     "forgotPassword": "Forgot password?",
     "loginBtn": "Sign in",
     "loggingIn": "Signing in…",
+    "completingSignIn": "Completing sign-in…",
     "redirecting": "Redirecting…",
     "signupBtn": "Sign up",
     "signingUp": "Creating account…",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -788,6 +788,7 @@
     "forgotPassword": "Quên mật khẩu?",
     "loginBtn": "Đăng nhập",
     "loggingIn": "Đang đăng nhập…",
+    "completingSignIn": "Đang hoàn tất đăng nhập…",
     "redirecting": "Đang chuyển trang…",
     "signupBtn": "Đăng ký",
     "signingUp": "Đang tạo tài khoản...",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,8 +1,73 @@
-const CACHE_VERSION = 'v7'
+// Bumped from v7 with the cache-owner rules below: the old `api-v1-v7` /
+// `pages-v7` entries were written without any account attached, so they can't
+// be trusted once ownership matters. The version bump makes `activate` drop
+// them on first deploy.
+const CACHE_VERSION = 'v8'
 const API_CACHE = `api-v1-${CACHE_VERSION}`
 const STATIC_CACHE = `static-assets-${CACHE_VERSION}`
 const PAGE_CACHE = `pages-${CACHE_VERSION}`
 const OFFLINE_URL = '/~offline'
+
+// ── Cache ownership ───────────────────────────────────────────────────────────
+// API responses and page HTML are per-account, but the caches above are keyed by
+// URL alone — on a shared browser profile user B could be served user A's cached
+// dashboard (#565). So the worker tracks which account the authenticated caches
+// belong to, and:
+//
+//   • only ever reads or writes them while an owner is known (fail closed), and
+//   • wipes them whenever the owner changes or is cleared.
+//
+// The record has to survive the worker being killed and restarted, and a worker
+// has no localStorage, so it lives in its own Cache Storage entry. STATIC_CACHE
+// is deliberately left alone: chunks, images and fonts carry no user data.
+const OWNER_CACHE = `cache-owner-${CACHE_VERSION}`
+// Same-origin-shaped key; never fetched, only used as a Cache Storage index.
+const OWNER_KEY = '/__cache-owner__'
+
+async function readCacheOwner() {
+  const cache = await caches.open(OWNER_CACHE)
+  const record = await cache.match(OWNER_KEY)
+  if (!record) return null
+  const owner = await record.text()
+  return owner || null
+}
+
+async function purgeUserCaches() {
+  await Promise.all([caches.delete(API_CACHE), caches.delete(PAGE_CACHE)])
+}
+
+/** Adopt `userId` as the cache owner, wiping the caches if it isn't the current one. */
+async function setCacheOwner(userId) {
+  if ((await readCacheOwner()) !== userId) await purgeUserCaches()
+  const cache = await caches.open(OWNER_CACHE)
+  if (userId) await cache.put(OWNER_KEY, new Response(userId))
+  else await cache.delete(OWNER_KEY)
+}
+
+/** Sign-out: drop every authenticated response and forget who they belonged to. */
+async function clearCacheOwner() {
+  await purgeUserCaches()
+  const cache = await caches.open(OWNER_CACHE)
+  await cache.delete(OWNER_KEY)
+}
+
+// ── Messages ──────────────────────────────────────────────────────────────────
+// The page announces the signed-in account on load and on every auth-state
+// change, and clears it on sign-out — see lib/clientCache.ts.
+self.addEventListener('message', (event) => {
+  const data = event.data
+  if (!data) return
+
+  let work = null
+  if (data.type === 'SET_CACHE_OWNER') work = setCacheOwner(data.userId ?? null)
+  else if (data.type === 'CLEAR_CACHE_OWNER') work = clearCacheOwner()
+  if (!work) return
+
+  // Reply when asked, so the page can await the purge before routing to login.
+  const port = event.ports && event.ports[0]
+  const done = port ? work.then(() => port.postMessage({ ok: true })) : work
+  if (event.waitUntil) event.waitUntil(done)
+})
 
 // ── Install ───────────────────────────────────────────────────────────────────
 // Pre-cache the offline fallback page so it's always available.
@@ -16,7 +81,7 @@ self.addEventListener('install', (event) => {
 // ── Activate ──────────────────────────────────────────────────────────────────
 // Remove stale caches from previous versions.
 self.addEventListener('activate', (event) => {
-  const currentCaches = [API_CACHE, STATIC_CACHE, PAGE_CACHE]
+  const currentCaches = [API_CACHE, STATIC_CACHE, PAGE_CACHE, OWNER_CACHE]
   event.waitUntil(
     caches
       .keys()
@@ -79,14 +144,22 @@ async function navigateHandler(event, request) {
     if (response.status === 200) {
       const clone = response.clone()
       event.waitUntil(
-        caches.open(PAGE_CACHE).then((cache) => cache.put(request.url, clone))
+        readCacheOwner().then((owner) => {
+          // Unattributable page: don't store it rather than risk serving it to
+          // whoever signs in next.
+          if (!owner) return
+          return caches.open(PAGE_CACHE).then((cache) => cache.put(request.url, clone))
+        })
       )
     }
     return response
   } catch {
-    // Network failed — serve cached page by URL (no Vary check)
-    const pageCache = await caches.open(PAGE_CACHE)
-    const cached = await pageCache.match(request.url)
+    // Network failed — serve cached page by URL (no Vary check), but only while
+    // an account owns the cache. With no owner (signed out, or a fresh worker)
+    // the offline fallback below is the safe answer.
+    const owner = await readCacheOwner()
+    const pageCache = owner ? await caches.open(PAGE_CACHE) : null
+    const cached = pageCache ? await pageCache.match(request.url) : null
     if (cached) return cached
 
     // No cached page — show offline fallback
@@ -111,7 +184,9 @@ async function networkFirst(event, request, cacheName, timeoutMs) {
     const response = await fetch(request, { signal: controller.signal })
     clearTimeout(timeoutId)
 
-    if (response.ok) {
+    // Only cache what can be attributed to the signed-in account, so a response
+    // fetched before the page announced itself can never outlive that session.
+    if (response.ok && (await readCacheOwner())) {
       const blob = await response.clone().blob()
       const headers = new Headers(response.headers)
       headers.set('sw-cached-at', Date.now().toString())
@@ -126,7 +201,7 @@ async function networkFirst(event, request, cacheName, timeoutMs) {
     return response
   } catch {
     clearTimeout(timeoutId)
-    const cached = await cache.match(request)
+    const cached = (await readCacheOwner()) ? await cache.match(request) : null
     if (cached) {
       const cachedAt = Number(cached.headers.get('sw-cached-at') ?? 0)
       const maxAge = 24 * 60 * 60 * 1000 // 24 h

--- a/public/sw.js
+++ b/public/sw.js
@@ -33,8 +33,12 @@ const OWNER_KEY = '/__cache-owner__'
 const API_CACHE_PREFIX = `api-v1-${CACHE_VERSION}-`
 const PAGE_CACHE_PREFIX = `pages-${CACHE_VERSION}-`
 
-/** @returns {Promise<{userId: string, token: string} | null>} */
-async function readCacheOwner() {
+/**
+ * The recorded owner, without waiting for a transition. Only for use *inside* a
+ * transition, which would otherwise wait on itself.
+ * @returns {Promise<{userId: string, token: string} | null>}
+ */
+async function loadCacheOwner() {
   const cache = await caches.open(OWNER_CACHE)
   const record = await cache.match(OWNER_KEY)
   if (!record) return null
@@ -44,6 +48,12 @@ async function readCacheOwner() {
   } catch {
     return null
   }
+}
+
+/** The owner a request should use: settled with respect to any transition under way. */
+async function readCacheOwner() {
+  await ownerTransition
+  return loadCacheOwner()
 }
 
 const apiCacheFor = (owner) => (owner ? API_CACHE_PREFIX + owner.token : null)
@@ -67,7 +77,7 @@ async function sweepPartitions(keep) {
  * ordinary reload or token refresh costs nothing.
  */
 async function setCacheOwner(userId) {
-  const current = await readCacheOwner()
+  const current = await loadCacheOwner()
   if (current && current.userId === userId) {
     await sweepPartitions(current)
     return
@@ -95,6 +105,19 @@ function mintToken() {
   return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
 }
 
+// An ownership change is several Cache Storage operations, and nothing makes
+// the worker finish handling a message before it answers the fetch events that
+// follow it. Requests therefore wait on any transition in progress before
+// resolving their partition, so a page that announces itself and immediately
+// starts fetching can't read the outgoing account's cache. Transitions are
+// chained so they also can't interleave with each other.
+let ownerTransition = Promise.resolve()
+
+const runOwnerTransition = (work) => {
+  ownerTransition = ownerTransition.then(work, work)
+  return ownerTransition
+}
+
 // ── Messages ──────────────────────────────────────────────────────────────────
 // The page announces the signed-in account on load and on every auth-state
 // change, and clears it on sign-out — see lib/clientCache.ts.
@@ -103,8 +126,8 @@ self.addEventListener('message', (event) => {
   if (!data) return
 
   let work = null
-  if (data.type === 'SET_CACHE_OWNER') work = setCacheOwner(data.userId ?? null)
-  else if (data.type === 'CLEAR_CACHE_OWNER') work = clearCacheOwner()
+  if (data.type === 'SET_CACHE_OWNER') work = runOwnerTransition(() => setCacheOwner(data.userId ?? null))
+  else if (data.type === 'CLEAR_CACHE_OWNER') work = runOwnerTransition(() => clearCacheOwner())
   if (!work) return
 
   // Reply when asked, so the page can await the purge before routing to login.

--- a/public/sw.js
+++ b/public/sw.js
@@ -196,10 +196,11 @@ async function navigateHandler(event, request) {
     return response
   } catch {
     // Network failed — serve the cached page by URL (no Vary check) from the
-    // current owner's partition. With no owner (signed out, or a fresh worker)
-    // there is no partition and the offline fallback below is the safe answer.
-    const current = pageCacheFor(await readCacheOwner())
-    const cached = current ? await (await caches.open(current)).match(request.url) : null
+    // same partition the request was issued under, never from whichever account
+    // happens to own the cache now. With no partition (signed out, or a fresh
+    // worker) the offline fallback below is the safe answer, and a partition
+    // swept by an account switch is empty, so this fails closed either way.
+    const cached = partition ? await (await caches.open(partition)).match(request.url) : null
     if (cached) return cached
 
     // No cached page — show offline fallback
@@ -242,8 +243,8 @@ async function networkFirst(event, request, partitionFor, timeoutMs) {
     return response
   } catch {
     clearTimeout(timeoutId)
-    const current = partitionFor(await readCacheOwner())
-    const cached = current ? await (await caches.open(current)).match(request) : null
+    // Same partition the request was issued under — see navigateHandler.
+    const cached = partition ? await (await caches.open(partition)).match(request) : null
     if (cached) {
       const cachedAt = Number(cached.headers.get('sw-cached-at') ?? 0)
       const maxAge = 24 * 60 * 60 * 1000 // 24 h

--- a/public/sw.js
+++ b/public/sw.js
@@ -137,6 +137,10 @@ self.addEventListener('fetch', (event) => {
 // ── Handlers ──────────────────────────────────────────────────────────────────
 
 async function navigateHandler(event, request) {
+  // Captured before the fetch: a response belongs to whoever was signed in when
+  // it was requested, and the account can change while it is in flight.
+  const ownerAtRequest = await readCacheOwner()
+
   try {
     const response = await fetch(request)
     // Clone BEFORE returning the response — once the browser starts reading
@@ -145,9 +149,10 @@ async function navigateHandler(event, request) {
       const clone = response.clone()
       event.waitUntil(
         readCacheOwner().then((owner) => {
-          // Unattributable page: don't store it rather than risk serving it to
-          // whoever signs in next.
-          if (!owner) return
+          // Store only if the page is still owned by the account that asked for
+          // it. No owner means unattributable; a different owner means the
+          // account switched mid-flight and this is the previous user's HTML.
+          if (!owner || owner !== ownerAtRequest) return
           return caches.open(PAGE_CACHE).then((cache) => cache.put(request.url, clone))
         })
       )
@@ -176,7 +181,8 @@ async function navigateHandler(event, request) {
  * Cached responses expire after 24 h (checked on retrieval).
  */
 async function networkFirst(event, request, cacheName, timeoutMs) {
-  const cache = await caches.open(cacheName)
+  // Captured before the fetch — see navigateHandler.
+  const ownerAtRequest = await readCacheOwner()
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
 
@@ -184,9 +190,10 @@ async function networkFirst(event, request, cacheName, timeoutMs) {
     const response = await fetch(request, { signal: controller.signal })
     clearTimeout(timeoutId)
 
-    // Only cache what can be attributed to the signed-in account, so a response
-    // fetched before the page announced itself can never outlive that session.
-    if (response.ok && (await readCacheOwner())) {
+    // Only cache what can still be attributed to the account that asked for it,
+    // so a response fetched before the page announced itself — or one that
+    // outlived its own session — can never be filed under the next account.
+    if (response.ok && ownerAtRequest && (await readCacheOwner()) === ownerAtRequest) {
       const blob = await response.clone().blob()
       const headers = new Headers(response.headers)
       headers.set('sw-cached-at', Date.now().toString())
@@ -195,12 +202,15 @@ async function networkFirst(event, request, cacheName, timeoutMs) {
         statusText: response.statusText,
         headers,
       })
-      // Extend SW lifetime so the cache write finishes before idle
-      event.waitUntil(cache.put(request, timestamped))
+      // Opened here rather than up front: a cache handle taken before an owner
+      // switch refers to the deleted cache, so the write would vanish silently.
+      // Extend SW lifetime so it finishes before idle.
+      event.waitUntil(caches.open(cacheName).then((cache) => cache.put(request, timestamped)))
     }
     return response
   } catch {
     clearTimeout(timeoutId)
+    const cache = await caches.open(cacheName)
     const cached = (await readCacheOwner()) ? await cache.match(request) : null
     if (cached) {
       const cachedAt = Number(cached.headers.get('sw-cached-at') ?? 0)

--- a/public/sw.js
+++ b/public/sw.js
@@ -3,52 +3,96 @@
 // be trusted once ownership matters. The version bump makes `activate` drop
 // them on first deploy.
 const CACHE_VERSION = 'v8'
-const API_CACHE = `api-v1-${CACHE_VERSION}`
 const STATIC_CACHE = `static-assets-${CACHE_VERSION}`
-const PAGE_CACHE = `pages-${CACHE_VERSION}`
 const OFFLINE_URL = '/~offline'
 
 // ── Cache ownership ───────────────────────────────────────────────────────────
-// API responses and page HTML are per-account, but the caches above are keyed by
-// URL alone — on a shared browser profile user B could be served user A's cached
-// dashboard (#565). So the worker tracks which account the authenticated caches
-// belong to, and:
+// API responses and page HTML are per-account, but they are keyed by URL alone —
+// on a shared browser profile user B could be served user A's cached dashboard
+// (#565). So authenticated responses are *partitioned*: each account gets its
+// own pair of caches, named after an opaque token minted when that account takes
+// ownership.
 //
-//   • only ever reads or writes them while an owner is known (fail closed), and
-//   • wipes them whenever the owner changes or is cleared.
+// Partitioning rather than a shared cache guarded by checks is what makes this
+// timing-independent. A response is written to the partition of whoever asked
+// for it, decided before the request goes out; reads only ever open the current
+// owner's partition. An account switch landing midway through a request can
+// therefore never misfile a response, however the awaits interleave — the worst
+// case is a write into a partition nobody will read again, which the next sweep
+// removes. With no owner recorded there is no partition at all, so the worker
+// fails closed: nothing is read and nothing is stored.
 //
 // The record has to survive the worker being killed and restarted, and a worker
-// has no localStorage, so it lives in its own Cache Storage entry. STATIC_CACHE
-// is deliberately left alone: chunks, images and fonts carry no user data.
+// has no localStorage, so it lives in its own Cache Storage entry. The token is
+// used instead of the user id so cache names, which are visible in devtools,
+// don't enumerate the accounts that have used this browser. STATIC_CACHE is
+// deliberately shared: chunks, images and fonts carry no user data.
 const OWNER_CACHE = `cache-owner-${CACHE_VERSION}`
 // Same-origin-shaped key; never fetched, only used as a Cache Storage index.
 const OWNER_KEY = '/__cache-owner__'
+const API_CACHE_PREFIX = `api-v1-${CACHE_VERSION}-`
+const PAGE_CACHE_PREFIX = `pages-${CACHE_VERSION}-`
 
+/** @returns {Promise<{userId: string, token: string} | null>} */
 async function readCacheOwner() {
   const cache = await caches.open(OWNER_CACHE)
   const record = await cache.match(OWNER_KEY)
   if (!record) return null
-  const owner = await record.text()
-  return owner || null
+  try {
+    const owner = JSON.parse(await record.text())
+    return owner && owner.userId && owner.token ? owner : null
+  } catch {
+    return null
+  }
 }
 
-async function purgeUserCaches() {
-  await Promise.all([caches.delete(API_CACHE), caches.delete(PAGE_CACHE)])
+const apiCacheFor = (owner) => (owner ? API_CACHE_PREFIX + owner.token : null)
+const pageCacheFor = (owner) => (owner ? PAGE_CACHE_PREFIX + owner.token : null)
+
+/** Delete every authenticated partition except the one `keep` owns (all, if null). */
+async function sweepPartitions(keep) {
+  const keys = await caches.keys()
+  const mine = [apiCacheFor(keep), pageCacheFor(keep)]
+  await Promise.all(
+    keys
+      .filter((key) => key.startsWith(API_CACHE_PREFIX) || key.startsWith(PAGE_CACHE_PREFIX))
+      .filter((key) => !mine.includes(key))
+      .map((key) => caches.delete(key))
+  )
 }
 
-/** Adopt `userId` as the cache owner, wiping the caches if it isn't the current one. */
+/**
+ * Adopt `userId` as the cache owner. A different account gets a fresh partition
+ * and the previous one is swept; the same account keeps its cache, so an
+ * ordinary reload or token refresh costs nothing.
+ */
 async function setCacheOwner(userId) {
-  if ((await readCacheOwner()) !== userId) await purgeUserCaches()
+  const current = await readCacheOwner()
+  if (current && current.userId === userId) {
+    await sweepPartitions(current)
+    return
+  }
+
+  const owner = userId ? { userId, token: mintToken() } : null
   const cache = await caches.open(OWNER_CACHE)
-  if (userId) await cache.put(OWNER_KEY, new Response(userId))
+  // Record first: until this lands, reads still resolve to the old partition,
+  // and after it they resolve to a partition that is empty by construction.
+  if (owner) await cache.put(OWNER_KEY, new Response(JSON.stringify(owner)))
   else await cache.delete(OWNER_KEY)
+  await sweepPartitions(owner)
 }
 
 /** Sign-out: drop every authenticated response and forget who they belonged to. */
 async function clearCacheOwner() {
-  await purgeUserCaches()
+  // Forget first, so any request racing this one finds no owner and fails closed.
   const cache = await caches.open(OWNER_CACHE)
   await cache.delete(OWNER_KEY)
+  await sweepPartitions(null)
+}
+
+function mintToken() {
+  if (self.crypto && self.crypto.randomUUID) return self.crypto.randomUUID()
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`
 }
 
 // ── Messages ──────────────────────────────────────────────────────────────────
@@ -79,19 +123,18 @@ self.addEventListener('install', (event) => {
 })
 
 // ── Activate ──────────────────────────────────────────────────────────────────
-// Remove stale caches from previous versions.
+// Remove stale caches from previous versions, along with any partition that is
+// not the current owner's — including the unpartitioned `api-v1-v7` / `pages-v7`
+// entries, which were written before ownership existed and can't be attributed.
 self.addEventListener('activate', (event) => {
-  const currentCaches = [API_CACHE, STATIC_CACHE, PAGE_CACHE, OWNER_CACHE]
   event.waitUntil(
-    caches
-      .keys()
-      .then((keys) =>
-        Promise.all(
-          keys
-            .filter((key) => !currentCaches.includes(key))
-            .map((key) => caches.delete(key))
-        )
-      )
+    readCacheOwner()
+      .then((owner) => {
+        const keep = [STATIC_CACHE, OWNER_CACHE, apiCacheFor(owner), pageCacheFor(owner)]
+        return caches
+          .keys()
+          .then((keys) => Promise.all(keys.filter((key) => !keep.includes(key)).map((key) => caches.delete(key))))
+      })
       .then(() => self.clients.claim())
   )
 })
@@ -111,7 +154,7 @@ self.addEventListener('fetch', (event) => {
   // dashboard overview). 10 s was too tight and surfaced spurious "Offline"
   // errors on good connections.
   if (url.pathname.startsWith('/api/v1/')) {
-    event.respondWith(networkFirst(event, request, API_CACHE, 30_000))
+    event.respondWith(networkFirst(event, request, apiCacheFor, 30_000))
     return
   }
 
@@ -137,34 +180,26 @@ self.addEventListener('fetch', (event) => {
 // ── Handlers ──────────────────────────────────────────────────────────────────
 
 async function navigateHandler(event, request) {
-  // Captured before the fetch: a response belongs to whoever was signed in when
-  // it was requested, and the account can change while it is in flight.
-  const ownerAtRequest = await readCacheOwner()
+  // Resolved before the fetch goes out: this page belongs to whoever was signed
+  // in when it was asked for, so that is the partition it may be written to,
+  // whatever happens to the current owner in the meantime.
+  const partition = pageCacheFor(await readCacheOwner())
 
   try {
     const response = await fetch(request)
     // Clone BEFORE returning the response — once the browser starts reading
     // the body the stream is disturbed and clone() silently produces an empty body.
-    if (response.status === 200) {
+    if (response.status === 200 && partition) {
       const clone = response.clone()
-      event.waitUntil(
-        readCacheOwner().then((owner) => {
-          // Store only if the page is still owned by the account that asked for
-          // it. No owner means unattributable; a different owner means the
-          // account switched mid-flight and this is the previous user's HTML.
-          if (!owner || owner !== ownerAtRequest) return
-          return caches.open(PAGE_CACHE).then((cache) => cache.put(request.url, clone))
-        })
-      )
+      event.waitUntil(caches.open(partition).then((cache) => cache.put(request.url, clone)))
     }
     return response
   } catch {
-    // Network failed — serve cached page by URL (no Vary check), but only while
-    // an account owns the cache. With no owner (signed out, or a fresh worker)
-    // the offline fallback below is the safe answer.
-    const owner = await readCacheOwner()
-    const pageCache = owner ? await caches.open(PAGE_CACHE) : null
-    const cached = pageCache ? await pageCache.match(request.url) : null
+    // Network failed — serve the cached page by URL (no Vary check) from the
+    // current owner's partition. With no owner (signed out, or a fresh worker)
+    // there is no partition and the offline fallback below is the safe answer.
+    const current = pageCacheFor(await readCacheOwner())
+    const cached = current ? await (await caches.open(current)).match(request.url) : null
     if (cached) return cached
 
     // No cached page — show offline fallback
@@ -179,10 +214,12 @@ async function navigateHandler(event, request) {
 /**
  * NetworkFirst: try network with a timeout, fall back to cache.
  * Cached responses expire after 24 h (checked on retrieval).
+ *
+ * `partitionFor` maps a cache owner to the cache this request may use, so the
+ * response is filed under the account that asked for it — see navigateHandler.
  */
-async function networkFirst(event, request, cacheName, timeoutMs) {
-  // Captured before the fetch — see navigateHandler.
-  const ownerAtRequest = await readCacheOwner()
+async function networkFirst(event, request, partitionFor, timeoutMs) {
+  const partition = partitionFor(await readCacheOwner())
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
 
@@ -190,10 +227,7 @@ async function networkFirst(event, request, cacheName, timeoutMs) {
     const response = await fetch(request, { signal: controller.signal })
     clearTimeout(timeoutId)
 
-    // Only cache what can still be attributed to the account that asked for it,
-    // so a response fetched before the page announced itself — or one that
-    // outlived its own session — can never be filed under the next account.
-    if (response.ok && ownerAtRequest && (await readCacheOwner()) === ownerAtRequest) {
+    if (response.ok && partition) {
       const blob = await response.clone().blob()
       const headers = new Headers(response.headers)
       headers.set('sw-cached-at', Date.now().toString())
@@ -202,16 +236,14 @@ async function networkFirst(event, request, cacheName, timeoutMs) {
         statusText: response.statusText,
         headers,
       })
-      // Opened here rather than up front: a cache handle taken before an owner
-      // switch refers to the deleted cache, so the write would vanish silently.
-      // Extend SW lifetime so it finishes before idle.
-      event.waitUntil(caches.open(cacheName).then((cache) => cache.put(request, timestamped)))
+      // Extend SW lifetime so the cache write finishes before idle
+      event.waitUntil(caches.open(partition).then((cache) => cache.put(request, timestamped)))
     }
     return response
   } catch {
     clearTimeout(timeoutId)
-    const cache = await caches.open(cacheName)
-    const cached = (await readCacheOwner()) ? await cache.match(request) : null
+    const current = partitionFor(await readCacheOwner())
+    const cached = current ? await (await caches.open(current)).match(request) : null
     if (cached) {
       const cachedAt = Number(cached.headers.get('sw-cached-at') ?? 0)
       const maxAge = 24 * 60 * 60 * 1000 // 24 h
@@ -228,10 +260,13 @@ async function networkFirst(event, request, cacheName, timeoutMs) {
  * CacheFirst: serve from cache if available, otherwise fetch and cache.
  */
 async function cacheFirst(request, cacheName) {
-  const cached = await caches.match(request)
+  // Scoped to the named cache rather than a global `caches.match`, which would
+  // search the account partitions too and could answer a static request from
+  // authenticated data.
+  const cache = await caches.open(cacheName)
+  const cached = await cache.match(request)
   if (cached) return cached
 
-  const cache = await caches.open(cacheName)
   try {
     const response = await fetch(request)
     if (response.ok) cache.put(request, response.clone())


### PR DESCRIPTION
Closes #565.

## Problem

`public/sw.js` cached `/api/v1/*` responses and page HTML in `api-v1-v7` / `pages-v7`, keyed by request URL with nothing tying an entry to the account it belonged to. Sign-out cleared a few `localStorage` keys and never touched Cache Storage, and a session that expired and was replaced by a different account skipped even that.

On a shared browser profile: user A populates the caches → signs out (or the session expires) → user B signs in → the network fails or the 30 s timeout fires before B has replaced a cached URL → the worker hands B user A's portfolio data, for up to 24 h.

## Fix

The worker now tracks **who owns the authenticated caches**:

- The record lives in its own Cache Storage entry (`cache-owner-v8`) so it survives the worker being killed and restarted — a worker has no `localStorage`.
- `api-v1-*` / `pages-*` are only read **or written** while an owner is known, so an unattributable response is never stored and a signed-out worker serves the offline fallback instead of a cached page.
- Any change of owner — or a clear — wipes both caches.

The page holds up its half in `lib/clientCache.ts`:

- `CacheOwnerAnnouncer` (mounted in the authenticated layout) announces the account on `INITIAL_SESSION` and every later auth-state change. This is what covers the session-expiry flow, where no sign-out ever runs.
- `clearAppCaches()` is now the single sign-out cleanup for both `localStorage` and Cache Storage, shared by `UserMenu` and the two settings views — previously the same key list was duplicated inline in `UserMenu`.

`CACHE_VERSION` goes v7 → v8 so the existing unattributed entries are dropped on the first deploy. `static-assets-*` is deliberately left shared: chunks, images and fonts are identical for every account.

## Tests

`public/sw.js` had no coverage at all (it only registers in production, so no E2E reaches it). `lib/__tests__/serviceWorker.test.ts` loads the real worker source against a fake Cache Storage/fetch environment and asserts the acceptance criteria directly:

- user A populates the cache → logout → user B signs in → B goes offline → 503, no user A data
- the same for session expiry with no logout
- no user A page HTML served to user B offline
- offline fallback rather than a cached page when no account is known
- nothing cached before an account is announced
- re-announcing the same account keeps the cache
- static assets survive an account change

Plus `lib/__tests__/clientCache.test.ts` and `app/components/__tests__/CacheOwnerAnnouncer.test.tsx`.

## Verification

- `npm test -- --run` — 154 files, 1634 passed
- `eslint` clean, `tsc --noEmit` clean
- `npx playwright test e2e/auth.spec.ts e2e/settings.spec.ts e2e/settings-desktop.spec.ts --project=chromium` — 33 passed

## Note for preview testing

The service worker does not register outside production (`ServiceWorkerRegistration` bails on `NODE_ENV !== 'production'`), so this behaviour is only observable on the Vercel preview/production build, not `next dev`. Existing users will see one cache-version rollover on first load after deploy.

## Residual gap

A cached response can still only be attributed once the page's JS has announced the account. The window where that isn't true — a brand-new account's very first navigation, before any script runs, with the network already dead — now resolves to the offline fallback rather than the previous account's page, because the worker fails closed with no owner recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)