### PR TITLE
fix(goals): stop the goal projection skipping a month on the 31st

### DIFF
--- a/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
+++ b/app/assets/components/__tests__/DesktopGoalDetail.test.tsx
@@ -434,11 +434,14 @@ describe('DesktopGoalDetail — singular month wording (issue #262)', () => {
   // 1,000,000₫ left to reach the target.
   const nearGoal: GoalData = { ...mockGoal, targetAmount: 10_000_000, currentValue: 9_000_000, targetDate: null }
 
-  // Format a YYYY-MM string `n` months from today (deterministic regardless of run date).
+  // Format a YYYY-MM string `n` months from today. Built from the first of the
+  // month: setMonth on today's date overflows when the day doesn't exist in the
+  // target month, so run on the 31st this returned n+1 months and the test failed
+  // with "2 months early" — the comment claiming determinism was the bug.
   function monthsFromNow(n: number): string {
     const d = new Date()
-    d.setMonth(d.getMonth() + n)
-    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`
+    const t = new Date(d.getFullYear(), d.getMonth() + n, 1)
+    return `${t.getFullYear()}-${String(t.getMonth() + 1).padStart(2, '0')}`
   }
 
   beforeEach(() => {

--- a/app/assets/components/__tests__/goalDetailShared.test.tsx
+++ b/app/assets/components/__tests__/goalDetailShared.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach, vi } from 'vitest'
 import { type GoalDetailTx } from '../goalDetailShared'
 import { buildInvRows, buildRenewalSummary } from '../goalDetailRows'
 import { fmtMaturity } from '../goalDetailMaturity'
@@ -326,6 +326,36 @@ describe('computeGoalCalculator', () => {
     expect(c.monthsToGoal).toBe(24)             // ceil(120M / 5M)
     expect(c.isOnTrack).toBe(false)             // 5M < 10M
     expect(c.gap).toBe(5_000_000)
+  })
+
+  // The projection is rendered as a month and year, so landing in the wrong month
+  // is the whole error. Adding months to TODAY's date overflows whenever today's
+  // day doesn't exist in the target month: on the 31st, "seven months from now" is
+  // 31 February, which JavaScript silently rolls into March. The user is told a
+  // month later than the pace actually reaches the goal, and only on the 29th-31st,
+  // which is why it went unnoticed.
+  describe('projected month across a short month (run-date dependent)', () => {
+    afterEach(() => vi.useRealTimers())
+
+    it('lands in February when seven months from 31 July', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(2026, 6, 31, 12))   // 31 July 2026
+
+      const c = computeGoalCalculator({ targetAmount: 7_000_000, targetDate: null, currentValue: 0 }, 1_000_000)
+
+      expect(c.monthsToGoal).toBe(7)
+      expect(c.projectedDate?.getFullYear()).toBe(2027)
+      expect(c.projectedDate?.getMonth()).toBe(1)   // February, not March
+    })
+
+    it('lands in the next month when one month from 31 January', () => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date(2026, 0, 31, 12))   // 31 January 2026
+
+      const c = computeGoalCalculator({ targetAmount: 1_000_000, targetDate: null, currentValue: 0 }, 1_000_000)
+
+      expect(c.projectedDate?.getMonth()).toBe(1)   // February, not March
+    })
   })
 
   it('returns no projection (null) when the input is zero', () => {

--- a/app/assets/components/goalDetailModel.ts
+++ b/app/assets/components/goalDetailModel.ts
@@ -68,8 +68,13 @@ export function computeGoalCalculator(
   const neededPerMonth = remaining > 0 ? remaining / monthsLeft : 0
   const input = Math.max(0, monthlyInput || 0)
   const monthsToGoal = input > 0 && remaining > 0 ? Math.ceil(remaining / input) : null
+  // Anchored to the FIRST of the month, because this date is only ever rendered as
+  // a month and year. Adding months to today overflows whenever today's day doesn't
+  // exist in the target month — 31 February rolls into March — and the user is then
+  // told a month later than their pace actually reaches the goal. Only bites on the
+  // 29th-31st, which is why it survived this long.
   const projectedDate = monthsToGoal != null
-    ? (() => { const d = new Date(); d.setMonth(d.getMonth() + monthsToGoal); return d })()
+    ? (() => { const d = new Date(); return new Date(d.getFullYear(), d.getMonth() + monthsToGoal, 1) })()
     : null
   const isOnTrack = input > 0 && input >= neededPerMonth
   const gap = Math.abs(neededPerMonth - input)


### PR DESCRIPTION
CI went red today on `DesktopGoalDetail` — "1 month early" reading "2 months early" — and the test was not the bug.

## The bug

Adding months to **today's** date overflows whenever today's day doesn't exist in the target month. On 31 July, seven months out is 31 February, which JavaScript silently rolls into 3 March:

```
today 2026-07-31, setMonth(+2) → 2026-10-01   (asked for two months, got three)
```

`computeGoalCalculator` does exactly that, and its `projectedDate` is rendered as a month and year in both goal-detail surfaces:

```tsx
projectedDate.toLocaleDateString(isVI ? 'vi-VN' : 'en-GB', { month: 'long', year: 'numeric' })
```

So on the 29th–31st of a month, a user is told their pace reaches the goal **a month later than it does**. Silent, wrong in the direction that discourages, and invisible for 28 days out of every 31 — which is how it survived.

The projection is now anchored to the first of the target month, which is the only part of it ever displayed.

## The test that caught it

The helper in `DesktopGoalDetail.test.tsx` had the same overflow, under a comment claiming it was "deterministic regardless of run date". The comment was the wrong part. Fixed the same way — and the failure it produced looked like a *wording* bug ("1 month" vs "1 months"), which is what sent me to the calendar rather than to the i18n strings.

## Coverage

At the model layer, where the arithmetic actually lives, rather than through the component that happened to expose it. Two cases with fake timers: 31 July + 7 months → February, and 31 January + 1 month → February. Both fail on `main` and pass here, and neither depends on the day the suite runs.

`npm test -- --run`: 167 files, 1840 tests, all pass. `npm run lint` clean.

## Not included

Unrelated to #611 (which is SQL-only and was red purely because of this). Kept separate so it can be reviewed and deployed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
