### PR TITLE
fix(withdraw): treat the entered bank amount as principal, not a slice of value

### DIFF
--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -350,7 +350,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
   const sell = computeSellPreview({ assetType, dir, holding: selectedHolding, sellAmount, received, goldSellQty, goldSellPrice })
   // The SellForm renders from the full `sell` preview; the sheet only needs these
   // for the submit gate, the buildSellPayload call, and the gold-price prefill.
-  const { sellDisabled, numSell, sellOverMax, sellNav, numReceived, bankPrincipalPortion, numGoldSellQty, isOverUnits, goldProceeds, goldCost } = sell
+  const { sellDisabled, numSell, sellOverMax, sellNav, numReceived, bankWithdrawPrincipal, numGoldSellQty, isOverUnits, goldProceeds, goldCost } = sell
 
   // Prefill the gold sale price with the holding's current price per chỉ.
   useEffect(() => {
@@ -396,7 +396,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
     // Sell / withdraw from the chosen holding (POST).
     if (dir === 'sell') {
       const r = buildSellPayload(selectedHolding, {
-        numSell, sellOverMax, sellNav, numGoldSellQty, isOverUnits, goldProceeds, goldCost, numReceived, bankPrincipalPortion,
+        numSell, sellOverMax, sellNav, numGoldSellQty, isOverUnits, goldProceeds, goldCost, numReceived, bankWithdrawPrincipal,
       }, { date, note })
       if (!r.ok) { setError(t(r.errorKey)); return }
       await submitTransaction('/api/v1/investment-transactions', 'POST', r.payload)

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -505,7 +505,11 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
                   />
                 </div>
                 <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 4 }}>
-                  {isVI ? 'Tạm tính theo giá trị hiện tại — sửa nếu rút sớm bị trừ lãi' : 'Pre-filled at current value — edit down if early withdrawal cuts interest'}
+                  {/* Not the whole current value any more: the prefill is the
+                      principal entered plus the interest accrued on that slice. */}
+                  {isVI
+                    ? 'Ước tính từ giá trị hiện tại — hãy đối chiếu với số tiền ngân hàng thực trả, nhất là khi rút trước hạn.'
+                    : "Estimated from the current value — verify it against the bank's actual payout, especially for an early withdrawal."}
                 </div>
               </div>
             )}

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -146,6 +146,16 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
   const bankPct = bankPrincipal > 0 ? Math.min(1, numAmount / bankPrincipal) : 0
 
   const withdrawMax = isBank ? bankPrincipal : maxAmount
+
+  // Value released from the holding by this withdrawal. After saving,
+  // valueNonFundHolding revalues the deposit from its remaining principal, so the
+  // holding falls by the withdrawn principal PLUS its projected interest —
+  // calcProjectedInterest is linear in principal, which makes that slice exact.
+  // The cash received is not that figure: an early withdrawal can forfeit the
+  // interest and still release it from the goal.
+  const bankValueReleased = isBank
+    ? estimateReceivedForPrincipal({ currentPrincipal: bankPrincipal, currentValue: maxAmount, amount: numAmount })
+    : 0
   const isOverMax = isGold ? isOverUnits : (numAmount > withdrawMax && withdrawMax > 0)
   const isValid = isGold
     ? (numUnits > 0 && !isOverUnits && numSalePrice > 0 && !saving)
@@ -655,8 +665,8 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
             )}
 
             {/* Count toward goal progress — only when withdrawing from a goal.
-                What leaves the goal is the cash: for a bank deposit that's the
-                payout, not the principal slice of it. */}
+                Keyed off the VALUE released (see bankValueReleased), which is what
+                the goal actually loses once the holding is revalued. */}
             {context === 'goal' && (
               <AffectsProgressControl
                 checked={affectsProgress}
@@ -664,7 +674,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
                 isVi={isVI}
                 currentValue={goalCurrentValue ?? 0}
                 targetAmount={goalTargetAmount ?? null}
-                withdrawnValue={isGold ? goldProceeds : isBank ? numReceived : numAmount}
+                withdrawnValue={isGold ? goldProceeds : isBank ? bankValueReleased : numAmount}
               />
             )}
 

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -10,6 +10,7 @@ import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { AffectsProgressControl } from './goalDetailShared'
 import { useDialogMount, useResetOnOpen } from '@/app/(app)/planning/components/useDialogMount'
+import { previewBankWithdrawal, estimateReceivedForPrincipal } from '@/lib/bankWithdrawal'
 const fmtVND = (n: number, _locale?: string) => fmt(n)
 
 export interface SellItem {
@@ -126,17 +127,26 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
   const goldRemUnits = isGold && item?.units != null ? item.units - numUnits : null
   const isOverUnits = isGold && item?.units != null && numUnits > item.units
 
-  // Bank: cash received is editable; split principal out of the withdrawn amount
-  // so the summary can show an accurate gain/loss. A book withdraws like any bank
-  // deposit (partial up to the balance, "All" = full close) — only the confirm
-  // routes to the book endpoint, spreading the principal across tranches.
+  // Bank: the entered amount is the PRINCIPAL leaving the book, and the cash
+  // received is editable on top of it — an early withdrawal can forfeit the
+  // accrued interest, so only the user's bank slip knows the real payout. The
+  // amount used to be a slice of currentValue (principal + projected interest)
+  // that got converted back into a principal fraction, which meant the recorded
+  // principal was never the number the user typed (#578).
+  //
+  // A book withdraws the same way (partial up to the principal, "All" = full
+  // close) — only the confirm routes to the book endpoint, which spreads the
+  // principal across tranches.
   const numReceived = Number(received) || 0
   const bankPrincipal = item?.purchasePrice ?? maxAmount
-  const bankFraction = maxAmount > 0 ? Math.min(1, numAmount / maxAmount) : 0
-  const bankPrincipalPortion = Math.round(bankPrincipal * bankFraction)
-  const bankGain = isBank && numReceived > 0 && numAmount > 0 ? numReceived - bankPrincipalPortion : null
+  const bankPreview = previewBankWithdrawal({ currentPrincipal: bankPrincipal, amount: numAmount, received: numReceived })
+  const bankGain = isBank && numReceived > 0 && numAmount > 0 ? bankPreview.interest : null
+  // Withdrawals are capped by what the holding actually holds: principal for a
+  // bank deposit, current value for anything sold at market.
+  const bankPct = bankPrincipal > 0 ? Math.min(1, numAmount / bankPrincipal) : 0
 
-  const isOverMax = isGold ? isOverUnits : (numAmount > maxAmount && maxAmount > 0)
+  const withdrawMax = isBank ? bankPrincipal : maxAmount
+  const isOverMax = isGold ? isOverUnits : (numAmount > withdrawMax && withdrawMax > 0)
   const isValid = isGold
     ? (numUnits > 0 && !isOverUnits && numSalePrice > 0 && !saving)
     : isBank
@@ -167,7 +177,14 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
     const raw = parseIntVN(val)
     setAmount(raw)
     setError('')
-    if (isBank) setReceived(raw)  // received tracks the amount until edited down
+    // Bank: the received field tracks the amount until edited down, but the
+    // amount is principal — so add back the interest accrued on that slice or an
+    // unedited field would record a withdrawal that earned nothing.
+    if (isBank) {
+      setReceived(raw
+        ? String(estimateReceivedForPrincipal({ currentPrincipal: bankPrincipal, currentValue: maxAmount, amount: Number(raw) }))
+        : '')
+    }
     if (navPerUnit && raw) {
       const u = Number(raw) / navPerUnit
       setUnits(u > 0 ? u.toFixed(2) : '')
@@ -194,8 +211,13 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
       setError('')
       return
     }
-    setAmount(String(maxAmount))
-    if (isBank) setReceived(String(Math.round(maxAmount)))
+    // Bank: "All" is the whole remaining PRINCIPAL, and the payout estimate for
+    // it is the full current value — the same figure this field was pre-filled
+    // with before the amount became principal.
+    setAmount(String(isBank ? bankPrincipal : maxAmount))
+    if (isBank) {
+      setReceived(String(estimateReceivedForPrincipal({ currentPrincipal: bankPrincipal, currentValue: maxAmount, amount: bankPrincipal })))
+    }
     if (navPerUnit && item?.units != null) setUnits(item.units.toFixed(2))
     setError('')
   }
