### PR TITLE
chore(db): screen the withdrawal ledger against the invariant (read-only)

### DIFF
--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -118,7 +118,8 @@ sale_dev as (
          abs(coalesce(w.principal_withdrawn, 0) - round(p.amount_vnd * w.units_withdrawn / p.units)) as dev,
          p.sells + 1 as base_tol,
          case when p.out_units >= p.units - 0.0001
-                then greatest(p.units - p.out_units, 0) * p.amount_vnd / p.units else 0 end as shortcut_tol
+                then least(abs(p.units - p.out_units), 0.0001) * p.amount_vnd / p.units else 0 end as shortcut_tol,
+         p.out_units >= p.units - 0.0001 as exhausted
     from wd w
     join parents p on p.transaction_id = w.parent_transaction_id
    where not w.fund_keyed and p.asset_type = 'gold' and coalesce(p.units, 0) > 0
@@ -133,7 +134,8 @@ sale_dev as (
          abs(coalesce(w.principal_withdrawn, 0) - round(b.basis * w.units_withdrawn / b.units)),
          b.sells + 1,
          case when b.out_units >= b.units - 0.0001
-                then greatest(b.units - b.out_units, 0) * b.basis / b.units else 0 end
+                then least(abs(b.units - b.out_units), 0.0001) * b.basis / b.units else 0 end,
+         b.out_units >= b.units - 0.0001
     from wd w
     join fund_buckets b
       on b.user_id = w.user_id and b.fund_id = w.fund_id and b.goal_id is not distinct from w.goal_id
@@ -151,14 +153,15 @@ sale_dev as (
 -- if two or more need the slack, the holding cannot be explained by any legal
 -- sequence and they are all reported; if just one does, it is allowed its value.
 --
--- Sub-epsilon slivers are left out of the count and never reported. A sale of
--- 0.0002 units or less can legitimately take a whole remaining basis in the tail
--- of an epsilon-exhausted holding, and which of those were legal depends on the
--- order they were written in — the same undecidable-from-state limit recorded in
--- the header, with the same bound on what it can hide.
+-- Sub-epsilon slivers are left out of the count, but only on a holding that ends
+-- EXHAUSTED. A sliver can take a whole remaining basis only if it closed the
+-- holding, and which slivers in that tail were legal depends on write order — the
+-- undecidable-from-state limit the header records. On a holding with units still
+-- unsold nothing closed anything, so a sliver there owes the flat rate like any
+-- other sale and is measured like one: 0.0002 units out of 1 closes nothing.
 sale_dev_ranked as (
   select d.*,
-         count(*) filter (where d.dev > d.base_tol and d.units_withdrawn > 0.0002)
+         count(*) filter (where d.dev > d.base_tol and not (d.exhausted and d.units_withdrawn <= 0.0002))
            over (partition by d.user_id, d.balance_key) as over_base
     from sale_dev d
 )
@@ -361,7 +364,11 @@ select 'fund_bucket_has_no_purchases', 'violation',
 --   sells   the ±1 allowance each sale may use, which the last sale inherits
 --   1       the two roundings between the flat rate and the invariant's expectation
 --   the value of the units left UNSOLD, and only on a holding that ends exhausted
---           at most one epsilon's worth, since that is as much as can be left. The clients round units to 4
+--           at most one epsilon's worth, since that is as much as can be over or
+--           under. The clients round units to 4 decimals in BOTH directions: a full
+--           sale of 4 chỉ posts as 3.9999 or 4.0001 with equal ease, and the
+--           invariant takes either for a full sale and hands it the whole basis, so
+--           the gap against the flat rate runs a thousand đồng each way. The clients round units to 4
 --           decimals, so "sell everything" routinely posts a hair UNDER the holding
 --           (4 chỉ leaves as 3.9999) and the invariant treats a sale within an
 --           epsilon of the rest as a FULL one, taking the whole basis. On an
@@ -385,7 +392,7 @@ select 'sale_basis_not_proportional', 'review',
        d.user_id, d.transaction_id, d.parent_transaction_id, d.fund_id, d.goal_id, d.detail
   from sale_dev_ranked d
  where d.dev > d.base_tol
-   and d.units_withdrawn > 0.0002
+   and not (d.exhausted and d.units_withdrawn <= 0.0002)
    and (d.over_base >= 2 or d.dev > d.base_tol + d.shortcut_tol)
 
 union all
@@ -401,7 +408,7 @@ select 'basis_not_proportional', 'review',
    and abs(p.out_principal
            - case when p.out_units >= p.units - 0.0001 then p.amount_vnd
                   else round(p.amount_vnd * p.out_units / p.units) end) > 2 * p.sells + case when p.out_units >= p.units - 0.0001
-                          then greatest(p.units - p.out_units, 0) * p.amount_vnd / p.units else 0 end
+                          then least(abs(p.units - p.out_units), 0.0001) * p.amount_vnd / p.units else 0 end
 
 union all
 select 'basis_not_proportional', 'review',
@@ -416,7 +423,7 @@ select 'basis_not_proportional', 'review',
    and abs(b.out_principal
            - case when b.out_units >= b.units - 0.0001 then b.basis
                   else round(b.basis * b.out_units / b.units) end) > 2 * b.sells + case when b.out_units >= b.units - 0.0001
-                          then greatest(b.units - b.out_units, 0) * b.basis / b.units else 0 end;
+                          then least(abs(b.units - b.out_units), 0.0001) * b.basis / b.units else 0 end;
 
 comment on view public.withdrawal_ledger_audit is
   'Read-only audit of existing withdrawal rows against the decision table enforced by check_withdrawal_balance. One row per finding: check_name, severity, and the holding it concerns (#609).';

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -110,7 +110,8 @@ fund_buckets as (
 sale_dev as (
   select w.transaction_id, w.user_id, w.goal_id, w.fund_id, w.parent_transaction_id,
          w.units_withdrawn, w.principal_withdrawn,
-         p.transaction_id as holding, p.amount_vnd as basis, p.units as units,
+         p.transaction_id as holding, p.transaction_id::text as balance_key,
+         p.amount_vnd as basis, p.units as units,
          format('a sale of %s of the holding''s %s units took %s đồng where the flat rate on a %s basis is %s',
                 w.units_withdrawn, p.units, w.principal_withdrawn, p.amount_vnd,
                 round(p.amount_vnd * w.units_withdrawn / p.units)) as detail,
@@ -124,7 +125,7 @@ sale_dev as (
   union all
   select w.transaction_id, w.user_id, w.goal_id, w.fund_id, w.parent_transaction_id,
          w.units_withdrawn, w.principal_withdrawn,
-         null::uuid, b.basis, b.units,
+         null::uuid, b.fund_id::text || ':' || coalesce(b.goal_id::text, ''), b.basis, b.units,
          format('a sell of %s of the bucket''s %s units took %s đồng where the flat rate on a %s basis is %s',
                 w.units_withdrawn, b.units, w.principal_withdrawn, b.basis,
                 round(b.basis * w.units_withdrawn / b.units)),
@@ -139,7 +140,12 @@ sale_dev as (
 ),
 
 -- Exactly ONE sale per holding can be the one that closed it, so at most one may
--- claim the full-sale slack. Rows past the base tolerance are counted per holding:
+-- claim the full-sale slack. Siblings are counted by the BALANCE key and nothing
+-- else — parent_transaction_id for bank/gold/stock, (fund, goal) for a fund bucket
+-- — because that is what the invariant measures. A withdrawal carries its own
+-- goal_id, and for a parent-backed row the invariant ignores it entirely; counting
+-- by it would split one holding's sales into separate partitions and hand each of
+-- them the slack that only one sale can have. Rows past the base tolerance are counted per holding:
 -- if two or more need the slack, the holding cannot be explained by any legal
 -- sequence and they are all reported; if just one does, it is allowed its value.
 --
@@ -151,7 +157,7 @@ sale_dev as (
 sale_dev_ranked as (
   select d.*,
          count(*) filter (where d.dev > d.base_tol and d.units_withdrawn > 0.0002)
-           over (partition by d.user_id, d.holding, d.fund_id, d.goal_id) as over_base
+           over (partition by d.user_id, d.balance_key) as over_base
     from sale_dev d
 )
 

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -340,12 +340,17 @@ union all
 -- of zero units, and the invariant refuses any positive quantity drawn on it
 -- ('5 units exceeds the remaining balance of 0 units'). Skipping the comparison
 -- when the parent's units are null let exactly that row report clean.
+--
+-- And the 4-decimal epsilon is granted only where the invariant grants it: while
+-- something is left to round. `case when v_left_units > 0 then c_units_epsilon else
+-- 0 end` is its own wording. A holding of zero units — the schema allows one — has
+-- no rounding to forgive, so a sliver sold out of it is an overdraw like any other.
 select 'holding_overdrawn', 'violation',
        p.user_id, null::uuid, p.transaction_id, null::uuid, p.goal_id,
        format('%s holding of %s đồng / %s units has %s đồng / %s units taken out across %s withdrawal(s)',
               p.asset_type, p.amount_vnd, coalesce(p.units, 0), p.out_principal, p.out_units, p.sells)
   from parents p
- where p.out_units > coalesce(p.units, 0) + 0.0001
+ where p.out_units > coalesce(p.units, 0) + case when coalesce(p.units, 0) > 0 then 0.0001 else 0 end
     or (p.asset_type is distinct from 'gold' and p.out_principal > p.amount_vnd)
 
 union all
@@ -354,7 +359,8 @@ select 'fund_bucket_overdrawn', 'violation',
        format('bucket holds %s đồng / %s units and has %s đồng / %s units sold across %s sell(s)',
               b.basis, b.units, b.out_principal, b.out_units, b.sells)
   from fund_buckets b
- where b.buys > 0 and b.out_units > b.units + 0.0001
+ where b.buys > 0
+   and b.out_units > b.units + case when b.units > 0 then 0.0001 else 0 end
 
 union all
 -- The same overrun on the principal side of a quantity-valued holding. Worth
@@ -381,12 +387,19 @@ union all
 -- A sell alone in a bucket: its purchases are in another goal, so nothing here
 -- offsets it and the goal that HAS the purchases shows them unsold. What an
 -- assign racing a sale leaves behind (#610).
+-- ...beyond what a relocation may legally leave behind. check_fund_bucket_solvent
+-- (#587) refuses a move only when the bucket would be left owing MORE than 0.0001
+-- units or one đồng, so an orphan that small is a state the invariant itself
+-- permits — reachable by moving a purchase out from under an epsilon-sized sell.
+-- Reporting it as provable corruption would send an operator to repair a ledger
+-- nobody wrote wrong; the same thresholds are mirrored here so the two agree.
 select 'fund_bucket_has_no_purchases', 'violation',
        b.user_id, b.a_sell::uuid, null::uuid, b.fund_id, b.goal_id,
        format('%s sell(s) taking %s đồng / %s units, with no purchases in this bucket',
               b.sells, b.out_principal, b.out_units)
   from fund_buckets b
  where b.buys = 0
+   and (b.out_units > 0.0001 or b.out_principal > 1)
 
 -- ── allocation, per quantity-valued holding ─────────────────────────────────
 -- Fund buckets and gold bind the principal TO the units: a sale of all remaining

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -153,16 +153,30 @@ sale_dev as (
 -- if two or more need the slack, the holding cannot be explained by any legal
 -- sequence and they are all reported; if just one does, it is allowed its value.
 --
--- Sub-epsilon slivers are left out of the count, but only on a holding that ends
--- EXHAUSTED. A sliver can take a whole remaining basis only if it closed the
+-- Sub-epsilon slivers in the tail of an exhausted holding are judged by the same
+-- one-closer rule rather than exempted outright: exactly one of them may have been
+-- the sale that emptied the basis, so the others must have taken either their flat
+-- share or (having come after it) nothing. Two slivers that did neither have no
+-- legal reading in any order — 0.9998 units taking 999,800 and then 0.0001 each
+-- taking 50 and 150 of the 200 left adds up perfectly and is refused by all six
+-- orderings, which is the shape this catches.
+--
+-- The exemption itself is still limited to a holding that ends EXHAUSTED. A sliver can take a whole remaining basis only if it closed the
 -- holding, and which slivers in that tail were legal depends on write order — the
 -- undecidable-from-state limit the header records. On a holding with units still
 -- unsold nothing closed anything, so a sliver there owes the flat rate like any
 -- other sale and is measured like one: 0.0002 units out of 1 closes nothing.
 sale_dev_ranked as (
   select d.*,
+         d.exhausted and d.units_withdrawn <= 0.0002 as sliver,
          count(*) filter (where d.dev > d.base_tol and not (d.exhausted and d.units_withdrawn <= 0.0002))
-           over (partition by d.user_id, d.balance_key) as over_base
+           over (partition by d.user_id, d.balance_key) as over_base,
+         -- Slivers in the tail that took NEITHER their flat share nor nothing at
+         -- all. One of those is the closer emptying the basis; a second one has no
+         -- legal reading, whatever order they were written in.
+         count(*) filter (where d.exhausted and d.units_withdrawn <= 0.0002
+                            and d.dev > d.base_tol and coalesce(d.principal_withdrawn, 0) > 1)
+           over (partition by d.user_id, d.balance_key) as odd_slivers
     from sale_dev d
 )
 
@@ -385,8 +399,12 @@ select 'sale_basis_not_proportional', 'review',
        d.user_id, d.transaction_id, d.parent_transaction_id, d.fund_id, d.goal_id, d.detail
   from sale_dev_ranked d
  where d.dev > d.base_tol
-   and not (d.exhausted and d.units_withdrawn <= 0.0002)
-   and (d.over_base >= 2 or d.dev > d.base_tol + d.shortcut_tol)
+   and case
+         when d.sliver
+           -- The tail exemption is for ONE closer, not for every sliver in it.
+           then d.odd_slivers >= 2 and coalesce(d.principal_withdrawn, 0) > 1
+         else d.over_base >= 2 or d.dev > d.base_tol + d.shortcut_tol
+       end
 
 union all
 select 'basis_not_proportional', 'review',

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -195,34 +195,27 @@ select 'gold_sale_missing_units', 'violation',
  where not w.fund_keyed and w.parent_asset = 'gold' and coalesce(w.units_withdrawn, 0) <= 0
 
 union all
--- No principal takes nothing out: the holding keeps its value while the row
--- claims cash left.
--- Per row, and per row for FUND sales too, not only for parent-backed ones. A
--- fund sale's principal is the units-proportional slice of the basis, so zero is
--- refused by the invariant — but the holding-level check below cannot see it: two
--- sells whose errors cancel (one takes nothing, its sibling takes double) leave
--- the bucket's totals exactly proportional and both invalid rows silent.
+-- No principal takes nothing out: the holding keeps its value while the row claims
+-- cash left. The invariant demands a positive principal from a parent-backed
+-- withdrawal outright, which is what makes this a violation.
+--
+-- FUND sells are deliberately not judged here, though they were until a review
+-- pointed at the hole. A fund sell's principal is a proportional slice, and a slice
+-- can correctly be ZERO when it is worth less than half a đồng — but whether it was
+-- worth that is decided by the bucket AS IT WAS when the sale was written, and a
+-- purchase arriving later moves the ratio. A 1 đồng / 100 unit bucket makes a
+-- 1-unit slice worth nothing; add a 999 đồng purchase afterwards and the same
+-- accepted row looks five đồng short. Nothing whose every write was legal may be
+-- called a violation, so fund sells are left to sale_basis_not_proportional, whose
+-- 'review' severity says exactly this about purchases added after a sale.
 select 'withdrawal_missing_principal', 'violation',
        w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
-       format('%s records principal %s',
-              case when w.fund_keyed then format('fund sale of %s units', w.units_withdrawn)
-                   else format('withdrawal from holding %s', w.parent_transaction_id) end,
-              w.principal_withdrawn)
+       format('withdrawal from holding %s records principal %s',
+              w.parent_transaction_id, w.principal_withdrawn)
   from wd w
-  left join fund_buckets b
-    on w.fund_keyed and b.user_id = w.user_id and b.fund_id = w.fund_id
-   and b.goal_id is not distinct from w.goal_id
  where coalesce(w.principal_withdrawn, 0) <= 0
-   and case when w.fund_keyed
-              -- units <= 0 is fund_sale_missing_units. And a slice can be worth
-              -- NOTHING: round(basis × units / total_units) below half a đồng makes
-              -- zero the correct principal, which the invariant accepts (and
-              -- lib/fundWithdrawal posts). Only a slice actually worth something —
-              -- more than the invariant's own đồng of tolerance — is missing here.
-              then coalesce(w.units_withdrawn, 0) > 0
-                   and coalesce(b.units, 0) > 0
-                   and round(b.basis * w.units_withdrawn / b.units) > 1
-            else w.parent_transaction_id is not null end
+   and not w.fund_keyed
+   and w.parent_transaction_id is not null
 
 union all
 -- A withdrawal is not a holding: parenting to one invents a balance out of money

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -117,7 +117,8 @@ sale_dev as (
                 round(p.amount_vnd * w.units_withdrawn / p.units)) as detail,
          abs(coalesce(w.principal_withdrawn, 0) - round(p.amount_vnd * w.units_withdrawn / p.units)) as dev,
          p.sells + 1 as base_tol,
-         case when p.out_units >= p.units - 0.0001 then 0.0001 * p.amount_vnd / p.units else 0 end as shortcut_tol
+         case when p.out_units >= p.units - 0.0001
+                then greatest(p.units - p.out_units, 0) * p.amount_vnd / p.units else 0 end as shortcut_tol
     from wd w
     join parents p on p.transaction_id = w.parent_transaction_id
    where not w.fund_keyed and p.asset_type = 'gold' and coalesce(p.units, 0) > 0
@@ -131,7 +132,8 @@ sale_dev as (
                 round(b.basis * w.units_withdrawn / b.units)),
          abs(coalesce(w.principal_withdrawn, 0) - round(b.basis * w.units_withdrawn / b.units)),
          b.sells + 1,
-         case when b.out_units >= b.units - 0.0001 then 0.0001 * b.basis / b.units else 0 end
+         case when b.out_units >= b.units - 0.0001
+                then greatest(b.units - b.out_units, 0) * b.basis / b.units else 0 end
     from wd w
     join fund_buckets b
       on b.user_id = w.user_id and b.fund_id = w.fund_id and b.goal_id is not distinct from w.goal_id
@@ -358,21 +360,24 @@ select 'fund_bucket_has_no_purchases', 'violation',
 -- The tolerance has THREE parts, and the third is the one that matters in practice:
 --   sells   the ±1 allowance each sale may use, which the last sale inherits
 --   1       the two roundings between the flat rate and the invariant's expectation
---   0.0001 × basis / units, and ONLY on a holding that ends up exhausted
---           the value of one epsilon of units. The clients round units to 4
+--   the value of the units left UNSOLD, and only on a holding that ends exhausted
+--           at most one epsilon's worth, since that is as much as can be left. The clients round units to 4
 --           decimals, so "sell everything" routinely posts a hair UNDER the holding
 --           (4 chỉ leaves as 3.9999) and the invariant treats a sale within an
 --           epsilon of the rest as a FULL one, taking the whole basis. On an
 --           ordinary 40,000,000 đồng gold holding that legitimate gap is a THOUSAND
 --           đồng — a flat tolerance reports every full gold sale in the ledger.
 --
---           The condition is what keeps that slack from covering ordinary partial
---           sales, where a thousand đồng of licence would hide real misallocation.
---           It is exact rather than heuristic: the shortcut requires the sale to
---           take within an epsilon of what REMAINS, so at most an epsilon of units
---           can be left behind afterwards — any legal use of it implies the holding
---           ends exhausted, which is state-visible. A sale of 1 chỉ out of 4 leaves
---           3 behind and gets no slack.
+--           Two conditions keep that slack from covering ordinary misallocation,
+--           and both are exact rather than heuristic. The shortcut requires a sale
+--           to take within an epsilon of what REMAINS, so (a) at most an epsilon of
+--           units can be left behind afterwards — any legal use implies the holding
+--           ends exhausted, and a sale of 1 chỉ out of 4 leaves 3 behind and gets
+--           nothing — and (b) the gap it opens against the flat rate is exactly the
+--           value of the units it did NOT take, which for the closer is the whole
+--           holding's unsold remainder. A holding sold out to the last unit had no
+--           gap to open: 4 units bought and 4 sold means every sale owes the flat
+--           rate exactly, however the sales were split up.
 -- Validated against 1.5M invariant-legal sale sequences across four magnitudes of
 -- basis and units: no row exceeded it, tightest margin 1.2 đồng.
 union all
@@ -396,7 +401,7 @@ select 'basis_not_proportional', 'review',
    and abs(p.out_principal
            - case when p.out_units >= p.units - 0.0001 then p.amount_vnd
                   else round(p.amount_vnd * p.out_units / p.units) end) > 2 * p.sells + case when p.out_units >= p.units - 0.0001
-                          then 0.0001 * p.amount_vnd / p.units else 0 end
+                          then greatest(p.units - p.out_units, 0) * p.amount_vnd / p.units else 0 end
 
 union all
 select 'basis_not_proportional', 'review',
@@ -411,7 +416,7 @@ select 'basis_not_proportional', 'review',
    and abs(b.out_principal
            - case when b.out_units >= b.units - 0.0001 then b.basis
                   else round(b.basis * b.out_units / b.units) end) > 2 * b.sells + case when b.out_units >= b.units - 0.0001
-                          then 0.0001 * b.basis / b.units else 0 end;
+                          then greatest(b.units - b.out_units, 0) * b.basis / b.units else 0 end;
 
 comment on view public.withdrawal_ledger_audit is
   'Read-only audit of existing withdrawal rows against the decision table enforced by check_withdrawal_balance. One row per finding: check_name, severity, and the holding it concerns (#609).';

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -125,12 +125,21 @@ select 'gold_sale_missing_units', 'violation',
 union all
 -- No principal takes nothing out: the holding keeps its value while the row
 -- claims cash left.
+-- Per row, and per row for FUND sales too, not only for parent-backed ones. A
+-- fund sale's principal is the units-proportional slice of the basis, so zero is
+-- refused by the invariant — but the holding-level check below cannot see it: two
+-- sells whose errors cancel (one takes nothing, its sibling takes double) leave
+-- the bucket's totals exactly proportional and both invalid rows silent.
 select 'withdrawal_missing_principal', 'violation',
        w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
-       format('withdrawal from holding %s records principal %s', w.parent_transaction_id, w.principal_withdrawn)
+       format('%s records principal %s',
+              case when w.fund_keyed then format('fund sale of %s units', w.units_withdrawn)
+                   else format('withdrawal from holding %s', w.parent_transaction_id) end,
+              w.principal_withdrawn)
   from wd w
- where not w.fund_keyed and w.parent_transaction_id is not null
-   and coalesce(w.principal_withdrawn, 0) <= 0
+ where coalesce(w.principal_withdrawn, 0) <= 0
+   and case when w.fund_keyed then coalesce(w.units_withdrawn, 0) > 0   -- else it is fund_sale_missing_units
+            else w.parent_transaction_id is not null end
 
 union all
 -- A withdrawal is not a holding: parenting to one invents a balance out of money
@@ -155,11 +164,20 @@ select 'parent_is_a_fund_purchase', 'review',
 union all
 -- Filed under neither key: it subtracts from nothing while the record says cash
 -- left. What deleting a source leaves behind (#607), among other routes.
+--
+-- A RETAINED fund_id does not save such a row, which is why this asks only about
+-- fund_keyed and the parent. Editing a fund sell's asset_type off 'fund' leaves the
+-- fund_id in place (the PUT clears it only when that field is sent), and a bare id
+-- is not a bucket key — buildWithdrawalMaps needs asset_type='fund' — so the row
+-- draws on nothing at all. Requiring fund_id is null here would have made that
+-- shape, the one the invariant refuses by name, invisible to the audit.
 select 'draws_on_no_holding', 'violation',
        w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
-       format('takes principal %s / units %s from no holding', w.principal_withdrawn, w.units_withdrawn)
+       format('takes principal %s / units %s from no holding%s',
+              w.principal_withdrawn, w.units_withdrawn,
+              case when w.fund_id is not null then ' (fund id retained without asset_type=fund)' else '' end)
   from wd w
- where not w.fund_keyed and w.parent_transaction_id is null and w.fund_id is null
+ where not w.fund_keyed and w.parent_transaction_id is null
    and (coalesce(w.principal_withdrawn, 0) > 0 or coalesce(w.units_withdrawn, 0) > 0)
 
 union all
@@ -168,9 +186,9 @@ union all
 -- may wear that exception.
 select 'sourceless_not_held_for_merge', 'violation',
        w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
-       'no parent, no fund, no deltas, and not held_for_merge'
+       'nothing it draws on, no deltas, and not held_for_merge'
   from wd w
- where not w.fund_keyed and w.parent_transaction_id is null and w.fund_id is null
+ where not w.fund_keyed and w.parent_transaction_id is null
    and coalesce(w.principal_withdrawn, 0) = 0 and coalesce(w.units_withdrawn, 0) = 0
    and not w.held_for_merge
 
@@ -180,13 +198,18 @@ union all
 -- Past zero. The dashboard then DROPS the holding (valueNonFundHolding returns
 -- null at effectiveAmount <= 0) while the excess withdrawal stays in history, so
 -- net worth is wrong in a way no screen shows.
+-- The tolerances are the invariant's own, per sale: one đồng of rounding wherever
+-- the principal is a proportional slice (gold; a deposit's principal is the user's
+-- own figure and is bounded exactly), and the 0.0001 units the clients' 4-decimal
+-- rounding can add to a full sell. An audit stricter than the invariant it audits
+-- reports ledgers nobody can repair, and that is how a report gets ignored.
 select 'holding_overdrawn', 'violation',
        p.user_id, null::uuid, p.transaction_id, null::uuid, p.goal_id,
        format('%s holding of %s đồng / %s units has %s đồng / %s units taken out across %s withdrawal(s)',
               p.asset_type, p.amount_vnd, coalesce(p.units, 0), p.out_principal, p.out_units, p.sells)
   from parents p
- where p.out_principal > p.amount_vnd
-    or (p.units is not null and p.out_units > p.units + 0.0001)
+ where p.out_principal > p.amount_vnd + (case when p.asset_type = 'gold' then p.sells else 0 end)
+    or (p.units is not null and p.out_units > p.units + 0.0001 * p.sells)
 
 union all
 select 'fund_bucket_overdrawn', 'violation',
@@ -195,7 +218,7 @@ select 'fund_bucket_overdrawn', 'violation',
               b.basis, b.units, b.out_principal, b.out_units, b.sells)
   from fund_buckets b
  where b.buys > 0
-   and (b.out_principal > b.basis or b.out_units > b.units + 0.0001)
+   and (b.out_principal > b.basis + b.sells or b.out_units > b.units + 0.0001 * b.sells)
 
 union all
 -- A sell alone in a bucket: its purchases are in another goal, so nothing here

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -1,0 +1,258 @@
+-- Read the ledger and report what would not be accepted today (#609).
+--
+-- #587 put the withdrawal decision table on the table as a trigger
+-- (20260730000002). A trigger validates writes, so it never looked at a single row
+-- written before it landed: the shapes it now refuses can all still be sitting in
+-- history, and every reader — dashboard/overview, withdrawal progress, goal
+-- progress — trusts them. Until someone looks, we don't know whether the ledger is
+-- clean. The not-knowing is the thing this closes; a backfill is a separate
+-- decision that depends on what the report says.
+--
+-- One check per row of that decision table, plus the two known valuation gaps
+-- (#606, #607) so a run is complete rather than nearly complete. Strictly
+-- read-only: it names rows and holdings, changes nothing, and is safe to run on
+-- production in the SQL editor:
+--
+--   select check_name, severity, count(*)
+--     from public.withdrawal_ledger_audit
+--    group by 1, 2 order by 2, 1;
+--
+-- Then drill into a check_name for the rows and the detail text.
+--
+-- severity 'violation' — the invariant would refuse this row today.
+-- severity 'review'    — legal to write, but it is not counted the way the ledger
+--                        assumes; #606 and the proportionality drift below.
+--
+-- Why a view and not a script kept in a folder: supabase/tests/
+-- withdrawal_ledger_audit.test.sql plants one row per check and asserts the audit
+-- names it. An audit that returns nothing is indistinguishable from an audit that
+-- looks for nothing, and the only way to keep it honest is to make it a database
+-- object a test can query. It also cannot drift from the invariant silently —
+-- both live in this directory and both are read by the same tests.
+--
+-- Aggregates deliberately mirror the invariant's own measurements, including the
+-- exclusions: pending DCA seeds (units null) hold nothing sellable, renewal
+-- snapshots are history copies, and a sell keyed by (goal, fund) draws on that
+-- bucket rather than on any parent. Getting one of those wrong doesn't produce a
+-- miss — it produces a report full of false positives, which is how an audit ends
+-- up ignored.
+create or replace view public.withdrawal_ledger_audit
+with (security_invoker = true) as
+with wd as (
+  select w.transaction_id, w.user_id, w.goal_id, w.fund_id, w.parent_transaction_id,
+         w.asset_type, w.principal_withdrawn, w.units_withdrawn, w.held_for_merge,
+         w.investment_date,
+         -- The same branch precedence as the invariant and lib/withdrawalProgress:
+         -- asset_type='fund' + fund_id wins, and such a row draws on its (goal,
+         -- fund) bucket no matter what parent it also names.
+         coalesce(w.asset_type = 'fund' and w.fund_id is not null, false) as fund_keyed,
+         p.transaction_type as parent_type,
+         p.asset_type       as parent_asset
+    from public.investment_transactions w
+    left join public.investment_transactions p on p.transaction_id = w.parent_transaction_id
+   where w.transaction_type = 'withdrawal'
+),
+-- One source row: bank, gold, stock. Only holdings that something draws on.
+parents as (
+  select p.transaction_id, p.user_id, p.goal_id, p.asset_type, p.amount_vnd, p.units,
+         sum(coalesce(w.principal_withdrawn, 0)) as out_principal,
+         sum(coalesce(w.units_withdrawn, 0))     as out_units,
+         count(*)                                as sells
+    from public.investment_transactions p
+    join wd w on w.parent_transaction_id = p.transaction_id and not w.fund_keyed
+   where p.transaction_type = 'investment'
+   group by p.transaction_id, p.user_id, p.goal_id, p.asset_type, p.amount_vnd, p.units
+),
+fund_buys as (
+  select t.user_id, t.goal_id, t.fund_id,
+         sum(t.amount_vnd) as basis, sum(t.units) as units, count(*) as buys
+    from public.investment_transactions t
+   where t.transaction_type = 'investment'
+     and t.asset_type = 'fund'
+     and t.fund_id is not null
+     and t.units is not null                       -- pending DCA seeds hold nothing
+     and t.renewed_from_transaction_id is null     -- renewal snapshots are history
+   group by t.user_id, t.goal_id, t.fund_id
+),
+fund_sells as (
+  select w.user_id, w.goal_id, w.fund_id,
+         sum(coalesce(w.principal_withdrawn, 0)) as out_principal,
+         sum(coalesce(w.units_withdrawn, 0))     as out_units,
+         count(*)                                as sells,
+         min(w.transaction_id::text)             as a_sell
+    from wd w
+   where w.fund_keyed
+   group by w.user_id, w.goal_id, w.fund_id
+),
+fund_buckets as (
+  select s.user_id, s.goal_id, s.fund_id, s.out_principal, s.out_units, s.sells, s.a_sell,
+         coalesce(b.basis, 0) as basis, coalesce(b.units, 0) as units, coalesce(b.buys, 0) as buys
+    from fund_sells s
+    left join fund_buys b
+      on b.user_id = s.user_id
+     and b.fund_id = s.fund_id
+     and b.goal_id is not distinct from s.goal_id
+)
+
+-- ── shape, per row ──────────────────────────────────────────────────────────
+
+-- A negative withdrawal ADDS to the holding and banks a credit the next one can
+-- spend: every sum here and in lib/depositValuation is signed.
+select 'negative_amounts'::text as check_name, 'violation'::text as severity,
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('principal %s, units %s', w.principal_withdrawn, w.units_withdrawn) as detail
+  from wd w
+ where coalesce(w.principal_withdrawn, 0) < 0 or coalesce(w.units_withdrawn, 0) < 0
+
+union all
+-- Without units the overview skips the subtraction entirely (it bails on
+-- `units <= 0`), so the fund keeps its full value while the row claims a sale.
+select 'fund_sale_missing_units', 'violation',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('fund sell of %s đồng records units %s', w.principal_withdrawn, w.units_withdrawn)
+  from wd w
+ where w.fund_keyed and coalesce(w.units_withdrawn, 0) <= 0
+
+union all
+-- Gold is the one non-fund holding valued by quantity, so a sale must move both:
+-- principal alone drops the cost while every chỉ stays in net worth.
+select 'gold_sale_missing_units', 'violation',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('gold sale of %s đồng records units %s', w.principal_withdrawn, w.units_withdrawn)
+  from wd w
+ where not w.fund_keyed and w.parent_asset = 'gold' and coalesce(w.units_withdrawn, 0) <= 0
+
+union all
+-- No principal takes nothing out: the holding keeps its value while the row
+-- claims cash left.
+select 'withdrawal_missing_principal', 'violation',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('withdrawal from holding %s records principal %s', w.parent_transaction_id, w.principal_withdrawn)
+  from wd w
+ where not w.fund_keyed and w.parent_transaction_id is not null
+   and coalesce(w.principal_withdrawn, 0) <= 0
+
+union all
+-- A withdrawal is not a holding: parenting to one invents a balance out of money
+-- that already left. Renewal snapshots ARE valid parents (#585) and are
+-- investments, so they are not caught here.
+select 'parent_is_not_an_investment', 'violation',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('parent %s is a %s', w.parent_transaction_id, w.parent_type)
+  from wd w
+ where not w.fund_keyed and w.parent_type is not null and w.parent_type <> 'investment'
+
+union all
+-- Legal to write, counted by nobody: buildWithdrawalMaps values a fund through
+-- the (goal, fund) map and never consults the parent map, so this row's principal
+-- never reduces anything. Issue #606.
+select 'parent_is_a_fund_purchase', 'review',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('draws %s đồng on fund purchase %s, which no valuation offsets', w.principal_withdrawn, w.parent_transaction_id)
+  from wd w
+ where not w.fund_keyed and w.parent_asset = 'fund'
+
+union all
+-- Filed under neither key: it subtracts from nothing while the record says cash
+-- left. What deleting a source leaves behind (#607), among other routes.
+select 'draws_on_no_holding', 'violation',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('takes principal %s / units %s from no holding', w.principal_withdrawn, w.units_withdrawn)
+  from wd w
+ where not w.fund_keyed and w.parent_transaction_id is null and w.fund_id is null
+   and (coalesce(w.principal_withdrawn, 0) > 0 or coalesce(w.units_withdrawn, 0) > 0)
+
+union all
+-- Claiming nothing and naming nothing is legal for exactly one kind of row: a
+-- held-for-merge settlement whose source isn't recorded yet (#588). Nothing else
+-- may wear that exception.
+select 'sourceless_not_held_for_merge', 'violation',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       'no parent, no fund, no deltas, and not held_for_merge'
+  from wd w
+ where not w.fund_keyed and w.parent_transaction_id is null and w.fund_id is null
+   and coalesce(w.principal_withdrawn, 0) = 0 and coalesce(w.units_withdrawn, 0) = 0
+   and not w.held_for_merge
+
+-- ── balance, per holding ────────────────────────────────────────────────────
+
+union all
+-- Past zero. The dashboard then DROPS the holding (valueNonFundHolding returns
+-- null at effectiveAmount <= 0) while the excess withdrawal stays in history, so
+-- net worth is wrong in a way no screen shows.
+select 'holding_overdrawn', 'violation',
+       p.user_id, null::uuid, p.transaction_id, null::uuid, p.goal_id,
+       format('%s holding of %s đồng / %s units has %s đồng / %s units taken out across %s withdrawal(s)',
+              p.asset_type, p.amount_vnd, coalesce(p.units, 0), p.out_principal, p.out_units, p.sells)
+  from parents p
+ where p.out_principal > p.amount_vnd
+    or (p.units is not null and p.out_units > p.units + 0.0001)
+
+union all
+select 'fund_bucket_overdrawn', 'violation',
+       b.user_id, null::uuid, null::uuid, b.fund_id, b.goal_id,
+       format('bucket holds %s đồng / %s units and has %s đồng / %s units sold across %s sell(s)',
+              b.basis, b.units, b.out_principal, b.out_units, b.sells)
+  from fund_buckets b
+ where b.buys > 0
+   and (b.out_principal > b.basis or b.out_units > b.units + 0.0001)
+
+union all
+-- A sell alone in a bucket: its purchases are in another goal, so nothing here
+-- offsets it and the goal that HAS the purchases shows them unsold. What an
+-- assign racing a sale leaves behind (#610).
+select 'fund_bucket_has_no_purchases', 'violation',
+       b.user_id, b.a_sell::uuid, null::uuid, b.fund_id, b.goal_id,
+       format('%s sell(s) taking %s đồng / %s units, with no purchases in this bucket',
+              b.sells, b.out_principal, b.out_units)
+  from fund_buckets b
+ where b.buys = 0
+
+-- ── allocation, per quantity-valued holding ─────────────────────────────────
+-- Fund buckets and gold bind the principal TO the units: a sale of all remaining
+-- units takes the remaining basis, a partial sale its units-proportional share.
+-- That rule is additive and order-independent — each sale takes units × basis /
+-- total_units regardless of sequence — so the aggregate is a sound check even
+-- though the per-sale history is not reconstructible. Tolerance is one đồng per
+-- sale, which is what rounding each slice can produce.
+--
+-- 'review', not 'violation': a purchase added to a bucket AFTER a sale legitimately
+-- shifts the ratio, and so does a hand-corrected row. The number is the useful
+-- part — expected vs actual says how far the basis has drifted from the units.
+
+union all
+select 'basis_not_proportional', 'review',
+       p.user_id, null::uuid, p.transaction_id, null::uuid, p.goal_id,
+       format('%s of %s units sold should have taken %s đồng of the %s basis, took %s',
+              p.out_units, p.units,
+              case when p.out_units >= p.units - 0.0001 then p.amount_vnd
+                   else round(p.amount_vnd * p.out_units / p.units) end,
+              p.amount_vnd, p.out_principal)
+  from parents p
+ where p.asset_type = 'gold' and coalesce(p.units, 0) > 0
+   and abs(p.out_principal
+           - case when p.out_units >= p.units - 0.0001 then p.amount_vnd
+                  else round(p.amount_vnd * p.out_units / p.units) end) > p.sells
+
+union all
+select 'basis_not_proportional', 'review',
+       b.user_id, null::uuid, null::uuid, b.fund_id, b.goal_id,
+       format('%s of %s units sold should have taken %s đồng of the %s basis, took %s',
+              b.out_units, b.units,
+              case when b.out_units >= b.units - 0.0001 then b.basis
+                   else round(b.basis * b.out_units / b.units) end,
+              b.basis, b.out_principal)
+  from fund_buckets b
+ where b.units > 0
+   and abs(b.out_principal
+           - case when b.out_units >= b.units - 0.0001 then b.basis
+                  else round(b.basis * b.out_units / b.units) end) > b.sells;
+
+comment on view public.withdrawal_ledger_audit is
+  'Read-only audit of existing withdrawal rows against the decision table enforced by check_withdrawal_balance. One row per finding: check_name, severity, and the holding it concerns (#609).';
+
+-- An operator tool, and there is no screen that reads it. security_invoker means
+-- RLS would confine a caller to their own rows anyway, but granting it adds a
+-- PostgREST surface for no gain — the same reasoning that revoked
+-- check_withdrawal_balance in 20260730000002.
+revoke all on public.withdrawal_ledger_audit from anon, authenticated;

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -30,6 +30,15 @@
 -- object a test can query. It also cannot drift from the invariant silently —
 -- both live in this directory and both are read by the same tests.
 --
+-- One known limit, worth stating rather than discovering later: whether an
+-- epsilon-sized sale was legal depends on the ORDER the rows were written in, and
+-- this view reads state. Taking 0.00005 units and then the whole unit is accepted
+-- (the epsilon is granted while something is left); exhausting the unit first and
+-- then taking 0.00005 is refused — and both leave identical totals, so no
+-- state-based check can separate them. The audit stays silent there on purpose,
+-- because reporting it would flag ledgers that were written legally. The exposure
+-- is bounded by one epsilon of units, and a clean-half test pins the silence.
+--
 -- Aggregates deliberately mirror the invariant's own measurements, including the
 -- exclusions: pending DCA seeds (units null) hold nothing sellable, renewal
 -- snapshots are history copies, and a sell keyed by (goal, fund) draws on that
@@ -268,6 +277,40 @@ select 'fund_bucket_has_no_purchases', 'violation',
 -- 'review', not 'violation': a purchase added to a bucket AFTER a sale legitimately
 -- shifts the ratio, and so does a hand-corrected row. The number is the useful
 -- part — expected vs actual says how far the basis has drifted from the units.
+
+-- Per SALE as well as per holding, because holding-level totals hide errors that
+-- CANCEL: 50 units taking 400 and 50 taking 600 out of a 1000 đồng / 100 unit
+-- holding add up to exactly the right basis, while the invariant refuses each one
+-- as a first write (50 of 100 units must take 500) — that state is unreachable in
+-- any order, and a totals-only audit calls it clean. The flat rate is the right
+-- yardstick per row precisely because the allocation rule is additive: each sale
+-- takes units × basis / total_units whatever the sequence. Same tolerance, and a
+-- measured one — the worst per-row deviation over invariant-legal sequences is 1
+-- đồng per sale (the last sale absorbs whatever the earlier ones drifted).
+union all
+select 'sale_basis_not_proportional', 'review',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('a sale of %s of the holding''s %s units took %s đồng where the flat rate on a %s basis is %s',
+              w.units_withdrawn, p.units, w.principal_withdrawn, p.amount_vnd,
+              round(p.amount_vnd * w.units_withdrawn / p.units))
+  from wd w
+  join parents p on p.transaction_id = w.parent_transaction_id
+ where not w.fund_keyed and p.asset_type = 'gold' and coalesce(p.units, 0) > 0
+   and coalesce(w.units_withdrawn, 0) > 0
+   and abs(coalesce(w.principal_withdrawn, 0) - round(p.amount_vnd * w.units_withdrawn / p.units)) > 2 * p.sells
+
+union all
+select 'sale_basis_not_proportional', 'review',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('a sell of %s of the bucket''s %s units took %s đồng where the flat rate on a %s basis is %s',
+              w.units_withdrawn, b.units, w.principal_withdrawn, b.basis,
+              round(b.basis * w.units_withdrawn / b.units))
+  from wd w
+  join fund_buckets b
+    on b.user_id = w.user_id and b.fund_id = w.fund_id and b.goal_id is not distinct from w.goal_id
+ where w.fund_keyed and b.units > 0
+   and coalesce(w.units_withdrawn, 0) > 0
+   and abs(coalesce(w.principal_withdrawn, 0) - round(b.basis * w.units_withdrawn / b.units)) > 2 * b.sells
 
 union all
 select 'basis_not_proportional', 'review',

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -1,16 +1,47 @@
--- Read the ledger and report what would not be accepted today (#609).
+-- Screen the ledger for withdrawal rows the invariant would not accept today (#609).
 --
 -- #587 put the withdrawal decision table on the table as a trigger
 -- (20260730000002). A trigger validates writes, so it never looked at a single row
 -- written before it landed: the shapes it now refuses can all still be sitting in
 -- history, and every reader — dashboard/overview, withdrawal progress, goal
--- progress — trusts them. Until someone looks, we don't know whether the ledger is
--- clean. The not-knowing is the thing this closes; a backfill is a separate
--- decision that depends on what the report says.
+-- progress — trusts them.
 --
--- One check per row of that decision table, plus the two known valuation gaps
--- (#606, #607) so a run is complete rather than nearly complete. Strictly
--- read-only: it names rows and holdings, changes nothing, and is safe to run on
+-- ─── What this view can and cannot tell you ──────────────────────────────────
+--
+-- AN EMPTY RESULT DOES NOT PROVE THE LEDGER CLEAN, and #609 must not be closed as
+-- "verified clean" on the strength of one. This is a limit of the approach, not a
+-- missing predicate, and no amount of extra checks removes it:
+--
+--   The invariant is STATEFUL. It measures each write against the balance
+--   remaining at that moment, so whether a row was legal depends on the order the
+--   rows were written in. This view reads the ledger as it stands now. Different
+--   histories — some legal, some not — reach the very same final state, and the
+--   state does not record which one happened.
+--
+-- The sharpest example, which no ordering of its rows makes legal:
+--
+--   1000 đồng over 100 units, two sales of 50 units taking 497 and 503. Each is
+--   refused as a first write (50 of 100 units must take 500) and neither can
+--   follow the other. The totals are exactly proportional, and every per-sale
+--   deviation is inside what a legal two-sale ledger can show on some OTHER
+--   holding — so nothing here can distinguish it. The audit is silent. A test
+--   pins that silence so it is never mistaken for a guarantee.
+--
+-- Deciding those needs the write order, which exists (created_at) but is only
+-- trustworthy once a source's amount and units can no longer be edited under a
+-- sale that already drew on them — that is #608. A replay audit on top of #608 is
+-- the design that could carry a "verified clean" guarantee; this view is not it.
+--
+-- ─── The two severities ──────────────────────────────────────────────────────
+--
+-- 'violation' — provable from the state alone. No ordering of any history could
+--               have produced this row, so it is wrong however it got here.
+-- 'review'    — the ledger looks off, but legally-written ledgers can look the
+--               same. Sequence-sensitive: judge these with the rows in front of
+--               you, and expect the drift a mid-stream purchase legitimately
+--               causes. Never automate a repair off a 'review' row.
+--
+-- Read-only. It names rows and holdings, changes nothing, and is safe to run on
 -- production in the SQL editor:
 --
 --   select check_name, severity, count(*)
@@ -19,10 +50,6 @@
 --
 -- Then drill into a check_name for the rows and the detail text.
 --
--- severity 'violation' — the invariant would refuse this row today.
--- severity 'review'    — legal to write, but it is not counted the way the ledger
---                        assumes; #606 and the proportionality drift below.
---
 -- Why a view and not a script kept in a folder: supabase/tests/
 -- withdrawal_ledger_audit.test.sql plants one row per check and asserts the audit
 -- names it. An audit that returns nothing is indistinguishable from an audit that
@@ -30,14 +57,11 @@
 -- object a test can query. It also cannot drift from the invariant silently —
 -- both live in this directory and both are read by the same tests.
 --
--- One known limit, worth stating rather than discovering later: whether an
--- epsilon-sized sale was legal depends on the ORDER the rows were written in, and
--- this view reads state. Taking 0.00005 units and then the whole unit is accepted
--- (the epsilon is granted while something is left); exhausting the unit first and
--- then taking 0.00005 is refused — and both leave identical totals, so no
--- state-based check can separate them. The audit stays silent there on purpose,
--- because reporting it would flag ledgers that were written legally. The exposure
--- is bounded by one epsilon of units, and a clean-half test pins the silence.
+-- A second known limit, narrower than the one above: whether an epsilon-sized sale
+-- was legal also depends on write order. Taking 0.00005 units and then the whole
+-- unit is accepted (the epsilon is granted while something is left); exhausting the
+-- unit first and then taking 0.00005 is refused — identical totals either way. The
+-- audit stays silent there rather than report a ledger that was written legally.
 --
 -- Aggregates deliberately mirror the invariant's own measurements, including the
 -- exclusions: pending DCA seeds (units null) hold nothing sellable, renewal
@@ -437,7 +461,7 @@ select 'basis_not_proportional', 'review',
                           then least(abs(b.units - b.out_units), 0.0001) * b.basis / b.units else 0 end;
 
 comment on view public.withdrawal_ledger_audit is
-  'Read-only audit of existing withdrawal rows against the decision table enforced by check_withdrawal_balance. One row per finding: check_name, severity, and the holding it concerns (#609).';
+  'Read-only screen of existing withdrawal rows against the decision table enforced by check_withdrawal_balance. severity=violation is provable from state; severity=review is sequence-sensitive. An empty result does NOT prove the ledger clean — see the header (#609).';
 
 -- An operator tool, and there is no screen that reads it. security_invoker means
 -- RLS would confine a caller to their own rows anyway, but granting it adds a

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -245,14 +245,25 @@ select 'fund_bucket_has_no_purchases', 'violation',
 -- units takes the remaining basis, a partial sale its units-proportional share.
 -- That rule is additive and order-independent — each sale takes units × basis /
 -- total_units regardless of sequence — so the aggregate is a sound check even
--- though the per-sale history is not reconstructible. Tolerance is one đồng per
--- sale, and here — unlike the overdraw bound above — the drift genuinely DOES
--- accumulate: each partial sale's expectation is recomputed from what is left, so
--- two sales may each under-take by a đồng and both be accepted. 100 đồng over 4
--- units, two sales of 1 unit taking 24 where the flat proportion says 25: the
--- aggregate is 48 against 50, both accepted (probed, and pinned by a test).
--- Over-taking gets no slack from that: the cumulative upper bound is enforced
--- tightly by holding_overdrawn / fund_bucket_overdrawn above.
+-- though the per-sale history is not reconstructible.
+--
+-- The tolerance is TWO đồng per sale, and unlike the overdraw bound above this one
+-- genuinely has to scale: each partial sale's expectation is recomputed from the
+-- ROUNDED remaining basis, so the error compounds rather than cancelling. Worked
+-- example, both writes accepted by the invariant — 100 đồng over 15 units, a sale
+-- of 7 units taking 48 where the expectation is 47, then 1 unit of the remaining 8
+-- taking 8 where the expectation is round(52/8) = 7: the aggregate is 56 against a
+-- flat expectation of 53, a drift of 3 across 2 sales.
+--
+-- Two rather than one-and-a-half because 1.5 is where the measured worst case sits:
+-- a search over 400k invariant-legal sale sequences (random basis, units, chain
+-- length up to 25, errors pushed to the allowance every time) never exceeded 1.5
+-- đồng per sale. It cannot run away, either — writing D for the drift, each sale
+-- gives D ← D × (1 − units/remaining_units) + e, a CONTRACTION, so the accumulated
+-- part shrinks as the chain grows and the worst cases are short chains.
+--
+-- Over-taking gains nothing from this slack: the cumulative upper bound stays tight
+-- in holding_overdrawn / fund_bucket_overdrawn above.
 --
 -- 'review', not 'violation': a purchase added to a bucket AFTER a sale legitimately
 -- shifts the ratio, and so does a hand-corrected row. The number is the useful
@@ -270,7 +281,7 @@ select 'basis_not_proportional', 'review',
  where p.asset_type = 'gold' and coalesce(p.units, 0) > 0
    and abs(p.out_principal
            - case when p.out_units >= p.units - 0.0001 then p.amount_vnd
-                  else round(p.amount_vnd * p.out_units / p.units) end) > p.sells
+                  else round(p.amount_vnd * p.out_units / p.units) end) > 2 * p.sells
 
 union all
 select 'basis_not_proportional', 'review',
@@ -284,7 +295,7 @@ select 'basis_not_proportional', 'review',
  where b.units > 0
    and abs(b.out_principal
            - case when b.out_units >= b.units - 0.0001 then b.basis
-                  else round(b.basis * b.out_units / b.units) end) > b.sells;
+                  else round(b.basis * b.out_units / b.units) end) > 2 * b.sells;
 
 comment on view public.withdrawal_ledger_audit is
   'Read-only audit of existing withdrawal rows against the decision table enforced by check_withdrawal_balance. One row per finding: check_name, severity, and the holding it concerns (#609).';

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -101,6 +101,58 @@ fund_buckets as (
       on b.user_id = s.user_id
      and b.fund_id = s.fund_id
      and b.goal_id is not distinct from s.goal_id
+),
+
+-- How far each individual sale sits from the flat rate units × basis / total_units,
+-- with the two tolerances it may claim. Split out as a CTE because the full-sale
+-- slack has to be RATIONED across the holding (see below), which needs a window
+-- over the per-sale deviations rather than a row-local predicate.
+sale_dev as (
+  select w.transaction_id, w.user_id, w.goal_id, w.fund_id, w.parent_transaction_id,
+         w.units_withdrawn, w.principal_withdrawn,
+         p.transaction_id as holding, p.amount_vnd as basis, p.units as units,
+         format('a sale of %s of the holding''s %s units took %s đồng where the flat rate on a %s basis is %s',
+                w.units_withdrawn, p.units, w.principal_withdrawn, p.amount_vnd,
+                round(p.amount_vnd * w.units_withdrawn / p.units)) as detail,
+         abs(coalesce(w.principal_withdrawn, 0) - round(p.amount_vnd * w.units_withdrawn / p.units)) as dev,
+         p.sells + 1 as base_tol,
+         case when p.out_units >= p.units - 0.0001 then 0.0001 * p.amount_vnd / p.units else 0 end as shortcut_tol
+    from wd w
+    join parents p on p.transaction_id = w.parent_transaction_id
+   where not w.fund_keyed and p.asset_type = 'gold' and coalesce(p.units, 0) > 0
+     and coalesce(w.units_withdrawn, 0) > 0
+  union all
+  select w.transaction_id, w.user_id, w.goal_id, w.fund_id, w.parent_transaction_id,
+         w.units_withdrawn, w.principal_withdrawn,
+         null::uuid, b.basis, b.units,
+         format('a sell of %s of the bucket''s %s units took %s đồng where the flat rate on a %s basis is %s',
+                w.units_withdrawn, b.units, w.principal_withdrawn, b.basis,
+                round(b.basis * w.units_withdrawn / b.units)),
+         abs(coalesce(w.principal_withdrawn, 0) - round(b.basis * w.units_withdrawn / b.units)),
+         b.sells + 1,
+         case when b.out_units >= b.units - 0.0001 then 0.0001 * b.basis / b.units else 0 end
+    from wd w
+    join fund_buckets b
+      on b.user_id = w.user_id and b.fund_id = w.fund_id and b.goal_id is not distinct from w.goal_id
+   where w.fund_keyed and b.units > 0
+     and coalesce(w.units_withdrawn, 0) > 0
+),
+
+-- Exactly ONE sale per holding can be the one that closed it, so at most one may
+-- claim the full-sale slack. Rows past the base tolerance are counted per holding:
+-- if two or more need the slack, the holding cannot be explained by any legal
+-- sequence and they are all reported; if just one does, it is allowed its value.
+--
+-- Sub-epsilon slivers are left out of the count and never reported. A sale of
+-- 0.0002 units or less can legitimately take a whole remaining basis in the tail
+-- of an epsilon-exhausted holding, and which of those were legal depends on the
+-- order they were written in — the same undecidable-from-state limit recorded in
+-- the header, with the same bound on what it can hide.
+sale_dev_ranked as (
+  select d.*,
+         count(*) filter (where d.dev > d.base_tol and d.units_withdrawn > 0.0002)
+           over (partition by d.user_id, d.holding, d.fund_id, d.goal_id) as over_base
+    from sale_dev d
 )
 
 -- ── shape, per row ──────────────────────────────────────────────────────────
@@ -146,8 +198,19 @@ select 'withdrawal_missing_principal', 'violation',
                    else format('withdrawal from holding %s', w.parent_transaction_id) end,
               w.principal_withdrawn)
   from wd w
+  left join fund_buckets b
+    on w.fund_keyed and b.user_id = w.user_id and b.fund_id = w.fund_id
+   and b.goal_id is not distinct from w.goal_id
  where coalesce(w.principal_withdrawn, 0) <= 0
-   and case when w.fund_keyed then coalesce(w.units_withdrawn, 0) > 0   -- else it is fund_sale_missing_units
+   and case when w.fund_keyed
+              -- units <= 0 is fund_sale_missing_units. And a slice can be worth
+              -- NOTHING: round(basis × units / total_units) below half a đồng makes
+              -- zero the correct principal, which the invariant accepts (and
+              -- lib/fundWithdrawal posts). Only a slice actually worth something —
+              -- more than the invariant's own đồng of tolerance — is missing here.
+              then coalesce(w.units_withdrawn, 0) > 0
+                   and coalesce(b.units, 0) > 0
+                   and round(b.basis * w.units_withdrawn / b.units) > 1
             else w.parent_transaction_id is not null end
 
 union all
@@ -308,32 +371,11 @@ select 'fund_bucket_has_no_purchases', 'violation',
 -- basis and units: no row exceeded it, tightest margin 1.2 đồng.
 union all
 select 'sale_basis_not_proportional', 'review',
-       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
-       format('a sale of %s of the holding''s %s units took %s đồng where the flat rate on a %s basis is %s',
-              w.units_withdrawn, p.units, w.principal_withdrawn, p.amount_vnd,
-              round(p.amount_vnd * w.units_withdrawn / p.units))
-  from wd w
-  join parents p on p.transaction_id = w.parent_transaction_id
- where not w.fund_keyed and p.asset_type = 'gold' and coalesce(p.units, 0) > 0
-   and coalesce(w.units_withdrawn, 0) > 0
-   and abs(coalesce(w.principal_withdrawn, 0) - round(p.amount_vnd * w.units_withdrawn / p.units))
-       > p.sells + 1 + case when p.out_units >= p.units - 0.0001
-                         then 0.0001 * p.amount_vnd / p.units else 0 end
-
-union all
-select 'sale_basis_not_proportional', 'review',
-       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
-       format('a sell of %s of the bucket''s %s units took %s đồng where the flat rate on a %s basis is %s',
-              w.units_withdrawn, b.units, w.principal_withdrawn, b.basis,
-              round(b.basis * w.units_withdrawn / b.units))
-  from wd w
-  join fund_buckets b
-    on b.user_id = w.user_id and b.fund_id = w.fund_id and b.goal_id is not distinct from w.goal_id
- where w.fund_keyed and b.units > 0
-   and coalesce(w.units_withdrawn, 0) > 0
-   and abs(coalesce(w.principal_withdrawn, 0) - round(b.basis * w.units_withdrawn / b.units))
-       > b.sells + 1 + case when b.out_units >= b.units - 0.0001
-                         then 0.0001 * b.basis / b.units else 0 end
+       d.user_id, d.transaction_id, d.parent_transaction_id, d.fund_id, d.goal_id, d.detail
+  from sale_dev_ranked d
+ where d.dev > d.base_tol
+   and d.units_withdrawn > 0.0002
+   and (d.over_base >= 2 or d.dev > d.base_tol + d.shortcut_tol)
 
 union all
 select 'basis_not_proportional', 'review',

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -289,13 +289,21 @@ select 'fund_bucket_has_no_purchases', 'violation',
 -- The tolerance has THREE parts, and the third is the one that matters in practice:
 --   sells   the ±1 allowance each sale may use, which the last sale inherits
 --   1       the two roundings between the flat rate and the invariant's expectation
---   0.0001 × basis / units
+--   0.0001 × basis / units, and ONLY on a holding that ends up exhausted
 --           the value of one epsilon of units. The clients round units to 4
 --           decimals, so "sell everything" routinely posts a hair UNDER the holding
 --           (4 chỉ leaves as 3.9999) and the invariant treats a sale within an
 --           epsilon of the rest as a FULL one, taking the whole basis. On an
 --           ordinary 40,000,000 đồng gold holding that legitimate gap is a THOUSAND
 --           đồng — a flat tolerance reports every full gold sale in the ledger.
+--
+--           The condition is what keeps that slack from covering ordinary partial
+--           sales, where a thousand đồng of licence would hide real misallocation.
+--           It is exact rather than heuristic: the shortcut requires the sale to
+--           take within an epsilon of what REMAINS, so at most an epsilon of units
+--           can be left behind afterwards — any legal use of it implies the holding
+--           ends exhausted, which is state-visible. A sale of 1 chỉ out of 4 leaves
+--           3 behind and gets no slack.
 -- Validated against 1.5M invariant-legal sale sequences across four magnitudes of
 -- basis and units: no row exceeded it, tightest margin 1.2 đồng.
 union all
@@ -309,7 +317,8 @@ select 'sale_basis_not_proportional', 'review',
  where not w.fund_keyed and p.asset_type = 'gold' and coalesce(p.units, 0) > 0
    and coalesce(w.units_withdrawn, 0) > 0
    and abs(coalesce(w.principal_withdrawn, 0) - round(p.amount_vnd * w.units_withdrawn / p.units))
-       > p.sells + 1 + 0.0001 * p.amount_vnd / p.units
+       > p.sells + 1 + case when p.out_units >= p.units - 0.0001
+                         then 0.0001 * p.amount_vnd / p.units else 0 end
 
 union all
 select 'sale_basis_not_proportional', 'review',
@@ -323,7 +332,8 @@ select 'sale_basis_not_proportional', 'review',
  where w.fund_keyed and b.units > 0
    and coalesce(w.units_withdrawn, 0) > 0
    and abs(coalesce(w.principal_withdrawn, 0) - round(b.basis * w.units_withdrawn / b.units))
-       > b.sells + 1 + 0.0001 * b.basis / b.units
+       > b.sells + 1 + case when b.out_units >= b.units - 0.0001
+                         then 0.0001 * b.basis / b.units else 0 end
 
 union all
 select 'basis_not_proportional', 'review',
@@ -337,7 +347,8 @@ select 'basis_not_proportional', 'review',
  where p.asset_type = 'gold' and coalesce(p.units, 0) > 0
    and abs(p.out_principal
            - case when p.out_units >= p.units - 0.0001 then p.amount_vnd
-                  else round(p.amount_vnd * p.out_units / p.units) end) > 2 * p.sells + 0.0001 * p.amount_vnd / p.units
+                  else round(p.amount_vnd * p.out_units / p.units) end) > 2 * p.sells + case when p.out_units >= p.units - 0.0001
+                          then 0.0001 * p.amount_vnd / p.units else 0 end
 
 union all
 select 'basis_not_proportional', 'review',
@@ -351,7 +362,8 @@ select 'basis_not_proportional', 'review',
  where b.units > 0
    and abs(b.out_principal
            - case when b.out_units >= b.units - 0.0001 then b.basis
-                  else round(b.basis * b.out_units / b.units) end) > 2 * b.sells + 0.0001 * b.basis / b.units;
+                  else round(b.basis * b.out_units / b.units) end) > 2 * b.sells + case when b.out_units >= b.units - 0.0001
+                          then 0.0001 * b.basis / b.units else 0 end;
 
 comment on view public.withdrawal_ledger_audit is
   'Read-only audit of existing withdrawal rows against the decision table enforced by check_withdrawal_balance. One row per finding: check_name, severity, and the holding it concerns (#609).';

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -35,7 +35,11 @@
 -- ─── The two severities ──────────────────────────────────────────────────────
 --
 -- 'violation' — provable from the state alone. No ordering of any history could
---               have produced this row, so it is wrong however it got here.
+--               have produced this row, so it is wrong however it got here. Note
+--               what that excludes: the principal taken out of a GOLD holding or a
+--               fund bucket is not capped by the invariant at all — those follow
+--               the proportional allocation, one sale at a time, and that allowance
+--               accumulates — so a basis overrun there is reported for review.
 -- 'review'    — the ledger looks off, but legally-written ledgers can look the
 --               same. Sequence-sensitive: judge these with the rows in front of
 --               you, and expect the drift a mid-stream purchase legitimately
@@ -312,15 +316,25 @@ union all
 -- Past zero. The dashboard then DROPS the holding (valueNonFundHolding returns
 -- null at effectiveAmount <= 0) while the excess withdrawal stays in history, so
 -- net worth is wrong in a way no screen shows.
--- The tolerances are the invariant's own, and they do NOT accumulate across sales,
--- however many there are: every constraint it applies bounds the CUMULATIVE sum,
--- because each sale is measured against what is left — which already carries the
--- previous sale's excess. Formally Σp ≤ basis + 1 and Σunits ≤ units + 0.0001 for
--- any number of sales; two sales totalling units + 0.00015 are refused, which the
--- test plants and a probe confirmed. So: one đồng wherever the principal is a
--- proportional slice (gold — a deposit's principal is the user's own figure and is
--- bounded exactly, with nothing to round), and one 0.0001 for the clients' 4-decimal
--- rounding on a full sell.
+-- What the invariant actually caps, and what it does not.
+--
+-- UNITS are capped for every kind of holding, and the bound is cumulative however
+-- many sales there are: each sale is measured against what is LEFT, which already
+-- carries the previous sale's excess, so Σunits ≤ units + 0.0001 whatever the
+-- count (two sales totalling units + 0.00015 are refused — probed). Selling more of
+-- a thing than exists is provable from state, so it is a violation.
+--
+-- PRINCIPAL is capped only where the invariant caps it: bank and stock, where the
+-- amount withdrawn is the user's own figure and the rule is literally
+-- `principal_withdrawn > remaining` → refused. There is NO principal cap in the
+-- quantity-valued branch. Gold and fund sells are governed by the proportional
+-- allocation instead, one sale at a time, and THAT allowance accumulates: a 1 đồng
+-- / 5 unit holding sold in three 1-unit slices has each slice's share round to
+-- zero, while the invariant separately demands a positive principal from a
+-- parent-backed withdrawal — so three đồng legally leave a one đồng holding, every
+-- write accepted. Calling that an overdraw would tell an operator to repair a
+-- correctly written ledger, which is the one thing 'violation' promises not to do.
+-- Quantity-valued basis overruns go to 'review' below instead.
 --
 -- Units are compared against coalesce: a holding with NO units still has a balance
 -- of zero units, and the invariant refuses any positive quantity drawn on it
@@ -331,8 +345,8 @@ select 'holding_overdrawn', 'violation',
        format('%s holding of %s đồng / %s units has %s đồng / %s units taken out across %s withdrawal(s)',
               p.asset_type, p.amount_vnd, coalesce(p.units, 0), p.out_principal, p.out_units, p.sells)
   from parents p
- where p.out_principal > p.amount_vnd + (case when p.asset_type = 'gold' then 1 else 0 end)
-    or p.out_units > coalesce(p.units, 0) + 0.0001
+ where p.out_units > coalesce(p.units, 0) + 0.0001
+    or (p.asset_type is distinct from 'gold' and p.out_principal > p.amount_vnd)
 
 union all
 select 'fund_bucket_overdrawn', 'violation',
@@ -340,8 +354,28 @@ select 'fund_bucket_overdrawn', 'violation',
        format('bucket holds %s đồng / %s units and has %s đồng / %s units sold across %s sell(s)',
               b.basis, b.units, b.out_principal, b.out_units, b.sells)
   from fund_buckets b
- where b.buys > 0
-   and (b.out_principal > b.basis + 1 or b.out_units > b.units + 0.0001)
+ where b.buys > 0 and b.out_units > b.units + 0.0001
+
+union all
+-- The same overrun on the principal side of a quantity-valued holding. Worth
+-- looking at — dashboard/overview subtracts exactly this sum from invested capital
+-- — but never provable, since accumulated rounding on small slices reaches it
+-- legally. The per-sale tolerance is what an honest reading needs, so it is the
+-- tolerance used here too.
+select 'basis_taken_exceeds_cost', 'review',
+       p.user_id, null::uuid, p.transaction_id, null::uuid, p.goal_id,
+       format('gold holding cost %s đồng and has %s đồng taken out across %s withdrawal(s)',
+              p.amount_vnd, p.out_principal, p.sells)
+  from parents p
+ where p.asset_type = 'gold' and p.out_principal > p.amount_vnd + p.sells
+
+union all
+select 'basis_taken_exceeds_cost', 'review',
+       b.user_id, null::uuid, null::uuid, b.fund_id, b.goal_id,
+       format('bucket cost %s đồng and has %s đồng sold out of it across %s sell(s)',
+              b.basis, b.out_principal, b.sells)
+  from fund_buckets b
+ where b.buys > 0 and b.out_principal > b.basis + b.sells
 
 union all
 -- A sell alone in a bucket: its purchases are in another goal, so nothing here

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -198,18 +198,27 @@ union all
 -- Past zero. The dashboard then DROPS the holding (valueNonFundHolding returns
 -- null at effectiveAmount <= 0) while the excess withdrawal stays in history, so
 -- net worth is wrong in a way no screen shows.
--- The tolerances are the invariant's own, per sale: one đồng of rounding wherever
--- the principal is a proportional slice (gold; a deposit's principal is the user's
--- own figure and is bounded exactly), and the 0.0001 units the clients' 4-decimal
--- rounding can add to a full sell. An audit stricter than the invariant it audits
--- reports ledgers nobody can repair, and that is how a report gets ignored.
+-- The tolerances are the invariant's own, and they do NOT accumulate across sales,
+-- however many there are: every constraint it applies bounds the CUMULATIVE sum,
+-- because each sale is measured against what is left — which already carries the
+-- previous sale's excess. Formally Σp ≤ basis + 1 and Σunits ≤ units + 0.0001 for
+-- any number of sales; two sales totalling units + 0.00015 are refused, which the
+-- test plants and a probe confirmed. So: one đồng wherever the principal is a
+-- proportional slice (gold — a deposit's principal is the user's own figure and is
+-- bounded exactly, with nothing to round), and one 0.0001 for the clients' 4-decimal
+-- rounding on a full sell.
+--
+-- Units are compared against coalesce: a holding with NO units still has a balance
+-- of zero units, and the invariant refuses any positive quantity drawn on it
+-- ('5 units exceeds the remaining balance of 0 units'). Skipping the comparison
+-- when the parent's units are null let exactly that row report clean.
 select 'holding_overdrawn', 'violation',
        p.user_id, null::uuid, p.transaction_id, null::uuid, p.goal_id,
        format('%s holding of %s đồng / %s units has %s đồng / %s units taken out across %s withdrawal(s)',
               p.asset_type, p.amount_vnd, coalesce(p.units, 0), p.out_principal, p.out_units, p.sells)
   from parents p
- where p.out_principal > p.amount_vnd + (case when p.asset_type = 'gold' then p.sells else 0 end)
-    or (p.units is not null and p.out_units > p.units + 0.0001 * p.sells)
+ where p.out_principal > p.amount_vnd + (case when p.asset_type = 'gold' then 1 else 0 end)
+    or p.out_units > coalesce(p.units, 0) + 0.0001
 
 union all
 select 'fund_bucket_overdrawn', 'violation',
@@ -218,7 +227,7 @@ select 'fund_bucket_overdrawn', 'violation',
               b.basis, b.units, b.out_principal, b.out_units, b.sells)
   from fund_buckets b
  where b.buys > 0
-   and (b.out_principal > b.basis + b.sells or b.out_units > b.units + 0.0001 * b.sells)
+   and (b.out_principal > b.basis + 1 or b.out_units > b.units + 0.0001)
 
 union all
 -- A sell alone in a bucket: its purchases are in another goal, so nothing here
@@ -237,7 +246,13 @@ select 'fund_bucket_has_no_purchases', 'violation',
 -- That rule is additive and order-independent — each sale takes units × basis /
 -- total_units regardless of sequence — so the aggregate is a sound check even
 -- though the per-sale history is not reconstructible. Tolerance is one đồng per
--- sale, which is what rounding each slice can produce.
+-- sale, and here — unlike the overdraw bound above — the drift genuinely DOES
+-- accumulate: each partial sale's expectation is recomputed from what is left, so
+-- two sales may each under-take by a đồng and both be accepted. 100 đồng over 4
+-- units, two sales of 1 unit taking 24 where the flat proportion says 25: the
+-- aggregate is 48 against 50, both accepted (probed, and pinned by a test).
+-- Over-taking gets no slack from that: the cumulative upper bound is enforced
+-- tightly by holding_overdrawn / fund_bucket_overdrawn above.
 --
 -- 'review', not 'violation': a purchase added to a bucket AFTER a sale legitimately
 -- shifts the ratio, and so does a hand-corrected row. The number is the useful

--- a/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
+++ b/supabase/migrations/20260730000003_withdrawal_ledger_audit.sql
@@ -284,9 +284,20 @@ select 'fund_bucket_has_no_purchases', 'violation',
 -- as a first write (50 of 100 units must take 500) — that state is unreachable in
 -- any order, and a totals-only audit calls it clean. The flat rate is the right
 -- yardstick per row precisely because the allocation rule is additive: each sale
--- takes units × basis / total_units whatever the sequence. Same tolerance, and a
--- measured one — the worst per-row deviation over invariant-legal sequences is 1
--- đồng per sale (the last sale absorbs whatever the earlier ones drifted).
+-- takes units × basis / total_units whatever the sequence.
+--
+-- The tolerance has THREE parts, and the third is the one that matters in practice:
+--   sells   the ±1 allowance each sale may use, which the last sale inherits
+--   1       the two roundings between the flat rate and the invariant's expectation
+--   0.0001 × basis / units
+--           the value of one epsilon of units. The clients round units to 4
+--           decimals, so "sell everything" routinely posts a hair UNDER the holding
+--           (4 chỉ leaves as 3.9999) and the invariant treats a sale within an
+--           epsilon of the rest as a FULL one, taking the whole basis. On an
+--           ordinary 40,000,000 đồng gold holding that legitimate gap is a THOUSAND
+--           đồng — a flat tolerance reports every full gold sale in the ledger.
+-- Validated against 1.5M invariant-legal sale sequences across four magnitudes of
+-- basis and units: no row exceeded it, tightest margin 1.2 đồng.
 union all
 select 'sale_basis_not_proportional', 'review',
        w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
@@ -297,7 +308,8 @@ select 'sale_basis_not_proportional', 'review',
   join parents p on p.transaction_id = w.parent_transaction_id
  where not w.fund_keyed and p.asset_type = 'gold' and coalesce(p.units, 0) > 0
    and coalesce(w.units_withdrawn, 0) > 0
-   and abs(coalesce(w.principal_withdrawn, 0) - round(p.amount_vnd * w.units_withdrawn / p.units)) > 2 * p.sells
+   and abs(coalesce(w.principal_withdrawn, 0) - round(p.amount_vnd * w.units_withdrawn / p.units))
+       > p.sells + 1 + 0.0001 * p.amount_vnd / p.units
 
 union all
 select 'sale_basis_not_proportional', 'review',
@@ -310,7 +322,8 @@ select 'sale_basis_not_proportional', 'review',
     on b.user_id = w.user_id and b.fund_id = w.fund_id and b.goal_id is not distinct from w.goal_id
  where w.fund_keyed and b.units > 0
    and coalesce(w.units_withdrawn, 0) > 0
-   and abs(coalesce(w.principal_withdrawn, 0) - round(b.basis * w.units_withdrawn / b.units)) > 2 * b.sells
+   and abs(coalesce(w.principal_withdrawn, 0) - round(b.basis * w.units_withdrawn / b.units))
+       > b.sells + 1 + 0.0001 * b.basis / b.units
 
 union all
 select 'basis_not_proportional', 'review',
@@ -324,7 +337,7 @@ select 'basis_not_proportional', 'review',
  where p.asset_type = 'gold' and coalesce(p.units, 0) > 0
    and abs(p.out_principal
            - case when p.out_units >= p.units - 0.0001 then p.amount_vnd
-                  else round(p.amount_vnd * p.out_units / p.units) end) > 2 * p.sells
+                  else round(p.amount_vnd * p.out_units / p.units) end) > 2 * p.sells + 0.0001 * p.amount_vnd / p.units
 
 union all
 select 'basis_not_proportional', 'review',
@@ -338,7 +351,7 @@ select 'basis_not_proportional', 'review',
  where b.units > 0
    and abs(b.out_principal
            - case when b.out_units >= b.units - 0.0001 then b.basis
-                  else round(b.basis * b.out_units / b.units) end) > 2 * b.sells;
+                  else round(b.basis * b.out_units / b.units) end) > 2 * b.sells + 0.0001 * b.basis / b.units;
 
 comment on view public.withdrawal_ledger_audit is
   'Read-only audit of existing withdrawal rows against the decision table enforced by check_withdrawal_balance. One row per finding: check_name, severity, and the holding it concerns (#609).';

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -43,6 +43,7 @@ declare
   v_cancel_src uuid; v_cancel_a uuid; v_cancel_b uuid;
   v_slack_src uuid; v_slack uuid;
   v_pair_src uuid; v_pair_a uuid; v_pair_b uuid;
+  v_split_goal_src uuid; v_sg_a uuid; v_sg_b uuid;
   -- the clean half
   v_tol_goal  uuid;
   v_drift_src uuid; v_comp_src uuid; v_f7_src uuid; v_full_src uuid; v_tail_src uuid;
@@ -431,6 +432,23 @@ begin
   values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 1, v_pair_src, 29999500, 3)
   returning transaction_id into v_pair_b;
 
+  -- 21. the same unexplainable pair, but with the two sales filed under DIFFERENT
+  --     goals. A withdrawal carries its own goal_id and the invariant ignores it
+  --     entirely for a parent-backed row — the balance is keyed by
+  --     parent_transaction_id alone — so these are siblings on one holding however
+  --     they are filed. Counting them apart would let each look like the only
+  --     claimant of the full-sale slack.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 40000000, 4, 10000000) returning transaction_id into v_split_goal_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 1, v_split_goal_src, 10000500, 1)
+  returning transaction_id into v_sg_a;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-03-01', 1, v_split_goal_src, 29999500, 3)
+  returning transaction_id into v_sg_b;
+
   alter table public.investment_transactions enable trigger user;
 
   -- ═══ every planted row must be named, by the right check ═══════════════════
@@ -455,7 +473,9 @@ begin
         ('sale_basis_not_proportional',   v_cancel_b),
         ('sale_basis_not_proportional',   v_slack),
         ('sale_basis_not_proportional',   v_pair_a),
-        ('sale_basis_not_proportional',   v_pair_b)
+        ('sale_basis_not_proportional',   v_pair_b),
+        ('sale_basis_not_proportional',   v_sg_a),
+        ('sale_basis_not_proportional',   v_sg_b)
       ) as x(name, tx)
   loop
     if v_count <> 1 then

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -47,6 +47,7 @@ declare
   v_closer_src uuid; v_closer uuid;
   v_sliver_src uuid; v_sliver_a uuid; v_sliver_b uuid;
   v_tail2_src uuid; v_tail2_a uuid; v_tail2_b uuid;
+  v_basisover_src uuid;
   -- the clean half
   v_tol_goal  uuid;
   v_drift_src uuid; v_comp_src uuid; v_f7_src uuid; v_full_src uuid; v_tail_src uuid;
@@ -539,6 +540,19 @@ begin
   values (v_user, v_goal, 'gold', 'withdrawal', '2026-04-01', 1, v_tail2_src, 150, 0.0001)
   returning transaction_id into v_tail2_b;
 
+  -- 25. basis taken far past what the holding cost: 40,000,000 over 4 units, two
+  --     sales of 2 units taking 30,000,000 each. The units add up, so nothing is
+  --     over-sold — but 60,000,000 of cost has left a 40,000,000 holding, and
+  --     dashboard/overview subtracts exactly that sum from invested capital. Not a
+  --     violation: the invariant places no cap on the principal of a
+  --     quantity-valued holding, so the audit can only raise it for review.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 40000000, 4, 10000000) returning transaction_id into v_basisover_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 1, v_basisover_src, 30000000, 2),
+         (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 1, v_basisover_src, 30000000, 2);
+
   alter table public.investment_transactions enable trigger user;
 
   -- ═══ every planted row must be named, by the right check ═══════════════════
@@ -609,6 +623,16 @@ begin
     raise exception 'the audit must report units taken out of a holding that has none';
   end if;
 
+  if not exists (select 1 from public.withdrawal_ledger_audit
+                  where check_name = 'basis_taken_exceeds_cost' and severity = 'review'
+                    and parent_transaction_id = v_basisover_src) then
+    raise exception 'the audit must raise basis taken past the holding cost for review';
+  end if;
+  if exists (select 1 from public.withdrawal_ledger_audit
+              where check_name = 'basis_taken_exceeds_cost' and severity = 'violation') then
+    raise exception 'a basis overrun on a quantity-valued holding is not provable and may not be a violation';
+  end if;
+
   -- Nothing whose every write was legal may be called a violation. 'review' is
   -- allowed here: the ratio really did move, and saying so is this check's job.
   if exists (select 1 from public.withdrawal_ledger_audit
@@ -674,7 +698,7 @@ end $$;
 -- Two claims the view's header makes, kept honest here rather than in prose alone.
 do $$
 declare
-  v_user uuid; v_g uuid; v_s uuid; v_violations int; v_any int;
+  v_user uuid; v_g uuid; v_s uuid; v_tiny uuid; v_violations int; v_any int; i int;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'wd-audit-contract@test.invalid') returning id into v_user;
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'G') returning goal_id into v_g;
@@ -699,6 +723,30 @@ begin
   select count(*) into v_any from public.withdrawal_ledger_audit where user_id = v_user;
   if v_any <> 0 then
     raise notice 'the known-blind ledger now reports % row(s) — the header limit may be stale', v_any;
+  end if;
+
+  -- CLAIM 1b: a legal ledger may never produce a VIOLATION, however odd it looks.
+  --
+  -- A 1 đồng / 5 unit gold holding sold in three 1-unit slices. Each slice's
+  -- proportional share rounds to zero, and the invariant still demands a positive
+  -- principal from a parent-backed withdrawal, so each records the single đồng it is
+  -- allowed — three đồng out of a one đồng holding, every write accepted. There is
+  -- no principal cap in the quantity-valued branch at all: it enforces the
+  -- proportional allocation, not a running total. 'Σ principal ≤ basis' was never
+  -- the invariant's rule for gold or funds, so it cannot be a violation.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_g, 'gold', 'investment', '2026-01-01', 1, 5, 1) returning transaction_id into v_tiny;
+  for i in 1..3 loop
+    insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+    values (v_user, v_g, 'gold', 'withdrawal', '2026-02-01', 1, v_tiny, 1, 1);
+  end loop;
+
+  select count(*) into v_violations
+    from public.withdrawal_ledger_audit
+   where severity = 'violation' and (parent_transaction_id = v_tiny or transaction_id in
+         (select transaction_id from public.investment_transactions where parent_transaction_id = v_tiny));
+  if v_violations <> 0 then
+    raise exception 'a ledger the invariant accepted was reported as a violation (% row(s))', v_violations;
   end if;
 
   -- CLAIM 2: 'violation' means provable from state. The sequence-sensitive checks

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -40,9 +40,10 @@ declare
   v_stray     uuid; v_stray_z  uuid;
   v_mask_goal uuid; v_mask_zero uuid;
   v_eps_src   uuid; v_nounits_src uuid;
+  v_cancel_src uuid; v_cancel_a uuid; v_cancel_b uuid;
   -- the clean half
   v_tol_goal  uuid;
-  v_drift_src uuid; v_comp_src uuid;
+  v_drift_src uuid; v_comp_src uuid; v_f7_src uuid;
   v_ok_bank   uuid; v_ok_bank_w  uuid;
   v_ok_gold   uuid; v_ok_gold_w1 uuid; v_ok_gold_w2 uuid;
   v_ok_buy    uuid; v_ok_sell1   uuid; v_ok_sell2   uuid;
@@ -157,6 +158,24 @@ begin
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
   values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-03-01', 1, v_comp_src, 8, 1);
+
+  -- An epsilon-sized sale is legal or not depending ONLY on the order it was
+  -- written in, and the audit reads state, not history. Taking 0.00005 units FIRST
+  -- and the whole unit second is accepted by the invariant (the epsilon is granted
+  -- while something is left); exhausting the unit first and then taking 0.00005 is
+  -- refused. Both leave the same totals behind, so no state-based check can tell
+  -- them apart — which means the audit must stay SILENT here rather than report a
+  -- ledger that was written legally. Pinned so a later "tighten the epsilon" cannot
+  -- turn this into a false positive; the exposure it leaves is bounded by one
+  -- epsilon of units, and is recorded as a known limit in the view's header.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal_b, 'gold', 'investment', '2026-01-01', 100, 1, 100) returning transaction_id into v_f7_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-02-01', 1, v_f7_src, 1, 0.00005);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-03-01', 1, v_f7_src, 99, 1);
 
   -- ═══ the planted violations ════════════════════════════════════════════════
   -- Disabling the user triggers is the only way in: these are precisely the shapes
@@ -313,6 +332,23 @@ begin
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
   values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 5000000, v_nounits_src, 5000000, 5);
 
+  -- 18. two sales whose allocation errors CANCEL while both principals are
+  --     positive: 50 units taking 400 and 50 taking 600 out of a 1000 đồng / 100
+  --     unit holding. The invariant refuses each one as a first write — 50 of 100
+  --     units must take 500 — so this state is unreachable in ANY order, unlike the
+  --     epsilon case above. The totals are exactly proportional, so the
+  --     holding-level check cannot see it: only a per-sale comparison can.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal_b, 'gold', 'investment', '2026-01-01', 1000, 100, 10) returning transaction_id into v_cancel_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-02-01', 1, v_cancel_src, 400, 50)
+  returning transaction_id into v_cancel_a;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-03-01', 1, v_cancel_src, 600, 50)
+  returning transaction_id into v_cancel_b;
+
   alter table public.investment_transactions enable trigger user;
 
   -- ═══ every planted row must be named, by the right check ═══════════════════
