### PR TITLE
fix(api): return 400 for malformed JSON request bodies

### DIFF
--- a/app/api/funds/[id]/__tests__/route.dca.test.ts
+++ b/app/api/funds/[id]/__tests__/route.dca.test.ts
@@ -30,8 +30,16 @@ vi.mock('@/lib/supabase-server', () => {
 
 import { PUT } from '../route'
 
+// A real Request, not a `{ json }` stand-in: the route reads the body through
+// readJsonBody, which reads it as text so an empty body is distinguishable from
+// an unparseable one (#566). A stub that only implements `json()` isn't the
+// shape the handler actually receives.
 function makeReq(body: Record<string, unknown>) {
-  return { json: async () => body } as unknown as Parameters<typeof PUT>[0]
+  return new Request('http://localhost/api/funds/f1', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as unknown as Parameters<typeof PUT>[0]
 }
 const ctx = { params: Promise.resolve({ id: 'f1' }) }
 

--- a/app/api/funds/[id]/route.ts
+++ b/app/api/funds/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { validateNavSourceUrl } from '@/lib/scrape-fund-nav'
 import { ValidationError, validateAmount } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 const FUND_TYPES = ['balanced', 'equity', 'debt', 'gold'] as const
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -42,7 +43,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { name, code, fund_type, nav, nav_source_url, is_dca, dca_monthly_amount_vnd, dca_goal_id } = body
 
   if (is_dca !== undefined && typeof is_dca !== 'boolean') {

--- a/app/api/funds/route.ts
+++ b/app/api/funds/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { validateNavSourceUrl } from '@/lib/scrape-fund-nav'
 import { ValidationError, validateAmount } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 const FUND_TYPES = ['balanced', 'equity', 'debt', 'gold'] as const
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -45,7 +46,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { name, code, fund_type, nav, nav_source_url, is_dca, dca_monthly_amount_vnd, dca_goal_id } = body
 
   // Validate required fields

--- a/app/api/v1/fixed-expenses/[id]/route.ts
+++ b/app/api/v1/fixed-expenses/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateText, validateUUID, validateYearMonth } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 function toDateCol(ym: string | undefined | null): string | null {
   if (!ym) return null
@@ -13,7 +14,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { expense_name, amount_vnd, category, effective_from, effective_to } = body
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }

--- a/app/api/v1/fixed-expenses/route.ts
+++ b/app/api/v1/fixed-expenses/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validatePlanMonthFilter, validateText, validateYearMonth, type PlanMonthFilter } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 function toDateCol(ym: string | undefined | null): string | null {
   if (!ym) return null
@@ -48,7 +49,9 @@ export async function POST(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { expense_name, amount_vnd, category, effective_from, effective_to } = body
 
   let cleanName: string

--- a/app/api/v1/fund-investments/[id]/goal/route.ts
+++ b/app/api/v1/fund-investments/[id]/goal/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateUUID } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function PATCH(
   request: NextRequest,
@@ -11,7 +12,9 @@ export async function PATCH(
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const { id } = await params
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { goal_id } = body
 
   let txId: string

--- a/app/api/v1/fund-investments/[id]/route.ts
+++ b/app/api/v1/fund-investments/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateUUID } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -8,7 +9,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { fund_id, goal_id, amount_vnd, units_purchased, nav_at_purchase, investment_date } = body
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }

--- a/app/api/v1/fund-investments/route.ts
+++ b/app/api/v1/fund-investments/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateUUID } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function GET(request: NextRequest) {
   const supabase = await createSupabaseServerClient()
@@ -48,7 +49,9 @@ export async function POST(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { plan_id, fund_id, goal_id, amount_vnd, units_purchased, nav_at_purchase, investment_date } = body
 
   let cleanFundId: string

--- a/app/api/v1/insurance-members/[id]/mark-paid/route.ts
+++ b/app/api/v1/insurance-members/[id]/mark-paid/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateUUID, validateDate } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 function err(status: number, code: string, message: string) {
   return NextResponse.json({ error: code, message }, { status })
@@ -36,8 +37,13 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
   // date other than today. Defaults to today when absent.
   const now = new Date()
   let paidISO = now.toISOString().split('T')[0]
-  const body = await _req.json().catch(() => null)
-  if (body && body.paid_date != null && body.paid_date !== '') {
+  // Optional: no body at all is the documented "paid today" case. A body that is
+  // present but unparseable is a client mistake, and used to be swallowed into
+  // that same default rather than reported (#566).
+  const parsed = await readJsonBody(_req, { optional: true })
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
+  if (body.paid_date != null && body.paid_date !== '') {
     try {
       paidISO = validateDate(body.paid_date, 'paid_date')
     } catch (e) {

--- a/app/api/v1/insurance-members/[id]/route.ts
+++ b/app/api/v1/insurance-members/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateText, validateUUID } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -8,7 +9,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { member_name, relationship, annual_payment_vnd, payment_date } = body
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }

--- a/app/api/v1/insurance-members/route.ts
+++ b/app/api/v1/insurance-members/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateText } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function GET() {
   const supabase = await createSupabaseServerClient()
@@ -29,7 +30,9 @@ export async function POST(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { member_name, relationship, annual_payment_vnd, payment_date } = body
 
   let cleanName: string

--- a/app/api/v1/insurance-savings/route.ts
+++ b/app/api/v1/insurance-savings/route.ts
@@ -2,13 +2,16 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateUUID } from '@/lib/validation'
 import { ownershipError } from '@/lib/assertOwned'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function POST(request: NextRequest) {
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { insurance_member_id, amount_saved_vnd, saved_date } = body
 
   let cleanMemberId: string

--- a/app/api/v1/investment-transactions/[id]/assign/route.ts
+++ b/app/api/v1/investment-transactions/[id]/assign/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateUUID } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -8,7 +9,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { goal_id } = body
 
   let txId: string

--- a/app/api/v1/investment-transactions/[id]/collapse/route.ts
+++ b/app/api/v1/investment-transactions/[id]/collapse/route.ts
@@ -3,6 +3,7 @@ import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateRate, validateUUID } from '@/lib/validation'
 import { isFutureInvestmentDate } from '@/lib/dates'
 import { buildCollapsePlan, type CollapseTrancheInput } from '@/lib/accumulating'
+import { readJsonBody } from '@/lib/apiBody'
 
 // Collapse an accumulating ("Loại 2") book at maturity into ONE fresh term
 // deposit (the book-level renewal). `id` is the deposit_group_id (= the anchor
@@ -23,7 +24,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { amount_vnd, interest_rate, expiry_date, investment_date, fulfill_recurring } = body
 
   let groupId: string

--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -3,6 +3,7 @@ import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateBankCode, validateDate, validateRate, validateUUID } from '@/lib/validation'
 import { isFutureInvestmentDate } from '@/lib/dates'
 import { isTermDeposit } from '@/lib/maturity'
+import { readJsonBody } from '@/lib/apiBody'
 
 // Renew a bank term deposit.
 //
@@ -21,7 +22,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { amount_vnd, interest_rate, expiry_date, investment_date, interest_earned_vnd, fulfill_recurring, merge_sources, bank_code, held_sources } = body
 
   let txId: string

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateBankCode, validateDate, validateEnum, validateNotes, validateRate, validateUUID } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 const ASSET_TYPES = ['fund', 'bank', 'stock', 'gold'] as const
 
@@ -36,7 +37,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { goal_id, asset_type, investment_date, amount_vnd, unit_price, units, interest_rate, expiry_date, notes, fund_id, bank_code } = body
 
   let txId: string

--- a/app/api/v1/investment-transactions/[id]/withdraw-book/route.ts
+++ b/app/api/v1/investment-transactions/[id]/withdraw-book/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateUUID } from '@/lib/validation'
 import { isFutureInvestmentDate } from '@/lib/dates'
+import { readJsonBody } from '@/lib/apiBody'
 
 // Withdraw from an accumulating ("Loại 2") book. `id` is the book anchor
 // (= deposit_group_id). One atomic RPC spreads `withdraw_principal` across the live
@@ -13,7 +14,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { withdraw_principal, total_received, investment_date, affects_progress } = body
 
   let bookId: string

--- a/app/api/v1/investment-transactions/batch/route.ts
+++ b/app/api/v1/investment-transactions/batch/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateUUID } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 interface BatchTransaction {
   fund_id: string
@@ -15,7 +16,9 @@ export async function POST(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { transactions } = body as { transactions: BatchTransaction[] }
 
   if (!Array.isArray(transactions) || transactions.length === 0) {

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateBankCode, validateDate, validateEnum, validateNotes, validatePositiveIntParam, validateRate, validateUUID } from '@/lib/validation'
 import { isFutureInvestmentDate } from '@/lib/dates'
+import { readJsonBody } from '@/lib/apiBody'
 
 const ASSET_TYPES = ['fund', 'bank', 'stock', 'gold'] as const
 
@@ -62,7 +63,9 @@ export async function POST(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { goal_id, asset_type, transaction_type = 'investment', investment_date, amount_vnd, unit_price, units, interest_rate, notes, fund_id, plan_id, expiry_date, parent_transaction_id, principal_withdrawn, units_withdrawn, affects_progress, accumulating, tops_up_deposit_id, bank_code, held_for_merge, merge_target_goal_id, merge_anchor_inv_id } = body
 
   const isWithdrawal = transaction_type === 'withdrawal'

--- a/app/api/v1/monthly-plans/[id]/dca-skips/route.ts
+++ b/app/api/v1/monthly-plans/[id]/dca-skips/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateUUID } from '@/lib/validation'
 import { ownershipError } from '@/lib/assertOwned'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -36,7 +37,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { fund_id } = body
 
   let planId: string

--- a/app/api/v1/monthly-plans/[id]/excluded-insurance/route.ts
+++ b/app/api/v1/monthly-plans/[id]/excluded-insurance/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateUUID } from '@/lib/validation'
 import { ownershipError } from '@/lib/assertOwned'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -36,7 +37,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { member_id } = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const { member_id } = parsed.body
 
   let planId: string
   let cleanMemberId: string

--- a/app/api/v1/monthly-plans/[id]/fixed-expense-overrides/route.ts
+++ b/app/api/v1/monthly-plans/[id]/fixed-expense-overrides/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateUUID } from '@/lib/validation'
 import { ownershipError } from '@/lib/assertOwned'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -37,7 +38,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { fixed_expense_id, monthly_amount_override_vnd } = body
 
   let planId: string

