### PR TITLE
refactor(dashboard): centralize the assign-to-goal mutation

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -28,6 +28,7 @@ import type { InvRow } from './components/goalDetailShared'
 import { loadOverview, overviewErrorText, getCachedOverview, setCachedOverview, computeAllocationTotals } from './overviewData'
 import { fetchNetWorthHistory, type TimeRange, type ChartPoint } from './components/netWorthHistory'
 import { fmtTimeAgo } from '@/lib/formatters'
+import { assignInvestmentToGoal } from '@/lib/assignToGoal'
 
 import TransactionHistorySheet from './components/TransactionHistorySheet'
 import DesktopNetWorthPanel from './components/DesktopNetWorthPanel'
@@ -812,30 +813,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
                       onAssignNonFundToGoal={(txId, name, value, type) => { setNonFundPickerTxId(txId); setNonFundPickerItem({ name, value, type }) }}
                       onSellNonFund={openSellNonFund}
                       desktopCard
-                      onDesktopAssign={async (kind, id, goalId) => {
-                        if (kind === 'fund') {
-                          const res = await fetch(`/api/v1/fund-investments?fund_id=${id}`)
-                          if (!res.ok) throw new Error('Failed to fetch fund investments')
-                          const investments = await res.json() as Array<{ id: string }>
-                          await Promise.all(investments.map((inv) =>
-                            fetch(`/api/v1/fund-investments/${inv.id}/goal`, {
-                              method: 'PATCH',
-                              headers: { 'Content-Type': 'application/json' },
-                              body: JSON.stringify({ goal_id: goalId }),
-                            }).then((r) => { if (!r.ok) throw new Error('Failed to assign') })
-                          ))
-                        } else {
-                          const res = await fetch(`/api/v1/investment-transactions/${id}/assign`, {
-                            method: 'PUT',
-                            headers: { 'Content-Type': 'application/json' },
-                            body: JSON.stringify({ goal_id: goalId }),
-                          })
-                          if (!res.ok) {
-                            const { error: e } = await res.json().catch(() => ({ error: 'Failed to assign' }))
-                            throw new Error(e ?? 'Failed to assign')
-                          }
-                        }
-                      }}
+                      onDesktopAssign={assignInvestmentToGoal}
                       // Refreshing drops the assigned row and unmounts the
                       // section showing the success flash, so the section decides
                       // when that is safe rather than both sides running their
@@ -1099,18 +1077,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
         desktop={isDesktop}
         onConfirm={async (goalId) => {
           if (!goalPickerFundId) return
-          const res = await fetch(`/api/v1/fund-investments?fund_id=${goalPickerFundId}`)
-          if (!res.ok) throw new Error('Failed to fetch fund investments')
-          const investments = await res.json() as Array<{ id: string }>
-          await Promise.all(
-            investments.map((inv) =>
-              fetch(`/api/v1/fund-investments/${inv.id}/goal`, {
-                method: 'PATCH',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ goal_id: goalId }),
-              }).then((r) => { if (!r.ok) throw new Error('Failed to assign') })
-            )
-          )
+          await assignInvestmentToGoal('fund', goalPickerFundId, goalId)
         }}
       />
 
@@ -1122,15 +1089,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
         desktop={isDesktop}
         onConfirm={async (goalId) => {
           if (!nonFundPickerTxId) return
-          const res = await fetch(`/api/v1/investment-transactions/${nonFundPickerTxId}/assign`, {
-            method: 'PUT',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ goal_id: goalId }),
-          })
-          if (!res.ok) {
-            const { error: e } = await res.json().catch(() => ({ error: 'Failed to assign' }))
-            throw new Error(e ?? 'Failed to assign')
-          }
+          await assignInvestmentToGoal('nonFund', nonFundPickerTxId, goalId)
         }}
       />
 

