### PR TITLE
fix(funds): move only the unallocated rows when assigning a fund (#589)

### DIFF
--- a/app/api/v1/fund-investments/assign/__tests__/route.test.ts
+++ b/app/api/v1/fund-investments/assign/__tests__/route.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// Assigning a fund row moves EVERY fund-investment behind that row, and the
+// client used to do it by listing the fund and PATCHing each id in a Promise.all
+// (#589). Two bugs in one: the list was unscoped, so assigning the *Unallocated*
+// row also dragged rows that belonged to another goal, and a partial failure left
+// the fund split across goals with no row in the UI to repair it from.
+//
+// This route is the replacement primitive: one UPDATE statement — hence one
+// transaction, all-or-nothing — that moves the fund's rows from ONE goal bucket
+// to another. `from_goal_id: null` is the Unallocated bucket, which is what the
+// assign flow uses; `to_goal_id: null` unassigns, which is what goal detail uses.
+//
+// What the filter chain contains is the whole fix, so the mock records it.
+
+type Filter = { table: string; kind: string; args: unknown[] }
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  goal: { data: null as unknown, error: null as unknown },
+  updated: { data: [] as unknown[] | null, error: null as unknown },
+  update: null as unknown,
+  filters: [] as Filter[],
+  tables: [] as string[],
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chain = (table: string) => {
+    const c: Record<string, unknown> = {
+      select: () => c,
+      update: (payload: unknown) => { h.update = payload; return c },
+      eq: (...args: unknown[]) => { h.filters.push({ table, kind: 'eq', args }); return c },
+      is: (...args: unknown[]) => { h.filters.push({ table, kind: 'is', args }); return c },
+      or: (...args: unknown[]) => { h.filters.push({ table, kind: 'or', args }); return c },
+      single: async () => h.goal,
+      // `.update(...).select()` is awaited directly — it resolves to the rows the
+      // statement actually touched, which is how the route counts the move.
+      then: (resolve: (v: unknown) => void) => resolve(h.updated),
+    }
+    h.tables.push(table)
+    return c
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (table: string) => chain(table),
+    }),
+  }
+})
+
+const { POST } = await import('../route')
+
+const FUND = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+const GOAL_A = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const GOAL_B = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+const TX_1 = '11111111-1111-4111-8111-111111111111'
+const TX_2 = '22222222-2222-4222-8222-222222222222'
+
+const call = (body: unknown) =>
+  POST(new NextRequest('https://app.test/api/v1/fund-investments/assign', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  }))
+
+// Only the UPDATE's own filters — the goal ownership lookup filters by goal_id too.
+const filter = (kind: string, col: string) => {
+  const found = h.filters.find((f) =>
+    f.table === 'investment_transactions' && f.kind === kind && f.args[0] === col)
+  return found ? { kind: found.kind, args: found.args } : undefined
+}
+
+describe('POST /api/v1/fund-investments/assign', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.goal = { data: { goal_id: GOAL_A }, error: null }
+    h.updated = { data: [{ transaction_id: TX_1 }, { transaction_id: TX_2 }], error: null }
+    h.update = null
+    h.filters = []
+    h.tables = []
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('moves the fund from Unallocated to the goal and reports how many rows moved', async () => {
+    const res = await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toMatchObject({ moved: 2 })
+    expect(h.update).toMatchObject({ goal_id: GOAL_A })
+  })
+
+  // The #589 bug: without this the UPDATE spans every goal's rows for the fund.
+  it('scopes the move to the source bucket — Unallocated means goal_id IS NULL', async () => {
+    await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })
+
+    expect(filter('is', 'goal_id')).toEqual({ kind: 'is', args: ['goal_id', null] })
+    // No eq on goal_id as well — that would contradict the IS NULL scope.
+    expect(filter('eq', 'goal_id')).toBeUndefined()
+  })
+
+  it('scopes an unassign to the goal it is leaving', async () => {
+    await call({ fund_id: FUND, from_goal_id: GOAL_A, to_goal_id: null })
+
+    expect(filter('eq', 'goal_id')).toEqual({ kind: 'eq', args: ['goal_id', GOAL_A] })
+    expect(filter('is', 'goal_id')).toBeUndefined()
+    expect(h.update).toMatchObject({ goal_id: null })
+  })
+
+  it('scopes a goal-to-goal move to the source goal', async () => {
+    await call({ fund_id: FUND, from_goal_id: GOAL_A, to_goal_id: GOAL_B })
+
+    expect(filter('eq', 'goal_id')).toEqual({ kind: 'eq', args: ['goal_id', GOAL_A] })
+    expect(h.update).toMatchObject({ goal_id: GOAL_B })
+  })
+
+  it('restricts the move to the caller, the fund, and fund rows', async () => {
+    await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })
+
+    expect(filter('eq', 'user_id')).toEqual({ kind: 'eq', args: ['user_id', 'user-1'] })
+    expect(filter('eq', 'fund_id')).toEqual({ kind: 'eq', args: ['fund_id', FUND] })
+    expect(filter('eq', 'asset_type')).toEqual({ kind: 'eq', args: ['asset_type', 'fund'] })
+  })
+
+  // Pending DCA seeds (is_dca_seeded with no units) are not holdings: the fund
+  // list excludes them and the dashboard never values them, so the old client
+  // path never moved them. Same filter here keeps that behaviour.
+  it('leaves pending DCA seed rows where they are', async () => {
+    await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })
+
+    expect(filter('or', 'is_dca_seeded.eq.false,units.not.is.null')).toBeTruthy()
+  })
+
+  it('rejects a goal the caller does not own', async () => {
+    h.goal = { data: null, error: null }
+
+    const res = await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })
+
+    expect(res.status).toBe(403)
+    // Nothing was written.
+    expect(h.update).toBeNull()
+  })
+
+  it('does not need a goal lookup when unassigning', async () => {
+    await call({ fund_id: FUND, from_goal_id: GOAL_A, to_goal_id: null })
+
+    expect(h.tables).toEqual(['investment_transactions'])
+  })
+
+  // The row is on screen, so rows were expected. Zero moved means something else
+  // moved them first — the caller has to be told rather than shown a success it
+  // can't see the result of.
+  it('reports a conflict when nothing was left to move', async () => {
+    h.updated = { data: [], error: null }
+
+    const res = await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })
+
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toMatchObject({ code: 'no_rows_moved' })
+  })
+
+  it('rejects a move whose source and target are the same bucket', async () => {
+    const res = await call({ fund_id: FUND, from_goal_id: GOAL_A, to_goal_id: GOAL_A })
+
+    expect(res.status).toBe(400)
+    expect(h.update).toBeNull()
+  })
+
+  it('rejects a missing or malformed fund id', async () => {
+    expect((await call({ to_goal_id: GOAL_A })).status).toBe(400)
+    expect((await call({ fund_id: 'not-a-uuid', to_goal_id: GOAL_A })).status).toBe(400)
+    expect((await call({ fund_id: FUND, from_goal_id: 'not-a-uuid', to_goal_id: null })).status).toBe(400)
+    expect(h.update).toBeNull()
+  })
+
+  it('requires a session', async () => {
+    h.user = null
+
+    expect((await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })).status).toBe(401)
+    expect(h.update).toBeNull()
+  })
+
+  it('reports a failed update instead of a silent success', async () => {
+    h.updated = { data: null, error: { message: 'deadlock detected' } }
+
+    const res = await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })
+
+    expect(res.status).toBe(500)
+  })
+})

