### PR TITLE
refactor(settings): share the desktop and mobile settings controller

### DIFF
--- a/app/(app)/settings/__tests__/useSettingsController.test.tsx
+++ b/app/(app)/settings/__tests__/useSettingsController.test.tsx
@@ -1,0 +1,375 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSettingsController } from '../useSettingsController'
+
+// The desktop and mobile settings views each carried their own controller around
+// settingsShared: the same Supabase client, the same five sync flags with the
+// same 3-second resets, the same profile save, the same export and sign-out
+// (#570). The copies had already drifted — only mobile cleared its timers.
+// Testing the shared controller is what proves both viewports now behave the
+// same, since what remains in each view is modals vs sheets.
+
+const { signOutMock, updateUserMock, setUserNameMock, toastErrorMock, setThemeMock, refreshMock, pushMock } = vi.hoisted(() => ({
+  signOutMock: vi.fn().mockResolvedValue({ error: null }),
+  updateUserMock: vi.fn().mockResolvedValue({ data: { user: {} }, error: null }),
+  setUserNameMock: vi.fn(),
+  toastErrorMock: vi.fn(),
+  setThemeMock: vi.fn(),
+  refreshMock: vi.fn(),
+  pushMock: vi.fn(),
+}))
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => 'en',
+}))
+
+vi.mock('sonner', () => ({ toast: { error: toastErrorMock, success: vi.fn() } }))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+}))
+
+vi.mock('@/app/components/navigation/NavigationContext', () => ({
+  useNavigation: () => ({ setMobileTopBar: vi.fn(), setUserName: setUserNameMock }),
+}))
+
+vi.mock('@/app/components/ThemeProvider', () => ({
+  useTheme: () => ({ theme: 'light', toggleTheme: vi.fn(), setTheme: setThemeMock }),
+}))
+
+vi.mock('@supabase/ssr', () => ({
+  createBrowserClient: () => ({ auth: { signOut: signOutMock, updateUser: updateUserMock } }),
+}))
+
+const { refreshPricesMock, fetchLastSyncMock, fetchOverviewMock, exportReportMock, clearAppCachesMock, setLocaleCookieMock } = vi.hoisted(() => ({
+  refreshPricesMock: vi.fn(),
+  fetchLastSyncMock: vi.fn().mockResolvedValue(null),
+  fetchOverviewMock: vi.fn().mockResolvedValue(null),
+  exportReportMock: vi.fn().mockResolvedValue(undefined),
+  clearAppCachesMock: vi.fn().mockResolvedValue(undefined),
+  setLocaleCookieMock: vi.fn(),
+}))
+
+vi.mock('../settingsShared', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../settingsShared')>()
+  return {
+    ...actual,
+    refreshPrices: refreshPricesMock,
+    fetchLastSync: fetchLastSyncMock,
+    fetchOverview: fetchOverviewMock,
+    exportPortfolioReport: exportReportMock,
+    clearAppCaches: clearAppCachesMock,
+    setLocaleCookie: setLocaleCookieMock,
+  }
+})
+
+const PROPS = { initials: 'PT', displayName: 'Phuong' }
+
+function setup() {
+  return renderHook(() => useSettingsController(PROPS))
+}
+
+// Let the effects that fire on mount (last-sync, theme hydration) settle so a
+// later assertion isn't racing an unflushed promise.
+async function mounted() {
+  const rendered = setup()
+  await act(async () => {})
+  return rendered
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  fetchLastSyncMock.mockResolvedValue(null)
+  fetchOverviewMock.mockResolvedValue(null)
+  localStorage.clear()
+})
+afterEach(() => { vi.useRealTimers() })
+
+// ─── Profile ─────────────────────────────────────────────────────────────────
+
+describe('useSettingsController — profile', () => {
+  it('derives initials from the display name', async () => {
+    const { result } = await mounted()
+    expect(result.current.displayName).toBe('Phuong')
+    expect(result.current.initials).toBe('P')
+  })
+
+  it('falls back to the server initials when the name has no usable letters', async () => {
+    const { result } = renderHook(() => useSettingsController({ initials: 'PT', displayName: '' }))
+    await act(async () => {})
+    expect(result.current.initials).toBe('PT')
+  })
+
+  it('persists the name, pushes it to the nav, and reports success', async () => {
+    const { result } = await mounted()
+
+    let ok: boolean | undefined
+    await act(async () => { ok = await result.current.saveProfile('Minh Phuong') })
+
+    expect(ok).toBe(true)
+    expect(updateUserMock).toHaveBeenCalledWith({ data: { display_name: 'Minh Phuong' } })
+    expect(setUserNameMock).toHaveBeenCalledWith('Minh Phuong')
+    expect(result.current.displayName).toBe('Minh Phuong')
+    expect(result.current.initials).toBe('MP')
+  })
+
+  it('reports failure and leaves the name untouched when the update errors', async () => {
+    updateUserMock.mockResolvedValueOnce({ data: { user: null }, error: { message: 'nope' } })
+    const { result } = await mounted()
+
+    let ok: boolean | undefined
+    await act(async () => { ok = await result.current.saveProfile('Broken') })
+
+    // The views key their "Saved" flash off this boolean — reporting success on
+    // a failed write would close the form over an unsaved name.
+    expect(ok).toBe(false)
+    expect(toastErrorMock).toHaveBeenCalled()
+    expect(result.current.displayName).toBe('Phuong')
+    expect(setUserNameMock).not.toHaveBeenCalled()
+  })
+})
+
+// ─── Price sync ──────────────────────────────────────────────────────────────
+
+describe('useSettingsController — price sync', () => {
+  it('reports success and advances the last-sync time', async () => {
+    refreshPricesMock.mockResolvedValue({ ok: true })
+    const { result } = await mounted()
+
+    await act(async () => { await result.current.runSync() })
+
+    expect(result.current.syncStatus).toBe('done')
+    expect(result.current.syncStatusLabel).toBe('syncUpdated')
+    expect(result.current.syncStatusColor).toBe('var(--c-pos)')
+    expect(result.current.lastSyncIso).not.toBeNull()
+  })
+
+  it('treats a partial sync as neutral but still advances the timestamp', async () => {
+    // Prices did move, just not all of them — nothing is broken.
+    refreshPricesMock.mockResolvedValue({ ok: true, partial: true })
+    const { result } = await mounted()
+
+    await act(async () => { await result.current.runSync() })
+
+    expect(result.current.syncStatus).toBe('partial')
+    expect(result.current.syncStatusLabel).toBe('syncPartial')
+    expect(result.current.syncStatusColor).toBe('var(--c-muted)')
+    expect(result.current.lastSyncIso).not.toBeNull()
+  })
+
+  it('distinguishes rate limiting from a failure and does not advance the timestamp', async () => {
+    refreshPricesMock.mockResolvedValue({ ok: false, reason: 'rate-limited', retryAfterSeconds: 42 })
+    const { result } = await mounted()
+
+    await act(async () => { await result.current.runSync() })
+
+    expect(result.current.syncStatus).toBe('limited')
+    expect(result.current.syncStatusLabel).toBe('syncRateLimited')
+    // Neutral, not negative: the user just has to wait.
+    expect(result.current.syncStatusColor).toBe('var(--c-muted)')
+    expect(result.current.lastSyncIso).toBeNull()
+  })
+
+  it('reports a failure without advancing the timestamp', async () => {
+    refreshPricesMock.mockResolvedValue({ ok: false, reason: 'error' })
+    const { result } = await mounted()
+
+    await act(async () => { await result.current.runSync() })
+
+    expect(result.current.syncStatus).toBe('failed')
+    expect(result.current.syncStatusLabel).toBe('syncFailed')
+    expect(result.current.syncStatusColor).toBe('var(--c-neg)')
+    expect(result.current.lastSyncIso).toBeNull()
+  })
+
+  it('shows the in-flight state while the refresh is running', async () => {
+    let settle!: (r: { ok: true }) => void
+    refreshPricesMock.mockImplementation(() => new Promise(res => { settle = res }))
+    const { result } = await mounted()
+
+    let done!: Promise<void>
+    await act(async () => { done = result.current.runSync() })
+    expect(result.current.syncStatus).toBe('syncing')
+    expect(result.current.syncStatusLabel).toBe('syncUpdating')
+
+    await act(async () => { settle({ ok: true }); await done })
+    expect(result.current.syncStatus).toBe('done')
+  })
+
+  it('returns to the last-synced label after the status flash expires', async () => {
+    vi.useFakeTimers()
+    refreshPricesMock.mockResolvedValue({ ok: true })
+    const { result } = renderHook(() => useSettingsController(PROPS))
+    await act(async () => {})
+
+    await act(async () => { await result.current.runSync() })
+    expect(result.current.syncStatus).toBe('done')
+
+    await act(async () => { vi.advanceTimersByTime(3000) })
+    expect(result.current.syncStatus).toBe('idle')
+    expect(result.current.syncStatusLabel).toContain('lastSyncedPrefix')
+  })
+
+  it('does not let a stale flash reset clobber a sync that started in the meantime', async () => {
+    vi.useFakeTimers()
+    refreshPricesMock.mockResolvedValue({ ok: false, reason: 'error' })
+    const { result } = renderHook(() => useSettingsController(PROPS))
+    await act(async () => {})
+
+    await act(async () => { await result.current.runSync() })
+
+    // Second sync starts before the first flash's 3s reset lands. If that reset
+    // still fired blind it would drop the button out of its disabled state
+    // while a request is genuinely in flight.
+    let settle!: (r: { ok: true }) => void
+    refreshPricesMock.mockImplementation(() => new Promise(res => { settle = res }))
+    let done!: Promise<void>
+    await act(async () => { done = result.current.runSync() })
+
+    await act(async () => { vi.advanceTimersByTime(3000) })
+    expect(result.current.syncStatus).toBe('syncing')
+
+    await act(async () => { settle({ ok: true }); await done })
+    expect(result.current.syncStatus).toBe('done')
+  })
+
+  it('clears its flash timer on unmount so a late reset never fires', async () => {
+    vi.useFakeTimers()
+    refreshPricesMock.mockResolvedValue({ ok: true })
+    const { result, unmount } = renderHook(() => useSettingsController(PROPS))
+    await act(async () => {})
+
+    await act(async () => { await result.current.runSync() })
+    unmount()
+
+    // Desktop used a bare setTimeout here, so navigating away mid-flash left a
+    // setState pointed at a torn-down tree.
+    expect(() => act(() => { vi.advanceTimersByTime(3000) })).not.toThrow()
+  })
+
+  it('loads the last-sync time on mount', async () => {
+    fetchLastSyncMock.mockResolvedValue('2026-07-29T00:00:00.000Z')
+    const { result } = await mounted()
+
+    expect(fetchLastSyncMock).toHaveBeenCalled()
+    expect(result.current.lastSyncIso).toBe('2026-07-29T00:00:00.000Z')
+  })
+})
+
+// ─── Language ────────────────────────────────────────────────────────────────
+
+describe('useSettingsController — language', () => {
+  it('writes the locale cookie and refreshes the route', async () => {
+    const { result } = await mounted()
+
+    act(() => { result.current.switchLocale('vi') })
+
+    expect(setLocaleCookieMock).toHaveBeenCalledWith('vi')
+    expect(refreshMock).toHaveBeenCalled()
+  })
+})
+
+// ─── Appearance ──────────────────────────────────────────────────────────────
+
+describe('useSettingsController — appearance', () => {
+  it('hydrates the persisted choice after mount', async () => {
+    localStorage.setItem('theme', 'dark')
+    const { result } = await mounted()
+    expect(result.current.themeChoice).toBe('dark')
+  })
+
+  it("treats the absence of a stored value as 'system'", async () => {
+    const { result } = await mounted()
+    expect(result.current.themeChoice).toBe('system')
+  })
+
+  it('applies a choice to the theme provider and to its own state', async () => {
+    const { result } = await mounted()
+
+    act(() => { result.current.selectTheme('dark') })
+
+    expect(setThemeMock).toHaveBeenCalledWith('dark')
+    expect(result.current.themeChoice).toBe('dark')
+  })
+})
+
+// ─── Report export ───────────────────────────────────────────────────────────
+
+const OVERVIEW = {
+  netWorth: { netWorth: 100_000_000, currentValue: 95_000_000, overallProfitLoss: 5_000_000 },
+  goals: [{ id: '1' }, { id: '2' }],
+}
+
+describe('useSettingsController — report', () => {
+  it('opens the sheet and prefetches the overview summary', async () => {
+    fetchOverviewMock.mockResolvedValue(OVERVIEW)
+    const { result } = await mounted()
+
+    await act(async () => { result.current.openReport() })
+
+    expect(result.current.showReport).toBe(true)
+    expect(result.current.reportSummary).toEqual({
+      netWorth: 100_000_000,
+      currentValue: 95_000_000,
+      totalPL: 5_000_000,
+      goalCount: 2,
+    })
+  })
+
+  it('still opens the sheet when the prefetch fails', async () => {
+    fetchOverviewMock.mockResolvedValue(null)
+    const { result } = await mounted()
+
+    await act(async () => { result.current.openReport() })
+
+    // The export path re-fetches and surfaces its own error, so a failed
+    // prefetch must not block the sheet.
+    expect(result.current.showReport).toBe(true)
+    expect(result.current.reportSummary).toBeNull()
+  })
+
+  it('exports using the prefetched overview and the active locale', async () => {
+    fetchOverviewMock.mockResolvedValue(OVERVIEW)
+    const { result } = await mounted()
+
+    await act(async () => { result.current.openReport() })
+    await act(async () => { await result.current.exportReport() })
+
+    expect(exportReportMock).toHaveBeenCalledWith(OVERVIEW, 'en')
+  })
+
+  it('closes the sheet', async () => {
+    const { result } = await mounted()
+    await act(async () => { result.current.openReport() })
+    act(() => { result.current.closeReport() })
+    expect(result.current.showReport).toBe(false)
+  })
+})
+
+// ─── Sign out ────────────────────────────────────────────────────────────────
+
+describe('useSettingsController — sign out', () => {
+  it('clears this account\'s caches before leaving for the login page', async () => {
+    const { result } = await mounted()
+
+    await act(async () => { await result.current.signOut() })
+
+    expect(signOutMock).toHaveBeenCalled()
+    expect(clearAppCachesMock).toHaveBeenCalled()
+    expect(pushMock).toHaveBeenCalledWith('/auth/login')
+  })
+
+  it('keeps the user in place and reports the error when sign-out fails', async () => {
+    signOutMock.mockResolvedValueOnce({ error: { message: 'nope' } })
+    const { result } = await mounted()
+
+    await act(async () => { await result.current.signOut() })
+
+    // Clearing caches on a failed sign-out would log the user out locally while
+    // the session is still live on the server.
+    expect(toastErrorMock).toHaveBeenCalled()
+    expect(clearAppCachesMock).not.toHaveBeenCalled()
+    expect(pushMock).not.toHaveBeenCalled()
+  })
+})

