### PR TITLE
security(api): close the legacy fund-investments mutation paths (#586)

### DIFF
--- a/app/api/v1/fund-investments/[id]/__tests__/route.test.ts
+++ b/app/api/v1/fund-investments/[id]/__tests__/route.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// The legacy fund-investments row endpoint used to expose PUT and DELETE that
+// wrote straight to investment_transactions (#586):
+//
+//   • PUT matched on transaction_id + user_id only — no `asset_type = 'fund'`
+//     filter — so a fund-shaped body could rewrite a BANK deposit's amount,
+//     units and unit_price, and an accumulating book tranche could be edited
+//     alone, splitting the book away from its group;
+//   • DELETE carried no `consumed_by_inv_id IS NULL` guard, so the withdrawal
+//     that closes a merged source could be deleted — re-opening the source at
+//     full value while its cash still sits in the anchor (double count).
+//
+// Nothing calls either path; the canonical /investment-transactions/[id] route
+// has both invariants. So they are gone, and the route answers 410 to say so
+// permanently rather than 405 (which reads as "wrong verb, try another").
+//
+// The point of these tests is that the answer costs nothing and reaches no
+// database: a removed mutation must not authenticate, read, or write.
+
+const h = vi.hoisted(() => ({
+  clientCreated: false,
+  tables: [] as string[],
+}))
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async () => {
+    h.clientCreated = true
+    return {
+      auth: { getUser: async () => ({ data: { user: { id: 'user-1' } } }) },
+      from: (table: string) => { h.tables.push(table); throw new Error('unreachable') },
+    }
+  },
+}))
+
+const route = await import('../route')
+
+const TX_ID = '88888888-8888-4888-8888-888888888888'
+
+const call = (method: 'PUT' | 'DELETE', id = TX_ID, body?: unknown) =>
+  route[method](
+    new Request(`https://app.test/api/v1/fund-investments/${id}`, {
+      method,
+      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+    }) as unknown as NextRequest,
+    { params: Promise.resolve({ id }) },
+  )
+
+describe('legacy /api/v1/fund-investments/[id] mutations', () => {
+  beforeEach(() => {
+    h.clientCreated = false
+    h.tables = []
+  })
+
+  it('answers PUT with 410 Gone', async () => {
+    const res = await call('PUT', TX_ID, { amount_vnd: 1_000_000 })
+
+    expect(res.status).toBe(410)
+    const body = await res.json()
+    expect(body.code).toBe('gone')
+    // Point the caller at the endpoint that does enforce the invariants.
+    expect(body.error).toMatch(/investment-transactions/)
+  })
+
+  it('answers DELETE with 410 Gone', async () => {
+    const res = await call('DELETE')
+
+    expect(res.status).toBe(410)
+    await expect(res.json()).resolves.toMatchObject({ code: 'gone' })
+  })
+
+  // The whole safety argument. If either handler still opened a client it could
+  // still write, and a later edit could quietly restore the unguarded update.
+  it('never reaches the database', async () => {
+    await call('PUT', TX_ID, { amount_vnd: 1_000_000 })
+    await call('DELETE')
+
+    expect(h.clientCreated).toBe(false)
+    expect(h.tables).toEqual([])
+  })
+
+  // A well-formed id is not a way back in either — the id is never even read.
+  it('answers 410 regardless of the id', async () => {
+    expect((await call('DELETE', 'not-a-uuid')).status).toBe(410)
+  })
+})

--- a/app/api/v1/fund-investments/[id]/__tests__/route.test.ts
+++ b/app/api/v1/fund-investments/[id]/__tests__/route.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { NextRequest } from 'next/server'
 
 // The legacy fund-investments row endpoint used to expose PUT and DELETE that
 // wrote straight to investment_transactions (#586):
@@ -34,18 +33,7 @@ vi.mock('@/lib/supabase-server', () => ({
   },
 }))
 
