### PR TITLE
refactor(dashboard): share the net-worth sparkline and relative-time helper

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -27,6 +27,7 @@ import { collapseUnallocatedBooks } from './unallocatedBooks'
 import type { InvRow } from './components/goalDetailShared'
 import { loadOverview, overviewErrorText, getCachedOverview, setCachedOverview, computeAllocationTotals } from './overviewData'
 import { fetchNetWorthHistory, type TimeRange, type ChartPoint } from './components/netWorthHistory'
+import { fmtTimeAgo } from '@/lib/formatters'
 
 import TransactionHistorySheet from './components/TransactionHistorySheet'
 import DesktopNetWorthPanel from './components/DesktopNetWorthPanel'
@@ -193,17 +194,6 @@ function SortDropdown({ value, onChange, options }: {
       )}
     </div>
   )
-}
-
-function fmtTimeAgo(isoString: string, locale: string): string {
-  const diffMs = Date.now() - new Date(isoString).getTime()
-  const mins = Math.floor(diffMs / 60_000)
-  const hours = Math.floor(mins / 60)
-  const days = Math.floor(hours / 24)
-  const isVi = locale === 'vi'
-  if (days > 0) return isVi ? `${days} ngày trước` : `${days}d ago`
-  if (hours > 0) return isVi ? `${hours} giờ trước` : `${hours}h ago`
-  return isVi ? `${mins} phút trước` : `${mins}m ago`
 }
 
 // Map a dashboard overview non-fund holding to the InvRow shape the maturity

--- a/app/assets/components/DesktopNetWorthPanel.tsx
+++ b/app/assets/components/DesktopNetWorthPanel.tsx
@@ -1,48 +1,15 @@
 'use client'
 
 import { ArrowDownToLine } from 'lucide-react'
-import { fmtCompact, fmtPct } from '@/lib/formatters'
+import { fmtCompact, fmtPct, fmtTimeAgo } from '@/lib/formatters'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import type { DashboardData } from '../DashboardClient'
 import type { AllocationTotals } from '../overviewData'
 import { TIME_RANGES, type TimeRange, type ChartPoint } from './netWorthHistory'
+import Sparkline from './Sparkline'
 
