### PR TITLE
refactor(api): share the fund create/update payload validation

### DIFF
--- a/app/api/funds/[id]/route.ts
+++ b/app/api/funds/[id]/route.ts
@@ -1,11 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { validateNavSourceUrl } from '@/lib/scrape-fund-nav'
-import { ValidationError, validateAmount } from '@/lib/validation'
 import { readJsonBody } from '@/lib/apiBody'
-
-const FUND_TYPES = ['balanced', 'equity', 'debt', 'gold'] as const
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+import { parseFundPayload, dcaGoalOwnershipError } from '@/lib/fundPayload'
 
 export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
@@ -45,86 +41,21 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
 
   const parsed = await readJsonBody(request)
   if (!parsed.ok) return parsed.response
-  const body = parsed.body
-  const { name, code, fund_type, nav, nav_source_url, is_dca, dca_monthly_amount_vnd, dca_goal_id } = body
 
-  if (is_dca !== undefined && typeof is_dca !== 'boolean') {
-    return NextResponse.json({ error: 'is_dca must be a boolean' }, { status: 400 })
-  }
+  // `dca` is null when the caller omitted is_dca — partial-update semantics, so
+  // a name/NAV edit from the Add/Edit form preserves the existing DCA config
+  // rather than silently wiping it. The toggle/amount/goal handlers always send
+  // is_dca, so they're unaffected.
+  const payload = parseFundPayload(parsed.body, 'update')
+  if (!payload.ok) return payload.response
+  const { fund: fields, dca } = payload
 