-const route = await import('../route')
-
-const TX_ID = '88888888-8888-4888-8888-888888888888'
-
-const call = (method: 'PUT' | 'DELETE', id = TX_ID, body?: unknown) =>
-  route[method](
-    new Request(`https://app.test/api/v1/fund-investments/${id}`, {
-      method,
-      ...(body === undefined ? {} : { body: JSON.stringify(body) }),
-    }) as unknown as NextRequest,
-    { params: Promise.resolve({ id }) },
-  )
+const { PUT, DELETE } = await import('../route')
 
 describe('legacy /api/v1/fund-investments/[id] mutations', () => {
   beforeEach(() => {
@@ -53,8 +41,11 @@ describe('legacy /api/v1/fund-investments/[id] mutations', () => {
     h.tables = []
   })
 
+  // Both handlers take no parameters at all — not the request, not the route
+  // params. That is the removal made structural: there is no id to look up and
+  // no body to apply, so no edit to this file can quietly grow back into a write.
   it('answers PUT with 410 Gone', async () => {
-    const res = await call('PUT', TX_ID, { amount_vnd: 1_000_000 })
+    const res = await PUT()
 
     expect(res.status).toBe(410)
     const body = await res.json()
@@ -64,7 +55,7 @@ describe('legacy /api/v1/fund-investments/[id] mutations', () => {
   })
 
   it('answers DELETE with 410 Gone', async () => {
-    const res = await call('DELETE')
+    const res = await DELETE()
 
     expect(res.status).toBe(410)
     await expect(res.json()).resolves.toMatchObject({ code: 'gone' })
@@ -73,15 +64,10 @@ describe('legacy /api/v1/fund-investments/[id] mutations', () => {
   // The whole safety argument. If either handler still opened a client it could
   // still write, and a later edit could quietly restore the unguarded update.
   it('never reaches the database', async () => {
-    await call('PUT', TX_ID, { amount_vnd: 1_000_000 })
-    await call('DELETE')
+    await PUT()
+    await DELETE()
 
     expect(h.clientCreated).toBe(false)
     expect(h.tables).toEqual([])
-  })
-
-  // A well-formed id is not a way back in either — the id is never even read.
-  it('answers 410 regardless of the id', async () => {
-    expect((await call('DELETE', 'not-a-uuid')).status).toBe(410)
   })
 })

--- a/app/api/v1/fund-investments/[id]/goal/__tests__/route.test.ts
+++ b/app/api/v1/fund-investments/[id]/goal/__tests__/route.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// PATCH /fund-investments/[id]/goal is the last legacy mutation still reachable:
+// it re-buckets a single fund transaction. It used to update on transaction_id +
+// user_id alone (#586), which made it a generic goal writer for ANY holding:
+//
+//   • a bank deposit's id moved that deposit between goals through a
+//     fund-scoped endpoint, bypassing the canonical route's checks;
+//   • an accumulating book tranche was moved on its own, splitting the book —
+//     goal is book-level and must cascade to every tranche at once;
+//   • the target goal was written without an ownership check, so a known
+//     foreign goal id could be stamped onto the caller's row (#474).
+//
+// The fixes, in the order the tests assert them: the row must be a fund, the
+// goal must be the caller's, and a row that somehow carries a deposit_group_id
+// goes through update_deposit_book — the same atomic RPC the canonical PUT uses
+// — instead of a lone-row update.
+
+type Filter = { table: string; kind: string; args: unknown[] }
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  existing: { data: null as unknown, error: null as unknown },
+  goal: { data: null as unknown, error: null as unknown },
+  updated: { data: null as unknown, error: null as unknown },
+  rpc: { data: null as unknown, error: null as unknown },
+  rpcCalls: [] as { fn: string; args: Record<string, unknown> }[],
+  update: null as unknown,
+  filters: [] as Filter[],
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chain = (table: string) => {
+    let op = 'select'
+    const c: Record<string, unknown> = {
+      select: () => c,
+      update: (payload: unknown) => { h.update = payload; op = 'update'; return c },
+      eq: (...args: unknown[]) => { h.filters.push({ table, kind: 'eq', args }); return c },
+      is: (...args: unknown[]) => { h.filters.push({ table, kind: 'is', args }); return c },
+      maybeSingle: async () => (op === 'update' ? h.updated : table === 'savings_goals' ? h.goal : h.existing),
+      single: async () => (op === 'update' ? h.updated : table === 'savings_goals' ? h.goal : h.existing),
+    }
+    return c
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (table: string) => chain(table),
+      rpc: (fn: string, args: Record<string, unknown>) => {
+        h.rpcCalls.push({ fn, args })
+        return { single: async () => h.rpc }
+      },
+    }),
+  }
+})
+
+const { PATCH } = await import('../route')
+
+const TX = '11111111-1111-4111-8111-111111111111'
+const GOAL = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const BOOK = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
+
+const call = (body: unknown, id = TX) =>
+  PATCH(
+    new NextRequest(`https://app.test/api/v1/fund-investments/${id}/goal`, {
+      method: 'PATCH',
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id }) },
+  )
+
+const filter = (kind: string, col: string) =>
+  h.filters.find((f) => f.table === 'investment_transactions' && f.kind === kind && f.args[0] === col)
+
+describe('PATCH /api/v1/fund-investments/[id]/goal', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.existing = { data: { transaction_id: TX, asset_type: 'fund', deposit_group_id: null }, error: null }
+    h.goal = { data: { goal_id: GOAL }, error: null }
+    h.updated = { data: { transaction_id: TX, goal_id: GOAL }, error: null }
+    h.rpc = { data: { transaction_id: TX, goal_id: GOAL }, error: null }
+    h.rpcCalls = []
+    h.update = null
+    h.filters = []
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('assigns a fund transaction to the goal', async () => {
+    const res = await call({ goal_id: GOAL })
+
+    expect(res.status).toBe(200)
+    expect(h.update).toMatchObject({ goal_id: GOAL })
+  })
+
+  it('unassigns when goal_id is null', async () => {
+    h.updated = { data: { transaction_id: TX, goal_id: null }, error: null }
+
+    const res = await call({ goal_id: null })
+
+    expect(res.status).toBe(200)
+    expect(h.update).toMatchObject({ goal_id: null })
+  })
+
+  // ── asset type ─────────────────────────────────────────────────────────────
+  // The endpoint is fund-scoped; a bank/stock/gold id is simply not a resource
+  // it addresses, so it reads as absent rather than forbidden.
+  it('refuses a transaction id that is not a fund holding', async () => {
+    h.existing = { data: { transaction_id: TX, asset_type: 'bank', deposit_group_id: null }, error: null }
+
+    const res = await call({ goal_id: GOAL })
+
+    expect(res.status).toBe(404)
+    expect(h.update).toBeNull()
+  })
+
+  // The pre-read is a classifier, not the guard: asset_type could change between
+  // the read and the write. The UPDATE has to carry the condition itself so
+  // Postgres re-evaluates it against the committed row.
+  it('carries the fund condition inside the update statement', async () => {
+    await call({ goal_id: GOAL })
+
+    expect(filter('eq', 'asset_type')).toMatchObject({ args: ['asset_type', 'fund'] })
+    expect(filter('eq', 'transaction_id')).toMatchObject({ args: ['transaction_id', TX] })
+    expect(filter('eq', 'user_id')).toMatchObject({ args: ['user_id', 'user-1'] })
+  })
+
+  it('returns 404 when the update matches nothing', async () => {
+    h.updated = { data: null, error: { message: 'no rows' } }
+
+    expect((await call({ goal_id: GOAL })).status).toBe(404)
+  })
+
+  // ── goal ownership ─────────────────────────────────────────────────────────
+  it('rejects a goal the caller does not own', async () => {
+    h.goal = { data: null, error: null }
+
+    const res = await call({ goal_id: GOAL })
+
+    expect(res.status).toBe(403)
+    expect(h.update).toBeNull()
+  })
+
+  it('does not look up a goal when unassigning', async () => {
+    await call({ goal_id: null })
+
+    expect(h.filters.some((f) => f.table === 'savings_goals')).toBe(false)
+  })
+
+  // ── accumulating book ──────────────────────────────────────────────────────
+  // goal_id is book-level: every tranche of a book shares it. Updating one row
+  // splits the book across two goals, and the halves can no longer be repaired
+  // from the UI. The canonical PUT routes books through update_deposit_book, a
+  // single-transaction cascade — so does this endpoint.
+  it('cascades a book tranche through the atomic RPC instead of updating one row', async () => {
+    h.existing = { data: { transaction_id: TX, asset_type: 'fund', deposit_group_id: BOOK }, error: null }
+
+    const res = await call({ goal_id: GOAL })
+
+    expect(res.status).toBe(200)
+    expect(h.update).toBeNull()
+    expect(h.rpcCalls).toHaveLength(1)
+    expect(h.rpcCalls[0].fn).toBe('update_deposit_book')
+    expect(h.rpcCalls[0].args).toMatchObject({ p_tx_id: TX, p_set_goal: true, p_goal_id: GOAL })
+    // Only the goal moves — every other book field must be left alone.
+    expect(h.rpcCalls[0].args).toMatchObject({
+      p_set_expiry: false, p_set_amount: false, p_set_rate: false,
+      p_set_investment: false, p_set_notes: false, p_set_bank: false,
+    })
+  })
+
+  it('reports a failed cascade instead of a silent success', async () => {
+    h.existing = { data: { transaction_id: TX, asset_type: 'fund', deposit_group_id: BOOK }, error: null }
+    h.rpc = { data: null, error: { message: 'deadlock detected' } }
+
+    expect((await call({ goal_id: GOAL })).status).toBe(500)
+  })
+
+  it('does not fall back to a lone-row update when the cascade fails', async () => {
+    h.existing = { data: { transaction_id: TX, asset_type: 'fund', deposit_group_id: BOOK }, error: null }
+    h.rpc = { data: null, error: { message: 'deadlock detected' } }
+
+    await call({ goal_id: GOAL })
+
+    expect(h.update).toBeNull()
+  })
+
+  // ── the ordinary refusals ──────────────────────────────────────────────────
+  it('returns 404 when the transaction is not the caller’s', async () => {
+    h.existing = { data: null, error: null }
+
+    const res = await call({ goal_id: GOAL })
+
+    expect(res.status).toBe(404)
+    expect(h.update).toBeNull()
+  })
+
+  it('requires a session', async () => {
+    h.user = null
+
+    expect((await call({ goal_id: GOAL })).status).toBe(401)
+    expect(h.update).toBeNull()
+  })
+
+  it('rejects malformed ids', async () => {
+    expect((await call({ goal_id: GOAL }, 'not-a-uuid')).status).toBe(400)
+    expect((await call({ goal_id: 'not-a-uuid' })).status).toBe(400)
+    expect(h.update).toBeNull()
+  })
+})

--- a/app/api/v1/fund-investments/[id]/goal/route.ts
+++ b/app/api/v1/fund-investments/[id]/goal/route.ts
@@ -3,6 +3,20 @@ import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateUUID } from '@/lib/validation'
 import { readJsonBody } from '@/lib/apiBody'
 
+// Re-bucket ONE fund transaction. The bulk move the dashboard uses is
+// POST /fund-investments/assign (#589); this stays as a compatibility path for
+// single-row callers, and it now carries the same invariants (#586).
+//
+// It used to update on transaction_id + user_id alone, which made a fund-scoped
+// endpoint into a generic goal writer:
+//
+//   • any asset type could be moved through it, bypassing the checks the
+//     canonical route applies to bank deposits;
+//   • an accumulating book tranche was moved on its own — goal is book-level, so
+//     that splits the book across two goals and the halves can no longer be
+//     repaired from the UI (a fund row shows one aggregate per fund);
+//   • the target goal was never checked for ownership, so a known foreign goal
+//     id could be stamped onto the caller's row (#474).
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
@@ -29,11 +43,68 @@ export async function PATCH(
     throw e
   }
 
-  const { data, error } = await supabase
+  const { data: existing } = await supabase
     .from('investment_transactions')
-    .update({ goal_id: cleanGoalId })
+    .select('transaction_id, asset_type, deposit_group_id')
     .eq('transaction_id', txId)
     .eq('user_id', user.id)
+    .maybeSingle()
+
+  // A non-fund id is not a resource this endpoint addresses, so it reads as
+  // absent rather than forbidden — and it tells a caller holding a bank/stock/
+  // gold id nothing about whether that row exists.
+  if (!existing || existing.asset_type !== 'fund') {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 })
+  }
+
+  // A valid UUID is not proof of ownership, and goal_id carries no FK back to
+  // the caller — an unchecked write would link this holding to another user's
+  // goal and report success.
+  if (cleanGoalId) {
+    const { data: goal } = await supabase
+      .from('savings_goals')
+      .select('goal_id')
+      .eq('goal_id', cleanGoalId)
+      .eq('user_id', user.id)
+      .maybeSingle()
+    if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
+  }
+
+  // Books are created as bank deposits, but POST /investment-transactions will
+  // group any asset type when asked, so a fund row CAN carry a deposit_group_id.
+  // goal is book-level, so such a row has to move with its whole group — through
+  // the same single-transaction RPC the canonical PUT uses. Doing the row update
+  // and the cascade as two statements risks a partial failure that splits the
+  // book, so a failed RPC fails the request rather than falling back.
+  if (existing.deposit_group_id) {
+    const { data: row, error: bookErr } = await supabase
+      .rpc('update_deposit_book', {
+        p_tx_id: txId,
+        p_set_goal: true, p_goal_id: cleanGoalId,
+        p_set_expiry: false, p_expiry_date: null,
+        p_set_amount: false, p_amount_vnd: null,
+        p_set_rate: false, p_interest_rate: null,
+        p_set_investment: false, p_investment_date: null,
+        p_set_notes: false, p_notes: null,
+        p_set_bank: false, p_bank_code: null,
+      })
+      .single()
+    if (bookErr || !row) {
+      console.error('fund-investments goal: atomic book edit failed', bookErr?.message)
+      return NextResponse.json({ error: 'Failed to update deposit book' }, { status: 500 })
+    }
+    return NextResponse.json(row)
+  }
+
+  // The read above classifies; this filter is the guard. asset_type could change
+  // between the two statements, so the UPDATE carries the condition itself and
+  // Postgres re-evaluates it against the committed row.
+  const { data, error } = await supabase
+    .from('investment_transactions')
+    .update({ goal_id: cleanGoalId, updated_at: new Date().toISOString() })
+    .eq('transaction_id', txId)
+    .eq('user_id', user.id)
+    .eq('asset_type', 'fund')
     .select()
     .single()
 

