### PR TITLE
docs: put typecheck in the pre-PR checklist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,12 @@ not a full E2E. Reach for E2E only when the loop itself crosses the network/DB b
 E2E was removed from CI (PR #313) and runs **locally only** — so local checks are
 the only automated gate before the Vercel preview. Scale the checks to the change:
 
-- **Always:** `npm test -- --run` (Vitest unit tests) and `npm run lint`. Fast, every PR.
+- **Always:** `npm run typecheck`, `npm test -- --run` (Vitest unit tests), and
+  `npm run lint`. Fast, every PR. Don't skip the typecheck because the tests are
+  green — Vitest ignores extra arguments and unused types, so a test that calls a
+  handler with a signature it no longer has passes locally and fails CI. CI runs
+  `typecheck` inside the "Unit Tests" job, so a red X there is often `tsc`, not a
+  failing assertion (#614).
 - **Targeted E2E** — when the change touches a feature area, run that area's specs,
   e.g. `npx playwright test e2e/planning.spec.ts --project=chromium`. This is the
   common case.


### PR DESCRIPTION
The "What to run before opening a PR" checklist listed only `npm test -- --run` and `npm run lint`. Both were green locally on #614, and CI still failed — on `tsc`, not on an assertion:

```
app/api/v1/fund-investments/[id]/__tests__/route.test.ts(43,5):
error TS2554: Expected 0 arguments, but got 2.
```

Two things made that easy to miss, and the wording now names both:

- **A green test run does not imply a green typecheck.** Vitest ignores extra arguments and unused types, so a test that calls a handler with a signature it no longer has passes locally.
- **CI runs `typecheck` inside the job labelled "Unit Tests"** (`.github/workflows/ci.yml`), so the red X reads as a failing assertion when it isn't.

Docs only — no code, no tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)