@@ -332,7 +368,9 @@ begin
         ('sourceless_not_held_for_merge', v_notheld),
         ('draws_on_no_holding',           v_stray),
         ('sourceless_not_held_for_merge', v_stray_z),
-        ('withdrawal_missing_principal',  v_mask_zero)
+        ('withdrawal_missing_principal',  v_mask_zero),
+        ('sale_basis_not_proportional',   v_cancel_a),
+        ('sale_basis_not_proportional',   v_cancel_b)
       ) as x(name, tx)
   loop
     if v_count <> 1 then
@@ -371,6 +409,13 @@ begin
     raise exception 'the audit must report units taken out of a holding that has none';
   end if;
 
+  -- Same lesson as the masked bucket, one level down: these two sales add up to
+  -- exactly the right basis, so the holding-level check is silent by design.
+  if exists (select 1 from public.withdrawal_ledger_audit
+              where check_name = 'basis_not_proportional' and parent_transaction_id = v_cancel_src) then
+    raise exception 'the cancelling pair adds up: the holding-level check is not what catches it';
+  end if;
+
   -- The masked bucket is the point of that per-row check: its TOTALS are exactly
   -- proportional, so the holding-level check is silent by design. Asserting the
   -- silence keeps the two checks from being justified by each other.
@@ -386,7 +431,7 @@ begin
     from public.withdrawal_ledger_audit
    where transaction_id in (v_ok_bank_w, v_ok_gold_w1, v_ok_gold_w2, v_ok_sell1, v_ok_sell2,
                             v_ok_held, v_seed, v_seed_buy, v_seed_sell)