--- a/app/api/v1/fund-investments/[id]/route.ts
+++ b/app/api/v1/fund-investments/[id]/route.ts
@@ -1,98 +1,40 @@
-import { NextRequest, NextResponse } from 'next/server'
-import { createSupabaseServerClient } from '@/lib/supabase-server'
-import { ValidationError, validateAmount, validateDate, validateUUID } from '@/lib/validation'
-import { readJsonBody } from '@/lib/apiBody'
+import { NextResponse } from 'next/server'
 
-export async function PUT(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params
-  const supabase = await createSupabaseServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+// Removed legacy mutations (#586).
+//
+// This route once exposed PUT and DELETE that wrote straight to
+// investment_transactions, matched on transaction_id + user_id and nothing else.
+// Both bypassed invariants the canonical /api/v1/investment-transactions/[id]
+// route enforces:
+//
+//   • PUT had no `asset_type = 'fund'` filter, so a fund-shaped body could
+//     rewrite a bank deposit's amount/units/unit_price, and it wrote a single
+//     row with no accumulating-book cascade — editing one tranche split the
+//     book away from its group (goal and maturity are book-level).
+//   • DELETE had no `consumed_by_inv_id IS NULL` guard, so the withdrawal that
+//     closes a merged source could be deleted. That re-opens the source at full
+//     value while its cash still sits in the anchor: the same money counted
+//     twice in net worth.
+//
+// Nothing in the app called either — the fund flows go through
+// POST /fund-investments/assign and the canonical transaction route — so rather
+// than duplicate the guards in a second place they are gone.
+//
+// 410 rather than dropping the handlers: an unexported method answers 405, which
+// reads as "wrong verb, try another one" and invites a retry. 410 says the path
+// itself is permanently gone, and it is a response a stale client can be tested
+// against. Neither handler authenticates or opens a database client — a removed
+// mutation must not be able to reach a row by any path through this file.
 
-  const parsed = await readJsonBody(request)
-  if (!parsed.ok) return parsed.response
-  const body = parsed.body
-  const { fund_id, goal_id, amount_vnd, units_purchased, nav_at_purchase, investment_date } = body
+const GONE = {
+  error: 'This endpoint has been removed. Use /api/v1/investment-transactions/[id] instead.',
+  code: 'gone',
+} as const
 
-  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }
-
-  try {
-    const txId = validateUUID(id, 'transaction_id')
-
-    if (fund_id !== undefined) {
-      updates.fund_id = fund_id === null || fund_id === '' ? null : validateUUID(fund_id, 'fund_id')
-    }
-    if (goal_id !== undefined) {
-      updates.goal_id = goal_id === null || goal_id === '' ? null : validateUUID(goal_id, 'goal_id')
-    }
-    if (amount_vnd !== undefined) {
-      const n = validateAmount(amount_vnd, 'amount_vnd')
-      if (n <= 0) throw new ValidationError('Amount and units are required and must be positive')
-      updates.amount_vnd = n
-    }
-    if (units_purchased !== undefined) {
-      const n = validateAmount(units_purchased, 'units_purchased')
-      if (n <= 0) throw new ValidationError('Amount and units are required and must be positive')
-      updates.units = n
-    }
-    if (nav_at_purchase !== undefined) {
-      const n = validateAmount(nav_at_purchase, 'nav_at_purchase')
-      if (n <= 0) throw new ValidationError('NAV at purchase must be positive')
-      updates.unit_price = n
-    }
-    if (investment_date !== undefined) {
-      updates.investment_date = investment_date === null || investment_date === '' ? null : validateDate(investment_date, 'investment_date')
-    }
-
-    const { data, error } = await supabase
-      .from('investment_transactions')
-      .update(updates)
-      .eq('transaction_id', txId)
-      .eq('user_id', user.id)
-      .select('transaction_id, fund_id, goal_id, amount_vnd, units, unit_price, investment_date, created_at, funds(name, nav), savings_goals(goal_name)')
-      .single()
-
-    if (error || !data) return NextResponse.json({ error: 'Investment not found' }, { status: 404 })
-
-    return NextResponse.json({
-      id: data.transaction_id,
-      fund_id: data.fund_id,
-      goal_id: data.goal_id,
-      amount_vnd: data.amount_vnd,
-      units_purchased: data.units,
-      nav_at_purchase: data.unit_price,
-      investment_date: data.investment_date,
-      created_at: data.created_at,
-      funds: data.funds,
-      savings_goals: data.savings_goals,
-    })
-  } catch (e) {
-    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
-    throw e
-  }
+export async function PUT() {
+  return NextResponse.json(GONE, { status: 410 })
 }
 