--- a/lib/__tests__/assignToGoal.test.ts
+++ b/lib/__tests__/assignToGoal.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { assignInvestmentToGoal } from '../assignToGoal'
+
+// The desktop inline flow and both AssignGoalSheet callbacks carried their own
+// copy of these requests, so error handling could be fixed on one surface and
+// missed on the others (#571). None of the three had any coverage.
+
+type Handler = (url: string, init?: RequestInit) => { ok: boolean; body?: unknown }
+
+function stubFetch(handler: Handler) {
+  const calls: Array<{ url: string; method: string; body: unknown }> = []
+  vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+    calls.push({
+      url,
+      method: init?.method ?? 'GET',
+      body: init?.body ? JSON.parse(init.body as string) : undefined,
+    })
+    const { ok, body } = handler(url, init)
+    return { ok, json: async () => body }
+  }))
+  return calls
+}
+
+const FUND_LIST = [{ id: 'inv-1' }, { id: 'inv-2' }, { id: 'inv-3' }]
+
+beforeEach(() => vi.unstubAllGlobals())
+afterEach(() => vi.unstubAllGlobals())
+
+describe('assignInvestmentToGoal — funds', () => {
+  it('moves every investment of the fund to the goal', async () => {
+    const calls = stubFetch((url) =>
+      url.includes('fund-investments?') ? { ok: true, body: FUND_LIST } : { ok: true })
+
+    await assignInvestmentToGoal('fund', 'fund-1', 'goal-1')
+
+    expect(calls[0].url).toBe('/api/v1/fund-investments?fund_id=fund-1')
+    // Every investment is PATCHed — a fund row on the dashboard aggregates them.
+    expect(calls.slice(1).map((c) => c.url)).toEqual([
+      '/api/v1/fund-investments/inv-1/goal',
+      '/api/v1/fund-investments/inv-2/goal',
+      '/api/v1/fund-investments/inv-3/goal',
+    ])
+    expect(calls.slice(1).every((c) => c.method === 'PATCH')).toBe(true)
+    expect(calls[1].body).toEqual({ goal_id: 'goal-1' })
+  })
+
+  it('throws when the investment list cannot be read', async () => {
+    stubFetch((url) => (url.includes('fund-investments?') ? { ok: false } : { ok: true }))
+
+    await expect(assignInvestmentToGoal('fund', 'fund-1', 'goal-1'))
+      .rejects.toThrow(/failed to fetch fund investments/i)
+  })
+
+  // The dashboard shows one row per fund, so a fund that half-moved is a state
+  // the user cannot see or correct from the list. It has to surface as an error.
+  it('throws when only some of the investments move', async () => {
+    stubFetch((url) => {
+      if (url.includes('fund-investments?')) return { ok: true, body: FUND_LIST }
+      return { ok: !url.includes('inv-2') }
+    })
+
+    await expect(assignInvestmentToGoal('fund', 'fund-1', 'goal-1'))
+      .rejects.toThrow(/failed to assign/i)
+  })
+
+  it('still issues the other requests when one fails — they are not sequenced', async () => {
+    const calls = stubFetch((url) => {
+      if (url.includes('fund-investments?')) return { ok: true, body: FUND_LIST }
+      return { ok: !url.includes('inv-1') }
+    })
+
+    await expect(assignInvestmentToGoal('fund', 'fund-1', 'goal-1')).rejects.toThrow()
+
+    expect(calls.filter((c) => c.method === 'PATCH')).toHaveLength(3)
+  })
+
+  it('accepts a fund with no investments as a no-op', async () => {
+    stubFetch((url) => (url.includes('fund-investments?') ? { ok: true, body: [] } : { ok: true }))
+
+    await expect(assignInvestmentToGoal('fund', 'fund-1', 'goal-1')).resolves.toBeUndefined()
+  })
+})
+
+describe('assignInvestmentToGoal — non-funds', () => {
+  it('assigns the transaction to the goal', async () => {
+    const calls = stubFetch(() => ({ ok: true }))
+
+    await assignInvestmentToGoal('nonFund', 'tx-1', 'goal-1')
+
+    expect(calls).toEqual([{
+      url: '/api/v1/investment-transactions/tx-1/assign',
+      method: 'PUT',
+      body: { goal_id: 'goal-1' },
+    }])
+  })
+
+  // The route explains *why* it refused — "book is held for merge", say — and
+  // the sheet shows that text. Replacing it with a generic message would lose
+  // the only explanation the user gets.
+  it('surfaces the message the server gave', async () => {
+    stubFetch(() => ({ ok: false, body: { error: 'Deposit is held for merge' } }))
+
+    await expect(assignInvestmentToGoal('nonFund', 'tx-1', 'goal-1'))
+      .rejects.toThrow('Deposit is held for merge')
+  })
+
+  it('falls back to a generic message when the error body is unreadable', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      json: async () => { throw new SyntaxError('not JSON') },
+    })))
+
+    await expect(assignInvestmentToGoal('nonFund', 'tx-1', 'goal-1'))
+      .rejects.toThrow(/failed to assign/i)
+  })
+
+  it('falls back when the error body carries no message', async () => {
+    stubFetch(() => ({ ok: false, body: {} }))
+
+    await expect(assignInvestmentToGoal('nonFund', 'tx-1', 'goal-1'))
+      .rejects.toThrow(/failed to assign/i)
+  })
+})