--- a/app/api/v1/monthly-plans/[id]/insurance-overrides/route.ts
+++ b/app/api/v1/monthly-plans/[id]/insurance-overrides/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateUUID } from '@/lib/validation'
 import { ownershipError } from '@/lib/assertOwned'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -36,7 +37,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const { member_id, monthly_amount_override_vnd } = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const { member_id, monthly_amount_override_vnd } = parsed.body
 
   let planId: string
   let cleanMemberId: string

--- a/app/api/v1/monthly-plans/[id]/other-expenses/[expenseId]/route.ts
+++ b/app/api/v1/monthly-plans/[id]/other-expenses/[expenseId]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateText, validateUUID } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: string; expenseId: string }> }) {
   const supabase = await createSupabaseServerClient()
@@ -8,7 +9,9 @@ export async function PUT(req: NextRequest, { params }: { params: Promise<{ id: 
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const { id, expenseId } = await params
-  const body = await req.json()
+  const parsed = await readJsonBody(req)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { description, amount_vnd } = body
 
   let planId: string

--- a/app/api/v1/monthly-plans/[id]/other-expenses/route.ts
+++ b/app/api/v1/monthly-plans/[id]/other-expenses/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateText, validateUUID } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 async function getPlanForUser(supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>, planId: string, userId: string) {
   const { data } = await supabase
@@ -46,7 +47,9 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   const { id } = await params
-  const body = await req.json()
+  const parsed = await readJsonBody(req)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { description, amount_vnd } = body
 
   let planId: string

--- a/app/api/v1/monthly-plans/[id]/recurring-saving-overrides/route.ts
+++ b/app/api/v1/monthly-plans/[id]/recurring-saving-overrides/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateUUID } from '@/lib/validation'
 import { ownershipError } from '@/lib/assertOwned'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -37,7 +38,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { recurring_saving_id, monthly_amount_override_vnd } = body
 
   let planId: string

--- a/app/api/v1/monthly-plans/[id]/route.ts
+++ b/app/api/v1/monthly-plans/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateUUID } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -88,7 +89,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
 
   let planId: string
   let cleanSalary: number

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateInteger } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function GET(request: NextRequest) {
   const supabase = await createSupabaseServerClient()
@@ -165,7 +166,9 @@ export async function POST(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { month, year, salary_vnd } = body
 
   let monthNum: number

--- a/app/api/v1/recurring-savings/[id]/route.ts
+++ b/app/api/v1/recurring-savings/[id]/route.ts
@@ -3,6 +3,7 @@ import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateText, validateUUID, validateYearMonth } from '@/lib/validation'
 import { validateLinkedDeposit } from '../linkValidation'
 import { ownershipError } from '@/lib/assertOwned'
+import { readJsonBody } from '@/lib/apiBody'
 
 function toDateCol(ym: string | undefined | null): string | null {
   if (!ym) return null
@@ -15,7 +16,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { name, goal_id, amount_vnd, effective_from, effective_to, linked_deposit_tx_id } = body
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }

--- a/app/api/v1/recurring-savings/[id]/topup/route.ts
+++ b/app/api/v1/recurring-savings/[id]/topup/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateRate, validateUUID, validateYearMonth } from '@/lib/validation'
 import { isFutureInvestmentDate } from '@/lib/dates'
+import { readJsonBody } from '@/lib/apiBody'
 
 // Record this month's recurring saving as a top-up into its linked accumulating
 // book: add a real tranche AND mark the recurring fulfilled for the month, in one
@@ -15,7 +16,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { book_id, amount_vnd, interest_rate, investment_date, ym, plan_id } = body
 
   let savingId: string

--- a/app/api/v1/recurring-savings/route.ts
+++ b/app/api/v1/recurring-savings/route.ts
@@ -3,6 +3,7 @@ import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validatePlanMonthFilter, validateText, validateUUID, validateYearMonth, type PlanMonthFilter } from '@/lib/validation'
 import { validateLinkedDeposit } from './linkValidation'
 import { ownershipError } from '@/lib/assertOwned'