--- a/app/(app)/settings/components/DesktopSettingsView.tsx
+++ b/app/(app)/settings/components/DesktopSettingsView.tsx
@@ -1,20 +1,16 @@
 'use client'
 
-import { useState, useEffect, useMemo, useRef, useTransition } from 'react'
+import { useState, useRef } from 'react'
 import { useLocale, useTranslations } from 'next-intl'
-import { useRouter } from 'next/navigation'
-import { createBrowserClient } from '@supabase/ssr'
-import { useTheme, type ThemeChoice } from '@/app/components/ThemeProvider'
-import { useNavigation } from '@/app/components/navigation/NavigationContext'
+import { type ThemeChoice } from '@/app/components/ThemeProvider'
 import { useDialogA11y } from '@/app/(app)/planning/components/useDialogA11y'
 import {
   Sun, Moon, Settings, RefreshCw, TrendingUp,
   Coins, LogOut, Download, X, Check, Edit2,
 } from 'lucide-react'
-import { toast } from 'sonner'
 import DownloadReportSheet from '@/app/assets/components/DownloadReportSheet'
-import type { DashboardData } from '@/app/assets/DashboardClient'
-import { clearAppCaches, setLocaleCookie, refreshPrices, fetchOverview, exportPortfolioReport, fetchLastSync, formatLastSync } from '../settingsShared'
+import { useSettingsController } from '../useSettingsController'
+import { useManagedTimeout } from '../useManagedTimeout'
 
 interface Props {
   email: string
@@ -135,142 +131,38 @@ function SettingRow({ icon, label, onClick, last = false }: {
 export default function DesktopSettingsView({ email, initials, displayName }: Props) {
   const locale = useLocale()
   const t = useTranslations('settings')
-  const router = useRouter()
-  const [, startTransition] = useTransition()
-  const { theme: currentTheme, setTheme } = useTheme()
-  const { setUserName } = useNavigation()
+  const c = useSettingsController({ initials, displayName })
 
-  const supabase = useMemo(
-    () => createBrowserClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-    ),
-    []
-  )
-
-  const [localDisplayName, setLocalDisplayName] = useState(displayName)
-  const localInitials = localDisplayName
-    .split(/\s+/).slice(0, 2)
-    .map(w => w[0]?.toUpperCase() ?? '').join('') || initials
-
-  // Modals
+  // Modal state — the desktop's own chrome. The editor lives inline here rather
+  // than in a child component (mobile's ProfileSheet), so its draft and its
+  // success flash stay with the modal.
   const [showProfile, setShowProfile] = useState(false)
   const [profileSaved, setProfileSaved] = useState(false)
   const [profileName, setProfileName] = useState(displayName)
-
-  // Appearance — read from localStorage so it matches the actual active choice
-  const storedTheme = (): ThemeChoice => {
-    if (typeof localStorage === 'undefined') return currentTheme
-    const v = localStorage.getItem('theme')
-    return (v === 'light' || v === 'dark') ? v : 'system'
-  }
-  const [selectedTheme, setSelectedTheme] = useState<ThemeChoice>(currentTheme)
-  // Sync to the persisted theme after mount (kept in an effect to avoid an SSR
-  // hydration mismatch; both lint rules below are intentional for that reason).
-  useEffect(() => { setSelectedTheme(storedTheme()) }, []) // eslint-disable-line react-hooks/exhaustive-deps, react-hooks/set-state-in-effect
-
-  // Price sync
-  const [syncing, setSyncing] = useState(false)
-  const [syncDone, setSyncDone] = useState(false)
-  const [syncFailed, setSyncFailed] = useState(false)
-  const [syncLimited, setSyncLimited] = useState(false)
-  const [syncPartial, setSyncPartial] = useState(false)
-  // undefined = loading, null = never synced, otherwise the last-sync ISO time.
-  const [lastSyncIso, setLastSyncIso] = useState<string | null | undefined>(undefined)
-  useEffect(() => { fetchLastSync().then(setLastSyncIso) }, [])
-
-  // Export
-  const [showReport, setShowReport] = useState(false)
-  const [overviewCache, setOverviewCache] = useState<DashboardData | null>(null)
-
-  function switchLocale(next: string) {
-    setLocaleCookie(next)
-    startTransition(() => router.refresh())
-  }
-
-  function handleTheme(v: ThemeChoice) {
-    setSelectedTheme(v)
-    setTheme(v)
-  }
-
-  async function handleSync() {
-    setSyncing(true)
-    setSyncDone(false)
-    setSyncFailed(false)
-    setSyncLimited(false)
-    setSyncPartial(false)
-    const result = await refreshPrices()
-    setSyncing(false)
-    if (result.ok) {
-      // Partial still advances the timestamp — prices did move, just not all.
-      setSyncDone(true)
-      if (result.partial) setSyncPartial(true)
-      setLastSyncIso(new Date().toISOString())
-      setTimeout(() => { setSyncDone(false); setSyncPartial(false) }, 3000)
-    } else if (result.reason === 'rate-limited') {
-      // Distinct from a failure: nothing is broken, the user just has to wait.
-      setSyncLimited(true)
-      setTimeout(() => setSyncLimited(false), 3000)
-    } else {
-      setSyncFailed(true)
-      setTimeout(() => setSyncFailed(false), 3000)
-    }
-  }
-
-  function handleOpenReport() {
-    setShowReport(true)
-    fetchOverview().then((json) => { if (json) setOverviewCache(json) })
-  }
-
-  async function handleExportReport() {
-    await exportPortfolioReport(overviewCache, locale)
-  }
+  const scheduleSaveFlashReset = useManagedTimeout()
 
   function handleOpenProfile() {
-    setProfileName(localDisplayName)
+    setProfileName(c.displayName)
     setProfileSaved(false)
     setShowProfile(true)
   }
 
   async function handleSaveProfile() {
-    // Persist first; only flash "Saved" once it succeeds. A failed update
-    // surfaces a toast and keeps the modal open instead of faking success.
-    const { error } = await supabase.auth.updateUser({ data: { display_name: profileName } })
-    if (error) {
-      toast.error(t('saveFailed'))
-      return
-    }
-    setLocalDisplayName(profileName)
-    setUserName(profileName)
+    // Only flash "Saved" and close once the persist succeeded — a failed update
+    // surfaces a toast (from saveProfile) and keeps the modal open.
+    const ok = await c.saveProfile(profileName)
+    if (!ok) return
     setProfileSaved(true)
-    setTimeout(() => { setProfileSaved(false); setShowProfile(false) }, SAVE_FLASH_MS)
+    scheduleSaveFlashReset(() => { setProfileSaved(false); setShowProfile(false) }, SAVE_FLASH_MS)
   }
 
-  async function handleSignOut() {
-    const { error } = await supabase.auth.signOut()
-    if (error) {
-      toast.error(t('signOutFailed'))
-    } else {
-      await clearAppCaches()
-      router.push('/auth/login')
-    }
-  }
+  const isSyncing = c.syncStatus === 'syncing'
 
   const themeOptions: { v: ThemeChoice; icon: React.ReactNode; label: string }[] = [
     { v: 'light',  icon: <Sun size={13} color="currentColor" />,      label: t('appearanceLight')  },
     { v: 'dark',   icon: <Moon size={13} color="currentColor" />,     label: t('appearanceDark')   },
     { v: 'system', icon: <Settings size={13} color="currentColor" />, label: t('appearanceSystem') },
   ]
-
-  // Rate-limited and partial are neutral, not negative: nothing is broken —
-  // the user is early, or some prices moved and some didn't.
-  const syncStatusColor = syncPartial
-    ? 'var(--c-muted)'
-    : syncDone
-    ? 'var(--c-pos)'
-    : syncFailed
-    ? 'var(--c-neg)'
-    : 'var(--c-muted)'
 
   return (
     <div data-testid="desktop-settings-view" className="hidden md:flex" style={{ flex: 1, flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
@@ -304,10 +196,10 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
                   display: 'flex', alignItems: 'center', justifyContent: 'center',
                   fontSize: 16, fontWeight: 700, letterSpacing: '0.02em', flexShrink: 0,
                 }}>
-                  {localInitials}
+                  {c.initials}
                 </div>
                 <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--c-ink)' }}>{localDisplayName}</div>
+                  <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--c-ink)' }}>{c.displayName}</div>
                   <div style={{ fontSize: 12, color: 'var(--c-muted)', marginTop: 2 }}>{email}</div>
                 </div>
                 <button
@@ -334,7 +226,7 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
                   {[{ v: 'en', l: t('languageEnglish') }, { v: 'vi', l: t('languageVietnamese') }].map(o => (
                     <button
                       key={o.v}
-                      onClick={() => switchLocale(o.v)}
+                      onClick={() => c.switchLocale(o.v)}
                       style={{
                         padding: '7px 14px', borderRadius: 8, fontSize: 12, fontWeight: 500,
                         background: locale === o.v ? 'var(--c-btn-primary)' : 'var(--c-card-2)',
@@ -358,13 +250,13 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
                   {themeOptions.map(o => (
                     <button
                       key={o.v}
-                      onClick={() => handleTheme(o.v)}
+                      onClick={() => c.selectTheme(o.v)}
                       style={{
                         display: 'flex', alignItems: 'center', gap: 6,
                         padding: '7px 14px', borderRadius: 8, fontSize: 12, fontWeight: 500,
-                        background: selectedTheme === o.v ? 'var(--c-navy-tint)' : 'var(--c-card-2)',
-                        color: selectedTheme === o.v ? 'var(--c-navy)' : 'var(--c-muted)',
-                        border: `1px solid ${selectedTheme === o.v ? 'var(--c-navy)' : 'var(--c-line)'}`,
+                        background: c.themeChoice === o.v ? 'var(--c-navy-tint)' : 'var(--c-card-2)',
+                        color: c.themeChoice === o.v ? 'var(--c-navy)' : 'var(--c-muted)',
+                        border: `1px solid ${c.themeChoice === o.v ? 'var(--c-navy)' : 'var(--c-line)'}`,
                         cursor: 'pointer', fontFamily: 'inherit', transition: 'all 120ms',
                       }}
                     >
@@ -378,7 +270,7 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
 
             {/* Sign out */}
             <button
-              onClick={handleSignOut}
+              onClick={c.signOut}
               aria-label={t('signOut')}
               style={{
                 width: '100%', padding: '12px 16px',
@@ -407,38 +299,28 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
               <CardLabel>{t('priceSync')}</CardLabel>
               <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 14 }}>
                 <div style={{ width: 32, height: 32, borderRadius: 8, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-                  <RefreshCw size={15} style={{ animation: syncing ? 'spin 1s linear infinite' : 'none' }} />
+                  <RefreshCw size={15} style={{ animation: isSyncing ? 'spin 1s linear infinite' : 'none' }} />
                 </div>
                 <div style={{ flex: 1 }}>
                   <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>
                     {t('syncAllPrices')}
                   </div>
-                  <div style={{ fontSize: 11, color: syncStatusColor, marginTop: 2, transition: 'color 200ms' }}>
-                    {syncing
-                      ? t('syncUpdating')
-                      : syncPartial
-                      ? t('syncPartial')
-                      : syncDone
-                      ? t('syncUpdated')
-                      : syncLimited
-                      ? t('syncRateLimited')
-                      : syncFailed
-                      ? t('syncFailed')
-                      : `${t('lastSyncedPrefix')}${formatLastSync(lastSyncIso, locale)}`}
+                  <div style={{ fontSize: 11, color: c.syncStatusColor, marginTop: 2, transition: 'color 200ms' }}>
+                    {c.syncStatusLabel}
                   </div>
                 </div>
                 <button
-                  onClick={handleSync}
-                  disabled={syncing}
+                  onClick={c.runSync}
+                  disabled={isSyncing}
                   aria-label={t('syncNow')}
                   style={{
                     padding: '7px 14px', fontSize: 12, fontWeight: 600,
                     background: 'var(--c-btn-primary)', border: 'none', borderRadius: 8,
-                    color: '#fff', cursor: syncing ? 'not-allowed' : 'pointer',
-                    fontFamily: 'inherit', opacity: syncing ? 0.6 : 1, transition: 'opacity 150ms',
+                    color: '#fff', cursor: isSyncing ? 'not-allowed' : 'pointer',
+                    fontFamily: 'inherit', opacity: isSyncing ? 0.6 : 1, transition: 'opacity 150ms',
                   }}
                 >
-                  {syncing ? t('syncingShort') : t('syncNow')}
+                  {isSyncing ? t('syncingShort') : t('syncNow')}
                 </button>
               </div>
               <div style={{ display: 'grid', gap: 10, paddingTop: 12, borderTop: '1px solid var(--c-line)' }}>
@@ -465,7 +347,7 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
               <SettingRow
                 icon={<Download size={15} />}
                 label={t('exportData')}
-                onClick={handleOpenReport}
+                onClick={c.openReport}
                 last
               />
             </Card>
@@ -544,16 +426,11 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
 
       {/* ─── Download report sheet ──────────────────────────────────────────── */}
       <DownloadReportSheet
-        open={showReport}
-        onClose={() => setShowReport(false)}
+        open={c.showReport}
+        onClose={c.closeReport}
         desktop
-        data={overviewCache ? {
-          netWorth: overviewCache.netWorth.netWorth,
-          currentValue: overviewCache.netWorth.currentValue,
-          totalPL: overviewCache.netWorth.overallProfitLoss,
-          goalCount: overviewCache.goals.length,
-        } : null}
-        onExport={handleExportReport}
+        data={c.reportSummary}
+        onExport={c.exportReport}
       />
     </div>
   )

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -1,20 +1,17 @@
 'use client'
 
-import { useState, useEffect, useMemo, useRef, useTransition } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useLocale, useTranslations } from 'next-intl'
-import { useRouter } from 'next/navigation'
-import { createBrowserClient } from '@supabase/ssr'
-import { useTheme, type ThemeChoice } from '@/app/components/ThemeProvider'
+import { type ThemeChoice } from '@/app/components/ThemeProvider'
 import { useDialogA11y } from '@/app/(app)/planning/components/useDialogA11y'
 import {
   Globe, Sun, Moon, Settings, Download, RefreshCw,
   TrendingUp, Coins, LogOut, ChevronRight, Check,
 } from 'lucide-react'
-import { toast } from 'sonner'
 import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import DownloadReportSheet from '@/app/assets/components/DownloadReportSheet'
-import type { DashboardData } from '@/app/assets/DashboardClient'
-import { clearAppCaches, setLocaleCookie, refreshPrices, fetchOverview, exportPortfolioReport, fetchLastSync, formatLastSync } from '../settingsShared'
+import { useSettingsController } from '../useSettingsController'
+import { useManagedTimeout } from '../useManagedTimeout'
 import { useDialogMount, useResetOnOpen } from '@/app/(app)/planning/components/useDialogMount'
 
 interface Props {
@@ -26,34 +23,6 @@ interface Props {
 // How long the "Saved" success flash stays up before the sheet/modal closes.
 // Kept in sync with DesktopSettingsView so both views feel identical.
 const SAVE_FLASH_MS = 1400
-
-// Read the persisted theme *choice* (not the resolved theme) from localStorage,
-// falling back to the resolved theme during SSR. 'system' is the absence of a
-// stored value. Mirrors DesktopSettingsView's storedTheme().
-function readThemeChoice(fallback: ThemeChoice): ThemeChoice {
-  if (typeof localStorage === 'undefined') return fallback
-  const v = localStorage.getItem('theme')
-  return (v === 'light' || v === 'dark') ? v : 'system'
-}
-
-// A status flash can outlive the sheet that started it. Keep one timeout per
-// owner and clear it on unmount so React never receives a late setState after a
-// route change or a test has torn the view down.
-function useManagedTimeout() {
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  useEffect(() => () => {
-    if (timeoutRef.current !== null) clearTimeout(timeoutRef.current)
-  }, [])
-
-  return (callback: () => void, delay: number) => {
-    if (timeoutRef.current !== null) clearTimeout(timeoutRef.current)
-    timeoutRef.current = setTimeout(() => {
-      timeoutRef.current = null
-      callback()
-    }, delay)
-  }
-}
 
 // ─── Bottom sheet wrapper ──────────────────────────────────────────────────────
 
@@ -224,18 +193,18 @@ function ProfileSheet({ open, onClose, onSave, displayName, email }: {
 
 // ─── Appearance sheet ──────────────────────────────────────────────────────────
 
-function AppearanceSheet({ open, onClose, onApply }: {
+function AppearanceSheet({ open, onClose, onApply, current }: {
   open: boolean
   onClose: () => void
   onApply: (choice: ThemeChoice) => void
+  current: ThemeChoice
 }) {
   const t = useTranslations('settings')
-  const { theme: currentTheme, setTheme } = useTheme()
 
-  const [selected, setSelected] = useState<ThemeChoice>(currentTheme)
+  const [selected, setSelected] = useState<ThemeChoice>(current)
 
   useEffect(() => {
-    if (open) setSelected(readThemeChoice(currentTheme))
+    if (open) setSelected(current)
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
 
@@ -245,8 +214,9 @@ function AppearanceSheet({ open, onClose, onApply }: {
     { v: 'system', icon: <Settings size={18} />, label: t('appearanceSystem') },
   ]
 
+  // onApply is the controller's selectTheme — it both persists the choice and
+  // hands it to the theme provider, so the sheet doesn't touch either directly.
   function handleApply() {
-    setTheme(selected)
     onApply(selected)
     onClose()
   }
@@ -408,49 +378,13 @@ function SettingsRow({ icon, label, value, onClick, last = false }: {
 export default function MobileSettingsView({ email, initials, displayName }: Props) {
   const locale = useLocale()
   const t = useTranslations('settings')
-  const router = useRouter()
-  const [, startTransition] = useTransition()
-  const { setMobileTopBar, setUserName } = useNavigation()
-  const { theme: currentTheme } = useTheme()
+  const { setMobileTopBar } = useNavigation()
+  const c = useSettingsController({ initials, displayName })
 
-  const supabase = useMemo(
-    () => createBrowserClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL!,
-      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-    ),
-    []
-  )
-
-  const [localDisplayName, setLocalDisplayName] = useState(displayName)
-
-  const localInitials = localDisplayName
-    .split(/\s+/)
-    .slice(0, 2)
-    .map(w => w[0]?.toUpperCase() ?? '')
-    .join('') || initials
-
+  // Sheet state — the mobile's own chrome.
   const [showProfile, setShowProfile] = useState(false)
   const [showLanguage, setShowLanguage] = useState(false)
   const [showAppearance, setShowAppearance] = useState(false)
-  const [showReport, setShowReport] = useState(false)
-  const [overviewCache, setOverviewCache] = useState<DashboardData | null>(null)
-
-  // Persisted theme choice, so the Appearance row reflects the real selection
-  // (light/dark/system) instead of a hardcoded label.
-  const [themeChoice, setThemeChoice] = useState<ThemeChoice>(currentTheme)
-  // Hydrate from the persisted choice after mount (avoids an SSR mismatch); the
-  // two lint rules below are intentional for that reason — same as DesktopSettingsView.
-  useEffect(() => { setThemeChoice(readThemeChoice(currentTheme)) }, []) // eslint-disable-line react-hooks/exhaustive-deps, react-hooks/set-state-in-effect
-
-  const [syncing, setSyncing] = useState(false)
-  const [syncDone, setSyncDone] = useState(false)
-  const [syncFailed, setSyncFailed] = useState(false)
-  const [syncLimited, setSyncLimited] = useState(false)
-  const [syncPartial, setSyncPartial] = useState(false)
-  const scheduleSyncStatusReset = useManagedTimeout()
-  // undefined = loading, null = never synced, otherwise the last-sync ISO time.
-  const [lastSyncIso, setLastSyncIso] = useState<string | null | undefined>(undefined)
-  useEffect(() => { fetchLastSync().then(setLastSyncIso) }, [])
 
   useEffect(() => {
     setMobileTopBar({
@@ -460,81 +394,14 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
     return () => setMobileTopBar({ title: '' })
   }, [t, setMobileTopBar])
 
-  function switchLocale(next: string) {
-    setLocaleCookie(next)
-    startTransition(() => router.refresh())
-  }
-
-  async function handleSync() {
-    setSyncing(true)
-    setSyncDone(false)
-    setSyncFailed(false)
-    setSyncLimited(false)
-    setSyncPartial(false)
-    const result = await refreshPrices()
-    setSyncing(false)
-    if (result.ok) {
-      // Partial still advances the timestamp — prices did move, just not all.
-      setSyncDone(true)
-      if (result.partial) setSyncPartial(true)
-      setLastSyncIso(new Date().toISOString())
-      scheduleSyncStatusReset(() => { setSyncDone(false); setSyncPartial(false) }, 3000)
-    } else if (result.reason === 'rate-limited') {
-      // Distinct from a failure: nothing is broken, the user just has to wait.
-      setSyncLimited(true)
-      scheduleSyncStatusReset(() => setSyncLimited(false), 3000)
-    } else {
-      setSyncFailed(true)
-      scheduleSyncStatusReset(() => setSyncFailed(false), 3000)
-    }
-  }
-
-  function handleOpenReport() {
-    setShowReport(true)
-    fetchOverview().then((json) => { if (json) setOverviewCache(json) })
-  }
-
-  async function handleExportReport() {
-    await exportPortfolioReport(overviewCache, locale)
-  }
-
-  async function handleSaveProfile(name: string): Promise<boolean> {
-    const { error } = await supabase.auth.updateUser({ data: { display_name: name } })
-    if (error) {
-      toast.error(t('saveFailed'))
-      return false
-    }
-    setLocalDisplayName(name)
-    setUserName(name)
-    return true
-  }
-
-  async function handleSignOut() {
-    const { error } = await supabase.auth.signOut()
-    if (error) {
-      toast.error(t('signOutFailed'))
-    } else {
-      await clearAppCaches()
-      router.push('/auth/login')
-    }
-  }
+  const isSyncing = c.syncStatus === 'syncing'
 
   const localeLabel = locale === 'vi' ? t('languageVietnamese') : t('languageEnglish')
-  const appearanceLabel = themeChoice === 'dark'
+  const appearanceLabel = c.themeChoice === 'dark'
     ? t('appearanceDark')
-    : themeChoice === 'light'
+    : c.themeChoice === 'light'
     ? t('appearanceLight')
     : t('appearanceSystem')
-
-  // Rate-limited and partial are neutral, not negative: nothing is broken —
-  // the user is early, or some prices moved and some didn't.
-  const syncStatusColor = syncPartial
-    ? 'var(--c-muted)'
-    : syncDone
-    ? 'var(--c-pos)'
-    : syncFailed
-    ? 'var(--c-neg)'
-    : 'var(--c-muted)'
 
   return (
     <>
@@ -559,10 +426,10 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
             display: 'flex', alignItems: 'center', justifyContent: 'center',
             fontSize: 16, fontWeight: 700, flexShrink: 0,
           }}>
-            {localInitials}
+            {c.initials}
           </div>
           <div style={{ flex: 1, minWidth: 0 }}>
-            <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--c-ink)' }}>{localDisplayName}</div>
+            <div style={{ fontSize: 15, fontWeight: 600, color: 'var(--c-ink)' }}>{c.displayName}</div>
             <div style={{ fontSize: 12, color: 'var(--c-muted)', marginTop: 2 }}>{email}</div>
           </div>
           <ChevronRight size={16} color="var(--c-muted)" />
@@ -602,40 +469,30 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
                 width: 32, height: 32, borderRadius: 8, background: 'var(--c-navy-tint)', color: 'var(--c-navy)',
                 display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
               }}>
-                <RefreshCw size={16} style={{ animation: syncing ? 'spin 1s linear infinite' : 'none' }} />
+                <RefreshCw size={16} style={{ animation: isSyncing ? 'spin 1s linear infinite' : 'none' }} />
               </div>
               <div style={{ flex: 1, minWidth: 0 }}>
                 <div style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>
                   {t('syncAllPrices')}
                 </div>
-                <div style={{ fontSize: 11, color: syncStatusColor, marginTop: 2, transition: 'color 200ms' }}>
-                  {syncing
-                    ? t('syncUpdating')
-                    : syncPartial
-                    ? t('syncPartial')
-                    : syncDone
-                    ? t('syncUpdated')
-                    : syncLimited
-                    ? t('syncRateLimited')
-                    : syncFailed
-                    ? t('syncFailed')
-                    : `${t('lastSyncedPrefix')}${formatLastSync(lastSyncIso, locale)}`}
+                <div style={{ fontSize: 11, color: c.syncStatusColor, marginTop: 2, transition: 'color 200ms' }}>
+                  {c.syncStatusLabel}
                 </div>
               </div>
               <button
-                onClick={handleSync}
-                disabled={syncing}
+                onClick={c.runSync}
+                disabled={isSyncing}
                 aria-label={t('syncNow')}
                 style={{
                   padding: '7px 14px', fontSize: 12, fontWeight: 600,
                   minHeight: 44, display: 'inline-flex', alignItems: 'center', justifyContent: 'center',
                   background: 'var(--c-btn-primary)', border: 'none', borderRadius: 8,
-                  color: '#fff', cursor: syncing ? 'not-allowed' : 'pointer',
-                  fontFamily: 'inherit', opacity: syncing ? 0.6 : 1,
+                  color: '#fff', cursor: isSyncing ? 'not-allowed' : 'pointer',
+                  fontFamily: 'inherit', opacity: isSyncing ? 0.6 : 1,
                   transition: 'opacity 150ms',
                 }}
               >
-                {syncing ? t('syncingShort') : t('syncNow')}
+                {isSyncing ? t('syncingShort') : t('syncNow')}
               </button>
             </div>
 
@@ -681,7 +538,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
             <SettingsRow
               icon={<Download size={16} />}
               label={t('exportData')}
-              onClick={handleOpenReport}
+              onClick={c.openReport}
               last
             />
           </div>
@@ -689,7 +546,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
 
         {/* Sign out */}
         <button
-          onClick={handleSignOut}
+          onClick={c.signOut}
           aria-label={t('signOut')}
           style={{
             width: '100%', marginTop: 22, padding: '13px 14px', minHeight: 44,
@@ -714,31 +571,27 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
       <ProfileSheet
         open={showProfile}
         onClose={() => setShowProfile(false)}
-        onSave={handleSaveProfile}
-        displayName={localDisplayName}
+        onSave={c.saveProfile}
+        displayName={c.displayName}
         email={email}
       />
       <LanguageSheet
         open={showLanguage}
         onClose={() => setShowLanguage(false)}
-        onApply={switchLocale}
+        onApply={c.switchLocale}
         currentLocale={locale}
       />
       <AppearanceSheet
         open={showAppearance}
         onClose={() => setShowAppearance(false)}
-        onApply={setThemeChoice}
+        onApply={c.selectTheme}
+        current={c.themeChoice}
       />
       <DownloadReportSheet
-        open={showReport}
-        onClose={() => setShowReport(false)}
-        data={overviewCache ? {
-          netWorth: overviewCache.netWorth.netWorth,
-          currentValue: overviewCache.netWorth.currentValue,
-          totalPL: overviewCache.netWorth.overallProfitLoss,
-          goalCount: overviewCache.goals.length,
-        } : null}
-        onExport={handleExportReport}
+        open={c.showReport}
+        onClose={c.closeReport}
+        data={c.reportSummary}
+        onExport={c.exportReport}
       />
     </>
   )

--- a/app/(app)/settings/useManagedTimeout.ts
+++ b/app/(app)/settings/useManagedTimeout.ts
@@ -1,0 +1,27 @@
+'use client'
+
+import { useCallback, useEffect, useRef } from 'react'
+
+// A status flash can outlive the thing that started it — a sync result, a
+// "Saved" confirmation. Keep one timeout per owner and clear it on unmount so
+// React never receives a late setState after a route change or a test has torn
+// the view down. Scheduling again replaces the pending timeout rather than
+// stacking a second one.
+//
+// Lived inside MobileSettingsView; desktop used a bare setTimeout and leaked
+// (#570). Shared so both views get the cleanup.
+export function useManagedTimeout() {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => () => {
+    if (timeoutRef.current !== null) clearTimeout(timeoutRef.current)
+  }, [])
+
+  return useCallback((callback: () => void, delay: number) => {
+    if (timeoutRef.current !== null) clearTimeout(timeoutRef.current)
+    timeoutRef.current = setTimeout(() => {
+      timeoutRef.current = null
+      callback()
+    }, delay)
+  }, [])
+}

--- a/app/(app)/settings/useSettingsController.ts
+++ b/app/(app)/settings/useSettingsController.ts
@@ -1,0 +1,257 @@
+'use client'
+
+import { useCallback, useEffect, useMemo, useState, useTransition } from 'react'
+import { useLocale, useTranslations } from 'next-intl'
+import { useRouter } from 'next/navigation'
+import { createBrowserClient } from '@supabase/ssr'
+import { toast } from 'sonner'
+import { useTheme, type ThemeChoice } from '@/app/components/ThemeProvider'
+import { useNavigation } from '@/app/components/navigation/NavigationContext'
+import type { DashboardData } from '@/app/assets/DashboardClient'
+import { useManagedTimeout } from './useManagedTimeout'
+import {
+  clearAppCaches, setLocaleCookie, refreshPrices, fetchOverview,
+  exportPortfolioReport, fetchLastSync, formatLastSync,
+} from './settingsShared'
+
+// The React orchestration behind the settings page, shared by
+// DesktopSettingsView and MobileSettingsView (#570). settingsShared already owns
+// the network calls; each view used to wrap them in its own copy of the same
+// controller — the same Supabase client, the same five sync flags with the same
+// 3-second resets, the same profile save and export and sign-out. The copies had
+// drifted: only mobile cleared its timers.
+//
+// What stays in the views is the chrome — desktop modals vs mobile sheets, the
+// mobile top bar, and the layout each needs. Presentation, not behaviour.
+
+/**
+ * The price-sync card shows exactly one thing at a time, so the five booleans
+ * the views carried were really one state with an illegal-combination problem
+ * (`syncDone` and `syncPartial` were both set for a partial result).
+ *
+ * 'partial' means something synced but not everything — it still advances the
+ * last-sync timestamp, because prices did move.
+ */
+export type SyncStatus = 'idle' | 'syncing' | 'done' | 'partial' | 'limited' | 'failed'
+
+/** How long a sync outcome stays on screen before the card returns to idle. */
+const SYNC_FLASH_MS = 3000
+
+/** What the download sheet needs — the four headline numbers, nothing else. */
+export interface ReportSummary {
+  netWorth: number
+  currentValue: number
+  totalPL: number
+  goalCount: number
+}
+
+export interface SettingsController {
+  /** The name as edited here, which can be ahead of the server-rendered prop. */
+  displayName: string
+  initials: string
+  /** True when the write succeeded — the views flash "Saved" only on true. */
+  saveProfile: (name: string) => Promise<boolean>
+
+  themeChoice: ThemeChoice
+  selectTheme: (choice: ThemeChoice) => void
+
+  switchLocale: (next: string) => void
+
+  syncStatus: SyncStatus
+  syncStatusLabel: string
+  syncStatusColor: string
+  /** undefined = loading, null = never synced, otherwise the last-sync ISO time. */
+  lastSyncIso: string | null | undefined
+  runSync: () => Promise<void>
+
+  showReport: boolean
+  openReport: () => void
+  closeReport: () => void
+  reportSummary: ReportSummary | null
+  exportReport: () => Promise<void>
+
+  signOut: () => Promise<void>
+}
+
+// Read the persisted theme *choice* (not the resolved theme) from localStorage,
+// falling back to the resolved theme during SSR. 'system' is the absence of a
+// stored value.
+function readThemeChoice(fallback: ThemeChoice): ThemeChoice {
+  if (typeof localStorage === 'undefined') return fallback
+  const v = localStorage.getItem('theme')
+  return (v === 'light' || v === 'dark') ? v : 'system'
+}
+
+function initialsOf(name: string, fallback: string): string {
+  return name
+    .split(/\s+/).slice(0, 2)
+    .map(w => w[0]?.toUpperCase() ?? '').join('') || fallback
+}
+
+export function useSettingsController({ initials, displayName }: {
+  initials: string
+  displayName: string
+}): SettingsController {
+  const locale = useLocale()
+  const t = useTranslations('settings')
+  const router = useRouter()
+  const [, startTransition] = useTransition()
+  const { theme: currentTheme, setTheme } = useTheme()
+  const { setUserName } = useNavigation()
+
+  const supabase = useMemo(
+    () => createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    ),
+    []
+  )
+
+  // ─── Profile ──────────────────────────────────────────────────────────────
+
+  const [localDisplayName, setLocalDisplayName] = useState(displayName)
+
+  const saveProfile = useCallback(async (name: string): Promise<boolean> => {
+    // Persist first. A failed update surfaces a toast and reports false so the
+    // view keeps its form open instead of faking success over an unsaved name.
+    const { error } = await supabase.auth.updateUser({ data: { display_name: name } })
+    if (error) {
+      toast.error(t('saveFailed'))
+      return false
+    }
+    setLocalDisplayName(name)
+    // Without this push the sidebar avatar/name stays stale until a refresh.
+    setUserName(name)
+    return true
+  }, [supabase, t, setUserName])
+
+  // ─── Appearance ───────────────────────────────────────────────────────────
+
+  const [themeChoice, setThemeChoice] = useState<ThemeChoice>(currentTheme)
+  // Hydrate from the persisted choice after mount (avoids an SSR mismatch); the
+  // two lint rules below are intentional for that reason.
+  useEffect(() => { setThemeChoice(readThemeChoice(currentTheme)) }, []) // eslint-disable-line react-hooks/exhaustive-deps, react-hooks/set-state-in-effect
+
+  const selectTheme = useCallback((choice: ThemeChoice) => {
+    setThemeChoice(choice)
+    setTheme(choice)
+  }, [setTheme])
+
+  // ─── Language ─────────────────────────────────────────────────────────────
+
+  const switchLocale = useCallback((next: string) => {
+    setLocaleCookie(next)
+    startTransition(() => router.refresh())
+  }, [router])
+
+  // ─── Price sync ───────────────────────────────────────────────────────────
+
+  const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle')
+  const [lastSyncIso, setLastSyncIso] = useState<string | null | undefined>(undefined)
+  const scheduleSyncStatusReset = useManagedTimeout()
+
+  useEffect(() => { fetchLastSync().then(setLastSyncIso) }, [])
+
+  const runSync = useCallback(async () => {
+    setSyncStatus('syncing')
+    const result = await refreshPrices()
+    // A flash scheduled by an earlier sync can still be pending. Clearing it
+    // blind would drop the card out of 'syncing' while a request is in flight,
+    // so the reset only lands if the status it set is still showing.
+    const clearFlash = (flashed: SyncStatus) =>
+      scheduleSyncStatusReset(
+        () => setSyncStatus(prev => (prev === flashed ? 'idle' : prev)),
+        SYNC_FLASH_MS,
+      )
+
+    if (result.ok) {
+      // Partial still advances the timestamp — prices did move, just not all.
+      const flashed: SyncStatus = result.partial ? 'partial' : 'done'
+      setSyncStatus(flashed)
+      setLastSyncIso(new Date().toISOString())
+      clearFlash(flashed)
+    } else if (result.reason === 'rate-limited') {
+      // Distinct from a failure: nothing is broken, the user just has to wait.
+      setSyncStatus('limited')
+      clearFlash('limited')
+    } else {
+      setSyncStatus('failed')
+      clearFlash('failed')
+    }
+  }, [scheduleSyncStatusReset])
+
+  const syncStatusLabel =
+    syncStatus === 'syncing' ? t('syncUpdating')
+    : syncStatus === 'partial' ? t('syncPartial')
+    : syncStatus === 'done' ? t('syncUpdated')
+    : syncStatus === 'limited' ? t('syncRateLimited')
+    : syncStatus === 'failed' ? t('syncFailed')
+    : `${t('lastSyncedPrefix')}${formatLastSync(lastSyncIso, locale)}`
+
+  // Rate-limited and partial are neutral, not negative: nothing is broken — the
+  // user is early, or some prices moved and some didn't.
+  const syncStatusColor =
+    syncStatus === 'done' ? 'var(--c-pos)'
+    : syncStatus === 'failed' ? 'var(--c-neg)'
+    : 'var(--c-muted)'
+
+  // ─── Report export ────────────────────────────────────────────────────────
+
+  const [showReport, setShowReport] = useState(false)
+  const [overviewCache, setOverviewCache] = useState<DashboardData | null>(null)
+
+  const openReport = useCallback(() => {
+    setShowReport(true)
+    // A failed prefetch must not block the sheet — the export path re-fetches
+    // and surfaces its own error.
+    fetchOverview().then((json) => { if (json) setOverviewCache(json) })
+  }, [])
+
+  const closeReport = useCallback(() => setShowReport(false), [])
+
+  const exportReport = useCallback(
+    () => exportPortfolioReport(overviewCache, locale),
+    [overviewCache, locale],
+  )
+
+  const reportSummary: ReportSummary | null = overviewCache ? {
+    netWorth: overviewCache.netWorth.netWorth,
+    currentValue: overviewCache.netWorth.currentValue,
+    totalPL: overviewCache.netWorth.overallProfitLoss,
+    goalCount: overviewCache.goals.length,
+  } : null
+
+  // ─── Session ──────────────────────────────────────────────────────────────
+
+  const signOut = useCallback(async () => {
+    const { error } = await supabase.auth.signOut()
+    if (error) {
+      // Clearing caches here would log the user out locally while the session
+      // is still live on the server.
+      toast.error(t('signOutFailed'))
+      return
+    }
+    await clearAppCaches()
+    router.push('/auth/login')
+  }, [supabase, t, router])
+
+  return {
+    displayName: localDisplayName,
+    initials: initialsOf(localDisplayName, initials),
+    saveProfile,
+    themeChoice,
+    selectTheme,
+    switchLocale,
+    syncStatus,
+    syncStatusLabel,
+    syncStatusColor,
+    lastSyncIso,
+    runSync,
+    showReport,
+    openReport,
+    closeReport,
+    reportSummary,
+    exportReport,
+    signOut,
+  }
+}


### PR DESCRIPTION
Closes #570.

`settingsShared.ts` already owned the network calls, but each view wrapped them in its own controller — the same Supabase browser client, the same five sync booleans with the same 3-second resets, the same profile save, report export, locale switch and sign-out. `useSettingsController` owns all of it.

**Views: 1305 → 1035 lines.** What stays is the chrome: desktop modals, mobile sheets, the mobile top bar, and the inline profile editor (desktop keeps its draft in the modal; mobile's lives in `ProfileSheet`).

## Two bugs the duplication was hiding

**Desktop leaked its timers.** Its status flashes and its "Saved" flash used bare `setTimeout`, so navigating away mid-flash left a `setState` pointed at a torn-down tree. Mobile had `useManagedTimeout` for exactly this; it's now shared and desktop uses it in both places.

**The five booleans allowed states the card can't show.** A partial result set `syncDone` *and* `syncPartial`; the render then had to re-derive which one wins. One `SyncStatus` replaces them. Its reset is also guarded — it only fires if the status it set is still showing, so a flash left over from an earlier sync can no longer drop a running one out of its disabled state. That guard has a test that goes red without it (verified by removing it).

## Tests

23 new tests drive the controller directly. The existing view tests — 155 of them across both viewports — **pass unchanged**, which is the real check that this is a refactor and not a rewrite.

- `npm test -- --run` — 162 files, **1763 passed**
- `eslint` clean, `tsc --noEmit` clean
- **Full E2E `npm run test:e2e` — 257 passed, 0 failed**, including all 5 settings specs (sync outcomes, rate-limited vs failure, partial, and the save→sidebar round-trip)