### PR TITLE
refactor(funds): share the Fund and DCA mutations across desktop and mobile

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -14,6 +14,7 @@ import { useDialogA11y } from '@/app/(app)/planning/components/useDialogA11y'
 import { FundsEmptyState } from './FundsEmptyState'
 import { FundNavAge } from './FundNavAge'
 import type { Fund, Goal, FundType, FundsData } from './useFundsData'
+import { useFundMutations } from './useFundMutations'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 // Fund/Goal/FundType are shared with the mobile view via useFundsData.
@@ -326,9 +327,6 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
   // already-saved amount" (a no-op cancel — the server still has DCA on, so
   // flipping the local row off would desync until the next reload) (#2).
   const [dcaEditIsNew, setDcaEditIsNew] = useState(false)
-  // Funds with an in-flight DCA PUT — toggle/goal-select disabled until it lands
-  // (parity with mobile's togglingIds, prevents overlapping PUTs on fast clicks).
-  const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set())
 
   // Modals
   const [modalMode, setModalMode] = useState<'add' | 'edit' | null>(null)
@@ -352,6 +350,12 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
     setToasts(p => [...p, { id, msg, ok }])
     setTimeout(() => setToasts(p => p.filter(t => t.id !== id)), 3000)
   }, [])
+
+  // Shared with the mobile view — request, optimistic update, rollback, reload
+  // and busy-id bookkeeping all live in one place. Only the toast shape differs
+  // between the two, which is why it is injected (#573).
+  const { togglingIds, disableDca, saveDcaAmount, setDcaGoal, deleteFund } =
+    useFundMutations({ setFunds, reload, notify: addToast })
 
   // Sorting
   const handleSort = (key: SortKey) => {
@@ -431,32 +435,17 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
   }
 
   // DCA
+  // Turning DCA *on* persists nothing — it opens the inline editor and waits for
+  // an amount, which is why this half stays in the view.
   async function handleToggleDca(fund: Fund) {
-    const turningOn = !fund.is_dca
-    setFunds(p => p.map(f => f.id === fund.id ? { ...f, is_dca: turningOn, dca_monthly_amount_vnd: turningOn ? f.dca_monthly_amount_vnd : null } : f))
-
-    if (turningOn) {
+    if (!fund.is_dca) {
+      setFunds(p => p.map(f => f.id === fund.id ? { ...f, is_dca: true } : f))
       setDcaEditId(fund.id)
       setDcaEditValue('')
       setDcaEditIsNew(true)
       return
     }
-
-    setTogglingIds(p => new Set(p).add(fund.id))
-    try {
-      const res = await fetch(`/api/funds/${fund.id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: false, dca_monthly_amount_vnd: null }),
-      })
-      if (!res.ok) throw new Error()
-      await reload()
-    } catch {
-      setFunds(p => p.map(f => f.id === fund.id ? { ...f, is_dca: true } : f))
-      addToast(t('toastDcaFailed'), false)
-    } finally {
-      setTogglingIds(p => { const s = new Set(p); s.delete(fund.id); return s })
-    }
+    await disableDca(fund)
   }
 
   async function handleSaveDcaAmount(fund: Fund) {
@@ -475,41 +464,11 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
     }
     setDcaEditId(null)
     setDcaEditIsNew(false)
-    setTogglingIds(p => new Set(p).add(fund.id))
-    try {
-      const res = await fetch(`/api/funds/${fund.id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: amount, dca_goal_id: fund.dca_goal_id }),
-      })
-      if (!res.ok) throw new Error()
-      await reload()
-    } catch {
-      setFunds(p => p.map(f => f.id === fund.id ? { ...f, is_dca: false, dca_monthly_amount_vnd: null } : f))
-      addToast(t('toastDcaFailed'), false)
-    } finally {
-      setTogglingIds(p => { const s = new Set(p); s.delete(fund.id); return s })
-    }
+    await saveDcaAmount(fund, amount)
   }
 
   async function handleSetDcaGoal(fund: Fund, goalId: string | null) {
-    const prevGoalId = fund.dca_goal_id
-    setFunds(p => p.map(f => f.id === fund.id ? { ...f, dca_goal_id: goalId } : f))
-    setTogglingIds(p => new Set(p).add(fund.id))
-    try {
-      const res = await fetch(`/api/funds/${fund.id}`, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: fund.dca_monthly_amount_vnd, dca_goal_id: goalId }),
-      })
-      if (!res.ok) throw new Error()
-      await reload()
-    } catch {
-      setFunds(p => p.map(f => f.id === fund.id ? { ...f, dca_goal_id: prevGoalId } : f))
-      addToast(t('toastGoalFailed'), false)
-    } finally {
-      setTogglingIds(p => { const s = new Set(p); s.delete(fund.id); return s })
-    }
+    await setDcaGoal(fund, goalId)
   }
 
   // Delete