-      or parent_transaction_id in (v_ok_bank, v_ok_gold, v_drift_src, v_comp_src)
+      or parent_transaction_id in (v_ok_bank, v_ok_gold, v_drift_src, v_comp_src, v_f7_src)
       or (fund_id = v_fund_ok);
   if v_count <> 0 then
     raise exception 'the audit reported % row(s) against a ledger the invariant accepted', v_count;

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -42,7 +42,7 @@ declare
   v_eps_src   uuid; v_nounits_src uuid;
   -- the clean half
   v_tol_goal  uuid;
-  v_drift_src uuid;
+  v_drift_src uuid; v_comp_src uuid;
   v_ok_bank   uuid; v_ok_bank_w  uuid;
   v_ok_gold   uuid; v_ok_gold_w1 uuid; v_ok_gold_w2 uuid;
   v_ok_buy    uuid; v_ok_sell1   uuid; v_ok_sell2   uuid;
@@ -140,6 +140,23 @@ begin
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
   values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-03-01', 1, v_drift_src, 24, 1);
+
+  -- Worse than additive, because each expectation is recomputed from the ROUNDED
+  -- remaining: 100 đồng over 15 units, a sale of 7 units taking 48 where the
+  -- expectation is 47, then 1 unit of the remaining 8 taking 8 where the
+  -- expectation is round(52/8) = 7. Both inside the allowance, so both accepted —
+  -- but the aggregate is 56 against a flat expectation of 53, a drift of 3 across
+  -- 2 sales. A simulation over invariant-legal sequences puts the worst case at
+  -- 1.5 đồng per sale (the drift CONTRACTS by 1 − units/remaining each step, so it
+  -- cannot run away), which is what the tolerance is set from.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal_b, 'gold', 'investment', '2026-01-01', 100, 15, 7) returning transaction_id into v_comp_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-02-01', 1, v_comp_src, 48, 7);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-03-01', 1, v_comp_src, 8, 1);
 
   -- ═══ the planted violations ════════════════════════════════════════════════
   -- Disabling the user triggers is the only way in: these are precisely the shapes