-export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
-  const { id } = await params
-
-  let txId: string
-  try {
-    txId = validateUUID(id, 'transaction_id')
-  } catch (e) {
-    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
-    throw e
-  }
-
-  const supabase = await createSupabaseServerClient()
-  const { data: { user } } = await supabase.auth.getUser()
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-
-  const { error } = await supabase
-    .from('investment_transactions')
-    .delete()
-    .eq('transaction_id', txId)
-    .eq('user_id', user.id)
-
-  if (error) return NextResponse.json({ error: 'Investment not found' }, { status: 404 })
-  return new NextResponse(null, { status: 204 })
+export async function DELETE() {
+  return NextResponse.json(GONE, { status: 410 })
 }

--- a/app/api/v1/fund-investments/__tests__/route.post.test.ts
+++ b/app/api/v1/fund-investments/__tests__/route.post.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// POST /fund-investments is the legacy create path. It validated fund_id and
+// goal_id as UUIDs and stopped there (#586) — but a well-formed UUID is not
+// proof of ownership, and neither column is protected by a physical FK to the
+// caller. A known foreign id therefore linked the caller's holding to someone
+// else's fund or goal, exactly the hole the canonical route closed in #474.
+//
+// Ownership is checked here the same way it is there: a scoped lookup, 403 when
+// it comes back empty, and nothing written.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  fund: { data: { id: 'fund' } as unknown, error: null as unknown },
+  goal: { data: { goal_id: 'goal' } as unknown, error: null as unknown },
+  plan: { data: { id: 'plan' } as unknown, error: null as unknown },
+  inserted: { data: null as unknown, error: null as unknown },
+  insert: null as unknown,
+  lookups: [] as string[],
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chain = (table: string) => {
+    let op = 'select'
+    const c: Record<string, unknown> = {
+      select: () => c,
+      insert: (payload: unknown) => { h.insert = payload; op = 'insert'; return c },
+      eq: () => c,
+      single: async () => resolve(),
+      maybeSingle: async () => resolve(),
+    }
+    const resolve = () => {
+      if (op === 'insert') return h.inserted
+      h.lookups.push(table)
+      if (table === 'funds') return h.fund
+      if (table === 'savings_goals') return h.goal
+      return h.plan
+    }
+    return c
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (table: string) => chain(table),
+    }),
+  }
+})
+
+const { POST } = await import('../route')
+
+const FUND = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+const GOAL = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const TX = '11111111-1111-4111-8111-111111111111'
+
+const body = (over: Record<string, unknown> = {}) => ({
+  fund_id: FUND, amount_vnd: 2_000_000, units_purchased: 100,
+  nav_at_purchase: 20_000, investment_date: '2026-01-01', ...over,
+})
+
+const call = (b: unknown) =>
+  POST(new NextRequest('https://app.test/api/v1/fund-investments', {
+    method: 'POST', body: JSON.stringify(b),
+  }))
+
+describe('POST /api/v1/fund-investments', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.fund = { data: { id: FUND }, error: null }
+    h.goal = { data: { goal_id: GOAL }, error: null }
+    h.plan = { data: { id: 'plan-1' }, error: null }
+    h.inserted = {
+      data: {
+        transaction_id: TX, fund_id: FUND, goal_id: GOAL, amount_vnd: 2_000_000,
+        units: 100, unit_price: 20_000, investment_date: '2026-01-01', created_at: 'now',
+      },
+      error: null,
+    }
+    h.insert = null
+    h.lookups = []
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('creates a fund investment the caller owns', async () => {
+    const res = await call(body({ goal_id: GOAL }))
+
+    expect(res.status).toBe(201)
+    expect(h.insert).toMatchObject({ user_id: 'user-1', fund_id: FUND, goal_id: GOAL, asset_type: 'fund' })
+  })
+
+  it('rejects a fund the caller does not own', async () => {
+    h.fund = { data: null, error: null }
+
+    const res = await call(body())
+
+    expect(res.status).toBe(403)
+    expect(h.insert).toBeNull()
+  })
+
+  it('rejects a goal the caller does not own', async () => {
+    h.goal = { data: null, error: null }
+
+    const res = await call(body({ goal_id: GOAL }))
+
+    expect(res.status).toBe(403)
+    expect(h.insert).toBeNull()
+  })
+
+  it('does not look up a goal when none was given', async () => {
+    await call(body())
+
+    expect(h.lookups).not.toContain('savings_goals')
+  })
+})