-  if (!name || typeof name !== 'string' || name.trim().length === 0) {
-    return NextResponse.json({ error: 'Name is required' }, { status: 400 })
-  }
-  if (name.trim().length > 255) {
-    return NextResponse.json({ error: 'Name must be 255 characters or less' }, { status: 400 })
-  }
-  if (!code || typeof code !== 'string' || code.trim().length === 0) {
-    return NextResponse.json({ error: 'Code is required' }, { status: 400 })
-  }
-  if (code.trim().length > 50) {
-    return NextResponse.json({ error: 'Code must be 50 characters or less' }, { status: 400 })
-  }
-  if (!fund_type || !FUND_TYPES.includes(fund_type)) {
-    return NextResponse.json({ error: 'Fund type is required' }, { status: 400 })
-  }
-  const navNum = Number(nav)
-  // Number('Infinity') is Infinity and would slip past a bare `< 0.01` check —
-  // require a finite value so it can't reach the DB numeric column.
-  if (!Number.isFinite(navNum) || navNum < 0.01) {
-    return NextResponse.json({ error: 'NAV must be greater than 0' }, { status: 400 })
-  }
-  if (dca_goal_id != null && dca_goal_id !== '' && (typeof dca_goal_id !== 'string' || !UUID_RE.test(dca_goal_id))) {
-    return NextResponse.json({ error: 'Invalid goal' }, { status: 400 })
-  }
-
-  // Validate the NAV source URL (https + exact vendor-host allowlist) before it
-  // is stored and later fetched server-side — prevents SSRF.
-  let cleanNavUrl: string | null
-  try {
-    cleanNavUrl = validateNavSourceUrl(nav_source_url)
-  } catch (e) {
-    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
-    throw e
-  }
-
-  const update: Record<string, unknown> = {
-    name: name.trim(),
-    code: code.trim().toUpperCase(),
-    fund_type,
-    nav: navNum,
-    nav_source_url: cleanNavUrl,
-  }
-  // DCA fields use partial-update semantics: only written when the caller
-  // actually sends is_dca. The Add/Edit form omits them, so a name/NAV edit
-  // must preserve the existing DCA config instead of silently wiping it. The
-  // DCA toggle/amount/goal handlers always send is_dca, so they're unaffected.
-  if (is_dca !== undefined) {
-    update.is_dca = is_dca === true
-    // Validate by *presence* (not truthiness) so a provided 0 is rejected rather
-    // than silently stored as null — a positive, whole (BIGINT) amount, else a
-    // 400 instead of a DB CHECK / type error (500).
-    let dcaAmount: number | null = null
-    if (is_dca === true && dca_monthly_amount_vnd != null && dca_monthly_amount_vnd !== '') {
-      try {
-        dcaAmount = validateAmount(dca_monthly_amount_vnd, 'dca_monthly_amount_vnd', { positive: true, integer: true })
-      } catch (e) {
-        if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
-        throw e
-      }
-    }
-    update.dca_monthly_amount_vnd = dcaAmount
-    // Goal target only applies while DCA is on; cleared otherwise.
-    update.dca_goal_id = is_dca === true && dca_goal_id ? dca_goal_id : null
-    // A valid-looking UUID isn't proof of ownership: verify the DCA goal is the
-    // caller's before linking it (#474).
-    if (update.dca_goal_id) {
-      const { data: goal } = await supabase
-        .from('savings_goals')
-        .select('goal_id')
-        .eq('goal_id', update.dca_goal_id)
-        .eq('user_id', user.id)
-        .single()
-      if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
+  const update: Record<string, unknown> = { ...fields }
+  if (dca) {
+    Object.assign(update, dca)
+    if (dca.dca_goal_id) {
+      const denied = await dcaGoalOwnershipError(supabase, dca.dca_goal_id, user.id)
+      if (denied) return denied
     }
   }
 
@@ -132,7 +63,7 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   // seeded allocation must commit (or roll back) together. The RPC also takes
   // the same row lock used by plan seeding, so a concurrent plan load cannot
   // commit a stale pending row after this cleanup finishes.
-  const disablingDca = is_dca === false
+  const disablingDca = dca?.is_dca === false
   const result = disablingDca
     ? await supabase
         .rpc('disable_fund_dca', {

--- a/app/api/funds/route.ts
+++ b/app/api/funds/route.ts
@@ -1,11 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { validateNavSourceUrl } from '@/lib/scrape-fund-nav'
-import { ValidationError, validateAmount } from '@/lib/validation'
 import { readJsonBody } from '@/lib/apiBody'
-
-const FUND_TYPES = ['balanced', 'equity', 'debt', 'gold'] as const
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+import { parseFundPayload, dcaGoalOwnershipError } from '@/lib/fundPayload'
 
 // Canonical funds-list contract (#470): GET /api/funds → `{ funds: Fund[] }`,
 // each a full fund row (`select('*')`), ordered by name. Every consumer reads
@@ -48,83 +44,20 @@ export async function POST(request: NextRequest) {
 
   const parsed = await readJsonBody(request)
   if (!parsed.ok) return parsed.response
-  const body = parsed.body
-  const { name, code, fund_type, nav, nav_source_url, is_dca, dca_monthly_amount_vnd, dca_goal_id } = body
 
-  // Validate required fields
-  if (!name || typeof name !== 'string' || name.trim().length === 0) {
-    return NextResponse.json({ error: 'Name is required' }, { status: 400 })
-  }
-  if (name.trim().length > 255) {
-    return NextResponse.json({ error: 'Name must be 255 characters or less' }, { status: 400 })
-  }
-  if (!code || typeof code !== 'string' || code.trim().length === 0) {
-    return NextResponse.json({ error: 'Code is required' }, { status: 400 })
-  }
-  if (code.trim().length > 50) {
-    return NextResponse.json({ error: 'Code must be 50 characters or less' }, { status: 400 })
-  }
-  if (!fund_type || !FUND_TYPES.includes(fund_type)) {
-    return NextResponse.json({ error: 'Fund type is required' }, { status: 400 })
-  }
-  const navNum = Number(nav)
-  // Number('Infinity') is Infinity and would slip past a bare `< 0.01` check —
-  // require a finite value so it can't reach the DB numeric column.
-  if (!Number.isFinite(navNum) || navNum < 0.01) {
-    return NextResponse.json({ error: 'NAV must be greater than 0' }, { status: 400 })
-  }
-  if (dca_goal_id != null && dca_goal_id !== '' && (typeof dca_goal_id !== 'string' || !UUID_RE.test(dca_goal_id))) {
-    return NextResponse.json({ error: 'Invalid goal' }, { status: 400 })
-  }
-  // DCA amount is only stored when DCA is on. Validate by *presence* (not
-  // truthiness) so a provided 0 is rejected rather than silently stored as null
-  // — a positive, whole (BIGINT) amount, else a 400 instead of a DB CHECK / type
-  // error (500). Absent leaves it null (DCA on, amount not yet set).
-  let dcaAmount: number | null = null
-  if (is_dca === true && dca_monthly_amount_vnd != null && dca_monthly_amount_vnd !== '') {
-    try {
-      dcaAmount = validateAmount(dca_monthly_amount_vnd, 'dca_monthly_amount_vnd', { positive: true, integer: true })
-    } catch (e) {
-      if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
-      throw e
-    }
-  }
-  // Validate the NAV source URL (https + exact vendor-host allowlist) before it
-  // is stored and later fetched server-side — prevents SSRF.
-  let cleanNavUrl: string | null
-  try {
-    cleanNavUrl = validateNavSourceUrl(nav_source_url)
-  } catch (e) {
-    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
-    throw e
-  }
+  // Create mode always yields DCA fields — defaults when the caller sends none.
+  const payload = parseFundPayload(parsed.body, 'create')
+  if (!payload.ok) return payload.response
+  const { fund: fields, dca } = payload
 
-  // A valid-looking UUID isn't proof of ownership: verify the DCA goal is the
-  // caller's before linking it, so a known foreign goal_id can't be attached (#474).
-  if (is_dca === true && dca_goal_id) {
-    const { data: goal } = await supabase
-      .from('savings_goals')
-      .select('goal_id')
-      .eq('goal_id', dca_goal_id)
-      .eq('user_id', user.id)
-      .single()
-    if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
+  if (dca.is_dca && dca.dca_goal_id) {
+    const denied = await dcaGoalOwnershipError(supabase, dca.dca_goal_id, user.id)
+    if (denied) return denied
   }
 
   const { data: fund, error } = await supabase
     .from('funds')
-    .insert({
-      user_id: user.id,
-      name: name.trim(),
-      code: code.trim().toUpperCase(),
-      fund_type,
-      nav: navNum,
-      nav_source_url: cleanNavUrl,
-      is_dca: is_dca === true,
-      dca_monthly_amount_vnd: dcaAmount,
-      // Goal target only applies while DCA is on; cleared otherwise.
-      dca_goal_id: is_dca === true && dca_goal_id ? dca_goal_id : null,
-    })
+    .insert({ user_id: user.id, ...fields, ...dca })
     .select()
     .single()
 

--- a/lib/__tests__/fundPayload.test.ts
+++ b/lib/__tests__/fundPayload.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from 'vitest'
+import { parseFundPayload } from '../fundPayload'
+
+// POST /api/funds and PUT /api/funds/[id] carried identical copies of this
+// validation, so a rule could be tightened on one and missed on the other
+// (#572). The create/update difference is real and stays explicit: create always
+// writes DCA fields, update only writes them when the caller sends is_dca.
+
+const valid = {
+  name: '  VFMVF1 Equity  ',
+  code: ' vfmvf1 ',
+  fund_type: 'equity',
+  nav: 36120,
+  nav_source_url: null,
+}
+
+const parse = (body: Record<string, unknown>, mode: 'create' | 'update' = 'create') =>
+  parseFundPayload(body, mode)
+
+async function rejection(body: Record<string, unknown>, mode: 'create' | 'update' = 'create') {
+  const result = parse(body, mode)
+  if (result.ok) throw new Error('expected the payload to be rejected')
+  return { status: result.response.status, ...(await result.response.json()) }
+}
+
+describe('parseFundPayload — common fields', () => {
+  it('normalizes name and code', () => {
+    const result = parse(valid)
+
+    expect(result.ok && result.fund).toMatchObject({
+      name: 'VFMVF1 Equity',   // trimmed
+      code: 'VFMVF1',          // trimmed and upper-cased
+      fund_type: 'equity',
+      nav: 36120,
+    })
+  })
+
+  it('requires a name', async () => {
+    expect(await rejection({ ...valid, name: '   ' })).toEqual({ status: 400, error: 'Name is required' })
+    expect(await rejection({ ...valid, name: undefined })).toEqual({ status: 400, error: 'Name is required' })
+    expect(await rejection({ ...valid, name: 42 })).toEqual({ status: 400, error: 'Name is required' })
+  })
+
+  it('caps the name at 255 characters, after trimming', async () => {
+    expect(parse({ ...valid, name: `  ${'a'.repeat(255)}  ` }).ok).toBe(true)
+    expect((await rejection({ ...valid, name: 'a'.repeat(256) })).status).toBe(400)
+  })
+
+  it('requires a code and caps it at 50', async () => {
+    expect(await rejection({ ...valid, code: '' })).toEqual({ status: 400, error: 'Code is required' })
+    expect((await rejection({ ...valid, code: 'a'.repeat(51) })).status).toBe(400)
+  })
+
+  it('requires a known fund type', async () => {
+    for (const fund_type of ['balanced', 'equity', 'debt', 'gold']) {
+      expect(parse({ ...valid, fund_type }).ok, fund_type).toBe(true)
+    }
+    expect(await rejection({ ...valid, fund_type: 'crypto' })).toEqual({ status: 400, error: 'Fund type is required' })
+    expect((await rejection({ ...valid, fund_type: undefined })).status).toBe(400)
+  })
+
+  // Number('Infinity') is Infinity and would slip past a bare `< 0.01` check,
+  // then reach the DB numeric column.
+  it('requires a finite NAV of at least 0.01', async () => {
+    expect((await rejection({ ...valid, nav: 'Infinity' })).status).toBe(400)
+    expect((await rejection({ ...valid, nav: 0 })).status).toBe(400)
+    expect((await rejection({ ...valid, nav: -1 })).status).toBe(400)
+    expect((await rejection({ ...valid, nav: 'abc' })).status).toBe(400)
+    expect(parse({ ...valid, nav: '0.01' }).ok).toBe(true)  // numeric strings still coerce
+  })
+
+  it('rejects a dca_goal_id that is not a UUID', async () => {
+    expect(await rejection({ ...valid, is_dca: true, dca_goal_id: 'not-a-uuid' }))
+      .toEqual({ status: 400, error: 'Invalid goal' })
+  })
+
+  // The stored URL is fetched server-side later, so the allowlist is what stops
+  // it being pointed at an internal address.
+  it('rejects a NAV source URL outside the vendor allowlist', async () => {
+    expect((await rejection({ ...valid, nav_source_url: 'http://169.254.169.254/latest/meta-data' })).status).toBe(400)
+    expect((await rejection({ ...valid, nav_source_url: 'https://evil.example.com/nav' })).status).toBe(400)
+  })
+})
+
+const GOAL = '123e4567-e89b-12d3-a456-426614174000'
+
+describe('parseFundPayload — create mode', () => {
+  it('always returns DCA fields, defaulting to off', () => {
+    const result = parse(valid, 'create')
+
+    expect(result.ok && result.dca).toEqual({
+      is_dca: false,
+      dca_monthly_amount_vnd: null,
+      dca_goal_id: null,
+    })
+  })
+
+  it('keeps the amount and goal when DCA is on', () => {
+    const result = parse({ ...valid, is_dca: true, dca_monthly_amount_vnd: 2_000_000, dca_goal_id: GOAL }, 'create')
+
+    expect(result.ok && result.dca).toEqual({
+      is_dca: true,
+      dca_monthly_amount_vnd: 2_000_000,
+      dca_goal_id: GOAL,
+    })
+  })
+
+  it('drops the amount and goal when DCA is off', () => {
+    const result = parse({ ...valid, is_dca: false, dca_monthly_amount_vnd: 2_000_000, dca_goal_id: GOAL }, 'create')
+
+    expect(result.ok && result.dca).toEqual({ is_dca: false, dca_monthly_amount_vnd: null, dca_goal_id: null })
+  })
+
+  // Checked by *presence*, not truthiness: a sent 0 is a mistake worth a 400,
+  // not something to store as null. The column is BIGINT, so a fraction would
+  // be a DB type error (500) rather than a validation failure.
+  it('rejects a zero or fractional DCA amount', async () => {
+    expect((await rejection({ ...valid, is_dca: true, dca_monthly_amount_vnd: 0 })).status).toBe(400)
+    expect((await rejection({ ...valid, is_dca: true, dca_monthly_amount_vnd: 1.5 })).status).toBe(400)
+    expect((await rejection({ ...valid, is_dca: true, dca_monthly_amount_vnd: -100 })).status).toBe(400)
+  })
+
+  it('leaves the amount null when DCA is on but no amount is sent yet', () => {
+    const result = parse({ ...valid, is_dca: true }, 'create')
+
+    expect(result.ok && result.dca?.dca_monthly_amount_vnd).toBeNull()
+  })
+})
+
+describe('parseFundPayload — update mode', () => {
+  // The Add/Edit form sends only name/code/type/nav, so a name edit must
+  // preserve the existing DCA config rather than silently wiping it.
+  it('returns no DCA fields at all when is_dca is absent', () => {
+    const result = parse(valid, 'update')
+
+    expect(result.ok && result.dca).toBeNull()
+  })
+
+  it('returns DCA fields when is_dca is sent', () => {
+    const result = parse({ ...valid, is_dca: true, dca_monthly_amount_vnd: 500_000, dca_goal_id: GOAL }, 'update')
+
+    expect(result.ok && result.dca).toEqual({
+      is_dca: true,
+      dca_monthly_amount_vnd: 500_000,
+      dca_goal_id: GOAL,
+    })
+  })
+
+  it('rejects a non-boolean is_dca', async () => {
+    for (const is_dca of [null, 'false', 0, 1, 'true']) {
+      expect((await rejection({ ...valid, is_dca }, 'update')).status, String(is_dca)).toBe(400)
+    }
+  })
+
+  // Asymmetric with create, which treats any non-`true` value as off rather
+  // than rejecting it. Preserved as-is: changing it is a behaviour change, not
+  // a refactor.
+  it('create does not reject a non-boolean is_dca, matching existing behaviour', () => {
+    const result = parse({ ...valid, is_dca: 'yes' }, 'create')
+
+    expect(result.ok && result.dca?.is_dca).toBe(false)
+  })
+})

--- a/lib/fundPayload.ts
+++ b/lib/fundPayload.ts
@@ -1,0 +1,159 @@
+// Shared parsing for the fund create/update payload. POST /api/funds and
+// PUT /api/funds/[id] validated the same fields with identical copies, so a rule
+// could be tightened on one and missed on the other (#572).
+//
+// The routes keep what genuinely differs: their DB writes, and the disable-DCA
+// RPC path. The one behavioural difference in *parsing* is explicit in `mode` —
+// create always produces DCA fields, update produces them only when the caller
+// sends `is_dca`.
+
+import { NextResponse } from 'next/server'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { ValidationError, validateAmount } from '@/lib/validation'
+import { validateNavSourceUrl } from '@/lib/scrape-fund-nav'
+
+export const FUND_TYPES = ['balanced', 'equity', 'debt', 'gold'] as const
+export type FundType = (typeof FUND_TYPES)[number]
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/** The always-written columns, normalized and ready to store. */
+export interface FundFields {
+  name: string
+  code: string
+  fund_type: FundType
+  nav: number
+  nav_source_url: string | null
+}
+
+/** The DCA columns. `null` in a result means "not sent" — leave them alone. */
+export interface DcaFields {
+  is_dca: boolean
+  dca_monthly_amount_vnd: number | null
+  dca_goal_id: string | null
+}
+
+export type FundPayloadResult<Dca extends DcaFields | null = DcaFields | null> =
+  | { ok: true; fund: FundFields; dca: Dca }
+  | { ok: false; response: NextResponse }
+
+const badRequest = (error: string) => NextResponse.json({ error }, { status: 400 })
+
+// Overloaded so the mode carries the invariant: create always produces DCA
+// fields, update produces them only when the caller sent is_dca. Without this
+// the create route would need a non-null assertion on every use.
+export function parseFundPayload(body: Record<string, unknown>, mode: 'create'): FundPayloadResult<DcaFields>
+export function parseFundPayload(body: Record<string, unknown>, mode: 'update'): FundPayloadResult<DcaFields | null>
+// For callers holding the mode in a variable, e.g. a test driving both.
+export function parseFundPayload(body: Record<string, unknown>, mode: 'create' | 'update'): FundPayloadResult
+export function parseFundPayload(
+  body: Record<string, unknown>,
+  mode: 'create' | 'update',
+): FundPayloadResult {
+  const { name, code, fund_type, nav, nav_source_url, is_dca, dca_monthly_amount_vnd, dca_goal_id } = body
+
+  // Update rejects a non-boolean is_dca because the value decides whether the
+  // DCA columns are written at all; create treats anything but `true` as off.
+  // Asymmetric, and preserved deliberately — changing it is a behaviour change.
+  if (mode === 'update' && is_dca !== undefined && typeof is_dca !== 'boolean') {
+    return { ok: false, response: badRequest('is_dca must be a boolean') }
+  }
+
+  if (!name || typeof name !== 'string' || name.trim().length === 0) {
+    return { ok: false, response: badRequest('Name is required') }
+  }
+  if (name.trim().length > 255) {
+    return { ok: false, response: badRequest('Name must be 255 characters or less') }
+  }
+  if (!code || typeof code !== 'string' || code.trim().length === 0) {
+    return { ok: false, response: badRequest('Code is required') }
+  }
+  if (code.trim().length > 50) {
+    return { ok: false, response: badRequest('Code must be 50 characters or less') }
+  }
+  if (!fund_type || !FUND_TYPES.includes(fund_type as FundType)) {
+    return { ok: false, response: badRequest('Fund type is required') }
+  }
+
+  const navNum = Number(nav)
+  // Number('Infinity') is Infinity and would slip past a bare `< 0.01` check —
+  // require a finite value so it can't reach the DB numeric column.
+  if (!Number.isFinite(navNum) || navNum < 0.01) {
+    return { ok: false, response: badRequest('NAV must be greater than 0') }
+  }
+  if (dca_goal_id != null && dca_goal_id !== '' && (typeof dca_goal_id !== 'string' || !UUID_RE.test(dca_goal_id))) {
+    return { ok: false, response: badRequest('Invalid goal') }
+  }
+
+  // Validate the NAV source URL (https + exact vendor-host allowlist) before it
+  // is stored and later fetched server-side — prevents SSRF.
+  let cleanNavUrl: string | null
+  try {
+    cleanNavUrl = validateNavSourceUrl(nav_source_url)
+  } catch (e) {
+    if (e instanceof ValidationError) return { ok: false, response: badRequest(e.message) }
+    throw e
+  }
+
+  const fund: FundFields = {
+    name: name.trim(),
+    code: code.trim().toUpperCase(),
+    fund_type: fund_type as FundType,
+    nav: navNum,
+    nav_source_url: cleanNavUrl,
+  }
+
+  // Partial-update semantics: the Add/Edit form omits the DCA fields, so a
+  // name/NAV edit must preserve the existing config rather than wipe it. The
+  // toggle/amount/goal handlers always send is_dca, so they're unaffected.
+  if (mode === 'update' && is_dca === undefined) return { ok: true, fund, dca: null }
+
+  const enabled = is_dca === true
+  let amount: number | null = null
+  // Checked by *presence*, not truthiness, so a sent 0 is rejected rather than
+  // silently stored as null — a positive, whole (BIGINT) amount, else a 400
+  // instead of a DB CHECK / type error (500). Absent leaves it null (DCA on,
+  // amount not yet set).
+  if (enabled && dca_monthly_amount_vnd != null && dca_monthly_amount_vnd !== '') {
+    try {
+      amount = validateAmount(dca_monthly_amount_vnd, 'dca_monthly_amount_vnd', { positive: true, integer: true })
+    } catch (e) {
+      if (e instanceof ValidationError) return { ok: false, response: badRequest(e.message) }
+      throw e
+    }
+  }
+
+  return {
+    ok: true,
+    fund,
+    dca: {
+      is_dca: enabled,
+      dca_monthly_amount_vnd: amount,
+      // Goal target only applies while DCA is on; cleared otherwise.
+      dca_goal_id: enabled && dca_goal_id ? (dca_goal_id as string) : null,
+    },
+  }
+}
+
+/**
+ * A valid-looking UUID isn't proof of ownership: verify the DCA goal is the
+ * caller's before linking it, so a known foreign goal_id can't be attached
+ * (#474). Returns the response to send when it isn't, or null to proceed.
+ */
+export async function dcaGoalOwnershipError(
+  supabase: SupabaseClient,
+  goalId: string,
+  userId: string,
+): Promise<NextResponse | null> {
+  const { data: goal } = await supabase
+    .from('savings_goals')
+    .select('goal_id')
+    .eq('goal_id', goalId)
+    .eq('user_id', userId)
+    .single()
+
+  if (!goal) {
+    return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
+  }
+  return null
+}


### PR DESCRIPTION
Closes #572.

## What was duplicated

A `diff` of the two validation blocks came back identical for every common field — name, code, fund type, NAV, DCA goal UUID, NAV source URL, DCA amount — with the only differences being exactly the create/update semantics the issue says should stay explicit.

`lib/fundPayload.ts` owns the parsing now: **161 lines removed, 25 added** across the two routes.

## The create/update difference lives in the type

Rather than a runtime flag the routes have to remember to respect, `parseFundPayload` is overloaded:

```ts
parseFundPayload(body, 'create'): FundPayloadResult<DcaFields>        // always
parseFundPayload(body, 'update'): FundPayloadResult<DcaFields | null> // null ⇒ not sent
```

`dca: null` is what preserves partial-update semantics — the Add/Edit form omits the DCA fields, so a name/NAV edit must not wipe an existing config. Encoding it this way also means the create route needs no non-null assertion to state that it always has them.

## Two things preserved on purpose, and now written down

**The `is_dca` asymmetry.** Update rejects a non-boolean `is_dca`; create treats anything but `true` as off. That's inconsistent, but it's existing behaviour with tests pinning the update half, so changing it is a behaviour change rather than a refactor. Both halves now have a test, and the module says why they differ.

**The DCA goal ownership check** moves across unchanged, including the part I'd rather change: it uses `.single()` and treats *any* falsy result as "not owned", so a database outage answers 403. `lib/assertOwned.ts` already exists and distinguishes those cases — its comment records that conflating them is the exact habit #533/#529/#532 removed from the read endpoints. Adopting it here changes a response code in an edge case, so I've left it out of a refactor PR. Happy to do it as a follow-up if you want it.

## Safety net

The strongest evidence this is behaviour-preserving isn't the new tests — it's the **9 existing tests in `route.dca.test.ts`** that pin the partial-update semantics (a name/NAV edit must not touch DCA columns, `is_dca:false` must go through the atomic disable RPC, non-boolean `is_dca` rejected, 404 on both zero-row paths). They pass untouched.

Plus `e2e/fk-ownership.spec.ts`, which asserts a cross-user `dca_goal_id` is rejected with 403 on **both** routes — the acceptance criterion about cross-user rejection staying intact.

## Tests

17 new cases for the parser: field-by-field validation including the `Infinity` NAV that would otherwise reach the DB numeric column and the SSRF allowlist, then mode-specific behaviour — create's defaults, update's "absent means leave alone", the zero/fractional DCA amount rejection, and both sides of the `is_dca` asymmetry.

## Verification

- `npm test -- --run` — 160 files, **1728 passed**
- `eslint` clean, `tsc --noEmit` clean
- **Full E2E** (`--project=chromium`) — **251 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)