### PR TITLE
fix(dashboard): await the net-worth snapshot write and log its failures (#592)

### DIFF
--- a/app/api/v1/dashboard/overview/__tests__/route.test.ts
+++ b/app/api/v1/dashboard/overview/__tests__/route.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { SNAPSHOT_WRITE_TIMEOUT_MS } from '@/lib/snapshots'
 
 // A partial dashboard read must never (a) return an understated 200 nor
 // (b) overwrite today's net-worth snapshot with the incomplete value (#513).
@@ -15,9 +16,30 @@ const h = vi.hoisted(() => ({
   user: { id: 'user-1' } as { id: string } | null,
   tables: {} as Record<string, { data: unknown; error: unknown }>,
   upsertCalls: [] as unknown[],
+  // How the snapshot upsert behaves, and whether it had actually settled by the
+  // time GET() resolved — the fire-and-forget bug (#592) is precisely a response
+  // that finishes while this is still false.
+  upsertOutcome: 'ok' as 'ok' | 'error' | 'reject' | 'hang',
+  upsertSettled: false,
 }))
 
 vi.mock('@/lib/supabase-server', () => {
+  /**
+   * The snapshot write resolves on a macrotask, so a handler that does not await
+   * it returns first — which is what the `upsertSettled` assertions detect.
+   */
+  function snapshotWrite() {
+    if (h.upsertOutcome === 'hang') return new Promise(() => { /* never settles */ })
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        h.upsertSettled = true
+        if (h.upsertOutcome === 'reject') reject(new Error('connection reset'))
+        else if (h.upsertOutcome === 'error') resolve({ error: { message: 'permission denied' } })
+        else resolve({ error: null })
+      }, 0)
+    })
+  }
+
   function chainFor(name: string) {
     const result = () => h.tables[name] ?? { data: [], error: null }
     const chain: Record<string, unknown> = {
@@ -28,8 +50,9 @@ vi.mock('@/lib/supabase-server', () => {
       maybeSingle: async () => result(),
       then: (resolve: (v: unknown) => void) => resolve(result()),
       upsert: (row: unknown) => {
-        if (name === 'net_worth_snapshots') h.upsertCalls.push(row)
-        return { then: (r: (v: unknown) => void) => r({ error: null }) }
+        if (name !== 'net_worth_snapshots') return { then: (r: (v: unknown) => void) => r({ error: null }) }
+        h.upsertCalls.push(row)
+        return snapshotWrite()
       },
     }
     return chain
@@ -76,6 +99,8 @@ function withOnePlan() {
 beforeEach(() => {
   h.user = { id: 'user-1' }
   h.upsertCalls = []
+  h.upsertOutcome = 'ok'
+  h.upsertSettled = false
   baseHappy()
 })
 
@@ -138,5 +163,68 @@ describe('GET /api/v1/dashboard/overview — optional gold price (#513)', () => 
     const res = await GET()
     expect(res.status).toBe(500)
     expect(h.upsertCalls).toHaveLength(0)
+  })
+})
+
+// #592 — the snapshot write used to be fire-and-forget, so on a serverless
+// runtime the response could finish (and the instance freeze) before the row
+// landed, silently dropping history points.
+describe('GET /api/v1/dashboard/overview — snapshot persistence is awaited (#592)', () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    errorSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
+  it('does not resolve the response until the snapshot write has settled', async () => {
+    const res = await GET()
+    expect(res.status).toBe(200)
+    expect(h.upsertSettled).toBe(true)
+  })
+
+  it('still returns 200 when the snapshot write fails', async () => {
+    h.upsertOutcome = 'error'
+    const res = await GET()
+    expect(res.status).toBe(200)
+    expect(await res.json()).toHaveProperty('netWorth')
+  })
+
+  it('logs the failure with user/date context but no financial payload', async () => {
+    h.upsertOutcome = 'error'
+    await GET()
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    const [message, context] = errorSpy.mock.calls[0] as [string, Record<string, unknown>]
+    expect(message).toContain('snapshot')
+    expect(context).toMatchObject({ user_id: 'user-1', reason: 'permission denied' })
+    expect(context.snapshot_date).toEqual(expect.any(String))
+    expect(JSON.stringify(context)).not.toContain('total_assets')
+  })
+
+  it('still returns 200 when the snapshot write rejects', async () => {
+    h.upsertOutcome = 'reject'
+    const res = await GET()
+    expect(res.status).toBe(200)
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('gives up on a hung write instead of hanging the response', async () => {
+    vi.useFakeTimers()
+    h.upsertOutcome = 'hang'
+    const pending = GET()
+    await vi.advanceTimersByTimeAsync(SNAPSHOT_WRITE_TIMEOUT_MS + 1)
+    const res = await pending
+    expect(res.status).toBe(200)
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    expect((errorSpy.mock.calls[0] as [string, Record<string, unknown>])[1]).toMatchObject({ reason: 'timeout' })
+  })
+
+  it('logs nothing when the write succeeds', async () => {
+    await GET()
+    expect(errorSpy).not.toHaveBeenCalled()
   })
 })

--- a/app/api/v1/dashboard/overview/route.ts
+++ b/app/api/v1/dashboard/overview/route.ts
@@ -4,7 +4,7 @@ import { isNavStale, insuranceStatus, isPlanMonthRealized, isInCurrentCycle, rea
 import { buildWithdrawalMaps } from '@/lib/withdrawalProgress'
 import { heldForMergeContributions } from '@/lib/heldForMerge'
 import { valueNonFundHolding } from '@/lib/depositValuation'
-import { shouldWriteSnapshot } from '@/lib/snapshots'
+import { persistSnapshot, shouldWriteSnapshot } from '@/lib/snapshots'
 import { todayIso } from '@/lib/dates'
 
 export const dynamic = 'force-dynamic'
@@ -559,15 +559,29 @@ export async function GET() {
 
   const hasGold = allTxsRaw.some((tx) => tx.asset_type === 'gold')
 
-  // Upsert today's snapshot for the history chart (fire-and-forget), but only
-  // when the rounded value actually changed. The dashboard is loaded many times
-  // a day; re-writing an identical row just burns disk I/O (WAL + dirtied page +
-  // autovacuum) for no benefit. See lib/snapshots.ts.
+  // Upsert today's snapshot for the history chart, but only when the rounded
+  // value actually changed. The dashboard is loaded many times a day; re-writing
+  // an identical row just burns disk I/O (WAL + dirtied page + autovacuum) for no
+  // benefit. See lib/snapshots.ts.
+  //
+  // The write is awaited (with a timeout) so a serverless instance can't freeze
+  // before the row lands — but it never fails the response: history is secondary
+  // to the numbers on screen, so a broken write is logged, not surfaced (#592).
   if (shouldWriteSnapshot(snapshotRes.data, totalAssets)) {
-    supabase.from('net_worth_snapshots').upsert(
-      { user_id: user.id, snapshot_date: today, total_assets: Math.round(totalAssets) },
-      { onConflict: 'user_id,snapshot_date' }
-    ).then(() => { /* ignore errors */ })
+    const written = await persistSnapshot(() =>
+      supabase.from('net_worth_snapshots').upsert(
+        { user_id: user.id, snapshot_date: today, total_assets: Math.round(totalAssets) },
+        { onConflict: 'user_id,snapshot_date' }
+      )
+    )
+    if (!written.ok) {
+      // Context only — never the balance itself.
+      console.error('[dashboard/overview] net-worth snapshot write failed', {
+        user_id: user.id,
+        snapshot_date: today,
+        reason: written.reason,
+      })
+    }
   }
 
   return NextResponse.json({

--- a/lib/__tests__/snapshots.test.ts
+++ b/lib/__tests__/snapshots.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { shouldWriteSnapshot } from '../snapshots'
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { shouldWriteSnapshot, persistSnapshot, SNAPSHOT_WRITE_TIMEOUT_MS } from '../snapshots'
 
 describe('shouldWriteSnapshot', () => {
   it('writes when there is no existing snapshot for today', () => {
@@ -20,5 +20,52 @@ describe('shouldWriteSnapshot', () => {
   it('writes when the rounded total changed', () => {
     expect(shouldWriteSnapshot({ total_assets: 1_000_000 }, 1_000_001)).toBe(true)
     expect(shouldWriteSnapshot({ total_assets: 1_000_000 }, 999_999)).toBe(true)
+  })
+})
+
+describe('persistSnapshot (#592)', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('resolves ok when the write succeeds', async () => {
+    await expect(persistSnapshot(async () => ({ error: null }))).resolves.toEqual({ ok: true })
+  })
+
+  it('reports a Supabase error without throwing', async () => {
+    const result = await persistSnapshot(async () => ({ error: { message: 'permission denied' } }))
+    expect(result).toEqual({ ok: false, reason: 'permission denied' })
+  })
+
+  it('reports a rejected write without throwing', async () => {
+    const result = await persistSnapshot(async () => { throw new Error('connection reset') })
+    expect(result).toEqual({ ok: false, reason: 'connection reset' })
+  })
+
+  it('reports a thrown non-Error without throwing', async () => {
+    const result = await persistSnapshot(async () => { throw 'boom' })
+    expect(result).toEqual({ ok: false, reason: 'boom' })
+  })
+
+  it('gives up after the timeout instead of holding the response open', async () => {
+    vi.useFakeTimers()
+    const pending = persistSnapshot(() => new Promise(() => { /* never settles */ }))
+    await vi.advanceTimersByTimeAsync(SNAPSHOT_WRITE_TIMEOUT_MS + 1)
+    await expect(pending).resolves.toEqual({ ok: false, reason: 'timeout' })
+  })
+
+  it('honours a caller-supplied timeout', async () => {
+    vi.useFakeTimers()
+    const pending = persistSnapshot(() => new Promise(() => {}), { timeoutMs: 50 })
+    await vi.advanceTimersByTimeAsync(51)
+    await expect(pending).resolves.toEqual({ ok: false, reason: 'timeout' })
+  })
+
+  it('clears the timeout timer once the write settles', async () => {
+    vi.useFakeTimers()
+    const clearSpy = vi.spyOn(globalThis, 'clearTimeout')
+    await persistSnapshot(async () => ({ error: null }))
+    expect(clearSpy).toHaveBeenCalled()
+    clearSpy.mockRestore()
   })
 })

--- a/lib/snapshots.ts
+++ b/lib/snapshots.ts
@@ -15,3 +15,40 @@ export function shouldWriteSnapshot(
   if (!existing) return true
   return Math.round(existing.total_assets) !== Math.round(newTotalAssets)
 }
+
+/**
+ * How long the dashboard response is willing to wait for the snapshot write.
+ * History is a nice-to-have next to the numbers on screen, so a slow database
+ * costs us one history point, never a slow (or failed) dashboard.
+ */
+export const SNAPSHOT_WRITE_TIMEOUT_MS = 2_000
+
+export type SnapshotWriteResult = { ok: true } | { ok: false; reason: string }
+
+/**
+ * Run the snapshot upsert to completion so a serverless instance cannot freeze
+ * mid-write (#592): the old fire-and-forget `.then()` let the response return
+ * first, dropping history points with no trace. Every failure mode — a Supabase
+ * error, a rejection, or a write that never settles — is reported back to the
+ * caller instead of thrown, so the dashboard response is never at risk.
+ */
+export async function persistSnapshot(
+  write: () => PromiseLike<{ error: { message?: string } | null }>,
+  { timeoutMs = SNAPSHOT_WRITE_TIMEOUT_MS }: { timeoutMs?: number } = {},
+): Promise<SnapshotWriteResult> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    const timeout = new Promise<'timeout'>((resolve) => {
+      timer = setTimeout(() => resolve('timeout'), timeoutMs)
+    })
+    const outcome = await Promise.race([Promise.resolve(write()), timeout])
+    if (outcome === 'timeout') return { ok: false, reason: 'timeout' }
+    if (outcome?.error) return { ok: false, reason: outcome.error.message ?? 'unknown error' }
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : String(err) }
+  } finally {
+    // Leave no pending timer behind — it would keep the function instance awake.
+    clearTimeout(timer)
+  }
+}


### PR DESCRIPTION
Closes #592.

## Problem

`app/api/v1/dashboard/overview/route.ts` started today's `net_worth_snapshots` upsert in a fire-and-forget `.then(() => { /* ignore errors */ })`. On a serverless runtime the response can finish — and the instance freeze — before the write lands, so history points go missing. The empty handler also swallowed every error, making that impossible to diagnose.

## Fix

New `persistSnapshot()` in `lib/snapshots.ts` runs the upsert to completion behind a 2s timeout and reports each failure mode (`error` result, rejection, hung write) instead of throwing. The route awaits it:

- history persistence never fails the dashboard — the response is still 200 when the write errors, rejects, or times out;
- failures log `user_id` + `snapshot_date` + reason, and deliberately **not** `total_assets`;
- the timeout timer is cleared so no pending timer keeps the function instance awake.

## Tests (TDD, red first)

- `lib/__tests__/snapshots.test.ts` — success, Supabase error, rejection, thrown non-Error, default + caller timeout, timer cleanup.
- `app/api/v1/dashboard/overview/__tests__/route.test.ts` — the snapshot mock now resolves on a macrotask, so the new assertion that the write has settled by the time `GET()` resolves genuinely fails against fire-and-forget. Covers: awaited write, 200 on error/rejection/timeout, log shape (no financial payload), and no log on success.

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test -- --run` ✅ 1929 tests
- `npm run test:e2e` ✅ 274 passed (10.0m) — full suite, since this touches the dashboard overview API

🤖 Generated with [Claude Code](https://claude.com/claude-code)