--- a/app/api/v1/fund-investments/route.ts
+++ b/app/api/v1/fund-investments/route.ts
@@ -81,6 +81,28 @@ export async function POST(request: NextRequest) {
     throw e
   }
 
+  // A well-formed UUID is not proof of ownership, and neither fund_id nor
+  // goal_id is protected by an FK back to the caller — so a known foreign id
+  // would link this holding to someone else's fund or goal and report success
+  // (#586, the same hole the canonical route closed in #474).
+  const { data: fund } = await supabase
+    .from('funds')
+    .select('id')
+    .eq('id', cleanFundId)
+    .eq('user_id', user.id)
+    .maybeSingle()
+  if (!fund) return NextResponse.json({ error: "You don't have permission to access this fund." }, { status: 403 })
+
+  if (cleanGoalId) {
+    const { data: goal } = await supabase
+      .from('savings_goals')
+      .select('goal_id')
+      .eq('goal_id', cleanGoalId)
+      .eq('user_id', user.id)
+      .maybeSingle()
+    if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
+  }
+
   if (cleanPlanId) {
     const { data: plan } = await supabase.from('monthly_plans').select('id').eq('id', cleanPlanId).eq('user_id', user.id).single()
     if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })

--- a/e2e/fund-unassign.spec.ts
+++ b/e2e/fund-unassign.spec.ts
@@ -132,3 +132,65 @@ test.describe('fund-investments goal-move contract (#467, #589)', () => {
     }
   })
 })