+import { readJsonBody } from '@/lib/apiBody'
 
 function toDateCol(ym: string | undefined | null): string | null {
   if (!ym) return null
@@ -71,7 +72,9 @@ export async function POST(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { name, goal_id, amount_vnd, effective_from, effective_to, linked_deposit_tx_id } = body
 
   let cleanName: string

--- a/app/api/v1/report/route.ts
+++ b/app/api/v1/report/route.ts
@@ -6,6 +6,7 @@ import { createElement } from 'react'
 import type { ReactElement } from 'react'
 import { PortfolioReport } from '@/components/report/PortfolioReport'
 import type { DashboardData } from '@/app/assets/DashboardClient'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function POST(req: NextRequest) {
   try {
@@ -13,7 +14,11 @@ export async function POST(req: NextRequest) {
     const { data: { user } } = await supabase.auth.getUser()
     if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-    const { data, locale }: { data: DashboardData; locale: string } = await req.json()
+    // Parsed before the render so a malformed body is a 400, not swallowed by
+    // the catch below and reported as a PDF generation failure (#566).
+    const parsed = await readJsonBody<{ data: DashboardData; locale: string }>(req)
+    if (!parsed.ok) return parsed.response
+    const { data, locale } = parsed.body
     const element = createElement(PortfolioReport, { data, locale }) as ReactElement<DocumentProps>
 
     const buffer = await renderToBuffer(element)

--- a/app/api/v1/savings-goals/[id]/route.ts
+++ b/app/api/v1/savings-goals/[id]/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateEnum, validateText, validateUUID, validateYearMonth } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -39,7 +40,9 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   let cleanIcon: string = 'target'
   let cleanPriority: string = 'med'
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { goal_name, description, target_amount, target_date, icon, priority } = body
 
   try {
@@ -100,7 +103,9 @@ export async function PATCH(request: NextRequest, { params }: { params: Promise<
   let goalId: string
   const updates: Record<string, unknown> = {}
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
 
   try {
     goalId = validateUUID(id, 'goal_id')

--- a/app/api/v1/savings-goals/route.ts
+++ b/app/api/v1/savings-goals/route.ts
@@ -4,6 +4,7 @@ import { ValidationError, validateAmount, validateEnum, validateText, validateYe
 // Shared bank-deposit valuation (simple interest, capped at maturity) so the
 // goals list matches the dashboard and goal detail.
 import { calcProjectedInterest } from '@/lib/finance'
+import { readJsonBody } from '@/lib/apiBody'
 
 export async function GET(request: NextRequest) {
   const supabase = await createSupabaseServerClient()
@@ -84,7 +85,9 @@ export async function POST(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const body = await request.json()
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
   const { goal_name, description, target_amount, target_date, icon, priority } = body
 
   let cleanGoalName: string

--- a/e2e/api-validation.spec.ts
+++ b/e2e/api-validation.spec.ts
@@ -191,4 +191,43 @@ test.describe('API input validation', () => {
       await api.deleteTransactionCascade(term.transaction_id)
     }
   })
+
+  // A malformed body is a client mistake, not a server failure. These used to
+  // throw an uncaught SyntaxError out of `await request.json()` and surface as
+  // 500s (#566). One canonical endpoint is enough here — the shared helper every
+  // write route now goes through is unit-tested in lib/__tests__/apiBody.test.ts.
+  //
+  // `Buffer`, not a string: Playwright JSON-encodes a string `data`, so the
+  // route would receive a perfectly valid JSON *string* and reject it in its own
+  // validators — 400 for the wrong reason, passing against the old code too.
+  // A Buffer is sent as raw bytes, which is what actually reproduces the 500.
+  const rawPost = (request: import('@playwright/test').APIRequestContext, raw: string) =>
+    request.post('/api/v1/savings-goals', {
+      headers: { 'Content-Type': 'application/json' },
+      data: Buffer.from(raw),
+    })
+
+  test('POST /api/v1/savings-goals rejects a syntactically invalid body (400)', async ({ request }) => {
+    const res = await rawPost(request, '{"goal_name": ')
+    expect(res.status()).toBe(400)
+  })
+
+  test('POST /api/v1/savings-goals rejects an empty body (400)', async ({ request }) => {
+    const res = await rawPost(request, '')
+    expect(res.status()).toBe(400)
+  })
+
+  test('POST /api/v1/savings-goals rejects a body that is not a JSON object (400)', async ({ request }) => {
+    const res = await rawPost(request, '"just a string"')
+    expect(res.status()).toBe(400)
+  })
+
+  test('POST /api/v1/savings-goals still validates a well-formed body the same way (400)', async ({ request }) => {
+    // Guards the other half of the change: valid JSON must still reach the
+    // route's own validators rather than being turned away by the new parser.
+    const res = await request.post('/api/v1/savings-goals', {
+      data: { goal_name: '' },
+    })
+    expect(res.status()).toBe(400)
+  })
 })

--- a/lib/__tests__/apiBody.test.ts
+++ b/lib/__tests__/apiBody.test.ts
@@ -51,6 +51,34 @@ describe('readJsonBody', () => {
   // destructuring (another 500), and a primitive or array silently yields
   // undefined for every field, which reads as "missing required field" rather
   // than "you sent the wrong shape".
+  // A few routes take an optional body — mark-paid defaults the payment date to
+  // today when none is sent. "Nothing sent" and "sent something broken" are
+  // different mistakes, and only the second is the client's.
+  describe('optional bodies', () => {
+    const read = (body: BodyInit | null) => readJsonBody(post(body), { optional: true })
+
+    it('treats an absent body as an empty object', async () => {
+      expect(await read(null)).toEqual({ ok: true, body: {} })
+    })
+
+    it('treats an empty body as an empty object', async () => {
+      expect(await read('')).toEqual({ ok: true, body: {} })
+      expect(await read('   ')).toEqual({ ok: true, body: {} })
+    })
+
+    it('still rejects a malformed body with 400', async () => {
+      const result = await read('{"paid_date": ')
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.response.status).toBe(400)
+    })
+
+    it('still rejects JSON that is not an object', async () => {
+      const result = await read('"2026-01-01"')
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.response.status).toBe(400)
+    })
+  })
+
   it('rejects JSON that is not an object', async () => {
     for (const body of ['null', '5', '"text"', 'true', '[{"goal_name":"House"}]']) {
       const { status, payload } = await reject(body)

--- a/lib/__tests__/apiBody.test.ts
+++ b/lib/__tests__/apiBody.test.ts
@@ -72,6 +72,23 @@ describe('readJsonBody', () => {
       if (!result.ok) expect(result.response.status).toBe(400)
     })
 
+    it('counts only JSON whitespace as empty', async () => {
+      expect(await read(' \t\r\n ')).toEqual({ ok: true, body: {} })
+    })
+
+    // `String.trim()` strips Unicode whitespace, but JSON allows only space,
+    // tab, CR and LF — so a body of U+00A0 would look empty here while
+    // JSON.parse rejects it, and mark-paid would run the mutation on a body it
+    // could not read. A BOM is deliberately absent from this list: `text()`
+    // strips it while decoding, so such a body really is empty by then.
+    it('rejects Unicode whitespace that JSON does not accept', async () => {
+      for (const raw of ['\u00A0', '\u2028', '\u000B']) {
+        const result = await read(raw)
+        expect(result.ok, JSON.stringify(raw)).toBe(false)
+        if (!result.ok) expect(result.response.status).toBe(400)
+      }
+    })
+
     it('still rejects JSON that is not an object', async () => {
       const result = await read('"2026-01-01"')
       expect(result.ok).toBe(false)

--- a/lib/__tests__/apiBody.test.ts
+++ b/lib/__tests__/apiBody.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest'
+import { readJsonBody } from '../apiBody'
+
+// Write handlers used to call `await request.json()` bare, so an invalid or
+// empty body threw an uncaught SyntaxError and Next reported it as a 500 — a
+// client mistake logged as a server failure, with retry semantics to match
+// (#566). Real Request objects here, so the parse failure is the browser's, not
+// a stand-in for it.
+const post = (body: BodyInit | null) =>
+  new Request('http://localhost/api/v1/savings-goals', { method: 'POST', body })
+
+async function reject(body: BodyInit | null) {
+  const result = await readJsonBody(post(body))
+  if (result.ok) throw new Error('expected the body to be rejected')
+  return { status: result.response.status, payload: await result.response.json() }
+}
+
+describe('readJsonBody', () => {
+  it('returns the parsed object for a valid body', async () => {
+    const result = await readJsonBody(post(JSON.stringify({ goal_name: 'House', target_amount: 100 })))
+
+    expect(result).toEqual({ ok: true, body: { goal_name: 'House', target_amount: 100 } })
+  })
+
+  it('accepts an empty object', async () => {
+    const result = await readJsonBody(post('{}'))
+
+    expect(result).toEqual({ ok: true, body: {} })
+  })
+
+  it('rejects a syntactically invalid body with 400', async () => {
+    expect(await reject('{"goal_name": ')).toEqual({
+      status: 400,
+      payload: { error: 'Request body must be valid JSON' },
+    })
+  })
+
+  it('rejects an empty body with 400', async () => {
+    expect((await reject('')).status).toBe(400)
+  })
+
+  it('rejects a body that is not sent at all with 400', async () => {
+    expect((await reject(null)).status).toBe(400)
+  })
+
+  it('rejects non-JSON content with 400', async () => {
+    expect((await reject('goal_name=House')).status).toBe(400)
+  })
+
+  // Handlers destructure the body straight away. `null` throws a TypeError on
+  // destructuring (another 500), and a primitive or array silently yields
+  // undefined for every field, which reads as "missing required field" rather
+  // than "you sent the wrong shape".
+  it('rejects JSON that is not an object', async () => {
+    for (const body of ['null', '5', '"text"', 'true', '[{"goal_name":"House"}]']) {
+      const { status, payload } = await reject(body)
+      expect(status, body).toBe(400)
+      expect(payload, body).toEqual({ error: 'Request body must be a JSON object' })
+    }
+  })
+})

--- a/lib/apiBody.ts
+++ b/lib/apiBody.ts
@@ -33,10 +33,31 @@ const badRequest = (error: string) => NextResponse.json({ error }, { status: 400
 
 export async function readJsonBody<T = JsonBody>(
   request: Request,
+  /**
+   * `optional` is for the few routes whose body is genuinely optional — mark-paid
+   * defaults the payment date to today when none is sent. Sending nothing and
+   * sending something broken are different mistakes, and only the second is the
+   * client's, so an absent body yields `{}` while a malformed one is still a 400.
+   */
+  { optional = false }: { optional?: boolean } = {},
 ): Promise<JsonBodyResult<T>> {
+  // Read as text rather than calling `.json()`, so "empty" is distinguishable
+  // from "unparseable" instead of both arriving as the same SyntaxError.
+  let raw: string
+  try {
+    raw = await request.text()
+  } catch {
+    return { ok: false, response: badRequest('Request body could not be read') }
+  }
+
+  if (raw.trim() === '') {
+    if (optional) return { ok: true, body: {} as T }
+    return { ok: false, response: badRequest('Request body must be valid JSON') }
+  }
+
   let parsed: unknown
   try {
-    parsed = await request.json()
+    parsed = JSON.parse(raw)
   } catch {
     return { ok: false, response: badRequest('Request body must be valid JSON') }
   }

--- a/lib/apiBody.ts
+++ b/lib/apiBody.ts
@@ -1,0 +1,54 @@
+// Request-body reading for API route handlers.
+//
+// Handlers used to call `await request.json()` bare, usually before entering the
+// `try` that converts ValidationError into a 400. An invalid or empty body threw
+// an uncaught SyntaxError, so a malformed client request was reported as HTTP
+// 500 — noise in error monitoring, misleading retry semantics, and a validation
+// contract that differed from every other bad input (#566).
+//
+// Returns a result rather than throwing so it works the same whether or not the
+// call site already has a try/catch, and so the 400 is visible at the call site:
+//
+//   const parsed = await readJsonBody(request)
+//   if (!parsed.ok) return parsed.response
+//   const { goal_name } = parsed.body
+
+import { NextResponse } from 'next/server'
+
+/**
+ * Field types stay as loose as `request.json()` was, so adopting this helper is
+ * a behaviour-preserving change and nothing else: routes narrow their own fields
+ * through lib/validation. A route that wants better than that can pass its own
+ * shape — `readJsonBody<{ ym?: string }>(request)` — which is the right way to
+ * tighten one route at a time.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type JsonBody = Record<string, any>
+
+export type JsonBodyResult<T> =
+  | { ok: true; body: T }
+  | { ok: false; response: NextResponse }
+
+const badRequest = (error: string) => NextResponse.json({ error }, { status: 400 })
+
+export async function readJsonBody<T = JsonBody>(
+  request: Request,
+): Promise<JsonBodyResult<T>> {
+  let parsed: unknown
+  try {
+    parsed = await request.json()
+  } catch {
+    return { ok: false, response: badRequest('Request body must be valid JSON') }
+  }
+
+  // Handlers destructure the body immediately. `null` throws a TypeError on
+  // destructuring — another 500 — and a primitive or array silently yields
+  // undefined for every field, which surfaces as "missing required field"
+  // rather than "wrong shape". Every write route here takes a JSON object;
+  // the one batch endpoint wraps its array in `{ transactions }`.
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return { ok: false, response: badRequest('Request body must be a JSON object') }
+  }
+
+  return { ok: true, body: parsed as T }
+}

--- a/lib/apiBody.ts
+++ b/lib/apiBody.ts
@@ -31,6 +31,12 @@ export type JsonBodyResult<T> =
 
 const badRequest = (error: string) => NextResponse.json({ error }, { status: 400 })
 
+// "Nothing but whitespace" by JSON's definition, which is only space, tab, LF
+// and CR. `String.trim()` uses the much wider Unicode set, so it would call a
+// body of U+00A0 or a BOM empty — and an optional route would accept that as
+// `{}` and mutate, on a body JSON.parse cannot read.
+const JSON_BLANK = /^[ \t\n\r]*$/
+
 export async function readJsonBody<T = JsonBody>(
   request: Request,
   /**
@@ -50,7 +56,7 @@ export async function readJsonBody<T = JsonBody>(
     return { ok: false, response: badRequest('Request body could not be read') }
   }
 
-  if (raw.trim() === '') {
+  if (JSON_BLANK.test(raw)) {
     if (optional) return { ok: true, body: {} as T }
     return { ok: false, response: badRequest('Request body must be valid JSON') }
   }


### PR DESCRIPTION
Closes #566.

## Problem

Write handlers called `await request.json()` bare, almost always *before* the `try/catch` that turns a `ValidationError` into a 400. An invalid or empty body threw an uncaught `SyntaxError`, and Next reported it as HTTP 500 — a client mistake logged as a server failure, with retry semantics to match.

Confirmed against the running app before fixing, with a raw malformed body to `POST /api/v1/savings-goals`:

```
STRING  400 {"error":"goal_name must be a string"}   ← Playwright JSON-encoded the string; not a real repro
BUFFER  500                                          ← actual raw body: the bug
EMPTY   500                                          ← empty body: same
```

## Fix

A shared `lib/apiBody.ts`. All **30 call sites across 29 route files** now go through it:

```ts
const parsed = await readJsonBody(request)
if (!parsed.ok) return parsed.response
const body = parsed.body
```

It returns a result rather than throwing, so it behaves the same whether or not the call site already sits inside a `try`, and the 400 stays visible at the call site.

It also rejects JSON that parses but isn't an object. Handlers destructure immediately: `null` throws a `TypeError` on destructuring (a second 500), and a primitive or array silently yields `undefined` for every field, which surfaces as "missing required field" rather than "wrong shape". No route wants a bare array — the one batch endpoint wraps its array in `{ transactions }`.

## On typing

The parsed body keeps the loose typing `request.json()` already had, so this is behaviour-preserving and nothing else — routes still narrow their own fields through `lib/validation`.

Tightening it properly is a separate change: `Record<string, unknown>` produced 12 type errors in 4 files, all pre-existing looseness that `any` was hiding (`fulfill_recurring.saving_id` reached through an untyped field; `FUND_TYPES.includes(fund_type)` on an unnarrowed value). Rather than fold that into a 29-file mechanical change, the helper takes a generic so a route can opt in one at a time: `readJsonBody<{ ym?: string }>(request)`.

## Tests

- `lib/__tests__/apiBody.test.ts` — 7 cases against **real `Request` objects**, so the parse failure is the platform's rather than a stand-in: valid body, empty object, invalid syntax, empty body, absent body, non-JSON content, and each non-object JSON shape.
- `e2e/api-validation.spec.ts` — extended rather than replaced, per the repo's E2E guidance. Three malformed-body cases on the canonical endpoint, plus one asserting a well-formed body still reaches the route's own validators unchanged.

One trap worth recording: the E2E cases must send `Buffer.from(raw)`, not a string. Playwright JSON-encodes a string `data`, so the route receives a valid JSON *string* and rejects it in its own validators — 400 for the wrong reason, and green against the old code too. I caught this by reverting a route and finding the tests still passed; the probe output above is what settled it.

## Verification

- `npm test -- --run` — 157 files, **1675 passed**
- `eslint` clean, `tsc --noEmit` clean
- **Full E2E** (`--project=chromium`) — **251 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)