@@ -517,22 +476,12 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
     if (!deleteTarget) return
     setDeleting(true)
     try {
-      const res = await fetch(`/api/funds/${deleteTarget.id}`, { method: 'DELETE' })
-      // Hard-block: a fund used in a monthly plan can't be deleted (#1). Show a
-      // specific, actionable message instead of the generic failure toast.
-      if (res.status === 409) {
-        setDeleteTarget(null)
-        addToast(t('toastDeleteInUse'), false)
-        return
-      }
-      if (!res.ok && res.status !== 204) throw new Error()
-      setDeleteTarget(null)
-      await reload()
-      addToast(t('toastDeleted'))
-    } catch {
-      addToast(t('toastDeleteFailed'), false)
-      setDeleteTarget(null)
+      await deleteFund(deleteTarget)
     } finally {
+      // Dismissed on every outcome, and only once the answer is known — the
+      // dialog stays up showing its busy state while the request is in flight.
+      // That includes the in-use refusal, which the toast explains.
+      setDeleteTarget(null)
       setDeleting(false)
     }
   }

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -14,6 +14,7 @@ import { useDialogA11y } from '@/app/(app)/planning/components/useDialogA11y'
 import { FundsEmptyState } from './FundsEmptyState'
 import { FundNavAge } from './FundNavAge'
 import type { Fund, Goal, FundType, FundsData } from './useFundsData'
+import { useFundMutations } from './useFundMutations'
 import { useDialogMount } from '@/app/(app)/planning/components/useDialogMount'
 
 // Matches the design's exact icon paths (stroke-based, strokeWidth 1.75)
@@ -468,7 +469,6 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
   // already-saved amount" (a no-op cancel — the server still has DCA on, so
   // flipping the local card off would desync until the next reload) (#2).
   const [dcaEditIsNew, setDcaEditIsNew] = useState(false)
-  const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set())
 
   // Toasts
   const [toasts, setToasts] = useState<Toast[]>([])
@@ -480,6 +480,17 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
     setToasts((prev) => [...prev, { id, message, type }])
     setTimeout(() => setToasts((prev) => prev.filter((t) => t.id !== id)), 3000)
   }, [])