--- a/lib/assignToGoal.ts
+++ b/lib/assignToGoal.ts
@@ -1,0 +1,62 @@
+// The single assign-to-goal mutation, shared by every surface that offers it:
+// the desktop inline flow in UnallocatedSection and both AssignGoalSheet
+// callbacks (fund and non-fund). Each used to carry its own copy, so a fix to
+// error handling or atomicity could land on one and miss the others (#571).
+//
+// Callers keep their own UI concerns — success flashes, closing, and refresh
+// sequencing (see #567) — and only await this.
+//
+// Deliberately *not* shared with `unassignInvestment` in goalActions.ts: that
+// scopes its fund query by goal_id, because the same fund can be split across
+// goals and an unfiltered query would clear the other goals' rows too (#467).
+// Same-looking requests, different operation.
+
+export type AssignKind = 'fund' | 'nonFund'
+
+/**
+ * @param kind  'fund' aggregates every fund-investment of the fund; 'nonFund' is
+ *              a single investment_transactions row (the route cascades a book).
+ * @param id    fund id, or transaction id
+ * @throws Error carrying a message suitable for display
+ */
+export async function assignInvestmentToGoal(
+  kind: AssignKind,
+  id: string,
+  goalId: string,
+): Promise<void> {
+  if (kind === 'fund') return assignFund(id, goalId)
+  return assignNonFund(id, goalId)
+}
+
+async function assignFund(fundId: string, goalId: string): Promise<void> {
+  // A dashboard fund row aggregates every investment in that fund, so assigning
+  // the row means moving all of them.
+  const res = await fetch(`/api/v1/fund-investments?fund_id=${fundId}`)
+  if (!res.ok) throw new Error('Failed to fetch fund investments')
+  const investments = await res.json() as Array<{ id: string }>
+
+  // Issued together rather than in sequence: they are independent, and the user
+  // is waiting on a success flash. A partial move still throws — the list shows
+  // one row per fund, so a half-moved fund is a state the user can't see.
+  await Promise.all(investments.map((inv) =>
+    fetch(`/api/v1/fund-investments/${inv.id}/goal`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ goal_id: goalId }),
+    }).then((r) => { if (!r.ok) throw new Error('Failed to assign') })
+  ))
+}
+
+async function assignNonFund(transactionId: string, goalId: string): Promise<void> {
+  const res = await fetch(`/api/v1/investment-transactions/${transactionId}/assign`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ goal_id: goalId }),
+  })
+  if (res.ok) return
+
+  // The route explains why it refused — a book held for merge, for instance —
+  // and that text is the only explanation the user gets.
+  const { error } = await res.json().catch(() => ({ error: null })) as { error?: string | null }
+  throw new Error(error ?? 'Failed to assign')
+}


### PR DESCRIPTION
Closes #571.

## What was duplicated

Three copies in `DashboardClient`, as the issue says — the desktop inline `onDesktopAssign`, and the fund and non-fund `AssignGoalSheet.onConfirm` callbacks. The fund branches were byte-identical; the non-fund branches likewise. None of the three had any test coverage.

`lib/assignToGoal.ts` owns both shapes now, and `DashboardClient` loses 45 lines for 4.

## A fourth copy that is deliberately *not* folded in

A repo-wide search turned up `unassignInvestment` in `app/assets/components/goalActions.ts`, which issues requests to the same two endpoints. It looks like the same operation and isn't:

```ts
// unassign — scoped
`/api/v1/fund-investments?fund_id=${fundId}&goal_id=${goalId}`
// assign — unscoped
`/api/v1/fund-investments?fund_id=${fundId}`
```

The scoping is deliberate and load-bearing: one fund can be split across goals, so an unfiltered query would clear the *other* goals' rows too — that's #467, fixed once already. It also returns `boolean` rather than throwing. Merging them would risk regressing that fix to save a few lines, so it stays where it is, and the new module says why in a comment.

## Behaviour preserved

- The fund path issues its PATCHes together rather than in sequence, and a partial failure still throws — the dashboard shows one row per fund, so a half-moved fund is a state the user can't see or correct from the list.
- The non-fund path still surfaces the **server's** message. That text ("Deposit is held for merge") is the only explanation the user gets; a generic string would lose it.
- The desktop flow still hands its refresh to `UnallocatedSection` via `onDesktopAssigned` rather than scheduling one itself, so the success-flash sequencing from #567 is untouched. The issue asked for this coordination explicitly.

## Tests

Nine cases, covering the four the issue asked for and a few the copies made easy to get wrong:

- fund success — asserts *every* investment is PATCHed, with the right method and body
- non-fund success — asserts the exact request
- partial fund failure — throws
- the other requests still go out when one fails (they aren't sequenced)
- a fund with no investments is a no-op
- server error propagation — the route's message reaches the caller
- unreadable error body, and an error body with no message — both fall back

## Verification

- `npm test -- --run` — 159 files, **1711 passed**
- `eslint` clean, `tsc --noEmit` clean
- **Full E2E** (`--project=chromium`) — **251 passed, 0 failed**. Run in full rather than targeted because this touches all three assign surfaces of the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)