@@ -369,7 +386,7 @@ begin
     from public.withdrawal_ledger_audit
    where transaction_id in (v_ok_bank_w, v_ok_gold_w1, v_ok_gold_w2, v_ok_sell1, v_ok_sell2,
                             v_ok_held, v_seed, v_seed_buy, v_seed_sell)
-      or parent_transaction_id in (v_ok_bank, v_ok_gold, v_drift_src)
+      or parent_transaction_id in (v_ok_bank, v_ok_gold, v_drift_src, v_comp_src)
       or (fund_id = v_fund_ok);
   if v_count <> 0 then
     raise exception 'the audit reported % row(s) against a ledger the invariant accepted', v_count;

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -50,7 +50,7 @@ declare
   v_tol_goal  uuid;
   v_drift_src uuid; v_comp_src uuid; v_f7_src uuid; v_full_src uuid; v_tail_src uuid;
   v_roundup_src uuid;
-  v_tiny_fund uuid;
+  v_tiny_fund uuid; v_late_fund uuid; v_late_sell uuid;
   v_ok_bank   uuid; v_ok_bank_w  uuid;
   v_ok_gold   uuid; v_ok_gold_w1 uuid; v_ok_gold_w2 uuid;
   v_ok_buy    uuid; v_ok_sell1   uuid; v_ok_sell2   uuid;
