### PR TITLE
fix(withdraw): cap a withdrawal at what the holding still holds (#587)

### DIFF
--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -221,6 +221,10 @@ export async function GET() {
       currentNAV: number
       currentValue: number
       purchasePrice: number
+      // Remaining cost basis of this bucket (Σ amount_vnd, net of prior sells) — the
+      // figure a sale must take out of it, surfaced so the sheets stop
+      // reconstructing it from purchasePrice (#587, lib/fundWithdrawal).
+      costBasis: number
       profitLoss: number
       profitLossPercentage: number
       goalId: string
@@ -367,7 +371,7 @@ export async function GET() {
   // Convert fund accumulators to breakdown items
   const unallocatedFunds: Array<{
     fundId: string; fundName: string; fundType: string; quantity: number; currentNAV: number
-    currentValue: number; purchasePrice: number; profitLoss: number; profitLossPercentage: number; goalId: null
+    currentValue: number; purchasePrice: number; costBasis: number; profitLoss: number; profitLossPercentage: number; goalId: null
   }> = []
   let unallocatedFundValue = 0
 
@@ -389,6 +393,7 @@ export async function GET() {
       currentNAV: acc.currentNAV,
       currentValue,
       purchasePrice,
+      costBasis: Math.round(acc.totalInvested),
       profitLoss,
       profitLossPercentage,
       goalId: acc.goalId,

--- a/app/api/v1/investment-transactions/__tests__/route.post.balance.test.ts
+++ b/app/api/v1/investment-transactions/__tests__/route.post.balance.test.ts
@@ -133,6 +133,55 @@ describe('POST /api/v1/investment-transactions — remaining balance', () => {
     await expect(res.json()).resolves.toEqual({ error: 'Failed to create transaction' })
   })
 
+  // ── the shape rules, refused before the insert ─────────────────────────────
+  // The trigger states the same rules, but a request that omits the very number to
+  // be measured deserves a message naming the field. See the decision table.
+  it('refuses a parent-backed withdrawal that records no principal', async () => {
+    for (const body of [
+      { ...SELL, principal_withdrawn: undefined },
+      { ...SELL, principal_withdrawn: 0 },
+    ]) {
+      const res = await call(body)
+      expect(res.status).toBe(400)
+      await expect(res.json()).resolves.toMatchObject({ error: expect.stringMatching(/principal_withdrawn is required/) })
+    }
+  })
+
+  it('refuses a gold sale with no units', async () => {
+    h.ref = { data: { transaction_id: SOURCE, deposit_group_id: null, asset_type: 'gold' }, error: null }
+
+    const res = await call({ ...SELL, asset_type: 'gold' })
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringMatching(/units_withdrawn is required/) })
+  })
+
+  it('accepts a gold sale that moves both', async () => {
+    h.ref = { data: { transaction_id: SOURCE, deposit_group_id: null, asset_type: 'gold' }, error: null }
+
+    const res = await call({ ...SELL, asset_type: 'gold', units_withdrawn: 5 })
+
+    expect(res.status).toBe(201)
+  })
+
+  it('refuses a fund sale with no units', async () => {
+    const res = await call({
+      transaction_type: 'withdrawal', asset_type: 'fund',
+      fund_id: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+      investment_date: '2026-07-01', amount_vnd: 1_000_000, principal_withdrawn: 1_000_000,
+    })
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringMatching(/units_withdrawn is required/) })
+  })
+
+  // A bank withdrawal has no units to move — requiring them would break every
+  // ordinary deposit withdrawal.
+  it('does not ask a bank withdrawal for units', async () => {
+    const res = await call()
+    expect(res.status).toBe(201)
+  })
+
   // A different check_violation (an ownership trigger, say) is not this
   // invariant's and must keep its own answer rather than borrowing this message.
   it('does not claim a balance problem for other constraint failures', async () => {

--- a/app/api/v1/investment-transactions/__tests__/route.post.balance.test.ts
+++ b/app/api/v1/investment-transactions/__tests__/route.post.balance.test.ts
@@ -112,13 +112,15 @@ describe('POST /api/v1/investment-transactions — remaining balance', () => {
     expect(res.status).not.toBe(500)
   })
 
-  // The trigger's other refusal: principal taken out of a row attached to no
-  // holding, which subtracts from nothing while claiming cash left.
-  it('answers 400 when the withdrawal draws on no holding', async () => {
+  // The trigger's other refusal, mapped by the route. The request shape here is a
+  // well-formed one — a sourceless withdrawal is now refused before the insert
+  // (see below), so this covers the mapping of a refusal raised by another writer's
+  // shape rather than trying to provoke it from the API.
+  it('answers 400 when the database says the row draws on no holding', async () => {
     h.insertResult = balanceRefusal(
       'withdrawal invariant: draws on no holding — it has neither a parent transaction nor a fund')
 
-    const res = await call({ ...SELL, parent_transaction_id: undefined })
+    const res = await call()
 
     expect(res.status).toBe(400)
     await expect(res.json()).resolves.toEqual({ error: 'This withdrawal does not match the holding it is drawn on.' })
@@ -179,6 +181,29 @@ describe('POST /api/v1/investment-transactions — remaining balance', () => {
   // ordinary deposit withdrawal.
   it('does not ask a bank withdrawal for units', async () => {
     const res = await call()
+    expect(res.status).toBe(201)
+  })
+
+  // The no-source exception belongs to the held-for-merge pool (#588) and to
+  // nothing else: an ordinary withdrawal that names no holding is cash leaving
+  // nowhere, whatever its amount says.
+  it('refuses a withdrawal that says nothing about what it draws on', async () => {
+    const res = await call({
+      transaction_type: 'withdrawal', asset_type: 'bank',
+      investment_date: '2026-07-01', amount_vnd: 50_000_000,
+    })
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringMatching(/must say what it draws on/) })
+  })
+
+  it('lets a held-for-merge settlement through as the tracked exception', async () => {
+    const res = await call({
+      transaction_type: 'withdrawal', asset_type: 'bank',
+      investment_date: '2026-07-01', amount_vnd: 50_000_000,
+      held_for_merge: true, merge_target_goal_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    })
+
     expect(res.status).toBe(201)
   })
 

--- a/app/api/v1/investment-transactions/__tests__/route.post.balance.test.ts
+++ b/app/api/v1/investment-transactions/__tests__/route.post.balance.test.ts
@@ -82,7 +82,7 @@ describe('POST /api/v1/investment-transactions — remaining balance', () => {
 
   it('answers 400 with the reason when the principal exceeds the balance', async () => {
     h.insertResult = balanceRefusal(
-      'withdrawal of 50000000 exceeds the remaining balance of 40000000 on this holding')
+      'withdrawal invariant: 50000000 exceeds the remaining balance of 40000000 on this holding')
 
     const res = await call()
 
@@ -92,7 +92,7 @@ describe('POST /api/v1/investment-transactions — remaining balance', () => {
 
   it('answers 400 for a unit overdraw too', async () => {
     h.insertResult = balanceRefusal(
-      'withdrawal of 5 units exceeds the remaining balance of 4 units on this holding')
+      'withdrawal invariant: 5 units exceeds the remaining balance of 4 units on this holding')
 
     const res = await call({ ...SELL, asset_type: 'gold', units_withdrawn: 5 })
 
@@ -105,7 +105,7 @@ describe('POST /api/v1/investment-transactions — remaining balance', () => {
   // and it must not be a 500 — nothing failed.
   it('does not report a balance refusal as a server error', async () => {
     h.insertResult = balanceRefusal(
-      'withdrawal of 1 exceeds the remaining balance of 0 on this holding')
+      'withdrawal invariant: 1 exceeds the remaining balance of 0 on this holding')
 
     const res = await call()
 
@@ -116,12 +116,12 @@ describe('POST /api/v1/investment-transactions — remaining balance', () => {
   // holding, which subtracts from nothing while claiming cash left.
   it('answers 400 when the withdrawal draws on no holding', async () => {
     h.insertResult = balanceRefusal(
-      'withdrawal draws on no holding: it has neither a parent transaction nor a fund')
+      'withdrawal invariant: draws on no holding — it has neither a parent transaction nor a fund')
 
     const res = await call({ ...SELL, parent_transaction_id: undefined })
 
     expect(res.status).toBe(400)
-    await expect(res.json()).resolves.toEqual({ error: 'A withdrawal must be attached to a holding.' })
+    await expect(res.json()).resolves.toEqual({ error: 'This withdrawal does not match the holding it is drawn on.' })
   })
 
   it('still reports an unrelated insert failure as a 500', async () => {
@@ -133,13 +133,29 @@ describe('POST /api/v1/investment-transactions — remaining balance', () => {
     await expect(res.json()).resolves.toEqual({ error: 'Failed to create transaction' })
   })
 
-  // A different check_violation (an ownership trigger, say) is not a balance
-  // problem and must keep its own answer rather than borrowing this message.
+  // A different check_violation (an ownership trigger, say) is not this
+  // invariant's and must keep its own answer rather than borrowing this message.
   it('does not claim a balance problem for other constraint failures', async () => {
     h.insertResult = balanceRefusal('parent_transaction_id does not belong to the row owner')
 
     const res = await call()
 
     expect(res.status).toBe(500)
+  })
+
+  // The reason the match is one PREFIX and not a list of phrases: every refusal
+  // the invariant adds is a bad request, and the route shouldn't have to be
+  // updated (and remembered) each time one is added. Half a fund sell is the case
+  // that was falling through as a 500.
+  it('answers 400 for any refusal the invariant raises, including ones added later', async () => {
+    for (const message of [
+      'withdrawal invariant: a fund sell must record both units_withdrawn and principal_withdrawn (got 50 units, <NULL> principal)',
+      'withdrawal invariant: amounts cannot be negative (principal -100, units <NULL>)',
+      'withdrawal invariant: cannot be detached from fund abc, which still exists',
+      'withdrawal invariant: something nobody has written yet',
+    ]) {
+      h.insertResult = balanceRefusal(message)
+      expect((await call()).status).toBe(400)
+    }
   })
 })

--- a/app/api/v1/investment-transactions/__tests__/route.post.balance.test.ts
+++ b/app/api/v1/investment-transactions/__tests__/route.post.balance.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// The remaining-balance invariant lives in the database — one trigger for every
+// writer, measuring under a lock so two concurrent sells can't both pass (#587,
+// supabase/migrations/20260730000002). This file covers the route's half of that
+// contract: a refusal has to reach the user as a 400 that says what happened, not
+// the generic 500 every insert failure used to collapse into.
+//
+// Same shape as the book withdrawal already does (withdraw-book maps 'more than
+// the book balance' to 'Withdrawal exceeds the book balance.'), so the two sell
+// paths answer alike.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  ref: { data: { transaction_id: 'src-1', deposit_group_id: null } as unknown, error: null as unknown },
+  insertResult: { data: null as unknown, error: null as unknown },
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chain = (table: string) => {
+    let op = 'select'
+    const c: Record<string, unknown> = {
+      select: () => c,
+      insert: () => { op = 'insert'; return c },
+      update: () => { op = 'update'; return c },
+      eq: () => c, is: () => c, not: () => c,
+      single: async () => (op === 'insert' ? h.insertResult : h.ref),
+      maybeSingle: async () => (op === 'insert' ? h.insertResult : h.ref),
+      then: (resolve: (v: unknown) => void) => resolve({ data: null, error: null }),
+    }
+    void table
+    return c
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (table: string) => chain(table),
+    }),
+  }
+})
+
+const { POST } = await import('../route')
+
+const SOURCE = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+const SELL = {
+  transaction_type: 'withdrawal',
+  asset_type: 'bank',
+  investment_date: '2026-07-01',
+  amount_vnd: 50_000_000,
+  parent_transaction_id: SOURCE,
+  principal_withdrawn: 50_000_000,
+}
+
+const call = (body: Record<string, unknown> = SELL) =>
+  POST(new NextRequest('https://app.test/api/v1/investment-transactions', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  }))
+
+// What the trigger raises; supabase-js surfaces the SQLSTATE as `code`.
+const balanceRefusal = (message: string) => ({
+  data: null,
+  error: { code: '23514', message },
+})
+
+describe('POST /api/v1/investment-transactions — remaining balance', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.ref = { data: { transaction_id: SOURCE, deposit_group_id: null }, error: null }
+    h.insertResult = { data: { transaction_id: 'new-1' }, error: null }
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('creates the withdrawal when the holding covers it', async () => {
+    const res = await call()
+    expect(res.status).toBe(201)
+  })
+
+  it('answers 400 with the reason when the principal exceeds the balance', async () => {
+    h.insertResult = balanceRefusal(
+      'withdrawal of 50000000 exceeds the remaining balance of 40000000 on this holding')
+
+    const res = await call()
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: 'Withdrawal exceeds the remaining balance of this holding.' })
+  })
+
+  it('answers 400 for a unit overdraw too', async () => {
+    h.insertResult = balanceRefusal(
+      'withdrawal of 5 units exceeds the remaining balance of 4 units on this holding')
+
+    const res = await call({ ...SELL, asset_type: 'gold', units_withdrawn: 5 })
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringMatching(/remaining balance/i) })
+  })
+
+  // A stale tab and a lost race look identical from here: the balance moved after
+  // the sheet read it. Telling the user the balance is gone is the useful answer,
+  // and it must not be a 500 — nothing failed.
+  it('does not report a balance refusal as a server error', async () => {
+    h.insertResult = balanceRefusal(
+      'withdrawal of 1 exceeds the remaining balance of 0 on this holding')
+
+    const res = await call()
+
+    expect(res.status).not.toBe(500)
+  })
+
+  it('still reports an unrelated insert failure as a 500', async () => {
+    h.insertResult = { data: null, error: { code: '08006', message: 'connection failure' } }
+
+    const res = await call()
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({ error: 'Failed to create transaction' })
+  })
+
+  // A different check_violation (an ownership trigger, say) is not a balance
+  // problem and must keep its own answer rather than borrowing this message.
+  it('does not claim a balance problem for other constraint failures', async () => {
+    h.insertResult = balanceRefusal('parent_transaction_id does not belong to the row owner')
+
+    const res = await call()
+
+    expect(res.status).toBe(500)
+  })
+})

--- a/app/api/v1/investment-transactions/__tests__/route.post.balance.test.ts
+++ b/app/api/v1/investment-transactions/__tests__/route.post.balance.test.ts
@@ -112,6 +112,18 @@ describe('POST /api/v1/investment-transactions — remaining balance', () => {
     expect(res.status).not.toBe(500)
   })
 
+  // The trigger's other refusal: principal taken out of a row attached to no
+  // holding, which subtracts from nothing while claiming cash left.
+  it('answers 400 when the withdrawal draws on no holding', async () => {
+    h.insertResult = balanceRefusal(
+      'withdrawal draws on no holding: it has neither a parent transaction nor a fund')
+
+    const res = await call({ ...SELL, parent_transaction_id: undefined })
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({ error: 'A withdrawal must be attached to a holding.' })
+  })
+
   it('still reports an unrelated insert failure as a 500', async () => {
     h.insertResult = { data: null, error: { code: '08006', message: 'connection failure' } }
 

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -293,7 +293,18 @@ export async function POST(request: NextRequest) {
     .select()
     .single()
 
-  if (error) return NextResponse.json({ error: 'Failed to create transaction' }, { status: 500 })
+  if (error) {
+    // The remaining-balance invariant refused it: a stale sheet, a retry, or a
+    // sell that lost a race against another one. Nothing failed, so this is a 400
+    // that says the balance moved — matching the book withdrawal's own answer.
+    // The wording is pinned by supabase/tests/withdrawal_balance.test.sql, which
+    // is where the trigger raising it lives (20260730000002).
+    if (error.message?.includes('exceeds the remaining balance')) {
+      return NextResponse.json({ error: 'Withdrawal exceeds the remaining balance of this holding.' }, { status: 400 })
+    }
+    console.error('investment-transactions POST insert failed', error.message)
+    return NextResponse.json({ error: 'Failed to create transaction' }, { status: 500 })
+  }
 
   // Holding a deposit for merge closes its source, so a recurring saving linked
   // to that source must be unlinked or it would keep topping up a settled

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -302,6 +302,12 @@ export async function POST(request: NextRequest) {
     if (error.message?.includes('exceeds the remaining balance')) {
       return NextResponse.json({ error: 'Withdrawal exceeds the remaining balance of this holding.' }, { status: 400 })
     }
+    // The same trigger's other refusal: principal or units taken out of a row that
+    // draws on no holding at all. No client can build that from the UI, but it is a
+    // bad request rather than a server fault, so say so.
+    if (error.message?.includes('draws on no holding')) {
+      return NextResponse.json({ error: 'A withdrawal must be attached to a holding.' }, { status: 400 })
+    }
     console.error('investment-transactions POST insert failed', error.message)
     return NextResponse.json({ error: 'Failed to create transaction' }, { status: 500 })
   }

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -188,13 +188,45 @@ export async function POST(request: NextRequest) {
   if (isWithdrawal && cleanParentTxId) {
     const { data: parent } = await supabase
       .from('investment_transactions')
-      .select('deposit_group_id')
+      .select('deposit_group_id, asset_type')
       .eq('transaction_id', cleanParentTxId)
       .eq('user_id', user.id)
       .single()
     if (parent?.deposit_group_id) {
       return NextResponse.json({ error: 'Cannot withdraw from an accumulating book yet.' }, { status: 400 })
     }
+    // The shape rules for a parent-backed withdrawal, checked here so a malformed
+    // request gets a message naming the field rather than the invariant's refusal
+    // (which the trigger still raises — this is the same rule stated earlier, not a
+    // replacement). See the withdrawal decision table in the PR / migration header.
+    //
+    // No principal means nothing leaves the holding: lib/depositValuation subtracts
+    // coalesce(principal_withdrawn, 0), so the deposit keeps its full value while
+    // the row claims cash left.
+    if (!cleanPrincipalWithdrawn || cleanPrincipalWithdrawn <= 0) {
+      return NextResponse.json(
+        { error: 'principal_withdrawn is required and must be positive for a withdrawal from a holding.' },
+        { status: 400 },
+      )
+    }
+    // Gold is valued by quantity, so a gold sale must move units too or the metal
+    // stays in net worth while its cost basis drops.
+    if (parent?.asset_type === 'gold' && (!cleanUnitsWithdrawn || cleanUnitsWithdrawn <= 0)) {
+      return NextResponse.json(
+        { error: 'units_withdrawn is required and must be positive for a gold sale.' },
+        { status: 400 },
+      )
+    }
+  }
+
+  // A fund sale has no parent row: it draws on the (goal, fund) bucket, and it is a
+  // QUANTITY — the units are what the cost basis is allocated from (lib/fundWithdrawal).
+  if (isWithdrawal && cleanAssetType === 'fund' && cleanFundId
+      && (!cleanUnitsWithdrawn || cleanUnitsWithdrawn <= 0)) {
+    return NextResponse.json(
+      { error: 'units_withdrawn is required and must be positive for a fund sale.' },
+      { status: 400 },
+    )
   }
 
   // Accumulating ("Loại 2") books. A top-up joins an existing book; creating one

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -229,6 +229,19 @@ export async function POST(request: NextRequest) {
     )
   }
 
+  // Everything else must say what it draws on. The one exception is a
+  // held-for-merge settlement whose source isn't recorded yet — the pool shape
+  // #588 exists to fix — and it is an exception for THAT, so an ordinary
+  // withdrawal cannot wear it to leave no holding behind. The DB says the same
+  // thing and remains the backstop for writers that don't come through here.
+  if (isWithdrawal && !cleanParentTxId && !(cleanAssetType === 'fund' && cleanFundId)
+      && !cleanHeldForMerge) {
+    return NextResponse.json(
+      { error: 'A withdrawal must say what it draws on: a holding, or a fund.' },
+      { status: 400 },
+    )
+  }
+
   // Accumulating ("Loại 2") books. A top-up joins an existing book; creating one
   // makes the anchor row self-group. The book's goal + maturity are book-level,
   // so a top-up inherits them (copied down) and the tranche just carries its own

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -294,19 +294,21 @@ export async function POST(request: NextRequest) {
     .single()
 
   if (error) {
-    // The remaining-balance invariant refused it: a stale sheet, a retry, or a
-    // sell that lost a race against another one. Nothing failed, so this is a 400
-    // that says the balance moved — matching the book withdrawal's own answer.
-    // The wording is pinned by supabase/tests/withdrawal_balance.test.sql, which
-    // is where the trigger raising it lives (20260730000002).
-    if (error.message?.includes('exceeds the remaining balance')) {
-      return NextResponse.json({ error: 'Withdrawal exceeds the remaining balance of this holding.' }, { status: 400 })
-    }
-    // The same trigger's other refusal: principal or units taken out of a row that
-    // draws on no holding at all. No client can build that from the UI, but it is a
-    // bad request rather than a server fault, so say so.
-    if (error.message?.includes('draws on no holding')) {
-      return NextResponse.json({ error: 'A withdrawal must be attached to a holding.' }, { status: 400 })
+    // The withdrawal invariant refused it (20260730000002). Every refusal it
+    // raises carries this prefix, so the whole family maps to a 400 with one
+    // match — listing the messages individually meant a new refusal fell through
+    // as a 500, reporting an invalid request as a server fault. The prefix is
+    // pinned by supabase/tests/withdrawal_balance.test.sql.
+    if (error.message?.includes('withdrawal invariant:')) {
+      // The one a real user can hit: a stale sheet, a retry, or a sell that lost a
+      // race. Matching the book withdrawal's own answer for the same condition.
+      if (error.message.includes('remaining balance')) {
+        return NextResponse.json({ error: 'Withdrawal exceeds the remaining balance of this holding.' }, { status: 400 })
+      }
+      // The rest are shapes no client builds from the UI — a withdrawal attached
+      // to nothing, half a fund sell, a negative amount. Still the caller's
+      // problem, not the server's.
+      return NextResponse.json({ error: 'This withdrawal does not match the holding it is drawn on.' }, { status: 400 })
     }
     console.error('investment-transactions POST insert failed', error.message)
     return NextResponse.json({ error: 'Failed to create transaction' }, { status: 500 })

--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -48,6 +48,8 @@ export interface FundBreakdownItem {
   currentNAV: number
   currentValue: number
   purchasePrice: number
+  /** Remaining cost basis (Σ amount_vnd, net of prior sells) — what a sale takes out (#587). */
+  costBasis: number
   profitLoss: number
   profitLossPercentage: number
   goalId: string | null
@@ -531,6 +533,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
       gainPct: fund.profitLossPercentage,
       fundId: fund.fundId,
       purchasePrice: fund.purchasePrice,
+      costBasis: fund.costBasis,
     })
     setSellSheetOpen(true)
   }

--- a/app/assets/__tests__/overviewData.test.ts
+++ b/app/assets/__tests__/overviewData.test.ts
@@ -18,6 +18,7 @@ function fund(fundType: string, currentValue: number): FundBreakdownItem {
     currentNAV: currentValue,
     currentValue,
     purchasePrice: currentValue,
+    costBasis: currentValue,
     profitLoss: 0,
     profitLossPercentage: 0,
     goalId: null,

--- a/app/assets/__tests__/overviewData.test.ts
+++ b/app/assets/__tests__/overviewData.test.ts
@@ -201,14 +201,36 @@ describe('getCachedOverview / setCachedOverview', () => {
 
   it('returns null for an entry past its TTL unless stale is allowed', () => {
     const data = sample(500)
-    // Hand-write an entry with an old timestamp.
+    // Hand-write an entry with an old timestamp, under the CURRENT schema key.
     localStorage.setItem(
-      `dashboardOverviewCache_${userId}`,
+      `dashboardOverviewCache_v2_${userId}`,
       JSON.stringify({ data, ts: Date.now() - 10 * 60 * 1000 }),
     )
 
     expect(getCachedOverview(userId)).toBeNull()
     expect(getCachedOverview(userId, { allowStale: true })).toEqual(data)
+  })
+
+  // A payload written by the previous deploy has no fund `costBasis`, which the
+  // sell flow now posts as the withdrawn principal (#587) — served, it produces a
+  // sale the database refuses. The TTL cannot express that kind of staleness, and
+  // `allowStale` reads have no age bound at all, so the key carries the schema.
+  it('ignores a snapshot written under an older schema, even as a stale read', () => {
+    localStorage.setItem(
+      `dashboardOverviewCache_${userId}`,
+      JSON.stringify({ data: sample(700), ts: Date.now() }),
+    )
+
+    expect(getCachedOverview(userId)).toBeNull()
+    expect(getCachedOverview(userId, { allowStale: true })).toBeNull()
+  })
+
+  // …and the versioned key still matches the prefix that sign-out and the
+  // price-refresh flows clear by (lib/clientCache, settingsShared).
+  it('keeps the dashboardOverviewCache prefix so the cache sweepers still find it', () => {
+    setCachedOverview(userId, sample(800))
+    const keys = Object.keys(localStorage).filter((k) => k.startsWith('dashboardOverviewCache'))
+    expect(keys).toHaveLength(1)
   })
 
   it('round-trips a fresh entry', () => {

--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -19,6 +19,12 @@ export interface Holding {
   key: string
   name: string
   source: string
+  /**
+   * The goal this position sits in (null = unallocated). `source` is its NAME,
+   * for display; the sell payload needs the id — a fund's balance is the
+   * (goal, fund) bucket, so a sell without it draws down the wrong one (#587).
+   */
+  goalId: string | null
   type: AssetType
   currentValue: number
   units: number | null
@@ -31,32 +37,33 @@ export interface Holding {
 }
 
 function collectHoldings(d: {
-  goals?: { goalName: string; funds?: FundLike[]; nonFunds?: NonFundLike[] }[]
+  goals?: { goalId?: string; goalName: string; funds?: FundLike[]; nonFunds?: NonFundLike[] }[]
   unallocated?: { funds?: FundLike[]; nonFunds?: NonFundLike[] }
 }): Holding[] {
   const out: Holding[] = []
-  // Funds: allocated to goals or unallocated.
-  const fundSources: { f: FundLike; source: string }[] = [
-    ...(d.goals ?? []).flatMap((g) => (g.funds ?? []).map((f) => ({ f, source: g.goalName }))),
-    ...((d.unallocated?.funds) ?? []).map((f) => ({ f, source: 'Unallocated' })),
+  // Funds: allocated to goals or unallocated. Each position keeps the goal's id
+  // as well as its name — the sell posts the id (#587).
+  const fundSources: { f: FundLike; source: string; goalId: string | null }[] = [
+    ...(d.goals ?? []).flatMap((g) => (g.funds ?? []).map((f) => ({ f, source: g.goalName, goalId: g.goalId ?? null }))),
+    ...((d.unallocated?.funds) ?? []).map((f) => ({ f, source: 'Unallocated', goalId: null })),
   ]
-  fundSources.forEach(({ f, source }, i) => {
+  fundSources.forEach(({ f, source, goalId }, i) => {
     out.push({
-      key: `fund-${f.fundId}-${i}`, name: f.fundName, source, type: 'fund',
+      key: `fund-${f.fundId}-${i}`, name: f.fundName, source, goalId, type: 'fund',
       currentValue: f.currentValue, units: f.quantity, navPerUnit: f.currentNAV,
       gainPct: f.profitLossPercentage, interestRate: null,
       fundId: f.fundId, purchasePrice: f.purchasePrice,
     })
   })
   // Bank / gold: also allocated to goals or unallocated.
-  const nonFundSources: { it: NonFundLike; source: string }[] = [
-    ...(d.goals ?? []).flatMap((g) => (g.nonFunds ?? []).map((it) => ({ it, source: g.goalName }))),
-    ...((d.unallocated?.nonFunds) ?? []).map((it) => ({ it, source: 'Unallocated' })),
+  const nonFundSources: { it: NonFundLike; source: string; goalId: string | null }[] = [
+    ...(d.goals ?? []).flatMap((g) => (g.nonFunds ?? []).map((it) => ({ it, source: g.goalName, goalId: g.goalId ?? null }))),
+    ...((d.unallocated?.nonFunds) ?? []).map((it) => ({ it, source: 'Unallocated', goalId: null })),
   ]
-  nonFundSources.forEach(({ it, source }, i) => {
+  nonFundSources.forEach(({ it, source, goalId }, i) => {
     if (it.type !== 'bank' && it.type !== 'gold') return
     out.push({
-      key: `nf-${it.transactionId}-${i}`, name: it.notes || it.type, source,
+      key: `nf-${it.transactionId}-${i}`, name: it.notes || it.type, source, goalId,
       type: it.type as AssetType,
       currentValue: it.currentValue, units: it.units,
       navPerUnit: it.units && it.units > 0 ? it.currentValue / it.units : null,

--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -34,6 +34,8 @@ export interface Holding {
   fundId?: string
   transactionId?: string
   purchasePrice?: number
+  /** Fund only: the bucket's remaining cost basis, which a sale draws from (#587). */
+  costBasis?: number
 }
 
 function collectHoldings(d: {
@@ -52,7 +54,7 @@ function collectHoldings(d: {
       key: `fund-${f.fundId}-${i}`, name: f.fundName, source, goalId, type: 'fund',
       currentValue: f.currentValue, units: f.quantity, navPerUnit: f.currentNAV,
       gainPct: f.profitLossPercentage, interestRate: null,
-      fundId: f.fundId, purchasePrice: f.purchasePrice,
+      fundId: f.fundId, purchasePrice: f.purchasePrice, costBasis: f.costBasis,
     })
   })
   // Bank / gold: also allocated to goals or unallocated.
@@ -74,7 +76,7 @@ function collectHoldings(d: {
   return out
 }
 
-interface FundLike { fundId: string; fundName: string; quantity: number; currentNAV: number; currentValue: number; purchasePrice: number; profitLossPercentage: number }
+interface FundLike { fundId: string; fundName: string; quantity: number; currentNAV: number; currentValue: number; purchasePrice: number; costBasis?: number; profitLossPercentage: number }
 interface NonFundLike { transactionId: string; type: string; amount: number; currentValue: number; interestRate: number | null; units: number | null; notes: string | null }
 
 // When set, the sheet opens in edit mode: fields are prefilled from this

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -12,6 +12,7 @@ import { AffectsProgressControl } from './goalDetailShared'
 import { useDialogMount, useResetOnOpen } from '@/app/(app)/planning/components/useDialogMount'
 import { previewBankWithdrawal, estimateReceivedForPrincipal } from '@/lib/bankWithdrawal'
 import { goldCostBasis, goldUnitCost } from '@/lib/goldWithdrawal'
+import { fundCostBasis } from '@/lib/fundWithdrawal'
 const fmtVND = (n: number, _locale?: string) => fmt(n)
 
 export interface SellItem {
@@ -26,6 +27,8 @@ export interface SellItem {
   fundId?: string
   transactionId?: string
   purchasePrice?: number
+  /** Fund only: remaining cost basis of the bucket, which a sale draws from (#587). */
+  costBasis?: number
   // Set when this bank item is an accumulating book (its anchor id). Switches the
   // sheet to a FULL close: every tranche is withdrawn at once (no partial amount).
   depositGroupId?: string | null
@@ -266,10 +269,14 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
           return
         }
       } else if (isFund && item.fundId) {
-        const principalWithdrawn = item.purchasePrice
-          ? Math.round((numAmount / item.currentValue) * (item.purchasePrice * (item.units ?? 0)))
-          : Math.round(numAmount)
-        const unitsWithdrawn = navPerUnit ? numAmount / navPerUnit : (item.units ?? 0)
+        // The units posted are the ones the basis is allocated from, so round them
+        // FIRST — otherwise the two disagree at the 4th decimal and a full sale can
+        // claim a đồng the holding doesn't have (#587, lib/fundWithdrawal).
+        const unitsWithdrawn = parseFloat(
+          (navPerUnit ? numAmount / navPerUnit : (item.units ?? 0)).toFixed(4))
+        const principalWithdrawn = fundCostBasis({
+          totalBasis: item.costBasis, totalUnits: item.units, sellUnits: unitsWithdrawn,
+        }) ?? Math.round(numAmount)
         const res = await fetch('/api/v1/investment-transactions', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -279,7 +286,7 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
             fund_id: item.fundId,
             investment_date: today,
             amount_vnd: Math.round(numAmount),
-            units_withdrawn: parseFloat(unitsWithdrawn.toFixed(4)),
+            units_withdrawn: unitsWithdrawn,
             principal_withdrawn: principalWithdrawn,
             goal_id: withdrawalGoalId,
             affects_progress: context === 'goal' ? affectsProgress : true,

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -11,6 +11,7 @@ import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { AffectsProgressControl } from './goalDetailShared'
 import { useDialogMount, useResetOnOpen } from '@/app/(app)/planning/components/useDialogMount'
 import { previewBankWithdrawal, estimateReceivedForPrincipal } from '@/lib/bankWithdrawal'
+import { goldCostBasis, goldUnitCost } from '@/lib/goldWithdrawal'
 const fmtVND = (n: number, _locale?: string) => fmt(n)
 
 export interface SellItem {
@@ -119,10 +120,13 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
   const numUnits = Number(units) || 0
   const numSalePrice = Number(salePrice) || 0
   const goldMaxUnits = item?.units ?? 0
-  const goldBuyUnit = isGold && item && item.units && item.units > 0 && item.purchasePrice != null
-    ? Math.round(item.purchasePrice / item.units) : null
+  // Per-unit price for display; the basis divides once and states a full sell
+  // exactly, so "sell all" can't post a đồng more than the holding has (#587).
+  const goldBuyUnit = isGold && item ? goldUnitCost(item.purchasePrice, item.units) : null
   const goldProceeds = isGold ? Math.round(numUnits * numSalePrice) : 0
-  const goldCostSold = goldBuyUnit != null ? Math.round(goldBuyUnit * numUnits) : null
+  const goldCostSold = isGold && item
+    ? goldCostBasis({ currentPrincipal: item.purchasePrice, units: item.units, sellUnits: numUnits })
+    : null
   const goldProfit = isGold && goldProceeds > 0 && goldCostSold != null ? goldProceeds - goldCostSold : null
   const goldRemUnits = isGold && item?.units != null ? item.units - numUnits : null
   const isOverUnits = isGold && item?.units != null && numUnits > item.units

--- a/app/assets/components/__tests__/AddTransactionSheet.test.tsx
+++ b/app/assets/components/__tests__/AddTransactionSheet.test.tsx
@@ -114,7 +114,7 @@ describe('AddTransactionSheet — goal selector (issue #232)', () => {
 describe('AddTransactionSheet — sell flow (issue #232)', () => {
   it('lists holdings from the overview and posts a fund withdrawal on confirm', async () => {
     const overview = {
-      goals: [{ goalName: 'Goal A', funds: [{ fundId: 'f1', fundName: 'VESAF', quantity: 100, currentNAV: 20000, currentValue: 2_000_000, purchasePrice: 18000, profitLossPercentage: 11.11 }] }],
+      goals: [{ goalId: 'g-a', goalName: 'Goal A', funds: [{ fundId: 'f1', fundName: 'VESAF', quantity: 100, currentNAV: 20000, currentValue: 2_000_000, purchasePrice: 18000, profitLossPercentage: 11.11 }] }],
       unallocated: { funds: [], nonFunds: [] },
     }
     const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
@@ -141,6 +141,9 @@ describe('AddTransactionSheet — sell flow (issue #232)', () => {
       expect(body.amount_vnd).toBe(1_000_000)
       expect(body.units_withdrawn).toBe(50)         // 1,000,000 / 20,000 NAV
       expect(body.principal_withdrawn).toBe(900_000) // 50% of cost basis (18,000 × 100)
+      // The sell draws down the bucket it was picked from. Posting null here sent
+      // it to Unallocated, which the server now refuses outright (#587).
+      expect(body.goal_id).toBe('g-a')
     })
   })
 })
@@ -148,7 +151,7 @@ describe('AddTransactionSheet — sell flow (issue #232)', () => {
 describe('AddTransactionSheet — fund sell units field (two-way linked)', () => {
   it('entering units fills the amount and posts the matching withdrawal', async () => {
     const overview = {
-      goals: [{ goalName: 'Goal A', funds: [{ fundId: 'f1', fundName: 'VESAF', quantity: 100, currentNAV: 20000, currentValue: 2_000_000, purchasePrice: 18000, profitLossPercentage: 11.11 }] }],
+      goals: [{ goalId: 'g-a', goalName: 'Goal A', funds: [{ fundId: 'f1', fundName: 'VESAF', quantity: 100, currentNAV: 20000, currentValue: 2_000_000, purchasePrice: 18000, profitLossPercentage: 11.11 }] }],
       unallocated: { funds: [], nonFunds: [] },
     }
     const fetchMock = vi.fn((url: string, _init?: RequestInit) => {

--- a/app/assets/components/__tests__/AddTransactionSheet.test.tsx
+++ b/app/assets/components/__tests__/AddTransactionSheet.test.tsx
@@ -114,7 +114,7 @@ describe('AddTransactionSheet — goal selector (issue #232)', () => {
 describe('AddTransactionSheet — sell flow (issue #232)', () => {
   it('lists holdings from the overview and posts a fund withdrawal on confirm', async () => {
     const overview = {
-      goals: [{ goalId: 'g-a', goalName: 'Goal A', funds: [{ fundId: 'f1', fundName: 'VESAF', quantity: 100, currentNAV: 20000, currentValue: 2_000_000, purchasePrice: 18000, profitLossPercentage: 11.11 }] }],
+      goals: [{ goalId: 'g-a', goalName: 'Goal A', funds: [{ fundId: 'f1', fundName: 'VESAF', quantity: 100, currentNAV: 20000, currentValue: 2_000_000, purchasePrice: 18000, costBasis: 1_800_000, profitLossPercentage: 11.11 }] }],
       unallocated: { funds: [], nonFunds: [] },
     }
     const fetchMock = vi.fn((url: string, _init?: RequestInit) => {
@@ -151,7 +151,7 @@ describe('AddTransactionSheet — sell flow (issue #232)', () => {
 describe('AddTransactionSheet — fund sell units field (two-way linked)', () => {
   it('entering units fills the amount and posts the matching withdrawal', async () => {
     const overview = {
-      goals: [{ goalId: 'g-a', goalName: 'Goal A', funds: [{ fundId: 'f1', fundName: 'VESAF', quantity: 100, currentNAV: 20000, currentValue: 2_000_000, purchasePrice: 18000, profitLossPercentage: 11.11 }] }],
+      goals: [{ goalId: 'g-a', goalName: 'Goal A', funds: [{ fundId: 'f1', fundName: 'VESAF', quantity: 100, currentNAV: 20000, currentValue: 2_000_000, purchasePrice: 18000, costBasis: 1_800_000, profitLossPercentage: 11.11 }] }],
       unallocated: { funds: [], nonFunds: [] },
     }
     const fetchMock = vi.fn((url: string, _init?: RequestInit) => {

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -20,6 +20,7 @@ const mockFund = {
   currentNAV: 25_000,
   currentValue: 2_500_000,
   purchasePrice: 22_000,
+  costBasis: 2_200_000,
   profitLoss: 300_000,
   profitLossPercentage: 13.64,
   goalId: 'goal-1',

--- a/app/assets/components/__tests__/addTransactionModel.test.ts
+++ b/app/assets/components/__tests__/addTransactionModel.test.ts
@@ -271,6 +271,22 @@ describe('buildSellPayload', () => {
     })
   })
 
+  // Selling the lot must post the holding's own principal, not a figure derived
+  // through a rounded per-unit price: 123,456,789 / 10 rounds up to 12,345,679,
+  // and ×10 is a đồng more than the holding has — which the server refuses as an
+  // overdraw (#587). Preview and payload have to agree on the exact basis.
+  it('gold: selling the lot posts exactly the remaining principal', () => {
+    const holding = { type: 'gold' as const, transactionId: 'g1', currentValue: 130_000_000, units: 10, purchasePrice: 123_456_789 }
+    const preview = computeSellPreview({
+      assetType: 'gold', dir: 'sell', holding, sellAmount: '', received: '',
+      goldSellQty: '10', goldSellPrice: '13000000',
+    })
+
+    expect(preview.goldCost).toBe(123_456_789)
+    expect(ok(buildSellPayload(holding, preview, { date, note: '' })))
+      .toMatchObject({ principal_withdrawn: 123_456_789, units_withdrawn: 10 })
+  })
+
   it('validation: no holding → holdingRequired; over balance → exceedsBalance; bank no received → amountRequired', () => {
     expect(buildSellPayload(null, zero, { date, note: '' })).toEqual({ ok: false, errorKey: 'holdingRequired' })
     const fund = { type: 'fund' as const, fundId: 'f1', currentValue: 2_000_000, units: 100 }

--- a/app/assets/components/__tests__/addTransactionModel.test.ts
+++ b/app/assets/components/__tests__/addTransactionModel.test.ts
@@ -225,6 +225,36 @@ describe('buildSellPayload', () => {
     })
   })
 
+  // The dashboard aggregates a fund per (goal, fund), and so does the balance the
+  // server now measures a sell against (#587). A sell of a goal-allocated fund
+  // posted with goal_id: null drew down the Unallocated bucket instead — the
+  // goal's holding never moved, and once the server enforces the balance that
+  // sell is refused outright. The sell has to carry the holding's own goal.
+  it('fund: the sell belongs to the goal the holding sits in', () => {
+    const holding = {
+      type: 'fund' as const, fundId: 'f1', goalId: 'goal-1',
+      purchasePrice: 18_000, currentValue: 2_000_000, units: 100,
+    }
+    const preview = { ...zero, numSell: 1_000_000, sellNav: 20_000 }
+    expect(ok(buildSellPayload(holding, preview, { date, note: '' }))).toMatchObject({ goal_id: 'goal-1' })
+  })
+
+  it('non-fund sells carry the holding’s goal too', () => {
+    const bank = { type: 'bank' as const, transactionId: 't1', goalId: 'goal-2', purchasePrice: 5_000_000, currentValue: 5_000_000 }
+    expect(ok(buildSellPayload(bank, { ...zero, numSell: 5_000_000, numReceived: 5_200_000, bankWithdrawPrincipal: 5_000_000 }, { date, note: '' })))
+      .toMatchObject({ goal_id: 'goal-2' })
+
+    const gold = { type: 'gold' as const, transactionId: 'g1', goalId: 'goal-3', currentValue: 18_400_000, units: 2 }
+    expect(ok(buildSellPayload(gold, { ...zero, numGoldSellQty: 1, goldProceeds: 9_200_000, goldCost: 9_000_000 }, { date, note: '' })))
+      .toMatchObject({ goal_id: 'goal-3' })
+  })
+
+  it('an unallocated holding still sells with no goal', () => {
+    const holding = { type: 'fund' as const, fundId: 'f1', goalId: null, purchasePrice: 18_000, currentValue: 2_000_000, units: 100 }
+    expect(ok(buildSellPayload(holding, { ...zero, numSell: 1_000_000, sellNav: 20_000 }, { date, note: '' })))
+      .toMatchObject({ goal_id: null })
+  })
+
   it('bank: amount is the received cash, principal is what the user entered', () => {
     const holding = { type: 'bank' as const, transactionId: 't1', purchasePrice: 5_000_000, currentValue: 5_000_000 }
     const preview = { ...zero, numSell: 5_000_000, numReceived: 5_200_000, bankWithdrawPrincipal: 5_000_000 }

--- a/app/assets/components/__tests__/addTransactionModel.test.ts
+++ b/app/assets/components/__tests__/addTransactionModel.test.ts
@@ -215,7 +215,9 @@ describe('buildSellPayload', () => {
   const zero = { numSell: 0, sellOverMax: false, sellNav: null, numGoldSellQty: 0, isOverUnits: false, goldProceeds: 0, goldCost: null, numReceived: 0, bankWithdrawPrincipal: 0 }
 
   it('fund: proportional principal_withdrawn + units_withdrawn=amount÷NAV', () => {
-    const holding = { type: 'fund' as const, fundId: 'f1', purchasePrice: 18_000, currentValue: 2_000_000, units: 100 }
+    // costBasis is what those 100 units cost; the sale takes half of it because it
+    // sells half the units. purchasePrice is display-only now (#587).
+    const holding = { type: 'fund' as const, fundId: 'f1', purchasePrice: 18_000, costBasis: 1_800_000, currentValue: 2_000_000, units: 100 }
     const preview = { ...zero, numSell: 1_000_000, sellNav: 20_000 }
     const p = ok(buildSellPayload(holding, preview, { date, note: '' }))
     expect(p).toEqual({

--- a/app/assets/components/__tests__/addTransactionModel.test.ts
+++ b/app/assets/components/__tests__/addTransactionModel.test.ts
@@ -276,7 +276,10 @@ describe('buildSellPayload', () => {
   // and ×10 is a đồng more than the holding has — which the server refuses as an
   // overdraw (#587). Preview and payload have to agree on the exact basis.
   it('gold: selling the lot posts exactly the remaining principal', () => {
-    const holding = { type: 'gold' as const, transactionId: 'g1', currentValue: 130_000_000, units: 10, purchasePrice: 123_456_789 }
+    const holding = {
+      type: 'gold' as const, transactionId: 'g1', currentValue: 130_000_000,
+      units: 10, purchasePrice: 123_456_789, navPerUnit: 13_000_000, gainPct: null,
+    }
     const preview = computeSellPreview({
       assetType: 'gold', dir: 'sell', holding, sellAmount: '', received: '',
       goldSellQty: '10', goldSellPrice: '13000000',

--- a/app/assets/components/__tests__/invToSellItem.test.ts
+++ b/app/assets/components/__tests__/invToSellItem.test.ts
@@ -8,11 +8,15 @@ describe('invToSellItem', () => {
   it('maps a fund row to a fund SellItem', () => {
     const inv = {
       id: 'row1', type: 'fund', name: 'Fund', value: 3_000_000, units: null, gainPct: null, principal: null,
-      fund: { fundId: 'f1', fundName: 'VF1', currentValue: 3_000_000, quantity: 100, currentNAV: 30_000, profitLossPercentage: 12, purchasePrice: 2_680_000 },
+      fund: { fundId: 'f1', fundName: 'VF1', currentValue: 3_000_000, quantity: 100, currentNAV: 30_000, profitLossPercentage: 12, purchasePrice: 2_680_000, costBasis: 2_680_000 },
     } as unknown as InvRow
+    // costBasis is what a sale takes out of the bucket (#587). Dropping it here sent
+    // the sheet down its fallback — posting the PROCEEDS as principal — which the
+    // invariant refuses for any fund whose NAV has moved, so every goal-detail fund
+    // sale would fail.
     expect(invToSellItem(inv)).toEqual({
       type: 'fund', name: 'VF1', currentValue: 3_000_000, units: 100, navPerUnit: 30_000,
-      gainPct: 12, fundId: 'f1', purchasePrice: 2_680_000,
+      gainPct: 12, fundId: 'f1', purchasePrice: 2_680_000, costBasis: 2_680_000,
     })
   })
 

--- a/app/assets/components/addTransactionModel.ts
+++ b/app/assets/components/addTransactionModel.ts
@@ -7,6 +7,7 @@
 
 import { previewBankWithdrawal, estimateReceivedForPrincipal } from '@/lib/bankWithdrawal'
 import { goldCostBasis, goldUnitCost } from '@/lib/goldWithdrawal'
+import { fundCostBasis } from '@/lib/fundWithdrawal'
 
 export type AssetType = 'fund' | 'bank' | 'gold'
 
@@ -291,6 +292,12 @@ export interface SellHolding {
    */
   goalId?: string | null
   purchasePrice?: number | null
+  /**
+   * Fund only: the bucket's remaining cost basis (Σ amount_vnd, net of prior
+   * sells) as the dashboard reports it. A sale takes it out directly instead of
+   * reconstructing it from the averaged purchasePrice (#587, lib/fundWithdrawal).
+   */
+  costBasis?: number | null
   currentValue: number
   units?: number | null
 }
@@ -322,14 +329,17 @@ export function buildSellPayload(
   if (holding.type === 'fund' && holding.fundId) {
     if (!preview.numSell) return { ok: false, errorKey: 'amountRequired' }
     if (preview.sellOverMax) return { ok: false, errorKey: 'exceedsBalance' }
-    const principalWithdrawn = holding.purchasePrice
-      ? Math.round((preview.numSell / holding.currentValue) * (holding.purchasePrice * (holding.units ?? 0)))
-      : Math.round(preview.numSell)
-    const unitsWithdrawn = preview.sellNav ? preview.numSell / preview.sellNav : (holding.units ?? 0)
+    // Round the units FIRST: they are what the basis is allocated from, so a
+    // mismatch at the 4th decimal is a đồng the holding may not have (#587).
+    const unitsWithdrawn = parseFloat(
+      (preview.sellNav ? preview.numSell / preview.sellNav : (holding.units ?? 0)).toFixed(4))
+    const principalWithdrawn = fundCostBasis({
+      totalBasis: holding.costBasis, totalUnits: holding.units, sellUnits: unitsWithdrawn,
+    }) ?? Math.round(preview.numSell)
     return { ok: true, payload: {
       transaction_type: 'withdrawal', asset_type: 'fund', fund_id: holding.fundId,
       investment_date: date, amount_vnd: Math.round(preview.numSell),
-      units_withdrawn: parseFloat(unitsWithdrawn.toFixed(4)),
+      units_withdrawn: unitsWithdrawn,
       principal_withdrawn: principalWithdrawn,
       goal_id: holding.goalId ?? null, notes: note || null,
     } }

--- a/app/assets/components/addTransactionModel.ts
+++ b/app/assets/components/addTransactionModel.ts
@@ -6,6 +6,7 @@
 // and stay in the component for now.
 
 import { previewBankWithdrawal, estimateReceivedForPrincipal } from '@/lib/bankWithdrawal'
+import { goldCostBasis, goldUnitCost } from '@/lib/goldWithdrawal'
 
 export type AssetType = 'fund' | 'bank' | 'gold'
 
@@ -114,10 +115,11 @@ export function computeSellPreview(input: {
   const goldMaxUnits = h?.units ?? 0
   const numGoldSellQty = Number(goldSellQty) || 0
   const numGoldSellPrice = Number(goldSellPrice) || 0
-  const goldBuyUnit = h?.units && h.units > 0 && h.purchasePrice != null
-    ? Math.round(h.purchasePrice / h.units) : null
+  // Per-unit price for display; the basis divides once and states a full sell
+  // exactly, so "sell all" can't post a đồng more than the holding has (#587).
+  const goldBuyUnit = goldUnitCost(h?.purchasePrice, h?.units)
   const goldProceeds = Math.round(numGoldSellQty * numGoldSellPrice)
-  const goldCost = goldBuyUnit != null ? Math.round(numGoldSellQty * goldBuyUnit) : null
+  const goldCost = goldCostBasis({ currentPrincipal: h?.purchasePrice, units: h?.units, sellUnits: numGoldSellQty })
   const goldProfit = goldProceeds > 0 && goldCost != null ? goldProceeds - goldCost : null
   const goldRemUnits = h?.units != null ? h.units - numGoldSellQty : null
   const isOverUnits = numGoldSellQty > goldMaxUnits && goldMaxUnits > 0

--- a/app/assets/components/addTransactionModel.ts
+++ b/app/assets/components/addTransactionModel.ts
@@ -281,6 +281,13 @@ export interface SellHolding {
   type: AssetType
   transactionId?: string
   fundId?: string
+  /**
+   * The goal the holding sits in, null when unallocated. A fund's balance is the
+   * (goal, fund) bucket the dashboard aggregates — and the one the server measures
+   * a sell against (#587) — so a sell that dropped this drew down the wrong
+   * bucket: the goal's holding stayed put and the sell is now refused outright.
+   */
+  goalId?: string | null
   purchasePrice?: number | null
   currentValue: number
   units?: number | null
@@ -306,7 +313,8 @@ export function buildSellPayload(
       parent_transaction_id: holding.transactionId,
       investment_date: date, amount_vnd: preview.goldProceeds,
       units_withdrawn: parseFloat(preview.numGoldSellQty.toFixed(4)),
-      principal_withdrawn: preview.goldCost ?? preview.goldProceeds, goal_id: null, notes: note || null,
+      principal_withdrawn: preview.goldCost ?? preview.goldProceeds,
+      goal_id: holding.goalId ?? null, notes: note || null,
     } }
   }
   if (holding.type === 'fund' && holding.fundId) {
@@ -320,7 +328,8 @@ export function buildSellPayload(
       transaction_type: 'withdrawal', asset_type: 'fund', fund_id: holding.fundId,
       investment_date: date, amount_vnd: Math.round(preview.numSell),
       units_withdrawn: parseFloat(unitsWithdrawn.toFixed(4)),
-      principal_withdrawn: principalWithdrawn, goal_id: null, notes: note || null,
+      principal_withdrawn: principalWithdrawn,
+      goal_id: holding.goalId ?? null, notes: note || null,
     } }
   }
   if (holding.transactionId) {
@@ -335,7 +344,7 @@ export function buildSellPayload(
       parent_transaction_id: holding.transactionId, investment_date: date,
       amount_vnd: isBankSell ? Math.round(preview.numReceived) : Math.round(preview.numSell),
       principal_withdrawn: isBankSell ? preview.bankWithdrawPrincipal : Math.round(preview.numSell),
-      goal_id: null, notes: note || null,
+      goal_id: holding.goalId ?? null, notes: note || null,
     } }
   }
   return { ok: false, errorKey: 'holdingRequired' }

--- a/app/assets/components/invToSellItem.ts
+++ b/app/assets/components/invToSellItem.ts
@@ -16,6 +16,11 @@ export function invToSellItem(inv: InvRow): SellItem {
       gainPct: inv.fund.profitLossPercentage,
       fundId: inv.fund.fundId,
       purchasePrice: inv.fund.purchasePrice,
+      // What a sale actually takes out of the bucket (#587). Without it the sheet
+      // falls back to posting the PROCEEDS as principal, which the invariant
+      // refuses for any fund whose NAV has moved — i.e. every real goal-detail
+      // fund sale. The third surface onto the same sheet; the other two pass it.
+      costBasis: inv.fund.costBasis,
     }
   }
   const navPerUnit = inv.units && inv.units > 0 ? inv.value / inv.units : undefined

--- a/app/assets/overviewData.ts
+++ b/app/assets/overviewData.ts
@@ -4,8 +4,16 @@ const OVERVIEW_ENDPOINT = '/api/v1/dashboard/overview'
 
 const OVERVIEW_CACHE_TTL = 2 * 60 * 1000 // 2 minutes
 
+// Bump when the cached shape gains a field a consumer RELIES on, so a payload
+// written by the previous deploy is never served to code that needs the new one.
+// v2: fund items carry `costBasis`, which the sell flow posts as the withdrawn
+// principal (#587). Served without it, a sale falls back to a figure the database
+// refuses — a pre-deploy snapshot is stale in a way the TTL cannot express, and
+// `allowStale` reads have no age bound at all.
+const OVERVIEW_CACHE_SCHEMA = 'v2'
+
 function overviewCacheKey(userId: string) {
-  return `dashboardOverviewCache_${userId}`
+  return `dashboardOverviewCache_${OVERVIEW_CACHE_SCHEMA}_${userId}`
 }
 
 /**

--- a/e2e/withdrawal-balance.spec.ts
+++ b/e2e/withdrawal-balance.spec.ts
@@ -120,6 +120,40 @@ test.describe('withdrawal balance enforcement (#587)', () => {
     }
   })
 
+  // fund_id is ON DELETE SET NULL too, so deleting a fund orphans its sells
+  // through the same kind of update as deleting a deposit. Same failure mode, a
+  // different route — and the helpers hide it the same way.
+  test('a fund that has been sold from can still be deleted', async ({ request }) => {
+    const fund = await api.createFund({
+      name: `E2E WdBalance Del ${Date.now()}`,
+      code: `WBD${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      fund_type: 'equity',
+      nav: 20_000,
+    })
+    const buy = await api.createTransaction({
+      asset_type: 'fund', fund_id: fund.id, goal_id: goalId,
+      amount_vnd: 2_000_000, units: 100, unit_price: 20_000, investment_date: '2026-01-01',
+    })
+    const sell = await request.post('/api/v1/investment-transactions', {
+      data: {
+        transaction_type: 'withdrawal', asset_type: 'fund', fund_id: fund.id,
+        investment_date: '2026-02-01', amount_vnd: 1_000_000,
+        units_withdrawn: 50, principal_withdrawn: 1_000_000, goal_id: goalId,
+        notes: 'E2E wd balance fund',
+      },
+    })
+    expect(sell.status()).toBe(201)
+
+    try {
+      const del = await request.delete(`/api/funds/${fund.id}`)
+      expect(del.ok()).toBeTruthy()
+    } finally {
+      await api.deleteTransactionCascade(buy.transaction_id)
+      await api.deleteAllTransactionsByNotes('E2E wd balance fund')
+      await api.deleteFund(fund.id)
+    }
+  })
+
   // A fund sell has no parent row: its balance is the (goal, fund) bucket the
   // dashboard aggregates. Units held for one goal must not fund another's sell.
   test('a fund sell draws only on the goal it was picked from', async ({ request }) => {

--- a/e2e/withdrawal-balance.spec.ts
+++ b/e2e/withdrawal-balance.spec.ts
@@ -1,0 +1,121 @@
+import { test, expect } from '@playwright/test'
+import * as api from './helpers/api'
+
+// A withdrawal may never take more than its holding still holds (#587). The sell
+// sheets capped it client-side; the API took what it was given.
+//
+// The invariant is a database trigger measuring the balance under a lock on the
+// source (supabase/migrations/20260730000002), and unit tests pin its filters and
+// the route's 400. What only a real stack can show is the part the whole design
+// exists for: two sells racing for the same balance, where exactly one may win.
+test.describe('withdrawal balance enforcement (#587)', () => {
+  let goalId: string
+  let depositId: string
+
+  test.beforeEach(async () => {
+    const goal = await api.createGoal({ goal_name: `E2E WdBalance ${Date.now()}` })
+    goalId = goal.goal_id
+    const tx = await api.createTransaction({
+      asset_type: 'bank', goal_id: goalId, amount_vnd: 100_000_000,
+      investment_date: '2026-01-01', notes: 'E2E wd balance',
+    })
+    depositId = tx.transaction_id
+  })
+
+  test.afterEach(async () => {
+    if (depositId) await api.deleteTransactionCascade(depositId)
+    if (goalId) await api.deleteGoal(goalId)
+  })
+
+  const withdraw = (principal: number) => ({
+    transaction_type: 'withdrawal',
+    asset_type: 'bank',
+    parent_transaction_id: depositId,
+    investment_date: '2026-02-01',
+    amount_vnd: principal,
+    principal_withdrawn: principal,
+    goal_id: goalId,
+  })
+
+  test('a withdrawal above the remaining principal is refused, and the balance still spends down to zero', async ({ request }) => {
+    const first = await request.post('/api/v1/investment-transactions', { data: withdraw(60_000_000) })
+    expect(first.status()).toBe(201)
+
+    // 50M more would take 110M out of a 100M book. Refused — and as a 400 saying
+    // why, not the 500 every insert failure used to collapse into.
+    const over = await request.post('/api/v1/investment-transactions', { data: withdraw(50_000_000) })
+    expect(over.status()).toBe(400)
+    expect((await over.json()).error).toMatch(/remaining balance/i)
+
+    // The 40M actually left still goes out: the guard is a cap, not a lock.
+    const rest = await request.post('/api/v1/investment-transactions', { data: withdraw(40_000_000) })
+    expect(rest.status()).toBe(201)
+
+    // Nothing is left, so even 1 đồng is refused.
+    const empty = await request.post('/api/v1/investment-transactions', { data: withdraw(1) })
+    expect(empty.status()).toBe(400)
+  })
+
+  // The race the invariant exists for. Both requests read the same balance before
+  // either commits, so a client-side cap — or a server-side read without a lock —
+  // lets both through and the deposit goes past zero.
+  test('two sells racing for the same balance: exactly one wins', async ({ request }) => {
+    const [a, b] = await Promise.all([
+      request.post('/api/v1/investment-transactions', { data: withdraw(100_000_000) }),
+      request.post('/api/v1/investment-transactions', { data: withdraw(100_000_000) }),
+    ])
+    const statuses = [a.status(), b.status()].sort()
+
+    expect(statuses).toEqual([201, 400])
+
+    // And the ledger agrees: one withdrawal, for the whole balance.
+    const listed = await (await request.get(
+      `/api/v1/investment-transactions?goal_id=${goalId}&limit=100`)).json()
+    const outgoing = (listed.transactions as Array<{ transaction_type: string; principal_withdrawn: number | null }>)
+      .filter((t) => t.transaction_type === 'withdrawal')
+    expect(outgoing).toHaveLength(1)
+    expect(outgoing[0].principal_withdrawn).toBe(100_000_000)
+  })
+
+  // A fund sell has no parent row: its balance is the (goal, fund) bucket the
+  // dashboard aggregates. Units held for one goal must not fund another's sell.
+  test('a fund sell draws only on the goal it was picked from', async ({ request }) => {
+    const fund = await api.createFund({
+      name: `E2E WdBalance Fund ${Date.now()}`,
+      code: `WBF${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      fund_type: 'equity',
+      nav: 20_000,
+    })
+    const otherGoal = await api.createGoal({ goal_name: `E2E WdBalance Other ${Date.now()}` })
+    const buy = await api.createTransaction({
+      asset_type: 'fund', fund_id: fund.id, goal_id: goalId,
+      amount_vnd: 2_000_000, units: 100, unit_price: 20_000, investment_date: '2026-01-01',
+    })
+    const sell = (goal: string | null, units: number) => ({
+      transaction_type: 'withdrawal', asset_type: 'fund', fund_id: fund.id,
+      investment_date: '2026-02-01', amount_vnd: units * 20_000,
+      units_withdrawn: units, principal_withdrawn: units * 20_000, goal_id: goal,
+      // A fund sell has no parent row to cascade from, so tag it for cleanup.
+      notes: 'E2E wd balance fund',
+    })
+    try {
+      // The other goal holds none of this fund.
+      const wrongGoal = await request.post('/api/v1/investment-transactions', { data: sell(otherGoal.goal_id, 10) })
+      expect(wrongGoal.status()).toBe(400)
+
+      // Unallocated holds none of it either — this is the bucket the sheet used to
+      // post to for a goal-allocated fund.
+      const unallocated = await request.post('/api/v1/investment-transactions', { data: sell(null, 10) })
+      expect(unallocated.status()).toBe(400)
+
+      // The goal that actually holds the units can sell them, up to its balance.
+      expect((await request.post('/api/v1/investment-transactions', { data: sell(goalId, 100) })).status()).toBe(201)
+      expect((await request.post('/api/v1/investment-transactions', { data: sell(goalId, 1) })).status()).toBe(400)
+    } finally {
+      await api.deleteTransactionCascade(buy.transaction_id)
+      await api.deleteAllTransactionsByNotes('E2E wd balance fund')
+      await api.deleteFund(fund.id)
+      await api.deleteGoal(otherGoal.goal_id)
+    }
+  })
+})

--- a/e2e/withdrawal-balance.spec.ts
+++ b/e2e/withdrawal-balance.spec.ts
@@ -95,6 +95,31 @@ test.describe('withdrawal balance enforcement (#587)', () => {
     expect(rows.find((t) => t.transaction_id === depositId)).toBeUndefined()
   })
 
+  // Selling a gold lot whose principal doesn't divide evenly by its units: the
+  // client used to derive the cost basis through a rounded per-unit price, which
+  // posts a đồng MORE than the holding has — so the balance guard would refuse an
+  // ordinary "sell all". The basis is now stated exactly for a full sale; this
+  // drives the arithmetic through the route to prove the two agree.
+  test('selling a whole gold holding is not refused by cost-basis rounding', async ({ request }) => {
+    const gold = await api.createTransaction({
+      asset_type: 'gold', goal_id: goalId, amount_vnd: 123_456_789, units: 10,
+      unit_price: 12_345_679, investment_date: '2026-01-01', notes: 'E2E wd balance gold',
+    })
+    try {
+      const res = await request.post('/api/v1/investment-transactions', {
+        data: {
+          transaction_type: 'withdrawal', asset_type: 'gold',
+          parent_transaction_id: gold.transaction_id, investment_date: '2026-02-01',
+          amount_vnd: 130_000_000, units_withdrawn: 10,
+          principal_withdrawn: 123_456_789, goal_id: goalId,
+        },
+      })
+      expect(res.status()).toBe(201)
+    } finally {
+      await api.deleteTransactionCascade(gold.transaction_id)
+    }
+  })
+
   // A fund sell has no parent row: its balance is the (goal, fund) bucket the
   // dashboard aggregates. Units held for one goal must not fund another's sell.
   test('a fund sell draws only on the goal it was picked from', async ({ request }) => {

--- a/e2e/withdrawal-balance.spec.ts
+++ b/e2e/withdrawal-balance.spec.ts
@@ -56,6 +56,23 @@ test.describe('withdrawal balance enforcement (#587)', () => {
     expect(empty.status()).toBe(400)
   })
 
+  // The shape rules, through the real route: a withdrawal that omits the number to
+  // be measured is a bad request, not a withdrawal of nothing (see the decision
+  // table in the PR / migration header).
+  test('a withdrawal must record what it takes out', async ({ request }) => {
+    // Bank: principal is the delta, and it is required.
+    for (const principal of [undefined, 0]) {
+      const res = await request.post('/api/v1/investment-transactions', {
+        data: { ...withdraw(10_000_000), principal_withdrawn: principal },
+      })
+      expect(res.status()).toBe(400)
+      expect((await res.json()).error).toMatch(/principal_withdrawn is required/)
+    }
+
+    // Bank needs no units, so an ordinary withdrawal still goes through.
+    expect((await request.post('/api/v1/investment-transactions', { data: withdraw(10_000_000) })).status()).toBe(201)
+  })
+
   // The race the invariant exists for. Both requests read the same balance before
   // either commits, so a client-side cap — or a server-side read without a lock —
   // lets both through and the deposit goes past zero.

--- a/e2e/withdrawal-balance.spec.ts
+++ b/e2e/withdrawal-balance.spec.ts
@@ -154,6 +154,58 @@ test.describe('withdrawal balance enforcement (#587)', () => {
     }
   })
 
+  // Assigning a fund moves its purchases AND its sells to the new goal in one
+  // statement (#589). A row-level check saw that half-applied, so whether it
+  // passed depended on heap order — and editing the buy is enough to flip it.
+  // This is the plain sequence a user does: buy, sell some, fix the buy, then
+  // assign the fund to a goal.
+  test('a fund with sell history can still be assigned to a goal', async ({ request }) => {
+    const fund = await api.createFund({
+      name: `E2E WdBalance Assign ${Date.now()}`,
+      code: `WBA${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      fund_type: 'equity',
+      nav: 20_000,
+    })
+    const target = await api.createGoal({ goal_name: `E2E WdBalance Target ${Date.now()}` })
+    const buy = await api.createTransaction({
+      asset_type: 'fund', fund_id: fund.id,
+      amount_vnd: 2_000_000, units: 100, unit_price: 20_000, investment_date: '2026-01-01',
+    })
+    try {
+      const sell = await request.post('/api/v1/investment-transactions', {
+        data: {
+          transaction_type: 'withdrawal', asset_type: 'fund', fund_id: fund.id,
+          investment_date: '2026-02-01', amount_vnd: 600_000,
+          units_withdrawn: 30, principal_withdrawn: 600_000, goal_id: null,
+          notes: 'E2E wd balance fund',
+        },
+      })
+      expect(sell.status()).toBe(201)
+
+      // Editing the purchase rewrites it later in the heap, so the assign's single
+      // UPDATE reaches the sell first — the order that used to fail.
+      const edit = await request.put(`/api/v1/investment-transactions/${buy.transaction_id}`, {
+        data: {
+          asset_type: 'fund', fund_id: fund.id, investment_date: '2026-01-02',
+          amount_vnd: 2_000_000, units: 100, unit_price: 20_000,
+        },
+      })
+      expect(edit.ok()).toBeTruthy()
+
+      const assign = await request.post('/api/v1/fund-investments/assign', {
+        data: { fund_id: fund.id, from_goal_id: null, to_goal_id: target.goal_id },
+      })
+      expect(assign.status()).toBe(200)
+      // The sell moved with its purchases — the bucket did not split.
+      expect((await assign.json()).moved).toBe(2)
+    } finally {
+      await api.deleteTransactionCascade(buy.transaction_id)
+      await api.deleteAllTransactionsByNotes('E2E wd balance fund')
+      await api.deleteFund(fund.id)
+      await api.deleteGoal(target.goal_id)
+    }
+  })
+
   // A fund sell has no parent row: its balance is the (goal, fund) bucket the
   // dashboard aggregates. Units held for one goal must not fund another's sell.
   test('a fund sell draws only on the goal it was picked from', async ({ request }) => {

--- a/e2e/withdrawal-balance.spec.ts
+++ b/e2e/withdrawal-balance.spec.ts
@@ -206,6 +206,58 @@ test.describe('withdrawal balance enforcement (#587)', () => {
     }
   })
 
+  // The basis a fund sale takes out now comes from the dashboard as a number
+  // (`costBasis`) instead of being reconstructed from the averaged purchase price.
+  // This drives the real DTO → helper → route → invariant path, on a bucket whose
+  // basis divides into no whole đồng per unit, which is where the old arithmetic
+  // landed a đồng above the holding and the invariant refused an ordinary sale.
+  test('the dashboard reports a fund cost basis a full sale can take exactly', async ({ request }) => {
+    const fund = await api.createFund({
+      name: `E2E WdBalance Basis ${Date.now()}`,
+      code: `WBB${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      fund_type: 'equity',
+      nav: 20_000,
+    })
+    // 1,000,001 over 3 units: no third of it is a whole đồng.
+    const buy = await api.createTransaction({
+      asset_type: 'fund', fund_id: fund.id, goal_id: goalId,
+      amount_vnd: 1_000_001, units: 3, unit_price: 333_334, investment_date: '2026-01-01',
+    })
+    try {
+      const overview = await (await request.get('/api/v1/dashboard/overview')).json()
+      const bucket = (overview.goals as Array<{ goalId: string; funds: Array<{ fundId: string; costBasis: number; quantity: number }> }>)
+        .find((g) => g.goalId === goalId)!
+        .funds.find((f) => f.fundId === fund.id)!
+      // The DTO carries it, so no client has to rebuild it from an average.
+      expect(bucket.costBasis).toBe(1_000_001)
+
+      const sell = await request.post('/api/v1/investment-transactions', {
+        data: {
+          transaction_type: 'withdrawal', asset_type: 'fund', fund_id: fund.id,
+          investment_date: '2026-02-01', amount_vnd: 1_000_001,
+          units_withdrawn: bucket.quantity, principal_withdrawn: bucket.costBasis,
+          goal_id: goalId, notes: 'E2E wd balance fund',
+        },
+      })
+      expect(sell.status()).toBe(201)
+
+      // And a đồng more than the basis is still an overdraw.
+      const over = await request.post('/api/v1/investment-transactions', {
+        data: {
+          transaction_type: 'withdrawal', asset_type: 'fund', fund_id: fund.id,
+          investment_date: '2026-03-01', amount_vnd: 1000,
+          units_withdrawn: 0.0001, principal_withdrawn: 1000,
+          goal_id: goalId, notes: 'E2E wd balance fund',
+        },
+      })
+      expect(over.status()).toBe(400)
+    } finally {
+      await api.deleteTransactionCascade(buy.transaction_id)
+      await api.deleteAllTransactionsByNotes('E2E wd balance fund')
+      await api.deleteFund(fund.id)
+    }
+  })
+
   // A fund sell has no parent row: its balance is the (goal, fund) bucket the
   // dashboard aggregates. Units held for one goal must not fund another's sell.
   test('a fund sell draws only on the goal it was picked from', async ({ request }) => {

--- a/e2e/withdrawal-balance.spec.ts
+++ b/e2e/withdrawal-balance.spec.ts
@@ -77,6 +77,24 @@ test.describe('withdrawal balance enforcement (#587)', () => {
     expect(outgoing[0].principal_withdrawn).toBe(100_000_000)
   })
 
+  // The guard sits on a BEFORE UPDATE too, and parent_transaction_id is
+  // ON DELETE SET NULL — so deleting a partially withdrawn deposit orphans its
+  // children through an update that lands on the trigger. An early version of
+  // this change refused that update and turned an ordinary delete into a 500.
+  // The suite missed it because the test helpers delete children first; the route
+  // does not, so drive the route.
+  test('a source that has been partly withdrawn can still be deleted', async ({ request }) => {
+    expect((await request.post('/api/v1/investment-transactions', { data: withdraw(30_000_000) })).status()).toBe(201)
+
+    const del = await request.delete(`/api/v1/investment-transactions/${depositId}`)
+    expect(del.status()).toBe(200)
+
+    const listed = await (await request.get(
+      `/api/v1/investment-transactions?goal_id=${goalId}&limit=100`)).json()
+    const rows = listed.transactions as Array<{ transaction_id: string }>
+    expect(rows.find((t) => t.transaction_id === depositId)).toBeUndefined()
+  })
+
   // A fund sell has no parent row: its balance is the (goal, fund) bucket the
   // dashboard aggregates. Units held for one goal must not fund another's sell.
   test('a fund sell draws only on the goal it was picked from', async ({ request }) => {

--- a/lib/__tests__/fundWithdrawal.test.ts
+++ b/lib/__tests__/fundWithdrawal.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { fundCostBasis } from '../fundWithdrawal'
+
+// One authoritative basis: amount_vnd, because that is the accumulator the
+// overview subtracts principal_withdrawn from. The sheets used to reconstruct a
+// NAV-based figure through an averaged unit price and post that instead — wrong
+// basis, plus the rounding of a round trip through the average.
+
+describe('fundCostBasis', () => {
+  it('a full sale takes the whole basis exactly, however it divides', () => {
+    // The shape that broke: 2 purchases, basis 2,000,100, 100.005 units. Going
+    // through the average (2,000,100 / 100.005 × 100.005) lands on 2,000,101.
+    expect(fundCostBasis({ totalBasis: 2_000_100, totalUnits: 100.005, sellUnits: 100.005 }))
+      .toBe(2_000_100)
+  })
+
+  it('never exceeds the basis, at any quantity', () => {
+    const totalBasis = 2_000_100
+    const totalUnits = 100.005
+    for (const sellUnits of [0.0001, 1, 33.333, 99.9, 100.005]) {
+      expect(fundCostBasis({ totalBasis, totalUnits, sellUnits })!).toBeLessThanOrEqual(totalBasis)
+    }
+  })
+
+  it('allocates a partial sale by units, out of the total', () => {
+    expect(fundCostBasis({ totalBasis: 3_000_000, totalUnits: 150, sellUnits: 50 })).toBe(1_000_000)
+    // Rounded once: 30 × 2,000,100 / 100.005 = 600,000.0 → 600,000.
+    expect(fundCostBasis({ totalBasis: 2_000_100, totalUnits: 100.005, sellUnits: 30 })).toBe(600_000)
+  })
+
+  // A stale holding record is not a licence to claim more basis than it cost.
+  it('caps a sale larger than the recorded units at the whole basis', () => {
+    expect(fundCostBasis({ totalBasis: 1_000_000, totalUnits: 50, sellUnits: 80 })).toBe(1_000_000)
+  })
+
+  it('has nothing to report without a basis or units', () => {
+    expect(fundCostBasis({ totalBasis: null, totalUnits: 100, sellUnits: 10 })).toBeNull()
+    expect(fundCostBasis({ totalBasis: 1_000_000, totalUnits: 0, sellUnits: 10 })).toBeNull()
+    expect(fundCostBasis({ totalBasis: 1_000_000, totalUnits: null, sellUnits: 10 })).toBeNull()
+  })
+
+  it('takes nothing for a zero sale', () => {
+    expect(fundCostBasis({ totalBasis: 1_000_000, totalUnits: 100, sellUnits: 0 })).toBe(0)
+  })
+
+  // A fee-bearing purchase: 1,000,000 paid for 49 units at NAV 20,000 (980,000 of
+  // NAV cost + 20,000 of fees). The basis is what was PAID, so a full sale removes
+  // 1,000,000 from invested — not the 980,000 the average-price route would give.
+  it('uses what the purchase cost, not its NAV cost', () => {
+    expect(fundCostBasis({ totalBasis: 1_000_000, totalUnits: 49, sellUnits: 49 })).toBe(1_000_000)
+  })
+})

--- a/lib/__tests__/goldWithdrawal.test.ts
+++ b/lib/__tests__/goldWithdrawal.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { goldCostBasis, goldUnitCost } from '../goldWithdrawal'
+
+// The cost basis used to be derived through a rounded per-unit price, which
+// rounds twice and drifts ABOVE the real basis whenever the principal isn't
+// divisible by the units. With the server measuring a withdrawal against the
+// balance (#587), that drift is the difference between "sell all" working and
+// being refused as an overdraw.
+
+describe('goldCostBasis', () => {
+  // The case that breaks a real sale: 123,456,789 / 10 = 12,345,678.9, rounded to
+  // 12,345,679, times 10 = 123,456,790 — one đồng more than the holding has.
+  it('a full sell takes exactly the remaining principal, however it divides', () => {
+    expect(goldCostBasis({ currentPrincipal: 123_456_789, units: 10, sellUnits: 10 }))
+      .toBe(123_456_789)
+  })
+
+  it('never exceeds the principal, at any quantity', () => {
+    const currentPrincipal = 123_456_789
+    const units = 10
+    for (const sellUnits of [0.5, 1, 3.3333, 7, 9.9999, 10]) {
+      expect(goldCostBasis({ currentPrincipal, units, sellUnits })!)
+        .toBeLessThanOrEqual(currentPrincipal)
+    }
+  })
+
+  it('splits a partial sale proportionally', () => {
+    expect(goldCostBasis({ currentPrincipal: 90_000_000, units: 10, sellUnits: 3 })).toBe(27_000_000)
+    // Rounded once, not twice: 2 × 123,456,789 / 10 = 24,691,357.8 → 24,691,358.
+    expect(goldCostBasis({ currentPrincipal: 123_456_789, units: 10, sellUnits: 2 })).toBe(24_691_358)
+  })
+
+  // A record showing fewer units than the user sells is stale, not a licence to
+  // claim more basis than the holding has.
+  it('caps a sale larger than the recorded units at the whole basis', () => {
+    expect(goldCostBasis({ currentPrincipal: 50_000_000, units: 2, sellUnits: 5 })).toBe(50_000_000)
+  })
+
+  it('has no basis to report without a principal or units', () => {
+    expect(goldCostBasis({ currentPrincipal: null, units: 10, sellUnits: 1 })).toBeNull()
+    expect(goldCostBasis({ currentPrincipal: 10_000_000, units: 0, sellUnits: 1 })).toBeNull()
+    expect(goldCostBasis({ currentPrincipal: 10_000_000, units: null, sellUnits: 1 })).toBeNull()
+  })
+})
+
+describe('goldUnitCost', () => {
+  it('is the rounded per-unit price, for display', () => {
+    expect(goldUnitCost(123_456_789, 10)).toBe(12_345_679)
+    expect(goldUnitCost(null, 10)).toBeNull()
+    expect(goldUnitCost(10_000_000, 0)).toBeNull()
+  })
+})

--- a/lib/fundWithdrawal.ts
+++ b/lib/fundWithdrawal.ts
@@ -1,0 +1,47 @@
+// The cost basis a fund sale takes out of its holding, shared by both sell
+// surfaces (AddTransactionSheet via addTransactionModel, and SellWithdrawSheet).
+//
+// ONE authoritative basis: `amount_vnd` — what the purchases actually cost,
+// fees included. That is not a preference, it is where the number lands:
+// dashboard/overview reduces the bucket by
+//
+//   acc.totalInvested -= Σ principal_withdrawn        // the invested/amount basis
+//   acc.totalNavCost  -= (units sold / units held) × totalNavCost
+//
+// so `principal_withdrawn` is subtracted from the AMOUNT basis, while the NAV cost
+// (Σ units × unit_price, fees excluded) is reduced by units and exists only to
+// derive the average entry price for display.
+//
+// Both sheets used to reconstruct the basis the other way round:
+//
+//   Math.round((sellAmount / currentValue) * (purchasePrice * units))
+//
+// where `purchasePrice` is itself `totalNavCost / totalUnits`. That divides, then
+// multiplies back, then rounds — so the figure posted was (a) NAV-based, subtracted
+// from an amount-based accumulator, and (b) carrying the error of a round trip
+// through an average. It could land a đồng or two above the real basis, which is
+// how it first surfaced: the #587 invariant refused an ordinary "sell everything",
+// and the trigger was given a tolerance to paper over it. Fixing the arithmetic
+// where it happens is the better end state — whatever the trigger tolerates is
+// money that stops being checked.
+//
+// So: the total remaining basis comes from the dashboard as a number
+// (`costBasis`), a full sale takes it exactly, and a partial sale is allocated by
+// UNITS out of that total — the same proportion the overview itself uses.
+
+export function fundCostBasis(input: {
+  /** Remaining basis of the (goal, fund) bucket: Σ amount_vnd, net of prior sells. */
+  totalBasis: number | null | undefined
+  /** Units the bucket still holds. */
+  totalUnits: number | null | undefined
+  /** Units being sold. */
+  sellUnits: number
+}): number | null {
+  const { totalBasis, totalUnits, sellUnits } = input
+  if (totalBasis == null || !totalUnits || totalUnits <= 0) return null
+  if (!(sellUnits > 0)) return 0
+  // Selling the lot (or more than the record shows) takes the whole basis. Stated,
+  // not derived, so no arithmetic can push it above what the holding cost.
+  if (sellUnits >= totalUnits) return Math.round(totalBasis)
+  return Math.round((sellUnits * totalBasis) / totalUnits)
+}

--- a/lib/goldWithdrawal.ts
+++ b/lib/goldWithdrawal.ts
@@ -1,0 +1,42 @@
+// Cost basis of the gold being sold, shared by the two sell surfaces
+// (AddTransactionSheet via addTransactionModel, and SellWithdrawSheet).
+//
+// Both used to derive it through a rounded per-unit price:
+//
+//   const goldBuyUnit = Math.round(purchasePrice / units)
+//   const goldCost    = Math.round(qty * goldBuyUnit)
+//
+// which rounds twice. Whenever the remaining principal isn't divisible by the
+// units, that drifts above the real basis: one lượng bought for 123,456,789 has
+// a per-unit price of 12,345,679 (rounded up from …8.9), so selling all 10 chỉ
+// posts 123,456,790 — one đồng more principal than the holding has. The server
+// now measures a withdrawal against the balance (#587), so that đồng is the
+// difference between "sell all" working and being refused as an overdraw.
+//
+// Dividing once fixes it, and a full sell is stated exactly rather than derived:
+// selling everything takes the whole remaining basis, whatever it is.
+//
+// The rounded per-unit figure is still fine for DISPLAY ("2 chỉ × 12,345,679"),
+// which is all it was ever meant for.
+
+export function goldCostBasis(input: {
+  /** Principal still in the holding, before this sale. */
+  currentPrincipal: number | null | undefined
+  /** Units (chỉ) the holding still has. */
+  units: number | null | undefined
+  /** Units (chỉ) being sold. */
+  sellUnits: number
+}): number | null {
+  const { currentPrincipal, units, sellUnits } = input
+  if (currentPrincipal == null || !units || units <= 0) return null
+  // Selling the lot (or more than the record shows) takes the whole basis. No
+  // arithmetic, so no rounding: the sale can never claim more than the holding.
+  if (sellUnits >= units) return Math.round(currentPrincipal)
+  return Math.round((sellUnits * currentPrincipal) / units)
+}
+
+/** The per-unit purchase price, for display only. */
+export function goldUnitCost(currentPrincipal: number | null | undefined, units: number | null | undefined): number | null {
+  if (currentPrincipal == null || !units || units <= 0) return null
+  return Math.round(currentPrincipal / units)
+}

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -225,10 +225,9 @@ begin
     -- Keyed off the PARENT's type, not the withdrawal's: the row's own asset_type
     -- is nullable and the route lets it be omitted. Bank and stock are unaffected —
     -- their valuation is principal-only, and a deposit has no units to move.
-    if v_parent_asset = 'gold'
-       and (coalesce(wd.units_withdrawn, 0) <= 0 or coalesce(wd.principal_withdrawn, 0) <= 0) then
-      raise exception 'withdrawal invariant: a gold sale must record both units_withdrawn and principal_withdrawn (got % units, % principal)',
-        wd.units_withdrawn, wd.principal_withdrawn using errcode = 'check_violation';
+    if v_parent_asset = 'gold' and coalesce(wd.units_withdrawn, 0) <= 0 then
+      raise exception 'withdrawal invariant: a gold sale must record units_withdrawn (got %)',
+        wd.units_withdrawn using errcode = 'check_violation';
     end if;
 
     -- A withdrawal that records no principal takes nothing out of the holding:
@@ -297,23 +296,28 @@ begin
     end if;
   end if;
 
-  if v_rows is not null then
-    -- FUND: the principal is BOUND TO THE UNITS, not merely capped. Capping the two
+  if v_rows is not null or v_parent_asset = 'gold' then
+    -- ANY quantity-valued holding — a fund bucket, or gold — has its principal
+    -- BOUND TO THE UNITS, not merely capped beside them. Capping the two
     -- independently let a sale of 1 unit out of 100 claim the whole basis and leave
-    -- 99 units with none, which corrupts every later sale's allocation and the P&L.
+    -- 99 units with none, which corrupts every later sale's allocation and the P&L,
+    -- and eventually makes the rest unsellable for lack of basis. Gold behaves the
+    -- same way: valueNonFundHolding prices it units × market and takes its basis
+    -- from amount_vnd.
     --
-    -- One allocation rule, shared with lib/fundWithdrawal and matching how the
-    -- overview itself reduces a bucket: a sale of ALL the remaining units takes the
-    -- remaining basis exactly, and a partial sale takes its units-proportional
-    -- share of it. ONE rounding rule: the two sides may differ by at most a đồng,
-    -- which is what rounding a proportional slice can produce.
+    -- One allocation rule, shared with lib/fundWithdrawal and lib/goldWithdrawal and
+    -- matching how the dashboard itself reduces a holding: a sale of ALL the
+    -- remaining units takes the remaining basis exactly, and a partial sale takes
+    -- its units-proportional share of it. ONE rounding rule: the two sides may
+    -- differ by at most a đồng, which is what rounding a proportional slice can
+    -- produce.
     if wd.units_withdrawn >= v_left_units - c_units_epsilon then
       v_expected := v_left;
     else
       v_expected := round(wd.units_withdrawn * v_left / v_left_units);
     end if;
     if abs(coalesce(wd.principal_withdrawn, 0) - v_expected) > c_dong_epsilon then
-      raise exception 'withdrawal invariant: a fund sale of % units out of % must take % of the % basis, not %',
+      raise exception 'withdrawal invariant: a sale of % units out of % must take % of the % basis, not %',
         wd.units_withdrawn, v_left_units, v_expected, v_left, wd.principal_withdrawn
         using errcode = 'check_violation';
     end if;
@@ -435,6 +439,91 @@ create trigger investment_transactions_withdrawal_balance
   for each row
   when (new.transaction_type = 'withdrawal')
   execute function public.enforce_withdrawal_within_balance();
+
+-- ── a bucket must be able to back the sales left in it ───────────────────────
+-- The row-by-row checks above measure a WITHDRAWAL against its bucket. Nothing
+-- measured the bucket after its PURCHASES moved away — and that is a reachable
+-- state: an assign and a sell of the same fund racing each other leaves the sale in
+-- the old bucket while its purchases move to the new one (the assign's UPDATE
+-- cannot see a withdrawal inserted after its snapshot, so the row is never
+-- relocated and no trigger fires for it). Verified with two sessions, and it
+-- happens with these triggers disabled too, so it is the shape of the move rather
+-- than anything this invariant introduced.
+--
+-- The dashboard then finds a withdrawal in a bucket with no accumulator, skips the
+-- subtraction entirely, and the sold units come back — silent net-worth inflation,
+-- exactly the class this migration exists to stop. So a relocation that would leave
+-- a bucket owing more than it holds is refused: a failed assign can be retried, a
+-- split bucket is found months later.
+create or replace function public.check_fund_bucket_solvent(p_user uuid, p_fund uuid, p_goal uuid)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_units      numeric;
+  v_out_units  numeric;
+  v_basis      bigint;
+  v_out_basis  bigint;
+begin
+  select coalesce(sum(t.units), 0), coalesce(sum(t.amount_vnd), 0)
+    into v_units, v_basis
+    from public.investment_transactions t
+   where t.user_id = p_user and t.fund_id = p_fund and t.asset_type = 'fund'
+     and t.transaction_type = 'investment'
+     and t.goal_id is not distinct from p_goal
+     and t.renewed_from_transaction_id is null
+     and t.units is not null;
+
+  select coalesce(sum(w.units_withdrawn), 0), coalesce(sum(w.principal_withdrawn), 0)
+    into v_out_units, v_out_basis
+    from public.investment_transactions w
+   where w.user_id = p_user and w.fund_id = p_fund and w.asset_type = 'fund'
+     and w.transaction_type = 'withdrawal'
+     and w.goal_id is not distinct from p_goal;
+
+  if v_out_units > v_units + 0.0001 or v_out_basis > v_basis + 1 then
+    raise exception 'withdrawal invariant: this fund bucket would be left owing % units / % of basis it does not hold',
+      v_out_units - v_units, v_out_basis - v_basis using errcode = 'check_violation';
+  end if;
+end;
+$$;
+
+comment on function public.check_fund_bucket_solvent(uuid, uuid, uuid) is
+  'Raises when a (goal, fund) bucket holds sales its purchases cannot back — the split a relocation can leave behind (#587).';
+
+revoke all on function public.check_fund_bucket_solvent(uuid, uuid, uuid) from public;
+revoke all on function public.check_fund_bucket_solvent(uuid, uuid, uuid) from anon, authenticated;
+
+create or replace function public.enforce_fund_bucket_after_move()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  -- Both ends: the bucket these purchases left, and the one they joined.
+  perform public.check_fund_bucket_solvent(new.user_id, new.fund_id, old.goal_id);
+  perform public.check_fund_bucket_solvent(new.user_id, new.fund_id, new.goal_id);
+  return null;
+end;
+$$;
+
+comment on function public.enforce_fund_bucket_after_move() is
+  'Re-measures both buckets when a fund purchase changes goal, at the end of the statement so a whole-bucket move is seen complete (#587).';
+
+drop trigger if exists investment_transactions_fund_bucket_moved on public.investment_transactions;
+create constraint trigger investment_transactions_fund_bucket_moved
+  after update of goal_id on public.investment_transactions
+  -- End of statement, like the withdrawal relocation check: an assign moves the
+  -- purchases and the sales in one UPDATE, and both ends are only settled once it
+  -- has finished.
+  deferrable initially immediate
+  for each row
+  when (new.transaction_type = 'investment' and new.fund_id is not null
+        and new.goal_id is distinct from old.goal_id)
+  execute function public.enforce_fund_bucket_after_move();
 
 -- ── deferred: a relocation, measured once the statement has landed ───────────
 create or replace function public.enforce_withdrawal_balance_after_move()

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -49,8 +49,20 @@ declare
   v_out_units     numeric;
   v_left          bigint;
   v_left_units    numeric;
+  v_parent_type   text;
+  v_parent_asset  text;
 begin
   if new.transaction_type is distinct from 'withdrawal' then return new; end if;
+
+  -- Deleting a source is an ordinary ledger action, and parent_transaction_id is
+  -- ON DELETE SET NULL — so Postgres orphans the children with an UPDATE that
+  -- lands right here. Measuring that update would refuse it (the row has just
+  -- lost the holding it drew on) and turn a plain delete into an error. The
+  -- leftover orphan is a shape this invariant would not let anyone CREATE;
+  -- cleaning those up as the source goes wants its own change.
+  if tg_op = 'UPDATE' and old.parent_transaction_id is not null and new.parent_transaction_id is null then
+    return new;
+  end if;
 
   -- The branch order is not a preference: it MIRRORS lib/withdrawalProgress, which
   -- keys any row with asset_type='fund' + fund_id by (goal, fund) and ignores its
@@ -96,7 +108,8 @@ begin
   elsif new.parent_transaction_id is not null then
     -- Bank / gold / stock: one source row. Lock it before measuring it, so two
     -- concurrent withdrawals of the same deposit serialize here.
-    select t.amount_vnd, t.units into v_principal, v_units
+    select t.amount_vnd, t.units, t.transaction_type, t.asset_type
+      into v_principal, v_units, v_parent_type, v_parent_asset
       from public.investment_transactions t
      where t.transaction_id = new.parent_transaction_id
        and t.user_id = new.user_id
@@ -105,6 +118,23 @@ begin
     -- make (#474 / #525); staying quiet here keeps that message the one the user
     -- sees instead of a confusing "no balance".
     if not found then return new; end if;
+
+    -- A withdrawal is not a holding, so parenting to one invents a balance out of
+    -- money that already left. Renewal snapshots ARE valid parents on purpose:
+    -- renew and collapse re-parent partial withdrawals onto them, which is how a
+    -- renewed deposit stops double-counting them (#585).
+    --
+    -- A parent that is a FUND purchase is left alone here, though review flagged
+    -- it: such a row is ignored by buildWithdrawalMaps (the fund is valued through
+    -- the goal/fund map, which never consults parentWdMap), so it is an UNCOUNTED
+    -- withdrawal rather than an overdraw — a valuation gap that predates this
+    -- change, and one supabase/tests/dca_seeding_heal.test.sql treats as data that
+    -- exists. Bounding it by the parent's own principal, as below, is the most
+    -- this invariant can honestly say about it.
+    if v_parent_type is distinct from 'investment' then
+      raise exception 'withdrawal draws on no holding: its parent % is not an investment',
+        new.parent_transaction_id using errcode = 'check_violation';
+    end if;
 
     select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
       into v_out_principal, v_out_units

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -269,9 +269,17 @@ begin
       raise exception 'withdrawal invariant: draws on no holding — it has neither a parent transaction nor a fund'
         using errcode = 'check_violation';
     end if;
-    -- Carrying neither is a settlement row with nothing to measure — a
-    -- held-for-merge with no source is exactly that shape, and giving it one is
-    -- #588's job.
+    -- Carrying neither delta leaves nothing to measure, and exactly ONE kind of row
+    -- is allowed to be in that state: a held-for-merge settlement whose source is
+    -- not recorded yet (#588 makes them source-backed). The exception is for that
+    -- pool, so nothing else may wear it — an ordinary withdrawal has to name what it
+    -- draws on, or it is cash leaving no holding at all. held_for_merge is in the
+    -- trigger's UPDATE OF list too, so an allowed held row cannot become an
+    -- ordinary one by dropping the flag.
+    if not wd.held_for_merge then
+      raise exception 'withdrawal invariant: draws on no holding — only a held-for-merge settlement may omit its source'
+        using errcode = 'check_violation';
+    end if;
     return;
   end if;
 
@@ -383,12 +391,20 @@ begin
     -- Its destination is only complete once the whole statement has landed (a
     -- fund assign moves purchases and sells together), so the deferred trigger
     -- measures this one.
+    --
+    -- Every column that can change what the row IS has to be listed here, or the
+    -- bypass hands out an exemption it was never meant to: held_for_merge was
+    -- missing, so clearing it turned a permitted no-source held settlement into an
+    -- ordinary sourceless withdrawal without anything re-measuring it. Keep this
+    -- list in step with the trigger's `update of` columns — goal_id is the only one
+    -- a relocation may touch.
     if new.principal_withdrawn is not distinct from old.principal_withdrawn
        and new.units_withdrawn is not distinct from old.units_withdrawn
        and new.parent_transaction_id is not distinct from old.parent_transaction_id
        and new.fund_id is not distinct from old.fund_id
        and new.asset_type is not distinct from old.asset_type
-       and new.transaction_type = old.transaction_type then
+       and new.transaction_type = old.transaction_type
+       and new.held_for_merge = old.held_for_merge then
       return new;
     end if;
   end if;
@@ -410,9 +426,11 @@ create trigger investment_transactions_withdrawal_balance
   --     nothing down, so it is not measured) and then activated by a one-column
   --     update that never fired this trigger.
   --   • asset_type — it picks the fund-bucket branch over the parent branch.
+  --   • held_for_merge — it is what licenses the no-source shape, so clearing it
+  --     has to re-measure the row rather than leave the exception behind.
   before insert or update of
     transaction_type, asset_type, principal_withdrawn, units_withdrawn,
-    parent_transaction_id, fund_id, goal_id
+    parent_transaction_id, fund_id, goal_id, held_for_merge
   on public.investment_transactions
   for each row
   when (new.transaction_type = 'withdrawal')

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -52,28 +52,14 @@ declare
 begin
   if new.transaction_type is distinct from 'withdrawal' then return new; end if;
 
-  if new.parent_transaction_id is not null then
-    -- Lock the source before measuring it (see the header): this is what makes
-    -- two concurrent withdrawals of the same deposit serialize.
-    select t.amount_vnd, t.units into v_principal, v_units
-      from public.investment_transactions t
-     where t.transaction_id = new.parent_transaction_id
-       and t.user_id = new.user_id
-       for update;
-    -- A parent that isn't the writer's own is the ownership trigger's refusal to
-    -- make (#474 / #525); staying quiet here keeps that message the one the user
-    -- sees instead of a confusing "no balance".
-    if not found then return new; end if;
-
-    select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
-      into v_out_principal, v_out_units
-      from public.investment_transactions w
-     where w.parent_transaction_id = new.parent_transaction_id
-       and w.transaction_type = 'withdrawal'
-       and w.transaction_id <> new.transaction_id;   -- an UPDATE re-measures without itself
-
-  elsif new.asset_type = 'fund' and new.fund_id is not null then
-    -- Lock the bucket's investment rows first, same ordering as above. Pending
+  -- The branch order is not a preference: it MIRRORS lib/withdrawalProgress, which
+  -- keys any row with asset_type='fund' + fund_id by (goal, fund) and ignores its
+  -- parent. Measuring such a row against a parent instead would check a balance
+  -- nothing draws down — a fat holding in one goal waving through a phantom fund
+  -- sell in another, since the API accepts both fields on one row.
+  if new.asset_type = 'fund' and new.fund_id is not null then
+    -- Lock the bucket's investment rows before measuring them (see the header):
+    -- this is what makes two concurrent sells of the same bucket serialize. Pending
     -- DCA seeds (units is null) are excluded: they carry a planned amount with no
     -- units bought yet, the dashboard never values them, so they hold nothing to
     -- sell. Renewal snapshots are history copies, not holdings.
@@ -106,6 +92,26 @@ begin
        and w.transaction_type = 'withdrawal'
        and w.goal_id is not distinct from new.goal_id
        and w.transaction_id <> new.transaction_id;
+
+  elsif new.parent_transaction_id is not null then
+    -- Bank / gold / stock: one source row. Lock it before measuring it, so two
+    -- concurrent withdrawals of the same deposit serialize here.
+    select t.amount_vnd, t.units into v_principal, v_units
+      from public.investment_transactions t
+     where t.transaction_id = new.parent_transaction_id
+       and t.user_id = new.user_id
+       for update;
+    -- A parent that isn't the writer's own is the ownership trigger's refusal to
+    -- make (#474 / #525); staying quiet here keeps that message the one the user
+    -- sees instead of a confusing "no balance".
+    if not found then return new; end if;
+
+    select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
+      into v_out_principal, v_out_units
+      from public.investment_transactions w
+     where w.parent_transaction_id = new.parent_transaction_id
+       and w.transaction_type = 'withdrawal'
+       and w.transaction_id <> new.transaction_id;   -- an UPDATE re-measures without itself
 
   else
     -- Nothing identifiable to draw down: a held-for-merge settlement with no
@@ -142,7 +148,12 @@ comment on function public.enforce_withdrawal_within_balance() is
 
 drop trigger if exists investment_transactions_withdrawal_balance on public.investment_transactions;
 create trigger investment_transactions_withdrawal_balance
-  before insert or update of principal_withdrawn, units_withdrawn, parent_transaction_id, fund_id, goal_id
+  -- transaction_type is in the list because the WHEN clause reads it: without it,
+  -- a row could be staged as an investment carrying principal_withdrawn (which
+  -- draws nothing down, so it is not measured) and then turned into a withdrawal
+  -- by a one-column update that never fires this trigger.
+  before insert or update of
+    transaction_type, principal_withdrawn, units_withdrawn, parent_transaction_id, fund_id, goal_id
   on public.investment_transactions
   for each row
   when (new.transaction_type = 'withdrawal')

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -57,10 +57,21 @@ begin
   -- Deleting a source is an ordinary ledger action, and parent_transaction_id is
   -- ON DELETE SET NULL — so Postgres orphans the children with an UPDATE that
   -- lands right here. Measuring that update would refuse it (the row has just
-  -- lost the holding it drew on) and turn a plain delete into an error. The
-  -- leftover orphan is a shape this invariant would not let anyone CREATE;
-  -- cleaning those up as the source goes wants its own change.
+  -- lost the holding it drew on) and turn a plain delete into an error.
+  --
+  -- Only THAT may orphan a row. Detaching a withdrawal from a source that is
+  -- still there restores the holding to full value while the withdrawal is filed
+  -- under no key at all — the same escape the rest of this function exists to
+  -- close. The tell is the source itself: by the time the FK action fires, the
+  -- parent row is already deleted and invisible to this query.
   if tg_op = 'UPDATE' and old.parent_transaction_id is not null and new.parent_transaction_id is null then
+    if exists (select 1 from public.investment_transactions t
+                where t.transaction_id = old.parent_transaction_id) then
+      raise exception 'withdrawal cannot be detached from holding %, which still exists',
+        old.parent_transaction_id using errcode = 'check_violation';
+    end if;
+    -- The source is gone. The leftover orphan is a shape this invariant would not
+    -- let anyone CREATE; cleaning those up as the source goes is issue #607.
     return new;
   end if;
 

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -28,12 +28,27 @@
 --   • fund — a sell has no parent row; the overview aggregates funds per
 --     (goal_id, fund_id), so that bucket is the balance a sell draws down.
 --
+-- Why the check runs from TWO triggers. A new claim (an insert, or an edit that
+-- raises the amounts) is measured IMMEDIATELY: the error points at the statement
+-- that caused it, and the lock is then held for the rest of the transaction.
+-- But MOVING a withdrawal between buckets is a multi-row change —
+-- POST /api/v1/fund-investments/assign relocates a fund's purchases AND its sells
+-- in one UPDATE, and deleting a goal does the same through ON DELETE SET NULL. A
+-- row-level trigger sees such a statement half-applied, so whether the destination
+-- bucket looked complete depended on heap order: an ordinary "buy, sell, edit the
+-- buy, assign the fund to a goal" failed. Relocations are therefore measured by a
+-- DEFERRED constraint trigger, once the whole statement has landed and the
+-- destination bucket is whatever it is going to be.
+--
 -- Not covered here, deliberately: lowering a *source's* amount_vnd below what has
 -- already been withdrawn (an edit, not a withdrawal) is the mirror hole and wants
 -- its own guard — collapse and renewal both rewrite amounts mid-transaction, so
 -- checking them needs care this change doesn't have room for.
-create or replace function public.enforce_withdrawal_within_balance()
-returns trigger
+
+-- The measurement itself, so the two triggers below share one implementation
+-- instead of drifting apart. Raises check_violation; returns quietly otherwise.
+create or replace function public.check_withdrawal_balance(wd public.investment_transactions)
+returns void
 language plpgsql
 security definer
 set search_path = ''
@@ -50,52 +65,17 @@ declare
   v_left          bigint;
   v_left_units    numeric;
   v_parent_type   text;
-  v_parent_asset  text;
 begin
-  if new.transaction_type is distinct from 'withdrawal' then return new; end if;
+  if wd.transaction_type is distinct from 'withdrawal' then return; end if;
 
   -- A negative withdrawal runs the ledger backwards: it ADDS to the holding and
   -- banks a credit the next withdrawal can spend (the sums below are signed, and
   -- so is lib/depositValuation's subtraction). Nothing in the schema stops one, so
   -- the invariant does — before anything is measured, since a negative amount
   -- would poison the measurement itself.
-  if coalesce(new.principal_withdrawn, 0) < 0 or coalesce(new.units_withdrawn, 0) < 0 then
+  if coalesce(wd.principal_withdrawn, 0) < 0 or coalesce(wd.units_withdrawn, 0) < 0 then
     raise exception 'withdrawal amounts cannot be negative (principal %, units %)',
-      new.principal_withdrawn, new.units_withdrawn using errcode = 'check_violation';
-  end if;
-
-  -- Deleting a source is an ordinary ledger action, and parent_transaction_id is
-  -- ON DELETE SET NULL — so Postgres orphans the children with an UPDATE that
-  -- lands right here. Measuring that update would refuse it (the row has just
-  -- lost the holding it drew on) and turn a plain delete into an error.
-  --
-  -- Only THAT may orphan a row. Detaching a withdrawal from a source that is
-  -- still there restores the holding to full value while the withdrawal is filed
-  -- under no key at all — the same escape the rest of this function exists to
-  -- close. The tell is the source itself: by the time the FK action fires, the
-  -- parent row is already deleted and invisible to this query.
-  -- Both links a withdrawal hangs on are ON DELETE SET NULL, so both deletions
-  -- arrive here the same way: the deposit (parent_transaction_id) and the fund
-  -- (fund_id, which a sell is keyed by).
-  if tg_op = 'UPDATE' then
-    if old.parent_transaction_id is not null and new.parent_transaction_id is null then
-      if exists (select 1 from public.investment_transactions t
-                  where t.transaction_id = old.parent_transaction_id) then
-        raise exception 'withdrawal cannot be detached from holding %, which still exists',
-          old.parent_transaction_id using errcode = 'check_violation';
-      end if;
-      -- The source is gone. The leftover orphan is a shape this invariant would
-      -- not let anyone CREATE; cleaning those up as the source goes is issue #607.
-      return new;
-    end if;
-
-    if old.fund_id is not null and new.fund_id is null then
-      if exists (select 1 from public.funds f where f.id = old.fund_id) then
-        raise exception 'withdrawal cannot be detached from fund %, which still exists',
-          old.fund_id using errcode = 'check_violation';
-      end if;
-      return new;   -- the fund was deleted; same story as above
-    end if;
+      wd.principal_withdrawn, wd.units_withdrawn using errcode = 'check_violation';
   end if;
 
   -- The branch order is not a preference: it MIRRORS lib/withdrawalProgress, which
@@ -103,7 +83,17 @@ begin
   -- parent. Measuring such a row against a parent instead would check a balance
   -- nothing draws down — a fat holding in one goal waving through a phantom fund
   -- sell in another, since the API accepts both fields on one row.
-  if new.asset_type = 'fund' and new.fund_id is not null then
+  if wd.asset_type = 'fund' and wd.fund_id is not null then
+    -- A fund sell moves BOTH ledger deltas or it disagrees with the valuation:
+    -- with no units the overview skips the whole subtraction (it bails on
+    -- `wd.units <= 0`, so the cost basis is never removed either) and the holding
+    -- keeps its full value; with no principal the units fall while the cost basis
+    -- stays, and P&L is wrong. Neither is a shape the sheets produce.
+    if coalesce(wd.units_withdrawn, 0) <= 0 or coalesce(wd.principal_withdrawn, 0) <= 0 then
+      raise exception 'a fund sell must record both units_withdrawn and principal_withdrawn (got % units, % principal)',
+        wd.units_withdrawn, wd.principal_withdrawn using errcode = 'check_violation';
+    end if;
+
     -- Both sides of the bucket carry `asset_type = 'fund'`, because that is what
     -- the valuation counts: a row whose asset_type was edited off 'fund' keeps its
     -- fund_id (the PUT clears fund_id only when that field is sent) but is valued
@@ -116,11 +106,11 @@ begin
     -- sell. Renewal snapshots are history copies, not holdings.
     perform 1
       from public.investment_transactions t
-     where t.user_id = new.user_id
-       and t.fund_id = new.fund_id
+     where t.user_id = wd.user_id
+       and t.fund_id = wd.fund_id
        and t.asset_type = 'fund'
        and t.transaction_type = 'investment'
-       and t.goal_id is not distinct from new.goal_id
+       and t.goal_id is not distinct from wd.goal_id
        and t.renewed_from_transaction_id is null
        and t.units is not null
      order by t.transaction_id      -- a stable lock order; concurrent sells can't deadlock
@@ -129,37 +119,37 @@ begin
     select coalesce(sum(t.amount_vnd), 0), coalesce(sum(t.units), 0)
       into v_principal, v_units
       from public.investment_transactions t
-     where t.user_id = new.user_id
-       and t.fund_id = new.fund_id
+     where t.user_id = wd.user_id
+       and t.fund_id = wd.fund_id
        and t.asset_type = 'fund'
        and t.transaction_type = 'investment'
-       and t.goal_id is not distinct from new.goal_id
+       and t.goal_id is not distinct from wd.goal_id
        and t.renewed_from_transaction_id is null
        and t.units is not null;
 
     select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
       into v_out_principal, v_out_units
       from public.investment_transactions w
-     where w.user_id = new.user_id
-       and w.fund_id = new.fund_id
+     where w.user_id = wd.user_id
+       and w.fund_id = wd.fund_id
        and w.asset_type = 'fund'
        and w.transaction_type = 'withdrawal'
-       and w.goal_id is not distinct from new.goal_id
-       and w.transaction_id <> new.transaction_id;
+       and w.goal_id is not distinct from wd.goal_id
+       and w.transaction_id <> wd.transaction_id;   -- measured without itself
 
-  elsif new.parent_transaction_id is not null then
+  elsif wd.parent_transaction_id is not null then
     -- Bank / gold / stock: one source row. Lock it before measuring it, so two
     -- concurrent withdrawals of the same deposit serialize here.
-    select t.amount_vnd, t.units, t.transaction_type, t.asset_type
-      into v_principal, v_units, v_parent_type, v_parent_asset
+    select t.amount_vnd, t.units, t.transaction_type
+      into v_principal, v_units, v_parent_type
       from public.investment_transactions t
-     where t.transaction_id = new.parent_transaction_id
-       and t.user_id = new.user_id
+     where t.transaction_id = wd.parent_transaction_id
+       and t.user_id = wd.user_id
        for update;
     -- A parent that isn't the writer's own is the ownership trigger's refusal to
     -- make (#474 / #525); staying quiet here keeps that message the one the user
     -- sees instead of a confusing "no balance".
-    if not found then return new; end if;
+    if not found then return; end if;
 
     -- A withdrawal is not a holding, so parenting to one invents a balance out of
     -- money that already left. Renewal snapshots ARE valid parents on purpose:
@@ -171,63 +161,127 @@ begin
     -- the goal/fund map, which never consults parentWdMap), so it is an UNCOUNTED
     -- withdrawal rather than an overdraw — a valuation gap that predates this
     -- change, and one supabase/tests/dca_seeding_heal.test.sql treats as data that
-    -- exists. Bounding it by the parent's own principal, as below, is the most
-    -- this invariant can honestly say about it.
+    -- exists (issue #606). Bounding it by the parent's own principal, as below, is
+    -- the most this invariant can honestly say about it.
     if v_parent_type is distinct from 'investment' then
       raise exception 'withdrawal draws on no holding: its parent % is not an investment',
-        new.parent_transaction_id using errcode = 'check_violation';
+        wd.parent_transaction_id using errcode = 'check_violation';
     end if;
 
     select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
       into v_out_principal, v_out_units
       from public.investment_transactions w
-     where w.parent_transaction_id = new.parent_transaction_id
+     where w.parent_transaction_id = wd.parent_transaction_id
        and w.transaction_type = 'withdrawal'
-       and w.transaction_id <> new.transaction_id;   -- an UPDATE re-measures without itself
+       and w.transaction_id <> wd.transaction_id;
 
   else
     -- Nothing identifiable to draw down. A row taking principal or units out of no
     -- holding at all is not a withdrawal — buildWithdrawalMaps files it under
     -- neither key, so it subtracts from nothing while the record claims cash left.
     -- Reachable by editing a fund sell's asset_type off 'fund' (the fund_id stays,
-    -- but the row leaves the fund bucket), which is why asset_type fires this
+    -- but the row leaves the fund bucket), which is why asset_type fires the
     -- trigger: running is not enough, the new shape has to be refused.
-    if coalesce(new.principal_withdrawn, 0) > 0 or coalesce(new.units_withdrawn, 0) > 0 then
+    if coalesce(wd.principal_withdrawn, 0) > 0 or coalesce(wd.units_withdrawn, 0) > 0 then
       raise exception 'withdrawal draws on no holding: it has neither a parent transaction nor a fund'
         using errcode = 'check_violation';
     end if;
     -- Carrying neither is a settlement row with nothing to measure — a
     -- held-for-merge with no source is exactly that shape, and giving it one is
     -- #588's job.
-    return new;
+    return;
   end if;
 
-  if coalesce(new.principal_withdrawn, 0) > 0 then
+  if coalesce(wd.principal_withdrawn, 0) > 0 then
     v_left := coalesce(v_principal, 0) - v_out_principal;
-    if new.principal_withdrawn > v_left then
+    if wd.principal_withdrawn > v_left then
       raise exception 'withdrawal of % exceeds the remaining balance of % on this holding',
-        new.principal_withdrawn, v_left using errcode = 'check_violation';
+        wd.principal_withdrawn, v_left using errcode = 'check_violation';
     end if;
   end if;
 
-  if coalesce(new.units_withdrawn, 0) > 0 then
+  if coalesce(wd.units_withdrawn, 0) > 0 then
     v_left_units := coalesce(v_units, 0) - v_out_units;
     -- The tolerance rounds a real balance; it does not create one. Applied to an
-    -- empty holding it would hand every sold-out bucket 0.0001 units it never
-    -- had — and since principal_withdrawn may be omitted, that is a withdrawal
-    -- row (carrying any amount_vnd) against a holding that is gone.
-    if new.units_withdrawn > v_left_units + (case when v_left_units > 0 then c_units_epsilon else 0 end) then
+    -- empty holding it would hand every sold-out bucket 0.0001 units it never had.
+    if wd.units_withdrawn > v_left_units + (case when v_left_units > 0 then c_units_epsilon else 0 end) then
       raise exception 'withdrawal of % units exceeds the remaining balance of % units on this holding',
-        new.units_withdrawn, v_left_units using errcode = 'check_violation';
+        wd.units_withdrawn, v_left_units using errcode = 'check_violation';
+    end if;
+  end if;
+end;
+$$;
+
+comment on function public.check_withdrawal_balance(public.investment_transactions) is
+  'Raises when a withdrawal/sell would take more principal or units than its holding still has. Measured under a lock on the source, so concurrent sells cannot both pass (#587).';
+
+-- ── immediate: a new or increased claim ──────────────────────────────────────
+create or replace function public.enforce_withdrawal_within_balance()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if tg_op = 'UPDATE' then
+    -- Deleting a source is an ordinary ledger action, and BOTH links a withdrawal
+    -- hangs on are ON DELETE SET NULL — the deposit (parent_transaction_id) and
+    -- the fund (fund_id, which a sell is keyed by). So Postgres orphans the
+    -- children with an UPDATE that lands right here, and measuring it would refuse
+    -- the row (it just lost the holding it drew on) and turn a plain delete into an
+    -- error.
+    --
+    -- Only the FK may orphan a row. Detaching a withdrawal from a source that is
+    -- still there restores the holding to full value while the withdrawal is filed
+    -- under no key at all — the same escape this function exists to close. The tell
+    -- is the source itself: by the time the FK action fires, the referenced row is
+    -- already deleted and invisible to these queries.
+    if old.parent_transaction_id is not null and new.parent_transaction_id is null then
+      if exists (select 1 from public.investment_transactions t
+                  where t.transaction_id = old.parent_transaction_id) then
+        raise exception 'withdrawal cannot be detached from holding %, which still exists',
+          old.parent_transaction_id using errcode = 'check_violation';
+      end if;
+      -- The source is gone. If the row still names a fund it now draws on that
+      -- bucket instead, so it has to be re-measured rather than waved through;
+      -- with nothing left to draw on, the leftover orphan is a shape this
+      -- invariant would not let anyone CREATE (issue #607).
+      if new.fund_id is null then return new; end if;
+    end if;
+
+    if old.fund_id is not null and new.fund_id is null then
+      if exists (select 1 from public.funds f where f.id = old.fund_id) then
+        raise exception 'withdrawal cannot be detached from fund %, which still exists',
+          old.fund_id using errcode = 'check_violation';
+      end if;
+      -- The fund is gone. buildWithdrawalMaps now keys the row by its PARENT, so
+      -- if it has one, it must be measured against that balance — a sell that fit
+      -- the fund bucket can overdraw a smaller deposit. With no parent either,
+      -- it is the orphan case above.
+      if new.parent_transaction_id is null then return new; end if;
+    end if;
+
+    -- A pure relocation: the claim is unchanged, only which bucket it sits in.
+    -- Its destination is only complete once the whole statement has landed (a
+    -- fund assign moves purchases and sells together), so the deferred trigger
+    -- measures this one.
+    if new.principal_withdrawn is not distinct from old.principal_withdrawn
+       and new.units_withdrawn is not distinct from old.units_withdrawn
+       and new.parent_transaction_id is not distinct from old.parent_transaction_id
+       and new.fund_id is not distinct from old.fund_id
+       and new.asset_type is not distinct from old.asset_type
+       and new.transaction_type = old.transaction_type then
+      return new;
     end if;
   end if;
 
+  perform public.check_withdrawal_balance(new);
   return new;
 end;
 $$;
 
 comment on function public.enforce_withdrawal_within_balance() is
-  'Refuses a withdrawal/sell that would take more principal or units than its holding still has, measured under a lock on the source so concurrent sells cannot both pass (#587).';
+  'Measures a new or increased withdrawal claim against its holding as it is written (#587).';
 
 drop trigger if exists investment_transactions_withdrawal_balance on public.investment_transactions;
 create trigger investment_transactions_withdrawal_balance
@@ -245,3 +299,45 @@ create trigger investment_transactions_withdrawal_balance
   for each row
   when (new.transaction_type = 'withdrawal')
   execute function public.enforce_withdrawal_within_balance();
+
+-- ── deferred: a relocation, measured once the statement has landed ───────────
+create or replace function public.enforce_withdrawal_balance_after_move()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row public.investment_transactions;
+begin
+  -- Re-read the row rather than trusting the queued image: by commit it may have
+  -- moved again, or been deleted, and the balance question is about what is
+  -- actually there now.
+  select * into v_row from public.investment_transactions t
+   where t.transaction_id = new.transaction_id;
+  if not found then return null; end if;
+  if v_row.transaction_type is distinct from 'withdrawal' then return null; end if;
+  -- Orphaned by a delete (see the immediate trigger): nothing to measure against,
+  -- and refusing here would fail the delete that caused it.
+  if v_row.fund_id is null and v_row.parent_transaction_id is null then return null; end if;
+
+  perform public.check_withdrawal_balance(v_row);
+  return null;
+end;
+$$;
+
+comment on function public.enforce_withdrawal_balance_after_move() is
+  'Re-measures a withdrawal that changed bucket, deferred to the end of the statement so a multi-row move (a fund assign, a deleted goal) is seen complete (#587).';
+
+drop trigger if exists investment_transactions_withdrawal_balance_moved on public.investment_transactions;
+create constraint trigger investment_transactions_withdrawal_balance_moved
+  after update of goal_id on public.investment_transactions
+  -- INITIALLY IMMEDIATE on a constraint trigger means "at the end of the
+  -- statement", not "during it" — which is exactly the boundary a multi-row move
+  -- needs. Deferring to commit would work too, but would report the problem far
+  -- from the statement that caused it (and a caller can still SET CONSTRAINTS
+  -- DEFERRED when it genuinely needs to move a bucket in several statements).
+  deferrable initially immediate
+  for each row
+  when (new.transaction_type = 'withdrawal' and new.goal_id is distinct from old.goal_id)
+  execute function public.enforce_withdrawal_balance_after_move();

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -71,14 +71,11 @@ declare
   v_left_units    numeric;
   v_parent_type   text;
   v_parent_asset  text;
-  -- Purchases in the fund bucket, and the rounding slack they imply (below).
-  -- Null outside the fund branch, where the basis is one row's stored amount and
-  -- there is nothing to reconcile.
+  -- Purchases in the fund bucket (null outside it) and prior sales out of it —
+  -- the second bounds how much independent rounding the slack has to explain.
   v_rows          int;
+  v_out_rows      int;
   v_slack         bigint;
-  -- Σ(units × unit_price) for the fund bucket — the basis the dashboard's avg
-  -- entry price, and so the sell builders, work from. Null outside that branch.
-  v_nav_basis     numeric;
 begin
   if wd.transaction_type is distinct from 'withdrawal' then return; end if;
 
@@ -130,17 +127,19 @@ begin
      order by t.transaction_id      -- a stable lock order; concurrent sells can't deadlock
        for update;
 
-    -- Two bases exist for a fund's principal and they can disagree outright, not
-    -- just by rounding: amount_vnd, units and unit_price are independent fields on
-    -- the POST route (and the sheet lets units be typed by hand), so a purchase may
-    -- store 1,000,000 with 60 units at 20,000 — a NAV cost of 1,200,000. The
-    -- dashboard's avg entry price, and therefore what the sell builders post, uses
-    -- the NAV basis; Σ amount_vnd is what the row says it cost. Bound by whichever
-    -- is larger: refusing on the smaller one refuses an ordinary full sale, and for
-    -- funds the UNITS check below is the load-bearing one anyway.
-    select coalesce(sum(t.amount_vnd), 0), coalesce(sum(t.units), 0), count(*),
-           coalesce(sum(t.units * coalesce(t.unit_price, 0)), 0)
-      into v_principal, v_units, v_rows, v_nav_basis
+    -- ONE authoritative basis: Σ amount_vnd, what the purchases cost. That is
+    -- where the number lands — dashboard/overview does
+    --   acc.totalInvested -= Σ principal_withdrawn
+    -- against exactly this sum, while the NAV cost (Σ units × unit_price, fees
+    -- excluded) is reduced by units and only feeds the average entry price.
+    --
+    -- The sheets used to post a NAV-derived figure into that amount-based
+    -- accumulator, reconstructed through the averaged purchasePrice, and this check
+    -- grew a tolerance to accommodate it. lib/fundWithdrawal now takes the basis
+    -- from the dashboard directly (a full sale takes it exactly), so the two agree
+    -- and the tolerance below covers only what rounding can still explain.
+    select coalesce(sum(t.amount_vnd), 0), coalesce(sum(t.units), 0), count(*)
+      into v_principal, v_units, v_rows
       from public.investment_transactions t
      where t.user_id = wd.user_id
        and t.fund_id = wd.fund_id
@@ -150,8 +149,8 @@ begin
        and t.renewed_from_transaction_id is null
        and t.units is not null;
 
-    select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
-      into v_out_principal, v_out_units
+    select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0), count(*)
+      into v_out_principal, v_out_units, v_out_rows
       from public.investment_transactions w
      where w.user_id = wd.user_id
        and w.fund_id = wd.fund_id
@@ -241,18 +240,14 @@ begin
   end if;
 
   if coalesce(wd.principal_withdrawn, 0) > 0 then
-    -- For a fund bucket, take the larger of the two bases (see above).
-    v_left := greatest(coalesce(v_principal, 0), ceil(coalesce(v_nav_basis, 0))::bigint)
-              - v_out_principal;
-    -- A fund bucket's principal is measured as Σ amount_vnd, while the sell
-    -- builders derive what they post from the NAV cost basis (Σ units × unit_price,
-    -- via the dashboard's avg entry price). Each purchase's stored amount_vnd was
-    -- itself rounded, so the two bases can differ by under half a đồng per row —
-    -- and a FULL sell of a multi-purchase bucket could land a few đồng above
-    -- Σ amount_vnd and be refused. Allow exactly that slack: half a đồng per
-    -- purchase, plus one for the sell's own rounding. Nothing outside the fund
-    -- branch gets any (v_rows is null there — one row's stored amount IS the basis).
-    v_slack := case when v_rows is null then 0 else ceil((v_rows + 1) * 0.5) end;
+    v_left := coalesce(v_principal, 0) - v_out_principal;
+    -- What rounding can still explain, and nothing more. A fund bucket's basis is
+    -- allocated by units, so each PRIOR partial sale rounded its own slice
+    -- independently (≤ half a đồng each) and this one rounds its own. A single
+    -- deposit has no allocation to round — v_rows is null outside the fund branch —
+    -- so it gets none. Anything larger than this is a real overdraw, and the
+    -- arithmetic that used to need more than this now lives in lib/fundWithdrawal.
+    v_slack := case when v_rows is null then 0 else ceil((v_out_rows + 1) * 0.5) end;
     if wd.principal_withdrawn > v_left + v_slack then
       raise exception 'withdrawal invariant: % exceeds the remaining balance of % on this holding',
         wd.principal_withdrawn, v_left using errcode = 'check_violation';

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -70,6 +70,7 @@ declare
   v_left          bigint;
   v_left_units    numeric;
   v_parent_type   text;
+  v_parent_asset  text;
   -- Purchases in the fund bucket, and the rounding slack they imply (below).
   -- Null outside the fund branch, where the basis is one row's stored amount and
   -- there is nothing to reconcile.
@@ -162,8 +163,8 @@ begin
   elsif wd.parent_transaction_id is not null then
     -- Bank / gold / stock: one source row. Lock it before measuring it, so two
     -- concurrent withdrawals of the same deposit serialize here.
-    select t.amount_vnd, t.units, t.transaction_type
-      into v_principal, v_units, v_parent_type
+    select t.amount_vnd, t.units, t.transaction_type, t.asset_type
+      into v_principal, v_units, v_parent_type, v_parent_asset
       from public.investment_transactions t
      where t.transaction_id = wd.parent_transaction_id
        and t.user_id = wd.user_id
@@ -190,6 +191,20 @@ begin
         wd.parent_transaction_id using errcode = 'check_violation';
     end if;
 
+    -- Gold is the one non-fund holding valued by QUANTITY: valueNonFundHolding
+    -- prices it as units × gold price and takes its cost basis from amount_vnd. So
+    -- a sale must move both, exactly as a fund sell must. Principal alone drops the
+    -- basis while every chỉ stays in net worth — P&L inflated and the sold gold
+    -- never leaves; units alone removes the metal and leaves its cost behind.
+    -- Keyed off the PARENT's type, not the withdrawal's: the row's own asset_type
+    -- is nullable and the route lets it be omitted. Bank and stock are unaffected —
+    -- their valuation is principal-only, and a deposit has no units to move.
+    if v_parent_asset = 'gold'
+       and (coalesce(wd.units_withdrawn, 0) <= 0 or coalesce(wd.principal_withdrawn, 0) <= 0) then
+      raise exception 'withdrawal invariant: a gold sale must record both units_withdrawn and principal_withdrawn (got % units, % principal)',
+        wd.units_withdrawn, wd.principal_withdrawn using errcode = 'check_violation';
+    end if;
+
     select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
       into v_out_principal, v_out_units
       from public.investment_transactions w
@@ -199,7 +214,13 @@ begin
        -- that is keyed by a fund draws on that bucket, not on this parent, so
        -- counting it here too would charge it twice and make an ordinary later
        -- withdrawal of this deposit look like an overdraw.
-       and not (w.asset_type = 'fund' and w.fund_id is not null)
+       --
+       -- coalesce, because asset_type is nullable and the route lets a caller omit
+       -- it: written bare, the predicate is NULL for a row with a fund_id and no
+       -- asset_type, which DROPS it from this sum — while buildWithdrawalMaps
+       -- counts that row against the parent (the fund key needs asset_type =
+       -- 'fund'). Two full withdrawals of one deposit both passed that way.
+       and not coalesce(w.asset_type = 'fund' and w.fund_id is not null, false)
        and w.transaction_id <> wd.transaction_id;
 
   else

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -21,12 +21,38 @@
 -- snapshot — so the second withdrawal sees the first one and is measured against
 -- the balance it left behind. Reading the sums first would let both pass.
 --
--- Two balances, mirroring the two buckets the dashboard aggregates:
+-- ─── The withdrawal decision table ───────────────────────────────────────────
+-- What a valid withdrawal looks like, per kind. This is the contract; every row
+-- here has direct coverage in supabase/tests/withdrawal_balance.test.sql, and each
+-- invalid near-neighbour has a refusal test. The schema alone cannot express it —
+-- asset_type, fund_id, parent_transaction_id, principal_withdrawn and
+-- units_withdrawn are all nullable and can coexist in shapes the UI never makes —
+-- so the API states it too (POST /api/v1/investment-transactions), and this
+-- function enforces it over whatever reaches the table.
+--
+--   Kind        | Holding (balance) key   | Required deltas
+--   ------------|-------------------------|--------------------------------------
+--   Fund        | (goal_id, fund_id)      | units > 0, and principal = the
+--               |   asset_type='fund'     | units-proportional share of the
+--               |                         | remaining basis (±1 đồng)
+--   Gold        | parent_transaction_id   | units > 0 and principal > 0
+--   Bank/stock  | parent_transaction_id   | principal > 0 (no units to move)
+--   Held-for-   | none, by definition     | claims NOTHING: no principal, no
+--   merge with  |                         | units. Making it source-backed is
+--   no source   |                         | #588; it is not silently treated as
+--               |                         | an ordinary withdrawal here.
+--
+-- The two balances the keys resolve to, mirroring what the dashboard aggregates:
 --   • bank / gold / stock — one source row, addressed by parent_transaction_id:
 --     remaining principal = amount_vnd − Σ principal_withdrawn, remaining units =
 --     units − Σ units_withdrawn (lib/depositValuation values it exactly so).
 --   • fund — a sell has no parent row; the overview aggregates funds per
 --     (goal_id, fund_id), so that bucket is the balance a sell draws down.
+--
+-- Fund principal is BOUND to units, not merely capped: capping them independently
+-- let a sale of 1 unit out of 100 claim the whole basis and leave 99 units with
+-- none. One allocation rule, shared by lib/fundWithdrawal (what the sheets post),
+-- the overview (how it reduces a bucket) and this function (what it will accept).
 --
 -- Why the check runs from TWO triggers. A new claim (an insert, or an edit that
 -- raises the amounts) is measured IMMEDIATELY: the error points at the statement
@@ -71,11 +97,13 @@ declare
   v_left_units    numeric;
   v_parent_type   text;
   v_parent_asset  text;
-  -- Purchases in the fund bucket (null outside it) and prior sales out of it —
-  -- the second bounds how much independent rounding the slack has to explain.
+  -- Purchases in the fund bucket; null outside that branch, which is also how the
+  -- allocation rule below knows which kind it is measuring.
   v_rows          int;
-  v_out_rows      int;
-  v_slack         bigint;
+  -- The basis a fund sale of these units is allowed to take, and the one đồng of
+  -- rounding the proportional split can produce.
+  v_expected      numeric;
+  c_dong_epsilon  constant numeric := 1;
 begin
   if wd.transaction_type is distinct from 'withdrawal' then return; end if;
 
@@ -95,14 +123,13 @@ begin
   -- nothing draws down — a fat holding in one goal waving through a phantom fund
   -- sell in another, since the API accepts both fields on one row.
   if wd.asset_type = 'fund' and wd.fund_id is not null then
-    -- A fund sell moves BOTH ledger deltas or it disagrees with the valuation:
-    -- with no units the overview skips the whole subtraction (it bails on
-    -- `wd.units <= 0`, so the cost basis is never removed either) and the holding
-    -- keeps its full value; with no principal the units fall while the cost basis
-    -- stays, and P&L is wrong. Neither is a shape the sheets produce.
-    if coalesce(wd.units_withdrawn, 0) <= 0 or coalesce(wd.principal_withdrawn, 0) <= 0 then
-      raise exception 'withdrawal invariant: a fund sell must record both units_withdrawn and principal_withdrawn (got % units, % principal)',
-        wd.units_withdrawn, wd.principal_withdrawn using errcode = 'check_violation';
+    -- A fund sale is a quantity: without units the overview skips the whole
+    -- subtraction (it bails on `wd.units <= 0`) and the holding keeps its value.
+    -- The principal is then not a free number — it is the allocation of the
+    -- remaining basis for those units, checked at the end of this function.
+    if coalesce(wd.units_withdrawn, 0) <= 0 then
+      raise exception 'withdrawal invariant: a fund sale must record units_withdrawn (got %)',
+        wd.units_withdrawn using errcode = 'check_violation';
     end if;
 
     -- Both sides of the bucket carry `asset_type = 'fund'`, because that is what
@@ -149,8 +176,8 @@ begin
        and t.renewed_from_transaction_id is null
        and t.units is not null;
 
-    select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0), count(*)
-      into v_out_principal, v_out_units, v_out_rows
+    select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
+      into v_out_principal, v_out_units
       from public.investment_transactions w
      where w.user_id = wd.user_id
        and w.fund_id = wd.fund_id
@@ -204,6 +231,15 @@ begin
         wd.units_withdrawn, wd.principal_withdrawn using errcode = 'check_violation';
     end if;
 
+    -- A withdrawal that records no principal takes nothing out of the holding:
+    -- lib/depositValuation subtracts coalesce(principal_withdrawn, 0), so the
+    -- deposit keeps its full value while the row claims cash left. A withdrawal
+    -- must not be valid merely because the number to measure was omitted.
+    if coalesce(wd.principal_withdrawn, 0) <= 0 then
+      raise exception 'withdrawal invariant: a withdrawal from holding % must record a positive principal_withdrawn (got %)',
+        wd.parent_transaction_id, wd.principal_withdrawn using errcode = 'check_violation';
+    end if;
+
     select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
       into v_out_principal, v_out_units
       from public.investment_transactions w
@@ -239,28 +275,47 @@ begin
     return;
   end if;
 
-  if coalesce(wd.principal_withdrawn, 0) > 0 then
-    v_left := coalesce(v_principal, 0) - v_out_principal;
-    -- What rounding can still explain, and nothing more. A fund bucket's basis is
-    -- allocated by units, so each PRIOR partial sale rounded its own slice
-    -- independently (≤ half a đồng each) and this one rounds its own. A single
-    -- deposit has no allocation to round — v_rows is null outside the fund branch —
-    -- so it gets none. Anything larger than this is a real overdraw, and the
-    -- arithmetic that used to need more than this now lives in lib/fundWithdrawal.
-    v_slack := case when v_rows is null then 0 else ceil((v_out_rows + 1) * 0.5) end;
-    if wd.principal_withdrawn > v_left + v_slack then
-      raise exception 'withdrawal invariant: % exceeds the remaining balance of % on this holding',
-        wd.principal_withdrawn, v_left using errcode = 'check_violation';
-    end if;
-  end if;
+  -- What the holding has left, after everything already taken out of it.
+  v_left := coalesce(v_principal, 0) - v_out_principal;
+  v_left_units := coalesce(v_units, 0) - v_out_units;
 
+  -- Quantity bound, for whichever kinds carry units.
   if coalesce(wd.units_withdrawn, 0) > 0 then
-    v_left_units := coalesce(v_units, 0) - v_out_units;
     -- The tolerance rounds a real balance; it does not create one. Applied to an
     -- empty holding it would hand every sold-out bucket 0.0001 units it never had.
     if wd.units_withdrawn > v_left_units + (case when v_left_units > 0 then c_units_epsilon else 0 end) then
       raise exception 'withdrawal invariant: % units exceeds the remaining balance of % units on this holding',
         wd.units_withdrawn, v_left_units using errcode = 'check_violation';
+    end if;
+  end if;
+
+  if v_rows is not null then
+    -- FUND: the principal is BOUND TO THE UNITS, not merely capped. Capping the two
+    -- independently let a sale of 1 unit out of 100 claim the whole basis and leave
+    -- 99 units with none, which corrupts every later sale's allocation and the P&L.
+    --
+    -- One allocation rule, shared with lib/fundWithdrawal and matching how the
+    -- overview itself reduces a bucket: a sale of ALL the remaining units takes the
+    -- remaining basis exactly, and a partial sale takes its units-proportional
+    -- share of it. ONE rounding rule: the two sides may differ by at most a đồng,
+    -- which is what rounding a proportional slice can produce.
+    if wd.units_withdrawn >= v_left_units - c_units_epsilon then
+      v_expected := v_left;
+    else
+      v_expected := round(wd.units_withdrawn * v_left / v_left_units);
+    end if;
+    if abs(coalesce(wd.principal_withdrawn, 0) - v_expected) > c_dong_epsilon then
+      raise exception 'withdrawal invariant: a fund sale of % units out of % must take % of the % basis, not %',
+        wd.units_withdrawn, v_left_units, v_expected, v_left, wd.principal_withdrawn
+        using errcode = 'check_violation';
+    end if;
+
+  elsif coalesce(wd.principal_withdrawn, 0) > 0 then
+    -- Non-fund: the principal is the user's own figure (the amount they withdrew),
+    -- bounded by what the holding still holds.
+    if wd.principal_withdrawn > v_left then
+      raise exception 'withdrawal invariant: % exceeds the remaining balance of % on this holding',
+        wd.principal_withdrawn, v_left using errcode = 'check_violation';
     end if;
   end if;
 end;

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -37,8 +37,13 @@
 -- row-level trigger sees such a statement half-applied, so whether the destination
 -- bucket looked complete depended on heap order: an ordinary "buy, sell, edit the
 -- buy, assign the fund to a goal" failed. Relocations are therefore measured by a
--- DEFERRED constraint trigger, once the whole statement has landed and the
--- destination bucket is whatever it is going to be.
+-- CONSTRAINT trigger, which runs at the END OF THE STATEMENT — once the whole move
+-- has landed and the destination bucket is whatever it is going to be.
+--
+-- Every refusal here is prefixed 'withdrawal invariant:' so the API can map the
+-- whole family to a 400 with one match. Adding a new refusal used to mean
+-- remembering to add a phrase to the route, and forgetting made an invalid request
+-- look like a server fault.
 --
 -- Not covered here, deliberately: lowering a *source's* amount_vnd below what has
 -- already been withdrawn (an edit, not a withdrawal) is the mirror hole and wants
@@ -65,6 +70,11 @@ declare
   v_left          bigint;
   v_left_units    numeric;
   v_parent_type   text;
+  -- Purchases in the fund bucket, and the rounding slack they imply (below).
+  -- Null outside the fund branch, where the basis is one row's stored amount and
+  -- there is nothing to reconcile.
+  v_rows          int;
+  v_slack         bigint;
 begin
   if wd.transaction_type is distinct from 'withdrawal' then return; end if;
 
@@ -74,7 +84,7 @@ begin
   -- the invariant does — before anything is measured, since a negative amount
   -- would poison the measurement itself.
   if coalesce(wd.principal_withdrawn, 0) < 0 or coalesce(wd.units_withdrawn, 0) < 0 then
-    raise exception 'withdrawal amounts cannot be negative (principal %, units %)',
+    raise exception 'withdrawal invariant: amounts cannot be negative (principal %, units %)',
       wd.principal_withdrawn, wd.units_withdrawn using errcode = 'check_violation';
   end if;
 
@@ -90,7 +100,7 @@ begin
     -- keeps its full value; with no principal the units fall while the cost basis
     -- stays, and P&L is wrong. Neither is a shape the sheets produce.
     if coalesce(wd.units_withdrawn, 0) <= 0 or coalesce(wd.principal_withdrawn, 0) <= 0 then
-      raise exception 'a fund sell must record both units_withdrawn and principal_withdrawn (got % units, % principal)',
+      raise exception 'withdrawal invariant: a fund sell must record both units_withdrawn and principal_withdrawn (got % units, % principal)',
         wd.units_withdrawn, wd.principal_withdrawn using errcode = 'check_violation';
     end if;
 
@@ -116,8 +126,8 @@ begin
      order by t.transaction_id      -- a stable lock order; concurrent sells can't deadlock
        for update;
 
-    select coalesce(sum(t.amount_vnd), 0), coalesce(sum(t.units), 0)
-      into v_principal, v_units
+    select coalesce(sum(t.amount_vnd), 0), coalesce(sum(t.units), 0), count(*)
+      into v_principal, v_units, v_rows
       from public.investment_transactions t
      where t.user_id = wd.user_id
        and t.fund_id = wd.fund_id
@@ -164,7 +174,7 @@ begin
     -- exists (issue #606). Bounding it by the parent's own principal, as below, is
     -- the most this invariant can honestly say about it.
     if v_parent_type is distinct from 'investment' then
-      raise exception 'withdrawal draws on no holding: its parent % is not an investment',
+      raise exception 'withdrawal invariant: draws on no holding — its parent % is not an investment',
         wd.parent_transaction_id using errcode = 'check_violation';
     end if;
 
@@ -183,7 +193,7 @@ begin
     -- but the row leaves the fund bucket), which is why asset_type fires the
     -- trigger: running is not enough, the new shape has to be refused.
     if coalesce(wd.principal_withdrawn, 0) > 0 or coalesce(wd.units_withdrawn, 0) > 0 then
-      raise exception 'withdrawal draws on no holding: it has neither a parent transaction nor a fund'
+      raise exception 'withdrawal invariant: draws on no holding — it has neither a parent transaction nor a fund'
         using errcode = 'check_violation';
     end if;
     -- Carrying neither is a settlement row with nothing to measure — a
@@ -194,8 +204,17 @@ begin
 
   if coalesce(wd.principal_withdrawn, 0) > 0 then
     v_left := coalesce(v_principal, 0) - v_out_principal;
-    if wd.principal_withdrawn > v_left then
-      raise exception 'withdrawal of % exceeds the remaining balance of % on this holding',
+    -- A fund bucket's principal is measured as Σ amount_vnd, while the sell
+    -- builders derive what they post from the NAV cost basis (Σ units × unit_price,
+    -- via the dashboard's avg entry price). Each purchase's stored amount_vnd was
+    -- itself rounded, so the two bases can differ by under half a đồng per row —
+    -- and a FULL sell of a multi-purchase bucket could land a few đồng above
+    -- Σ amount_vnd and be refused. Allow exactly that slack: half a đồng per
+    -- purchase, plus one for the sell's own rounding. Nothing outside the fund
+    -- branch gets any (v_rows is null there — one row's stored amount IS the basis).
+    v_slack := case when v_rows is null then 0 else ceil((v_rows + 1) * 0.5) end;
+    if wd.principal_withdrawn > v_left + v_slack then
+      raise exception 'withdrawal invariant: % exceeds the remaining balance of % on this holding',
         wd.principal_withdrawn, v_left using errcode = 'check_violation';
     end if;
   end if;
@@ -205,7 +224,7 @@ begin
     -- The tolerance rounds a real balance; it does not create one. Applied to an
     -- empty holding it would hand every sold-out bucket 0.0001 units it never had.
     if wd.units_withdrawn > v_left_units + (case when v_left_units > 0 then c_units_epsilon else 0 end) then
-      raise exception 'withdrawal of % units exceeds the remaining balance of % units on this holding',
+      raise exception 'withdrawal invariant: % units exceeds the remaining balance of % units on this holding',
         wd.units_withdrawn, v_left_units using errcode = 'check_violation';
     end if;
   end if;
@@ -239,7 +258,7 @@ begin
     if old.parent_transaction_id is not null and new.parent_transaction_id is null then
       if exists (select 1 from public.investment_transactions t
                   where t.transaction_id = old.parent_transaction_id) then
-        raise exception 'withdrawal cannot be detached from holding %, which still exists',
+        raise exception 'withdrawal invariant: cannot be detached from holding %, which still exists',
           old.parent_transaction_id using errcode = 'check_violation';
       end if;
       -- The source is gone. If the row still names a fund it now draws on that
@@ -251,7 +270,7 @@ begin
 
     if old.fund_id is not null and new.fund_id is null then
       if exists (select 1 from public.funds f where f.id = old.fund_id) then
-        raise exception 'withdrawal cannot be detached from fund %, which still exists',
+        raise exception 'withdrawal invariant: cannot be detached from fund %, which still exists',
           old.fund_id using errcode = 'check_violation';
       end if;
       -- The fund is gone. buildWithdrawalMaps now keys the row by its PARENT, so

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -1,0 +1,145 @@
+-- A withdrawal may never take more than its holding still holds (#587).
+--
+-- The sell/withdraw sheets capped the amount client-side (computeSellPreview's
+-- sellOverMax / isOverUnits); POST /api/v1/investment-transactions validated the
+-- numeric shape and inserted whatever it was given. So a stale tab, a retried
+-- request, or two sells racing each other could each pass their own read of the
+-- balance and both land: the holding goes past zero, the dashboard drops it
+-- (valueNonFundHolding returns null at effectiveAmount <= 0) while the excess
+-- withdrawal stays in history, and net worth and P&L are wrong from then on.
+--
+-- Why a trigger and not a service or an RPC the route calls: the balance has
+-- several writers already — this route, renew_term_deposit_with_merge,
+-- withdraw_accumulating_book, record_recurring_book_topup — and the next one is
+-- written by whoever forgets. An invariant on the table holds for all of them,
+-- including service-role and SQL writes, which is the same reasoning that moved
+-- the recurring-link cleanup into the database in #531.
+--
+-- Why it is atomic: the check LOCKS THE SOURCE ROWS FIRST, then reads the sums in
+-- a following statement. Under READ COMMITTED a competing insert holds that lock
+-- until it commits, and the statement that reads the sums afterwards takes a new
+-- snapshot — so the second withdrawal sees the first one and is measured against
+-- the balance it left behind. Reading the sums first would let both pass.
+--
+-- Two balances, mirroring the two buckets the dashboard aggregates:
+--   • bank / gold / stock — one source row, addressed by parent_transaction_id:
+--     remaining principal = amount_vnd − Σ principal_withdrawn, remaining units =
+--     units − Σ units_withdrawn (lib/depositValuation values it exactly so).
+--   • fund — a sell has no parent row; the overview aggregates funds per
+--     (goal_id, fund_id), so that bucket is the balance a sell draws down.
+--
+-- Not covered here, deliberately: lowering a *source's* amount_vnd below what has
+-- already been withdrawn (an edit, not a withdrawal) is the mirror hole and wants
+-- its own guard — collapse and renewal both rewrite amounts mid-transaction, so
+-- checking them needs care this change doesn't have room for.
+create or replace function public.enforce_withdrawal_within_balance()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  -- Clients round units_withdrawn to 4 decimals (parseFloat(u.toFixed(4))), so a
+  -- FULL sell can post a hair more than the holding: 50.12345 units becomes
+  -- 50.1235. Allow exactly that much and no more, or "sell everything" breaks.
+  c_units_epsilon constant numeric := 0.0001;
+  v_principal     bigint;
+  v_units         numeric;
+  v_out_principal bigint;
+  v_out_units     numeric;
+  v_left          bigint;
+  v_left_units    numeric;
+begin
+  if new.transaction_type is distinct from 'withdrawal' then return new; end if;
+
+  if new.parent_transaction_id is not null then
+    -- Lock the source before measuring it (see the header): this is what makes
+    -- two concurrent withdrawals of the same deposit serialize.
+    select t.amount_vnd, t.units into v_principal, v_units
+      from public.investment_transactions t
+     where t.transaction_id = new.parent_transaction_id
+       and t.user_id = new.user_id
+       for update;
+    -- A parent that isn't the writer's own is the ownership trigger's refusal to
+    -- make (#474 / #525); staying quiet here keeps that message the one the user
+    -- sees instead of a confusing "no balance".
+    if not found then return new; end if;
+
+    select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
+      into v_out_principal, v_out_units
+      from public.investment_transactions w
+     where w.parent_transaction_id = new.parent_transaction_id
+       and w.transaction_type = 'withdrawal'
+       and w.transaction_id <> new.transaction_id;   -- an UPDATE re-measures without itself
+
+  elsif new.asset_type = 'fund' and new.fund_id is not null then
+    -- Lock the bucket's investment rows first, same ordering as above. Pending
+    -- DCA seeds (units is null) are excluded: they carry a planned amount with no
+    -- units bought yet, the dashboard never values them, so they hold nothing to
+    -- sell. Renewal snapshots are history copies, not holdings.
+    perform 1
+      from public.investment_transactions t
+     where t.user_id = new.user_id
+       and t.fund_id = new.fund_id
+       and t.transaction_type = 'investment'
+       and t.goal_id is not distinct from new.goal_id
+       and t.renewed_from_transaction_id is null
+       and t.units is not null
+     order by t.transaction_id      -- a stable lock order; concurrent sells can't deadlock
+       for update;
+
+    select coalesce(sum(t.amount_vnd), 0), coalesce(sum(t.units), 0)
+      into v_principal, v_units
+      from public.investment_transactions t
+     where t.user_id = new.user_id
+       and t.fund_id = new.fund_id
+       and t.transaction_type = 'investment'
+       and t.goal_id is not distinct from new.goal_id
+       and t.renewed_from_transaction_id is null
+       and t.units is not null;
+
+    select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
+      into v_out_principal, v_out_units
+      from public.investment_transactions w
+     where w.user_id = new.user_id
+       and w.fund_id = new.fund_id
+       and w.transaction_type = 'withdrawal'
+       and w.goal_id is not distinct from new.goal_id
+       and w.transaction_id <> new.transaction_id;
+
+  else
+    -- Nothing identifiable to draw down: a held-for-merge settlement with no
+    -- source is exactly this shape, and making it source-backed is #588's job.
+    return new;
+  end if;
+
+  if coalesce(new.principal_withdrawn, 0) > 0 then
+    v_left := coalesce(v_principal, 0) - v_out_principal;
+    if new.principal_withdrawn > v_left then
+      raise exception 'withdrawal of % exceeds the remaining balance of % on this holding',
+        new.principal_withdrawn, v_left using errcode = 'check_violation';
+    end if;
+  end if;
+
+  if coalesce(new.units_withdrawn, 0) > 0 then
+    v_left_units := coalesce(v_units, 0) - v_out_units;
+    if new.units_withdrawn > v_left_units + c_units_epsilon then
+      raise exception 'withdrawal of % units exceeds the remaining balance of % units on this holding',
+        new.units_withdrawn, v_left_units using errcode = 'check_violation';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.enforce_withdrawal_within_balance() is
+  'Refuses a withdrawal/sell that would take more principal or units than its holding still has, measured under a lock on the source so concurrent sells cannot both pass (#587).';
+
+drop trigger if exists investment_transactions_withdrawal_balance on public.investment_transactions;
+create trigger investment_transactions_withdrawal_balance
+  before insert or update of principal_withdrawn, units_withdrawn, parent_transaction_id, fund_id, goal_id
+  on public.investment_transactions
+  for each row
+  when (new.transaction_type = 'withdrawal')
+  execute function public.enforce_withdrawal_within_balance();

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -74,15 +74,28 @@ begin
   -- under no key at all — the same escape the rest of this function exists to
   -- close. The tell is the source itself: by the time the FK action fires, the
   -- parent row is already deleted and invisible to this query.
-  if tg_op = 'UPDATE' and old.parent_transaction_id is not null and new.parent_transaction_id is null then
-    if exists (select 1 from public.investment_transactions t
-                where t.transaction_id = old.parent_transaction_id) then
-      raise exception 'withdrawal cannot be detached from holding %, which still exists',
-        old.parent_transaction_id using errcode = 'check_violation';
+  -- Both links a withdrawal hangs on are ON DELETE SET NULL, so both deletions
+  -- arrive here the same way: the deposit (parent_transaction_id) and the fund
+  -- (fund_id, which a sell is keyed by).
+  if tg_op = 'UPDATE' then
+    if old.parent_transaction_id is not null and new.parent_transaction_id is null then
+      if exists (select 1 from public.investment_transactions t
+                  where t.transaction_id = old.parent_transaction_id) then
+        raise exception 'withdrawal cannot be detached from holding %, which still exists',
+          old.parent_transaction_id using errcode = 'check_violation';
+      end if;
+      -- The source is gone. The leftover orphan is a shape this invariant would
+      -- not let anyone CREATE; cleaning those up as the source goes is issue #607.
+      return new;
     end if;
-    -- The source is gone. The leftover orphan is a shape this invariant would not
-    -- let anyone CREATE; cleaning those up as the source goes is issue #607.
-    return new;
+
+    if old.fund_id is not null and new.fund_id is null then
+      if exists (select 1 from public.funds f where f.id = old.fund_id) then
+        raise exception 'withdrawal cannot be detached from fund %, which still exists',
+          old.fund_id using errcode = 'check_violation';
+      end if;
+      return new;   -- the fund was deleted; same story as above
+    end if;
   end if;
 
   -- The branch order is not a preference: it MIRRORS lib/withdrawalProgress, which

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -123,7 +123,11 @@ begin
 
   if coalesce(new.units_withdrawn, 0) > 0 then
     v_left_units := coalesce(v_units, 0) - v_out_units;
-    if new.units_withdrawn > v_left_units + c_units_epsilon then
+    -- The tolerance rounds a real balance; it does not create one. Applied to an
+    -- empty holding it would hand every sold-out bucket 0.0001 units it never
+    -- had — and since principal_withdrawn may be omitted, that is a withdrawal
+    -- row (carrying any amount_vnd) against a holding that is gone.
+    if new.units_withdrawn > v_left_units + (case when v_left_units > 0 then c_units_epsilon else 0 end) then
       raise exception 'withdrawal of % units exceeds the remaining balance of % units on this holding',
         new.units_withdrawn, v_left_units using errcode = 'check_violation';
     end if;

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -75,6 +75,9 @@ declare
   -- there is nothing to reconcile.
   v_rows          int;
   v_slack         bigint;
+  -- Σ(units × unit_price) for the fund bucket — the basis the dashboard's avg
+  -- entry price, and so the sell builders, work from. Null outside that branch.
+  v_nav_basis     numeric;
 begin
   if wd.transaction_type is distinct from 'withdrawal' then return; end if;
 
@@ -126,8 +129,17 @@ begin
      order by t.transaction_id      -- a stable lock order; concurrent sells can't deadlock
        for update;
 
-    select coalesce(sum(t.amount_vnd), 0), coalesce(sum(t.units), 0), count(*)
-      into v_principal, v_units, v_rows
+    -- Two bases exist for a fund's principal and they can disagree outright, not
+    -- just by rounding: amount_vnd, units and unit_price are independent fields on
+    -- the POST route (and the sheet lets units be typed by hand), so a purchase may
+    -- store 1,000,000 with 60 units at 20,000 — a NAV cost of 1,200,000. The
+    -- dashboard's avg entry price, and therefore what the sell builders post, uses
+    -- the NAV basis; Σ amount_vnd is what the row says it cost. Bound by whichever
+    -- is larger: refusing on the smaller one refuses an ordinary full sale, and for
+    -- funds the UNITS check below is the load-bearing one anyway.
+    select coalesce(sum(t.amount_vnd), 0), coalesce(sum(t.units), 0), count(*),
+           coalesce(sum(t.units * coalesce(t.unit_price, 0)), 0)
+      into v_principal, v_units, v_rows, v_nav_basis
       from public.investment_transactions t
      where t.user_id = wd.user_id
        and t.fund_id = wd.fund_id
@@ -183,6 +195,11 @@ begin
       from public.investment_transactions w
      where w.parent_transaction_id = wd.parent_transaction_id
        and w.transaction_type = 'withdrawal'
+       -- Same precedence as the branch above, applied to the OTHER rows: a sibling
+       -- that is keyed by a fund draws on that bucket, not on this parent, so
+       -- counting it here too would charge it twice and make an ordinary later
+       -- withdrawal of this deposit look like an overdraw.
+       and not (w.asset_type = 'fund' and w.fund_id is not null)
        and w.transaction_id <> wd.transaction_id;
 
   else
@@ -203,7 +220,9 @@ begin
   end if;
 
   if coalesce(wd.principal_withdrawn, 0) > 0 then
-    v_left := coalesce(v_principal, 0) - v_out_principal;
+    -- For a fund bucket, take the larger of the two bases (see above).
+    v_left := greatest(coalesce(v_principal, 0), ceil(coalesce(v_nav_basis, 0))::bigint)
+              - v_out_principal;
     -- A fund bucket's principal is measured as Σ amount_vnd, while the sell
     -- builders derive what they post from the NAV cost basis (Σ units × unit_price,
     -- via the dashboard's avg entry price). Each purchase's stored amount_vnd was
@@ -233,6 +252,15 @@ $$;
 
 comment on function public.check_withdrawal_balance(public.investment_transactions) is
   'Raises when a withdrawal/sell would take more principal or units than its holding still has. Measured under a lock on the source, so concurrent sells cannot both pass (#587).';
+
+-- Postgres grants EXECUTE on a new function to PUBLIC, and this one is SECURITY
+-- DEFINER — so left open it is an oracle: call it with a hand-built row naming
+-- someone else's holding, and the refusal message reports that holding's exact
+-- remaining principal or units, RLS bypassed, taking row locks on the way. It is
+-- the triggers' helper and nothing else's; they call it as the definer, so they
+-- keep working without these grants.
+revoke all on function public.check_withdrawal_balance(public.investment_transactions) from public;
+revoke all on function public.check_withdrawal_balance(public.investment_transactions) from anon, authenticated;
 
 -- ── immediate: a new or increased claim ──────────────────────────────────────
 create or replace function public.enforce_withdrawal_within_balance()

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -114,8 +114,19 @@ begin
        and w.transaction_id <> new.transaction_id;   -- an UPDATE re-measures without itself
 
   else
-    -- Nothing identifiable to draw down: a held-for-merge settlement with no
-    -- source is exactly this shape, and making it source-backed is #588's job.
+    -- Nothing identifiable to draw down. A row taking principal or units out of no
+    -- holding at all is not a withdrawal — buildWithdrawalMaps files it under
+    -- neither key, so it subtracts from nothing while the record claims cash left.
+    -- Reachable by editing a fund sell's asset_type off 'fund' (the fund_id stays,
+    -- but the row leaves the fund bucket), which is why asset_type fires this
+    -- trigger: running is not enough, the new shape has to be refused.
+    if coalesce(new.principal_withdrawn, 0) > 0 or coalesce(new.units_withdrawn, 0) > 0 then
+      raise exception 'withdrawal draws on no holding: it has neither a parent transaction nor a fund'
+        using errcode = 'check_violation';
+    end if;
+    -- Carrying neither is a settlement row with nothing to measure — a
+    -- held-for-merge with no source is exactly that shape, and giving it one is
+    -- #588's job.
     return new;
   end if;
 
@@ -148,12 +159,16 @@ comment on function public.enforce_withdrawal_within_balance() is
 
 drop trigger if exists investment_transactions_withdrawal_balance on public.investment_transactions;
 create trigger investment_transactions_withdrawal_balance
-  -- transaction_type is in the list because the WHEN clause reads it: without it,
-  -- a row could be staged as an investment carrying principal_withdrawn (which
-  -- draws nothing down, so it is not measured) and then turned into a withdrawal
-  -- by a one-column update that never fires this trigger.
+  -- Every column that decides WHICH balance the row is measured against, plus the
+  -- two that say how much it takes:
+  --   • transaction_type — the WHEN clause reads it, so without it a row could be
+  --     staged as an investment carrying principal_withdrawn (an investment draws
+  --     nothing down, so it is not measured) and then activated by a one-column
+  --     update that never fired this trigger.
+  --   • asset_type — it picks the fund-bucket branch over the parent branch.
   before insert or update of
-    transaction_type, principal_withdrawn, units_withdrawn, parent_transaction_id, fund_id, goal_id
+    transaction_type, asset_type, principal_withdrawn, units_withdrawn,
+    parent_transaction_id, fund_id, goal_id
   on public.investment_transactions
   for each row
   when (new.transaction_type = 'withdrawal')

--- a/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
+++ b/supabase/migrations/20260730000002_enforce_withdrawal_balance.sql
@@ -54,6 +54,16 @@ declare
 begin
   if new.transaction_type is distinct from 'withdrawal' then return new; end if;
 
+  -- A negative withdrawal runs the ledger backwards: it ADDS to the holding and
+  -- banks a credit the next withdrawal can spend (the sums below are signed, and
+  -- so is lib/depositValuation's subtraction). Nothing in the schema stops one, so
+  -- the invariant does — before anything is measured, since a negative amount
+  -- would poison the measurement itself.
+  if coalesce(new.principal_withdrawn, 0) < 0 or coalesce(new.units_withdrawn, 0) < 0 then
+    raise exception 'withdrawal amounts cannot be negative (principal %, units %)',
+      new.principal_withdrawn, new.units_withdrawn using errcode = 'check_violation';
+  end if;
+
   -- Deleting a source is an ordinary ledger action, and parent_transaction_id is
   -- ON DELETE SET NULL — so Postgres orphans the children with an UPDATE that
   -- lands right here. Measuring that update would refuse it (the row has just
@@ -81,6 +91,11 @@ begin
   -- nothing draws down — a fat holding in one goal waving through a phantom fund
   -- sell in another, since the API accepts both fields on one row.
   if new.asset_type = 'fund' and new.fund_id is not null then
+    -- Both sides of the bucket carry `asset_type = 'fund'`, because that is what
+    -- the valuation counts: a row whose asset_type was edited off 'fund' keeps its
+    -- fund_id (the PUT clears fund_id only when that field is sent) but is valued
+    -- as a bank holding, so its units are no longer fund inventory to sell.
+    --
     -- Lock the bucket's investment rows before measuring them (see the header):
     -- this is what makes two concurrent sells of the same bucket serialize. Pending
     -- DCA seeds (units is null) are excluded: they carry a planned amount with no
@@ -90,6 +105,7 @@ begin
       from public.investment_transactions t
      where t.user_id = new.user_id
        and t.fund_id = new.fund_id
+       and t.asset_type = 'fund'
        and t.transaction_type = 'investment'
        and t.goal_id is not distinct from new.goal_id
        and t.renewed_from_transaction_id is null
@@ -102,6 +118,7 @@ begin
       from public.investment_transactions t
      where t.user_id = new.user_id
        and t.fund_id = new.fund_id
+       and t.asset_type = 'fund'
        and t.transaction_type = 'investment'
        and t.goal_id is not distinct from new.goal_id
        and t.renewed_from_transaction_id is null
@@ -112,6 +129,7 @@ begin
       from public.investment_transactions w
      where w.user_id = new.user_id
        and w.fund_id = new.fund_id
+       and w.asset_type = 'fund'
        and w.transaction_type = 'withdrawal'
        and w.goal_id is not distinct from new.goal_id
        and w.transaction_id <> new.transaction_id;

--- a/supabase/tests/hold_clears_recurring_link.test.sql
+++ b/supabase/tests/hold_clears_recurring_link.test.sql
@@ -39,6 +39,8 @@ declare
   v_goal2  uuid;
   v_src    uuid;
   v_src2   uuid;
+  v_src3   uuid;
+  v_src4   uuid;
   v_osrc   uuid;
   v_saving uuid;
   v_osav   uuid;
@@ -67,10 +69,12 @@ begin
   values (v_other, 'Theirs', v_goal2, 5000000, v_osrc) returning saving_id into v_osav;
 
   -- 1) A held settlement on that source clears the link, within the insert itself.
+  -- The settlement closes the source, so it records the principal it takes out —
+  -- the withdrawal invariant (#587) refuses one that measures nothing.
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
-     parent_transaction_id, held_for_merge, merge_target_goal_id)
-  values (v_user, v_goal, 'bank', 'withdrawal', '2026-07-01', 100000000, v_src, true, v_goal);
+     parent_transaction_id, principal_withdrawn, held_for_merge, merge_target_goal_id)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-07-01', 100000000, v_src, 100000000, true, v_goal);
 
   select linked_deposit_tx_id into v_link from public.recurring_savings where saving_id = v_saving;
   if v_link is not null then
@@ -84,15 +88,19 @@ begin
   end if;
 
   -- 2) A PLAIN withdrawal must NOT clear the link — only holding closes the
-  --    source for merge. Re-link, then withdraw normally.
-  update public.recurring_savings set linked_deposit_tx_id = v_src where saving_id = v_saving;
+  --    source for merge. v_src is settled now, so re-link to a live deposit and
+  --    withdraw part of THAT (a withdrawal cannot exceed its holding, #587).
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-03-01', 50000000) returning transaction_id into v_src3;
+
+  update public.recurring_savings set linked_deposit_tx_id = v_src3 where saving_id = v_saving;
 
   insert into public.investment_transactions
-    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id)
-  values (v_user, v_goal, 'bank', 'withdrawal', '2026-07-02', 10000000, v_src);
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-07-02', 10000000, v_src3, 10000000);
 
   select linked_deposit_tx_id into v_link from public.recurring_savings where saving_id = v_saving;
-  if v_link is distinct from v_src then
+  if v_link is distinct from v_src3 then
     raise exception 'a plain withdrawal must leave the link intact, got %', v_link;
   end if;
 
@@ -102,17 +110,23 @@ begin
 
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
-     parent_transaction_id, held_for_merge, merge_target_goal_id)
-  values (v_user, v_goal, 'bank', 'withdrawal', '2026-07-03', 50000000, v_src2, true, v_goal);
+     parent_transaction_id, principal_withdrawn, held_for_merge, merge_target_goal_id)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-07-03', 50000000, v_src2, 50000000, true, v_goal);
 
   select linked_deposit_tx_id into v_link from public.recurring_savings where saving_id = v_saving;
-  if v_link is distinct from v_src then
+  if v_link is distinct from v_src3 then
     raise exception 'holding an unrelated deposit must not clear this link, got %', v_link;
   end if;
 
   -- 4) The rollback guarantee. Force the cleanup UPDATE to fail and assert the
   --    settlement insert does not survive it — the exact failure the old
   --    two-statement route turned into a dangling link behind a 201.
+  -- The source this hold will settle, linked so the cleanup UPDATE fires — both
+  -- BEFORE the breaking trigger exists, or they would blow up outside the block.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-04-01', 100000000) returning transaction_id into v_src4;
+  update public.recurring_savings set linked_deposit_tx_id = v_src4 where saving_id = v_saving;
+
   create trigger tmp_break_recurring_update
     before update on public.recurring_savings
     for each row execute function public.tmp_raise_on_update();
@@ -120,8 +134,8 @@ begin
   begin
     insert into public.investment_transactions
       (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
-       parent_transaction_id, held_for_merge, merge_target_goal_id)
-    values (v_user, v_goal, 'bank', 'withdrawal', '2026-07-04', 100000000, v_src, true, v_goal);
+       parent_transaction_id, principal_withdrawn, held_for_merge, merge_target_goal_id)
+    values (v_user, v_goal, 'bank', 'withdrawal', '2026-07-04', 100000000, v_src4, 100000000, true, v_goal);
     -- Reached only if the insert survived a failing cleanup. P0001, so the
     -- ZZ999 handler below does NOT catch it: it propagates and fails the test.
     raise exception 'the insert must survive nothing: the cleanup failure did not abort it';
@@ -148,7 +162,7 @@ begin
 
   -- Nothing committed, so the link is exactly as it was.
   select linked_deposit_tx_id into v_link from public.recurring_savings where saving_id = v_saving;
-  if v_link is distinct from v_src then
+  if v_link is distinct from v_src4 then
     raise exception 'a rolled-back hold must leave the link untouched, got %', v_link;
   end if;
 

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -980,7 +980,19 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
-  -- Both together are fine, and a bank withdrawal still needs only principal.
+  -- Gold's principal is bound to its units, like a fund's: selling a sliver while
+  -- claiming the whole basis would leave nearly all the metal at market value with
+  -- no cost behind it, and nothing left to sell it against.
+  begin
+    insert into public.investment_transactions
+      (user_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+    values (v_user, 'gold', 'withdrawal', '2026-02-01', 40000000, v_gold, 80000000, 0.5);
+    raise exception 'a 0.5-chi sale must not take the whole gold basis';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Both together, in proportion, are fine — and a bank withdrawal still needs
+  -- only principal.
   insert into public.investment_transactions
     (user_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
   values (v_user, 'gold', 'withdrawal', '2026-02-01', 40000000, v_gold, 40000000, 5);
@@ -1014,6 +1026,56 @@ begin
   values (v_user, 'bank', 'withdrawal', '2026-03-02', 20000000, v_bank, 20000000);
 
   raise notice 'gold sale deltas + required principal: ok';
+end;
+$$;
+
+-- ── a relocation may not leave a bucket holding sales it cannot back ─────────
+-- Moving a fund's PURCHASES without their sales splits the bucket: the sales are
+-- left drawing on nothing while the units reappear in the destination, so the
+-- dashboard ignores the sale and restores the sold units (silent net-worth
+-- inflation). That is exactly what the assign-vs-sell race produces — verified
+-- with two sessions, and it happens with these triggers disabled too, so it is
+-- the shape of the move, not of this invariant. Refuse the move instead: a failed
+-- assign can be retried, a split bucket is discovered months later.
+do $$
+declare
+  v_user uuid;
+  v_a    uuid;
+  v_b    uuid;
+  v_fund uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-split@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'A') returning goal_id into v_a;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'B') returning goal_id into v_b;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Split Fund', 'SPF', 'equity', 20000) returning id into v_fund;
+
+  insert into public.investment_transactions (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_a, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000);
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_a, v_fund, 'fund', 'withdrawal', '2026-02-01', 600000, 600000, 30);
+
+  -- Purchases only: the end state the race leaves behind.
+  begin
+    update public.investment_transactions
+       set goal_id = v_b
+     where user_id = v_user and fund_id = v_fund and transaction_type = 'investment';
+    raise exception 'moving purchases away from their sales must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- The whole bucket together — what the assign route actually does — is fine.
+  update public.investment_transactions
+     set goal_id = v_b
+   where user_id = v_user and fund_id = v_fund and asset_type = 'fund' and goal_id = v_a;
+
+  if (select count(*) from public.investment_transactions
+       where user_id = v_user and fund_id = v_fund and goal_id = v_b) <> 2 then
+    raise exception 'the whole bucket should have moved together';
+  end if;
+
+  raise notice 'a relocation cannot split a bucket: ok';
 end;
 $$;
 

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -1,0 +1,209 @@
+-- A withdrawal can never take more than its holding still holds (#587).
+--
+-- The sell/withdraw sheets capped the amount client-side; the API took whatever
+-- was posted. A stale tab, a retry, or two sells racing each other could each
+-- pass their own read of the balance and both insert, so the holding went
+-- negative: the dashboard drops it (effectiveAmount <= 0) while the withdrawal
+-- history keeps the excess cash, and net worth is wrong for good.
+--
+-- The cap belongs where every writer meets it — the route, the renewal RPCs, the
+-- book RPC, and whatever writes next — so it is a trigger on the table, taking a
+-- row lock on the SOURCE before it reads the sums. That ordering is what makes
+-- two concurrent sells serialize instead of both passing (the lock releases only
+-- on commit, and the next statement then reads a fresh snapshot).
+--
+-- Two balances, per the dashboard's own two buckets:
+--   • bank / gold / stock — one source row, addressed by parent_transaction_id.
+--   • fund — the (goal, fund) bucket the overview aggregates, since a fund sell
+--     has no parent row.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_user    uuid;
+  v_goal    uuid;
+  v_goal_b  uuid;
+  v_fund    uuid;
+  v_bank    uuid;
+  v_gold    uuid;
+  v_seed    uuid;
+  -- Each attempt below catches ONLY 23514 (check_violation). Any other error
+  -- propagates and fails the test: counting a null-violation as "rejected" would
+  -- pass while proving nothing.
+  v_msg     text;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-balance@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Car') returning goal_id into v_goal_b;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Test Fund', 'TFX', 'equity', 20000) returning id into v_fund;
+
+  -- ── bank: principal is the balance ────────────────────────────────────────
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_bank;
+
+  -- 60M out of 100M: fine.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 61000000, v_bank, 60000000);
+
+  -- 50M more would take 110M out of a 100M book.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+    values (v_user, v_goal, 'bank', 'withdrawal', '2026-03-01', 50000000, v_bank, 50000000);
+    raise exception 'a withdrawal above the remaining principal must be refused';
+  exception when sqlstate '23514' then
+    v_msg := sqlerrm;
+  end;
+  -- The route matches on this text to answer 400 instead of a generic 500, so
+  -- the wording is a contract, not a detail (see the POST route).
+  if v_msg not like '%exceeds the remaining balance%' then
+    raise exception 'the refusal must say it exceeds the remaining balance, got: %', v_msg;
+  end if;
+
+  -- Exactly the remaining 40M: the boundary is allowed, not off by one.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-04-01', 40000000, v_bank, 40000000);
+
+  -- Now empty: even 1 đồng is refused.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+    values (v_user, v_goal, 'bank', 'withdrawal', '2026-05-01', 1, v_bank, 1);
+    raise exception 'a withdrawal from a fully withdrawn deposit must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── gold: units are the balance ───────────────────────────────────────────
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 80000000, 10, 8000000) returning transaction_id into v_gold;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 50000000, v_gold, 48000000, 6);
+
+  -- 5 more chỉ out of the 4 left — refused on units even though the cost basis
+  -- passed would still fit inside the remaining principal.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+    values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 20000000, v_gold, 1000000, 5);
+    raise exception 'selling more units than the holding has must be refused';
+  exception when sqlstate '23514' then
+    v_msg := sqlerrm;
+  end;
+  if v_msg not like '%units%' then
+    raise exception 'the units refusal must name units, got: %', v_msg;
+  end if;
+
+  -- The remaining 4 chỉ sell fine.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 33000000, v_gold, 32000000, 4);
+
+  -- ── funds: the (goal, fund) bucket ────────────────────────────────────────
+  -- 100 + 50 units in the House goal.
+  insert into public.investment_transactions (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000);
+  insert into public.investment_transactions (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-02-01', 1000000, 50, 20000);
+
+  -- 120 of the 150 units held in that goal.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-03-01', 2400000, 2400000, 120);
+
+  -- 40 more against the 30 left.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+    values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-04-01', 800000, 500000, 40);
+    raise exception 'a fund sell above the units held in that goal must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- The SAME fund in another goal is a different balance: the House units must
+  -- not fund a Car sell. (Selling 10 units from a goal holding nothing.)
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+    values (v_user, v_goal_b, v_fund, 'fund', 'withdrawal', '2026-04-01', 200000, 200000, 10);
+    raise exception 'a fund sell must not draw on another goal''s units';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Unallocated is its own bucket too, and it is empty for this fund.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+    values (v_user, null, v_fund, 'fund', 'withdrawal', '2026-04-01', 200000, 200000, 10);
+    raise exception 'an unallocated fund sell must not draw on a goal''s units';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- The 30 units actually left in the House goal still sell.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-05-01', 600000, 600000, 30);
+
+  -- ── a pending DCA seed is not a holding ───────────────────────────────────
+  -- Seeded rows carry the planned amount with no units until the buy is
+  -- recorded; the dashboard never values them, so they cannot back a sell.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, is_dca_seeded)
+  values (v_user, v_goal_b, v_fund, 'fund', 'investment', '2026-06-01', 5000000, null, true)
+  returning transaction_id into v_seed;
+
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+    values (v_user, v_goal_b, v_fund, 'fund', 'withdrawal', '2026-06-02', 1000000, 1000000, 50);
+    raise exception 'a pending DCA seed must not back a sell';
+  exception when sqlstate '23514' then null;
+  end;
+
+  raise notice 'withdrawal balance invariant: ok';
+end;
+$$;
+
+-- ── units rounding: a full sell must not be refused by the 4th decimal ───────
+-- Clients round units_withdrawn to 4 dp (parseFloat(x.toFixed(4))), so a full
+-- sell of 50.12345 units posts 50.1235 — more than the holding, by 0.00005.
+-- Refusing that would make "sell everything" fail; the tolerance is exactly one
+-- unit of that rounding, so a real overdraw is still refused.
+do $$
+declare
+  v_user uuid;
+  v_fund uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-rounding@test.invalid') returning id into v_user;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Rounding Fund', 'RFX', 'equity', 20000) returning id into v_fund;
+
+  insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_fund, 'fund', 'investment', '2026-01-01', 1000000, 50.12345, 20000);
+
+  insert into public.investment_transactions
+    (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_fund, 'fund', 'withdrawal', '2026-02-01', 1000000, 1000000, 50.1235);
+
+  -- A tenth of a unit over is not rounding.
+  begin
+    insert into public.investment_transactions
+      (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+    values (v_user, v_fund, 'fund', 'withdrawal', '2026-03-01', 1000, 1000, 0.1);
+    raise exception 'the rounding tolerance must not swallow a real overdraw';
+  exception when sqlstate '23514' then null;
+  end;
+
+  raise notice 'withdrawal units rounding tolerance: ok';
+end;
+$$;
+
+rollback;

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -388,6 +388,18 @@ begin
 
   update public.investment_transactions set parent_transaction_id = v_snap where transaction_id = v_wd;
 
+  -- Detaching a withdrawal while its source is still there is not a deletion: the
+  -- holding comes back to full value and the withdrawal is filed under no key at
+  -- all. Only the FK's own ON DELETE SET NULL may orphan a row, and the tell is
+  -- that the source is already gone by then.
+  begin
+    update public.investment_transactions
+       set parent_transaction_id = null
+     where transaction_id = v_wd;
+    raise exception 'a withdrawal must not be detached from a source that still exists';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- Deleting a source that has withdrawals is an ordinary ledger action. The FK
   -- is ON DELETE SET NULL, so Postgres orphans the children — an UPDATE that
   -- lands on this trigger. It must not turn a delete into an error.

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -625,11 +625,11 @@ end;
 $$;
 
 -- ── a full fund sell must survive the two cost bases disagreeing ─────────────
--- The bucket's principal is measured as Σ amount_vnd; the sell builders derive
--- what they post from the NAV cost basis (Σ units × unit_price). Each stored
--- amount_vnd was itself rounded, so on a multi-purchase bucket the two differ by
--- a đồng or two — enough to refuse an ordinary "sell everything" without a slack
--- of exactly that size.
+-- The basis is Σ amount_vnd — what the purchases cost — because that is the
+-- accumulator dashboard/overview subtracts principal_withdrawn from. A full sale
+-- takes it exactly (lib/fundWithdrawal states it rather than deriving it), so the
+-- only drift left is between SUCCESSIVE PARTIAL sales, each of which rounded its
+-- own units-proportional slice. The slack covers exactly that, and no more.
 do $$
 declare
   v_user uuid;
@@ -639,28 +639,33 @@ begin
   insert into public.funds (user_id, name, code, fund_type, nav)
   values (v_user, 'Basis Fund', 'BSF', 'equity', 20000) returning id into v_fund;
 
-  -- Two purchases whose raw basis is 1,000,050.4 each: stored amount_vnd rounds
-  -- DOWN to 1,000,050, so Σ amount_vnd = 2,000,100 while the NAV cost the sheet
-  -- computes rounds to 2,000,101.
+  -- One purchase of 1,000,001 over 3 units: no third of it is a whole đồng.
   insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
-  values (v_user, v_fund, 'fund', 'investment', '2026-01-01', 1000050, 50.0025, 20000);
-  insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
-  values (v_user, v_fund, 'fund', 'investment', '2026-02-01', 1000050, 50.0025, 20000);
+  values (v_user, v_fund, 'fund', 'investment', '2026-01-01', 1000001, 3, 333334);
 
+  -- Three partial sales of one unit each: round(1,000,001 / 3) = 333,334 apiece,
+  -- which totals 1,000,002 — a đồng more than the bucket cost. That is the
+  -- rounding the slack exists for, and the LAST one is where it lands.
   insert into public.investment_transactions
     (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
-  values (v_user, v_fund, 'fund', 'withdrawal', '2026-03-01', 2000101, 2000101, 100.005);
+  values (v_user, v_fund, 'fund', 'withdrawal', '2026-02-01', 333334, 333334, 1);
+  insert into public.investment_transactions
+    (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_fund, 'fund', 'withdrawal', '2026-03-01', 333334, 333334, 1);
+  insert into public.investment_transactions
+    (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_fund, 'fund', 'withdrawal', '2026-04-01', 333334, 333334, 1);
 
-  -- The slack is bounded, not a licence: a thousand đồng over is still refused.
+  -- Bounded, not a licence: a thousand đồng over is still refused.
   begin
     insert into public.investment_transactions
       (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
-    values (v_user, v_fund, 'fund', 'withdrawal', '2026-04-01', 1000, 1000, 0.0001);
-    raise exception 'the cost-basis slack must not cover a real overdraw';
+    values (v_user, v_fund, 'fund', 'withdrawal', '2026-05-01', 1000, 1000, 0.0001);
+    raise exception 'the rounding slack must not cover a real overdraw';
   exception when sqlstate '23514' then null;
   end;
 
-  raise notice 'fund cost-basis slack: ok';
+  raise notice 'fund partial-sale rounding slack: ok';
 end;
 $$;
 
@@ -786,14 +791,14 @@ begin
 end;
 $$;
 
--- ── a purchase whose stored amount and NAV cost disagree outright ────────────
--- The POST route takes amount_vnd, units and unit_price as independent fields and
--- enforces no relationship between them, and the sheet lets units be typed by
--- hand. So a purchase can store 1,000,000 with 60 units at 20,000 — a NAV cost of
--- 1,200,000. The dashboard and the sell builders use the NAV basis, so a full sell
--- posts 1,200,000: measuring only against Σ amount_vnd refuses an ordinary sale.
--- The bound is whichever basis is larger; for funds, units are the load-bearing
--- check anyway.
+-- ── one authoritative basis: what the purchases cost ─────────────────────────
+-- amount_vnd, units and unit_price are independent fields on the POST route (and
+-- the sheet lets units be typed by hand), so a purchase can store 1,000,000 with
+-- 60 units at 20,000 — a NAV cost of 1,200,000. Only one of those can be the
+-- basis, and it is amount_vnd: dashboard/overview subtracts principal_withdrawn
+-- from Σ amount_vnd, while the NAV cost is reduced by units and only feeds the
+-- average entry price. lib/fundWithdrawal posts from the same number, so a sale
+-- above it is a real overdraw and is refused rather than accommodated.
 do $$
 declare
   v_user uuid;
@@ -806,11 +811,22 @@ begin
   insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
   values (v_user, v_fund, 'fund', 'investment', '2026-01-01', 1000000, 60, 20000);
 
+  -- The NAV-derived figure the sheets used to post is above what the purchase
+  -- cost, so it is refused now that nothing produces it.
+  begin
+    insert into public.investment_transactions
+      (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+    values (v_user, v_fund, 'fund', 'withdrawal', '2026-02-01', 1200000, 1200000, 60);
+    raise exception 'a sale above what the purchase cost must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- The whole basis, which is what a full sale now posts.
   insert into public.investment_transactions
     (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
-  values (v_user, v_fund, 'fund', 'withdrawal', '2026-02-01', 1200000, 1200000, 60);
+  values (v_user, v_fund, 'fund', 'withdrawal', '2026-02-01', 1200000, 1000000, 60);
 
-  raise notice 'fund principal bound takes the larger basis: ok';
+  raise notice 'one authoritative fund basis: ok';
 end;
 $$;
 

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -845,4 +845,86 @@ begin
 end;
 $$;
 
+-- ── the fund exclusion must be null-safe ─────────────────────────────────────
+-- The parent branch excludes siblings that draw on a fund bucket instead. Written
+-- as `not (asset_type = 'fund' and fund_id is not null)`, that predicate is NULL —
+-- so the row is dropped from the sum — when asset_type is NULL and fund_id is set,
+-- a shape the POST route accepts. buildWithdrawalMaps counts such a row against
+-- its PARENT (it needs asset_type = 'fund' to use the fund key), so dropping it
+-- let two full withdrawals of the same deposit both pass.
+do $$
+declare
+  v_user uuid;
+  v_fund uuid;
+  v_dep  uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-nullsafe@test.invalid') returning id into v_user;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'NullSafe Fund', 'NSF', 'equity', 20000) returning id into v_fund;
+  insert into public.investment_transactions (user_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_dep;
+
+  insert into public.investment_transactions
+    (user_id, fund_id, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_fund, 'withdrawal', '2026-02-01', 100000000, v_dep, 100000000);
+
+  begin
+    insert into public.investment_transactions
+      (user_id, fund_id, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+    values (v_user, v_fund, 'withdrawal', '2026-03-01', 100000000, v_dep, 100000000);
+    raise exception 'a second full withdrawal must be refused whatever the row''s asset_type is';
+  exception when sqlstate '23514' then null;
+  end;
+
+  raise notice 'fund exclusion is null-safe: ok';
+end;
+$$;
+
+-- ── a gold sale moves both deltas, like a fund sale ──────────────────────────
+-- valueNonFundHolding values gold by UNITS × price and takes the cost basis from
+-- amount_vnd, so a sale carrying only principal drops the basis while every chỉ
+-- stays in net worth (P&L inflated, the sold gold never leaves), and one carrying
+-- only units removes the metal while its cost stays. The bank case is different
+-- and must keep working: a deposit has no units to move.
+do $$
+declare
+  v_user uuid;
+  v_gold uuid;
+  v_bank uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-gold-deltas@test.invalid') returning id into v_user;
+  insert into public.investment_transactions (user_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, 'gold', 'investment', '2026-01-01', 80000000, 10, 8000000) returning transaction_id into v_gold;
+  insert into public.investment_transactions (user_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_bank;
+
+  begin
+    insert into public.investment_transactions
+      (user_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+    values (v_user, 'gold', 'withdrawal', '2026-02-01', 40000000, v_gold, 40000000);
+    raise exception 'a gold sale without units_withdrawn must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  begin
+    insert into public.investment_transactions
+      (user_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, units_withdrawn)
+    values (v_user, 'gold', 'withdrawal', '2026-02-01', 40000000, v_gold, 5);
+    raise exception 'a gold sale without principal_withdrawn must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Both together are fine, and a bank withdrawal still needs only principal.
+  insert into public.investment_transactions
+    (user_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, 'gold', 'withdrawal', '2026-02-01', 40000000, v_gold, 40000000, 5);
+
+  insert into public.investment_transactions
+    (user_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, 'bank', 'withdrawal', '2026-02-01', 30000000, v_bank, 30000000);
+
+  raise notice 'gold sale deltas: ok';
+end;
+$$;
+
 rollback;

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -726,4 +726,123 @@ begin
 end;
 $$;
 
+-- ── the helper is the trigger's, not the API's ───────────────────────────────
+-- Postgres grants EXECUTE on a new function to PUBLIC, and this one is SECURITY
+-- DEFINER: left open, a caller who knows a holding's UUID could invoke it with a
+-- hand-built row, read the exact remaining balance out of the refusal message, and
+-- take locks on those rows while they were at it.
+do $$
+begin
+  begin
+    set local role authenticated;
+    -- A null composite is enough: EXECUTE is checked before the body runs.
+    perform public.check_withdrawal_balance(null::public.investment_transactions);
+    reset role;
+    raise exception 'check_withdrawal_balance must not be callable by authenticated';
+  exception
+    when insufficient_privilege then
+      reset role;
+    when others then
+      reset role;
+      -- Anything else means the call got THROUGH the privilege check.
+      raise exception 'expected a privilege error, got % (%)', sqlerrm, sqlstate;
+  end;
+
+  raise notice 'helper is not callable by the API roles: ok';
+end;
+$$;
+
+-- ── each withdrawal is counted against ONE balance ───────────────────────────
+do $$
+declare
+  v_user uuid;
+  v_fund uuid;
+  v_dep  uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-onecount@test.invalid') returning id into v_user;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'OneCount Fund', 'OCF', 'equity', 20000) returning id into v_fund;
+
+  insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000);
+  insert into public.investment_transactions (user_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_dep;
+
+  -- A fund sell that also names a parent is measured against the FUND bucket
+  -- (mirroring buildWithdrawalMaps, which ignores its parent). The parent's own
+  -- balance must therefore not be reduced by it as well — counting it twice made a
+  -- later, perfectly ordinary bank withdrawal look like an overdraw.
+  insert into public.investment_transactions
+    (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_fund, 'fund', 'withdrawal', '2026-02-01', 1000000, v_dep, 1000000, 50);
+
+  -- The deposit still has all 100M.
+  insert into public.investment_transactions
+    (user_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, 'bank', 'withdrawal', '2026-03-01', 100000000, v_dep, 100000000);
+
+  raise notice 'one withdrawal, one balance: ok';
+end;
+$$;
+
+-- ── a purchase whose stored amount and NAV cost disagree outright ────────────
+-- The POST route takes amount_vnd, units and unit_price as independent fields and
+-- enforces no relationship between them, and the sheet lets units be typed by
+-- hand. So a purchase can store 1,000,000 with 60 units at 20,000 — a NAV cost of
+-- 1,200,000. The dashboard and the sell builders use the NAV basis, so a full sell
+-- posts 1,200,000: measuring only against Σ amount_vnd refuses an ordinary sale.
+-- The bound is whichever basis is larger; for funds, units are the load-bearing
+-- check anyway.
+do $$
+declare
+  v_user uuid;
+  v_fund uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-navbasis@test.invalid') returning id into v_user;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'NavBasis Fund', 'NBF', 'equity', 20000) returning id into v_fund;
+
+  insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_fund, 'fund', 'investment', '2026-01-01', 1000000, 60, 20000);
+
+  insert into public.investment_transactions
+    (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_fund, 'fund', 'withdrawal', '2026-02-01', 1200000, 1200000, 60);
+
+  raise notice 'fund principal bound takes the larger basis: ok';
+end;
+$$;
+
+-- The other direction: a stored amount ABOVE the NAV cost is still the bound, and
+-- neither basis licenses a real overdraw.
+do $$
+declare
+  v_user uuid;
+  v_fund uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-navbasis2@test.invalid') returning id into v_user;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'NavBasis2 Fund', 'NB2', 'equity', 20000) returning id into v_fund;
+
+  -- amount_vnd 2,000,000 (fees included) vs NAV cost 1,200,000.
+  insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 60, 20000);
+
+  insert into public.investment_transactions
+    (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_fund, 'fund', 'withdrawal', '2026-02-01', 2000000, 2000000, 60);
+
+  begin
+    insert into public.investment_transactions
+      (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+    values (v_user, v_fund, 'fund', 'withdrawal', '2026-03-01', 500000, 500000, 0.0001);
+    raise exception 'neither basis may license an overdraw';
+  exception when sqlstate '23514' then null;
+  end;
+
+  raise notice 'fund principal bound, other direction: ok';
+end;
+$$;
+
 rollback;

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -421,6 +421,7 @@ declare
   v_fund uuid;
   v_buy  uuid;
   v_dep  uuid;
+  v_sell uuid;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'wd-bucket2@test.invalid') returning id into v_user;
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
@@ -471,7 +472,30 @@ begin
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
   values (v_user, v_goal, 'bank', 'withdrawal', '2026-03-01', 100000000, v_dep, 100000000);
 
-  raise notice 'withdrawal bucket asset type + negative amounts: ok';
+  -- Deleting the FUND is the same story as deleting a deposit: fund_id is also
+  -- ON DELETE SET NULL, so the sells are orphaned by an update that lands here.
+  -- Only the FK may do it — detaching a sell from a fund that still exists puts
+  -- the units back and files the sell under no key at all.
+  insert into public.investment_transactions (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000);
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-02-01', 1000000, 1000000, 50)
+  returning transaction_id into v_sell;
+
+  begin
+    update public.investment_transactions set fund_id = null where transaction_id = v_sell;
+    raise exception 'a sell must not be detached from a fund that still exists';
+  exception when sqlstate '23514' then null;
+  end;
+
+  delete from public.funds where id = v_fund;
+
+  if (select fund_id from public.investment_transactions where transaction_id = v_sell) is not null then
+    raise exception 'deleting the fund should have orphaned its sell';
+  end if;
+
+  raise notice 'withdrawal bucket asset type + negative amounts + fund deletion: ok';
 end;
 $$;
 

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -499,4 +499,129 @@ begin
 end;
 $$;
 
+-- ── relocating a bucket is a multi-row move, and row order must not decide it ─
+-- POST /api/v1/fund-investments/assign moves a fund's purchases AND its sells to
+-- the new goal in ONE update. A row trigger sees that statement half-applied, so
+-- whether the destination bucket looked complete depended on heap order: after an
+-- ordinary edit of the purchase (which rewrites it to the end of the heap), the
+-- sell was visited first, measured against an empty destination, and an everyday
+-- assign returned 500. Deleting a goal does the same thing through
+-- ON DELETE SET NULL. The relocation check is therefore deferred to the end of
+-- the statement — but it still has to refuse a sell moved somewhere on its own.
+do $$
+declare
+  v_user uuid;
+  v_a    uuid;
+  v_b    uuid;
+  v_fund uuid;
+  v_buy  uuid;
+  v_sell uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-move@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'A') returning goal_id into v_a;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'B') returning goal_id into v_b;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Move Fund', 'MVF', 'equity', 20000) returning id into v_fund;
+
+  insert into public.investment_transactions (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_a, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000) returning transaction_id into v_buy;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_a, v_fund, 'fund', 'withdrawal', '2026-02-01', 600000, 600000, 30) returning transaction_id into v_sell;
+
+  -- Editing the purchase rewrites it to the end of the heap, so the bulk update
+  -- below visits the SELL first. This is the order that used to fail.
+  update public.investment_transactions set notes = 'edited' where transaction_id = v_buy;
+
+  update public.investment_transactions
+     set goal_id = v_b, updated_at = now()
+   where user_id = v_user and fund_id = v_fund and asset_type = 'fund' and goal_id = v_a;
+
+  if (select count(*) from public.investment_transactions
+       where fund_id = v_fund and goal_id = v_b) <> 2 then
+    raise exception 'the whole bucket should have moved';
+  end if;
+
+  -- Deleting the goal relocates the bucket to Unallocated the same way.
+  delete from public.savings_goals where goal_id = v_b;
+
+  if (select count(*) from public.investment_transactions
+       where fund_id = v_fund and goal_id is null) <> 2 then
+    raise exception 'deleting the goal should have moved the whole bucket to unallocated';
+  end if;
+
+  -- But a sell moved on its own still has to be refused — the units stay in one
+  -- bucket while the sale is filed against another. Deferred means the error
+  -- arrives at the end of the statement, not during it.
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'C') returning goal_id into v_a;
+  begin
+    update public.investment_transactions set goal_id = v_a where transaction_id = v_sell;
+    raise exception 'moving a lone sell into a bucket that holds nothing must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  raise notice 'withdrawal bucket relocation: ok';
+end;
+$$;
+
+-- ── a fund sell records both deltas, and losing a fund re-measures the parent ─
+do $$
+declare
+  v_user uuid;
+  v_goal uuid;
+  v_fund uuid;
+  v_small uuid;
+  v_sell  uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-deltas@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Deltas Fund', 'DLF', 'equity', 20000) returning id into v_fund;
+
+  insert into public.investment_transactions (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 20000000, 1000, 20000);
+
+  -- Units but no principal: the units fall while the cost basis stays, so P&L is
+  -- wrong. Principal but no units: the overview bails on `units <= 0` and skips
+  -- the subtraction entirely, leaving the holding untouched while the balance was
+  -- consumed. Neither is a shape the sell sheets produce.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units_withdrawn)
+    values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-02-01', 1000000, 50);
+    raise exception 'a fund sell without principal_withdrawn must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn)
+    values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-02-01', 1000000, 1000000);
+    raise exception 'a fund sell without units_withdrawn must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- A sell carrying BOTH a fund and a parent is measured against the fund bucket
+  -- (mirroring buildWithdrawalMaps). Delete the fund and the same row starts
+  -- drawing on its parent instead — which may be far smaller, so losing the fund
+  -- has to re-measure rather than wave the row through.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 1000000) returning transaction_id into v_small;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-02-01', 10000000, v_small, 10000000, 500)
+  returning transaction_id into v_sell;
+
+  begin
+    delete from public.funds where id = v_fund;
+    raise exception 'losing the fund must re-measure the sell against its parent';
+  exception when sqlstate '23514' then null;
+  end;
+
+  raise notice 'fund sell deltas + re-measure on fund loss: ok';
+end;
+$$;
+
 rollback;

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -624,4 +624,106 @@ begin
 end;
 $$;
 
+-- ── a full fund sell must survive the two cost bases disagreeing ─────────────
+-- The bucket's principal is measured as Σ amount_vnd; the sell builders derive
+-- what they post from the NAV cost basis (Σ units × unit_price). Each stored
+-- amount_vnd was itself rounded, so on a multi-purchase bucket the two differ by
+-- a đồng or two — enough to refuse an ordinary "sell everything" without a slack
+-- of exactly that size.
+do $$
+declare
+  v_user uuid;
+  v_fund uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-basis@test.invalid') returning id into v_user;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Basis Fund', 'BSF', 'equity', 20000) returning id into v_fund;
+
+  -- Two purchases whose raw basis is 1,000,050.4 each: stored amount_vnd rounds
+  -- DOWN to 1,000,050, so Σ amount_vnd = 2,000,100 while the NAV cost the sheet
+  -- computes rounds to 2,000,101.
+  insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_fund, 'fund', 'investment', '2026-01-01', 1000050, 50.0025, 20000);
+  insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_fund, 'fund', 'investment', '2026-02-01', 1000050, 50.0025, 20000);
+
+  insert into public.investment_transactions
+    (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_fund, 'fund', 'withdrawal', '2026-03-01', 2000101, 2000101, 100.005);
+
+  -- The slack is bounded, not a licence: a thousand đồng over is still refused.
+  begin
+    insert into public.investment_transactions
+      (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+    values (v_user, v_fund, 'fund', 'withdrawal', '2026-04-01', 1000, 1000, 0.0001);
+    raise exception 'the cost-basis slack must not cover a real overdraw';
+  exception when sqlstate '23514' then null;
+  end;
+
+  raise notice 'fund cost-basis slack: ok';
+end;
+$$;
+
+-- ── every refusal is recognisable to the API ─────────────────────────────────
+-- The route maps this family to a 400 by one prefix. When each message had to be
+-- listed individually, a new refusal fell through as a 500 — an invalid request
+-- reported as a server fault.
+do $$
+declare
+  v_user uuid;
+  v_fund uuid;
+  v_msg  text;
+  v_seen int := 0;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-prefix@test.invalid') returning id into v_user;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Prefix Fund', 'PXF', 'equity', 20000) returning id into v_fund;
+
+  -- negative amounts
+  begin
+    insert into public.investment_transactions
+      (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+    values (v_user, v_fund, 'fund', 'withdrawal', '2026-02-01', 1000, -1000, -1);
+  exception when sqlstate '23514' then
+    v_msg := sqlerrm;
+    if v_msg not like 'withdrawal invariant:%' then
+      raise exception 'the negative-amount refusal must carry the prefix, got: %', v_msg;
+    end if;
+    v_seen := v_seen + 1;
+  end;
+
+  -- incomplete fund deltas
+  begin
+    insert into public.investment_transactions
+      (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn)
+    values (v_user, v_fund, 'fund', 'withdrawal', '2026-02-01', 1000, 1000);
+  exception when sqlstate '23514' then
+    v_msg := sqlerrm;
+    if v_msg not like 'withdrawal invariant:%' then
+      raise exception 'the incomplete-deltas refusal must carry the prefix, got: %', v_msg;
+    end if;
+    v_seen := v_seen + 1;
+  end;
+
+  -- an empty bucket
+  begin
+    insert into public.investment_transactions
+      (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+    values (v_user, v_fund, 'fund', 'withdrawal', '2026-02-01', 1000, 1000, 1);
+  exception when sqlstate '23514' then
+    v_msg := sqlerrm;
+    if v_msg not like 'withdrawal invariant:%' then
+      raise exception 'the balance refusal must carry the prefix, got: %', v_msg;
+    end if;
+    v_seen := v_seen + 1;
+  end;
+
+  if v_seen <> 3 then
+    raise exception 'expected three refusals, saw %', v_seen;
+  end if;
+
+  raise notice 'refusal prefix: ok';
+end;
+$$;
+
 rollback;

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -325,4 +325,80 @@ begin
 end;
 $$;
 
+-- ── the parent has to be a holding, and deleting one must stay possible ──────
+-- A withdrawal is not a holding: parenting to one invents a balance out of money
+-- that already left. Renewal snapshots, on the other hand, are valid parents on
+-- purpose — renew and collapse re-parent partial withdrawals onto them (#585).
+--
+-- A FUND purchase as parent is bounded by that row rather than refused: such a
+-- row is ignored by buildWithdrawalMaps, so it is an uncounted withdrawal rather
+-- than an overdraw (a valuation gap older than this change, and a shape
+-- dca_seeding_heal.test.sql treats as data that exists).
+do $$
+declare
+  v_user uuid;
+  v_goal uuid;
+  v_fund uuid;
+  v_buy  uuid;
+  v_dep  uuid;
+  v_wd   uuid;
+  v_snap uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-parent@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Parent Fund', 'PRF', 'equity', 20000) returning id into v_fund;
+
+  insert into public.investment_transactions (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 90000000, 4500, 20000) returning transaction_id into v_buy;
+
+  -- Parented to that fund purchase: allowed, but still bounded by the row it
+  -- names — 90M is there, 200M is not.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 10000000, v_buy, 10000000);
+
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+    values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-02', 200000000, v_buy, 200000000);
+    raise exception 'even an oddly parented withdrawal is bounded by the row it names';
+  exception when sqlstate '23514' then null;
+  end;
+
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_dep;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 30000000, v_dep, 30000000) returning transaction_id into v_wd;
+
+  -- A withdrawal is not a holding: parenting to one is a phantom balance.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+    values (v_user, v_goal, 'bank', 'withdrawal', '2026-03-01', 20000000, v_wd, 20000000);
+    raise exception 'a withdrawal must not draw on another withdrawal';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- A renewal snapshot IS a valid parent — renew/collapse re-parent onto it.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, renewed_from_transaction_id)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000, v_dep) returning transaction_id into v_snap;
+
+  update public.investment_transactions set parent_transaction_id = v_snap where transaction_id = v_wd;
+
+  -- Deleting a source that has withdrawals is an ordinary ledger action. The FK
+  -- is ON DELETE SET NULL, so Postgres orphans the children — an UPDATE that
+  -- lands on this trigger. It must not turn a delete into an error.
+  delete from public.investment_transactions where transaction_id = v_snap;
+
+  if (select parent_transaction_id from public.investment_transactions where transaction_id = v_wd) is not null then
+    raise exception 'the orphaned withdrawal should have lost its parent';
+  end if;
+
+  raise notice 'withdrawal parent kinds + source deletion: ok';
+end;
+$$;
+
 rollback;

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -861,6 +861,56 @@ begin
 end;
 $$;
 
+-- ── a fund sale's principal is bound to its units ────────────────────────────
+-- Capping principal and units independently was not enough: a sale of 1 unit out
+-- of 100 could claim the WHOLE basis, passing both caps while leaving 99 units
+-- with none — which corrupts every later allocation and the P&L. The principal is
+-- the units-proportional share of the remaining basis, within one đồng.
+do $$
+declare
+  v_user uuid;
+  v_fund uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-alloc@test.invalid') returning id into v_user;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Alloc Fund', 'ALF', 'equity', 10000) returning id into v_fund;
+
+  insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_fund, 'fund', 'investment', '2026-01-01', 1000000, 100, 10000);
+
+  -- 1 unit, whole basis: the case that used to pass.
+  begin
+    insert into public.investment_transactions
+      (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+    values (v_user, v_fund, 'fund', 'withdrawal', '2026-02-01', 10000, 1000000, 1);
+    raise exception 'a 1-unit sale must not take the whole basis';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Too little basis for the units sold is equally wrong: it leaves basis behind
+  -- with no units to carry it.
+  begin
+    insert into public.investment_transactions
+      (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+    values (v_user, v_fund, 'fund', 'withdrawal', '2026-02-01', 500000, 1, 50);
+    raise exception 'a 50-unit sale must not take 1 đồng of basis';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- The proportional share is what passes: 50 units of 100 takes half.
+  insert into public.investment_transactions
+    (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_fund, 'fund', 'withdrawal', '2026-02-01', 500000, 500000, 50);
+
+  -- And the rest of the bucket sells for the rest of the basis.
+  insert into public.investment_transactions
+    (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_fund, 'fund', 'withdrawal', '2026-03-01', 500000, 500000, 50);
+
+  raise notice 'fund principal is bound to units: ok';
+end;
+$$;
+
 -- ── the fund exclusion must be null-safe ─────────────────────────────────────
 -- The parent branch excludes siblings that draw on a fund bucket instead. Written
 -- as `not (asset_type = 'fund' and fund_id is not null)`, that predicate is NULL —
@@ -939,7 +989,65 @@ begin
     (user_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
   values (v_user, 'bank', 'withdrawal', '2026-02-01', 30000000, v_bank, 30000000);
 
-  raise notice 'gold sale deltas: ok';
+  -- Omitted and zero principal, the two ways to withdraw nothing while claiming
+  -- cash left: lib/depositValuation subtracts coalesce(principal_withdrawn, 0), so
+  -- the deposit would keep its full value behind a withdrawal row.
+  begin
+    insert into public.investment_transactions
+      (user_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id)
+    values (v_user, 'bank', 'withdrawal', '2026-03-01', 20000000, v_bank);
+    raise exception 'a withdrawal with no principal_withdrawn must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  begin
+    insert into public.investment_transactions
+      (user_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+    values (v_user, 'bank', 'withdrawal', '2026-03-01', 20000000, v_bank, 0);
+    raise exception 'a withdrawal of zero principal must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- And the positive case still lands, out of what is left.
+  insert into public.investment_transactions
+    (user_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, 'bank', 'withdrawal', '2026-03-02', 20000000, v_bank, 20000000);
+
+  raise notice 'gold sale deltas + required principal: ok';
+end;
+$$;
+
+-- ── held-for-merge is an explicit exception, not a silent one ────────────────
+-- A settle-with-hold row that names NO source has nothing to measure: it is the
+-- shape #588 exists to make source-backed. This invariant leaves it alone ONLY
+-- when it also claims no deltas — the moment it claims principal, it is a
+-- withdrawal drawing on nothing and is refused. That boundary is deliberate, so it
+-- is pinned rather than left to the reader.
+do $$
+declare
+  v_user uuid;
+  v_goal uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-held@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+
+  -- No source, no deltas: passes here, and #588 is where it gets a source.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     held_for_merge, merge_target_goal_id)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 50000000, true, v_goal);
+
+  -- No source but claiming principal: that is a withdrawal against nothing.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+       principal_withdrawn, held_for_merge, merge_target_goal_id)
+    values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 50000000, 50000000, true, v_goal);
+    raise exception 'a held row claiming principal with no source must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  raise notice 'held-for-merge exception boundary: ok';
 end;
 $$;
 

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -413,4 +413,66 @@ begin
 end;
 $$;
 
+-- ── the bucket must hold only what the valuation counts, and only forwards ───
+do $$
+declare
+  v_user uuid;
+  v_goal uuid;
+  v_fund uuid;
+  v_buy  uuid;
+  v_dep  uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-bucket2@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Bucket2 Fund', 'BK2', 'equity', 20000) returning id into v_fund;
+
+  -- A fund purchase whose asset_type is edited to 'bank' keeps its fund_id (the
+  -- PUT route clears fund_id only when that field is sent). The dashboard then
+  -- values it as a bank holding — so its units are no longer fund inventory and
+  -- must not back a fund sell.
+  insert into public.investment_transactions (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000) returning transaction_id into v_buy;
+
+  update public.investment_transactions set asset_type = 'bank' where transaction_id = v_buy;
+
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+    values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-02-01', 1000000, 1000000, 50);
+    raise exception 'units that are no longer valued as a fund must not back a fund sell';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- A negative withdrawal runs the ledger backwards: it ADDS to the holding and
+  -- leaves a credit the next withdrawal can spend. Nothing in the schema stops
+  -- one, so the invariant has to.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_dep;
+
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+    values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 100000, v_dep, -100000000);
+    raise exception 'a negative principal withdrawal must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+    values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 100000, v_dep, 0, -5);
+    raise exception 'a negative units withdrawal must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- And the deposit still has its whole balance: nothing was credited to it.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-03-01', 100000000, v_dep, 100000000);
+
+  raise notice 'withdrawal bucket asset type + negative amounts: ok';
+end;
+$$;
+
 rollback;

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -229,4 +229,69 @@ begin
 end;
 $$;
 
+-- ── the balance a row is measured against must be the one it draws down ──────
+-- Two ways to hand the invariant the wrong balance, both caught by review on
+-- PR #599:
+--
+--   1. A fund withdrawal carrying BOTH fund_id and parent_transaction_id.
+--      lib/withdrawalProgress keys any row with asset_type='fund' + fund_id by
+--      (goal, fund) and ignores its parent — so measuring it against the parent
+--      instead lets a fat deposit in one goal wave through a phantom fund sell
+--      in another. The check has to follow the same precedence the valuation does.
+--   2. Staging the row as an investment and flipping transaction_type afterwards.
+--      A one-column update has to re-measure, or the guard is opt-in.
+do $$
+declare
+  v_user  uuid;
+  v_goal  uuid;
+  v_goal_b uuid;
+  v_fund  uuid;
+  v_fat   uuid;
+  v_staged uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-bucket@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Car') returning goal_id into v_goal_b;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Bucket Fund', 'BKF', 'equity', 20000) returning id into v_fund;
+
+  -- Plenty of this fund held in the House goal — principal AND units, so the
+  -- parent-row check would pass on both counts if it were the one applied.
+  insert into public.investment_transactions (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 4000000, 200, 20000) returning transaction_id into v_fat;
+
+  -- 1) The Car goal holds none of the fund. Parenting the sell to the fat House
+  --    row must not buy it a balance: the dashboard will subtract these units
+  --    from (Car, fund), which holds nothing.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date,
+       amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+    values (v_user, v_goal_b, v_fund, 'fund', 'withdrawal', '2026-02-01',
+            2000000, v_fat, 2000000, 100);
+    raise exception 'a fund sell must be measured against its fund bucket, not its parent';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- 2) Staged as an investment (which the invariant leaves alone, since an
+  --    investment draws nothing down), then activated. 9M of principal against a
+  --    4M holding.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'investment', '2026-02-01', 9000000, v_fat, 9000000)
+  returning transaction_id into v_staged;
+
+  begin
+    update public.investment_transactions
+       set transaction_type = 'withdrawal'
+     where transaction_id = v_staged;
+    raise exception 'becoming a withdrawal must be measured too';
+  exception when sqlstate '23514' then null;
+  end;
+
+  raise notice 'withdrawal bucket precedence + activation: ok';
+end;
+$$;
+
 rollback;

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -1027,15 +1027,35 @@ do $$
 declare
   v_user uuid;
   v_goal uuid;
+  v_held uuid;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'wd-held@test.invalid') returning id into v_user;
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
 
-  -- No source, no deltas: passes here, and #588 is where it gets a source.
+  -- No source, no deltas, and HELD: the tracked #588 exception, allowed.
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
      held_for_merge, merge_target_goal_id)
-  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 50000000, true, v_goal);
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 50000000, true, v_goal)
+  returning transaction_id into v_held;
+
+  -- The same row shape WITHOUT held_for_merge is an ordinary withdrawal with no
+  -- holding at all. The exception is for the held-for-merge pool, so nothing else
+  -- may wear it: an ordinary withdrawal must name what it draws on.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+    values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 50000000);
+    raise exception 'an ordinary withdrawal with no source must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- And an allowed held row cannot be turned into one by dropping the flag.
+  begin
+    update public.investment_transactions set held_for_merge = false where transaction_id = v_held;
+    raise exception 'clearing held_for_merge must re-measure the row, not wave it through';
+  exception when sqlstate '23514' then null;
+  end;
 
   -- No source but claiming principal: that is a withdrawal against nothing.
   begin

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -248,6 +248,7 @@ declare
   v_fund  uuid;
   v_fat   uuid;
   v_staged uuid;
+  v_sold  uuid;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'wd-bucket@test.invalid') returning id into v_user;
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
@@ -287,6 +288,36 @@ begin
        set transaction_type = 'withdrawal'
      where transaction_id = v_staged;
     raise exception 'becoming a withdrawal must be measured too';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- 3) Changing asset_type off 'fund' takes the row out of the fund bucket
+  --    (buildWithdrawalMaps stops keying it by goal/fund) and, with no parent, it
+  --    then subtracts from nothing at all: the sold units come back into net worth
+  --    while the withdrawal record stays. Adding asset_type to the trigger's
+  --    columns only gets the trigger to run — what refuses the change is that a
+  --    withdrawal drawing on NO holding is not a withdrawal.
+  insert into public.investment_transactions (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal_b, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000);
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, v_fund, 'fund', 'withdrawal', '2026-02-01', 2000000, 2000000, 100)
+  returning transaction_id into v_sold;
+
+  begin
+    update public.investment_transactions
+       set asset_type = 'bank'
+     where transaction_id = v_sold;
+    raise exception 'a withdrawal must not be able to stop drawing on anything';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Same shape, created directly: principal out of thin air, attached to nothing.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn)
+    values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 7000000, 7000000);
+    raise exception 'a withdrawal with no holding to draw on must be refused';
   exception when sqlstate '23514' then null;
   end;
 

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -179,8 +179,9 @@ $$;
 -- unit of that rounding, so a real overdraw is still refused.
 do $$
 declare
-  v_user uuid;
-  v_fund uuid;
+  v_user  uuid;
+  v_fund  uuid;
+  v_fund2 uuid;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'wd-rounding@test.invalid') returning id into v_user;
   insert into public.funds (user_id, name, code, fund_type, nav)
@@ -199,6 +200,28 @@ begin
       (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
     values (v_user, v_fund, 'fund', 'withdrawal', '2026-03-01', 1000, 1000, 0.1);
     raise exception 'the rounding tolerance must not swallow a real overdraw';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Nothing left means nothing to round. A holding sold out to EXACTLY zero (no
+  -- rounding remainder to hide behind) must not still yield 0.0001 units, or every
+  -- empty bucket carries a balance it never had — and with principal_withdrawn
+  -- omitted, that is a withdrawal carrying any amount_vnd it likes against a
+  -- holding that is gone.
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Exact Fund', 'EXF', 'equity', 20000) returning id into v_fund2;
+
+  insert into public.investment_transactions (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_fund2, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000);
+  insert into public.investment_transactions
+    (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_fund2, 'fund', 'withdrawal', '2026-02-01', 2000000, 2000000, 100);
+
+  begin
+    insert into public.investment_transactions
+      (user_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units_withdrawn)
+    values (v_user, v_fund2, 'fund', 'withdrawal', '2026-03-01', 5000000, 0.0001);
+    raise exception 'an empty holding must not get the rounding tolerance as a balance';
   exception when sqlstate '23514' then null;
   end;
 


### PR DESCRIPTION
Closes #587.

## The bug

The sell/withdraw sheets bounded the amount client-side (`computeSellPreview`'s `sellOverMax` / `isOverUnits`). `POST /api/v1/investment-transactions` validated the numeric shape and inserted whatever it was handed — no balance check, no lock. So a stale tab, a retried request, or two sells racing each other could each pass their *own* read of the balance and both land.

Past zero, the holding disappears: `valueNonFundHolding` returns null at `effectiveAmount <= 0`, so the dashboard drops it while the excess withdrawal stays in history. Net worth and P&L are wrong from then on, and nothing surfaces it.

## The fix: an invariant on the table

A trigger, `investment_transactions_withdrawal_balance` (`supabase/migrations/20260730000002`), not a service the route calls:

- **Every writer meets it.** The balance already has several — this route, `renew_term_deposit_with_merge`, `withdraw_accumulating_book` — and the next one is written by whoever forgets to call the service. An invariant on the table holds for all of them, service-role and raw SQL included. Same reasoning that moved the recurring-link cleanup into the database in #531.
- **It is atomic because of the ordering.** The check **locks the source rows first**, then reads the withdrawal sums in a *following* statement. Under READ COMMITTED the loser of a race blocks on that lock until the winner commits, and its next statement takes a fresh snapshot — so it is measured against the balance the winner left behind. Reading the sums first would let both pass, which is exactly the bug.

Two balances, mirroring the two buckets the dashboard aggregates:

| holding | balance |
|---|---|
| bank / gold / stock | the source row via `parent_transaction_id`: `amount_vnd − Σ principal_withdrawn`, `units − Σ units_withdrawn` |
| fund | the `(goal_id, fund_id)` bucket the overview aggregates — a fund sell has no parent row |

Details that matter:
- **Pending DCA seeds back nothing.** They carry a planned amount with `units IS NULL` and the dashboard never values them.
- **Units get a 0.0001 tolerance.** Clients round `units_withdrawn` to 4 dp, so a full sell of 50.12345 units posts 50.1235 — refusing that would break "sell everything". One unit of that rounding, no more.
- **The boundary is allowed:** withdrawing exactly what's left succeeds; 1 đồng more does not.
- The route maps the refusal to a **400 that says the balance moved**, matching `withdraw-book`'s answer for the same condition, instead of the generic 500 every insert failure collapsed into.

## Also here, because the invariant requires it

`AddTransactionSheet` posted `goal_id: null` for a fund sell even when the holding sat in a goal — so the sell drew down the **Unallocated** bucket. That was already a mis-valuation (the goal's holding never moved), and under the new invariant that sell is refused outright. The holdings picker now keeps the goal's **id** alongside the name it displays, and all three sell payloads carry it.

## Not covered, deliberately

- Lowering a **source's own** `amount_vnd` below what has already been withdrawn is the mirror hole. `collapse_accumulating_book` and the renewal RPCs rewrite amounts mid-transaction, so guarding that needs care this change has no room for — it wants its own issue.
- **No backfill.** Existing overdrawn rows aren't rewritten (that was #585's territory); the trigger stops new ones.
- **No idempotency key.** A repeated identical withdrawal is indistinguishable from a legitimate second one, so guessing would be worse than not; the balance check now bounds what a retry storm can do to the real balance.

## Tests

- **`supabase/tests/withdrawal_balance.test.sql`** — the invariant against a real database: spend-down to zero, the exact boundary, gold refused on *units* while its cost basis would have fit, per-goal fund buckets (House units can't fund a Car sell, and neither can Unallocated), pending DCA seeds, the rounding tolerance, and the refusal **wording** the route matches on. Every attempt catches only `23514`, so a null-violation can't masquerade as a rejection.
- **`route.post.balance.test.ts`** — the 400 and its message; an unrelated insert failure still 500s; another `check_violation` doesn't borrow the balance message.
- **`e2e/withdrawal-balance.spec.ts`** — API-level, real stack: overdraw refused, balance still spends to zero, a fund sell drawing only on its own goal, and **two sells fired at one balance where exactly one wins** (then asserts the ledger holds one withdrawal, not two). That race is what the design exists for and no unit test can show it.
- Component: the sheet's fund-sell flow now asserts the posted `goal_id` is the goal the holding was picked from.

Verified red: dropping the trigger fails all 3 E2E cases; the DB test fails on its first overdraw.

## Checks

- `npm test -- --run` — 1813 passed (165 files)
- `npm run test:db` — 14/14 (12 existing + the new one's 2 blocks)
- `npm run lint`, `npm run typecheck` — clean
- `npm run test:e2e` (full) — **263 passed** in 6.3m, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)