@@ -217,8 +239,8 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            withdraw_principal: bankPrincipalPortion,
-            total_received: Math.round(numReceived),
+            withdraw_principal: bankPreview.principal,
+            total_received: bankPreview.received,
             investment_date: today,
             affects_progress: context === 'goal' ? affectsProgress : true,
           }),
@@ -262,9 +284,10 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
           parent_transaction_id: item.transactionId,
           investment_date: today,
           // Gold: amount = proceeds (qty × sale price), principal = cost basis of
-          // the sold chỉ. Bank: amount = cash received, principal = principal portion.
-          amount_vnd: isGold ? goldProceeds : isBank ? Math.round(numReceived) : Math.round(numAmount),
-          principal_withdrawn: isGold ? (goldCostSold ?? goldProceeds) : isBank ? bankPrincipalPortion : Math.round(numAmount),
+          // the sold chỉ. Bank: amount = cash received, principal = the principal
+          // the user entered.
+          amount_vnd: isGold ? goldProceeds : isBank ? bankPreview.received : Math.round(numAmount),
+          principal_withdrawn: isGold ? (goldCostSold ?? goldProceeds) : isBank ? bankPreview.principal : Math.round(numAmount),
           goal_id: withdrawalGoalId,
           affects_progress: context === 'goal' ? affectsProgress : true,
         }
@@ -301,8 +324,10 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
   const titleText = isBank
     ? (isVI ? 'Rút tiền' : 'Withdraw')
     : (isVI ? 'Bán' : 'Sell')
+  // "Principal", explicitly: the field is the principal leaving the book, not a
+  // share of the deposit's current value (#578).
   const amountLabel = isBank
-    ? (isVI ? 'Số tiền muốn rút' : 'Amount to withdraw')
+    ? (isVI ? 'Số tiền gốc muốn rút' : 'Principal amount to withdraw')
     : (isVI ? 'Số tiền muốn bán' : 'Amount to sell')
   const confirmLabel = isBank
     ? (isVI ? 'Xác nhận rút' : 'Confirm withdrawal')
@@ -399,7 +424,12 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
                 <div style={{ flex: 1, minWidth: 0 }}>
                   <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{item.name}</div>
                   <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2, display: 'flex', gap: 10, flexWrap: 'wrap' }}>
-                    <span>{isVI ? 'Khả dụng' : 'Available'}: <span style={{ fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(maxAmount, locale)}</span></span>
+                    {/* Bank: the withdrawable figure is the PRINCIPAL, so show
+                        that as available and the current value beside it —
+                        offering a value you can't enter is what made the old cap
+                        misleading. */}
+                    <span>{isBank ? (isVI ? 'Gốc khả dụng' : 'Principal available') : (isVI ? 'Khả dụng' : 'Available')}: <span style={{ fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(isBank ? bankPrincipal : maxAmount, locale)}</span></span>
+                    {isBank && <span>{isVI ? 'Giá trị' : 'Value'}: <span style={{ fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(maxAmount, locale)}</span></span>}
                     {item.units != null && <span>{item.units.toLocaleString()} {isVI ? 'phần' : 'units'}</span>}
                     {isBank && item.interestRate && <span>{item.interestRate}%/yr</span>}
                   </div>
@@ -441,7 +471,9 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
               {isOverMax && (
                 <div style={{ fontSize: 11, color: 'var(--c-neg, #dc2626)', marginTop: 5, display: 'flex', alignItems: 'center', gap: 4 }}>
                   <X size={12} strokeWidth={2.5} />
-                  {isVI ? 'Vượt quá số dư khả dụng' : 'Exceeds available balance'} · {isVI ? 'Tối đa' : 'Max'} {fmtVND(maxAmount, locale)}
+                  {isBank
+                    ? (isVI ? 'Vượt quá tiền gốc còn lại' : 'Exceeds remaining principal')
+                    : (isVI ? 'Vượt quá số dư khả dụng' : 'Exceeds available balance')} · {isVI ? 'Tối đa' : 'Max'} {fmtVND(withdrawMax, locale)}
                 </div>
               )}
             </div>
@@ -518,23 +550,25 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
             {/* Bank summary: principal portion / received / gain-loss / remaining */}
             {isBank && numAmount > 0 && !isOverMax && numReceived > 0 && (
               <div data-testid="sell-summary-strip" style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
-                  <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Tiền gốc' : 'Principal'}{bankFraction < 0.999 && <span style={{ opacity: 0.7 }}> · {Math.round(bankFraction * 100)}%</span>}</span>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(bankPrincipalPortion, locale)}</span>
+                <div data-testid="sell-bank-principal" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
+                  <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Tiền gốc' : 'Principal'}{bankPct < 0.999 && <span style={{ opacity: 0.7 }}> · {Math.round(bankPct * 100)}%</span>}</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(bankPreview.principal, locale)}</span>
                 </div>
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
                   <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Số tiền thực nhận' : "Amount you'll receive"}</span>
                   <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(numReceived, locale)}</span>
                 </div>
                 {bankGain != null && (
-                  <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '11px 14px', borderBottom: '1px solid var(--c-line)' }}>
+                  <div data-testid="sell-bank-gain" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '11px 14px', borderBottom: '1px solid var(--c-line)' }}>
                     <span style={{ fontSize: 12, fontWeight: 600 }}>{isVI ? 'Lãi/Lỗ' : 'Gain / Loss'}</span>
                     <span style={{ fontSize: 15, fontWeight: 700, color: bankGain >= 0 ? 'var(--c-pos, #16a34a)' : 'var(--c-neg, #dc2626)' }}>{bankGain >= 0 ? '+' : '−'}{fmtVND(Math.abs(bankGain), locale)}</span>
                   </div>
                 )}
-                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px' }}>
-                  <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Còn lại sau giao dịch' : 'Remaining after transaction'}</span>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(Math.max(0, maxAmount - numAmount), locale)}</span>
+                {/* Remaining PRINCIPAL — what the next withdrawal is capped
+                    against, and what depositValuation reduces. */}
+                <div data-testid="sell-bank-remaining" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px' }}>
+                  <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{isVI ? 'Tiền gốc còn lại' : 'Remaining principal'}</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--c-ink)' }}>{fmtVND(bankPreview.remainingPrincipal, locale)}</span>
                 </div>
               </div>
             )}
@@ -620,7 +654,9 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
             </>
             )}
 
-            {/* Count toward goal progress — only when withdrawing from a goal */}
+            {/* Count toward goal progress — only when withdrawing from a goal.
+                What leaves the goal is the cash: for a bank deposit that's the
+                payout, not the principal slice of it. */}
             {context === 'goal' && (
               <AffectsProgressControl
                 checked={affectsProgress}
@@ -628,7 +664,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
                 isVi={isVI}
                 currentValue={goalCurrentValue ?? 0}
                 targetAmount={goalTargetAmount ?? null}
-                withdrawnValue={isGold ? goldProceeds : numAmount}
+                withdrawnValue={isGold ? goldProceeds : isBank ? numReceived : numAmount}
               />
             )}
 