@@ -244,6 +244,24 @@ begin
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
   values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-02-01', 48000000, v_roundup_src, 40000000, 4.0001);
+
+  -- A zero-principal sale that was right when it was written, judged later against
+  -- a bucket that grew. 1 đồng over 100 units makes a 1-unit slice worth nothing, so
+  -- zero is the correct principal and the invariant accepts it; a 999 đồng purchase
+  -- arriving afterwards moves the bucket's ratio and the same row now looks 5 đồng
+  -- short. Every write was legal, so the audit may not call it a VIOLATION — the
+  -- proportionality check may still raise it for review, which is what that severity
+  -- is for and why its own comment names purchases added after a sale.
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Late Fund', 'LATE', 'equity', 1) returning id into v_late_fund;
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id)
+  values (v_user, v_goal_b, 'fund', 'investment', '2026-01-01', 1, 100, 1, v_late_fund);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'fund', 'withdrawal', '2026-02-01', 1, v_late_fund, 0, 1)
+  returning transaction_id into v_late_sell;
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id)
+  values (v_user, v_goal_b, 'fund', 'investment', '2026-03-01', 999, 100, 10, v_late_fund);
 
   -- ═══ the planted violations ════════════════════════════════════════════════
   -- Disabling the user triggers is the only way in: these are precisely the shapes