--- a/app/api/v1/fund-investments/assign/route.ts
+++ b/app/api/v1/fund-investments/assign/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateUUID } from '@/lib/validation'
+import { readJsonBody } from '@/lib/apiBody'
+
+// Move every fund-investment of one fund from one goal bucket to another.
+//
+// A fund row on the dashboard aggregates all of that fund's transactions, so
+// assigning or unassigning the row means moving the whole set. Both clients used
+// to do that themselves — list the fund, then PATCH each id in a Promise.all
+// (#589). That was wrong twice over:
+//
+//   1. The assign path listed the fund WITHOUT a goal filter, so assigning the
+//      Unallocated row also moved rows already sitting in another goal.
+//   2. Either path could half-succeed. The list shows one row per fund, so a
+//      fund split between two goals is a state the user cannot see or repair.
+//
+// One UPDATE statement fixes both: Postgres runs it in its own transaction, so
+// it is all-or-nothing, and the WHERE clause carries the source scope the client
+// could only approximate. Under concurrency the statement re-checks its qual
+// after taking each row lock, so rows a competing assign/unassign already moved
+// out of the source bucket are skipped rather than dragged along.
+//
+// The buckets are addressed by goal id, with null meaning Unallocated:
+//   assign   from_goal_id: null    → to_goal_id: goal
+//   unassign from_goal_id: goal    → to_goal_id: null
+//   move     from_goal_id: goalA   → to_goal_id: goalB
+export async function POST(request: NextRequest) {
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const { fund_id, from_goal_id, to_goal_id } = parsed.body
+
+  let cleanFundId: string
+  let fromGoalId: string | null = null
+  let toGoalId: string | null = null
+  try {
+    if (!fund_id) throw new ValidationError('Fund is required')
+    cleanFundId = validateUUID(fund_id, 'fund_id')
+    if (from_goal_id !== null && from_goal_id !== undefined && from_goal_id !== '') {
+      fromGoalId = validateUUID(from_goal_id, 'from_goal_id')
+    }
+    if (to_goal_id !== null && to_goal_id !== undefined && to_goal_id !== '') {
+      toGoalId = validateUUID(to_goal_id, 'to_goal_id')
+    }
+    if (fromGoalId === toGoalId) {
+      throw new ValidationError('from_goal_id and to_goal_id must be different')
+    }
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  // RLS already confines the update to the caller's rows, but a target goal that
+  // isn't theirs has to be refused explicitly — the UPDATE would otherwise write
+  // a foreign goal id and report a successful move.
+  if (toGoalId) {
+    const { data: goal } = await supabase
+      .from('savings_goals')
+      .select('goal_id')
+      .eq('goal_id', toGoalId)
+      .eq('user_id', user.id)
+      .single()
+    if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
+  }
+
+  let query = supabase
+    .from('investment_transactions')
+    .update({ goal_id: toGoalId, updated_at: new Date().toISOString() })
+    .eq('user_id', user.id)
+    .eq('fund_id', cleanFundId)
+    .eq('asset_type', 'fund')
+    // Pending DCA seeds (seeded with no units yet) are plan placeholders, not
+    // holdings: GET /fund-investments hides them and the dashboard never values
+    // them, so the old client path never moved them either. Same filter keeps
+    // planning's rows out of an assign.
+    .or('is_dca_seeded.eq.false,units.not.is.null')
+
+  query = fromGoalId === null
+    ? query.is('goal_id', null)
+    : query.eq('goal_id', fromGoalId)
+
+  const { data, error } = await query.select('transaction_id')
+
+  if (error) {
+    console.error('fund assign: update failed', error.message)
+    return NextResponse.json({ error: 'Failed to assign fund' }, { status: 500 })
+  }
+
+  const moved = data?.length ?? 0
+  if (moved === 0) {
+    // The caller acted on a row it could see, so rows were expected. Zero means
+    // something else moved them first (another tab, or a stale dashboard) — the
+    // user needs to hear that, not a success flash for a move that didn't happen.
+    return NextResponse.json({
+      error: 'This fund has already been moved. Refresh and try again.',
+      code: 'no_rows_moved',
+    }, { status: 409 })
+  }
+
+  return NextResponse.json({ moved, transaction_ids: data!.map((r) => r.transaction_id) })
+}

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -317,7 +317,7 @@ describe('GoalDetailSheet — unassign from goal', () => {
     )
   })
 