-function fmtTimeAgo(isoString: string, locale: string): string {
-  const diffMs = Date.now() - new Date(isoString).getTime()
-  const mins = Math.floor(diffMs / 60_000)
-  const hours = Math.floor(mins / 60)
-  const days = Math.floor(hours / 24)
-  const isVi = locale === 'vi'
-  if (days > 0) return isVi ? `${days} ngày trước` : `${days}d ago`
-  if (hours > 0) return isVi ? `${hours} giờ trước` : `${hours}h ago`
-  return isVi ? `${mins} phút trước` : `${mins}m ago`
-}
-
-function Sparkline({ data, positive }: { data: ChartPoint[]; positive: boolean }) {
-  if (data.length < 2) return null
-  const values = data.map((d) => d.value)
-  const rawMin = Math.min(...values)
-  const rawMax = Math.max(...values)
-  const pad = (rawMax - rawMin) * 0.15 || rawMax * 0.1 || 1
-  const min = Math.max(0, rawMin - pad)
-  const max = rawMax + pad
-  const range = max - min || 1
-  const W = 100
-  const H = 40
-  const points = values
-    .map((v, i) => {
-      const x = (i / (values.length - 1)) * W
-      const y = H - ((v - min) / range) * (H - 6) - 3
-      return `${x.toFixed(2)},${y.toFixed(2)}`
-    })
-    .join(' ')
-  const color = positive ? 'var(--c-pos)' : 'var(--c-neg)'
-  return (
-    <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ width: '100%', height: H, display: 'block' }}>
-      <polyline points={points} fill="none" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-    </svg>
-  )
-}
+// Taller than the mobile card's — the desktop panel has the room for it.
+const SPARKLINE_HEIGHT = 40
 
 const ALLOC_COLORS: Record<string, { color: string; label: string; labelVi: string }> = {
   fund:  { color: '#2563eb', label: 'Funds',   labelVi: 'Quỹ' },
@@ -134,7 +101,7 @@ export default function DesktopNetWorthPanel({ data, allocationTotals, goldUnits
         {/* Sparkline */}
         <div style={{ marginTop: 16, paddingBottom: 4 }}>
           {history.length > 1
-            ? <Sparkline data={history} positive={isPos} />
+            ? <Sparkline data={history} positive={isPos} height={SPARKLINE_HEIGHT} />
             : <div style={{ height: 40, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                 <span style={{ fontSize: 11, color: 'var(--c-muted)' }}>{isVi ? 'Không có dữ liệu' : 'No history yet'}</span>
               </div>

--- a/app/assets/components/NetWorthCard.tsx
+++ b/app/assets/components/NetWorthCard.tsx
@@ -5,33 +5,10 @@ import { TrendingUp, TrendingDown } from 'lucide-react'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { TIME_RANGES, type TimeRange, type ChartPoint } from './netWorthHistory'
+import Sparkline from './Sparkline'
 
-// SVG sparkline — no recharts dependency
-function Sparkline({ data, positive }: { data: ChartPoint[]; positive: boolean }) {
-  if (data.length < 2) return null
-  const values = data.map((d) => d.value)
-  const rawMin = Math.min(...values)
-  const rawMax = Math.max(...values)
-  const pad = (rawMax - rawMin) * 0.15 || rawMax * 0.1 || 1
-  const min = Math.max(0, rawMin - pad)
-  const max = rawMax + pad
-  const range = max - min || 1
-  const W = 100
-  const H = 36
-  const points = values
-    .map((v, i) => {
-      const x = (i / (values.length - 1)) * W
-      const y = H - ((v - min) / range) * (H - 6) - 3
-      return `${x.toFixed(2)},${y.toFixed(2)}`
-    })
-    .join(' ')
-  const color = positive ? 'var(--c-pos)' : 'var(--c-neg)'
-  return (
-    <svg viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" style={{ width: '100%', height: H, display: 'block' }}>
-      <polyline points={points} fill="none" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
-    </svg>
-  )
-}
+// Shorter than the desktop panel's — this card sits in a denser mobile stack.
+const SPARKLINE_HEIGHT = 36
 
 const ALLOC_COLORS = {
   fund:  '#2563eb',
@@ -201,7 +178,7 @@ export default function NetWorthCard({
       {/* Sparkline */}
       <div style={{ marginTop: 16, paddingBottom: 6 }}>
         {history.length > 1
-          ? <Sparkline data={history} positive={plPositive} />
+          ? <Sparkline data={history} positive={plPositive} height={SPARKLINE_HEIGHT} />
           : <div style={{ height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
               <span style={{ fontSize: 11, color: 'var(--c-muted)' }}>{t('noHistoryYet')}</span>
             </div>

--- a/app/assets/components/Sparkline.tsx
+++ b/app/assets/components/Sparkline.tsx
@@ -1,0 +1,63 @@
+import type { ChartPoint } from './netWorthHistory'
+
+// A fixed-width viewBox scaled to the container by `preserveAspectRatio="none"`,
+// so the only thing a caller varies is the height.
+export const SPARKLINE_WIDTH = 100
+
+// Breathing room above and below the line so the stroke isn't clipped at the
+// extremes of the range.
+const STROKE_INSET = 3
+
+/**
+ * Net-worth trend line, shared by the mobile card and the desktop panel — the
+ * two used byte-identical copies that differed only in height (#569).
+ *
+ * `height` is required rather than defaulted: the two call sites genuinely
+ * differ, and a default would quietly hide which one a caller meant.
+ */
+export function sparklinePoints(values: number[], height: number): string {
+  const rawMin = Math.min(...values)
+  const rawMax = Math.max(...values)
+  // Pad the range so a nearly-flat series still reads as a line rather than
+  // hugging an edge. The fallbacks keep a flat or all-zero series finite.
+  const pad = (rawMax - rawMin) * 0.15 || rawMax * 0.1 || 1
+  const min = Math.max(0, rawMin - pad)
+  const max = rawMax + pad
+  const range = max - min || 1
+  const usable = height - STROKE_INSET * 2
+
+  return values
+    .map((v, i) => {
+      const x = (i / (values.length - 1)) * SPARKLINE_WIDTH
+      // SVG y grows downward, so a higher value sits at a smaller y.
+      const y = height - ((v - min) / range) * usable - STROKE_INSET
+      return `${x.toFixed(2)},${y.toFixed(2)}`
+    })
+    .join(' ')
+}
+
+export default function Sparkline({
+  data,
+  positive,
+  height,
+}: {
+  data: ChartPoint[]
+  positive: boolean
+  height: number
+}) {
+  // One point is not a line, and the x maths would divide by zero.
+  if (data.length < 2) return null
+
+  const points = sparklinePoints(data.map((d) => d.value), height)
+  const color = positive ? 'var(--c-pos)' : 'var(--c-neg)'
+
+  return (
+    <svg
+      viewBox={`0 0 ${SPARKLINE_WIDTH} ${height}`}
+      preserveAspectRatio="none"
+      style={{ width: '100%', height, display: 'block' }}
+    >
+      <polyline points={points} fill="none" stroke={color} strokeWidth="1.5" vectorEffect="non-scaling-stroke" />
+    </svg>
+  )
+}

--- a/app/assets/components/__tests__/Sparkline.test.tsx
+++ b/app/assets/components/__tests__/Sparkline.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import Sparkline, { SPARKLINE_WIDTH, sparklinePoints } from '../Sparkline'
+import type { ChartPoint } from '../netWorthHistory'
+
+// The point maths and the SVG were copied byte-for-byte between NetWorthCard and
+// DesktopNetWorthPanel, differing only in height, so neither copy was covered
+// (#569). The maths lives on its own here so it can be checked without a DOM.
+const points = (values: number[], height: number) =>
+  sparklinePoints(values, height)
+    .split(' ')
+    .map((pair) => pair.split(',').map(Number))
+
+describe('sparklinePoints', () => {
+  it('spreads points evenly across the full width', () => {
+    const xs = points([1, 2, 3], 36).map(([x]) => x)
+
+    expect(xs).toEqual([0, SPARKLINE_WIDTH / 2, SPARKLINE_WIDTH])
+  })
+
+  it('draws a rising series downward in SVG coordinates', () => {
+    const ys = points([1, 5, 9], 36).map(([, y]) => y)
+
+    // SVG y grows downward, so a rising value must produce a falling y.
+    expect(ys[0]).toBeGreaterThan(ys[1])
+    expect(ys[1]).toBeGreaterThan(ys[2])
+  })
+
+  it('keeps every point inside the box, with room for the stroke', () => {
+    for (const height of [36, 40]) {
+      for (const [, y] of points([1, 50, 3, 99, 20], height)) {
+        expect(y).toBeGreaterThanOrEqual(3)
+        expect(y).toBeLessThanOrEqual(height - 3)
+      }
+    }
+  })
+
+  it('scales to the height it is given', () => {
+    const short = points([1, 9], 36).map(([, y]) => y)
+    const tall = points([1, 9], 40).map(([, y]) => y)
+
+    expect(tall).not.toEqual(short)
+  })
+
+  // A flat series has no range to scale by; the old code guarded this with
+  // `|| 1` fallbacks, and losing that would divide by zero and emit NaN.
+  it('survives a flat series', () => {
+    for (const [, y] of points([5, 5, 5], 36)) expect(Number.isFinite(y)).toBe(true)
+  })
+
+  it('survives an all-zero series', () => {
+    for (const [, y] of points([0, 0], 36)) expect(Number.isFinite(y)).toBe(true)
+  })
+})
+
+describe('Sparkline', () => {
+  const data: ChartPoint[] = [
+    { label: 'a', value: 1 },
+    { label: 'b', value: 2 },
+  ]
+
+  it('renders nothing for a single point — a line needs two', () => {
+    const { container } = render(<Sparkline data={[data[0]]} positive height={36} />)
+
+    expect(container.querySelector('svg')).toBeNull()
+  })
+
+  it('renders at the height it is given, so mobile and desktop can differ', () => {
+    const { container: mobile } = render(<Sparkline data={data} positive height={36} />)
+    const { container: desktop } = render(<Sparkline data={data} positive height={40} />)
+
+    expect(mobile.querySelector('svg')).toHaveAttribute('viewBox', `0 0 ${SPARKLINE_WIDTH} 36`)
+    expect(desktop.querySelector('svg')).toHaveAttribute('viewBox', `0 0 ${SPARKLINE_WIDTH} 40`)
+  })
+
+  it('colours by direction', () => {
+    const { container: up } = render(<Sparkline data={data} positive height={36} />)
+    const { container: down } = render(<Sparkline data={data} positive={false} height={36} />)
+
+    expect(up.querySelector('polyline')).toHaveAttribute('stroke', 'var(--c-pos)')
+    expect(down.querySelector('polyline')).toHaveAttribute('stroke', 'var(--c-neg)')
+  })
+})

--- a/lib/__tests__/formatters.test.ts
+++ b/lib/__tests__/formatters.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { fmt, fmtNav, fmtUnits, fmtPct } from '../formatters'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { fmt, fmtNav, fmtUnits, fmtPct, fmtTimeAgo } from '../formatters'
 
 describe('fmt', () => {
   it('formats whole VND amounts with vi-VN thousands separator', () => {
@@ -61,5 +61,66 @@ describe('fmtPct', () => {
   })
   it('always shows 2 decimal places', () => {
     expect(fmtPct(1)).toBe('+1.00%')
+  })
+})
+
+// The "NAV updated N ago" label under the net-worth figure. It was copied
+// byte-for-byte into DashboardClient and DesktopNetWorthPanel, so neither copy
+// had any coverage of its Vietnamese output (#569).
+describe('fmtTimeAgo', () => {
+  const NOW = new Date('2026-07-29T12:00:00Z')
+  const ago = (ms: number) => new Date(NOW.getTime() - ms).toISOString()
+  const MIN = 60_000
+  const HOUR = 60 * MIN
+  const DAY = 24 * HOUR
+
+  const withClock = (fn: () => void) => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    fn()
+  }
+
+  afterEach(() => vi.useRealTimers())
+
+  it('reads minutes in English and Vietnamese', () => {
+    withClock(() => {
+      expect(fmtTimeAgo(ago(5 * MIN), 'en')).toBe('5m ago')
+      expect(fmtTimeAgo(ago(5 * MIN), 'vi')).toBe('5 phút trước')
+    })
+  })
+
+  it('reads hours in English and Vietnamese', () => {
+    withClock(() => {
+      expect(fmtTimeAgo(ago(3 * HOUR), 'en')).toBe('3h ago')
+      expect(fmtTimeAgo(ago(3 * HOUR), 'vi')).toBe('3 giờ trước')
+    })
+  })
+
+  it('reads days in English and Vietnamese', () => {
+    withClock(() => {
+      expect(fmtTimeAgo(ago(2 * DAY), 'en')).toBe('2d ago')
+      expect(fmtTimeAgo(ago(2 * DAY), 'vi')).toBe('2 ngày trước')
+    })
+  })
+
+  it('reports the largest whole unit, not a rounded one', () => {
+    withClock(() => {
+      // 90 minutes is an hour and a half — "1h ago", never "2h ago".
+      expect(fmtTimeAgo(ago(90 * MIN), 'en')).toBe('1h ago')
+      expect(fmtTimeAgo(ago(47 * HOUR), 'en')).toBe('1d ago')
+    })
+  })
+
+  it('falls back to minutes for anything under an hour, including just now', () => {
+    withClock(() => {
+      expect(fmtTimeAgo(ago(0), 'en')).toBe('0m ago')
+      expect(fmtTimeAgo(ago(59 * MIN), 'vi')).toBe('59 phút trước')
+    })
+  })
+
+  it('treats any locale that is not Vietnamese as English', () => {
+    withClock(() => {
+      expect(fmtTimeAgo(ago(5 * MIN), 'fr')).toBe('5m ago')
+    })
   })
 })

--- a/lib/formatters.ts
+++ b/lib/formatters.ts
@@ -8,6 +8,24 @@ export const fmtUnits = (n: number) =>
 
 export const fmtPct = (n: number) => `${n >= 0 ? '+' : ''}${n.toFixed(2)}%`
 
+/**
+ * Coarse "N ago" for the NAV-updated label under the net-worth figure. Reports
+ * the largest whole unit and stops at days — this labels a price sync, so
+ * anything older than a few days reads the same to the user either way.
+ *
+ * Any locale that isn't Vietnamese renders in English.
+ */
+export function fmtTimeAgo(isoString: string, locale: string): string {
+  const diffMs = Date.now() - new Date(isoString).getTime()
+  const mins = Math.floor(diffMs / 60_000)
+  const hours = Math.floor(mins / 60)
+  const days = Math.floor(hours / 24)
+  const isVi = locale === 'vi'
+  if (days > 0) return isVi ? `${days} ngày trước` : `${days}d ago`
+  if (hours > 0) return isVi ? `${hours} giờ trước` : `${hours}h ago`
+  return isVi ? `${mins} phút trước` : `${mins}m ago`
+}
+
 // Compact money for dense lists: 15.5M ₫, 350K ₫, 1.2B ₫
 export const fmtCompact = (n: number) => {
   const abs = Math.abs(n)


### PR DESCRIPTION
Closes #569.

## What was duplicated

Verified before touching anything — the two `Sparkline` implementations are **byte-identical apart from one line**:

```
NetWorthCard.tsx          const H = 36
DesktopNetWorthPanel.tsx  const H = 40
```

`fmtTimeAgo` was duplicated a third time, character for character, between `DashboardClient` and `DesktopNetWorthPanel`.

## What changed

`app/assets/components/Sparkline.tsx` owns the point maths and the SVG. `height` is a **required** prop rather than a defaulted one: the two call sites genuinely differ, and a default would quietly hide which one a caller meant. Each site now names its own constant with the reason for its value, so the difference is stated rather than buried in a copy.

The point maths is exported as `sparklinePoints` so it can be checked without a DOM. The two magic numbers it carried are named — `SPARKLINE_WIDTH`, `STROKE_INSET` — which is what makes `H - 6` legible as "the height, less the stroke inset at each end".

`fmtTimeAgo` moves to `lib/formatters`, alongside the other locale-aware formatters.

## Behaviour is unchanged, and not only by inspection

A refactor's whole risk is silently changing output, so I ran the extracted formula against the original across 16 series × height combinations — rising, flat, all-zero, negative, billions, sub-unit, and a 30-point wave — at both 36 and 40:

```
IDENTICAL across 16 cases
```

## Tests

New, covering what neither copy had:

- `sparklinePoints` — even x distribution, rising series drawing downward in SVG coordinates, every point inside the box at both heights, scaling with height, and finite output for flat and all-zero series (the `|| 1` guards the original relied on)
- `Sparkline` — renders nothing below two points, honours the height it is given, colours by direction
- `fmtTimeAgo` — minutes/hours/days in **both** Vietnamese and English, largest-whole-unit rather than rounding (90 min is "1h ago", not "2h"), the under-an-hour fallback, and non-`vi` locales falling back to English

## Verification

- `npm test -- --run` — 158 files, **1702 passed**
- `eslint` clean, `tsc --noEmit` clean
- `npx playwright test e2e/dashboard.spec.ts e2e/dashboard-desktop.spec.ts --project=chromium` — **25 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)