@@ -518,7 +536,7 @@ begin
         ('sourceless_not_held_for_merge', v_notheld),
         ('draws_on_no_holding',           v_stray),
         ('sourceless_not_held_for_merge', v_stray_z),
-        ('withdrawal_missing_principal',  v_mask_zero),
+        ('sale_basis_not_proportional',   v_mask_zero),
         ('sale_basis_not_proportional',   v_cancel_a),
         ('sale_basis_not_proportional',   v_cancel_b),
         ('sale_basis_not_proportional',   v_slack),
@@ -565,6 +583,13 @@ begin
   if not exists (select 1 from public.withdrawal_ledger_audit
                   where check_name = 'holding_overdrawn' and parent_transaction_id = v_nounits_src) then
     raise exception 'the audit must report units taken out of a holding that has none';
+  end if;
+
+  -- Nothing whose every write was legal may be called a violation. 'review' is
+  -- allowed here: the ratio really did move, and saying so is this check's job.
+  if exists (select 1 from public.withdrawal_ledger_audit
+              where transaction_id = v_late_sell and severity = 'violation') then
+    raise exception 'a sale that was correct when written must not become a violation because the bucket grew';
   end if;
 
   -- Same lesson as the masked bucket, one level down: these two sales add up to

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -42,9 +42,11 @@ declare
   v_eps_src   uuid; v_nounits_src uuid;
   v_cancel_src uuid; v_cancel_a uuid; v_cancel_b uuid;
   v_slack_src uuid; v_slack uuid;
+  v_pair_src uuid; v_pair_a uuid; v_pair_b uuid;
   -- the clean half
   v_tol_goal  uuid;
-  v_drift_src uuid; v_comp_src uuid; v_f7_src uuid; v_full_src uuid;
+  v_drift_src uuid; v_comp_src uuid; v_f7_src uuid; v_full_src uuid; v_tail_src uuid;
+  v_tiny_fund uuid;
   v_ok_bank   uuid; v_ok_bank_w  uuid;
   v_ok_gold   uuid; v_ok_gold_w1 uuid; v_ok_gold_w2 uuid;
   v_ok_buy    uuid; v_ok_sell1   uuid; v_ok_sell2   uuid;
@@ -190,6 +192,42 @@ begin
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
   values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-02-01', 48000000, v_full_src, 40000000, 3.9999);
+
+  -- A slice so small its proportional basis rounds to nothing: 100 units of a
+  -- 1,000,000-unit bucket worth 1000 đồng. round(1000 × 100 / 1000000) = 0, and the
+  -- invariant accepts a zero principal because it is within a đồng of that
+  -- expectation — lib/fundWithdrawal returns 0 here too. So "a fund sell with no
+  -- principal" is not universally invalid, and the audit may only call it that when
+  -- the expected slice is actually worth something.
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Tiny Fund', 'TINY', 'equity', 1) returning id into v_tiny_fund;
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id)
+  values (v_user, v_goal_b, 'fund', 'investment', '2026-01-01', 1000, 1000000, 1, v_tiny_fund);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'fund', 'withdrawal', '2026-02-01', 1, v_tiny_fund, 0, 100);
+
+  -- The tail of an epsilon-exhausted holding, built one accepted insert at a time.
+  -- 1,000,000 đồng over 1 unit: 0.9998 units takes its 999,800, then 0.0001 units
+  -- is within an epsilon of the 0.0002 remaining and so is a FULL sale taking all
+  -- 200 left, then a last 0.0001 takes the 1 đồng the invariant insists a
+  -- parent-backed withdrawal must record. Measured against the flat rate those two
+  -- slivers are 100 and 99 đồng out — TWO rows past the base tolerance on one
+  -- holding, which is exactly the pattern that says "no legal sequence explains
+  -- this". Here a legal sequence does explain it, so slivers are left out of that
+  -- count; which of them were legal depends on write order, the same
+  -- undecidable-from-state limit as the header records.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal_b, 'gold', 'investment', '2026-01-01', 1000000, 1, 1000000) returning transaction_id into v_tail_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-02-01', 1, v_tail_src, 999800, 0.9998);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-03-01', 1, v_tail_src, 200, 0.0001);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-04-01', 1, v_tail_src, 1, 0.0001);
 
   -- ═══ the planted violations ════════════════════════════════════════════════
   -- Disabling the user triggers is the only way in: these are precisely the shapes
@@ -377,6 +415,22 @@ begin
   values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 12000000, v_slack_src, 10000500, 1)
   returning transaction_id into v_slack;
 
+  -- 20. two sales that exhaust the holding and total the right basis, but neither
+  --     allocation is legal in any order: 1 unit taking 10,000,500 (rule: 10,000,000)
+  --     and 3 units taking 29,999,500 (rule: 30,000,000). Only ONE sale per holding
+  --     can be the one that closes it, so granting the full-sale slack to every
+  --     sibling of an exhausted holding hides both.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 40000000, 4, 10000000) returning transaction_id into v_pair_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 1, v_pair_src, 10000500, 1)
+  returning transaction_id into v_pair_a;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 1, v_pair_src, 29999500, 3)
+  returning transaction_id into v_pair_b;
+
   alter table public.investment_transactions enable trigger user;
 
   -- ═══ every planted row must be named, by the right check ═══════════════════
@@ -399,7 +453,9 @@ begin
         ('withdrawal_missing_principal',  v_mask_zero),
         ('sale_basis_not_proportional',   v_cancel_a),
         ('sale_basis_not_proportional',   v_cancel_b),
-        ('sale_basis_not_proportional',   v_slack)
+        ('sale_basis_not_proportional',   v_slack),
+        ('sale_basis_not_proportional',   v_pair_a),
+        ('sale_basis_not_proportional',   v_pair_b)
       ) as x(name, tx)
   loop
     if v_count <> 1 then
@@ -460,8 +516,8 @@ begin
     from public.withdrawal_ledger_audit
    where transaction_id in (v_ok_bank_w, v_ok_gold_w1, v_ok_gold_w2, v_ok_sell1, v_ok_sell2,
                             v_ok_held, v_seed, v_seed_buy, v_seed_sell)
-      or parent_transaction_id in (v_ok_bank, v_ok_gold, v_drift_src, v_comp_src, v_f7_src, v_full_src)
-      or (fund_id = v_fund_ok);
+      or parent_transaction_id in (v_ok_bank, v_ok_gold, v_drift_src, v_comp_src, v_f7_src, v_full_src, v_tail_src)
+      or fund_id in (v_fund_ok, v_tiny_fund);
   if v_count <> 0 then
     raise exception 'the audit reported % row(s) against a ledger the invariant accepted', v_count;
   end if;

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -670,4 +670,49 @@ begin
   end if;
 end $$;
 
+-- ═══ the contract itself ═══════════════════════════════════════════════════
+-- Two claims the view's header makes, kept honest here rather than in prose alone.
+do $$
+declare
+  v_user uuid; v_g uuid; v_s uuid; v_violations int; v_any int;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-audit-contract@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'G') returning goal_id into v_g;
+
+  -- CLAIM 1: an empty result does not prove the ledger clean.
+  --
+  -- 1000 đồng over 100 units, two sales of 50 units taking 497 and 503. Refused as
+  -- a first write (50 of 100 must take 500) and neither can follow the other — all
+  -- orderings are illegal — yet the totals are exactly proportional and each
+  -- per-sale deviation is inside what a legal two-sale ledger shows elsewhere. The
+  -- audit CANNOT see it, and this test exists so that silence is never mistaken for
+  -- a guarantee: if someone later makes this ledger report, the header's claim has
+  -- changed and both must be revisited together.
+  alter table public.investment_transactions disable trigger user;
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_g, 'gold', 'investment', '2026-01-01', 1000, 100, 10) returning transaction_id into v_s;
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_g, 'gold', 'withdrawal', '2026-02-01', 1, v_s, 497, 50),
+         (v_user, v_g, 'gold', 'withdrawal', '2026-03-01', 1, v_s, 503, 50);
+  alter table public.investment_transactions enable trigger user;
+
+  select count(*) into v_any from public.withdrawal_ledger_audit where user_id = v_user;
+  if v_any <> 0 then
+    raise notice 'the known-blind ledger now reports % row(s) — the header limit may be stale', v_any;
+  end if;
+
+  -- CLAIM 2: 'violation' means provable from state. The sequence-sensitive checks
+  -- may never wear it, whatever they find — a repair automated off one of those
+  -- would be acting on a ledger that might have been written legally.
+  select count(*) into v_violations
+    from public.withdrawal_ledger_audit
+   where severity = 'violation'
+     and check_name in ('sale_basis_not_proportional', 'basis_not_proportional', 'parent_is_a_fund_purchase');
+  if v_violations <> 0 then
+    raise exception 'a sequence-sensitive check reported % row(s) as a violation', v_violations;
+  end if;
+
+  raise notice 'withdrawal_ledger_audit: contract holds — sequence-sensitive findings stay advisory';
+end $$;
+
 rollback;

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -37,7 +37,10 @@ declare
   v_ob_goal   uuid;
   v_split     uuid;
   v_prop_src  uuid; v_prop     uuid;
+  v_stray     uuid; v_stray_z  uuid;
+  v_mask_goal uuid; v_mask_zero uuid;
   -- the clean half
+  v_tol_goal  uuid;
   v_ok_bank   uuid; v_ok_bank_w  uuid;
   v_ok_gold   uuid; v_ok_gold_w1 uuid; v_ok_gold_w2 uuid;
   v_ok_buy    uuid; v_ok_sell1   uuid; v_ok_sell2   uuid;
@@ -109,6 +112,18 @@ begin
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
   values (v_user, v_goal_b, 'fund', 'withdrawal', '2026-05-01', 1100000, v_fund_ok, 1000000, 50)
   returning transaction_id into v_seed_sell;
+
+  -- The invariant's allocation rule tolerates one đồng per sale, because that is
+  -- what rounding a proportional slice produces. A full sale taking basis + 1 is
+  -- therefore ACCEPTED — the insert below proves it, since the triggers are still
+  -- on — and an audit stricter than the invariant it audits would report a ledger
+  -- nobody can fix.
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Rounding') returning goal_id into v_tol_goal;
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id)
+  values (v_user, v_tol_goal, 'fund', 'investment', '2026-01-01', 1000000, 100, 10000, v_fund_ok);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_tol_goal, 'fund', 'withdrawal', '2026-02-01', 1200000, v_fund_ok, 1000001, 100);
 
   -- ═══ the planted violations ════════════════════════════════════════════════
   -- Disabling the user triggers is the only way in: these are precisely the shapes
@@ -210,6 +225,37 @@ begin
   values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-02-01', 12000000, v_prop_src, 40000000, 1)
   returning transaction_id into v_prop;
 
+  -- 13. a fund sell whose asset_type was edited off 'fund': it KEEPS its fund_id,
+  --     but a retained id is not a bucket key without asset_type='fund', so the
+  --     row draws on nothing (the invariant refuses exactly this shape). Keying the
+  --     audit off `fund_id is null` would make this reachable corruption invisible.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 5000000, v_fund, 5000000)
+  returning transaction_id into v_stray;
+
+  -- 14. the same stranded shape carrying no deltas: still not a held-for-merge row
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 5000000, v_fund)
+  returning transaction_id into v_stray_z;
+
+  -- 15. two sells whose basis errors CANCEL: one takes nothing, the other takes
+  --     double. The invariant refuses each on its own, but the bucket's totals come
+  --     out exactly proportional — so a holding-level check alone reports a clean
+  --     bucket and both invalid rows stay silent. This is why the missing-principal
+  --     check has to be per row.
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Masked') returning goal_id into v_mask_goal;
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id)
+  values (v_user, v_mask_goal, 'fund', 'investment', '2026-01-01', 1000000, 100, 10000, v_fund);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_mask_goal, 'fund', 'withdrawal', '2026-02-01', 600000, v_fund, 0, 50)
+  returning transaction_id into v_mask_zero;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_mask_goal, 'fund', 'withdrawal', '2026-03-01', 600000, v_fund, 1000000, 50);
+
   alter table public.investment_transactions enable trigger user;
 
   -- ═══ every planted row must be named, by the right check ═══════════════════
@@ -226,7 +272,10 @@ begin
         ('parent_is_not_an_investment',   v_pnotinv),
         ('parent_is_a_fund_purchase',     v_onfund),
         ('draws_on_no_holding',           v_nothing),
-        ('sourceless_not_held_for_merge', v_notheld)
+        ('sourceless_not_held_for_merge', v_notheld),
+        ('draws_on_no_holding',           v_stray),
+        ('sourceless_not_held_for_merge', v_stray_z),
+        ('withdrawal_missing_principal',  v_mask_zero)
       ) as x(name, tx)
   loop
     if v_count <> 1 then
@@ -254,6 +303,14 @@ begin
   if not exists (select 1 from public.withdrawal_ledger_audit
                   where check_name = 'basis_not_proportional' and parent_transaction_id = v_prop_src) then
     raise exception 'the audit must report the gold sale that took the whole basis for one of four units';
+  end if;
+
+  -- The masked bucket is the point of that per-row check: its TOTALS are exactly
+  -- proportional, so the holding-level check is silent by design. Asserting the
+  -- silence keeps the two checks from being justified by each other.
+  if exists (select 1 from public.withdrawal_ledger_audit
+              where check_name = 'basis_not_proportional' and goal_id = v_mask_goal) then
+    raise exception 'the masked bucket adds up: the holding-level check is not what catches it';
   end if;
 
   -- ═══ and nothing the invariant itself accepted ═════════════════════════════

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -46,6 +46,7 @@ declare
   v_split_goal_src uuid; v_sg_a uuid; v_sg_b uuid;
   v_closer_src uuid; v_closer uuid;
   v_sliver_src uuid; v_sliver_a uuid; v_sliver_b uuid;
+  v_tail2_src uuid; v_tail2_a uuid; v_tail2_b uuid;
   -- the clean half
   v_tol_goal  uuid;
   v_drift_src uuid; v_comp_src uuid; v_f7_src uuid; v_full_src uuid; v_tail_src uuid;
@@ -517,6 +518,27 @@ begin
   values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 1, v_sliver_src, 199, 0.0001)
   returning transaction_id into v_sliver_b;
 
+  -- 24. an exhausted tail whose slivers are BOTH wrong: 0.9998 units takes its
+  --     999,800, then two 0.0001 slivers take 50 and 150 of the 200 left. Units and
+  --     principal both add up exactly, so the holding-level checks are silent, and
+  --     the tail exemption skipped the slivers. But only one sliver can be the
+  --     closer that empties the basis; the other must take its flat share or, if it
+  --     came after, nothing. Neither of these does — all six orderings were run
+  --     against the invariant and every one is refused.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 1000000, 1, 1000000) returning transaction_id into v_tail2_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 1, v_tail2_src, 999800, 0.9998);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 1, v_tail2_src, 50, 0.0001)
+  returning transaction_id into v_tail2_a;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-04-01', 1, v_tail2_src, 150, 0.0001)
+  returning transaction_id into v_tail2_b;
+
   alter table public.investment_transactions enable trigger user;
 
   -- ═══ every planted row must be named, by the right check ═══════════════════
@@ -546,7 +568,9 @@ begin
         ('sale_basis_not_proportional',   v_sg_b),
         ('sale_basis_not_proportional',   v_closer),
         ('sale_basis_not_proportional',   v_sliver_a),
-        ('sale_basis_not_proportional',   v_sliver_b)
+        ('sale_basis_not_proportional',   v_sliver_b),
+        ('sale_basis_not_proportional',   v_tail2_a),
+        ('sale_basis_not_proportional',   v_tail2_b)
       ) as x(name, tx)
   loop
     if v_count <> 1 then

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -43,7 +43,7 @@ declare
   v_cancel_src uuid; v_cancel_a uuid; v_cancel_b uuid;
   -- the clean half
   v_tol_goal  uuid;
-  v_drift_src uuid; v_comp_src uuid; v_f7_src uuid;
+  v_drift_src uuid; v_comp_src uuid; v_f7_src uuid; v_full_src uuid;
   v_ok_bank   uuid; v_ok_bank_w  uuid;
   v_ok_gold   uuid; v_ok_gold_w1 uuid; v_ok_gold_w2 uuid;
   v_ok_buy    uuid; v_ok_sell1   uuid; v_ok_sell2   uuid;