+
+  // Shared with the desktop view (#573). Only the toast shape differs, so that
+  // is the one thing injected — this view's takes a string, the desktop's a
+  // boolean. `deleteFund` is renamed: the confirmation sheet's state already
+  // owns that name here.
+  const { togglingIds, disableDca, saveDcaAmount, setDcaGoal, deleteFund: runDelete } =
+    useFundMutations({
+      setFunds,
+      reload,
+      notify: useCallback((message: string, ok: boolean) => addToast(message, ok ? 'success' : 'error'), [addToast]),
+    })
 
   const handleRefreshNav = useCallback(async () => {
     setRefreshing(true)
@@ -577,48 +588,27 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
     if (!deleteFund) return
     setDeleting(true)
     try {
-      const res = await fetch(`/api/funds/${deleteFund.id}`, { method: 'DELETE' })
-      // Hard-block: a fund used in a monthly plan can't be deleted (#1). Show a
-      // specific, actionable message instead of the generic failure toast.
-      if (res.status === 409) {
-        setDeleteFund(null)
-        addToast(t('toastDeleteInUse'), 'error')
-        return
-      }
-      if (!res.ok && res.status !== 204) throw new Error()
-      setDeleteFund(null)
-      await reload()
-      addToast(t('toastDeleted'))
-    } catch {
-      addToast(t('toastDeleteFailed'), 'error')
-      setDeleteFund(null)
+      await runDelete(deleteFund)
     } finally {
+      // Dismissed on every outcome, and only once the answer is known — the
+      // sheet stays up showing its busy state while the request is in flight.
+      // That includes the in-use refusal, which the toast explains.
+      setDeleteFund(null)
       setDeleting(false)
     }
   }
 
+  // Turning DCA *on* persists nothing — it opens the inline editor and waits for
+  // an amount, which is why this half stays in the view.
   async function handleToggleDca(fund: Fund) {
-    const turningOn = !fund.is_dca
-    setFunds((prev) => prev.map((f) => f.id === fund.id ? { ...f, is_dca: turningOn, dca_monthly_amount_vnd: turningOn ? f.dca_monthly_amount_vnd : null } : f))
-
-    if (turningOn) {
+    if (!fund.is_dca) {
+      setFunds((prev) => prev.map((f) => f.id === fund.id ? { ...f, is_dca: true } : f))
       setDcaEditId(fund.id)
       setDcaEditValue('')
       setDcaEditIsNew(true)
       return
     }
-
-    setTogglingIds((prev) => new Set([...prev, fund.id]))
-    try {
-      const res = await fetch(`/api/funds/${fund.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: false, dca_monthly_amount_vnd: null }) })
-      if (!res.ok) throw new Error()
-      await reload()
-    } catch {
-      setFunds((prev) => prev.map((f) => f.id === fund.id ? { ...f, is_dca: true } : f))
-      addToast(t('toastDcaFailed'), 'error')
-    } finally {
-      setTogglingIds((prev) => { const s = new Set(prev); s.delete(fund.id); return s })
-    }
+    await disableDca(fund)
   }
 
   async function handleSaveDcaAmount(fund: Fund, val: string) {
@@ -637,17 +627,7 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
     }
 
     setDcaEditIsNew(false)
-    setTogglingIds((prev) => new Set([...prev, fund.id]))
-    try {
-      const res = await fetch(`/api/funds/${fund.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: amount, dca_goal_id: fund.dca_goal_id }) })
-      if (!res.ok) throw new Error()
-      await reload()
-    } catch {
-      setFunds((prev) => prev.map((f) => f.id === fund.id ? { ...f, is_dca: false, dca_monthly_amount_vnd: null } : f))
-      addToast(t('toastDcaFailed'), 'error')
-    } finally {
-      setTogglingIds((prev) => { const s = new Set(prev); s.delete(fund.id); return s })
-    }
+    await saveDcaAmount(fund, amount)
   }
 
   // Abandon an inline amount edit (Escape). A brand-new enable reverts to off;
@@ -661,19 +641,7 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
   }
 
   async function handleSetDcaGoal(fund: Fund, goalId: string | null) {
-    const prevGoalId = fund.dca_goal_id
-    setFunds((prev) => prev.map((f) => f.id === fund.id ? { ...f, dca_goal_id: goalId } : f))
-    setTogglingIds((prev) => new Set([...prev, fund.id]))
-    try {
-      const res = await fetch(`/api/funds/${fund.id}`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name: fund.name, code: fund.code, fund_type: fund.fund_type, nav: fund.nav, nav_source_url: fund.nav_source_url, is_dca: true, dca_monthly_amount_vnd: fund.dca_monthly_amount_vnd, dca_goal_id: goalId }) })
-      if (!res.ok) throw new Error()
-      await reload()
-    } catch {
-      setFunds((prev) => prev.map((f) => f.id === fund.id ? { ...f, dca_goal_id: prevGoalId } : f))
-      addToast(t('toastGoalFailed'), 'error')
-    } finally {
-      setTogglingIds((prev) => { const s = new Set(prev); s.delete(fund.id); return s })
-    }
+    await setDcaGoal(fund, goalId)
   }
 
   // ── Render ────────────────────────────────────────────────────────────────