+
+// The legacy row endpoints wrote to investment_transactions with no asset-type
+// filter and no consumed-settlement guard (#586). The route unit tests pin the
+// status codes and the filter chain; what only a live database can show is that
+// a *real* bank deposit is untouched by a call made through the fund-scoped
+// path — i.e. that the id really is cross-type and really is refused.
+test.describe('legacy fund-investments mutations are closed (#586)', () => {
+  test('PUT and DELETE are gone, and the transaction survives them', async ({ request }) => {
+    const goal = await api.createGoal({ goal_name: `E2E Legacy586 ${Date.now()}` })
+    const fund = await api.createFund({
+      name: `E2E Legacy586 Fund ${Date.now()}`,
+      code: `L58${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      fund_type: 'equity',
+      nav: 20_000,
+    })
+    const tx = await api.createTransaction({
+      asset_type: 'fund', fund_id: fund.id, goal_id: goal.goal_id,
+      amount_vnd: 2_000_000, units: 100, unit_price: 20_000, investment_date: '2026-01-01',
+    })
+    try {
+      const put = await request.put(`/api/v1/fund-investments/${tx.transaction_id}`, {
+        data: { amount_vnd: 999_000_000 },
+      })
+      expect(put.status()).toBe(410)
+
+      const del = await request.delete(`/api/v1/fund-investments/${tx.transaction_id}`)
+      expect(del.status()).toBe(410)
+
+      // Neither call reached the row.
+      const rows = await (await request.get(`/api/v1/fund-investments?fund_id=${fund.id}`)).json()
+      const row = rows.find((r: { id: string }) => r.id === tx.transaction_id)
+      expect(row).toBeTruthy()
+      expect(row.amount_vnd).toBe(2_000_000)
+    } finally {
+      await api.deleteTransaction(tx.transaction_id)
+      await api.deleteFund(fund.id)
+      await api.deleteGoal(goal.goal_id)
+    }
+  })
+
+  test('the goal PATCH refuses a bank deposit id and leaves it in its goal', async ({ request }) => {
+    const goalA = await api.createGoal({ goal_name: `E2E Legacy586 A ${Date.now()}` })
+    const goalB = await api.createGoal({ goal_name: `E2E Legacy586 B ${Date.now()}` })
+    const bank = await api.createTransaction({
+      asset_type: 'bank', goal_id: goalA.goal_id, amount_vnd: 5_000_000,
+      interest_rate: 5, expiry_date: '2027-01-01', investment_date: '2026-01-01',
+    })
+    try {
+      const patch = await request.patch(`/api/v1/fund-investments/${bank.transaction_id}/goal`, {
+        data: { goal_id: goalB.goal_id },
+      })
+      expect(patch.status()).toBe(404)
+
+      const after = await (await request.get(`/api/v1/investment-transactions/${bank.transaction_id}`)).json()
+      expect(after.goal_id).toBe(goalA.goal_id)
+    } finally {
+      await api.deleteTransaction(bank.transaction_id)
+      await api.deleteGoal(goalA.goal_id)
+      await api.deleteGoal(goalB.goal_id)
+    }
+  })
+})


### PR DESCRIPTION
Closes #586.

## The hole

`app/api/v1/fund-investments/*` wrote straight to `investment_transactions`, matched on `transaction_id + user_id` and nothing else — so it bypassed every invariant the canonical `/investment-transactions` route enforces.

| Path | What it could do |
|---|---|
| `PUT /[id]` | No `asset_type = 'fund'` filter → a fund-shaped body rewrote a **bank deposit's** amount/units/unit_price. One-row write, no book cascade → a tranche split away from its group (goal + maturity are book-level). |
| `DELETE /[id]` | No `consumed_by_inv_id IS NULL` guard → the withdrawal that closes a merged source could be deleted. The source re-opens at full value while its cash still sits in the anchor: **the same money counted twice** in net worth. |
| `PATCH /[id]/goal` | Moved **any** asset type between goals; split a book the same way; never checked the target goal belonged to the caller. |
| `POST /` | Linked `fund_id` / `goal_id` after a UUID check only. Neither column has an FK back to the caller, so a known foreign id was accepted — the hole #474 closed on the canonical route. |

## The fix

**PUT and DELETE are gone.** Nothing called them (the fund flows go through `/fund-investments/assign` and the canonical route), so rather than duplicate the guards in a second place they now answer `410 Gone` — 405 reads as "wrong verb, try another" and invites a retry. Neither handler authenticates or opens a database client.

**`PATCH /[id]/goal` stays** as a compatibility path (it is what `e2e/fund-unassign.spec.ts` pins) and now carries the invariants:
- the row must be a fund — and the condition is in the `UPDATE`'s own `WHERE` clause, not only in the pre-read, so there is no window for `asset_type` to change between the two statements;
- the target goal must be the caller's (403 otherwise);
- a row carrying a `deposit_group_id` cascades through `update_deposit_book` — the same single-transaction RPC the canonical PUT uses — instead of moving alone. A failed cascade fails the request rather than falling back to a lone-row update.

> A book is normally a bank deposit, but `POST /investment-transactions` will group any asset type when passed `accumulating: true`, so a fund row *can* carry a `deposit_group_id`. The cascade branch is not dead code.

**`POST /`** verifies fund and goal ownership before inserting.

## Tests

TDD, red first (13 failing), then green.

- `app/api/v1/fund-investments/[id]/__tests__/route.test.ts` — 410 on both verbs, and the structural assertion that neither reaches the database.
- `app/api/v1/fund-investments/[id]/goal/__tests__/route.test.ts` — cross-type id refused; the fund condition is *inside* the update statement; goal ownership; the book cascade goes through the RPC with only `p_set_goal` true, and a failed cascade does not fall back.
- `app/api/v1/fund-investments/__tests__/route.post.test.ts` — fund/goal ownership.
- `e2e/fund-unassign.spec.ts` — two cases appended to the existing spec: PUT/DELETE are 410 and the row survives unchanged; the goal PATCH refuses a **real bank deposit's** id and leaves it in its goal. Only a live database shows the cross-type refusal is real.

## Checks

- `npm test -- --run` — 1861 passed (170 files)
- `npm run lint` — clean
- `npx playwright test e2e/fund-unassign.spec.ts --project=chromium` — 6 passed
- `npx playwright test e2e/fk-ownership.spec.ts --project=chromium` — 19 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)