@@ -176,6 +176,19 @@ begin
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
   values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-03-01', 1, v_f7_src, 99, 1);
+
+  -- The clients round units to 4 decimals, so "sell everything" routinely posts a
+  -- hair UNDER the holding — 4 chỉ leaves as 3.9999 — and the invariant treats a
+  -- sale within an epsilon of the rest as a FULL one, taking the whole basis. A
+  -- per-sale check against the flat rate units × basis / total_units therefore sees
+  -- a legitimate gap of 0.0001 × basis / units, which on an ordinary 40,000,000
+  -- gold holding is a thousand đồng. Nothing exotic: this is what a full gold sale
+  -- looks like in this app.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal_b, 'gold', 'investment', '2026-01-01', 40000000, 4, 10000000) returning transaction_id into v_full_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-02-01', 48000000, v_full_src, 40000000, 3.9999);
 
   -- ═══ the planted violations ════════════════════════════════════════════════
   -- Disabling the user triggers is the only way in: these are precisely the shapes
@@ -431,7 +444,7 @@ begin
     from public.withdrawal_ledger_audit
    where transaction_id in (v_ok_bank_w, v_ok_gold_w1, v_ok_gold_w2, v_ok_sell1, v_ok_sell2,
                             v_ok_held, v_seed, v_seed_buy, v_seed_sell)
-      or parent_transaction_id in (v_ok_bank, v_ok_gold, v_drift_src, v_comp_src, v_f7_src)
+      or parent_transaction_id in (v_ok_bank, v_ok_gold, v_drift_src, v_comp_src, v_f7_src, v_full_src)
       or (fund_id = v_fund_ok);
   if v_count <> 0 then
     raise exception 'the audit reported % row(s) against a ledger the invariant accepted', v_count;

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -45,9 +45,11 @@ declare
   v_pair_src uuid; v_pair_a uuid; v_pair_b uuid;
   v_split_goal_src uuid; v_sg_a uuid; v_sg_b uuid;
   v_closer_src uuid; v_closer uuid;
+  v_sliver_src uuid; v_sliver_a uuid; v_sliver_b uuid;
   -- the clean half
   v_tol_goal  uuid;
   v_drift_src uuid; v_comp_src uuid; v_f7_src uuid; v_full_src uuid; v_tail_src uuid;
+  v_roundup_src uuid;
   v_tiny_fund uuid;
   v_ok_bank   uuid; v_ok_bank_w  uuid;
   v_ok_gold   uuid; v_ok_gold_w1 uuid; v_ok_gold_w2 uuid;
@@ -230,6 +232,18 @@ begin
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
   values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-04-01', 1, v_tail_src, 1, 0.0001);
+
+  -- The same 4-decimal rounding that posts 3.9999 for a full sale posts 4.0001 for
+  -- one just as often, and the invariant accepts both — the units cap allows the
+  -- epsilon, and the sale is a full one either way, so it takes the whole basis.
+  -- Measured against the flat rate that row is a thousand đồng UNDER, where the
+  -- 3.9999 one is a thousand over. A slack that only forgives the under-rounded
+  -- direction reports half the full gold sales in the ledger.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal_b, 'gold', 'investment', '2026-01-01', 40000000, 4, 10000000) returning transaction_id into v_roundup_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-02-01', 48000000, v_roundup_src, 40000000, 4.0001);
 
   -- ═══ the planted violations ════════════════════════════════════════════════
   -- Disabling the user triggers is the only way in: these are precisely the shapes
@@ -467,6 +481,24 @@ begin
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
   values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 1, v_closer_src, 30000000, 3);
 
+  -- 23. two slivers that are the ONLY sales on the holding, taking 1 and 199 đồng
+  --     where each owes about 100. Their total is exactly proportional, so the
+  --     holding-level check is silent, and both are sub-epsilon so the sliver
+  --     exception hid them as well. But the exception is for the TAIL of an
+  --     exhausted holding — a sliver can only take a whole remaining basis if it
+  --     closed the holding, and 0.0002 of 1 unit closes nothing. Here 0.9998 units
+  --     are still unsold, so no ordering makes either row legal.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 1000000, 1, 1000000) returning transaction_id into v_sliver_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 1, v_sliver_src, 1, 0.0001)
+  returning transaction_id into v_sliver_a;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 1, v_sliver_src, 199, 0.0001)
+  returning transaction_id into v_sliver_b;
+
   alter table public.investment_transactions enable trigger user;
 
   -- ═══ every planted row must be named, by the right check ═══════════════════
@@ -494,7 +526,9 @@ begin
         ('sale_basis_not_proportional',   v_pair_b),
         ('sale_basis_not_proportional',   v_sg_a),
         ('sale_basis_not_proportional',   v_sg_b),
-        ('sale_basis_not_proportional',   v_closer)
+        ('sale_basis_not_proportional',   v_closer),
+        ('sale_basis_not_proportional',   v_sliver_a),
+        ('sale_basis_not_proportional',   v_sliver_b)
       ) as x(name, tx)
   loop
     if v_count <> 1 then
@@ -555,7 +589,7 @@ begin
     from public.withdrawal_ledger_audit
    where transaction_id in (v_ok_bank_w, v_ok_gold_w1, v_ok_gold_w2, v_ok_sell1, v_ok_sell2,
                             v_ok_held, v_seed, v_seed_buy, v_seed_sell)
-      or parent_transaction_id in (v_ok_bank, v_ok_gold, v_drift_src, v_comp_src, v_f7_src, v_full_src, v_tail_src)
+      or parent_transaction_id in (v_ok_bank, v_ok_gold, v_drift_src, v_comp_src, v_f7_src, v_full_src, v_tail_src, v_roundup_src)
       or fund_id in (v_fund_ok, v_tiny_fund);
   if v_count <> 0 then
     raise exception 'the audit reported % row(s) against a ledger the invariant accepted', v_count;

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -1,0 +1,298 @@
+-- The ledger audit has to CATCH things (#609).
+--
+-- #587's invariant is a trigger, so it never validated a single row written before
+-- it landed. public.withdrawal_ledger_audit reads the ledger and reports what
+-- would not be accepted today, one check per row of the decision table in
+-- supabase/migrations/20260730000002.
+--
+-- The whole point of this file: an audit that returns nothing is indistinguishable
+-- from an audit that looks for nothing. So every check gets a row PLANTED with the
+-- triggers disabled — the only way to create shapes the invariant now refuses —
+-- and the audit must name it. The other half matters just as much: a set of rows
+-- built with the triggers ENABLED (so the invariant itself vouched for them) must
+-- come back completely clean, or the audit's output is noise nobody will read.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_user      uuid;
+  v_goal      uuid;
+  v_goal_b    uuid;
+  v_fund      uuid;
+  v_fund_ok   uuid;
+  -- planted violations, one holding each so they can't flag each other
+  v_neg_src   uuid; v_neg      uuid;
+  v_fnu       uuid;
+  v_gold_nu_s uuid; v_gold_nu  uuid;
+  v_nop_src   uuid; v_nop      uuid;
+  v_pnotinv   uuid;
+  v_fundbuy   uuid; v_onfund   uuid;
+  v_nothing   uuid;
+  v_notheld   uuid;
+  v_over_src  uuid;
+  v_ob_goal   uuid;
+  v_split     uuid;
+  v_prop_src  uuid; v_prop     uuid;
+  -- the clean half
+  v_ok_bank   uuid; v_ok_bank_w  uuid;
+  v_ok_gold   uuid; v_ok_gold_w1 uuid; v_ok_gold_w2 uuid;
+  v_ok_buy    uuid; v_ok_sell1   uuid; v_ok_sell2   uuid;
+  v_ok_held   uuid;
+  v_seed      uuid; v_seed_buy   uuid; v_seed_sell  uuid;
+  v_found     text;
+  v_count     int;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-audit@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Car') returning goal_id into v_goal_b;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Audit Fund', 'AUDF', 'equity', 20000) returning id into v_fund;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Clean Fund', 'CLNF', 'equity', 20000) returning id into v_fund_ok;
+
+  -- ═══ the clean half, written with the invariant WATCHING ═══════════════════
+  -- Built first and with the triggers on, so each row below is legal by
+  -- construction — the audit has no licence to complain about any of them.
+
+  -- bank: principal-only, partly withdrawn
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_ok_bank;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 41000000, v_ok_bank, 40000000)
+  returning transaction_id into v_ok_bank_w;
+
+  -- gold: quantity-valued, sold in two proportional slices down to nothing
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 40000000, 4, 10000000) returning transaction_id into v_ok_gold;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 12000000, v_ok_gold, 10000000, 1)
+  returning transaction_id into v_ok_gold_w1;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 36000000, v_ok_gold, 30000000, 3)
+  returning transaction_id into v_ok_gold_w2;
+
+  -- fund: basis 1,050,000 (fees in) against a NAV cost of 1,000,000, sold out in
+  -- two slices. The two figures differing is the normal case, not a corner one.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id)
+  values (v_user, v_goal, 'fund', 'investment', '2026-01-01', 1050000, 100, 10000, v_fund_ok) returning transaction_id into v_ok_buy;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'fund', 'withdrawal', '2026-02-01', 720000, v_fund_ok, 630000, 60)
+  returning transaction_id into v_ok_sell1;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'fund', 'withdrawal', '2026-03-01', 480000, v_fund_ok, 420000, 40)
+  returning transaction_id into v_ok_sell2;
+
+  -- held-for-merge with no source: the ONE legal sourceless withdrawal (#588)
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, held_for_merge, merge_target_goal_id)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 5000000, true, v_goal_b)
+  returning transaction_id into v_ok_held;
+
+  -- a pending DCA seed (units null) shares the bucket with a real purchase. It
+  -- holds nothing sellable, so a FULL sale takes the purchase's basis only — the
+  -- audit must exclude seeds from the basis exactly as the invariant does, or
+  -- every DCA bucket in the ledger reports as under-taken.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, is_dca_seeded)
+  values (v_user, v_goal_b, 'fund', 'investment', '2026-04-01', 2000000, v_fund_ok, true) returning transaction_id into v_seed;
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id)
+  values (v_user, v_goal_b, 'fund', 'investment', '2026-01-01', 1000000, 50, 20000, v_fund_ok) returning transaction_id into v_seed_buy;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'fund', 'withdrawal', '2026-05-01', 1100000, v_fund_ok, 1000000, 50)
+  returning transaction_id into v_seed_sell;
+
+  -- ═══ the planted violations ════════════════════════════════════════════════
+  -- Disabling the user triggers is the only way in: these are precisely the shapes
+  -- the invariant refuses, which is why they can only exist as HISTORY.
+  alter table public.investment_transactions disable trigger user;
+
+  -- 1. a negative withdrawal runs the ledger backwards
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 10000000) returning transaction_id into v_neg_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 1000000, v_neg_src, -1000000)
+  returning transaction_id into v_neg;
+
+  -- 2. a fund sale with no units: the overview skips the subtraction entirely
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id)
+  values (v_user, v_goal, 'fund', 'investment', '2026-01-01', 1000000, 100, 10000, v_fund);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn)
+  values (v_user, v_goal, 'fund', 'withdrawal', '2026-02-01', 100000, v_fund, 100000)
+  returning transaction_id into v_fnu;
+
+  -- 3. a gold sale with no units: the basis drops, every chỉ stays in net worth
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 40000000, 4, 10000000) returning transaction_id into v_gold_nu_s;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 12000000, v_gold_nu_s, 10000000)
+  returning transaction_id into v_gold_nu;
+
+  -- 4. no principal: claims cash left while the deposit keeps its full value
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 10000000) returning transaction_id into v_nop_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 1000000, v_nop_src, 0)
+  returning transaction_id into v_nop;
+
+  -- 5. parented to a withdrawal: a balance invented out of money already gone
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-03-01', 1000000, v_ok_bank_w, 1000000)
+  returning transaction_id into v_pnotinv;
+
+  -- 6. parented to a FUND purchase: never counted by anything (#606)
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id)
+  values (v_user, v_goal_b, 'fund', 'investment', '2026-01-01', 500000, 25, 20000, v_fund) returning transaction_id into v_fundbuy;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal_b, 'bank', 'withdrawal', '2026-02-01', 100000, v_fundbuy, 100000)
+  returning transaction_id into v_onfund;
+
+  -- 7. an orphan: takes money out of no holding at all (#607)
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 5000000, 5000000)
+  returning transaction_id into v_nothing;
+
+  -- 8. sourceless and NOT held-for-merge, claiming nothing: no holding, no
+  --    exception to stand under
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 5000000)
+  returning transaction_id into v_notheld;
+
+  -- 9. a deposit withdrawn past zero: 60M + 60M out of 100M
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_over_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 60000000, v_over_src, 60000000);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-03-01', 60000000, v_over_src, 60000000);
+
+  -- 10. a fund bucket sold twice over: 60 + 60 units out of 100
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Overdrawn bucket') returning goal_id into v_ob_goal;
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id)
+  values (v_user, v_ob_goal, 'fund', 'investment', '2026-01-01', 1000000, 100, 10000, v_fund);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_ob_goal, 'fund', 'withdrawal', '2026-02-01', 700000, v_fund, 600000, 60);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_ob_goal, 'fund', 'withdrawal', '2026-03-01', 700000, v_fund, 400000, 60);
+
+  -- 11. a sell alone in its bucket — the split an assign racing a sale leaves
+  --     behind (#610). Its purchases are in another goal, so nothing here offsets.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
+  values (v_user, null, 'fund', 'withdrawal', '2026-02-01', 300000, v_fund, 300000, 30)
+  returning transaction_id into v_split;
+
+  -- 12. basis taken out of step with the units: 1 chỉ of 4 taking the whole cost
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal_b, 'gold', 'investment', '2026-01-01', 40000000, 4, 10000000) returning transaction_id into v_prop_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-02-01', 12000000, v_prop_src, 40000000, 1)
+  returning transaction_id into v_prop;
+
+  alter table public.investment_transactions enable trigger user;
+
+  -- ═══ every planted row must be named, by the right check ═══════════════════
+  -- Asserting the CHECK NAME and not merely "something was reported": a row caught
+  -- by the wrong check sends whoever reads the report after the wrong repair.
+  for v_found, v_count in
+    select x.name, (select count(*) from public.withdrawal_ledger_audit a
+                     where a.check_name = x.name and a.transaction_id = x.tx)
+      from (values
+        ('negative_amounts',              v_neg),
+        ('fund_sale_missing_units',       v_fnu),
+        ('gold_sale_missing_units',       v_gold_nu),
+        ('withdrawal_missing_principal',  v_nop),
+        ('parent_is_not_an_investment',   v_pnotinv),
+        ('parent_is_a_fund_purchase',     v_onfund),
+        ('draws_on_no_holding',           v_nothing),
+        ('sourceless_not_held_for_merge', v_notheld)
+      ) as x(name, tx)
+  loop
+    if v_count <> 1 then
+      raise exception 'the audit must report % exactly once for the planted row, got %', v_found, v_count;
+    end if;
+  end loop;
+
+  -- the three group-level checks, keyed by holding rather than by row
+  if not exists (select 1 from public.withdrawal_ledger_audit
+                  where check_name = 'holding_overdrawn' and parent_transaction_id = v_over_src) then
+    raise exception 'the audit must report the deposit withdrawn past zero';
+  end if;
+  if not exists (select 1 from public.withdrawal_ledger_audit
+                  where check_name = 'fund_bucket_overdrawn' and goal_id = v_ob_goal and fund_id = v_fund) then
+    raise exception 'the audit must report the fund bucket sold twice over';
+  end if;
+  if not exists (select 1 from public.withdrawal_ledger_audit
+                  where check_name = 'fund_bucket_has_no_purchases' and transaction_id = v_split) then
+    raise exception 'the audit must report the sell left alone in its bucket';
+  end if;
+  -- Proportionality is a HOLDING-level fact, not a per-row one: the allocation rule
+  -- is additive (each sale takes units × basis / total_units regardless of order),
+  -- so what the ledger can still be measured against after the fact is the sum.
+  -- Keyed by the holding for that reason.
+  if not exists (select 1 from public.withdrawal_ledger_audit
+                  where check_name = 'basis_not_proportional' and parent_transaction_id = v_prop_src) then
+    raise exception 'the audit must report the gold sale that took the whole basis for one of four units';
+  end if;
+
+  -- ═══ and nothing the invariant itself accepted ═════════════════════════════
+  -- The half that decides whether the report is worth reading. A false positive
+  -- here is worse than a miss: it teaches whoever runs this to ignore the output.
+  select count(*) into v_count
+    from public.withdrawal_ledger_audit
+   where transaction_id in (v_ok_bank_w, v_ok_gold_w1, v_ok_gold_w2, v_ok_sell1, v_ok_sell2,
+                            v_ok_held, v_seed, v_seed_buy, v_seed_sell)
+      or parent_transaction_id in (v_ok_bank, v_ok_gold)
+      or (fund_id = v_fund_ok);
+  if v_count <> 0 then
+    raise exception 'the audit reported % row(s) against a ledger the invariant accepted', v_count;
+  end if;
+
+  -- A withdrawal-free ledger is silent too: the checks must key off withdrawals,
+  -- not flag every holding that has none.
+  if exists (select 1 from public.withdrawal_ledger_audit
+              where parent_transaction_id = v_seed_buy or transaction_id = v_seed_buy) then
+    raise exception 'a purchase with no withdrawals must not be reported';
+  end if;
+
+  raise notice 'withdrawal_ledger_audit: every check proven to fire, clean rows silent';
+end $$;
+
+-- The audit is an operator tool: it reports one user's ledger health, and there is
+-- no screen that reads it. Left granted, it would be one more PostgREST surface to
+-- reason about for no gain — same reasoning as check_withdrawal_balance's REVOKE.
+do $$
+declare v_ok boolean;
+begin
+  select has_table_privilege('authenticated', 'public.withdrawal_ledger_audit', 'select') into v_ok;
+  if v_ok then
+    raise exception 'authenticated must not be able to select the ledger audit';
+  end if;
+  select has_table_privilege('anon', 'public.withdrawal_ledger_audit', 'select') into v_ok;
+  if v_ok then
+    raise exception 'anon must not be able to select the ledger audit';
+  end if;
+end $$;
+
+rollback;

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -41,6 +41,7 @@ declare
   v_mask_goal uuid; v_mask_zero uuid;
   v_eps_src   uuid; v_nounits_src uuid;
   v_cancel_src uuid; v_cancel_a uuid; v_cancel_b uuid;