@@ -685,12 +721,14 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
                   : isBank ? <ArrowDownToLine size={15} strokeWidth={2.2} /> : <ArrowDownRight size={15} strokeWidth={2.2} />}
                 {(isGold ? numUnits <= 0 : numAmount <= 0)
                   ? (isVI
-                      ? (isBank ? 'Nhập số tiền rút' : isGold ? 'Nhập số lượng bán' : 'Nhập số tiền bán')
-                      : (isBank ? 'Enter withdrawal amount' : isGold ? 'Enter quantity to sell' : 'Enter sale amount'))
+                      ? (isBank ? 'Nhập số tiền gốc rút' : isGold ? 'Nhập số lượng bán' : 'Nhập số tiền bán')
+                      : (isBank ? 'Enter principal to withdraw' : isGold ? 'Enter quantity to sell' : 'Enter sale amount'))
                   : (isGold && numSalePrice <= 0)
                   ? (isVI ? 'Nhập giá bán' : 'Enter sale price')
                   : isOverMax
-                  ? (isVI ? (isGold ? 'Vượt quá số lượng' : 'Vượt quá số dư') : (isGold ? 'Exceeds quantity' : 'Exceeds balance'))
+                  ? (isVI
+                      ? (isGold ? 'Vượt quá số lượng' : isBank ? 'Vượt quá tiền gốc' : 'Vượt quá số dư')
+                      : (isGold ? 'Exceeds quantity' : isBank ? 'Exceeds principal' : 'Exceeds balance'))
                   : (isBank && numReceived <= 0)
                   ? (isVI ? 'Nhập số tiền thực nhận' : 'Enter amount received')
                   : saving

--- a/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
+++ b/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
@@ -40,6 +40,89 @@ describe('SellWithdrawSheet — bank withdraw (received + principal portion)', (
   })
 })
 