-  it('fires PATCH on fund-investments/:id/goal with goal_id null when confirmed (fund row)', async () => {
+  it('moves the fund out of this goal only when confirmed (fund row)', async () => {
     const fetchMock = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
       if (url.includes('/api/v1/investment-transactions') && (!init || init.method === undefined || init.method === 'GET')) {
         return Promise.resolve({ ok: true, json: async () => ({ transactions: [mockTx] }) })
@@ -326,8 +326,8 @@ describe('GoalDetailSheet — unassign from goal', () => {
         // Bare array — matches the real route (the object shape hid the #467 no-op).
         return Promise.resolve({ ok: true, json: async () => [{ id: 'fi-1' }, { id: 'fi-2' }] })
       }
-      if (url.includes('/api/v1/fund-investments/') && init?.method === 'PATCH') {
-        return Promise.resolve({ ok: true, json: async () => ({}) })
+      if (url.includes('/api/v1/fund-investments/assign')) {
+        return Promise.resolve({ ok: true, json: async () => ({ moved: 2 }) })
       }
       return Promise.resolve({ ok: true, json: async () => ({}) })
     })
@@ -345,15 +345,14 @@ describe('GoalDetailSheet — unassign from goal', () => {
     const confirmBtn = screen.getByRole('button', { name: /^unassign$/i })
     await userEvent.click(confirmBtn)
 
-    // Each fund-investment under this fund must be PATCHed to goal_id: null
+    // One scoped move: this fund, out of THIS goal, back to Unallocated (#589).
     await waitFor(() => {
-      const patchCalls = (fetchMock.mock.calls as Array<[string, RequestInit | undefined]>).filter(
-        ([url, init]) => url.includes('/api/v1/fund-investments/') && init?.method === 'PATCH'
+      const moves = (fetchMock.mock.calls as Array<[string, RequestInit | undefined]>).filter(
+        ([url]) => url.includes('/api/v1/fund-investments/assign')
       )
-      expect(patchCalls.length).toBe(2)
-      patchCalls.forEach(([, init]) => {
-        expect(String(init?.body ?? '')).toContain('"goal_id":null')
-      })
+      expect(moves.length).toBe(1)
+      expect(JSON.parse(String(moves[0][1]?.body)))
+        .toEqual({ fund_id: 'fund-1', from_goal_id: 'goal-1', to_goal_id: null })
     })
     await waitFor(() => expect(onDataChanged).toHaveBeenCalled())
   })
@@ -690,10 +689,10 @@ describe('GoalDetailSheet — refreshKey triggers refetch', () => {
       if (url.includes('/api/v1/fund-investments?fund_id=')) {
         return Promise.resolve({ ok: true, json: async () => [{ id: 'fi-1' }] })
       }
-      if (url.includes('/api/v1/fund-investments/') && init?.method === 'PATCH') {
+      if (url.includes('/api/v1/fund-investments/assign')) {
         // Simulate that the unassign succeeded: the next GET will omit the tx
         assigned = false
-        return Promise.resolve({ ok: true, json: async () => ({}) })
+        return Promise.resolve({ ok: true, json: async () => ({ moved: 1 }) })
       }
       return Promise.resolve({ ok: true, json: async () => ({}) })
     })

--- a/app/assets/components/__tests__/goalActions.test.ts
+++ b/app/assets/components/__tests__/goalActions.test.ts
@@ -48,28 +48,23 @@ describe('goalActions (#467)', () => {
     expect(await unholdTransaction('tx1')).toEqual({ ok: false, code: 'settlement_consumed' })
   })
 
-  // GET /fund-investments returns a BARE ARRAY (matches the real route), not
-  // { investments: [...] } — a wrong mock here would hide the #467 no-op bug.
-  it('unassignInvestment (fund) scopes the query to the goal and PATCHes each row back to null', async () => {
-    const calls = mockFetch((url, init) => {
-      if (url.includes('/fund-investments?fund_id=')) return { ok: true, body: [{ id: 'fi1' }, { id: 'fi2' }] }
-      if (init?.method === 'PATCH') return { ok: true }
-      return { ok: false }
-    })
+  // A fund unassign used to list the goal's rows and PATCH each one back to null
+  // in a Promise.all — a partial failure left the fund split between the goal and
+  // Unallocated (#589). It is now the same single scoped UPDATE the assign uses,
+  // in the opposite direction, so the two can't interleave into a split fund.
+  it('unassignInvestment (fund) moves the fund out of the goal in one scoped request', async () => {
+    const calls = mockFetch(() => ({ ok: true, body: { moved: 2 } }))
     expect(await unassignInvestment({ id: 'row1', fund: { fundId: 'f1' } }, 'goal-1')).toBe(true)
-    // Scoped to the goal so a fund split across goals isn't cleared elsewhere.
-    expect(calls[0].url).toBe('/api/v1/fund-investments?fund_id=f1&goal_id=goal-1')
-    const patched = calls.filter(c => c.init?.method === 'PATCH').map(c => c.url)
-    expect(patched).toEqual(['/api/v1/fund-investments/fi1/goal', '/api/v1/fund-investments/fi2/goal'])
-    expect(JSON.parse(String(calls.find(c => c.init?.method === 'PATCH')!.init!.body))).toEqual({ goal_id: null })
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe('/api/v1/fund-investments/assign')
+    expect(calls[0].init?.method).toBe('POST')
+    // Scoped to this goal so a fund split across goals isn't cleared elsewhere.
+    expect(JSON.parse(String(calls[0].init?.body)))
+      .toEqual({ fund_id: 'f1', from_goal_id: 'goal-1', to_goal_id: null })
   })
 
-  it('unassignInvestment (fund) returns false when any PATCH fails', async () => {
-    mockFetch((url, init) => {
-      if (url.includes('/fund-investments?fund_id=')) return { ok: true, body: [{ id: 'fi1' }, { id: 'fi2' }] }
-      if (init?.method === 'PATCH') return { ok: url.includes('fi1') }
-      return { ok: false }
-    })
+  it('unassignInvestment (fund) returns false when the move is refused', async () => {
+    mockFetch(() => ({ ok: false, body: { error: 'nothing left to move' } }))
     expect(await unassignInvestment({ id: 'row1', fund: { fundId: 'f1' } }, 'goal-1')).toBe(false)
   })
 
@@ -81,8 +76,8 @@ describe('goalActions (#467)', () => {
     expect(JSON.parse(String(calls[0].init?.body))).toEqual({ goal_id: null })
   })
 
-  it('unassignInvestment (fund) returns false when the fund-investments fetch fails', async () => {
-    mockFetch(() => ({ ok: false }))
+  it('unassignInvestment (fund) returns false when the request never lands', async () => {
+    global.fetch = vi.fn(async () => { throw new Error('offline') }) as unknown as typeof fetch
     expect(await unassignInvestment({ id: 'row1', fund: { fundId: 'f1' } }, 'goal-1')).toBe(false)
   })
 })

--- a/app/assets/components/goalActions.ts
+++ b/app/assets/components/goalActions.ts
@@ -59,31 +59,26 @@ export async function unholdTransaction(heldTxId: string): Promise<DeleteResult>
 }
 
 // Unassign an investment from a specific goal. A fund row aggregates every
-// fund-investment of that fund UNDER THIS GOAL (PATCH each back to goal_id=null);
-// a non-fund row is a single investment_transactions row (PUT assign goal_id=null).
+// fund-investment of that fund UNDER THIS GOAL (one scoped move back to
+// Unallocated); a non-fund row is a single investment_transactions row (PUT
+// assign goal_id=null).
 export async function unassignInvestment(
   inv: { id: string; fund?: { fundId: string } | null },
   goalId: string,
 ): Promise<boolean> {
   try {
     if (inv.fund) {
-      // Scope to this goal: the same fund can be split across goals, so an
-      // unfiltered fund_id query would clear the OTHER goals' rows too. The route
-      // filters by goal_id when supplied.
-      const res = await fetch(`/api/v1/fund-investments?fund_id=${inv.fund.fundId}&goal_id=${goalId}`)
-      if (!res.ok) return false
-      // GET /fund-investments returns a bare array (see the route handler) — the
-      // old `data.investments` read undefined, so Promise.all([]) sent no PATCH
-      // yet reported success, silently no-op'ing the fund unassign (#467).
-      const investments = await res.json() as Array<{ id: string }>
-      const results = await Promise.all((investments ?? []).map((fi) =>
-        fetch(`/api/v1/fund-investments/${fi.id}/goal`, {
-          method: 'PATCH',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ goal_id: null }),
-        })
-      ))
-      return results.every((r) => r.ok)
+      // Scoped to this goal: the same fund can be split across goals, so the move
+      // must not touch the OTHER goals' rows (#467). It used to list the goal's
+      // rows and PATCH each one, which could half-succeed and split the fund
+      // between the goal and Unallocated — the route now moves the whole bucket
+      // in a single statement (#589).
+      const res = await fetch('/api/v1/fund-investments/assign', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ fund_id: inv.fund.fundId, from_goal_id: goalId, to_goal_id: null }),
+      })
+      return res.ok
     }
     const res = await fetch(`/api/v1/investment-transactions/${inv.id}/assign`, {
       method: 'PUT',

--- a/e2e/fk-ownership.spec.ts
+++ b/e2e/fk-ownership.spec.ts
@@ -75,6 +75,17 @@ test.describe('FK ownership enforcement (#474)', () => {
     expect(res.status()).toBe(403)
   })
 
+  // ---- fund-investments/assign: to_goal_id ---------------------------------
+  // The scoped move writes goal_id onto every unallocated row of a fund, so an
+  // unchecked target would park the caller's own holdings under a stranger's goal
+  // and report a successful move (#589).
+  test('POST /api/v1/fund-investments/assign rejects a cross-user to_goal_id (403)', async ({ request }) => {
+    const res = await request.post('/api/v1/fund-investments/assign', {
+      data: { fund_id: ownFundId, from_goal_id: null, to_goal_id: foreign.goalId },
+    })
+    expect(res.status()).toBe(403)
+  })
+
   // ---- funds: dca_goal_id ---------------------------------------------------
   test('POST /api/funds rejects a cross-user dca_goal_id (403)', async ({ request }) => {
     const res = await request.post('/api/funds', {

--- a/e2e/fund-unassign.spec.ts
+++ b/e2e/fund-unassign.spec.ts
@@ -1,11 +1,15 @@
 import { test, expect } from '@playwright/test'
 import * as api from './helpers/api'
 
-// The fund-unassign flow (goalActions.unassignInvestment) reads GET
-// /fund-investments and PATCHes each row's goal back to null. That GET returns a
-// BARE ARRAY — a wrong read there silently no-ops the unassign. Drive the real
-// route contract end-to-end so a unit mock's shape can't hide it again (#467).
-test.describe('fund-investments unassign contract (#467)', () => {
+// Moving a fund between goal buckets is now one scoped UPDATE — POST
+// /fund-investments/assign (#589). What a unit test cannot check is whether that
+// statement's WHERE clause really selects the bucket we mean against a live
+// database, so the scoping cases run here.
+//
+// GET /fund-investments still backs the fund detail views and returns a BARE
+// ARRAY; a wrong read there once silently no-op'd the unassign (#467), so its
+// shape stays pinned too.
+test.describe('fund-investments goal-move contract (#467, #589)', () => {
   let goalId: string
   let fundId: string
   let txId: string
@@ -51,8 +55,60 @@ test.describe('fund-investments unassign contract (#467)', () => {
     expect(rowAfter.goal_id).toBeNull()
   })
 
+  // The scoped move is one UPDATE statement inside PostgREST, so its WHERE clause
+  // is the only thing standing between an assign and another goal's rows (#589).
+  // A unit test can assert the filters were *asked for*; only a real database
+  // shows that they select what we think they do.
+  test('assigning the Unallocated bucket moves only the unallocated rows', async ({ request }) => {
+    const goalB = await api.createGoal({ goal_name: `E2E FundAssign B ${Date.now()}` })
+    const goalC = await api.createGoal({ goal_name: `E2E FundAssign C ${Date.now()}` })
+    // Same fund in goalA (txId, from beforeEach), in goalB, and twice unallocated.
+    const txB = await api.createTransaction({
+      asset_type: 'fund', fund_id: fundId, goal_id: goalB.goal_id,
+      amount_vnd: 1_000_000, units: 50, unit_price: 20_000, investment_date: '2026-02-01',
+    })
+    const free1 = await api.createTransaction({
+      asset_type: 'fund', fund_id: fundId,
+      amount_vnd: 600_000, units: 30, unit_price: 20_000, investment_date: '2026-03-01',
+    })
+    const free2 = await api.createTransaction({
+      asset_type: 'fund', fund_id: fundId,
+      amount_vnd: 400_000, units: 20, unit_price: 20_000, investment_date: '2026-04-01',
+    })
+    try {
+      const res = await request.post('/api/v1/fund-investments/assign', {
+        data: { fund_id: fundId, from_goal_id: null, to_goal_id: goalC.goal_id },
+      })
+      expect(res.status()).toBe(200)
+      expect((await res.json()).moved).toBe(2)
+
+      const rows = await (await request.get(`/api/v1/fund-investments?fund_id=${fundId}`)).json()
+      const goalOf = (id: string) => rows.find((r: { id: string }) => r.id === id).goal_id
+      // Both unallocated rows moved together...
+      expect(goalOf(free1.transaction_id)).toBe(goalC.goal_id)
+      expect(goalOf(free2.transaction_id)).toBe(goalC.goal_id)
+      // ...and the rows that already belonged to a goal stayed there. The old
+      // client-side loop moved these too.
+      expect(goalOf(txId)).toBe(goalId)
+      expect(goalOf(txB.transaction_id)).toBe(goalB.goal_id)
+
+      // Nothing unallocated is left, so a stale repeat is a conflict, not a
+      // silent success the dashboard can't explain.
+      const repeat = await request.post('/api/v1/fund-investments/assign', {
+        data: { fund_id: fundId, from_goal_id: null, to_goal_id: goalC.goal_id },
+      })
+      expect(repeat.status()).toBe(409)
+    } finally {
+      await api.deleteTransaction(free1.transaction_id)
+      await api.deleteTransaction(free2.transaction_id)
+      await api.deleteTransaction(txB.transaction_id)
+      await api.deleteGoal(goalB.goal_id)
+      await api.deleteGoal(goalC.goal_id)
+    }
+  })
+
   test('unassigning a fund from one goal leaves its other-goal rows intact', async ({ request }) => {
-    // Same fund split across two goals. The goal_id-scoped query must clear only
+    // Same fund split across two goals. The goal-scoped move must clear only
     // goalA's row, not goalB's (#467 P1).
     const goalB = await api.createGoal({ goal_name: `E2E FundUnassign B ${Date.now()}` })
     const txB = await api.createTransaction({
@@ -60,12 +116,11 @@ test.describe('fund-investments unassign contract (#467)', () => {
       amount_vnd: 1_000_000, units: 50, unit_price: 20_000, investment_date: '2026-02-01',
     })
     try {
-      // Scoped fetch returns only this goal's row.
-      const scoped = await (await request.get(`/api/v1/fund-investments?fund_id=${fundId}&goal_id=${goalId}`)).json()
-      expect(scoped.map((r: { id: string }) => r.id)).toEqual([txId])
-
-      const patch = await request.patch(`/api/v1/fund-investments/${txId}/goal`, { data: { goal_id: null } })
-      expect(patch.ok()).toBeTruthy()
+      const res = await request.post('/api/v1/fund-investments/assign', {
+        data: { fund_id: fundId, from_goal_id: goalId, to_goal_id: null },
+      })
+      expect(res.status()).toBe(200)
+      expect((await res.json()).moved).toBe(1)
 
       const all = await (await request.get(`/api/v1/fund-investments?fund_id=${fundId}`)).json()
       expect(all.find((r: { id: string }) => r.id === txId).goal_id).toBeNull()

--- a/lib/__tests__/assignToGoal.test.ts
+++ b/lib/__tests__/assignToGoal.test.ts
@@ -21,63 +21,50 @@ function stubFetch(handler: Handler) {
   return calls
 }
 
-const FUND_LIST = [{ id: 'inv-1' }, { id: 'inv-2' }, { id: 'inv-3' }]
-
 beforeEach(() => vi.unstubAllGlobals())
 afterEach(() => vi.unstubAllGlobals())
 
 describe('assignInvestmentToGoal — funds', () => {
-  it('moves every investment of the fund to the goal', async () => {
-    const calls = stubFetch((url) =>
-      url.includes('fund-investments?') ? { ok: true, body: FUND_LIST } : { ok: true })
+  // A fund row on the dashboard aggregates every investment of that fund, so the
+  // assign has to move all of them. It used to do that client-side: list the fund,
+  // then PATCH each id in a Promise.all (#589). The list was unscoped, so
+  // assigning the *Unallocated* row moved rows that belonged to other goals too,
+  // and a partial failure split the fund across goals. Both are now one request
+  // the server executes as a single scoped UPDATE.
+  it('moves the fund out of Unallocated in one scoped request', async () => {
+    const calls = stubFetch(() => ({ ok: true, body: { moved: 3 } }))
 
     await assignInvestmentToGoal('fund', 'fund-1', 'goal-1')
 
-    expect(calls[0].url).toBe('/api/v1/fund-investments?fund_id=fund-1')
-    // Every investment is PATCHed — a fund row on the dashboard aggregates them.
-    expect(calls.slice(1).map((c) => c.url)).toEqual([
-      '/api/v1/fund-investments/inv-1/goal',
-      '/api/v1/fund-investments/inv-2/goal',
-      '/api/v1/fund-investments/inv-3/goal',
-    ])
-    expect(calls.slice(1).every((c) => c.method === 'PATCH')).toBe(true)
-    expect(calls[1].body).toEqual({ goal_id: 'goal-1' })
+    expect(calls).toEqual([{
+      url: '/api/v1/fund-investments/assign',
+      method: 'POST',
+      // from_goal_id: null is the whole point — only unallocated rows move.
+      body: { fund_id: 'fund-1', from_goal_id: null, to_goal_id: 'goal-1' },
+    }])
   })
 
-  it('throws when the investment list cannot be read', async () => {
-    stubFetch((url) => (url.includes('fund-investments?') ? { ok: false } : { ok: true }))
+  it('never lists or PATCHes individual rows any more', async () => {
+    const calls = stubFetch(() => ({ ok: true, body: { moved: 1 } }))
+
+    await assignInvestmentToGoal('fund', 'fund-1', 'goal-1')
+
+    expect(calls.some((c) => c.url.includes('fund-investments?'))).toBe(false)
+    expect(calls.some((c) => c.method === 'PATCH')).toBe(false)
+  })
+
+  it('surfaces the message the server gave — a concurrent move, for instance', async () => {
+    stubFetch(() => ({ ok: false, body: { error: 'This fund has already been moved. Refresh and try again.' } }))
 
     await expect(assignInvestmentToGoal('fund', 'fund-1', 'goal-1'))
-      .rejects.toThrow(/failed to fetch fund investments/i)
+      .rejects.toThrow(/already been moved/i)
   })
 
-  // The dashboard shows one row per fund, so a fund that half-moved is a state
-  // the user cannot see or correct from the list. It has to surface as an error.
-  it('throws when only some of the investments move', async () => {
-    stubFetch((url) => {
-      if (url.includes('fund-investments?')) return { ok: true, body: FUND_LIST }
-      return { ok: !url.includes('inv-2') }
-    })
+  it('falls back to a generic message when the error body is unusable', async () => {
+    stubFetch(() => ({ ok: false, body: {} }))
 
     await expect(assignInvestmentToGoal('fund', 'fund-1', 'goal-1'))
       .rejects.toThrow(/failed to assign/i)
-  })
-
-  it('still issues the other requests when one fails — they are not sequenced', async () => {
-    const calls = stubFetch((url) => {
-      if (url.includes('fund-investments?')) return { ok: true, body: FUND_LIST }
-      return { ok: !url.includes('inv-1') }
-    })
-
-    await expect(assignInvestmentToGoal('fund', 'fund-1', 'goal-1')).rejects.toThrow()
-
-    expect(calls.filter((c) => c.method === 'PATCH')).toHaveLength(3)
-  })
-
-  it('accepts a fund with no investments as a no-op', async () => {
-    stubFetch((url) => (url.includes('fund-investments?') ? { ok: true, body: [] } : { ok: true }))
-
-    await expect(assignInvestmentToGoal('fund', 'fund-1', 'goal-1')).resolves.toBeUndefined()
   })
 })
 

--- a/lib/assignToGoal.ts
+++ b/lib/assignToGoal.ts
@@ -6,10 +6,8 @@
 // Callers keep their own UI concerns — success flashes, closing, and refresh
 // sequencing (see #567) — and only await this.
 //
-// Deliberately *not* shared with `unassignInvestment` in goalActions.ts: that
-// scopes its fund query by goal_id, because the same fund can be split across
-// goals and an unfiltered query would clear the other goals' rows too (#467).
-// Same-looking requests, different operation.
+// The fund direction shares its endpoint with `unassignInvestment` in
+// goalActions.ts — same scoped move, opposite direction (#589).
 
 export type AssignKind = 'fund' | 'nonFund'
 
@@ -29,22 +27,19 @@ export async function assignInvestmentToGoal(
 }
 
 async function assignFund(fundId: string, goalId: string): Promise<void> {
-  // A dashboard fund row aggregates every investment in that fund, so assigning
-  // the row means moving all of them.
-  const res = await fetch(`/api/v1/fund-investments?fund_id=${fundId}`)
-  if (!res.ok) throw new Error('Failed to fetch fund investments')
-  const investments = await res.json() as Array<{ id: string }>
+  // Every fund assign starts from the Unallocated section, so the source bucket
+  // is Unallocated — `from_goal_id: null`. This used to list the fund and PATCH
+  // each row, which moved other goals' rows too and could half-succeed (#589);
+  // the route now does the whole move as one scoped statement.
+  const res = await fetch('/api/v1/fund-investments/assign', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ fund_id: fundId, from_goal_id: null, to_goal_id: goalId }),
+  })
+  if (res.ok) return
 
-  // Issued together rather than in sequence: they are independent, and the user
-  // is waiting on a success flash. A partial move still throws — the list shows
-  // one row per fund, so a half-moved fund is a state the user can't see.
-  await Promise.all(investments.map((inv) =>
-    fetch(`/api/v1/fund-investments/${inv.id}/goal`, {
-      method: 'PATCH',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ goal_id: goalId }),
-    }).then((r) => { if (!r.ok) throw new Error('Failed to assign') })
-  ))
+  const { error } = await res.json().catch(() => ({ error: null })) as { error?: string | null }
+  throw new Error(error ?? 'Failed to assign')
 }
 
 async function assignNonFund(transactionId: string, goalId: string): Promise<void> {


### PR DESCRIPTION
Closes #589.

## The bug

A fund row on the dashboard aggregates every transaction of that fund, so assigning it has to move the whole set. Both clients did that themselves — `GET /fund-investments?fund_id=…`, then a `PATCH` per id in a `Promise.all`. Two problems:

1. **The assign path had no goal filter.** Assigning the row in **Unallocated** moved *every* row of that fund — including rows already sitting in another goal. A fund split across goals silently collapsed into one.
2. **Either path could half-succeed.** The list shows one row per fund, so a fund left split between two goals is a state the user can't see, let alone repair.

## The fix

One endpoint, `POST /api/v1/fund-investments/assign`, doing the move as a single `UPDATE` — hence a single Postgres transaction, all-or-nothing — with the source scope in the `WHERE` clause instead of in the client's head. Buckets are addressed by goal id with `null` meaning Unallocated:

| operation | from_goal_id | to_goal_id |
|---|---|---|
| assign (Unallocated → goal) | `null` | goal |
| unassign (goal → Unallocated) | goal | `null` |
| move between goals | goalA | goalB |

So assign and unassign are the same primitive in opposite directions and can't interleave into a split fund: the statement re-checks its qual after taking each row lock, so rows a competing move already took out of the source bucket are skipped rather than dragged along.

Also:
- **0 rows moved → 409**, not a success flash for nothing. The caller acted on a row it could see, so zero means something else moved it first.
- **Cross-user `to_goal_id` → 403.** RLS confines *which rows* get updated, not *which goal id* is written onto them.
- **Pending DCA seeds** (seeded, no units yet) are still left alone — plan placeholders that `GET /fund-investments` hides and the dashboard never values, so the old client path never moved them either.

`goalActions.unassignInvestment` now uses the same endpoint, which fixes its own partial-failure split.

## Tests

- **New route unit tests** — the fix *is* the `WHERE` clause, so the mock records the filter chain and asserts the source scope (`is('goal_id', null)` vs `eq('goal_id', from)`), the user/fund/asset_type restriction, the DCA-seed filter, and the 409/403/400/401/500 paths. Verified red: dropping the scope fails 3 of them.
- **Client tests** — assign and unassign each pin one scoped request, and that no per-row `PATCH` fan-out comes back.
- **`e2e/fund-unassign.spec.ts`** — against a real database, same fund in goalA + goalB + two unallocated rows: only the unallocated pair moves, the goal-assigned rows stay put, and a stale repeat gets a 409. A unit test can prove the filters were *asked for*; only Postgres proves they select what we mean.
- **`e2e/fk-ownership.spec.ts`** — the cross-user `to_goal_id` 403.

## Checks

- `npm test -- --run` — 1804 passed (164 files)
- `npm run lint`, `npm run typecheck` — clean
- Targeted E2E: `fund-unassign`, `fk-ownership`, `assign-goal-desktop`, `goal-detail-desktop`, `unallocated-book`, `dashboard` — 58 passed
- Full E2E — running locally; I'll post the result here

🤖 Generated with [Claude Code](https://claude.com/claude-code)