+  v_slack_src uuid; v_slack uuid;
   -- the clean half
   v_tol_goal  uuid;
   v_drift_src uuid; v_comp_src uuid; v_f7_src uuid; v_full_src uuid;
@@ -362,6 +363,20 @@ begin
   values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-03-01', 1, v_cancel_src, 600, 50)
   returning transaction_id into v_cancel_b;
 
+  -- 19. an ORDINARY partial sale taking the wrong basis: 1 chỉ of 4, taking
+  --     10,000,500 where the rule says 10,000,000. The invariant refuses it. The
+  --     full-sale slack must not cover this row — that slack exists because a sale
+  --     within an epsilon of the REST takes the whole basis, and a sale of 1 of 4
+  --     units is nowhere near the rest. The tell is state-visible: using the
+  --     shortcut leaves at most an epsilon of units behind, so it can only have
+  --     happened on a holding that ends up exhausted. This one has 3 units left.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 40000000, 4, 10000000) returning transaction_id into v_slack_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 12000000, v_slack_src, 10000500, 1)
+  returning transaction_id into v_slack;
+
   alter table public.investment_transactions enable trigger user;
 
   -- ═══ every planted row must be named, by the right check ═══════════════════
@@ -383,7 +398,8 @@ begin
         ('sourceless_not_held_for_merge', v_stray_z),
         ('withdrawal_missing_principal',  v_mask_zero),
         ('sale_basis_not_proportional',   v_cancel_a),
-        ('sale_basis_not_proportional',   v_cancel_b)
+        ('sale_basis_not_proportional',   v_cancel_b),
+        ('sale_basis_not_proportional',   v_slack)
       ) as x(name, tx)
   loop
     if v_count <> 1 then

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -48,11 +48,13 @@ declare
   v_sliver_src uuid; v_sliver_a uuid; v_sliver_b uuid;
   v_tail2_src uuid; v_tail2_a uuid; v_tail2_b uuid;
   v_basisover_src uuid;
+  v_zerounit_goal uuid;
   -- the clean half
   v_tol_goal  uuid;
   v_drift_src uuid; v_comp_src uuid; v_f7_src uuid; v_full_src uuid; v_tail_src uuid;
   v_roundup_src uuid;
   v_tiny_fund uuid; v_late_fund uuid; v_late_sell uuid;
+  v_orphan_fund uuid; v_orphan_buy uuid; v_orphan_goal uuid;
   v_ok_bank   uuid; v_ok_bank_w  uuid;
   v_ok_gold   uuid; v_ok_gold_w1 uuid; v_ok_gold_w2 uuid;
   v_ok_buy    uuid; v_ok_sell1   uuid; v_ok_sell2   uuid;
@@ -264,6 +266,22 @@ begin
   returning transaction_id into v_late_sell;
   insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id)
   values (v_user, v_goal_b, 'fund', 'investment', '2026-03-01', 999, 100, 10, v_late_fund);
+
+  -- An orphan bucket the invariant itself allows. A 0.0001-unit sell worth a đồng
+  -- is left behind when its purchase moves to another goal: check_fund_bucket_solvent
+  -- (#587) refuses a relocation only when the bucket would be left owing MORE than
+  -- 0.0001 units or one đồng, so this state is reachable with every trigger enabled.
+  -- A purchase-less bucket is therefore not corrupt by itself, and calling it one
+  -- would hand an operator a repair to make on a ledger nobody wrote wrong.
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Orphan target') returning goal_id into v_orphan_goal;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Orphan Fund', 'ORPH', 'equity', 1) returning id into v_orphan_fund;
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id)
+  values (v_user, v_goal_b, 'fund', 'investment', '2026-01-01', 1000000, 100, 10000, v_orphan_fund) returning transaction_id into v_orphan_buy;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'fund', 'withdrawal', '2026-02-01', 1, v_orphan_fund, 1, 0.0001);
+  update public.investment_transactions set goal_id = v_orphan_goal where transaction_id = v_orphan_buy;
 
   -- ═══ the planted violations ════════════════════════════════════════════════
   -- Disabling the user triggers is the only way in: these are precisely the shapes
@@ -553,6 +571,18 @@ begin
   values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 1, v_basisover_src, 30000000, 2),
          (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 1, v_basisover_src, 30000000, 2);
 
+  -- 26. a bucket whose purchase holds ZERO units, sold from anyway. The schema
+  --     permits zero units; the invariant does not permit selling them — it grants
+  --     the 4-decimal epsilon only while something is left, so 0.0001 units out of
+  --     nothing is refused. Granting that epsilon unconditionally made this ledger
+  --     audit clean.
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Zero units') returning goal_id into v_zerounit_goal;
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id)
+  values (v_user, v_zerounit_goal, 'fund', 'investment', '2026-01-01', 1000, 0, 0, v_fund);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_zerounit_goal, 'fund', 'withdrawal', '2026-02-01', 1, v_fund, 0, 0.0001);
+
   alter table public.investment_transactions enable trigger user;
 
   -- ═══ every planted row must be named, by the right check ═══════════════════
@@ -600,6 +630,10 @@ begin
   if not exists (select 1 from public.withdrawal_ledger_audit
                   where check_name = 'fund_bucket_overdrawn' and goal_id = v_ob_goal and fund_id = v_fund) then
     raise exception 'the audit must report the fund bucket sold twice over';
+  end if;
+  if not exists (select 1 from public.withdrawal_ledger_audit
+                  where check_name = 'fund_bucket_overdrawn' and goal_id = v_zerounit_goal) then
+    raise exception 'the audit must report units sold out of a bucket that holds none';
   end if;
   if not exists (select 1 from public.withdrawal_ledger_audit
                   where check_name = 'fund_bucket_has_no_purchases' and transaction_id = v_split) then
@@ -663,7 +697,7 @@ begin
    where transaction_id in (v_ok_bank_w, v_ok_gold_w1, v_ok_gold_w2, v_ok_sell1, v_ok_sell2,
                             v_ok_held, v_seed, v_seed_buy, v_seed_sell)
       or parent_transaction_id in (v_ok_bank, v_ok_gold, v_drift_src, v_comp_src, v_f7_src, v_full_src, v_tail_src, v_roundup_src)
-      or fund_id in (v_fund_ok, v_tiny_fund);
+      or fund_id in (v_fund_ok, v_tiny_fund, v_orphan_fund);
   if v_count <> 0 then
     raise exception 'the audit reported % row(s) against a ledger the invariant accepted', v_count;
   end if;
@@ -718,6 +752,7 @@ begin
   insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
   values (v_user, v_g, 'gold', 'withdrawal', '2026-02-01', 1, v_s, 497, 50),
          (v_user, v_g, 'gold', 'withdrawal', '2026-03-01', 1, v_s, 503, 50);
+
   alter table public.investment_transactions enable trigger user;
 
   select count(*) into v_any from public.withdrawal_ledger_audit where user_id = v_user;

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -44,6 +44,7 @@ declare
   v_slack_src uuid; v_slack uuid;
   v_pair_src uuid; v_pair_a uuid; v_pair_b uuid;
   v_split_goal_src uuid; v_sg_a uuid; v_sg_b uuid;
+  v_closer_src uuid; v_closer uuid;
   -- the clean half
   v_tol_goal  uuid;
   v_drift_src uuid; v_comp_src uuid; v_f7_src uuid; v_full_src uuid; v_tail_src uuid;
@@ -449,6 +450,23 @@ begin
   values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-03-01', 1, v_split_goal_src, 29999500, 3)
   returning transaction_id into v_sg_b;
 
+  -- 22. one wrong sale beside a correct one, on a holding sold out EXACTLY: 1 unit
+  --     taking 9,999,500 (rule: 10,000,000) and 3 units taking their exact
+  --     30,000,000. Only the first row is past the base tolerance, so the rationing
+  --     hands it the full-sale slack — but that slack exists only for a closer that
+  --     took slightly FEWER units than remained, and here nothing was left over:
+  --     4 units bought, 4 sold. The row is refused as a first write and refused as
+  --     the closer (probed both ways), so no slack is owed to it.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 40000000, 4, 10000000) returning transaction_id into v_closer_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 1, v_closer_src, 9999500, 1)
+  returning transaction_id into v_closer;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 1, v_closer_src, 30000000, 3);
+
   alter table public.investment_transactions enable trigger user;
 
   -- ═══ every planted row must be named, by the right check ═══════════════════
@@ -475,7 +493,8 @@ begin
         ('sale_basis_not_proportional',   v_pair_a),
         ('sale_basis_not_proportional',   v_pair_b),
         ('sale_basis_not_proportional',   v_sg_a),
-        ('sale_basis_not_proportional',   v_sg_b)
+        ('sale_basis_not_proportional',   v_sg_b),
+        ('sale_basis_not_proportional',   v_closer)
       ) as x(name, tx)
   loop
     if v_count <> 1 then

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -39,8 +39,10 @@ declare
   v_prop_src  uuid; v_prop     uuid;
   v_stray     uuid; v_stray_z  uuid;
   v_mask_goal uuid; v_mask_zero uuid;
+  v_eps_src   uuid; v_nounits_src uuid;
   -- the clean half
   v_tol_goal  uuid;
+  v_drift_src uuid;
   v_ok_bank   uuid; v_ok_bank_w  uuid;
   v_ok_gold   uuid; v_ok_gold_w1 uuid; v_ok_gold_w2 uuid;
   v_ok_buy    uuid; v_ok_sell1   uuid; v_ok_sell2   uuid;
@@ -124,6 +126,20 @@ begin
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
   values (v_user, v_tol_goal, 'fund', 'withdrawal', '2026-02-01', 1200000, v_fund_ok, 1000001, 100);
+
+  -- The đồng of rounding, unlike the overdraw bound, DOES accumulate across sales:
+  -- each partial sale's expectation is recomputed from what is left, so two sales
+  -- may each under-take by a đồng and the invariant accepts both. 100 đồng over 4
+  -- units, two sales of 1 unit taking 24 where the flat proportion says 25 — the
+  -- aggregate is 48 against 50, and the audit must not call that a finding.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal_b, 'gold', 'investment', '2026-01-01', 100, 4, 25) returning transaction_id into v_drift_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-02-01', 1, v_drift_src, 24, 1);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal_b, 'gold', 'withdrawal', '2026-03-01', 1, v_drift_src, 24, 1);
 
   -- ═══ the planted violations ════════════════════════════════════════════════
   -- Disabling the user triggers is the only way in: these are precisely the shapes
@@ -256,6 +272,30 @@ begin
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
   values (v_user, v_mask_goal, 'fund', 'withdrawal', '2026-03-01', 600000, v_fund, 1000000, 50);
 
+  -- 16. two sales past the units by MORE than one epsilon between them. The unit
+  --     tolerance does not accumulate: every constraint the invariant applies bounds
+  --     the CUMULATIVE sum (each sale is measured against what is left, which
+  --     already carries the previous sale's excess), so 4.00015 out of 4 units is a
+  --     ledger it would never have produced — the second insert is refused, proven
+  --     by probe. Principals are kept proportional so nothing else speaks up.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 40000000, 4, 10000000) returning transaction_id into v_eps_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 1, v_eps_src, 20000500, 2.00005);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 1, v_eps_src, 19999500, 2.0001);
+
+  -- 17. units taken out of a holding that HAS no units. The invariant coalesces the
+  --     parent's units to zero and refuses any positive quantity; skipping the check
+  --     when the parent's units are null lets the row through instead.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 10000000) returning transaction_id into v_nounits_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 5000000, v_nounits_src, 5000000, 5);
+
   alter table public.investment_transactions enable trigger user;
 
   -- ═══ every planted row must be named, by the right check ═══════════════════
@@ -305,6 +345,15 @@ begin
     raise exception 'the audit must report the gold sale that took the whole basis for one of four units';
   end if;
 
+  if not exists (select 1 from public.withdrawal_ledger_audit
+                  where check_name = 'holding_overdrawn' and parent_transaction_id = v_eps_src) then
+    raise exception 'the audit must report units sold past the holding by more than one epsilon';
+  end if;
+  if not exists (select 1 from public.withdrawal_ledger_audit
+                  where check_name = 'holding_overdrawn' and parent_transaction_id = v_nounits_src) then
+    raise exception 'the audit must report units taken out of a holding that has none';
+  end if;
+
   -- The masked bucket is the point of that per-row check: its TOTALS are exactly
   -- proportional, so the holding-level check is silent by design. Asserting the
   -- silence keeps the two checks from being justified by each other.
@@ -320,7 +369,7 @@ begin
     from public.withdrawal_ledger_audit
    where transaction_id in (v_ok_bank_w, v_ok_gold_w1, v_ok_gold_w2, v_ok_sell1, v_ok_sell2,
                             v_ok_held, v_seed, v_seed_buy, v_seed_sell)
-      or parent_transaction_id in (v_ok_bank, v_ok_gold)
+      or parent_transaction_id in (v_ok_bank, v_ok_gold, v_drift_src)
       or (fund_id = v_fund_ok);
   if v_count <> 0 then
     raise exception 'the audit reported % row(s) against a ledger the invariant accepted', v_count;


### PR DESCRIPTION
**Does not close #609.** Contributes to it: a read-only screen for withdrawal rows the invariant would not accept today. #609 stays open until the ledger has actually been looked at, and closing it as "verified clean" needs #613, not this.

## What this is

`public.withdrawal_ledger_audit` — a read-only view, one row per finding, with `check_name`, `severity` and the holding it concerns. #587's invariant is a trigger: it has validated every write since it landed and never looked at a row written before that.

## The contract (narrowed after review — see [the merge-gate discussion](https://github.com/mphuongth/allocate/pull/611#issuecomment-5138348517))

| severity | means |
| --- | --- |
| `violation` | provable from the state alone — no ordering of any history could have produced this row |
| `review` | the ledger looks off, but legally-written ledgers can look the same. Sequence-sensitive; never automate a repair off one |

**An empty result does not prove the ledger clean.** That is a limit of the approach, not a missing predicate. The invariant is stateful — it measures each write against the balance remaining at that moment — while this view reads the ledger as it stands, and different histories reach the same final state. Demonstrated against the live invariant:

```
1000 đồng / 100 units, sales of 50 taking 497 and 503
  → orderings the invariant accepts: 0 of 2
  → the audit says: (SILENT)
```

Each sale is refused as a first write and neither can follow the other, yet the totals are exactly proportional and every per-sale deviation is inside what a legal two-sale ledger shows elsewhere. A test plants that ledger and records the silence, so it is never mistaken for a guarantee.

The boundary runs the other way too. `violation` covers only what the invariant actually caps: **units** on any holding (that bound is cumulative — each sale is measured against what is left) and **principal on bank/stock**, where the rule is literally `principal_withdrawn > remaining` → refused. There is no principal cap in the quantity-valued branch at all, so a basis overrun on gold or a fund bucket is `review`. Three 1-đồng sales of a 1 đồng / 5 unit holding are all accepted by the invariant and take three đồng out of one đồng of cost — legal, and reported for review rather than as corruption.

## The checks

**violation — provable from state**

| check_name | what it means |
| --- | --- |
| `negative_amounts` | runs the ledger backwards: adds to the holding, banks a credit |
| `fund_sale_missing_units` | the overview skips the subtraction entirely; the fund keeps its value |
| `gold_sale_missing_units` | basis drops, every chỉ stays in net worth |
| `withdrawal_missing_principal` | claims cash left, takes nothing out (parent-backed rows only) |
| `parent_is_not_an_investment` | a balance invented out of money already gone |
| `draws_on_no_holding` | filed under neither key; what deleting a source leaves (#607) |
| `sourceless_not_held_for_merge` | wearing an exception that belongs to #588's pool alone |
| `holding_overdrawn` | more units sold than exist, or a bank/stock deposit withdrawn past zero |
| `fund_bucket_overdrawn` | more units sold out of a (goal, fund) bucket than it holds |
| `fund_bucket_has_no_purchases` | a sell alone in its bucket — what an assign racing a sale leaves (#610) |

**review — sequence-sensitive**

| check_name | what it means |
| --- | --- |
| `basis_taken_exceeds_cost` | more basis has left a gold holding or fund bucket than it cost |
| `sale_basis_not_proportional` | a sale's basis is out of step with its units |
| `basis_not_proportional` | the holding's totals are out of step |
| `parent_is_a_fund_purchase` | legal, counted by nobody (#606) |

## How it's tested

`supabase/tests/withdrawal_ledger_audit.test.sql` plants a row per check with the triggers disabled — the only way those shapes can exist — and asserts the audit names each **by the right check**. The other half: 13 holdings built with the triggers *enabled*, so the invariant itself vouched for them, must come back completely silent. Two further tests carry the contract: the known-blind ledger's silence is recorded, and a sequence-sensitive check may never emit `violation`.

Every fix in this PR was mutation-checked — the predicate reverted, the suite confirmed red — because an audit that returns nothing is indistinguishable from an audit that looks for nothing. 29 planted violations, 13 clean-half holdings, `npm run test:db` 13 files green.

## Running it

```sql
select check_name, severity, count(*)
  from public.withdrawal_ledger_audit
 group by 1, 2 order by 2, 1;
```

Not granted to `anon`/`authenticated` — an operator tool with no screen behind it, same reasoning as `check_withdrawal_balance`'s REVOKE.

## What happens next

- `violation` rows → repair, by hand or by a migration deriving values from `lib/goldWithdrawal.ts` / `lib/fundWithdrawal.ts`.
- `review` rows → read them with the numbers in front of you.
- nothing at all → **not** "verified clean"; #609 stays open and #613 (replay audit, gated on #608) is what could close it.

## Review history

Twelve rounds, 18 findings, 16 real and fixed, each probed against the live invariant before being changed. The last of them is what produced the narrowed contract above rather than a thirteenth predicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
