### PR TITLE
fix(auth): remove the dead Forgot password control

### DIFF
--- a/app/auth/login/__tests__/LoginPage.test.tsx
+++ b/app/auth/login/__tests__/LoginPage.test.tsx
@@ -83,3 +83,31 @@ describe('LoginPage — navigation after successful sign-in', () => {
     expect(pushMock).not.toHaveBeenCalled()
   })
 })
+
+// The form used to render a "Forgot password?" button with no onClick, no href
+// and no reset flow behind it — clicking it did nothing (#568). There is no
+// password-reset feature yet, so the control is gone until there is one.
+describe('LoginPage — no dead controls', () => {
+  it('offers no password-reset control while the feature does not exist', () => {
+    render(<LoginPage />)
+
+    expect(screen.queryByRole('button', { name: /forgotPassword/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: /forgotPassword/i })).not.toBeInTheDocument()
+  })
+
+  it('gives every non-submit button something to do when clicked', () => {
+    render(<LoginPage />)
+
+    // Guards against another decorative control creeping in. React attaches
+    // handlers through its own props object rather than the DOM `onclick`
+    // attribute, so read the props React stored on the element.
+    const inert = screen.getAllByRole('button').filter((button) => {
+      if (button.getAttribute('type') === 'submit') return false
+      const props = Object.entries(button)
+        .find(([key]) => key.startsWith('__reactProps$'))?.[1] as { onClick?: unknown } | undefined
+      return typeof props?.onClick !== 'function'
+    })
+
+    expect(inert.map((b) => b.textContent)).toEqual([])
+  })
+})

--- a/app/auth/login/page.tsx
+++ b/app/auth/login/page.tsx
@@ -123,16 +123,9 @@ function LoginForm() {
             </div>
           </div>
 
-          <button
-            type="button"
-            style={{
-              background: 'transparent', border: 'none', padding: '10px 0 0',
-              fontSize: 12, color: 'var(--c-navy)', fontWeight: 500, cursor: 'pointer',
-              fontFamily: 'inherit', textAlign: 'left',
-            }}
-          >
-            {t('forgotPassword')}
-          </button>
+          {/* A "Forgot password?" control used to sit here with nothing behind
+              it — no handler, no reset flow (#568). Removed until the feature
+              exists; restore it together with the reset route. */}
 
           <button
             type="submit"

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -40,10 +40,10 @@ test('login page h1 says Welcome back', async ({ page }) => {
   await expect(page.locator('h1').first()).toContainText('Welcome back')
 })
 
-test('login page shows Forgot password button', async ({ page }) => {
-  await page.goto('/auth/login')
-  await expect(page.getByRole('button', { name: /forgot password/i })).toBeVisible()
-})
+// The "Forgot password?" button was removed in #568 — it had no handler and no
+// reset flow, and this spec asserted only that it was visible, so the dead
+// control passed. Its absence is now asserted where it belongs, in
+// app/auth/login/__tests__/LoginPage.test.tsx.
 
 // ─── Login behaviour ────────────────────────────────────────────────────────
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -785,7 +785,6 @@
     "passwordLabel": "Password",
     "fullNameLabel": "Full name",
     "confirmPasswordLabel": "Confirm password",
-    "forgotPassword": "Forgot password?",
     "loginBtn": "Sign in",
     "loggingIn": "Signing in…",
     "redirecting": "Redirecting…",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -785,7 +785,6 @@
     "passwordLabel": "Mật khẩu",
     "fullNameLabel": "Họ và tên",
     "confirmPasswordLabel": "Xác nhận mật khẩu",
-    "forgotPassword": "Quên mật khẩu?",
     "loginBtn": "Đăng nhập",
     "loggingIn": "Đang đăng nhập…",
     "redirecting": "Đang chuyển trang…",


### PR DESCRIPTION
Closes #568.

## Problem

`app/auth/login/page.tsx` rendered "Forgot password?" as a `type="button"` with no `onClick`, no `href` and no reset flow behind it. Clicking it did nothing. There is no password-reset feature in the app — no `resetPasswordForEmail` call anywhere, and no route under `app/auth/` for it.

`e2e/auth.spec.ts` asserted only that the button was *visible*, so the broken interaction passed.

## Fix

Removed the control (option two in the issue's acceptance criteria — "or the control is removed until the feature exists"), along with its now-unused `auth.forgotPassword` key in both `messages/en.json` and `messages/vi.json`. A comment marks the spot so the control comes back together with the reset route.

Spacing is unchanged: the submit button already carried `marginTop: 18`, which is exactly how the signup form spaces its submit after the last field.

## Tests

Coverage moves down a layer, per the repo's testing guidance — this is a rendering concern, not something that needs a browser. `app/auth/login/__tests__/LoginPage.test.tsx` now asserts:

- there is no password-reset button or link on the login form
- every non-submit button carries a click handler, so another decorative dead control can't creep back in

Both failed before the change and pass after. The E2E presence assertion is deleted, with a comment pointing at its replacement.

## Verification

- `npm test -- --run` — 151 files, 1615 passed
- `eslint` clean, `tsc --noEmit` clean
- `npx playwright test e2e/auth.spec.ts --project=chromium` — 24 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)