### PR TITLE
fix(funds): restore the original DCA state when a save fails (#590)

### DIFF
--- a/app/(app)/funds/FundLibraryClient.tsx
+++ b/app/(app)/funds/FundLibraryClient.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import MobileFundLibraryView from './components/MobileFundLibraryView'
 import DesktopFundLibraryView from './components/DesktopFundLibraryView'
 import { useFundsData } from './components/useFundsData'
@@ -10,10 +11,18 @@ export default function FundLibraryClient() {
   // updates the one shared copy (#10).
   const data = useFundsData()
 
+  // In-flight funds belong here for the same reason. A request started in one
+  // view is still out when a resize across the breakpoint hands the user the
+  // other one; with a busy set per view, that view would let a second write
+  // stack on the first and each rollback would then aim at the other's
+  // optimistic value instead of at what the server holds (#590).
+  const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set())
+  const busy = { togglingIds, setTogglingIds }
+
   return (
     <>
-      <MobileFundLibraryView {...data} />
-      <DesktopFundLibraryView {...data} />
+      <MobileFundLibraryView {...data} {...busy} />
+      <DesktopFundLibraryView {...data} {...busy} />
     </>
   )
 }

--- a/app/(app)/funds/__tests__/FundLibraryClient.busy.test.tsx
+++ b/app/(app)/funds/__tests__/FundLibraryClient.busy.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { useState } from 'react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import FundLibraryClient from '../FundLibraryClient'
+import type { Fund } from '../components/useFundsData'
+
+// Both fund views stay mounted at once — the desktop one is hidden with a CSS
+// breakpoint, not unmounted — so a request started in one is still in flight
+// when a resize hands the user the other. The in-flight bookkeeping has to be
+// shared or the second view happily starts a stacked write, and the two
+// rollbacks then aim at each other's optimistic values instead of at the
+// server's state (#590 review).
+
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+
+vi.mock('@/lib/formatters', () => ({
+  fmtNav: (n: number) => String(n),
+  fmtCompact: (n: number) => `${n}`,
+}))
+
+vi.mock('@/app/components/navigation/NavigationContext', () => ({
+  useNavigation: () => ({ setMobileTopBar: vi.fn() }),
+}))
+
+const FUND: Fund = {
+  id: 'f1',
+  name: 'VFMVF1 Equity Fund',
+  code: 'VFMVF1',
+  fund_type: 'equity',
+  nav: 36120,
+  nav_source_url: null,
+  is_dca: true,
+  dca_monthly_amount_vnd: 2_000_000,
+  dca_goal_id: null,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+vi.mock('../components/useFundsData', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../components/useFundsData')>()),
+  useFundsData: () => {
+    const [funds, setFunds] = useState<Fund[]>([FUND])
+    return { funds, setFunds, goals: [], loading: false, error: false, reload: async () => {} }
+  },
+}))
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  fetchMock = vi.fn(() => new Promise(() => {}))
+  vi.stubGlobal('fetch', fetchMock)
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe('FundLibraryClient — DCA busy state is shared by both mounted views', () => {
+  it('marks the fund busy in the mobile card while the desktop save is in flight', async () => {
+    render(<FundLibraryClient />)
+
+    const row = screen.getByTestId('fund-row-f1')
+    await userEvent.click(within(row).getByTestId('dca-amount-btn-f1'))
+    const input = within(row).getByTestId('dca-amount-input-f1')
+    await userEvent.clear(input)
+    await userEvent.type(input, '3000000')
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    // The other viewport must not offer a second write on the same fund.
+    const card = screen.getByTestId('fund-card-f1')
+    expect(within(card).getByTestId('dca-amount-btn-f1')).toBeDisabled()
+    expect(within(card).getByLabelText('disableDca')).toBeDisabled()
+    await userEvent.click(within(card).getByTestId('dca-amount-btn-f1'))
+    expect(within(card).queryByTestId('dca-amount-input-f1')).not.toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -13,7 +13,7 @@ import { SyncPill } from '@/app/components/ui/SyncPill'
 import { useDialogA11y } from '@/app/(app)/planning/components/useDialogA11y'
 import { FundsEmptyState } from './FundsEmptyState'
 import { FundNavAge } from './FundNavAge'
-import type { Fund, Goal, FundType, FundsData } from './useFundsData'
+import type { Fund, Goal, FundType, FundsData, FundsBusy } from './useFundsData'
 import { useFundMutations } from './useFundMutations'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -311,7 +311,7 @@ function FormField({ label, children }: { label: string; children: ReactNode }) 
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
-export default function DesktopFundLibraryView({ funds, setFunds, goals, loading, error, reload }: FundsData) {
+export default function DesktopFundLibraryView({ funds, setFunds, goals, loading, error, reload, togglingIds: busyIds, setTogglingIds }: FundsData & FundsBusy) {
   const t = useTranslations('funds')
   const tc = useTranslations('common')
   const locale = useLocale()
@@ -360,7 +360,7 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
   // and busy-id bookkeeping all live in one place. Only the toast shape differs
   // between the two, which is why it is injected (#573).
   const { togglingIds, disableDca, saveDcaAmount, setDcaGoal, deleteFund } =
-    useFundMutations({ setFunds, reload, notify: addToast })
+    useFundMutations({ setFunds, reload, notify: addToast, togglingIds: busyIds, setTogglingIds })
 
   // Sorting
   const handleSort = (key: SortKey) => {

--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -254,12 +254,17 @@ function DcaToggle({ fund, editId, editValue, toggling, goals, goalLabel, unallo
         ) : (
           <button
             data-testid={`dca-amount-btn-${fund.id}`}
+            // Busy until the save settles: a second amount write stacked on the
+            // first leaves each rollback aiming at the other's optimistic value
+            // rather than at what the server holds (#590).
+            disabled={toggling}
             onClick={e => { e.stopPropagation(); onEditStart() }}
             style={{
               fontSize: 11, fontWeight: 500, padding: '2px 8px',
+              opacity: toggling ? 0.5 : 1,
               background: 'var(--c-navy-tint)', color: 'var(--c-navy)',
               border: '1px solid var(--c-navy-tint)', borderRadius: 6,
-              cursor: 'pointer', fontFamily: 'inherit',
+              cursor: toggling ? 'not-allowed' : 'pointer', fontFamily: 'inherit',
             }}
           >
             {fund.dca_monthly_amount_vnd ? fmtCompact(fund.dca_monthly_amount_vnd) : t('setAmount')}

--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -462,9 +462,12 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
       setDcaEditIsNew(false)
       return
     }
+    // Captured before the flag is cleared: it decides what a failed save rolls
+    // back to — off for a never-persisted enable, the saved amount otherwise.
+    const wasNew = dcaEditIsNew
     setDcaEditId(null)
     setDcaEditIsNew(false)
-    await saveDcaAmount(fund, amount)
+    await saveDcaAmount(fund, amount, wasNew)
   }
 
   async function handleSetDcaGoal(fund: Fund, goalId: string | null) {

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -626,8 +626,11 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
       return
     }
 
+    // Captured before the flag is cleared: it decides what a failed save rolls
+    // back to — off for a never-persisted enable, the saved amount otherwise.
+    const wasNew = dcaEditIsNew
     setDcaEditIsNew(false)
-    await saveDcaAmount(fund, amount)
+    await saveDcaAmount(fund, amount, wasNew)
   }
 
   // Abandon an inline amount edit (Escape). A brand-new enable reverts to off;

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -13,7 +13,7 @@ import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/
 import { useDialogA11y } from '@/app/(app)/planning/components/useDialogA11y'
 import { FundsEmptyState } from './FundsEmptyState'
 import { FundNavAge } from './FundNavAge'
-import type { Fund, Goal, FundType, FundsData } from './useFundsData'
+import type { Fund, Goal, FundType, FundsData, FundsBusy } from './useFundsData'
 import { useFundMutations } from './useFundMutations'
 import { useDialogMount } from '@/app/(app)/planning/components/useDialogMount'
 
@@ -440,7 +440,7 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
 
 // ─── Main component ───────────────────────────────────────────────────────────
 
-export default function MobileFundLibraryView({ funds, setFunds, goals, loading, error, reload }: FundsData) {
+export default function MobileFundLibraryView({ funds, setFunds, goals, loading, error, reload, togglingIds: busyIds, setTogglingIds }: FundsData & FundsBusy) {
   const t = useTranslations('funds')
   const tc = useTranslations('common')
   const locale = useLocale()
@@ -495,6 +495,8 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
       setFunds,
       reload,
       notify: useCallback((message: string, ok: boolean) => addToast(message, ok ? 'success' : 'error'), [addToast]),
+      togglingIds: busyIds,
+      setTogglingIds,
     })
 
   const handleRefreshNav = useCallback(async () => {

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -412,6 +412,12 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
               value={fund.dca_goal_id ?? ''}
               title={goalLabel}
               aria-label={goalLabel}
+              // Waits out an in-flight write like the desktop selector already
+              // did: the goal PUT carries the amount, so running it during an
+              // amount save would persist a value that save hasn't confirmed
+              // yet — and the failed save could then no longer tell the
+              // server's value from its own optimistic one (#590).
+              disabled={toggling}
               onChange={(e) => onGoalChange(e.target.value || null)}
               style={{
                 // 16px (not 13) so iOS Safari doesn't zoom the viewport on focus
@@ -425,7 +431,8 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
                 // --c-ink-2 (not --c-muted): the select holds a real chosen goal, so
                 // it needs readable contrast, not faint placeholder-grey.
                 background: 'var(--c-card)', color: 'var(--c-ink-2)',
-                fontFamily: 'inherit', cursor: 'pointer', appearance: 'none', outline: 'none',
+                fontFamily: 'inherit', appearance: 'none', outline: 'none',
+                cursor: toggling ? 'not-allowed' : 'pointer', opacity: toggling ? 0.5 : 1,
               }}
             >
               {goals.map((g) => <option key={g.goal_id} value={g.goal_id}>{g.goal_name}</option>)}

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -384,16 +384,21 @@ function FundCard({ fund, dcaEditId, dcaEditValue, togglingIds, goals, goalLabel
               <button
                 type="button"
                 data-testid={`dca-amount-btn-${fund.id}`}
+                // Busy until the save settles: a second amount write stacked on
+                // the first leaves each rollback aiming at the other's
+                // optimistic value rather than at what the server holds (#590).
+                disabled={toggling}
                 onClick={() => { setDcaEditId(fund.id); setDcaEditValue(String(fund.dca_monthly_amount_vnd)); setDcaEditIsNew(false) }}
-                style={{ fontSize: 11, fontWeight: 500, padding: '2px 8px', background: 'var(--c-navy-tint)', color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)', borderRadius: 6, cursor: 'pointer', fontFamily: 'inherit' }}
+                style={{ fontSize: 11, fontWeight: 500, padding: '2px 8px', background: 'var(--c-navy-tint)', color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)', borderRadius: 6, cursor: toggling ? 'not-allowed' : 'pointer', opacity: toggling ? 0.5 : 1, fontFamily: 'inherit' }}
               >
                 {fmtCompact(fund.dca_monthly_amount_vnd)}
               </button>
             ) : (
               <button
                 type="button"
+                disabled={toggling}
                 onClick={() => { setDcaEditId(fund.id); setDcaEditValue(''); setDcaEditIsNew(false) }}
-                style={{ fontSize: 11, fontWeight: 500, padding: '2px 8px', background: 'var(--c-navy-tint)', color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)', borderRadius: 6, cursor: 'pointer', fontFamily: 'inherit' }}
+                style={{ fontSize: 11, fontWeight: 500, padding: '2px 8px', background: 'var(--c-navy-tint)', color: 'var(--c-navy)', border: '1px solid var(--c-navy-tint)', borderRadius: 6, cursor: toggling ? 'not-allowed' : 'pointer', opacity: toggling ? 0.5 : 1, fontFamily: 'inherit' }}
               >
                 {t('setAmount')}
               </button>

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.a11y.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.a11y.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent, waitFor, within } from '@testing-library/rea
 import userEvent from '@testing-library/user-event'
 import DesktopFundLibraryView from '../DesktopFundLibraryView'
 import type { Fund } from '../useFundsData'
+import { useFundsBusy } from './helpers/fundsBusy'
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
@@ -21,7 +22,7 @@ function makeFund(over: Partial<Fund> = {}): Fund {
 }
 function Harness() {
   const [funds, setFunds] = useState([makeFund()])
-  return <DesktopFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
+  return <DesktopFundLibraryView {...useFundsBusy()} funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
 }
 
 beforeEach(() => { vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))) })

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.dca.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.dca.test.tsx
@@ -178,6 +178,10 @@ describe('DesktopFundLibraryView — DCA amount edit must not desync from the se
     await userEvent.click(amountBtn)
     expect(screen.queryByTestId('dca-amount-input-f1')).not.toBeInTheDocument()
     expect(fetchMock).toHaveBeenCalledTimes(1)
+    // The goal write is a full PUT carrying the amount, so it waits too — it
+    // would otherwise persist the still-unconfirmed amount and reload it (#590
+    // review).
+    expect(screen.getByTestId('dca-goal-f1')).toBeDisabled()
   })
 
   it('a valid amount edit still persists with a PUT (is_dca true) and reloads', async () => {

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.dca.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.dca.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { Mock } from 'vitest'
 import { useState } from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DesktopFundLibraryView from '../DesktopFundLibraryView'
 import type { Fund } from '../useFundsData'
@@ -133,6 +133,27 @@ describe('DesktopFundLibraryView — DCA amount edit must not desync from the se
     await waitFor(() => expect(fetchMock).toHaveBeenCalled())
     await waitFor(() => expect(screen.getByLabelText('enableDca')).toBeInTheDocument())
     expect(screen.queryByTestId('dca-amount-btn-f1')).not.toBeInTheDocument()
+  })
+
+  // The "brand-new enable" flag is single, shared editor state, so a pending
+  // enable must never outlive its editor — otherwise a later save of that row
+  // would roll back to a locally-enabled state the server never had (#590
+  // review). Moving to another row blurs the pending input, which reverts it.
+  it('a pending enable does not survive moving to another row', async () => {
+    render(
+      <Harness
+        initial={[makeFund({ is_dca: false }), makeFund({ id: 'f2', code: 'VESAF', is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]}
+        reload={reload}
+      />,
+    )
+
+    await userEvent.click(within(screen.getByTestId('fund-row-f1')).getByLabelText('enableDca'))
+    await userEvent.click(screen.getByTestId('dca-amount-btn-f2'))
+
+    // f1 is back off — no half-enabled row is left behind, and nothing was PUT.
+    expect(within(screen.getByTestId('fund-row-f1')).getByLabelText('enableDca')).toBeInTheDocument()
+    expect(screen.queryByTestId('dca-amount-btn-f1')).not.toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('a valid amount edit still persists with a PUT (is_dca true) and reloads', async () => {

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.dca.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.dca.test.tsx
@@ -103,6 +103,38 @@ describe('DesktopFundLibraryView — DCA amount edit must not desync from the se
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  // Same assertion as the mobile spec: after a failed edit both viewports must
+  // still show the configuration the server kept, not "DCA off" (#590).
+  it('a failed edit of a saved amount leaves the row enabled at its previous amount', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, json: () => Promise.resolve({}) })
+    render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
+
+    await userEvent.click(screen.getByTestId('dca-amount-btn-f1'))
+    const input = screen.getByTestId('dca-amount-input-f1')
+    await userEvent.clear(input)
+    await userEvent.type(input, '3000000')
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    await waitFor(() => expect(screen.getByLabelText('disableDca')).toBeInTheDocument())
+    expect(screen.getByTestId('dca-amount-btn-f1')).toHaveTextContent('2000000')
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('a failed first save of a just-enabled DCA leaves the row off', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, json: () => Promise.resolve({}) })
+    render(<Harness initial={[makeFund({ is_dca: false })]} reload={reload} />)
+
+    await userEvent.click(screen.getByLabelText('enableDca'))
+    const input = screen.getByTestId('dca-amount-input-f1')
+    await userEvent.type(input, '3000000')
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    await waitFor(() => expect(screen.getByLabelText('enableDca')).toBeInTheDocument())
+    expect(screen.queryByTestId('dca-amount-btn-f1')).not.toBeInTheDocument()
+  })
+
   it('a valid amount edit still persists with a PUT (is_dca true) and reloads', async () => {
     render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
 

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.dca.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.dca.test.tsx
@@ -156,6 +156,28 @@ describe('DesktopFundLibraryView — DCA amount edit must not desync from the se
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  // Two saves of the same amount must not overlap: stacked writes make each
+  // one's rollback target the other's optimistic value instead of what the
+  // server holds, and the row keeps an amount that was never persisted (#590
+  // review). The row is busy until the first save settles.
+  it('does not let a second amount save stack on one still in flight', async () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
+
+    await userEvent.click(screen.getByTestId('dca-amount-btn-f1'))
+    const input = screen.getByTestId('dca-amount-input-f1')
+    await userEvent.clear(input)
+    await userEvent.type(input, '3000000')
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    const amountBtn = screen.getByTestId('dca-amount-btn-f1')
+    expect(amountBtn).toBeDisabled()
+    await userEvent.click(amountBtn)
+    expect(screen.queryByTestId('dca-amount-input-f1')).not.toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('a valid amount edit still persists with a PUT (is_dca true) and reloads', async () => {
     render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
 

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.dca.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.dca.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, fireEvent, waitFor, within } from '@testing-library/rea
 import userEvent from '@testing-library/user-event'
 import DesktopFundLibraryView from '../DesktopFundLibraryView'
 import type { Fund } from '../useFundsData'
+import { useFundsBusy } from './helpers/fundsBusy'
 
 // next-intl → return the key (and append params) so assertions stay language-agnostic.
 vi.mock('next-intl', () => ({
@@ -40,6 +41,7 @@ function Harness({ initial, reload }: { initial: Fund[]; reload: () => Promise<v
   const [funds, setFunds] = useState(initial)
   return (
     <DesktopFundLibraryView
+      {...useFundsBusy()}
       funds={funds}
       setFunds={setFunds}
       goals={[]}

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.delete.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.delete.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, within, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DesktopFundLibraryView from '../DesktopFundLibraryView'
 import type { Fund } from '../useFundsData'
+import { useFundsBusy } from './helpers/fundsBusy'
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
@@ -22,7 +23,7 @@ function makeFund(over: Partial<Fund> = {}): Fund {
 }
 function Harness({ reload }: { reload: () => Promise<void> }) {
   const [funds, setFunds] = useState([makeFund()])
-  return <DesktopFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={reload} />
+  return <DesktopFundLibraryView {...useFundsBusy()} funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={reload} />
 }
 
 let reload: Mock<() => Promise<void>>

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.parity.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.parity.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DesktopFundLibraryView from '../DesktopFundLibraryView'
 import type { Fund } from '../useFundsData'
+import { useFundsBusy } from './helpers/fundsBusy'
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
@@ -21,7 +22,7 @@ function makeFund(over: Partial<Fund> = {}): Fund {
 }
 function Harness({ initial }: { initial: Fund[] }) {
   const [funds, setFunds] = useState(initial)
-  return <DesktopFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
+  return <DesktopFundLibraryView {...useFundsBusy()} funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
 }
 
 beforeEach(() => { vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))) })

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.render.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.render.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DesktopFundLibraryView from '../DesktopFundLibraryView'
 import type { Fund } from '../useFundsData'
+import { useFundsBusy } from './helpers/fundsBusy'
 
 // Presence/render + filter coverage for the desktop Funds table. Moved off E2E
 // (each spun a browser, duplicated the mobile view) per the test-layering policy.
@@ -45,6 +46,7 @@ function Harness({ initial }: { initial: Fund[] }) {
   const [funds, setFunds] = useState(initial)
   return (
     <DesktopFundLibraryView
+      {...useFundsBusy()}
       funds={funds}
       setFunds={setFunds}
       goals={[]}

--- a/app/(app)/funds/components/__tests__/DesktopFundLibraryView.sortheader.test.tsx
+++ b/app/(app)/funds/components/__tests__/DesktopFundLibraryView.sortheader.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DesktopFundLibraryView from '../DesktopFundLibraryView'
 import type { Fund } from '../useFundsData'
+import { useFundsBusy } from './helpers/fundsBusy'
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
@@ -24,7 +25,7 @@ function Harness() {
     makeFund(),
     makeFund({ id: 'f2', code: 'BBB', name: 'Beta Fund', nav: 200 }),
   ])
-  return <DesktopFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
+  return <DesktopFundLibraryView {...useFundsBusy()} funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
 }
 
 beforeEach(() => { vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))) })

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.a11y.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.a11y.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MobileFundLibraryView from '../MobileFundLibraryView'
 import type { Fund } from '../useFundsData'
+import { useFundsBusy } from './helpers/fundsBusy'
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
@@ -22,7 +23,7 @@ function makeFund(over: Partial<Fund> = {}): Fund {
 }
 function Harness() {
   const [funds, setFunds] = useState([makeFund()])
-  return <MobileFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
+  return <MobileFundLibraryView {...useFundsBusy()} funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
 }
 
 beforeEach(() => { vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))) })

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.dca.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.dca.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import type { Mock } from 'vitest'
 import { useState } from 'react'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MobileFundLibraryView from '../MobileFundLibraryView'
 import type { Fund } from '../useFundsData'
@@ -118,6 +118,26 @@ describe('MobileFundLibraryView — DCA amount edit must not desync from the ser
     await waitFor(() => expect(fetchMock).toHaveBeenCalled())
     await waitFor(() => expect(screen.getByLabelText('enableDca')).toBeInTheDocument())
     expect(screen.queryByTestId('dca-amount-btn-f1')).not.toBeInTheDocument()
+  })
+
+  // The "brand-new enable" flag is single, shared editor state, so a pending
+  // enable must never outlive its editor — otherwise a later save of that card
+  // would roll back to a locally-enabled state the server never had (#590
+  // review). Moving to another card blurs the pending input, which reverts it.
+  it('a pending enable does not survive moving to another card', async () => {
+    render(
+      <Harness
+        initial={[makeFund({ is_dca: false }), makeFund({ id: 'f2', code: 'VESAF', is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]}
+        reload={reload}
+      />,
+    )
+
+    await userEvent.click(within(screen.getByTestId('fund-card-f1')).getByLabelText('enableDca'))
+    await userEvent.click(screen.getByTestId('dca-amount-btn-f2'))
+
+    expect(within(screen.getByTestId('fund-card-f1')).getByLabelText('enableDca')).toBeInTheDocument()
+    expect(screen.queryByTestId('dca-amount-btn-f1')).not.toBeInTheDocument()
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   it('a valid amount edit still persists with a PUT (is_dca true) and reloads', async () => {

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.dca.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.dca.test.tsx
@@ -140,6 +140,28 @@ describe('MobileFundLibraryView — DCA amount edit must not desync from the ser
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  // Two saves of the same amount must not overlap: stacked writes make each
+  // one's rollback target the other's optimistic value instead of what the
+  // server holds, and the card keeps an amount that was never persisted (#590
+  // review). The card is busy until the first save settles.
+  it('does not let a second amount save stack on one still in flight', async () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
+
+    await userEvent.click(screen.getByTestId('dca-amount-btn-f1'))
+    const input = screen.getByTestId('dca-amount-input-f1')
+    await userEvent.clear(input)
+    await userEvent.type(input, '3000000')
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    const amountBtn = screen.getByTestId('dca-amount-btn-f1')
+    expect(amountBtn).toBeDisabled()
+    await userEvent.click(amountBtn)
+    expect(screen.queryByTestId('dca-amount-input-f1')).not.toBeInTheDocument()
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
   it('a valid amount edit still persists with a PUT (is_dca true) and reloads', async () => {
     render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
 

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.dca.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.dca.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, fireEvent, waitFor, within } from '@testing-library/rea
 import userEvent from '@testing-library/user-event'
 import MobileFundLibraryView from '../MobileFundLibraryView'
 import type { Fund } from '../useFundsData'
+import { useFundsBusy } from './helpers/fundsBusy'
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
@@ -42,6 +43,7 @@ function Harness({ initial, reload }: { initial: Fund[]; reload: () => Promise<v
   const [funds, setFunds] = useState(initial)
   return (
     <MobileFundLibraryView
+      {...useFundsBusy()}
       funds={funds}
       setFunds={setFunds}
       goals={[]}

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.dca.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.dca.test.tsx
@@ -88,6 +88,38 @@ describe('MobileFundLibraryView — DCA amount edit must not desync from the ser
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  // Same assertion as the desktop spec: after a failed edit both viewports must
+  // still show the configuration the server kept, not "DCA off" (#590).
+  it('a failed edit of a saved amount leaves the card enabled at its previous amount', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, json: () => Promise.resolve({}) })
+    render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
+
+    await userEvent.click(screen.getByTestId('dca-amount-btn-f1'))
+    const input = screen.getByTestId('dca-amount-input-f1')
+    await userEvent.clear(input)
+    await userEvent.type(input, '3000000')
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    await waitFor(() => expect(screen.getByLabelText('disableDca')).toBeInTheDocument())
+    expect(screen.getByTestId('dca-amount-btn-f1')).toHaveTextContent('2000000')
+    expect(reload).not.toHaveBeenCalled()
+  })
+
+  it('a failed first save of a just-enabled DCA leaves the card off', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500, json: () => Promise.resolve({}) })
+    render(<Harness initial={[makeFund({ is_dca: false })]} reload={reload} />)
+
+    await userEvent.click(screen.getByLabelText('enableDca'))
+    const input = screen.getByTestId('dca-amount-input-f1')
+    await userEvent.type(input, '3000000')
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled())
+    await waitFor(() => expect(screen.getByLabelText('enableDca')).toBeInTheDocument())
+    expect(screen.queryByTestId('dca-amount-btn-f1')).not.toBeInTheDocument()
+  })
+
   it('a valid amount edit still persists with a PUT (is_dca true) and reloads', async () => {
     render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
 

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.dca.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.dca.test.tsx
@@ -164,6 +164,25 @@ describe('MobileFundLibraryView — DCA amount edit must not desync from the ser
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
+  // The goal write is a full PUT that carries the amount, so letting it run
+  // during an amount save persists that still-unconfirmed amount and reloads
+  // it — after which the failed save's rollback can no longer tell the
+  // server's value from its own optimistic one (#590 review). Every DCA
+  // control on a busy fund waits, as the desktop selector already did.
+  it('locks the goal selector while an amount save is in flight', async () => {
+    fetchMock.mockReturnValue(new Promise(() => {}))
+    render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
+
+    await userEvent.click(screen.getByTestId('dca-amount-btn-f1'))
+    const input = screen.getByTestId('dca-amount-input-f1')
+    await userEvent.clear(input)
+    await userEvent.type(input, '3000000')
+    fireEvent.blur(input)
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(screen.getByTestId('dca-goal-f1')).toBeDisabled()
+  })
+
   it('a valid amount edit still persists with a PUT (is_dca true) and reloads', async () => {
     render(<Harness initial={[makeFund({ is_dca: true, dca_monthly_amount_vnd: 2_000_000 })]} reload={reload} />)
 

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.delete.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.delete.test.tsx
@@ -5,6 +5,7 @@ import { render, screen, within, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MobileFundLibraryView from '../MobileFundLibraryView'
 import type { Fund } from '../useFundsData'
+import { useFundsBusy } from './helpers/fundsBusy'
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
@@ -23,7 +24,7 @@ function makeFund(over: Partial<Fund> = {}): Fund {
 }
 function Harness({ reload }: { reload: () => Promise<void> }) {
   const [funds, setFunds] = useState([makeFund()])
-  return <MobileFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={reload} />
+  return <MobileFundLibraryView {...useFundsBusy()} funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={reload} />
 }
 
 let reload: Mock<() => Promise<void>>

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.parity.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.parity.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MobileFundLibraryView from '../MobileFundLibraryView'
 import type { Fund } from '../useFundsData'
+import { useFundsBusy } from './helpers/fundsBusy'
 
 vi.mock('next-intl', () => ({
   useTranslations: () => (key: string, params?: Record<string, unknown>) =>
@@ -22,7 +23,7 @@ function makeFund(over: Partial<Fund> = {}): Fund {
 }
 function Harness({ initial }: { initial: Fund[] }) {
   const [funds, setFunds] = useState(initial)
-  return <MobileFundLibraryView funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
+  return <MobileFundLibraryView {...useFundsBusy()} funds={funds} setFunds={setFunds} goals={[]} loading={false} error={false} reload={() => Promise.resolve()} />
 }
 
 beforeEach(() => { vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }))) })

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.reltime.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.reltime.test.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react'
 import { render, screen } from '@testing-library/react'
 import MobileFundLibraryView from '../MobileFundLibraryView'
 import type { Fund } from '../useFundsData'
+import { useFundsBusy } from './helpers/fundsBusy'
 
 // Same translation mock as the DCA suite — params are echoed as JSON so the
 // relative-time bucket (relMinutes/relHours/…) is observable in the DOM:
@@ -43,6 +44,7 @@ function Harness({ initial, reload }: { initial: Fund[]; reload: () => Promise<v
   const [funds, setFunds] = useState(initial)
   return (
     <MobileFundLibraryView
+      {...useFundsBusy()}
       funds={funds}
       setFunds={setFunds}
       goals={[]}

--- a/app/(app)/funds/components/__tests__/MobileFundLibraryView.render.test.tsx
+++ b/app/(app)/funds/components/__tests__/MobileFundLibraryView.render.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, within, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MobileFundLibraryView from '../MobileFundLibraryView'
 import type { Fund } from '../useFundsData'
+import { useFundsBusy } from './helpers/fundsBusy'
 
 // Presence/render + filter coverage for the mobile Funds list. Moved off E2E per
 // the test-layering policy. The header add/refresh actions live in the mobile top
@@ -50,6 +51,7 @@ function Harness({ initial }: { initial: Fund[] }) {
   const [funds, setFunds] = useState(initial)
   return (
     <MobileFundLibraryView
+      {...useFundsBusy()}
       funds={funds}
       setFunds={setFunds}
       goals={[]}

--- a/app/(app)/funds/components/__tests__/helpers/fundsBusy.ts
+++ b/app/(app)/funds/components/__tests__/helpers/fundsBusy.ts
@@ -1,0 +1,12 @@
+import { useState } from 'react'
+import type { FundsBusy } from '../../useFundsData'
+
+/**
+ * The in-flight fund set the two views normally get from FundLibraryClient,
+ * for specs that render a single view on its own. Real state, not a stub, so a
+ * spec can assert that a busy fund's controls are disabled (#590).
+ */
+export function useFundsBusy(): FundsBusy {
+  const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set())
+  return { togglingIds, setTogglingIds }
+}

--- a/app/(app)/funds/components/__tests__/useFundMutations.test.tsx
+++ b/app/(app)/funds/components/__tests__/useFundMutations.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
 import { useFundMutations } from '../useFundMutations'
 import type { Fund } from '../useFundsData'
+import { useFundsBusy } from './helpers/fundsBusy'
 
 // The desktop and mobile fund libraries each carried their own copy of these
 // mutations, down to the optimistic update and its rollback, and the copies had
@@ -51,7 +52,9 @@ function setup(
   const reload = vi.fn(async () => {})
   const notify = vi.fn()
 
-  const { result } = renderHook(() => useFundMutations({ setFunds, reload, notify }))
+  // The busy set lives in FundLibraryClient so both views share it (#590); the
+  // hook is handed it, exactly as a view hands it down.
+  const { result } = renderHook(() => useFundMutations({ setFunds, reload, notify, ...useFundsBusy() }))
   return { result, requests, reload, notify, current: () => funds[0] }
 }
 
@@ -233,7 +236,7 @@ describe('useFundMutations — deleting', () => {
     const setFunds = vi.fn()
     const reload = vi.fn(async () => {})
     const notify = vi.fn()
-    const { result } = renderHook(() => useFundMutations({ setFunds, reload, notify }))
+    const { result } = renderHook(() => useFundMutations({ setFunds, reload, notify, ...useFundsBusy() }))
 
     let outcome: string | undefined
     await act(async () => { outcome = await result.current.deleteFund(FUND) })

--- a/app/(app)/funds/components/__tests__/useFundMutations.test.tsx
+++ b/app/(app)/funds/components/__tests__/useFundMutations.test.tsx
@@ -25,7 +25,10 @@ const FUND: Fund = {
   updated_at: '',
 }
 
-function setup(fetchImpl: (url: string, init?: RequestInit) => { ok: boolean; status?: number }) {
+function setup(
+  fetchImpl: (url: string, init?: RequestInit) => { ok: boolean; status?: number },
+  initial: Fund = FUND,
+) {
   const requests: Array<{ url: string; method: string; body: Record<string, unknown> | undefined }> = []
   vi.stubGlobal('fetch', vi.fn(async (url: string, init?: RequestInit) => {
     requests.push({
@@ -37,7 +40,7 @@ function setup(fetchImpl: (url: string, init?: RequestInit) => { ok: boolean; st
     return { ok, status: status ?? (ok ? 200 : 500) }
   }))
 
-  let funds: Fund[] = [FUND]
+  let funds: Fund[] = [initial]
   const setFunds = vi.fn((update: Fund[] | ((prev: Fund[]) => Fund[])) => {
     funds = typeof update === 'function' ? update(funds) : update
   })
@@ -91,10 +94,29 @@ describe('useFundMutations — saving the DCA amount', () => {
     expect(reload).toHaveBeenCalled()
   })
 
-  it('reverts DCA to off when the save fails', async () => {
+  // A failed save must leave the row showing what the server still has, not a
+  // blanket "DCA off" — the previous rollback lied about an untouched
+  // configuration after any transient error (#590).
+  it('restores the previously saved amount and goal when editing fails', async () => {
     const { result, notify, current } = setup(fails)
 
     await act(async () => { await result.current.saveDcaAmount(FUND, 2_000_000) })
+
+    expect(current()).toMatchObject({
+      is_dca: true,
+      dca_monthly_amount_vnd: 1_000_000,
+      dca_goal_id: 'goal-1',
+    })
+    expect(notify).toHaveBeenCalledWith('toastDcaFailed', false)
+  })
+
+  // A brand-new enable has nothing persisted behind it: the view flipped
+  // `is_dca` on locally when the editor opened, so the state to restore is off.
+  it('reverts to off when the first save of a new enable fails', async () => {
+    const enabling: Fund = { ...FUND, is_dca: true, dca_monthly_amount_vnd: null, dca_goal_id: null }
+    const { result, notify, current } = setup(fails, enabling)
+
+    await act(async () => { await result.current.saveDcaAmount(enabling, 2_000_000, true) })
 
     expect(current()).toMatchObject({ is_dca: false, dca_monthly_amount_vnd: null })
     expect(notify).toHaveBeenCalledWith('toastDcaFailed', false)

--- a/app/(app)/funds/components/__tests__/useFundMutations.test.tsx
+++ b/app/(app)/funds/components/__tests__/useFundMutations.test.tsx
@@ -137,6 +137,29 @@ describe('useFundMutations — saving the DCA amount', () => {
     expect(current()).toMatchObject({ dca_goal_id: 'goal-2', is_dca: true, dca_monthly_amount_vnd: 1_000_000 })
   })
 
+  // Both viewports stay mounted and share the funds state, so a disable can
+  // land while an amount save is still in flight. The late rollback must not
+  // resurrect the amount over it — its optimistic write is no longer what the
+  // row holds, so there is nothing of its own left to undo (#590 review).
+  it('skips the rollback when a later mutation already moved the fund', async () => {
+    let failAmountSave = () => {}
+    const amountSave = new Promise<{ ok: boolean; status: number }>((resolve) => {
+      failAmountSave = () => resolve({ ok: false, status: 500 })
+    })
+    const { result, current } = setup((_url, init) => {
+      const body = JSON.parse(init!.body as string)
+      return body.is_dca === false ? { ok: true } : amountSave
+    })
+
+    let saving: Promise<void> | undefined
+    act(() => { saving = result.current.saveDcaAmount(FUND, 2_000_000) })
+    // The other viewport turns DCA off, and the server accepts it.
+    await act(async () => { await result.current.disableDca({ ...FUND, dca_monthly_amount_vnd: 2_000_000 }) })
+    await act(async () => { failAmountSave(); await saving })
+
+    expect(current()).toMatchObject({ is_dca: false, dca_monthly_amount_vnd: null })
+  })
+
   // A brand-new enable has nothing persisted behind it: the view flipped
   // `is_dca` on locally when the editor opened, so the state to restore is off.
   it('reverts to off when the first save of a new enable fails', async () => {

--- a/app/(app)/funds/components/__tests__/useFundMutations.test.tsx
+++ b/app/(app)/funds/components/__tests__/useFundMutations.test.tsx
@@ -25,8 +25,12 @@ const FUND: Fund = {
   updated_at: '',
 }
 
+type FetchResult = { ok: boolean; status?: number }
+
 function setup(
-  fetchImpl: (url: string, init?: RequestInit) => { ok: boolean; status?: number },
+  // May return a pending promise, so a test can hold one request open while
+  // another completes.
+  fetchImpl: (url: string, init?: RequestInit) => FetchResult | Promise<FetchResult>,
   initial: Fund = FUND,
 ) {
   const requests: Array<{ url: string; method: string; body: Record<string, unknown> | undefined }> = []
@@ -36,7 +40,7 @@ function setup(
       method: init?.method ?? 'GET',
       body: init?.body ? JSON.parse(init.body as string) : undefined,
     })
-    const { ok, status } = fetchImpl(url, init)
+    const { ok, status } = await fetchImpl(url, init)
     return { ok, status: status ?? (ok ? 200 : 500) }
   }))
 
@@ -108,6 +112,29 @@ describe('useFundMutations — saving the DCA amount', () => {
       dca_goal_id: 'goal-1',
     })
     expect(notify).toHaveBeenCalledWith('toastDcaFailed', false)
+  })
+
+  // The goal selector stays live while an amount save is in flight, so the two
+  // writes can overlap. The amount rollback must stay out of the goal: rolling
+  // back to the goal this save captured would undo a goal change the server
+  // already accepted (#590 review).
+  it('leaves a goal that changed mid-flight alone when the amount save fails', async () => {
+    let failAmountSave = () => {}
+    const amountSave = new Promise<{ ok: boolean; status: number }>((resolve) => {
+      failAmountSave = () => resolve({ ok: false, status: 500 })
+    })
+    const { result, current } = setup((_url, init) => {
+      const body = JSON.parse(init!.body as string)
+      return body.dca_goal_id === 'goal-2' ? { ok: true } : amountSave
+    })
+
+    let saving: Promise<void> | undefined
+    act(() => { saving = result.current.saveDcaAmount(FUND, 2_000_000) })
+    // The goal write lands, and reloads, while the amount is still in flight.
+    await act(async () => { await result.current.setDcaGoal({ ...FUND, dca_monthly_amount_vnd: 2_000_000 }, 'goal-2') })
+    await act(async () => { failAmountSave(); await saving })
+
+    expect(current()).toMatchObject({ dca_goal_id: 'goal-2', is_dca: true, dca_monthly_amount_vnd: 1_000_000 })
   })
 
   // A brand-new enable has nothing persisted behind it: the view flipped

--- a/app/(app)/funds/components/useFundMutations.ts
+++ b/app/(app)/funds/components/useFundMutations.ts
@@ -58,6 +58,21 @@ export function useFundMutations({
   }, [setFunds])
 
   /**
+   * Undo an optimistic write, but only while the row still holds it. Both
+   * viewports stay mounted on the same funds state, so a second mutation (or
+   * its reload) can land while the first request is still out — and then the
+   * loser's rollback would overwrite a result the server actually confirmed.
+   * If our own optimistic values are gone, someone else owns those fields now.
+   */
+  const rollbackFund = useCallback((id: string, optimistic: Partial<Fund>, rollback: Partial<Fund>) => {
+    setFunds((prev) => prev.map((f) => {
+      if (f.id !== id) return f
+      const stillOurs = Object.entries(optimistic).every(([key, value]) => f[key as keyof Fund] === value)
+      return stillOurs ? { ...f, ...rollback } : f
+    }))
+  }, [setFunds])
+
+  /**
    * Every DCA write is a full PUT: the route's partial-update semantics key off
    * whether `is_dca` is present, and the unchanged columns have to come along or
    * they'd be overwritten with undefined.
@@ -85,7 +100,8 @@ export function useFundMutations({
    * call site is what produced #590: the amount save rolled back to a blanket
    * "DCA off", so a transient error told the user their configuration was gone
    * while the server still had it. `rollbackOverride` exists for the one case
-   * the fund object can't describe — see `saveDcaAmount`.
+   * the fund object can't describe — see `saveDcaAmount`. The undo itself is
+   * conditional: see `rollbackFund`.
    */
   const persist = useCallback(async (
     fund: Fund,
@@ -104,12 +120,12 @@ export function useFundMutations({
       if (!res.ok) throw new Error()
       await reload()
     } catch {
-      patchFund(fund.id, rollback)
+      rollbackFund(fund.id, optimistic, rollback)
       notify(failureMessage, false)
     } finally {
       setTogglingIds((prev) => { const next = new Set(prev); next.delete(fund.id); return next })
     }
-  }, [patchFund, putFund, reload, notify])
+  }, [patchFund, rollbackFund, putFund, reload, notify])
 
   const disableDca = useCallback((fund: Fund) => persist(
     fund,

--- a/app/(app)/funds/components/useFundMutations.ts
+++ b/app/(app)/funds/components/useFundMutations.ts
@@ -24,8 +24,14 @@ export interface FundMutations {
   togglingIds: Set<string>
   /** Turn DCA off and persist it. */
   disableDca: (fund: Fund) => Promise<void>
-  /** Persist a validated monthly amount, keeping the fund's existing goal. */
-  saveDcaAmount: (fund: Fund, amount: number) => Promise<void>
+  /**
+   * Persist a validated monthly amount, keeping the fund's existing goal.
+   *
+   * @param isNewEnable this is the first save of a DCA the view just toggled
+   *   on, so nothing is persisted behind it — a failure goes back to DCA off
+   *   rather than to the fund's (locally already-enabled) state.
+   */
+  saveDcaAmount: (fund: Fund, amount: number, isNewEnable?: boolean) => Promise<void>
   setDcaGoal: (fund: Fund, goalId: string | null) => Promise<void>
   deleteFund: (fund: Fund) => Promise<DeleteOutcome>
 }
@@ -73,14 +79,24 @@ export function useFundMutations({
   /**
    * Apply an optimistic change, persist it, and undo it if the request fails.
    * One place, so the two viewports can't drift on when a rollback happens.
+   *
+   * The undo is the fund's own values for exactly the fields the optimistic
+   * update touched, captured before the write. Spelling the rollback out per
+   * call site is what produced #590: the amount save rolled back to a blanket
+   * "DCA off", so a transient error told the user their configuration was gone
+   * while the server still had it. `rollbackOverride` exists for the one case
+   * the fund object can't describe — see `saveDcaAmount`.
    */
   const persist = useCallback(async (
     fund: Fund,
     optimistic: Partial<Fund>,
     body: Partial<Fund>,
-    rollback: Partial<Fund>,
     failureMessage: string,
+    rollbackOverride?: Partial<Fund>,
   ) => {
+    const rollback: Partial<Fund> = rollbackOverride ?? Object.fromEntries(
+      Object.keys(optimistic).map((key) => [key, fund[key as keyof Fund]]),
+    )
     patchFund(fund.id, optimistic)
     setTogglingIds((prev) => new Set(prev).add(fund.id))
     try {
@@ -99,25 +115,23 @@ export function useFundMutations({
     fund,
     { is_dca: false, dca_monthly_amount_vnd: null },
     { is_dca: false, dca_monthly_amount_vnd: null },
-    { is_dca: true },
     t('toastDcaFailed'),
   ), [persist, t])
 
-  const saveDcaAmount = useCallback((fund: Fund, amount: number) => persist(
+  const saveDcaAmount = useCallback((fund: Fund, amount: number, isNewEnable = false) => persist(
     fund,
-    { is_dca: true, dca_monthly_amount_vnd: amount },
     { is_dca: true, dca_monthly_amount_vnd: amount, dca_goal_id: fund.dca_goal_id },
-    // A failed save leaves nothing persisted, so the row goes back to DCA off
-    // rather than showing an amount the server never accepted.
-    { is_dca: false, dca_monthly_amount_vnd: null },
+    { is_dca: true, dca_monthly_amount_vnd: amount, dca_goal_id: fund.dca_goal_id },
     t('toastDcaFailed'),
+    // Turning DCA on flips `is_dca` locally before anything is persisted, so on
+    // a first save the fund's own state isn't what to restore — off is (#2).
+    isNewEnable ? { is_dca: false, dca_monthly_amount_vnd: null } : undefined,
   ), [persist, t])
 
   const setDcaGoal = useCallback((fund: Fund, goalId: string | null) => persist(
     fund,
     { dca_goal_id: goalId },
     { is_dca: true, dca_monthly_amount_vnd: fund.dca_monthly_amount_vnd, dca_goal_id: goalId },
-    { dca_goal_id: fund.dca_goal_id },
     t('toastGoalFailed'),
   ), [persist, t])
 

--- a/app/(app)/funds/components/useFundMutations.ts
+++ b/app/(app)/funds/components/useFundMutations.ts
@@ -120,7 +120,11 @@ export function useFundMutations({
 
   const saveDcaAmount = useCallback((fund: Fund, amount: number, isNewEnable = false) => persist(
     fund,
-    { is_dca: true, dca_monthly_amount_vnd: amount, dca_goal_id: fund.dca_goal_id },
+    // Amount fields only, so the derived rollback stays out of the goal: the
+    // goal selector is live while this is in flight, and a goal change that
+    // lands first is the server's truth — restoring the goal captured here
+    // would undo it.
+    { is_dca: true, dca_monthly_amount_vnd: amount },
     { is_dca: true, dca_monthly_amount_vnd: amount, dca_goal_id: fund.dca_goal_id },
     t('toastDcaFailed'),
     // Turning DCA on flips `is_dca` locally before anything is persisted, so on

--- a/app/(app)/funds/components/useFundMutations.ts
+++ b/app/(app)/funds/components/useFundMutations.ts
@@ -1,9 +1,9 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useCallback } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import { useTranslations } from 'next-intl'
-import type { Fund } from './useFundsData'
+import type { Fund, FundsBusy } from './useFundsData'
 
 // The persistence half of the Fund Library's DCA and delete actions, shared by
 // DesktopFundLibraryView and MobileFundLibraryView. Both used to carry their own
@@ -20,7 +20,11 @@ import type { Fund } from './useFundsData'
 export type DeleteOutcome = 'deleted' | 'in-use' | 'failed'
 
 export interface FundMutations {
-  /** Funds with a request in flight — views disable their controls on these. */
+  /**
+   * Funds with a request in flight — views disable their controls on these.
+   * Passed straight back out from the shared set both views were given, so a
+   * request started before a resize still reads as busy afterwards (#590).
+   */
   togglingIds: Set<string>
   /** Turn DCA off and persist it. */
   disableDca: (fund: Fund) => Promise<void>
@@ -40,18 +44,23 @@ export interface FundMutations {
  * @param notify presentation is the one thing left to the view — the desktop
  *   toast takes a boolean, the mobile one a string. Both get the same message
  *   and the same success flag.
+ * @param togglingIds owned by FundLibraryClient, not by this hook: both views
+ *   are mounted at once and each calls this hook, so a set per instance would
+ *   let the view a resize hands the user start a write on a fund the other one
+ *   still has in flight (#590).
  */
 export function useFundMutations({
   setFunds,
   reload,
   notify,
+  togglingIds,
+  setTogglingIds,
 }: {
   setFunds: Dispatch<SetStateAction<Fund[]>>
   reload: () => Promise<void>
   notify: (message: string, ok: boolean) => void
-}): FundMutations {
+} & FundsBusy): FundMutations {
   const t = useTranslations('funds')
-  const [togglingIds, setTogglingIds] = useState<Set<string>>(new Set())
 
   const patchFund = useCallback((id: string, changes: Partial<Fund>) => {
     setFunds((prev) => prev.map((f) => (f.id === id ? { ...f, ...changes } : f)))
@@ -125,7 +134,7 @@ export function useFundMutations({
     } finally {
       setTogglingIds((prev) => { const next = new Set(prev); next.delete(fund.id); return next })
     }
-  }, [patchFund, rollbackFund, putFund, reload, notify])
+  }, [patchFund, rollbackFund, putFund, reload, notify, setTogglingIds])
 
   const disableDca = useCallback((fund: Fund) => persist(
     fund,

--- a/app/(app)/funds/components/useFundsData.ts
+++ b/app/(app)/funds/components/useFundsData.ts
@@ -34,6 +34,16 @@ export interface FundsData {
   reload: () => Promise<void>
 }
 
+/**
+ * Funds with a DCA request in flight, owned by FundLibraryClient so both
+ * mounted views share one set — a save started before a resize still counts as
+ * busy in the view the user lands on (#590).
+ */
+export interface FundsBusy {
+  togglingIds: Set<string>
+  setTogglingIds: Dispatch<SetStateAction<Set<string>>>
+}
+
 // ─── Cache ──────────────────────────────────────────────────────────────────
 
 const CACHE_KEY = 'fundLibraryCache'

--- a/e2e/funds-desktop.spec.ts
+++ b/e2e/funds-desktop.spec.ts
@@ -66,6 +66,38 @@ test('DCA enabled on desktop is reflected when switching to mobile viewport', as
   await expect(card.getByRole('button', { name: /disable dca|tắt dca/i })).toBeVisible({ timeout: 5_000 })
 })
 
+// The "brand-new enable" marker is per-view editor state while the funds copy
+// is shared, so a pending enable crossing the breakpoint would look like an
+// existing DCA to the other view — and a first failed save would then restore
+// a locally enabled row the server never had (#590). It can't: hiding the
+// desktop view blurs its focused amount input, which cancels the pending
+// enable. Only a real browser does that — jsdom keeps focus on hidden nodes —
+// so this invariant can only be pinned here.
+test('a pending DCA enable does not survive crossing to the mobile viewport (#590)', async ({ page }) => {
+  const fund = await api.createFund({ name: 'E2E Pending Enable Handoff', code: 'DPENDH', fund_type: 'equity', nav: 20000 })
+  cleanup.add(() => api.deleteFund(fund.id))
+
+  const puts: string[] = []
+  page.on('request', r => {
+    if (r.method() === 'PUT' && r.url().includes(`/api/funds/${fund.id}`)) puts.push(r.url())
+  })
+
+  await page.goto('/funds')
+  await page.waitForLoadState('networkidle')
+
+  // Toggle DCA on and leave the amount editor open — nothing is persisted yet.
+  const row = page.getByTestId('desktop-funds-table').getByTestId(`fund-row-${fund.id}`)
+  await row.getByTestId('dca-toggle').click()
+  await expect(row.getByTestId(`dca-amount-input-${fund.id}`)).toBeVisible()
+
+  await page.setViewportSize({ width: 390, height: 844 })
+
+  // The mobile card shows DCA off, and nothing was written.
+  const card = page.getByTestId('mobile-funds').getByTestId(`fund-card-${fund.id}`)
+  await expect(card.getByRole('button', { name: /enable dca|bật dca/i })).toBeVisible({ timeout: 5_000 })
+  expect(puts).toEqual([])
+})
+
 test('desktop funds DCA goal selection persists across reload', async ({ page }) => {
   const goal = await api.createGoal({ goal_name: 'E2E Desktop DCA Goal Target' })
   cleanup.add(() => api.deleteGoal(goal.goal_id))


### PR DESCRIPTION
Closes #590.

## Problem

`useFundMutations.saveDcaAmount` rolled back to a hard-coded `is_dca: false` / amount `null` on every failed save. That path serves both enabling DCA and editing an already-enabled amount, so after a transient network/server error the row claimed DCA was off while the server still held the previous enabled configuration — a lie until the next reload.

## Fix

`persist` now derives the rollback from the fund's own values for exactly the fields the optimistic update touched, captured before the write. One rule for every mutation instead of a per-call-site guess (`disableDca` now also restores the amount it cleared, not just `is_dca`).

The one case the fund object can't describe is the first save of a DCA the view just toggled on: `is_dca` is already `true` locally with nothing persisted behind it. Both views pass that through as `saveDcaAmount(fund, amount, isNewEnable)`, and it still reverts to off.

## Tests (TDD — red first)

- `useFundMutations.test.tsx`: the old "reverts DCA to off when the save fails" assertion is replaced by two — a failed *edit* restores the previous amount and goal, and a failed *new enable* still reverts to off.
- `DesktopFundLibraryView.dca.test.tsx` / `MobileFundLibraryView.dca.test.tsx`: one smoke assertion each that both viewports recover consistently — the failed edit keeps the row/card enabled at its saved amount, and the failed new enable leaves it off.

Kept at the component layer rather than E2E, per CLAUDE.md (no desktop+mobile E2E pair for the same logic).

## Checks

- `npm run typecheck` ✅
- `npm test -- --run` ✅ 1872 passed
- `npx eslint` ✅
- `npx playwright test e2e/funds.spec.ts e2e/funds-desktop.spec.ts --project=chromium` ✅ 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)