### PR TITLE
fix(dates): derive every business date in Asia/Ho_Chi_Minh (#591)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,23 @@ path that recomputes the same value. Close the loop: action → assert the rende
 But "rendered outcome" usually means a component test asserting the rendered DOM from props —
 not a full E2E. Reach for E2E only when the loop itself crosses the network/DB boundary.
 
+## Business dates — one timezone, one helper
+
+The app has exactly **one business timezone: `Asia/Ho_Chi_Minh` (UTC+7)**. Every
+"today", "current month", and plain-date comparison is derived in that zone, wherever
+the code runs — a browser in any timezone, a Vercel function in UTC, a cron job.
+
+Use `lib/dates`: `todayIso()`, `businessYearMonth()`, `businessTodayDate()`,
+`daysUntilIso()`. Never derive a business date from UTC
+(`new Date().toISOString().slice(0, 10)`) or from the runtime's local zone
+(`new Date().getMonth()`) — between 00:00 and 06:59 Vietnam time the UTC date is still
+*yesterday*, which recorded transactions on the wrong day and filed contributions under
+the wrong month (#591). An eslint `no-restricted-syntax` rule blocks both idioms in
+`app/`, `lib/`, and `components/`.
+
+`new Date().toISOString()` on its own is fine and correct for *timestamps*
+(`updated_at`, `created_at`) — those are instants, not business dates.
+
 ## What to run before opening a PR
 
 E2E was removed from CI (PR #313) and runs **locally only** — so local checks are

--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -8,6 +8,7 @@ import { useNavigation } from '@/app/components/navigation/NavigationContext'
 import MobilePlanningView from './components/MobilePlanningView'
 import DesktopPlanningView from './components/DesktopPlanningView'
 import { useAdoptCacheOnce } from '@/lib/useHydrated'
+import { businessYearMonth } from '@/lib/dates'
 
 export interface MonthlyPlan {
   id: string
@@ -130,9 +131,10 @@ export default function PlanningClient() {
   const isVI = locale === 'vi'
   const { setMobileTopBar } = useNavigation()
   const MONTHS = t('months').split(',')
-  const now = new Date()
-  const initialMonth = now.getMonth() + 1
-  const initialYear = now.getFullYear()
+  // The plan opens on the *business* month (see lib/dates) — deriving it from the
+  // browser's local zone put a user abroad, or one loading the page between 00:00
+  // and 06:59 Vietnam time in a UTC browser, on the wrong month's plan (#591).
+  const { year: initialYear, month: initialMonth } = businessYearMonth()
   // Start where the server starts. These used to seed from getPlanCache(), but a
   // useState initialiser runs during the *hydration* render and the server has no
   // localStorage — so a warm cache made the client render the real cards over
@@ -308,9 +310,9 @@ export default function PlanningClient() {
   }, [month, year])
 
   const navigateToday = useCallback(() => {
-    const now = new Date()
-    setMonth(now.getMonth() + 1)
-    setYear(now.getFullYear())
+    const { year, month } = businessYearMonth()
+    setMonth(month)
+    setYear(year)
   }, [])
 
   useEffect(() => {

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -24,6 +24,7 @@ import { usePlanningDerivations } from '../usePlanningDerivations'
 import { usePlanningActions, buildBuyEdit, buildContributionPrefill } from '../usePlanningActions'
 import { saveIncome, deletePlan, saveOtherExpense } from '../planActions'
 import { relationshipLabel } from '@/app/assets/components/insuranceShared'
+import { businessYearMonth } from '@/lib/dates'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
   InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, RecurringFulfillment, DcaSkip, Fund, Goal,
@@ -130,8 +131,8 @@ export default function DesktopPlanningView({
   const longMonths  = isVI ? LONG_MONTHS_VI  : LONG_MONTHS_EN
   const monthLabel  = `${longMonths[month - 1]} ${year}`
   const shortLabel  = `${shortMonths[month - 1]} ${year}`
-  const todayD      = new Date()
-  const isCurrentMonth = month === todayD.getMonth() + 1 && year === todayD.getFullYear()
+  const today       = businessYearMonth()
+  const isCurrentMonth = month === today.month && year === today.year
 
   // ── API handlers ──
   // Skip/restore/override/record actions are shared with the mobile view via

--- a/app/(app)/planning/usePlanningActions.ts
+++ b/app/(app)/planning/usePlanningActions.ts
@@ -1,4 +1,5 @@
 import { toast } from 'sonner'
+import { todayIso } from '@/lib/dates'
 import type { GoalItem, GoalRow } from '@/lib/planning'
 import type { EditableTransaction, PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import type { BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
@@ -23,7 +24,7 @@ export function buildBuyEdit(
   return {
     transaction_id: inv.transaction_id,
     asset_type: 'fund',
-    investment_date: inv.investment_date ?? new Date().toISOString().slice(0, 10),
+    investment_date: inv.investment_date ?? todayIso(),
     amount_vnd: inv.amount_vnd,
     unit_price: inv.unit_price,
     units: inv.units,
@@ -45,7 +46,7 @@ export function buildContributionPrefill(
   return {
     goal_id: entry.isUnallocated ? null : entry.goalId,
     plan_id: planId,
-    investment_date: new Date().toISOString().slice(0, 10),
+    investment_date: todayIso(),
     ...prefill,
   }
 }
@@ -198,7 +199,7 @@ export function usePlanningActions(ctx: PlanningActionsCtx) {
           const dep = await res.json()
           const isBookAnchor = dep.deposit_group_id && dep.deposit_group_id === dep.transaction_id
           if (isBookAnchor) {
-            const matured = dep.expiry_date && dep.expiry_date < new Date().toISOString().slice(0, 10)
+            const matured = dep.expiry_date && dep.expiry_date < todayIso()
             if (matured) {
               onToast(isVI ? 'Sổ đã đáo hạn — hãy xử lý đáo hạn trước.' : 'This book has matured — handle its maturity first.')
               return { kind: 'matured' }

--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -5,6 +5,7 @@ import { buildWithdrawalMaps } from '@/lib/withdrawalProgress'
 import { heldForMergeContributions } from '@/lib/heldForMerge'
 import { valueNonFundHolding } from '@/lib/depositValuation'
 import { shouldWriteSnapshot } from '@/lib/snapshots'
+import { todayIso } from '@/lib/dates'
 
 export const dynamic = 'force-dynamic'
 
@@ -61,9 +62,11 @@ export async function GET() {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  // Today's date (server local) — used both to read the existing snapshot below
-  // and to upsert it at the end.
-  const today = new Date().toISOString().split('T')[0]
+  // The business day (Asia/Ho_Chi_Minh, see lib/dates) — used both to read the
+  // existing snapshot below and to upsert it at the end. Derived in that zone,
+  // not from the server's UTC clock, or a snapshot taken between 00:00 and 06:59
+  // Vietnam time would be filed under the previous day (#591).
+  const today = todayIso()
   // Pin interest accrual to UTC midnight so the displayed networth is stable
   // across multiple API calls within the same day. Using Date.now() makes
   // calcProjectedInterest return a slightly different value every millisecond —

--- a/app/api/v1/fund-investments/route.ts
+++ b/app/api/v1/fund-investments/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateUUID } from '@/lib/validation'
 import { readJsonBody } from '@/lib/apiBody'
+import { todayIso } from '@/lib/dates'
 
 export async function GET(request: NextRequest) {
   const supabase = await createSupabaseServerClient()
@@ -75,7 +76,7 @@ export async function POST(request: NextRequest) {
     if (plan_id) cleanPlanId = validateUUID(plan_id, 'plan_id')
     cleanInvestmentDate = investment_date
       ? validateDate(investment_date, 'investment_date')
-      : new Date().toISOString().slice(0, 10)
+      : todayIso()
   } catch (e) {
     if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
     throw e

--- a/app/api/v1/insurance-members/[id]/mark-paid/route.ts
+++ b/app/api/v1/insurance-members/[id]/mark-paid/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateUUID, validateDate } from '@/lib/validation'
 import { readJsonBody } from '@/lib/apiBody'
+import { todayIso } from '@/lib/dates'
 
 function err(status: number, code: string, message: string) {
   return NextResponse.json({ error: code, message }, { status })
@@ -34,9 +35,11 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
   if (member.user_id !== user.id) return err(403, 'FORBIDDEN', "You don't have permission to mark this payment")
 
   // Optional payment date from the body — when the user records the payment on a
-  // date other than today. Defaults to today when absent.
+  // date other than today. Defaults to the business day (Asia/Ho_Chi_Minh) when
+  // absent: the server clock is UTC, which between 00:00 and 06:59 Vietnam time
+  // would settle the premium against the previous date (#591).
   const now = new Date()
-  let paidISO = now.toISOString().split('T')[0]
+  let paidISO = todayIso(now)
   // Optional: no body at all is the documented "paid today" case. A body that is
   // present but unparseable is a client mistake, and used to be swallowed into
   // that same default rather than reported (#566).

--- a/app/api/v1/insurance-members/[id]/mark-paid/route.ts
+++ b/app/api/v1/insurance-members/[id]/mark-paid/route.ts
@@ -38,6 +38,10 @@ export async function POST(_req: NextRequest, { params }: { params: Promise<{ id
   // date other than today. Defaults to the business day (Asia/Ho_Chi_Minh) when
   // absent: the server clock is UTC, which between 00:00 and 06:59 Vietnam time
   // would settle the premium against the previous date (#591).
+  // The one place the clock is aliased: `updated_at`, the value read back for the
+  // response, and the audit line must all name the *same* instant. That's a UTC
+  // timestamp, not a business date — the business date is derived from it below.
+  // eslint-disable-next-line no-restricted-syntax
   const now = new Date()
   let paidISO = todayIso(now)
   // Optional: no body at all is the documented "paid today" case. A body that is

--- a/app/api/v1/investment-transactions/[id]/collapse/route.ts
+++ b/app/api/v1/investment-transactions/[id]/collapse/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateRate, validateUUID } from '@/lib/validation'
-import { isFutureInvestmentDate } from '@/lib/dates'
+import { isFutureInvestmentDate, MATURITY_ANCHOR_GRACE_DAYS } from '@/lib/dates'
 import { buildCollapsePlan, type CollapseTrancheInput } from '@/lib/accumulating'
 import { readJsonBody } from '@/lib/apiBody'
 
@@ -59,7 +59,8 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     throw e
   }
 
-  if (isFutureInvestmentDate(cleanInvestmentDate)) {
+  // Same maturity anchor as renew: the book's old maturity can be a day out (#591).
+  if (isFutureInvestmentDate(cleanInvestmentDate, new Date(), MATURITY_ANCHOR_GRACE_DAYS)) {
     return NextResponse.json({ error: 'Investment date cannot be in the future.' }, { status: 400 })
   }
   // The new cycle must have positive length (ISO date strings sort chronologically).

--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateBankCode, validateDate, validateRate, validateUUID } from '@/lib/validation'
-import { isFutureInvestmentDate } from '@/lib/dates'
+import { isFutureInvestmentDate, MATURITY_ANCHOR_GRACE_DAYS } from '@/lib/dates'
 import { isTermDeposit } from '@/lib/maturity'
 import { readJsonBody } from '@/lib/apiBody'
 
@@ -102,7 +102,10 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     throw e
   }
 
-  if (isFutureInvestmentDate(cleanInvestmentDate)) {
+  // Anchored to the OLD maturity date, which the reminder window can surface a day
+  // before it falls — hence the grace. Without it the sheet's enabled "Confirm
+  // renewal" button 400s for a deposit maturing tomorrow (#591).
+  if (isFutureInvestmentDate(cleanInvestmentDate, new Date(), MATURITY_ANCHOR_GRACE_DAYS)) {
     return NextResponse.json({ error: 'Investment date cannot be in the future.' }, { status: 400 })
   }
 

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateBankCode, validateDate, validateEnum, validateNotes, validateRate, validateUUID } from '@/lib/validation'
 import { readJsonBody } from '@/lib/apiBody'
+import { isFutureInvestmentDate } from '@/lib/dates'
 
 const ASSET_TYPES = ['fund', 'bank', 'stock', 'gold'] as const
 
@@ -101,7 +102,10 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     throw e
   }
 
-  if (cleanInvestmentDate && new Date(cleanInvestmentDate) > new Date()) {
+  // The same business-day check POST uses. Comparing `new Date(date) > new Date()`
+  // parsed the plain date at UTC midnight, so between 00:00 and 06:59 Vietnam time
+  // an edit was refused for the very date creation had just accepted (#591).
+  if (cleanInvestmentDate && isFutureInvestmentDate(cleanInvestmentDate)) {
     return NextResponse.json({ error: 'Investment date cannot be in the future.' }, { status: 400 })
   }
 

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'crypto'
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateBankCode, validateDate, validateEnum, validateNotes, validatePositiveIntParam, validateRate, validateUUID } from '@/lib/validation'
-import { isFutureInvestmentDate } from '@/lib/dates'
+import { isFutureInvestmentDate, todayIso } from '@/lib/dates'
 import { readJsonBody } from '@/lib/apiBody'
 
 const ASSET_TYPES = ['fund', 'bank', 'stock', 'gold'] as const
@@ -327,7 +327,7 @@ export async function POST(request: NextRequest) {
     // A matured book is closed: a new tranche dated today would sit past the
     // book's maturity and accrue zero interest (capped at expiry) — i.e. money
     // silently into a dead book. Block it.
-    if (anchor.expiry_date && anchor.expiry_date < new Date().toISOString().slice(0, 10)) {
+    if (anchor.expiry_date && anchor.expiry_date < todayIso()) {
       return NextResponse.json({ error: 'Cannot top up a deposit that has already matured.' }, { status: 400 })
     }
     depositGroupId = anchor.deposit_group_id

--- a/app/api/v1/report/route.ts
+++ b/app/api/v1/report/route.ts
@@ -7,6 +7,7 @@ import type { ReactElement } from 'react'
 import { PortfolioReport } from '@/components/report/PortfolioReport'
 import type { DashboardData } from '@/app/assets/DashboardClient'
 import { readJsonBody } from '@/lib/apiBody'
+import { todayIso } from '@/lib/dates'
 
 export async function POST(req: NextRequest) {
   try {
@@ -23,7 +24,7 @@ export async function POST(req: NextRequest) {
 
     const buffer = await renderToBuffer(element)
 
-    const filename = `allocate-report-${new Date().toISOString().slice(0, 10)}.pdf`
+    const filename = `allocate-report-${todayIso()}.pdf`
 
     return new Response(new Uint8Array(buffer), {
       headers: {

--- a/app/assets/components/AddInsuranceMemberModal.tsx
+++ b/app/assets/components/AddInsuranceMemberModal.tsx
@@ -5,6 +5,7 @@ import { Plus, X } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
 import { formatIntVN, parseIntVN } from '@/lib/numberFormat'
 import { COVERAGE_OPTIONS } from './insuranceShared'
+import { todayIso } from '@/lib/dates'
 
 interface Props {
   open: boolean
@@ -20,7 +21,7 @@ export default function AddInsuranceMemberModal({ open, onClose, onCreated, loca
   const [name, setName] = useState('')
   const [coverage, setCoverage] = useState('Self')
   const [premium, setPremium] = useState<number>(12_000_000)
-  const [startDate, setStartDate] = useState(() => new Date().toISOString().slice(0, 10))
+  const [startDate, setStartDate] = useState(() => todayIso())
   const [submitting, setSubmitting] = useState(false)
   const [error, setError] = useState<string | null>(null)
   // Keep the mobile sheet mounted through its slide-down exit animation.
@@ -33,7 +34,7 @@ export default function AddInsuranceMemberModal({ open, onClose, onCreated, loca
       setName('')
       setCoverage('Self')
       setPremium(12_000_000)
-      setStartDate(new Date().toISOString().slice(0, 10))
+      setStartDate(todayIso())
       setSubmitting(false)
       setError(null)
     } else {

--- a/app/assets/components/CreateGoalSheet.tsx
+++ b/app/assets/components/CreateGoalSheet.tsx
@@ -8,6 +8,7 @@ import { fmt } from '@/lib/formatters'
 import { formatIntVN, parseIntVN } from '@/lib/numberFormat'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
 import { useDialogMount, useResetOnOpen } from '@/app/(app)/planning/components/useDialogMount'
+import { monthsUntilYm } from '@/lib/dates'
 
 interface Props {
   open: boolean
@@ -26,12 +27,6 @@ const GOAL_ICONS = [
 
 const PRIORITY_KEYS = ['low', 'med', 'high'] as const
 type PriorityKey = typeof PRIORITY_KEYS[number]
-
-function monthsUntil(ym: string): number {
-  const [y, m] = ym.split('-').map(Number)
-  const now = new Date()
-  return Math.max(1, (y - now.getFullYear()) * 12 + (m - 1 - now.getMonth()))
-}
 
 export function CreateGoalSheet({ open, onClose, onSuccess, desktop }: Props) {
   const tg = useTranslations('goals')
@@ -61,9 +56,9 @@ export function CreateGoalSheet({ open, onClose, onSuccess, desktop }: Props) {
   const perMonth = (() => {
     const amount = Number(target)
     if (!amount || !targetDate) return null
-    return Math.round(amount / monthsUntil(targetDate))
+    return Math.round(amount / monthsUntilYm(targetDate))
   })()
-  const months = targetDate ? monthsUntil(targetDate) : null
+  const months = targetDate ? monthsUntilYm(targetDate) : null
 
   async function handleSave() {
     if (!name.trim()) { setError(tg('nameRequired')); return }

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -21,6 +21,7 @@ import { SellWithdrawSheet } from './SellWithdrawSheet'
 import { invToSellItem } from './invToSellItem'
 import { useTranslations } from 'next-intl'
 import { useResetOnOpen, useResetOnChange } from '@/app/(app)/planning/components/useDialogMount'
+import { monthsUntilYm } from '@/lib/dates'
 
 interface Props {
   goal: GoalData
@@ -878,12 +879,7 @@ function EditGoalModal({ open, onClose, goal, onSaved, isVi }: {
     setError('')
   }, goal)
 
-  const monthsTo = (() => {
-    if (!date) return 1
-    const [y, m] = date.split('-').map(Number)
-    const now = new Date()
-    return Math.max(1, (y - now.getFullYear()) * 12 + (m - 1 - now.getMonth()))
-  })()
+  const monthsTo = date ? monthsUntilYm(date) : 1
   const perMonth = target ? Number(target) / monthsTo : 0
 
   async function handleSave() {

--- a/app/assets/components/DownloadReportSheet.tsx
+++ b/app/assets/components/DownloadReportSheet.tsx
@@ -6,6 +6,7 @@ import { iconHit } from './iconHit'
 import { useLocale } from 'next-intl'
 import { fmt } from '@/lib/formatters'
 import { CairnLoader } from '@/app/components/ui/CairnLoader'
+import { formatBusinessDate } from '@/lib/dates'
 import { useDialogA11y } from '@/app/(app)/planning/components/useDialogA11y'
 import { useDialogMount, useResetOnOpen } from '@/app/(app)/planning/components/useDialogMount'
 
@@ -50,7 +51,8 @@ export default function DownloadReportSheet({ open, onClose, data, onExport, des
 
   if (desktop ? !open : !mounted) return null
 
-  const today = new Date().toLocaleDateString(isVI ? 'vi-VN' : 'en-GB', { day: 'numeric', month: 'long', year: 'numeric' })
+  // The "as of" day must match the day the data is keyed to, not the browser's.
+  const today = formatBusinessDate(isVI ? 'vi-VN' : 'en-GB', { day: 'numeric', month: 'long', year: 'numeric' })
 
   const t = isVI ? {
     title: 'Báo cáo danh mục',

--- a/app/assets/components/LogInsurancePaymentModal.tsx
+++ b/app/assets/components/LogInsurancePaymentModal.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { Check, Shield, X } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
 import { formatIntVN, parseIntVN } from '@/lib/numberFormat'
+import { todayIso } from '@/lib/dates'
 import type { InsuranceData } from '../DashboardClient'
 
 interface Props {
@@ -17,18 +18,13 @@ interface Props {
   settle?: boolean
 }
 
-function todayLocalISO(): string {
-  const n = new Date()
-  return `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, '0')}-${String(n.getDate()).padStart(2, '0')}`
-}
-
 export default function LogInsurancePaymentModal({ open, onClose, onSaved, ins, locale, settle = false }: Props) {
   const isVi = locale === 'vi'
   // In settle mode you're paying the whole annual premium; otherwise suggest a
   // single monthly contribution.
   const suggested = ins ? (settle ? ins.annualPremium : Math.round(ins.annualPremium / 12)) : 0
   const [amount, setAmount] = useState('')
-  const [date, setDate] = useState(todayLocalISO)
+  const [date, setDate] = useState(() => todayIso())
   const [submitting, setSubmitting] = useState(false)
   const [done, setDone] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -36,7 +32,7 @@ export default function LogInsurancePaymentModal({ open, onClose, onSaved, ins, 
   useEffect(() => {
     if (open) {
       setAmount('')
-      setDate(todayLocalISO())
+      setDate(todayIso())
       setSubmitting(false)
       setDone(false)
       setError(null)

--- a/app/assets/components/RecurringBookTopUpSheet.tsx
+++ b/app/assets/components/RecurringBookTopUpSheet.tsx
@@ -11,6 +11,7 @@
 import { useEffect, useState, type CSSProperties } from 'react'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 import { fmtCompact } from '@/lib/formatters'
+import { todayIso } from '@/lib/dates'
 
 export interface BookTopUpTarget {
   savingId: string
@@ -39,7 +40,7 @@ export default function RecurringBookTopUpSheet({
 }) {
   const [amount, setAmount] = useState('')
   const [rate, setRate] = useState('')
-  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10))
+  const [date, setDate] = useState(() => todayIso())
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
 
@@ -48,7 +49,7 @@ export default function RecurringBookTopUpSheet({
     if (!target) return
     setAmount(String(target.amount))
     setRate(target.rate != null ? String(Math.round(target.rate * 10) / 10) : '')
-    setDate(new Date().toISOString().slice(0, 10))
+    setDate(todayIso())
     setError('')
   }, [target])
 

--- a/app/assets/components/__tests__/LogInsurancePaymentModal.test.tsx
+++ b/app/assets/components/__tests__/LogInsurancePaymentModal.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import LogInsurancePaymentModal from '../LogInsurancePaymentModal'
 import type { InsuranceData } from '../../DashboardClient'
+import { todayIso } from '@/lib/dates'
 
 const ins: InsuranceData = {
   insuranceId: 'ins-1',
@@ -23,7 +24,10 @@ beforeEach(() => {
 })
 
 describe('LogInsurancePaymentModal (issue #223)', () => {
-  it('posts the amount and the local saved_date', async () => {
+  // The date defaults to the business day (Asia/Ho_Chi_Minh), not the browser's
+  // local one — otherwise a contribution logged abroad, or in a UTC browser
+  // between 00:00 and 06:59 Vietnam time, is filed under the wrong day (#591).
+  it('posts the amount and the business saved_date', async () => {
     render(<LogInsurancePaymentModal open ins={ins} locale="en" onClose={vi.fn()} onSaved={vi.fn()} />)
 
     await userEvent.type(screen.getByRole('textbox'), '1500000')
@@ -35,8 +39,7 @@ describe('LogInsurancePaymentModal (issue #223)', () => {
     const body = JSON.parse((init as RequestInit).body as string)
     expect(body.amount_saved_vnd).toBe(1_500_000)
 
-    const now = new Date()
-    const expected = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
+    const expected = todayIso()
     expect(body.saved_date).toBe(expected)
   })
 })
@@ -66,8 +69,7 @@ describe('LogInsurancePaymentModal — settle mode', () => {
     expect(url).toBe('/api/v1/insurance-members/ins-1/mark-paid')
     expect((init as RequestInit).method).toBe('POST')
     const body = JSON.parse((init as RequestInit).body as string)
-    const now = new Date()
-    const expected = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`
+    const expected = todayIso()
     expect(body.paid_date).toBe(expected)
   })
 })

--- a/app/assets/components/__tests__/MaturityActionCard.test.tsx
+++ b/app/assets/components/__tests__/MaturityActionCard.test.tsx
@@ -3,12 +3,14 @@ import { render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MaturityActionCard from '../MaturityActionCard'
 import type { InvRow } from '../goalDetailShared'
+import { todayIso, addDaysIso } from '@/lib/dates'
 
+// Built on the BUSINESS calendar, because that is what daysUntil/fmtMaturity
+// measure against. Deriving these from the runtime's local clock made every
+// maturity assertion off by one whenever the runner's date differed from
+// Vietnam's — on a UTC runner, that is 17:00–23:59 every day (#591).
 function daysFromNow(n: number): string {
-  const d = new Date()
-  d.setHours(0, 0, 0, 0)
-  d.setDate(d.getDate() + n)
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  return addDaysIso(todayIso(), n)
 }
 
 const mk = (over: Partial<InvRow>): InvRow => ({

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -7,13 +7,15 @@ import { fmt } from '@/lib/formatters'
 import { formatIntVN } from '@/lib/numberFormat'
 import { SUCCESS_FLASH_MS } from '../../successFlash'
 import type { InvRow } from '../goalDetailShared'
+import { todayIso, addDaysIso } from '@/lib/dates'
 
 // A YYYY-MM-DD string `n` days from today (deterministic regardless of run date).
+// Built on the BUSINESS calendar, because that is what daysUntil/fmtMaturity
+// measure against. Deriving these from the runtime's local clock made every
+// maturity assertion off by one whenever the runner's date differed from
+// Vietnam's — on a UTC runner, that is 17:00–23:59 every day (#591).
 function daysFromNow(n: number): string {
-  const d = new Date()
-  d.setHours(0, 0, 0, 0)
-  d.setDate(d.getDate() + n)
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  return addDaysIso(todayIso(), n)
 }
 // A matured term deposit: value (compounded) > principal, expiry in the past.
 const maturedDeposit: InvRow = {

--- a/app/assets/components/__tests__/goalDetailShared.test.tsx
+++ b/app/assets/components/__tests__/goalDetailShared.test.tsx
@@ -5,13 +5,15 @@ import { fmtMaturity } from '../goalDetailMaturity'
 import { calcDeadlineMonths, computeGoalCalculator, describeHistoryRow } from '../goalDetailModel'
 import type { FundBreakdownItem } from '../../DashboardClient'
 import { ArrowUpRight, ArrowDownRight, PiggyBank, GitMerge, RefreshCw } from 'lucide-react'
+import { todayIso, addDaysIso } from '@/lib/dates'
 
 // A YYYY-MM-DD string `n` days from today (deterministic regardless of run date).
+// Built on the BUSINESS calendar, because that is what daysUntil/fmtMaturity
+// measure against. Deriving these from the runtime's local clock made every
+// maturity assertion off by one whenever the runner's date differed from
+// Vietnam's — on a UTC runner, that is 17:00–23:59 every day (#591).
 function daysFromNow(n: number): string {
-  const d = new Date()
-  d.setHours(0, 0, 0, 0)
-  d.setDate(d.getDate() + n)
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  return addDaysIso(todayIso(), n)
 }
 
 const baseTx = (over: Partial<GoalDetailTx>): GoalDetailTx => ({
@@ -339,7 +341,7 @@ describe('computeGoalCalculator', () => {
 
     it('lands in February when seven months from 31 July', () => {
       vi.useFakeTimers()
-      vi.setSystemTime(new Date(2026, 6, 31, 12))   // 31 July 2026
+      vi.setSystemTime(new Date('2026-07-31T05:00:00Z'))   // 31 July 2026, 12:00 in Vietnam
 
       const c = computeGoalCalculator({ targetAmount: 7_000_000, targetDate: null, currentValue: 0 }, 1_000_000)
 
@@ -350,7 +352,7 @@ describe('computeGoalCalculator', () => {
 
     it('lands in the next month when one month from 31 January', () => {
       vi.useFakeTimers()
-      vi.setSystemTime(new Date(2026, 0, 31, 12))   // 31 January 2026
+      vi.setSystemTime(new Date('2026-01-31T05:00:00Z'))   // 31 January 2026, 12:00 in Vietnam
 
       const c = computeGoalCalculator({ targetAmount: 1_000_000, targetDate: null, currentValue: 0 }, 1_000_000)
 

--- a/app/assets/components/goalDetailMaturity.ts
+++ b/app/assets/components/goalDetailMaturity.ts
@@ -2,7 +2,7 @@
 // "time left" + tone, and the "needs action" predicates for term deposits and
 // accumulating books. Split out of goalDetailShared so the shared UI file stays
 // presentational. Imports InvRow as a type only (no runtime dependency back).
-import { isTermDeposit, depositMaturityState, isMaturityActionable, isActionableAccumulatingBook } from '@/lib/maturity'
+import { isTermDeposit, depositMaturityState, isMaturityActionable, isActionableAccumulatingBook, daysUntil } from '@/lib/maturity'
 import { fmtTxDate } from './transactionUtils'
 import type { InvRow } from './goalDetailShared'
 
@@ -38,11 +38,10 @@ export function needsBookMaturityAction(inv: InvRow): boolean {
 
 export function fmtMaturity(dateStr: string | null | undefined, isVi: boolean): Maturity | null {
   if (!dateStr) return null
-  const d = new Date(dateStr + 'T00:00:00')
-  if (isNaN(d.getTime())) return null
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-  const diffDays = Math.round((d.getTime() - today.getTime()) / 86_400_000)
+  // Both the diff and the "matured/today" wording key off the business day, the
+  // same one daysUntil uses — so the card, the badge and the copy never disagree.
+  const diffDays = daysUntil(dateStr)
+  if (isNaN(diffDays)) return null
   const formatted = fmtTxDate(dateStr, isVi ? 'vi' : 'en')
 
   let relative: string

--- a/app/assets/components/goalDetailModel.ts
+++ b/app/assets/components/goalDetailModel.ts
@@ -4,6 +4,7 @@
 // its own.
 import { RefreshCw, PiggyBank, GitMerge, ArrowDownRight, ArrowUpRight, type LucideIcon } from 'lucide-react'
 import { txKind, type TxKind, type TxKindFields } from './transactionUtils'
+import { monthsUntilYm, businessYearMonth } from '@/lib/dates'
 
 export interface HistoryRowDescriptor {
   kind: TxKind
@@ -37,9 +38,7 @@ export function describeHistoryRow(
 
 export function calcDeadlineMonths(targetDate: string | null): number {
   if (!targetDate) return 12
-  const [ty, tm] = targetDate.split('-').map(Number)
-  const now = new Date()
-  return Math.max(1, (ty - now.getFullYear()) * 12 + (tm - 1 - now.getMonth()))
+  return monthsUntilYm(targetDate)
 }
 
 export interface GoalCalculator {
@@ -73,8 +72,9 @@ export function computeGoalCalculator(
   // exist in the target month — 31 February rolls into March — and the user is then
   // told a month later than their pace actually reaches the goal. Only bites on the
   // 29th-31st, which is why it survived this long.
+  // Counted forward from the *business* month, not the browser's local one (#591).
   const projectedDate = monthsToGoal != null
-    ? (() => { const d = new Date(); return new Date(d.getFullYear(), d.getMonth() + monthsToGoal, 1) })()
+    ? (() => { const { year, month } = businessYearMonth(); return new Date(year, month - 1 + monthsToGoal, 1) })()
     : null
   const isOnTrack = input > 0 && input >= neededPerMonth
   const gap = Math.abs(neededPerMonth - input)

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -6,6 +6,7 @@
 import { useState, type CSSProperties } from 'react'
 import { TrendingUp, Building, Coins, BarChart2, Target, RefreshCw, Plus } from 'lucide-react'
 import { fmtCompact } from '@/lib/formatters'
+import { todayIso } from '@/lib/dates'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 import { fmtTxDate } from './transactionUtils'
 import { fmtMaturity, type Maturity } from './goalDetailMaturity'
@@ -346,7 +347,7 @@ export function TopUpControl({ inv, isVi, onDone }: { inv: InvRow; isVi: boolean
   const [open, setOpen] = useState(false)
   const [amount, setAmount] = useState('')
   const [rate, setRate] = useState(inv.interestRate != null ? String(Math.round(inv.interestRate * 10) / 10) : '')
-  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10))
+  const [date, setDate] = useState(() => todayIso())
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
   if (!inv.depositGroupId) return null

--- a/app/components/navigation/__tests__/useMaturingDepositsCount.test.tsx
+++ b/app/components/navigation/__tests__/useMaturingDepositsCount.test.tsx
@@ -2,12 +2,14 @@ import { describe, it, expect, vi, afterEach } from 'vitest'
 import { render, screen, act, waitFor } from '@testing-library/react'
 import { useMaturingDepositsCount } from '../useMaturingDepositsCount'
 import { MATURING_COUNT_EVENT } from '@/lib/maturity'
+import { todayIso, addDaysIso } from '@/lib/dates'
 
+// Built on the BUSINESS calendar, because that is what daysUntil/fmtMaturity
+// measure against. Deriving these from the runtime's local clock made every
+// maturity assertion off by one whenever the runner's date differed from
+// Vietnam's — on a UTC runner, that is 17:00–23:59 every day (#591).
 function daysFromNow(n: number): string {
-  const d = new Date()
-  d.setHours(0, 0, 0, 0)
-  d.setDate(d.getDate() + n)
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  return addDaysIso(todayIso(), n)
 }
 
 function Probe() {

--- a/components/report/PortfolioReport.tsx
+++ b/components/report/PortfolioReport.tsx
@@ -2,6 +2,7 @@ import { Document, Page, View, Text, StyleSheet, Font } from '@react-pdf/rendere
 import path from 'path'
 import type { DashboardData } from '@/app/assets/DashboardClient'
 import { fmt, fmtPct } from '@/lib/formatters'
+import { formatBusinessDate } from '@/lib/dates'
 
 Font.register({
   family: 'Roboto',
@@ -93,7 +94,9 @@ function LabelRow({ label, value, profitValue }: { label: string; value: string;
 export function PortfolioReport({ data, locale = 'vi' }: { data: DashboardData; locale?: string }) {
   const l = labels[(locale as Locale) in labels ? (locale as Locale) : 'vi']
   const { netWorth, goals, byType } = data
-  const generatedDate = new Date().toLocaleDateString(locale === 'vi' ? 'vi-VN' : 'en-GB', { day: '2-digit', month: '2-digit', year: 'numeric' })
+  // Rendered on the server (UTC), so the zone has to be explicit or the PDF prints
+  // yesterday while its own filename says today (#591).
+  const generatedDate = formatBusinessDate(locale === 'vi' ? 'vi-VN' : 'en-GB', { day: '2-digit', month: '2-digit', year: 'numeric' })
 
   const mutualFundsTotal = [
     ...data.goals.flatMap((g) => g.funds),

--- a/e2e/api-validation.spec.ts
+++ b/e2e/api-validation.spec.ts
@@ -109,6 +109,36 @@ test.describe('API input validation', () => {
     }
   })
 
+  // Creating and editing must agree on what "the future" is. POST goes through
+  // isFutureInvestmentDate (the business day, Asia/Ho_Chi_Minh); the edit route
+  // used to compare `new Date(date) > new Date()`, which parses a plain date at
+  // UTC midnight — so between 00:00 and 06:59 Vietnam time it rejected the very
+  // date POST had just accepted, and an edit that didn't touch the date at all
+  // failed with "cannot be in the future" (#591).
+  test('PUT /api/v1/investment-transactions/<id> accepts the business-day date POST accepts', async ({ request }) => {
+    const today = new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Ho_Chi_Minh' })
+    const tx = await api.createTransaction({
+      asset_type: 'bank',
+      amount_vnd: 5_000_000,
+      investment_date: today,
+      notes: 'E2E business-day edit guard',
+    })
+    try {
+      const ok = await request.put(`/api/v1/investment-transactions/${tx.transaction_id}`, {
+        data: { investment_date: today, amount_vnd: 6_000_000 },
+      })
+      expect(ok.status()).toBe(200)
+
+      // A date genuinely past the business day is still refused.
+      const future = await request.put(`/api/v1/investment-transactions/${tx.transaction_id}`, {
+        data: { investment_date: new Date(Date.now() + 5 * 86_400_000).toISOString().slice(0, 10) },
+      })
+      expect(future.status()).toBe(400)
+    } finally {
+      await api.deleteTransaction(tx.transaction_id)
+    }
+  })
+
   // Pagination / month / DCA hardening (#471): junk inputs that used to reach
   // the DB as NaN ranges, parseInt('1abc') → 1, or CHECK-violating amounts must
   // now be a clean 400 at the route.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -58,6 +58,17 @@ const eslintConfig = defineConfig([
           selector: "CallExpression[callee.object.type='NewExpression'][callee.object.callee.name='Date'][callee.object.arguments.length=0][callee.property.name=/^(getMonth|getFullYear|getDate)$/]",
           message: "Don't derive a business date/month from the runtime's local zone — use todayIso()/businessYearMonth() from lib/dates.",
         },
+        {
+          // The two selectors above only see the direct form. Aliasing the clock
+          // first (`const now = new Date(); now.getMonth()`) reads identically to
+          // reading parts off a *parsed* date, which is legitimate — so the alias
+          // itself is what gets rejected, and the author has to say which they
+          // meant. A genuine timestamp is `new Date().toISOString()` inline, or
+          // this rule disabled with a note (see mark-paid, which needs one instant
+          // shared across updated_at and its audit line).
+          selector: "VariableDeclarator[init.type='NewExpression'][init.callee.name='Date'][init.arguments.length=0]",
+          message: "Don't alias the current clock — a business date/month comes from lib/dates (todayIso, businessYearMonth); a UTC timestamp is `new Date().toISOString()` inline.",
+        },
       ],
     },
   },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -38,6 +38,29 @@ const eslintConfig = defineConfig([
       "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
     },
   },
+  // Business dates come from lib/dates, never from UTC or the runtime's local
+  // zone (#591). Between 00:00 and 06:59 Vietnam time the UTC calendar date is
+  // still yesterday, so `new Date().toISOString().slice(0, 10)` recorded the
+  // wrong business day; `new Date().getMonth()` has the mirror problem of
+  // depending on where the code runs. This keeps them from creeping back.
+  // (`new Date().toISOString()` on its own is fine — that's a UTC *timestamp*,
+  // which is exactly what `updated_at` and friends want.)
+  {
+    files: ["app/**/*.{ts,tsx}", "lib/**/*.{ts,tsx}", "components/**/*.{ts,tsx}"],
+    ignores: ["lib/dates.ts", "**/__tests__/**"],
+    rules: {
+      "no-restricted-syntax": ["error",
+        {
+          selector: "MemberExpression[object.callee.property.name='toISOString'][object.callee.object.type='NewExpression'][object.callee.object.callee.name='Date'][object.callee.object.arguments.length=0][property.name=/^(slice|split)$/]",
+          message: "Don't derive a business date from the UTC date — use todayIso() from lib/dates.",
+        },
+        {
+          selector: "CallExpression[callee.object.type='NewExpression'][callee.object.callee.name='Date'][callee.object.arguments.length=0][callee.property.name=/^(getMonth|getFullYear|getDate)$/]",
+          message: "Don't derive a business date/month from the runtime's local zone — use todayIso()/businessYearMonth() from lib/dates.",
+        },
+      ],
+    },
+  },
 ]);
 
 export default eslintConfig;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -59,7 +59,14 @@ const eslintConfig = defineConfig([
           message: "Don't derive a business date/month from the runtime's local zone — use todayIso()/businessYearMonth() from lib/dates.",
         },
         {
-          // The two selectors above only see the direct form. Aliasing the clock
+          // Displayed dates drift the same way: without an explicit timeZone,
+          // toLocaleDateString reads the renderer's clock, so a PDF built on the
+          // UTC server printed yesterday under a filename that said today.
+          selector: "CallExpression[callee.object.type='NewExpression'][callee.object.callee.name='Date'][callee.object.arguments.length=0][callee.property.name=/^(toLocaleDateString|toLocaleString)$/]",
+          message: "Don't format today's date in the renderer's zone — use formatBusinessDate() from lib/dates.",
+        },
+        {
+          // The three selectors above only see the direct form. Aliasing the clock
           // first (`const now = new Date(); now.getMonth()`) reads identically to
           // reading parts off a *parsed* date, which is legitimate — so the alias
           // itself is what gets rejected, and the author has to say which they

--- a/lib/__tests__/dates.test.ts
+++ b/lib/__tests__/dates.test.ts
@@ -4,6 +4,7 @@ import {
   todayIso,
   businessYearMonth,
   businessTodayDate,
+  monthsUntilYm,
   daysUntilIso,
   isFutureInvestmentDate,
 } from '../dates'
@@ -68,6 +69,36 @@ describe('businessYearMonth', () => {
   it('defaults to the current instant', () => {
     vi.setSystemTime(VN_0030)
     expect(businessYearMonth()).toEqual({ year: 2026, month: 6 })
+  })
+})
+
+describe('monthsUntilYm', () => {
+  // One helper for the goal-deadline horizon that CreateGoalSheet,
+  // calcDeadlineMonths and the desktop goal editor each used to compute inline.
+  const JUNE = new Date('2026-06-14T03:00:00Z') // 10:00 in Vietnam
+
+  it('counts whole months to a future target', () => {
+    expect(monthsUntilYm('2026-12', JUNE)).toBe(6)
+    expect(monthsUntilYm('2027-06', JUNE)).toBe(12)
+  })
+
+  it('floors at 1 for the current or a past month', () => {
+    expect(monthsUntilYm('2026-06', JUNE)).toBe(1)
+    expect(monthsUntilYm('2025-01', JUNE)).toBe(1)
+  })
+
+  it('accepts a full YYYY-MM-DD target (the day is irrelevant)', () => {
+    expect(monthsUntilYm('2026-12-31', JUNE)).toBe(6)
+  })
+
+  it('measures from the Vietnam month at 00:30 on the 1st, not the previous UTC one', () => {
+    // 1 Jun 2026, 00:30 in Vietnam — still 31 May by the UTC clock, which would
+    // stretch every horizon by a month.
+    expect(monthsUntilYm('2026-12', new Date('2026-05-31T17:30:00Z'))).toBe(6)
+  })
+
+  it('falls back to 1 for an unparseable target', () => {
+    expect(monthsUntilYm('', JUNE)).toBe(1)
   })
 })
 

--- a/lib/__tests__/dates.test.ts
+++ b/lib/__tests__/dates.test.ts
@@ -1,34 +1,114 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { todayIso, isFutureInvestmentDate } from '../dates'
+import {
+  BUSINESS_TIMEZONE,
+  todayIso,
+  businessYearMonth,
+  businessTodayDate,
+  daysUntilIso,
+  isFutureInvestmentDate,
+} from '../dates'
 import { daysUntil } from '../maturity'
 
 afterEach(() => vi.useRealTimers())
 
+// The business day runs on Asia/Ho_Chi_Minh (UTC+7) wherever the code executes —
+// a browser in any timezone, or a server in UTC. The instants below are the ones
+// that used to drift: between 00:00 and 06:59 Vietnam time the UTC calendar date
+// is still *yesterday*, so a UTC-derived "today" recorded the wrong business day.
+const VN_0030 = new Date('2026-06-14T17:30:00Z') // 2026-06-15 00:30 in Vietnam
+const VN_0659 = new Date('2026-06-13T23:59:00Z') // 2026-06-14 06:59 in Vietnam
+const VN_0700 = new Date('2026-06-14T00:00:00Z') // 2026-06-14 07:00 in Vietnam
+
+describe('BUSINESS_TIMEZONE', () => {
+  it('is Asia/Ho_Chi_Minh', () => {
+    expect(BUSINESS_TIMEZONE).toBe('Asia/Ho_Chi_Minh')
+  })
+})
+
 describe('todayIso', () => {
   // The contract that ties todayIso to the maturity code: "today" must be 0 days
-  // until today. daysUntil/fmtMaturity parse plain dates at LOCAL midnight, so a
-  // UTC-derived today (new Date().toISOString()) would read as -1 in the first
-  // hours of the day in a timezone ahead of UTC (e.g. VN, UTC+7) — the drift
-  // this helper exists to remove.
-  it('is the local calendar day (daysUntil(todayIso()) === 0)', () => {
+  // until today.
+  it('is 0 days until itself (daysUntil(todayIso()) === 0)', () => {
     expect(daysUntil(todayIso())).toBe(0)
   })
 
-  it('formats from local date parts', () => {
-    // Pin the clock so both new Date() reads see the same instant (no midnight-
-    // rollover flake between todayIso()'s read and the expectation's).
-    vi.setSystemTime(new Date('2026-06-14T08:30:00'))
-    const now = new Date()
-    const p = (n: number) => String(n).padStart(2, '0')
-    expect(todayIso()).toBe(`${now.getFullYear()}-${p(now.getMonth() + 1)}-${p(now.getDate())}`)
+  it('is the Vietnam calendar day just after midnight, not the UTC one', () => {
+    expect(todayIso(VN_0030)).toBe('2026-06-15')
+    expect(VN_0030.toISOString().slice(0, 10)).toBe('2026-06-14') // what it used to return
+  })
+
+  it('holds the same business day across the 06:59 → 07:00 UTC-date rollover', () => {
+    expect(todayIso(VN_0659)).toBe('2026-06-14')
+    expect(todayIso(VN_0700)).toBe('2026-06-14')
+  })
+
+  it('rolls into the new month at Vietnam midnight, not UTC midnight', () => {
+    expect(todayIso(new Date('2026-05-31T17:30:00Z'))).toBe('2026-06-01')
+  })
+
+  it('rolls into the new year at Vietnam midnight, not UTC midnight', () => {
+    expect(todayIso(new Date('2025-12-31T17:30:00Z'))).toBe('2026-01-01')
+  })
+
+  it('defaults to the current instant', () => {
+    vi.setSystemTime(VN_0030)
+    expect(todayIso()).toBe('2026-06-15')
+  })
+})
+
+describe('businessYearMonth', () => {
+  it('reports the Vietnam month at 00:30, not the previous UTC month', () => {
+    expect(businessYearMonth(new Date('2026-05-31T17:30:00Z'))).toEqual({ year: 2026, month: 6 })
+  })
+
+  it('reports the Vietnam year at 00:30 on 1 January', () => {
+    expect(businessYearMonth(new Date('2025-12-31T17:30:00Z'))).toEqual({ year: 2026, month: 1 })
+  })
+
+  it('defaults to the current instant', () => {
+    vi.setSystemTime(VN_0030)
+    expect(businessYearMonth()).toEqual({ year: 2026, month: 6 })
+  })
+})
+
+describe('businessTodayDate', () => {
+  // A local-midnight Date of the business day, for the date arithmetic that still
+  // works in Date objects (insuranceStatus's next-due comparison).
+  it('is the business day at local midnight', () => {
+    const d = businessTodayDate(VN_0030)
+    expect([d.getFullYear(), d.getMonth() + 1, d.getDate()]).toEqual([2026, 6, 15])
+    expect([d.getHours(), d.getMinutes(), d.getSeconds(), d.getMilliseconds()]).toEqual([0, 0, 0, 0])
+  })
+})
+
+describe('daysUntilIso', () => {
+  it('counts whole days between plain dates', () => {
+    expect(daysUntilIso('2026-06-14', '2026-06-14')).toBe(0)
+    expect(daysUntilIso('2026-06-20', '2026-06-14')).toBe(6)
+    expect(daysUntilIso('2026-06-13', '2026-06-14')).toBe(-1)
+  })
+
+  it('crosses month and year boundaries', () => {
+    expect(daysUntilIso('2026-01-01', '2025-12-31')).toBe(1)
+    expect(daysUntilIso('2026-03-01', '2026-02-28')).toBe(1)
+  })
+
+  it('reads today from the business timezone at 00:30 Vietnam time', () => {
+    vi.setSystemTime(VN_0030)
+    // A deposit maturing 2026-06-15 has matured *today* in Vietnam (0), not
+    // tomorrow (1) as the UTC date would have it.
+    expect(daysUntilIso('2026-06-15')).toBe(0)
+  })
+
+  it('returns NaN for an unparseable date', () => {
+    expect(daysUntilIso('not-a-date', '2026-06-14')).toBeNaN()
   })
 })
 
 describe('isFutureInvestmentDate', () => {
-  // The server runs in UTC but clients send their LOCAL "today". A client ahead
-  // of UTC (VN) can legitimately send the server's "tomorrow", so the guard
-  // allows one day of skew and only rejects dates clearly in the future.
-  const asOf = new Date('2026-06-14T00:00:00Z')
+  // Client and server now derive "today" in the same business timezone, so no
+  // skew allowance is needed: anything past the business day is future-dated.
+  const asOf = new Date('2026-06-14T03:00:00Z') // 10:00 in Vietnam, same date
 
   it('accepts today', () => {
     expect(isFutureInvestmentDate('2026-06-14', asOf)).toBe(false)
@@ -38,17 +118,20 @@ describe('isFutureInvestmentDate', () => {
     expect(isFutureInvestmentDate('2026-01-01', asOf)).toBe(false)
   })
 
-  it('tolerates one day of client/server timezone skew', () => {
-    expect(isFutureInvestmentDate('2026-06-15', asOf)).toBe(false)
-  })
-
-  it('rejects a date clearly in the future', () => {
-    expect(isFutureInvestmentDate('2026-06-16', asOf)).toBe(true)
+  it('rejects tomorrow and beyond', () => {
+    expect(isFutureInvestmentDate('2026-06-15', asOf)).toBe(true)
     expect(isFutureInvestmentDate('2027-01-01', asOf)).toBe(true)
   })
 
+  it('accepts the Vietnam date that is still tomorrow in UTC', () => {
+    // 00:30 on 2026-06-15 in Vietnam. A client legitimately recording "today"
+    // sends 2026-06-15 while the UTC date is still 2026-06-14.
+    expect(isFutureInvestmentDate('2026-06-15', VN_0030)).toBe(false)
+    expect(isFutureInvestmentDate('2026-06-16', VN_0030)).toBe(true)
+  })
+
   it('ignores any time portion on the input', () => {
-    expect(isFutureInvestmentDate('2026-06-15T23:59:59Z', asOf)).toBe(false)
-    expect(isFutureInvestmentDate('2026-06-16T00:00:00Z', asOf)).toBe(true)
+    expect(isFutureInvestmentDate('2026-06-14T23:59:59Z', asOf)).toBe(false)
+    expect(isFutureInvestmentDate('2026-06-15T00:00:00Z', asOf)).toBe(true)
   })
 })

--- a/lib/__tests__/dates.test.ts
+++ b/lib/__tests__/dates.test.ts
@@ -5,6 +5,7 @@ import {
   businessYearMonth,
   businessTodayDate,
   monthsUntilYm,
+  formatBusinessDate,
   daysUntilIso,
   isFutureInvestmentDate,
 } from '../dates'
@@ -133,6 +134,30 @@ describe('daysUntilIso', () => {
 
   it('returns NaN for an unparseable date', () => {
     expect(daysUntilIso('not-a-date', '2026-06-14')).toBeNaN()
+  })
+})
+
+describe('formatBusinessDate', () => {
+  // The "generated on" / "as of" date a report displays. Formatted in the business
+  // zone so the PDF rendered on the UTC server can't say yesterday while its own
+  // filename says today, and so a user abroad sees the same day the data is keyed
+  // to rather than their browser's.
+  it('formats the business day, not the UTC one', () => {
+    const vnMidnight = new Date('2026-06-14T17:30:00Z') // 15 Jun 2026, 00:30 in VN
+    expect(formatBusinessDate('en-GB', { day: '2-digit', month: '2-digit', year: 'numeric' }, vnMidnight))
+      .toBe('15/06/2026')
+  })
+
+  it('agrees with todayIso on the day it names', () => {
+    const vnMidnight = new Date('2026-06-14T17:30:00Z')
+    const formatted = formatBusinessDate('en-CA', { year: 'numeric', month: '2-digit', day: '2-digit' }, vnMidnight)
+    expect(formatted.replace(/\//g, '-')).toBe(todayIso(vnMidnight))
+  })
+
+  it('honours the requested locale and style', () => {
+    const noon = new Date('2026-06-14T05:00:00Z') // 12:00 in Vietnam
+    expect(formatBusinessDate('en-GB', { day: 'numeric', month: 'long', year: 'numeric' }, noon))
+      .toBe('14 June 2026')
   })
 })
 

--- a/lib/__tests__/dates.test.ts
+++ b/lib/__tests__/dates.test.ts
@@ -6,6 +6,7 @@ import {
   businessTodayDate,
   monthsUntilYm,
   formatBusinessDate,
+  addDaysIso,
   daysUntilIso,
   isFutureInvestmentDate,
 } from '../dates'
@@ -137,6 +138,24 @@ describe('daysUntilIso', () => {
   })
 })
 
+describe('addDaysIso', () => {
+  it('steps forward and back by whole calendar days', () => {
+    expect(addDaysIso('2026-06-14', 0)).toBe('2026-06-14')
+    expect(addDaysIso('2026-06-14', 1)).toBe('2026-06-15')
+    expect(addDaysIso('2026-06-14', -1)).toBe('2026-06-13')
+  })
+
+  it('crosses month and year boundaries, and leap days', () => {
+    expect(addDaysIso('2026-06-30', 1)).toBe('2026-07-01')
+    expect(addDaysIso('2026-12-31', 1)).toBe('2027-01-01')
+    expect(addDaysIso('2028-02-28', 1)).toBe('2028-02-29') // 2028 is a leap year
+  })
+
+  it('round-trips with daysUntilIso', () => {
+    expect(daysUntilIso(addDaysIso('2026-06-14', 9), '2026-06-14')).toBe(9)
+  })
+})
+
 describe('formatBusinessDate', () => {
   // The "generated on" / "as of" date a report displays. Formatted in the business
   // zone so the PDF rendered on the UTC server can't say yesterday while its own
@@ -189,5 +208,30 @@ describe('isFutureInvestmentDate', () => {
   it('ignores any time portion on the input', () => {
     expect(isFutureInvestmentDate('2026-06-14T23:59:59Z', asOf)).toBe(false)
     expect(isFutureInvestmentDate('2026-06-15T00:00:00Z', asOf)).toBe(true)
+  })
+
+  // The renew / book-collapse flows anchor the new cycle to the OLD maturity
+  // date, and the 7-day reminder window surfaces a deposit before that date
+  // falls — so those routes legitimately post a date up to a day ahead. They opt
+  // in explicitly; a user-entered create/edit date stays strict.
+  describe('graceDays', () => {
+    it('accepts tomorrow when a grace day is allowed', () => {
+      expect(isFutureInvestmentDate('2026-06-15', asOf, 1)).toBe(false)
+    })
+
+    it('still rejects beyond the grace', () => {
+      expect(isFutureInvestmentDate('2026-06-16', asOf, 1)).toBe(true)
+    })
+
+    it('defaults to no grace at all', () => {
+      expect(isFutureInvestmentDate('2026-06-15', asOf)).toBe(true)
+    })
+
+    it('measures the grace from the business day, not the UTC one', () => {
+      // 00:30 on 15 Jun in Vietnam: today is the 15th, so one grace day reaches
+      // the 16th — even though the UTC date is still the 14th.
+      expect(isFutureInvestmentDate('2026-06-16', VN_0030, 1)).toBe(false)
+      expect(isFutureInvestmentDate('2026-06-17', VN_0030, 1)).toBe(true)
+    })
   })
 })

--- a/lib/__tests__/finance.test.ts
+++ b/lib/__tests__/finance.test.ts
@@ -281,3 +281,49 @@ describe('insurancePaidYear', () => {
     expect(insurancePaidYear('2026-05-29T00:00:00+00:00')).toBe(2026)
   })
 })
+
+// Between 00:00 and 06:59 Vietnam time the UTC calendar date is still yesterday,
+// so a UTC- or server-local-derived "now" assigns the wrong business month/year.
+// These pin the boundary instants that used to drift (#591).
+describe('business-day boundaries (Asia/Ho_Chi_Minh)', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('realizes the new month at 00:30 Vietnam time on the 1st', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-31T17:30:00Z')) // 1 Jun 2026, 00:30 in VN
+    expect(isPlanMonthRealized(2026, 6)).toBe(true)
+    expect(isPlanMonthRealized(2026, 7)).toBe(false)
+  })
+
+  it('realizes the new year at 00:30 Vietnam time on 1 January', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-12-31T17:30:00Z')) // 1 Jan 2026, 00:30 in VN
+    expect(isPlanMonthRealized(2026, 1)).toBe(true)
+    expect(isPlanMonthRealized(2025, 12)).toBe(true)
+    expect(isPlanMonthRealized(2026, 2)).toBe(false)
+  })
+
+  it('holds the month across the 06:59 → 07:00 UTC-date rollover', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-31T23:59:00Z')) // 1 Jun 2026, 06:59 in VN
+    expect(isPlanMonthRealized(2026, 6)).toBe(true)
+    vi.setSystemTime(new Date('2026-06-01T00:00:00Z')) // 1 Jun 2026, 07:00 in VN
+    expect(isPlanMonthRealized(2026, 6)).toBe(true)
+  })
+
+  it('counts a 1 January payment as the current year at 00:30 Vietnam time', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-12-31T17:30:00Z')) // 1 Jan 2026, 00:30 in VN
+    expect(insurancePaidYear('2026-01-01')).toBe(2026)
+  })
+
+  it('reads a premium that came due yesterday as overdue at 00:30 Vietnam time', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-06-14T17:30:00Z')) // 15 Jun 2026, 00:30 in VN
+    // Anniversary fell on 14 Jun 2026 — yesterday in Vietnam, but still "today"
+    // by the UTC clock, which read it as merely upcoming.
+    expect(insuranceStatus('2025-06-14')).toBe('overdue')
+    // The one falling today is due, not yet missed.
+    expect(insuranceStatus('2025-06-15')).toBe('upcoming')
+  })
+})

--- a/lib/__tests__/historyRange.test.ts
+++ b/lib/__tests__/historyRange.test.ts
@@ -28,6 +28,29 @@ describe('rangeStartDate', () => {
     expect(rangeStartDate('bogus', NOW)).toBeNull()
   })
 
+  // Snapshots are keyed to the business day (Asia/Ho_Chi_Minh), so the cutoff
+  // that filters them has to be measured from the same calendar. Subtracting from
+  // the UTC date parts moved the cutoff back a day for the first seven hours of
+  // each Vietnam day — the chart silently gained a snapshot before 07:00 and lost
+  // it again afterwards, within one business day (#591).
+  it('measures back from the business day, not the UTC one', () => {
+    const vnMidnight = new Date('2026-08-14T17:30:00Z') // 15 Aug 2026, 00:30 in VN
+    expect(rangeStartDate('1m', vnMidnight)).toBe('2026-07-15')
+    expect(rangeStartDate('1y', vnMidnight)).toBe('2025-08-15')
+  })
+
+  it('gives the same cutoff either side of the 06:59 → 07:00 UTC-date rollover', () => {
+    const before = new Date('2026-08-14T23:59:00Z') // 15 Aug 2026, 06:59 in VN
+    const after = new Date('2026-08-15T00:00:00Z')  // 15 Aug 2026, 07:00 in VN
+    expect(rangeStartDate('1m', before)).toBe(rangeStartDate('1m', after))
+  })
+
+  it('clamps to the last valid day when the target month is shorter', () => {
+    // 31 Mar − 1 month has no 31 Feb; land on the last day of February instead of
+    // rolling forward into March (which would drop a month of history).
+    expect(rangeStartDate('1m', new Date('2026-03-31T03:00:00Z'))).toBe('2026-02-28')
+  })
+
   it('every selectable range yields a distinct cutoff (the bug: 1m/3m collapsed to All)', () => {
     const cutoffs = ['1m', '3m', '6m', '1y'].map((r) => rangeStartDate(r, NOW))
     expect(cutoffs).toEqual(['2026-05-15', '2026-03-15', '2025-12-15', '2025-06-15'])

--- a/lib/__tests__/maturity.test.ts
+++ b/lib/__tests__/maturity.test.ts
@@ -11,13 +11,15 @@ import {
   isActionableTermDeposit,
   isActionableAccumulatingBook,
 } from '../maturity'
+import { todayIso, addDaysIso } from '../dates'
 
 // A YYYY-MM-DD string `n` days from today (deterministic regardless of run date).
+// Built on the BUSINESS calendar, because that is what daysUntil/fmtMaturity
+// measure against. Deriving these from the runtime's local clock made every
+// maturity assertion off by one whenever the runner's date differed from
+// Vietnam's — on a UTC runner, that is 17:00–23:59 every day (#591).
 function daysFromNow(n: number): string {
-  const d = new Date()
-  d.setHours(0, 0, 0, 0)
-  d.setDate(d.getDate() + n)
-  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+  return addDaysIso(todayIso(), n)
 }
 
 describe('isTermDeposit', () => {

--- a/lib/dates.ts
+++ b/lib/dates.ts
@@ -1,27 +1,72 @@
-// Plain-date ("YYYY-MM-DD") helpers that treat a date as a LOCAL calendar day,
-// matching how daysUntil/fmtMaturity parse maturity dates (`new Date(d + 'T00:00:00')`).
+// Business-date policy and plain-date ("YYYY-MM-DD") helpers.
 //
-// Why this exists: `new Date().toISOString().slice(0, 10)` yields the UTC date,
-// which in a timezone ahead of UTC (e.g. Vietnam, UTC+7) is yesterday during the
-// first hours of the local day. Mixing that with the local-parsing maturity code
-// drifted "today" — and a recorded investment_date — by up to a day. Use these so
-// every plain-date "today"/comparison agrees on the user's local calendar.
+// POLICY: this app has exactly one business timezone — Asia/Ho_Chi_Minh (UTC+7).
+// Every "today", "current month" and plain-date comparison is derived in that
+// zone, no matter where the code runs: a browser in any timezone, a Vercel
+// function in UTC, or a cron job. Nothing derives a business date from UTC
+// (`new Date().toISOString().slice(0, 10)`) or from the runtime's local zone
+// (`new Date().getMonth()`) — both drift.
+//
+// Why it matters: between 00:00 and 06:59 Vietnam time the UTC calendar date is
+// still *yesterday*. A UTC-derived "today" recorded transactions on the previous
+// date, assigned contributions to the previous month, and keyed the dashboard's
+// daily snapshot to the wrong day. Runtime-local derivation has the mirror
+// problem — it makes the answer depend on where the code happens to run (#591).
+//
+// Plain dates are treated as whole calendar days: compared and differenced from
+// their parts, never parsed into an instant, so no timezone can shift them.
 
-const pad = (n: number) => String(n).padStart(2, '0')
+export const BUSINESS_TIMEZONE = 'Asia/Ho_Chi_Minh'
 
-// Today in the local timezone as YYYY-MM-DD (not the UTC date).
-export function todayIso(): string {
-  const d = new Date()
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
+const businessParts = new Intl.DateTimeFormat('en-US', {
+  timeZone: BUSINESS_TIMEZONE,
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+
+// Today as YYYY-MM-DD in the business timezone. Pass `now` to pin the instant.
+export function todayIso(now: Date = new Date()): string {
+  const parts = businessParts.formatToParts(now)
+  const part = (type: Intl.DateTimeFormatPartTypes) => parts.find(p => p.type === type)?.value ?? ''
+  return `${part('year')}-${part('month')}-${part('day')}`
 }
 
-// Whether a plain investment date is clearly in the future. The server runs in
-// UTC but clients send their LOCAL "today", so a client ahead of UTC can send
-// the server's "tomorrow" for a perfectly valid same-day entry. Allow one day of
-// skew and reject only dates beyond it. Compared as plain dates (ISO strings sort
-// chronologically), so any time portion on the input is ignored.
+// The business year and 1-based month — for the monthly-plan / recurring-savings
+// logic that reasons in months rather than dates.
+export function businessYearMonth(now: Date = new Date()): { year: number; month: number } {
+  const [year, month] = todayIso(now).split('-').map(Number)
+  return { year, month }
+}
+
+// The business day as a Date at *local* midnight, for the date arithmetic that
+// still runs on Date objects (e.g. stepping a premium anniversary forward a
+// year). Only the date parts are meaningful — never read a time off it.
+export function businessTodayDate(now: Date = new Date()): Date {
+  const [year, month, day] = todayIso(now).split('-').map(Number)
+  return new Date(year, month - 1, day)
+}
+
+// Whole days from `from` (default: business today) until a plain YYYY-MM-DD
+// date; negative once the date has passed. Both sides are read as calendar
+// dates, so the result never depends on the runtime timezone.
+export function daysUntilIso(isoDate: string, from: string = todayIso()): number {
+  const utcMidnight = (iso: string) => {
+    const [y, m, d] = iso.slice(0, 10).split('-').map(Number)
+    if (!y || !m || !d) return NaN
+    return Date.UTC(y, m - 1, d)
+  }
+  const target = utcMidnight(isoDate)
+  const base = utcMidnight(from)
+  if (isNaN(target) || isNaN(base)) return NaN
+  return Math.round((target - base) / 86_400_000)
+}
+
+// Whether a plain investment date is in the future. Client and server both derive
+// "today" in the business timezone, so they agree on the boundary and no
+// clock-skew allowance is needed: anything past the business day is future-dated.
+// Compared as plain dates (ISO strings sort chronologically), so any time portion
+// on the input is ignored.
 export function isFutureInvestmentDate(isoDate: string, asOf: Date = new Date()): boolean {
-  const max = new Date(asOf)
-  max.setUTCDate(max.getUTCDate() + 1)
-  return isoDate.slice(0, 10) > max.toISOString().slice(0, 10)
+  return isoDate.slice(0, 10) > todayIso(asOf)
 }

--- a/lib/dates.ts
+++ b/lib/dates.ts
@@ -54,6 +54,14 @@ export function addMonths(isoDate: string, n: number): string {
   return `${year}-${pad(month + 1)}-${pad(Math.min(d, lastDay))}`
 }
 
+// Add `n` whole calendar days to a YYYY-MM-DD date (negative to go back).
+// Computed in UTC from the date parts, so no timezone or DST shift can move it.
+export function addDaysIso(isoDate: string, n: number): string {
+  const [y, m, d] = isoDate.slice(0, 10).split('-').map(Number)
+  const target = new Date(Date.UTC(y, m - 1, d + n))
+  return `${target.getUTCFullYear()}-${pad(target.getUTCMonth() + 1)}-${pad(target.getUTCDate())}`
+}
+
 // A date formatted for *display* in the business timezone — the "generated on" /
 // "as of" line on a report. Without the explicit zone this reads the renderer's
 // clock: the PDF built on the UTC server would print yesterday while its own
@@ -101,9 +109,25 @@ export function daysUntilIso(isoDate: string, from: string = todayIso()): number
 
 // Whether a plain investment date is in the future. Client and server both derive
 // "today" in the business timezone, so they agree on the boundary and no
-// clock-skew allowance is needed: anything past the business day is future-dated.
-// Compared as plain dates (ISO strings sort chronologically), so any time portion
-// on the input is ignored.
-export function isFutureInvestmentDate(isoDate: string, asOf: Date = new Date()): boolean {
-  return isoDate.slice(0, 10) > todayIso(asOf)
+// clock-skew allowance is needed: by default anything past the business day is
+// future-dated. Compared as plain dates (ISO strings sort chronologically), so any
+// time portion on the input is ignored.
+//
+// `graceDays` is for the flows that anchor a new cycle to a date the app itself
+// chose rather than one the user typed — see MATURITY_ANCHOR_GRACE_DAYS. A
+// user-entered create/edit date must stay on the strict default.
+export function isFutureInvestmentDate(
+  isoDate: string,
+  asOf: Date = new Date(),
+  graceDays: number = 0,
+): boolean {
+  return isoDate.slice(0, 10) > addDaysIso(todayIso(asOf), graceDays)
 }
+
+// Renewing a term deposit (and collapsing an accumulating book) anchors the new
+// cycle to the OLD maturity date, not to today — so the next maturity is
+// old-maturity + term and accrual doesn't skip the overdue days. The 7-day
+// reminder window deliberately surfaces a deposit *before* it matures, so that
+// anchor can be up to a day ahead of the business date. The renew UI gates itself
+// at one day (`daysLeft > 1`); this is the server side of that same allowance.
+export const MATURITY_ANCHOR_GRACE_DAYS = 1

--- a/lib/dates.ts
+++ b/lib/dates.ts
@@ -39,6 +39,33 @@ export function businessYearMonth(now: Date = new Date()): { year: number; month
   return { year, month }
 }
 
+const pad = (n: number) => String(n).padStart(2, '0')
+
+// Add `n` whole months to a YYYY-MM-DD date (negative to go back), keeping the
+// day of month but clamping to the last valid day when the target month is
+// shorter — so 31 Jan + 1 month → 28 Feb rather than rolling into March.
+// Computed in UTC from the date parts, so it's timezone-independent.
+export function addMonths(isoDate: string, n: number): string {
+  const [y, m, d] = isoDate.slice(0, 10).split('-').map(Number)
+  const target = new Date(Date.UTC(y, m - 1 + n, 1))
+  const year = target.getUTCFullYear()
+  const month = target.getUTCMonth()
+  const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate()
+  return `${year}-${pad(month + 1)}-${pad(Math.min(d, lastDay))}`
+}
+
+// A date formatted for *display* in the business timezone — the "generated on" /
+// "as of" line on a report. Without the explicit zone this reads the renderer's
+// clock: the PDF built on the UTC server would print yesterday while its own
+// filename said today, and a user abroad would see their browser's day.
+export function formatBusinessDate(
+  locale: string,
+  options: Intl.DateTimeFormatOptions = { day: '2-digit', month: '2-digit', year: 'numeric' },
+  now: Date = new Date(),
+): string {
+  return new Intl.DateTimeFormat(locale, { ...options, timeZone: BUSINESS_TIMEZONE }).format(now)
+}
+
 // Whole months from the business month until a `YYYY-MM` target, floored at 1 —
 // the horizon a goal's monthly contribution is spread over. Floored because a
 // target in the current or a past month still needs one month to save into.

--- a/lib/dates.ts
+++ b/lib/dates.ts
@@ -39,6 +39,16 @@ export function businessYearMonth(now: Date = new Date()): { year: number; month
   return { year, month }
 }
 
+// Whole months from the business month until a `YYYY-MM` target, floored at 1 —
+// the horizon a goal's monthly contribution is spread over. Floored because a
+// target in the current or a past month still needs one month to save into.
+export function monthsUntilYm(ym: string, now: Date = new Date()): number {
+  const [y, m] = ym.split('-').map(Number)
+  if (!y || !m) return 1
+  const { year, month } = businessYearMonth(now)
+  return Math.max(1, (y - year) * 12 + (m - month))
+}
+
 // The business day as a Date at *local* midnight, for the date arithmetic that
 // still runs on Date objects (e.g. stepping a premium anniversary forward a
 // year). Only the date parts are meaningful — never read a time off it.

--- a/lib/finance.ts
+++ b/lib/finance.ts
@@ -1,3 +1,5 @@
+import { businessTodayDate, businessYearMonth } from './dates'
+
 // The single source of truth for a bank term deposit's accrued interest, used by
 // the dashboard/net-worth, the goals list and the goal-detail holding rows so
 // the same deposit never shows a different value across screens.
@@ -48,8 +50,7 @@ export function insuranceStatus(
   const anchor = parseLocalDate(paymentDate)
   if (!anchor) return 'on_track'
 
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
+  const today = businessTodayDate()
   const last = lastPaymentDate ? parseLocalDate(lastPaymentDate) : null
 
   // Work out the next due date.
@@ -79,25 +80,23 @@ export function insuranceStatus(
 }
 
 // Returns the calendar year a member's premium was last settled for, but only
-// when that payment happened in the current year — i.e. the current cycle is
-// paid. Returns null otherwise. The date is parsed as local so a plain
-// YYYY-MM-DD string never shifts across a timezone boundary.
+// when that payment happened in the current business year — i.e. the current
+// cycle is paid. Returns null otherwise. The date is parsed from its parts so a
+// plain YYYY-MM-DD string never shifts across a timezone boundary.
 export function insurancePaidYear(lastPaymentDate: string | null): number | null {
   if (!lastPaymentDate) return null
   // last_payment_date is a timestamptz, so trim any time part to the date first.
   const [y, m, d] = lastPaymentDate.slice(0, 10).split('-').map(Number)
   const paid = new Date(y, (m ?? 1) - 1, d ?? 1)
   if (isNaN(paid.getTime())) return null
-  return paid.getFullYear() === new Date().getFullYear() ? paid.getFullYear() : null
+  return paid.getFullYear() === businessYearMonth().year ? paid.getFullYear() : null
 }
 
 // A monthly plan exists only once income is set for that month, and its
 // insurance allocation counts as saved once the month has arrived — the current
 // month or any past month. A future month's allocation is not saved yet.
 export function isPlanMonthRealized(year: number, month: number): boolean {
-  const now = new Date()
-  const nowYear = now.getFullYear()
-  const nowMonth = now.getMonth() + 1
+  const { year: nowYear, month: nowMonth } = businessYearMonth()
   return year < nowYear || (year === nowYear && month <= nowMonth)
 }
 

--- a/lib/generateReport.ts
+++ b/lib/generateReport.ts
@@ -1,4 +1,5 @@
 import type { DashboardData } from '@/app/assets/DashboardClient'
+import { todayIso } from '@/lib/dates'
 
 export async function downloadPortfolioPDF(data: DashboardData, locale: string): Promise<void> {
   const res = await fetch('/api/v1/report', {
@@ -13,7 +14,7 @@ export async function downloadPortfolioPDF(data: DashboardData, locale: string):
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url
-  a.download = `allocate-report-${new Date().toISOString().slice(0, 10)}.pdf`
+  a.download = `allocate-report-${todayIso()}.pdf`
   a.click()
   URL.revokeObjectURL(url)
 }

--- a/lib/historyRange.ts
+++ b/lib/historyRange.ts
@@ -2,17 +2,25 @@
 // inclusive lower-bound date (YYYY-MM-DD) used to filter snapshots. Returns null
 // for "all" / unknown, meaning no lower bound.
 //
-// UTC methods keep the cutoff deterministic regardless of server timezone — the
-// result is compared against date-only strings (snapshot_date / YYYY-MM).
+// Measured back from the *business* day, because that is what the snapshots are
+// keyed to (see lib/dates). Subtracting from the UTC date parts moved the cutoff
+// a day earlier for the first seven hours of each Vietnam day, so the chart
+// gained a snapshot before 07:00 and lost it again afterwards — inside a single
+// business day (#591). Month steps clamp to the last valid day, so a cutoff
+// measured from the 31st can't overflow into the next month and silently drop a
+// month of history.
+import { todayIso, addMonths } from './dates'
+
+const RANGE_MONTHS: Record<string, number> = {
+  '1m': 1,
+  '3m': 3,
+  '6m': 6,
+  '1y': 12,
+  '3y': 36,
+}
+
 export function rangeStartDate(range: string, now: Date = new Date()): string | null {
-  const d = new Date(now)
-  switch (range) {
-    case '1m': d.setUTCMonth(d.getUTCMonth() - 1); break
-    case '3m': d.setUTCMonth(d.getUTCMonth() - 3); break
-    case '6m': d.setUTCMonth(d.getUTCMonth() - 6); break
-    case '1y': d.setUTCFullYear(d.getUTCFullYear() - 1); break
-    case '3y': d.setUTCFullYear(d.getUTCFullYear() - 3); break
-    default: return null // 'all' or anything unrecognised
-  }
-  return d.toISOString().split('T')[0]
+  const months = RANGE_MONTHS[range]
+  if (!months) return null // 'all' or anything unrecognised
+  return addMonths(todayIso(now), -months)
 }

--- a/lib/maturity.ts
+++ b/lib/maturity.ts
@@ -8,6 +8,8 @@
 // app/assets/components/MaturityResolveSheet.tsx. See also `fmtMaturity` in
 // goalDetailShared.tsx for the display formatting.
 
+import { daysUntilIso } from './dates'
+
 // Surface a deposit as "needs attention" once it is within this many days of
 // maturity (in addition to already-matured ones). A week of lead time lets the
 // user decide (renew / withdraw) before the deposit actually matures.
@@ -53,14 +55,11 @@ export function isMaturityActionable(state: MaturityState): boolean {
   return state === 'matured' || state === 'maturing'
 }
 
-// Whole days from today until the given YYYY-MM-DD date (negative once past).
-// Mirrors the diffDays computation in fmtMaturity so the two never diverge.
+// Whole days from the business day until the given YYYY-MM-DD date (negative
+// once past). fmtMaturity computes diffDays through the same helper so the two
+// never diverge.
 export function daysUntil(isoDate: string): number {
-  const d = new Date(isoDate + 'T00:00:00')
-  if (isNaN(d.getTime())) return NaN
-  const today = new Date()
-  today.setHours(0, 0, 0, 0)
-  return Math.round((d.getTime() - today.getTime()) / 86_400_000)
+  return daysUntilIso(isoDate)
 }
 
 // Whether a non-fund holding is a term deposit that needs a decision right now

--- a/lib/maturity.ts
+++ b/lib/maturity.ts
@@ -85,20 +85,9 @@ export function isActionableAccumulatingBook(
   return isMaturityActionable(depositMaturityState(daysUntil(it.expiryDate)))
 }
 
-const pad = (n: number) => String(n).padStart(2, '0')
-
-// Add `n` whole months to a YYYY-MM-DD date, keeping the day of month but
-// clamping to the last valid day when the target month is shorter (so
-// 31 Jan + 1 month → 28 Feb rather than rolling into March). Computed in UTC
-// from the date parts to stay timezone-independent.
-export function addMonths(isoDate: string, n: number): string {
-  const [y, m, d] = isoDate.split('-').map(Number)
-  const target = new Date(Date.UTC(y, m - 1 + n, 1))
-  const year = target.getUTCFullYear()
-  const month = target.getUTCMonth()
-  const lastDay = new Date(Date.UTC(year, month + 1, 0)).getUTCDate()
-  return `${year}-${pad(month + 1)}-${pad(Math.min(d, lastDay))}`
-}
+// Plain-date month arithmetic now lives with the other plain-date helpers in
+// lib/dates; re-exported here so the maturity call sites keep one import.
+export { addMonths } from './dates'
 
 // Whole months between two YYYY-MM-DD dates (the count of complete months from
 // `fromIso` to `toIso`). Used to derive a deposit's original term length from

--- a/lib/scrape-fund-nav.ts
+++ b/lib/scrape-fund-nav.ts
@@ -1,5 +1,6 @@
 import https from 'https'
 import { ValidationError } from './validation'
+import { todayIso } from './dates'
 import {
   boundedFetchText,
   httpSemaphore,
@@ -158,7 +159,10 @@ async function scrapeDragonCapital(url: string): Promise<number> {
   const urlReportCode = pathSegments[pathSegments.length - 1].toUpperCase()
   if (!urlReportCode) throw new Error('Dragon Capital: could not extract fund report code from URL')
 
-  const today = new Date().toISOString().split('T')[0]
+  // Upper bound of the NAV query window. The provider publishes on Vietnam
+  // business days, so the window must close on the Vietnam date — the UTC one
+  // lags it by a day for the first seven hours (#591).
+  const today = todayIso()
   const siteId = '0DMJ2000000oLukOAE'
   const classname = '@udd/01pJ2000000CgSu'
 


### PR DESCRIPTION
Closes #591.

## The problem

`lib/dates` had a `todayIso()` helper whose comment documented the UTC+7 drift, but most call sites never used it — they derived "today" from UTC (`toISOString().slice(0, 10)`) or from the runtime's local zone (`new Date().getMonth()`).

**Between 00:00 and 06:59 Vietnam time the UTC calendar date is still yesterday.** During those seven hours each day the dashboard snapshot was keyed to the previous day, insurance premiums settled against the previous date, and monthly-plan / recurring contributions landed in the previous month.

## The policy

One business timezone — **`Asia/Ho_Chi_Minh`** — and every "today", "current month" and plain-date comparison derives in it, wherever the code runs: a browser in any timezone, a Vercel function in UTC, a cron job. Documented at the top of `lib/dates.ts` and in `CLAUDE.md`.

`new Date().toISOString()` on its own stays correct and allowed — that's a UTC *timestamp* (`updated_at`), not a business date.

## What changed

**`lib/dates` — the single source.** `BUSINESS_TIMEZONE`, `todayIso(now?)`, `businessYearMonth()`, `businessTodayDate()`, `daysUntilIso()`, `addDaysIso()`, `addMonths()`, `monthsUntilYm()`, `formatBusinessDate()`. Plain dates are compared and differenced **from their parts**, never parsed into an instant, so no timezone can shift them.

**Server** — dashboard snapshot key, insurance mark-paid default, fund-investment default date, matured-book top-up guard, the create *and* edit future-date guards, Dragon Capital NAV window, history-range cutoffs, report filename.

**Client** — planning (initial month, "today" nav), the desktop planning pill, recurring book top-up, goal-detail top-up, add-insurance-member, log-insurance-payment, goal projection date, and the goal-deadline horizon.

**Deduplication.** `daysUntil`/`fmtMaturity` shared into one helper; three inlined copies of "months until a YYYY-MM" became `monthsUntilYm()`; `LogInsurancePaymentModal`'s private `todayLocalISO()` deleted; `addMonths` moved to `lib/dates` (re-exported from `lib/maturity`, so no importer changed).

**Regression guard.** An eslint `no-restricted-syntax` rule blocks four forms in `app/`, `lib/`, `components/`: the UTC truncation, local date-part reads, unzoned `toLocaleDateString`, and — since reading parts off an aliased `Date` is indistinguishable from reading them off a legitimately *parsed* one — aliasing a bare `new Date()` at all. Exactly one site legitimately needs the alias (`mark-paid` shares one instant across `updated_at`, the response and its audit line); it carries a disable and a note.

## Behaviour changes worth review

1. **`isFutureInvestmentDate` is strict by default.** Its old one-day allowance existed for client/server clock skew, which no longer exists. But that tolerance was quietly doing a *second* job: the renew and book-collapse flows anchor a new cycle to the **old maturity date**, which the 7-day reminder window can surface a day before it falls. Those two routes now opt in explicitly via `MATURITY_ANCHOR_GRACE_DAYS = 1`; user-typed create/edit dates stay strict.
2. **Editing a transaction now uses the same rule as creating one.** The edit route compared `new Date(date) > new Date()`, so between 00:00–06:59 VN it rejected the very date creation had just accepted — and because the check fires whenever `investment_date` is present, an edit that only changed the *amount* failed with "cannot be in the future".

## Bugs found along the way

- **`rangeStartDate` month overflow** (pre-existing): `31 Mar − 1 month` returned `3 Mar` instead of `28 Feb`, silently dropping a month of history.
- **Report date/filename disagreement**: correcting the filename to the business day left `PortfolioReport`'s "generated on" line printing yesterday from the UTC server.
- **Timezone-fragile test fixtures**: five files built maturity fixtures from the runtime-local clock. Against the new business calendar that is a deterministic CI failure for seven hours a day on a UTC runner.

## Tests

Boundary tests pin **00:30, 06:59 and 07:00 Vietnam time** across day, month and year rollovers, written as instants (`2026-05-31T17:30:00Z`) so they assert the same thing on any machine.

**Timezone independence is verified, not assumed:** the full unit suite passes **identically (1916/1916) under `Pacific/Honolulu`, `UTC` and `America/New_York`**. Before the fixture fix, Honolulu alone produced 9 failures including `expected -1 to be +0`.

## Checks

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test -- --run` ✅ 1916 tests, identical across three timezones
- `npm run test:e2e` ✅ 274 passed (full suite)

Full E2E was warranted: this touches the dashboard overview API, shared maturity components, the insurance settlement path and the transactions routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)