+// The existing coverage above only exercises a FULL withdrawal, where the old
+// proportional conversion happened to return the whole principal — so it stayed
+// green while every partial withdrawal recorded the wrong principal (#578).
+describe('SellWithdrawSheet — partial bank withdrawal where value != principal (#578)', () => {
+  // The reported PVcombank book: 20,385,398 of app value on 20,239,452 of
+  // principal. The user asks the bank for 4,365,100 and receives 4,366,416.
+  const book = {
+    type: 'bank' as const, name: 'PVcombank',
+    currentValue: 20_385_398, interestRate: 5.5,
+    transactionId: 't1', purchasePrice: 20_239_452,
+  }
+
+  function enterWithdrawal() {
+    fireEvent.change(screen.getByTestId('sell-amount-input'), { target: { value: '4365100' } })
+    fireEvent.change(screen.getByTestId('sell-received-input'), { target: { value: '4366416' } })
+  }
+
+  it('previews the entered amount as the principal withdrawn', () => {
+    render(<SellWithdrawSheet item={book} open context="unallocated" onClose={vi.fn()} onSuccess={vi.fn()} />)
+    enterWithdrawal()
+    // The old proportional conversion previewed 4.333.849 here.
+    expect(screen.getByTestId('sell-bank-principal')).toHaveTextContent('4.365.100')
+  })
+
+  it('previews the interest the bank actually paid', () => {
+    render(<SellWithdrawSheet item={book} open context="unallocated" onClose={vi.fn()} onSuccess={vi.fn()} />)
+    enterWithdrawal()
+    expect(screen.getByTestId('sell-bank-gain')).toHaveTextContent('1.316')
+  })
+
+  it('previews the principal the bank says remains', () => {
+    render(<SellWithdrawSheet item={book} open context="unallocated" onClose={vi.fn()} onSuccess={vi.fn()} />)
+    enterWithdrawal()
+    // Remaining PRINCIPAL, not remaining value — it is what the next withdrawal
+    // is capped against, and what depositValuation reduces.
+    expect(screen.getByTestId('sell-bank-remaining')).toHaveTextContent('15.874.352')
+  })
+
+  it('posts the entered principal and the received cash unchanged', async () => {
+    const fetchMock = vi.fn((_url?: string, _init?: RequestInit) =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    render(<SellWithdrawSheet item={book} open context="unallocated" onClose={vi.fn()} onSuccess={vi.fn()} />)
+    enterWithdrawal()
+    fireEvent.click(screen.getByTestId('sell-confirm-btn'))
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find((c) => String(c[0]).includes('/investment-transactions'))
+      const body = JSON.parse(String((post![1] as RequestInit).body))
+      expect(body.principal_withdrawn).toBe(4_365_100)
+      expect(body.amount_vnd).toBe(4_366_416)
+    })
+  })
+
+  it('caps the withdrawal at the remaining principal, not the current value', () => {
+    render(<SellWithdrawSheet item={book} open context="unallocated" onClose={vi.fn()} onSuccess={vi.fn()} />)
+    // Between principal and current value: the old cap allowed this, and then
+    // silently scaled the recorded principal down to fit.
+    fireEvent.change(screen.getByTestId('sell-amount-input'), { target: { value: '20300000' } })
+    expect(screen.getByTestId('sell-confirm-btn')).toBeDisabled()
+  })
+
+  it('prefills the received amount with the interest accrued on that principal', () => {
+    render(<SellWithdrawSheet item={book} open context="unallocated" onClose={vi.fn()} onSuccess={vi.fn()} />)
+    fireEvent.change(screen.getByTestId('sell-amount-input'), { target: { value: '4365100' } })
+    // Principal alone would record a withdrawal that earned nothing; the user
+    // still edits this down to the slip when an early withdrawal cuts interest.
+    const received = screen.getByTestId('sell-received-input') as HTMLInputElement
+    expect(Number(received.value.replace(/\./g, ''))).toBe(4_396_577)
+  })
+
+  it('fills the remaining principal — and the full current value — from "All"', () => {
+    render(<SellWithdrawSheet item={book} open context="unallocated" onClose={vi.fn()} onSuccess={vi.fn()} />)
+    fireEvent.click(screen.getByTestId('sell-all-btn'))
+    const amount = screen.getByTestId('sell-amount-input') as HTMLInputElement
+    const received = screen.getByTestId('sell-received-input') as HTMLInputElement
+    expect(Number(amount.value.replace(/\./g, ''))).toBe(20_239_452)
+    expect(Number(received.value.replace(/\./g, ''))).toBe(20_385_398)
+    expect(screen.getByTestId('sell-confirm-btn')).not.toBeDisabled()
+  })
+})
+
 describe('SellWithdrawSheet — links the withdrawal to its goal (issue #261)', () => {
   it('posts goal_id when withdrawing in a goal context', async () => {
     const fetchMock = vi.fn((_url?: string, _init?: RequestInit) =>

--- a/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
+++ b/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
@@ -123,6 +123,41 @@ describe('SellWithdrawSheet — partial bank withdrawal where value != principal
   })
 })
 
+// The goal-progress preview subtracts its input from the goal's VALUE, and after
+// saving, valueNonFundHolding revalues the holding from the remaining principal:
+// the goal drops by the withdrawn principal plus its projected interest
+// (calcProjectedInterest is linear in principal, so that slice is exact). The cash
+// received never enters that calculation — it leaves for Unallocated.
+describe('SellWithdrawSheet — goal-progress preview tracks the value released, not the payout', () => {
+  // 20M principal carrying 4M of accrued interest, in a goal worth exactly its
+  // target. Withdrawing half the principal releases 10M + 2M = 12M of value.
+  const book = {
+    type: 'bank' as const, name: 'PVcombank',
+    currentValue: 24_000_000, interestRate: 6,
+    transactionId: 't1', purchasePrice: 20_000_000,
+  }
+  const goalProps = { context: 'goal' as const, goalId: 'g1', goalCurrentValue: 24_000_000, goalTargetAmount: 24_000_000 }
+
+  it('previews the drop from the value released', () => {
+    render(<SellWithdrawSheet item={book} open {...goalProps} onClose={vi.fn()} onSuccess={vi.fn()} />)
+    fireEvent.change(screen.getByTestId('sell-amount-input'), { target: { value: '10000000' } })
+    const control = screen.getByTestId('affects-progress-control')
+    // 24M → 12M of 24M = 50%. Using the payout would leave 14M → 58%.
+    expect(control).toHaveTextContent('50%')
+    expect(control).not.toHaveTextContent('58%')
+  })
+
+  it('does not shrink the previewed drop when an early withdrawal forfeits the interest', () => {
+    render(<SellWithdrawSheet item={book} open {...goalProps} onClose={vi.fn()} onSuccess={vi.fn()} />)
+    fireEvent.change(screen.getByTestId('sell-amount-input'), { target: { value: '10000000' } })
+    // The bank pays back principal only — but the holding is still revalued from
+    // the remaining principal, so the goal falls by the same 12M either way. A
+    // preview keyed off the payout would promise a smaller drop than it delivers.
+    fireEvent.change(screen.getByTestId('sell-received-input'), { target: { value: '10000000' } })
+    expect(screen.getByTestId('affects-progress-control')).toHaveTextContent('50%')
+  })
+})
+
 describe('SellWithdrawSheet — links the withdrawal to its goal (issue #261)', () => {
   it('posts goal_id when withdrawing in a goal context', async () => {
     const fetchMock = vi.fn((_url?: string, _init?: RequestInit) =>

--- a/app/assets/components/__tests__/addTransactionModel.test.ts
+++ b/app/assets/components/__tests__/addTransactionModel.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import {
-  computeFundPricing, computeSellPreview, buildBuyPayload, buildEditPayload, buildSellPayload,
+  computeFundPricing, computeSellPreview, bankReceivedPrefill, buildBuyPayload, buildEditPayload, buildSellPayload,
   type PreviewHolding, type TxForm,
 } from '../addTransactionModel'
 
@@ -69,15 +69,59 @@ describe('computeSellPreview — bank', () => {
   it('splits principal out of the received cash and shows the gain', () => {
     const s = computeSellPreview({ assetType: 'bank', dir: 'sell', holding: bank, sellAmount: '5000000', received: '5200000', goldSellQty: '', goldSellPrice: '' })
     expect(s.numReceived).toBe(5_200_000)
-    expect(s.bankFraction).toBe(1)
-    expect(s.bankPrincipalPortion).toBe(5_000_000)
-    expect(s.bankGain).toBe(200_000)         // received − principal portion
+    expect(s.bankPctOfPrincipal).toBe(1)
+    expect(s.bankWithdrawPrincipal).toBe(5_000_000)
+    expect(s.bankGain).toBe(200_000)         // received − principal withdrawn
     expect(s.sellDisabled).toBe(false)
   })
 
   it('disables when nothing received', () => {
     const s = computeSellPreview({ assetType: 'bank', dir: 'sell', holding: bank, sellAmount: '5000000', received: '0', goldSellQty: '', goldSellPrice: '' })
     expect(s.sellDisabled).toBe(true)
+  })
+})
+
+// Same defect as the withdrawal sheet's (#578), in the Add-transaction sell path:
+// the entered amount was converted into a fraction of the deposit's current value
+// and applied to the principal, so a partial withdrawal never recorded the
+// principal the user typed. Only reachable when value != principal, which the
+// `bank` fixture above (5M on 5M) can't express.
+describe('computeSellPreview — partial bank withdrawal where value != principal (#578)', () => {
+  const book: PreviewHolding = {
+    type: 'bank', currentValue: 20_385_398, navPerUnit: null, gainPct: null,
+    purchasePrice: 20_239_452, units: null,
+  }
+
+  it('withdraws exactly the entered principal, and reports the interest paid', () => {
+    const s = computeSellPreview({ assetType: 'bank', dir: 'sell', holding: book, sellAmount: '4365100', received: '4366416', goldSellQty: '', goldSellPrice: '' })
+    // The old proportional conversion produced 4,333,849 and a gain of 32,567.
+    expect(s.bankWithdrawPrincipal).toBe(4_365_100)
+    expect(s.bankGain).toBe(1_316)
+    expect(s.sellRemaining).toBe(15_874_352)
+    expect(s.sellDisabled).toBe(false)
+  })
+
+  it('caps the withdrawal at the remaining principal, not the current value', () => {
+    const s = computeSellPreview({ assetType: 'bank', dir: 'sell', holding: book, sellAmount: '20300000', received: '20300000', goldSellQty: '', goldSellPrice: '' })
+    expect(s.sellMax).toBe(20_239_452)
+    expect(s.sellOverMax).toBe(true)
+    expect(s.sellDisabled).toBe(true)
+  })
+
+  it('still caps a fund sell at its current value', () => {
+    const s = computeSellPreview({ assetType: 'fund', dir: 'sell', holding: fund, sellAmount: '1900000', ...base })
+    expect(s.sellMax).toBe(2_000_000)
+    expect(s.sellOverMax).toBe(false)
+  })
+
+  it('prefills the received cash with the interest accrued on that principal', () => {
+    expect(bankReceivedPrefill(book, 4_365_100)).toBe(4_396_577)
+    // "All" withdraws the whole principal and estimates the whole current value.
+    expect(bankReceivedPrefill(book, 20_239_452)).toBe(20_385_398)
+  })
+
+  it('prefills nothing extra for a holding it has no principal for', () => {
+    expect(bankReceivedPrefill(null, 1_000)).toBe(1_000)
   })
 })
 
@@ -168,7 +212,7 @@ describe('buildEditPayload', () => {
 
 describe('buildSellPayload', () => {
   const date = '2026-07-24'
-  const zero = { numSell: 0, sellOverMax: false, sellNav: null, numGoldSellQty: 0, isOverUnits: false, goldProceeds: 0, goldCost: null, numReceived: 0, bankPrincipalPortion: 0 }
+  const zero = { numSell: 0, sellOverMax: false, sellNav: null, numGoldSellQty: 0, isOverUnits: false, goldProceeds: 0, goldCost: null, numReceived: 0, bankWithdrawPrincipal: 0 }
 
   it('fund: proportional principal_withdrawn + units_withdrawn=amount÷NAV', () => {
     const holding = { type: 'fund' as const, fundId: 'f1', purchasePrice: 18_000, currentValue: 2_000_000, units: 100 }
@@ -181,9 +225,9 @@ describe('buildSellPayload', () => {
     })
   })
 
-  it('bank: amount is received cash, principal is the split portion', () => {
+  it('bank: amount is the received cash, principal is what the user entered', () => {
     const holding = { type: 'bank' as const, transactionId: 't1', purchasePrice: 5_000_000, currentValue: 5_000_000 }
-    const preview = { ...zero, numSell: 5_000_000, numReceived: 5_200_000, bankPrincipalPortion: 5_000_000 }
+    const preview = { ...zero, numSell: 5_000_000, numReceived: 5_200_000, bankWithdrawPrincipal: 5_000_000 }
     expect(ok(buildSellPayload(holding, preview, { date, note: '' }))).toMatchObject({
       asset_type: 'bank', parent_transaction_id: 't1', amount_vnd: 5_200_000, principal_withdrawn: 5_000_000,
     })

--- a/app/assets/components/addTransactionForms.tsx
+++ b/app/assets/components/addTransactionForms.tsx
@@ -10,6 +10,7 @@ import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/
 import LoadError from './LoadError'
 import type { Fund, Bank, Holding } from './AddTransactionSheet'
 import type { SellPreview, AssetType } from './addTransactionModel'
+import { bankReceivedPrefill } from './addTransactionModel'
 
 const GOLD_PROVIDERS = ['PNJ', 'DOJI', 'SJC', 'Bảo Tín']
 
@@ -374,7 +375,7 @@ export function SellForm({
   const t = useTranslations('addTx')
   const {
     sellMax, numSell, sellOverMax, sellRemaining, sellNav, sellGainLoss, sellTax,
-    numReceived, bankFraction, bankPrincipalPortion, bankGain,
+    numReceived, bankPctOfPrincipal, bankWithdrawPrincipal, bankGain,
     goldMaxUnits, numGoldSellQty, numGoldSellPrice, goldBuyUnit, goldProceeds, goldCost,
     goldProfit, goldRemUnits, isOverUnits,
   } = sell
@@ -416,7 +417,12 @@ export function SellForm({
                     <div style={{ flex: 1, minWidth: 0 }}>
                       <div style={{ fontSize: 13, fontWeight: 600, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{selectedHolding.name}</div>
                       <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2, display: 'flex', gap: 10, flexWrap: 'wrap' }}>
-                        <span>{t('available')}: <span style={{ fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{selectedHolding.currentValue.toLocaleString('vi-VN')} ₫</span></span>
+                        {/* Bank: what you can withdraw is the PRINCIPAL, so show
+                            that as available and the value beside it — offering a
+                            figure you can't enter is what made the old cap
+                            misleading. */}
+                        <span>{assetType === 'bank' ? t('principalAvailable') : t('available')}: <span style={{ fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{Math.round(sellMax).toLocaleString('vi-VN')} ₫</span></span>
+                        {assetType === 'bank' && <span>{t('valueShort')}: <span style={{ fontWeight: 600, color: 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}>{selectedHolding.currentValue.toLocaleString('vi-VN')} ₫</span></span>}
                         {selectedHolding.units != null && <span style={{ fontVariantNumeric: 'tabular-nums' }}>{selectedHolding.units.toLocaleString('vi-VN')} {t('unitsShort')}</span>}
                         {assetType === 'bank' && selectedHolding.interestRate != null && <span>{selectedHolding.interestRate}%/yr</span>}
                       </div>
@@ -427,7 +433,9 @@ export function SellForm({
                 {assetType !== 'gold' ? (
                   <>
                     <div>
-                      <label style={labelStyle}>{assetType === 'bank' ? t('amountToWithdraw') : t('amountToSell')}</label>
+                      {/* "Principal", explicitly: the field is the principal
+                          leaving the book, not a share of its value (#578). */}
+                      <label style={labelStyle}>{assetType === 'bank' ? t('principalToWithdraw') : t('amountToSell')}</label>
                       <div style={{ display: 'flex', gap: 8 }}>
                         <div style={{ flex: 1, display: 'flex', alignItems: 'center', gap: 8, padding: '10px 12px', background: 'var(--c-card)', border: `1.5px solid ${sellOverMax ? 'var(--c-neg)' : 'var(--c-navy)'}`, borderRadius: 10 }}>
                           <span style={{ fontSize: 14, color: 'var(--c-muted)' }}>₫</span>
@@ -440,7 +448,9 @@ export function SellForm({
                               setSellAmount(v)
                               const n = Number(v) || 0
                               if (assetType === 'fund') setFundSellUnits(sellNav && n ? (n / sellNav).toFixed(2) : '')
-                              if (assetType === 'bank') setReceived(n ? String(Math.round(n)) : '')
+                              // The amount is principal, so the prefill adds the
+                              // interest accrued on that slice back on top (#578).
+                              if (assetType === 'bank') setReceived(n ? String(bankReceivedPrefill(selectedHolding, n)) : '')
                             }}
                             placeholder="0"
                             style={{ flex: 1, minWidth: 0, border: 'none', outline: 'none', fontSize: 16, fontWeight: 600, fontFamily: 'inherit', background: 'transparent', color: sellOverMax ? 'var(--c-neg)' : 'var(--c-ink)', fontVariantNumeric: 'tabular-nums' }}
@@ -449,12 +459,12 @@ export function SellForm({
                         <button type="button" onClick={() => {
                           setSellAmount(String(Math.round(sellMax)))
                           if (assetType === 'fund') setFundSellUnits(selectedHolding?.units != null ? selectedHolding.units.toFixed(2) : '')
-                          if (assetType === 'bank') setReceived(String(Math.round(sellMax)))
+                          if (assetType === 'bank') setReceived(String(bankReceivedPrefill(selectedHolding, sellMax)))
                         }} style={{ padding: '8px 12px', background: 'var(--c-navy-tint)', color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)', borderRadius: 10, fontSize: 12, fontWeight: 600, cursor: 'pointer', whiteSpace: 'nowrap', fontFamily: 'inherit' }}>{t('all')}</button>
                       </div>
                       {sellOverMax && (
                         <div style={{ fontSize: 11, color: 'var(--c-neg)', marginTop: 5, display: 'flex', alignItems: 'center', gap: 4 }}>
-                          <X size={12} strokeWidth={2.5} /> {t('exceedsBalance')} · {t('max')} {Math.round(sellMax).toLocaleString('vi-VN')} ₫
+                          <X size={12} strokeWidth={2.5} /> {assetType === 'bank' ? t('exceedsPrincipal') : t('exceedsBalance')} · {t('max')} {Math.round(sellMax).toLocaleString('vi-VN')} ₫
                         </div>
                       )}
                     </div>
@@ -530,8 +540,8 @@ export function SellForm({
                     {assetType === 'bank' && numSell > 0 && !sellOverMax && numReceived > 0 && (
                       <div style={{ background: 'var(--c-card-2)', borderRadius: 12, overflow: 'hidden' }}>
                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
-                          <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{t('principalPortion')}{bankFraction < 0.999 && <span style={{ opacity: 0.7 }}> · {Math.round(bankFraction * 100)}%</span>}</span>
-                          <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{bankPrincipalPortion.toLocaleString('vi-VN')} ₫</span>
+                          <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{t('principalPortion')}{bankPctOfPrincipal < 0.999 && <span style={{ opacity: 0.7 }}> · {Math.round(bankPctOfPrincipal * 100)}%</span>}</span>
+                          <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{bankWithdrawPrincipal.toLocaleString('vi-VN')} ₫</span>
                         </div>
                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px', borderBottom: '1px solid var(--c-line)' }}>
                           <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{t('amountReceived')}</span>
@@ -544,7 +554,7 @@ export function SellForm({
                           </div>
                         )}
                         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '10px 14px' }}>
-                          <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{t('remainingAfter')}</span>
+                          <span style={{ fontSize: 12, color: 'var(--c-muted)' }}>{t('remainingPrincipal')}</span>
                           <span style={{ fontSize: 13, fontWeight: 600, fontVariantNumeric: 'tabular-nums' }}>{sellRemaining.toLocaleString('vi-VN')} ₫</span>
                         </div>
                       </div>

--- a/app/assets/components/addTransactionModel.ts
+++ b/app/assets/components/addTransactionModel.ts
@@ -5,6 +5,8 @@
 // directly. The DB-write payload builders inside handleSave are a separate concern
 // and stay in the component for now.
 
+import { previewBankWithdrawal, estimateReceivedForPrincipal } from '@/lib/bankWithdrawal'
+
 export type AssetType = 'fund' | 'bank' | 'gold'
 
 // The sell-side holding fields the preview reads — a structural subset of the
@@ -55,8 +57,10 @@ export interface SellPreview {
   sellGainLoss: number | null
   sellTax: number | null
   numReceived: number
-  bankFraction: number
-  bankPrincipalPortion: number
+  /** Share of the remaining PRINCIPAL this withdrawal takes — display only. */
+  bankPctOfPrincipal: number
+  /** Principal leaving the book: exactly what the user entered (#578). */
+  bankWithdrawPrincipal: number
   bankGain: number | null
   goldMaxUnits: number
   numGoldSellQty: number
@@ -84,7 +88,12 @@ export function computeSellPreview(input: {
 }): SellPreview {
   const { assetType, dir, holding: h, sellAmount, received, goldSellQty, goldSellPrice } = input
 
-  const sellMax = h?.currentValue ?? 0
+  // A bank withdrawal is bounded by the PRINCIPAL still in the book, not by its
+  // current value: the amount entered is the principal being taken out, and the
+  // interest is whatever the bank pays on top (#578). Anything sold at market is
+  // still bounded by its value.
+  const bankPrincipal = h?.purchasePrice ?? h?.currentValue ?? 0
+  const sellMax = assetType === 'bank' ? bankPrincipal : (h?.currentValue ?? 0)
   const numSell = Number(sellAmount) || 0
   const sellOverMax = numSell > sellMax && sellMax > 0
   const sellRemaining = Math.max(0, sellMax - numSell)
@@ -93,13 +102,13 @@ export function computeSellPreview(input: {
     ? numSell * h.gainPct / (100 + h.gainPct) : null
   const sellTax = assetType === 'fund' && numSell > 0 ? Math.round(numSell * 0.001) : null
 
-  // Bank withdrawal: received cash is editable (early withdrawal can cut interest);
-  // split the principal out so the summary can show the gain/loss.
+  // Bank withdrawal: received cash is editable (early withdrawal can cut
+  // interest), and the gain is simply what the bank paid above the principal.
   const numReceived = Number(received) || 0
-  const bankPrincipal = h?.purchasePrice ?? sellMax
-  const bankFraction = sellMax > 0 ? Math.min(1, numSell / sellMax) : 0
-  const bankPrincipalPortion = Math.round(bankPrincipal * bankFraction)
-  const bankGain = assetType === 'bank' && numReceived > 0 && numSell > 0 ? numReceived - bankPrincipalPortion : null
+  const bankView = previewBankWithdrawal({ currentPrincipal: bankPrincipal, amount: numSell, received: numReceived })
+  const bankWithdrawPrincipal = bankView.principal
+  const bankPctOfPrincipal = bankPrincipal > 0 ? Math.min(1, numSell / bankPrincipal) : 0
+  const bankGain = assetType === 'bank' && numReceived > 0 && numSell > 0 ? bankView.interest : null
 
   // Gold sells are quantity-based: chỉ to sell × the sale price per chỉ.
   const goldMaxUnits = h?.units ?? 0
@@ -124,10 +133,23 @@ export function computeSellPreview(input: {
 
   return {
     sellMax, numSell, sellOverMax, sellRemaining, sellNav, sellGainLoss, sellTax,
-    numReceived, bankFraction, bankPrincipalPortion, bankGain,
+    numReceived, bankPctOfPrincipal, bankWithdrawPrincipal, bankGain,
     goldMaxUnits, numGoldSellQty, numGoldSellPrice, goldBuyUnit, goldProceeds, goldCost,
     goldProfit, goldRemUnits, isOverUnits, sellDisabled,
   }
+}
+
+/**
+ * Prefill for the bank "amount you'll receive" field, given the principal being
+ * withdrawn. The amount field is principal, so the accrued interest has to be
+ * added back or an unedited field would record a withdrawal that earned nothing.
+ */
+export function bankReceivedPrefill(holding: PreviewHolding | null, amount: number): number {
+  return estimateReceivedForPrincipal({
+    currentPrincipal: holding?.purchasePrice ?? holding?.currentValue ?? 0,
+    currentValue: holding?.currentValue ?? 0,
+    amount,
+  })
 }
 
 // ── DB-write payload builders ────────────────────────────────────────────────
@@ -270,7 +292,7 @@ export function buildSellPayload(
   holding: SellHolding | null,
   preview: Pick<SellPreview,
     'numSell' | 'sellOverMax' | 'sellNav' | 'numGoldSellQty' | 'isOverUnits' |
-    'goldProceeds' | 'goldCost' | 'numReceived' | 'bankPrincipalPortion'>,
+    'goldProceeds' | 'goldCost' | 'numReceived' | 'bankWithdrawPrincipal'>,
   opts: { date: string; note: string },
 ): BuildResult {
   const { date, note } = opts
@@ -304,15 +326,15 @@ export function buildSellPayload(
   if (holding.transactionId) {
     if (!preview.numSell) return { ok: false, errorKey: 'amountRequired' }
     if (preview.sellOverMax) return { ok: false, errorKey: 'exceedsBalance' }
-    // Bank: received cash is what the user gets; principal portion is what leaves the
-    // deposit's principal, so the gain/loss is recorded accurately.
+    // Bank: received cash is what the user gets; the principal withdrawn is the
+    // amount they entered, so the gain/loss is recorded accurately (#578).
     const isBankSell = holding.type === 'bank'
     if (isBankSell && preview.numReceived <= 0) return { ok: false, errorKey: 'amountRequired' }
     return { ok: true, payload: {
       transaction_type: 'withdrawal', asset_type: holding.type,
       parent_transaction_id: holding.transactionId, investment_date: date,
       amount_vnd: isBankSell ? Math.round(preview.numReceived) : Math.round(preview.numSell),
-      principal_withdrawn: isBankSell ? preview.bankPrincipalPortion : Math.round(preview.numSell),
+      principal_withdrawn: isBankSell ? preview.bankWithdrawPrincipal : Math.round(preview.numSell),
       goal_id: null, notes: note || null,
     } }
   }

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -180,6 +180,53 @@ test('sell unallocated fund via action sheet', async ({ page }) => {
   await expect(page.getByTestId('sell-sheet')).not.toBeVisible({ timeout: 8_000 })
 })
 
+// #578 — the partial-withdrawal coverage that existed called the API directly with
+// an already-correct withdraw_principal, so it never exercised the sheet's
+// conversion. This drives the real UI and then reads back what was persisted,
+// because the persisted principal is what depositValuation subtracts from the
+// holding forever after.
+test('partial bank withdrawal records the principal entered in the UI, not a slice of the current value', async ({ page }) => {
+  // A deposit whose current value is above its principal: 5.5%/yr, opened 60 days
+  // ago. Without accrued interest the old proportional bug is invisible.
+  const tx = await api.createTransaction({
+    asset_type: 'bank',
+    amount_vnd: 20_239_452,
+    interest_rate: 5.5,
+    investment_date: new Date(Date.now() - 60 * 86_400_000).toISOString().slice(0, 10),
+    expiry_date: new Date(Date.now() + 305 * 86_400_000).toISOString().slice(0, 10),
+    notes: 'E2E Partial Withdraw Deposit',
+  })
+  cleanup.add(() => api.deleteTransactionCascade(tx.transaction_id))
+
+  await gotoFreshDashboard(page)
+
+  const row = page.getByTestId('unallocated-row').filter({ hasText: 'E2E Partial Withdraw Deposit' }).first()
+  await expect(row).toBeVisible({ timeout: 10_000 })
+  await row.click()
+  await page.getByTestId('action-sell').click()
+  await expect(page.getByTestId('sell-sheet')).toBeVisible({ timeout: 5_000 })
+
+  // The reported numbers: ask the bank for 4,365,100 of principal, receive 4,366,416.
+  await page.getByTestId('sell-amount-input').fill('4365100')
+  await page.getByTestId('sell-received-input').fill('4366416')
+  // The preview must show the entered principal — the bug previewed 4.333.849.
+  await expect(page.getByTestId('sell-bank-principal')).toContainText('4.365.100')
+  await expect(page.getByTestId('sell-bank-remaining')).toContainText('15.874.352')
+
+  const [resp] = await Promise.all([
+    page.waitForResponse(r => r.url().includes('/api/v1/investment-transactions') && r.request().method() === 'POST'),
+    page.getByTestId('sell-confirm-btn').click(),
+  ])
+  expect(resp.status()).toBe(201)
+
+  const all = await (await page.request.get('/api/v1/investment-transactions?asset_type=bank&limit=1000')).json()
+  const wd = (all.transactions as Array<{ transaction_type: string; parent_transaction_id: string | null; amount_vnd: number; principal_withdrawn: number | null }>)
+    .filter(r => r.transaction_type === 'withdrawal' && r.parent_transaction_id === tx.transaction_id)
+  expect(wd).toHaveLength(1)
+  expect(wd[0].principal_withdrawn).toBe(4_365_100)
+  expect(wd[0].amount_vnd).toBe(4_366_416)
+})
+
 test('sell success state appears after confirm', async ({ page }) => {
   const fund = await api.createFund({ name: 'E2E Success Fund', code: 'E2ESUCFUND', fund_type: 'equity', nav: 10000 })
   cleanup.add(() => api.deleteFund(fund.id))

--- a/lib/__tests__/bankWithdrawal.test.ts
+++ b/lib/__tests__/bankWithdrawal.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest'
+import { previewBankWithdrawal, estimateReceivedForPrincipal } from '../bankWithdrawal'
+
+// The withdrawal sheet used to treat the entered amount as a slice of the
+// deposit's *current value* (principal + projected interest) and then apply that
+// fraction to the principal — so the principal it recorded was never the number
+// the user typed (#578). The entered amount IS the principal leaving the book;
+// interest is whatever the bank paid on top of it.
+
+describe('previewBankWithdrawal — the reported PVcombank case (#578)', () => {
+  // App value 20,385,398 on a principal of 20,239,452. The user asks the bank for
+  // 4,365,100 of principal and receives 4,366,416.
+  const CASE = { currentPrincipal: 20_239_452, amount: 4_365_100, received: 4_366_416 }
+
+  it('withdraws exactly the principal the user entered', () => {
+    // The old proportional conversion produced 4,333,849 here — 31,251 short.
+    expect(previewBankWithdrawal(CASE).principal).toBe(4_365_100)
+  })
+
+  it('reports the interest actually received', () => {
+    expect(previewBankWithdrawal(CASE).interest).toBe(1_316)
+  })
+
+  it('leaves the principal the bank says remains', () => {
+    expect(previewBankWithdrawal(CASE).remainingPrincipal).toBe(15_874_352)
+  })
+})
+
+describe('previewBankWithdrawal', () => {
+  it('reports a loss when an early withdrawal pays back less than the principal', () => {
+    const p = previewBankWithdrawal({ currentPrincipal: 10_000_000, amount: 5_000_000, received: 4_900_000 })
+    expect(p.interest).toBe(-100_000)
+    expect(p.principal).toBe(5_000_000)
+  })
+
+  it('empties the book on a full withdrawal', () => {
+    const p = previewBankWithdrawal({ currentPrincipal: 10_000_000, amount: 10_000_000, received: 10_300_000 })
+    expect(p.remainingPrincipal).toBe(0)
+    expect(p.exceedsPrincipal).toBe(false)
+    expect(p.interest).toBe(300_000)
+  })
+
+  it('flags an amount above the remaining principal', () => {
+    // The old cap was currentValue, so a user could withdraw more principal than
+    // the book holds and the recorded principal would silently be scaled down.
+    const p = previewBankWithdrawal({ currentPrincipal: 10_000_000, amount: 10_000_001, received: 10_300_000 })
+    expect(p.exceedsPrincipal).toBe(true)
+  })
+
+  it('never reports a negative remaining principal', () => {
+    const p = previewBankWithdrawal({ currentPrincipal: 10_000_000, amount: 12_000_000, received: 12_000_000 })
+    expect(p.remainingPrincipal).toBe(0)
+  })
+
+  it('rounds both money inputs to whole đồng', () => {
+    const p = previewBankWithdrawal({ currentPrincipal: 10_000_000, amount: 4_365_100.6, received: 4_366_416.4 })
+    expect(p.principal).toBe(4_365_101)
+    expect(p.received).toBe(4_366_416)
+    expect(p.interest).toBe(1_315)
+  })
+
+  it('treats a book with no principal left as fully withdrawn', () => {
+    const p = previewBankWithdrawal({ currentPrincipal: 0, amount: 1_000, received: 1_000 })
+    expect(p.exceedsPrincipal).toBe(true)
+    expect(p.remainingPrincipal).toBe(0)
+  })
+})
+
+// The "amount you'll receive" field is a prefill the user confirms against their
+// bank slip. Because the amount field is now principal, the prefill has to add
+// back the accrued interest or an unedited field would record zero interest.
+describe('estimateReceivedForPrincipal', () => {
+  const BOOK = { currentPrincipal: 20_239_452, currentValue: 20_385_398 }
+
+  it('adds the accrued interest in proportion to the principal withdrawn', () => {
+    // 145,946 accrued × 4,365,100/20,239,452 = 31,477.
+    expect(estimateReceivedForPrincipal({ ...BOOK, amount: 4_365_100 })).toBe(4_396_577)
+  })
+
+  it('estimates the whole current value for a full withdrawal', () => {
+    // This is what "All" fills in, and it keeps the pre-#578 behaviour of the
+    // received field for a full close: principal + all accrued interest.
+    expect(estimateReceivedForPrincipal({ ...BOOK, amount: BOOK.currentPrincipal })).toBe(20_385_398)
+  })
+
+  it('never estimates above the current value', () => {
+    expect(estimateReceivedForPrincipal({ ...BOOK, amount: 30_000_000 })).toBe(20_385_398)
+  })
+
+  it('estimates nothing extra when the deposit has accrued nothing', () => {
+    expect(estimateReceivedForPrincipal({ currentPrincipal: 10_000_000, currentValue: 10_000_000, amount: 4_000_000 })).toBe(4_000_000)
+  })
+
+  it('ignores a current value below the principal instead of estimating a loss', () => {
+    // Stale valuation, not a real loss — a savings book cannot accrue negative
+    // interest, and guessing one would understate what the user receives.
+    expect(estimateReceivedForPrincipal({ currentPrincipal: 10_000_000, currentValue: 9_500_000, amount: 4_000_000 })).toBe(4_000_000)
+  })
+
+  it('falls back to the entered amount when the book has no principal', () => {
+    expect(estimateReceivedForPrincipal({ currentPrincipal: 0, currentValue: 0, amount: 1_000 })).toBe(1_000)
+  })
+})

--- a/lib/bankWithdrawal.ts
+++ b/lib/bankWithdrawal.ts
@@ -1,0 +1,75 @@
+// Money math for withdrawing from a bank savings book.
+//
+// The withdrawal sheet used to treat the entered amount as a slice of the
+// deposit's *current value* — principal plus projected interest — and then apply
+// that fraction to the principal:
+//
+//   const bankFraction = numAmount / item.currentValue
+//   const bankPrincipalPortion = Math.round(principal * bankFraction)
+//
+// so the principal it previewed and posted was never the number the user typed
+// (#578). A user withdrawing 4,365,100 of principal had 4,333,849 recorded, and
+// lib/depositValuation subtracted that short figure from the holding, leaving the
+// remaining balance overstated for good.
+//
+// The entered amount IS the principal leaving the book. Interest is whatever the
+// bank paid on top of it — which the user reads off their slip, because an early
+// withdrawal can forfeit accrued interest entirely.
+
+export interface BankWithdrawalInput {
+  /** Principal still in the book, before this withdrawal. */
+  currentPrincipal: number
+  /** Principal the user is withdrawing. */
+  amount: number
+  /** Cash the bank actually paid out. */
+  received: number
+}
+
+export interface BankWithdrawalPreview {
+  /** Principal removed from the book — exactly what the user entered. */
+  principal: number
+  received: number
+  /** received − principal. Negative when an early withdrawal costs money. */
+  interest: number
+  remainingPrincipal: number
+  /** The book doesn't hold this much principal — the confirm is blocked. */
+  exceedsPrincipal: boolean
+}
+
+export function previewBankWithdrawal({ currentPrincipal, amount, received }: BankWithdrawalInput): BankWithdrawalPreview {
+  const principal = Math.round(amount)
+  const paid = Math.round(received)
+  return {
+    principal,
+    received: paid,
+    interest: paid - principal,
+    remainingPrincipal: Math.max(0, currentPrincipal - principal),
+    exceedsPrincipal: principal > currentPrincipal,
+  }
+}
+
+/**
+ * Prefill for the "amount you'll receive" field: the principal being withdrawn
+ * plus its share of the interest accrued so far.
+ *
+ * The amount field is principal, so without adding the interest back an unedited
+ * field would record a withdrawal that earned nothing. At a full withdrawal this
+ * returns the whole current value, which is what the received field was
+ * pre-filled with before #578 — the user still edits it down when an early
+ * withdrawal cuts the interest.
+ */
+export function estimateReceivedForPrincipal({ currentPrincipal, currentValue, amount }: {
+  currentPrincipal: number
+  currentValue: number
+  amount: number
+}): number {
+  const principal = Math.round(amount)
+  if (currentPrincipal <= 0) return principal
+  // A savings book cannot accrue negative interest: a current value below the
+  // principal is stale data, and guessing a loss would understate the payout.
+  const accrued = Math.max(0, currentValue - currentPrincipal)
+  // An amount above the remaining principal is already flagged as invalid; cap
+  // the estimate at what the book is worth rather than inventing a bigger payout.
+  const capped = Math.min(principal, currentPrincipal)
+  return capped + Math.round(accrued * (capped / currentPrincipal))
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -91,7 +91,7 @@
     "unitsToSell": "Units to sell",
     "navLinkHint": "Enter an amount or units — they stay in sync",
     "amountReceived": "Amount you'll receive",
-    "receivedHint": "Pre-filled at current value — edit down if early withdrawal cuts interest",
+    "receivedHint": "Estimated from the current value — verify it against the bank's actual payout, especially for an early withdrawal.",
     "principalPortion": "Principal",
     "gainLoss": "Gain / Loss",
     "principalToWithdraw": "Principal amount to withdraw",

--- a/messages/en.json
+++ b/messages/en.json
@@ -93,7 +93,12 @@
     "amountReceived": "Amount you'll receive",
     "receivedHint": "Pre-filled at current value — edit down if early withdrawal cuts interest",
     "principalPortion": "Principal",
-    "gainLoss": "Gain / Loss"
+    "gainLoss": "Gain / Loss",
+    "principalToWithdraw": "Principal amount to withdraw",
+    "principalAvailable": "Principal available",
+    "valueShort": "Value",
+    "exceedsPrincipal": "Exceeds remaining principal",
+    "remainingPrincipal": "Remaining principal"
   },
   "common": {
     "save": "Save",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -93,7 +93,12 @@
     "amountReceived": "Số tiền thực nhận",
     "receivedHint": "Tạm tính theo giá trị hiện tại — sửa nếu rút sớm bị trừ lãi",
     "principalPortion": "Tiền gốc",
-    "gainLoss": "Lãi/Lỗ"
+    "gainLoss": "Lãi/Lỗ",
+    "principalToWithdraw": "Số tiền gốc muốn rút",
+    "principalAvailable": "Gốc khả dụng",
+    "valueShort": "Giá trị",
+    "exceedsPrincipal": "Vượt quá tiền gốc còn lại",
+    "remainingPrincipal": "Tiền gốc còn lại"
   },
   "common": {
     "save": "Lưu",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -91,7 +91,7 @@
     "unitsToSell": "Số phần muốn bán",
     "navLinkHint": "Nhập số tiền hoặc số phần — tự động đồng bộ",
     "amountReceived": "Số tiền thực nhận",
-    "receivedHint": "Tạm tính theo giá trị hiện tại — sửa nếu rút sớm bị trừ lãi",
+    "receivedHint": "Ước tính từ giá trị hiện tại — hãy đối chiếu với số tiền ngân hàng thực trả, nhất là khi rút trước hạn.",
     "principalPortion": "Tiền gốc",
     "gainLoss": "Lãi/Lỗ",
     "principalToWithdraw": "Số tiền gốc muốn rút",


### PR DESCRIPTION
Closes #578.

## The bug

A partial bank withdrawal converted the entered amount into a fraction of the deposit's **current value** (principal + projected interest) and applied that fraction back to the principal:

```ts
const bankFraction = numAmount / item.currentValue   // maxAmount = currentValue
const bankPrincipalPortion = Math.round(bankPrincipal * bankFraction)
```

So the principal previewed and posted was never the number the user typed. Withdrawing 4,365,100 recorded 4,333,849. `lib/depositValuation` subtracts the *recorded* principal from the holding, so the remaining balance stayed overstated permanently — the wrong number is durable, not cosmetic.

## The fix

The entered amount **is** the principal leaving the book; interest is whatever the bank paid on top of it — which only the user's slip knows, since an early withdrawal can forfeit it entirely. `lib/bankWithdrawal` owns that math:

- capped by remaining **principal**, not current value (the old cap let you withdraw more principal than the book held, then silently scaled it down to fit)
- gain = `received − principal`
- remaining principal = `principal − withdrawn`
- the field is labelled **"Principal amount to withdraw"**, and a bank holding now shows principal-available beside its value — offering an "Available" figure you can't actually enter is what made the old cap misleading
- **"All"** fills the remaining principal

One consequence worth calling out: because the amount is now principal, the received field can't just mirror it — an unedited field would record a withdrawal that earned nothing. It's pre-filled with the interest accrued on that slice, which at a full withdrawal comes out to the whole current value, exactly what the field was pre-filled with before.

## A second copy of the same bug

`addTransactionModel.computeSellPreview` had those same four lines, reachable from the Add-transaction sell path. The issue only names `SellWithdrawSheet`, but fixing one surface would have left the money bug shipping from the other, so both are fixed. `bankPrincipalPortion` → `bankWithdrawPrincipal` and `bankFraction` → `bankPctOfPrincipal`: the old names described the computation that was wrong, and a field called "portion" is part of why this survived review.

## Tests

The issue's own diagnosis of the test gap held up: the existing component test covered only a *full* withdrawal, where the proportional conversion happens to return the whole principal, and the partial-withdrawal E2E called the API directly with an already-correct `withdraw_principal`.

- **15 unit tests** on `lib/bankWithdrawal` — the reported case, early-withdrawal loss, the principal cap, rounding, and the prefill's edges
- **7 component tests** on the sheet and **5** on `computeSellPreview`, all using a holding where value ≠ principal (the old `bank` fixture was 5M on 5M, which cannot express this bug)
- **1 new E2E** that drives the real UI and then reads back the persisted row — `principal_withdrawn = 4,365,100`, `amount_vnd = 4,366,416`

**I verified the new E2E is red on the old code**: with the proportional conversion restored it fails with `Received "Tiền gốc · 22%₫ 4.325.988"` against the expected `4.365.100`.

- `npm test -- --run` — 163 files, **1790 passed**
- `eslint` clean, `tsc --noEmit` clean
- **Full E2E — 258 passed, 0 failed** (i18n strings changed, so the whole suite ran)