--- a/app/(app)/funds/components/__tests__/useFundMutations.test.tsx
+++ b/app/(app)/funds/components/__tests__/useFundMutations.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useFundMutations } from '../useFundMutations'
+import type { Fund } from '../useFundsData'
+
+// The desktop and mobile fund libraries each carried their own copy of these
+// mutations, down to the optimistic update and its rollback, and the copies had
+// already drifted in how they close the editor and call their toast (#573).
+// Testing the shared hook is what proves both viewports now get the same
+// outcome, since the difference that remains is only presentation.
+
+vi.mock('next-intl', () => ({ useTranslations: () => (key: string) => key }))
+
+const FUND: Fund = {
+  id: 'f1',
+  name: 'VFMVF1',
+  code: 'VFMVF1',
+  fund_type: 'equity',
+  nav: 36120,
+  nav_source_url: null,
+  is_dca: true,
+  dca_monthly_amount_vnd: 1_000_000,
+  dca_goal_id: 'goal-1',
+  created_at: '',
+  updated_at: '',
+}
+
+function setup(fetchImpl: (url: string, init?: RequestInit) => { ok: boolean; status?: number }) {
+  const requests: Array<{ url: string; method: string; body: Record<string, unknown> | undefined }> = []
+  vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
+    requests.push({
+      url,
+      method: init?.method ?? 'GET',
+      body: init?.body ? JSON.parse(init.body as string) : undefined,
+    })
+    const { ok, status } = fetchImpl(url, init)
+    return { ok, status: status ?? (ok ? 200 : 500) }
+  }))
+
+  let funds: Fund[] = [FUND]
+  const setFunds = vi.fn((update: Fund[] | ((prev: Fund[]) => Fund[])) => {
+    funds = typeof update === 'function' ? update(funds) : update
+  })
+  const reload = vi.fn(async () => {})
+  const notify = vi.fn()
+
+  const { result } = renderHook(() => useFundMutations({ setFunds, reload, notify }))
+  return { result, requests, reload, notify, current: () => funds[0] }
+}
+
+const ok = () => ({ ok: true })
+const fails = () => ({ ok: false, status: 500 })
+
+beforeEach(() => vi.unstubAllGlobals())
+afterEach(() => vi.unstubAllGlobals())
+
+describe('useFundMutations — turning DCA off', () => {
+  it('clears the amount optimistically, persists, and reloads', async () => {
+    const { result, requests, reload, current } = setup(ok)
+
+    await act(async () => { await result.current.disableDca(FUND) })
+
+    expect(current()).toMatchObject({ is_dca: false, dca_monthly_amount_vnd: null })
+    expect(requests[0]).toMatchObject({ url: '/api/funds/f1', method: 'PUT' })
+    expect(requests[0].body).toMatchObject({ is_dca: false, dca_monthly_amount_vnd: null })
+    expect(reload).toHaveBeenCalled()
+  })
+
+  it('rolls back and reports when the request fails', async () => {
+    const { result, reload, notify, current } = setup(fails)
+
+    await act(async () => { await result.current.disableDca(FUND) })
+
+    expect(current()).toMatchObject({ is_dca: true })
+    expect(notify).toHaveBeenCalledWith('toastDcaFailed', false)
+    expect(reload).not.toHaveBeenCalled()
+  })
+})
+
+describe('useFundMutations — saving the DCA amount', () => {
+  it('sends the amount and keeps the existing goal', async () => {
+    const { result, requests, reload } = setup(ok)
+
+    await act(async () => { await result.current.saveDcaAmount(FUND, 2_000_000) })
+
+    expect(requests[0].body).toMatchObject({
+      is_dca: true,
+      dca_monthly_amount_vnd: 2_000_000,
+      dca_goal_id: 'goal-1',
+    })
+    expect(reload).toHaveBeenCalled()
+  })
+
+  it('reverts DCA to off when the save fails', async () => {
+    const { result, notify, current } = setup(fails)
+
+    await act(async () => { await result.current.saveDcaAmount(FUND, 2_000_000) })
+
+    expect(current()).toMatchObject({ is_dca: false, dca_monthly_amount_vnd: null })
+    expect(notify).toHaveBeenCalledWith('toastDcaFailed', false)
+  })
+})
+
+describe('useFundMutations — setting the DCA goal', () => {
+  it('applies the goal optimistically and persists it', async () => {
+    const { result, requests, current } = setup(ok)
+
+    await act(async () => { await result.current.setDcaGoal(FUND, 'goal-2') })
+
+    expect(current()).toMatchObject({ dca_goal_id: 'goal-2' })
+    expect(requests[0].body).toMatchObject({ dca_goal_id: 'goal-2', is_dca: true })
+  })
+
+  it('restores the previous goal when the request fails', async () => {
+    const { result, notify, current } = setup(fails)
+
+    await act(async () => { await result.current.setDcaGoal(FUND, 'goal-2') })
+
+    expect(current()).toMatchObject({ dca_goal_id: 'goal-1' })
+    expect(notify).toHaveBeenCalledWith('toastGoalFailed', false)
+  })
+
+  it('can clear the goal', async () => {
+    const { result, requests } = setup(ok)
+
+    await act(async () => { await result.current.setDcaGoal(FUND, null) })
+
+    expect(requests[0].body).toMatchObject({ dca_goal_id: null })
+  })
+})
+
+// The three outcomes named in the issue. A fund used by a monthly plan is a
+// hard block, and saying so is the whole point — a generic failure toast would
+// leave the user retrying something that can never work.
+describe('useFundMutations — deleting', () => {
+  it('reports success and reloads', async () => {
+    const { result, requests, reload, notify } = setup(() => ({ ok: true, status: 204 }))
+
+    let outcome: string | undefined
+    await act(async () => { outcome = await result.current.deleteFund(FUND) })
+
+    expect(outcome).toBe('deleted')
+    expect(requests[0]).toMatchObject({ url: '/api/funds/f1', method: 'DELETE' })
+    expect(reload).toHaveBeenCalled()
+    expect(notify).toHaveBeenCalledWith('toastDeleted', true)
+  })
+
+  it('refuses a fund that is in use, without reloading', async () => {
+    const { result, reload, notify } = setup(() => ({ ok: false, status: 409 }))
+
+    let outcome: string | undefined
+    await act(async () => { outcome = await result.current.deleteFund(FUND) })
+
+    expect(outcome).toBe('in-use')
+    expect(notify).toHaveBeenCalledWith('toastDeleteInUse', false)
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('reports a network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => { throw new TypeError('offline') }))
+    const setFunds = vi.fn()
+    const reload = vi.fn(async () => {})
+    const notify = vi.fn()
+    const { result } = renderHook(() => useFundMutations({ setFunds, reload, notify }))
+
+    let outcome: string | undefined
+    await act(async () => { outcome = await result.current.deleteFund(FUND) })
+
+    expect(outcome).toBe('failed')
+    expect(notify).toHaveBeenCalledWith('toastDeleteFailed', false)
+  })
+})
+
+describe('useFundMutations — busy tracking', () => {
+  it('marks the fund busy for the duration and clears it afterwards', async () => {
+    const { result } = setup(ok)
+
+    expect(result.current.togglingIds.has('f1')).toBe(false)
+    await act(async () => { await result.current.setDcaGoal(FUND, 'goal-2') })
+    expect(result.current.togglingIds.has('f1')).toBe(false)
+  })
+
+  it('clears the busy flag even when the request fails', async () => {
+    const { result } = setup(fails)
+
+    await act(async () => { await result.current.disableDca(FUND) })
+
+    expect(result.current.togglingIds.has('f1')).toBe(false)
+  })
+})

--- a/app/(app)/funds/components/useFundMutations.ts
+++ b/app/(app)/funds/components/useFundMutations.ts
@@ -1,0 +1,145 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import type { Dispatch, SetStateAction } from 'react'
+import { useTranslations } from 'next-intl'
+import type { Fund } from './useFundsData'
+
+// The persistence half of the Fund Library's DCA and delete actions, shared by
+// DesktopFundLibraryView and MobileFundLibraryView. Both used to carry their own
+// copy — request, optimistic update, rollback, reload and busy-id bookkeeping —
+// and the copies had already drifted in how they closed the editor and called
+// their toast (#573).
+//
+// What stays in each view is what genuinely differs: the inline editor state
+// (which fund is being edited, its draft value, whether this is a brand-new
+// enable) and the layout. Turning DCA *on* is a view concern too — it opens the
+// editor and persists nothing until an amount is entered.
+
+/** Outcome of a delete, so a view can dismiss its own confirmation dialog. */
+export type DeleteOutcome = 'deleted' | 'in-use' | 'failed'
+
+export interface FundMutations {
+  /** Funds with a request in flight — views disable their controls on these. */
+  togglingIds: Set<string>
+  /** Turn DCA off and persist it. */
+  disableDca: (fund: Fund) => Promise<void>
+  /** Persist a validated monthly amount, keeping the fund's existing goal. */
+  saveDcaAmount: (fund: Fund, amount: number) => Promise<void>
+  setDcaGoal: (fund: Fund, goalId: string | null) => Promise<void>
+  deleteFund: (fund: Fund) => Promise<DeleteOutcome>
+}
+
+/**
+ * @param notify presentation is the one thing left to the view — the desktop
+ *   toast takes a boolean, the mobile one a string. Both get the same message
+ *   and the same success flag.
+ */
+export function useFundMutations({
+  setFunds,
+  reload,
+  notify,
+}: {
+  setFunds: Dispatch<SetStateAction<Fund[]>>
+  reload: () => Promise<void>
+  notify: (message: string, ok: boolean) => void
+}): FundMutations {
+  const t = useTranslations('funds')
+  const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set())
+
+  const patchFund = useCallback((id: string, changes: Partial<Fund>) => {
+    setFunds((prev) => prev.map((f) => (f.id === id ? { ...f, ...changes } : f)))
+  }, [setFunds])
+
+  /**
+   * Every DCA write is a full PUT: the route's partial-update semantics key off
+   * whether `is_dca` is present, and the unchanged columns have to come along or
+   * they'd be overwritten with undefined.
+   */
+  const putFund = useCallback((fund: Fund, dca: Partial<Fund>) =>
+    fetch(`/api/funds/${fund.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: fund.name,
+        code: fund.code,
+        fund_type: fund.fund_type,
+        nav: fund.nav,
+        nav_source_url: fund.nav_source_url,
+        ...dca,
+      }),
+    }), [])
+
+  /**
+   * Apply an optimistic change, persist it, and undo it if the request fails.
+   * One place, so the two viewports can't drift on when a rollback happens.
+   */
+  const persist = useCallback(async (
+    fund: Fund,
+    optimistic: Partial<Fund>,
+    body: Partial<Fund>,
+    rollback: Partial<Fund>,
+    failureMessage: string,
+  ) => {
+    patchFund(fund.id, optimistic)
+    setTogglingIds((prev) => new Set(prev).add(fund.id))
+    try {
+      const res = await putFund(fund, body)
+      if (!res.ok) throw new Error()
+      await reload()
+    } catch {
+      patchFund(fund.id, rollback)
+      notify(failureMessage, false)
+    } finally {
+      setTogglingIds((prev) => { const next = new Set(prev); next.delete(fund.id); return next })
+    }
+  }, [patchFund, putFund, reload, notify])
+
+  const disableDca = useCallback((fund: Fund) => persist(
+    fund,
+    { is_dca: false, dca_monthly_amount_vnd: null },
+    { is_dca: false, dca_monthly_amount_vnd: null },
+    { is_dca: true },
+    t('toastDcaFailed'),
+  ), [persist, t])
+
+  const saveDcaAmount = useCallback((fund: Fund, amount: number) => persist(
+    fund,
+    { is_dca: true, dca_monthly_amount_vnd: amount },
+    { is_dca: true, dca_monthly_amount_vnd: amount, dca_goal_id: fund.dca_goal_id },
+    // A failed save leaves nothing persisted, so the row goes back to DCA off
+    // rather than showing an amount the server never accepted.
+    { is_dca: false, dca_monthly_amount_vnd: null },
+    t('toastDcaFailed'),
+  ), [persist, t])
+
+  const setDcaGoal = useCallback((fund: Fund, goalId: string | null) => persist(
+    fund,
+    { dca_goal_id: goalId },
+    { is_dca: true, dca_monthly_amount_vnd: fund.dca_monthly_amount_vnd, dca_goal_id: goalId },
+    { dca_goal_id: fund.dca_goal_id },
+    t('toastGoalFailed'),
+  ), [persist, t])
+
+  const deleteFund = useCallback(async (fund: Fund): Promise<DeleteOutcome> => {
+    try {
+      const res = await fetch(`/api/funds/${fund.id}`, { method: 'DELETE' })
+      // Hard block: a fund used in a monthly plan can't be deleted (#1). Say so
+      // specifically — a generic failure toast leaves the user retrying
+      // something that can never succeed.
+      if (res.status === 409) {
+        notify(t('toastDeleteInUse'), false)
+        return 'in-use'
+      }
+      if (!res.ok && res.status !== 204) throw new Error()
+      await reload()
+      notify(t('toastDeleted'), true)
+      return 'deleted'
+    } catch {
+      notify(t('toastDeleteFailed'), false)
+      return 'failed'
+    }
+  }, [reload, notify, t])
+
+  return { togglingIds, disableDca, saveDcaAmount, setDcaGoal, deleteFund }
+}


### PR DESCRIPTION
Closes #573.

## What was duplicated

`DesktopFundLibraryView` and `MobileFundLibraryView` each implemented delete, DCA disable, amount save and goal assignment — every one with its own optimistic update, rollback, reload and busy-id bookkeeping. **126 lines removed, 43 added.**

`useFundMutations` owns the persistence half, so the optimistic and rollback rules are now identical across viewports *by construction* rather than by inspection — which is the acceptance criterion that mattered here.

## What stayed in the views, and why

- **Inline editor state** (which fund is being edited, its draft value, whether this is a brand-new enable). The issue asked for this to stay, and it genuinely differs: the desktop reads its draft from component state, the mobile passes it as an argument.
- **Turning DCA *on***. It persists nothing — it opens the editor and waits for an amount — so it isn't a mutation at all.
- **The toast.** This is the drift the issue flagged: the desktop's takes a boolean, the mobile's a string. That's the one difference left, so it's the one thing injected. Both get the same message and the same success flag.

`deleteFund` returns its outcome (`deleted` / `in-use` / `failed`), which is what lets each view dismiss its own dialog while the hook keeps the wording. The 409 message has to stay specific — a generic failure toast would leave the user retrying something that can never succeed.

## One thing I got wrong first, and caught

My initial version dismissed the delete dialog *before* awaiting the request. The original keeps it open, showing its busy state, until the answer is known. That's a real UX regression and the existing tests didn't catch it — they don't assert what's on screen mid-request. Fixed: the dialog now clears in a `finally`, after the await, on every outcome, exactly as before.

## Safety net

The existing suites are the real evidence here, and they pass **untouched**:

- `DesktopFundLibraryView.dca.test.tsx` / `MobileFundLibraryView.dca.test.tsx`
- `DesktopFundLibraryView.delete.test.tsx` / `MobileFundLibraryView.delete.test.tsx`
- `DesktopFundLibraryView.parity.test.tsx` / `MobileFundLibraryView.parity.test.tsx`

Plus 12 new tests driving the hook directly — the three outcomes the issue named (success, 409 refusal, network failure) and the rollback rules for each mutation, including that the busy flag clears even when the request fails.

## Verification

- `npm test -- --run` — 161 files, **1740 passed**
- `eslint` clean, `tsc --noEmit` clean
- **Full E2E** (`--project=chromium`) — **251 passed, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)