### PR TITLE
fix(transactions): clear the old subtype when a transaction changes asset type (#593)

### DIFF
--- a/app/api/v1/investment-transactions/[id]/__tests__/route.put.subtype.test.ts
+++ b/app/api/v1/investment-transactions/[id]/__tests__/route.put.subtype.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// Changing a transaction's asset type used to leave the previous subtype's
+// columns behind (#593): Bank -> Fund/Gold kept the rate, maturity and bank
+// code; Gold -> Bank kept the units and unit price. The row then described two
+// kinds of holding at once, and every later reader — valuation, reports,
+// migrations — had to guess which half was true.
+//
+// The edit route is the one place every type change passes through, so it is
+// where the old subtype is cleared.
+
+const TX_ID = '11111111-1111-4111-8111-111111111111'
+const GOAL_ID = '22222222-2222-4222-8222-222222222222'
+const FUND_ID = '33333333-3333-4333-8333-333333333333'
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  existing: { deposit_group_id: null as string | null, asset_type: 'bank' as string | null },
+  updates: null as Record<string, unknown> | null,
+  updateResult: { data: { transaction_id: '11111111-1111-4111-8111-111111111111' } as unknown, error: null as unknown },
+  rpcCalls: [] as { name: string; args: Record<string, unknown> }[],
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  function chainFor(table: string) {
+    let op: 'select' | 'update' = 'select'
+    const c: Record<string, unknown> = {
+      select: () => c,
+      eq: () => c,
+      update: (payload: Record<string, unknown>) => { op = 'update'; h.updates = payload; return c },
+      single: async () => {
+        if (op === 'update') return h.updateResult
+        if (table === 'savings_goals') return { data: { goal_id: GOAL_ID }, error: null }
+        if (table === 'funds') return { data: { id: FUND_ID }, error: null }
+        return { data: h.existing, error: null }
+      },
+    }
+    return c
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (table: string) => chainFor(table),
+      rpc: (name: string, args: Record<string, unknown>) => {
+        h.rpcCalls.push({ name, args })
+        return { single: async () => ({ data: { transaction_id: TX_ID }, error: null }) }
+      },
+    }),
+  }
+})
+
+const { PUT } = await import('../route')
+
+const put = (body: Record<string, unknown>) =>
+  PUT(
+    new Request(`https://app.test/api/v1/investment-transactions/${TX_ID}`, {
+      method: 'PUT',
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest,
+    { params: Promise.resolve({ id: TX_ID }) },
+  )
+
+/** The columns that belong to exactly one asset type. */
+const EXCLUSIVE = [
+  'fund_id', 'units', 'unit_price',
+  'interest_rate', 'expiry_date', 'bank_code', 'interest_earned_vnd', 'deposit_group_id',
+] as const
+
+beforeEach(() => {
+  h.user = { id: 'user-1' }
+  h.existing = { deposit_group_id: null, asset_type: 'bank' }
+  h.updates = null
+  h.updateResult = { data: { transaction_id: TX_ID }, error: null }
+  h.rpcCalls = []
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('PUT /api/v1/investment-transactions/[id] — subtype normalization (#593)', () => {
+  it('clears the bank metadata when a deposit becomes a fund', async () => {
+    h.existing = { deposit_group_id: null, asset_type: 'bank' }
+    const res = await put({
+      asset_type: 'fund', fund_id: FUND_ID, amount_vnd: 5_000_000,
+      units: 250, unit_price: 20_000,
+    })
+    expect(res.status).toBe(200)
+    expect(h.updates).toMatchObject({
+      asset_type: 'fund', fund_id: FUND_ID, units: 250, unit_price: 20_000,
+      interest_rate: null, expiry_date: null, bank_code: null,
+      interest_earned_vnd: null, deposit_group_id: null,
+    })
+  })
+
+  it('clears the bank metadata when a deposit becomes gold', async () => {
+    h.existing = { deposit_group_id: null, asset_type: 'bank' }
+    await put({ asset_type: 'gold', amount_vnd: 7_000_000, units: 2, unit_price: 3_500_000 })
+    expect(h.updates).toMatchObject({
+      asset_type: 'gold', fund_id: null, units: 2, unit_price: 3_500_000,
+      interest_rate: null, expiry_date: null, bank_code: null,
+      interest_earned_vnd: null, deposit_group_id: null,
+    })
+  })
+
+  it('clears the units and unit price when gold becomes a bank deposit', async () => {
+    h.existing = { deposit_group_id: null, asset_type: 'gold' }
+    await put({ asset_type: 'bank', amount_vnd: 10_000_000, interest_rate: 5.5, expiry_date: '2027-01-01' })
+    expect(h.updates).toMatchObject({
+      asset_type: 'bank', units: null, unit_price: null, fund_id: null,
+      interest_rate: 5.5, expiry_date: '2027-01-01',
+    })
+  })
+
+  it('clears the fund link and stale units when a fund becomes a bank deposit', async () => {
+    h.existing = { deposit_group_id: null, asset_type: 'fund' }
+    await put({ asset_type: 'bank', amount_vnd: 10_000_000 })
+    expect(h.updates).toMatchObject({ asset_type: 'bank', fund_id: null, units: null, unit_price: null })
+  })
+
+  it('clears the stale gold units when gold becomes a fund and the caller omits them', async () => {
+    // Gold units are chỉ and fund units are shares — carrying them over would
+    // value the fund holding off the gold quantity.
+    h.existing = { deposit_group_id: null, asset_type: 'gold' }
+    await put({ asset_type: 'fund', fund_id: FUND_ID, amount_vnd: 5_000_000 })
+    expect(h.updates).toMatchObject({ asset_type: 'fund', fund_id: FUND_ID, units: null, unit_price: null })
+  })
+
+  // Both directions of every transition: nothing exclusive to the old type may
+  // survive, whether or not the caller sent a replacement for it.
+  const TYPES = ['fund', 'bank', 'gold'] as const
+  for (const from of TYPES) {
+    for (const to of TYPES) {
+      if (from === to) continue
+      it(`leaves no ${from} field set after a change to ${to}`, async () => {
+        h.existing = { deposit_group_id: null, asset_type: from }
+        await put({ asset_type: to, ...(to === 'fund' ? { fund_id: FUND_ID } : {}), amount_vnd: 1_000_000 })
+        const updates = h.updates ?? {}
+        for (const field of EXCLUSIVE) {
+          expect(updates).toHaveProperty(field)
+          if (to === 'fund' && field === 'fund_id') expect(updates[field]).toBe(FUND_ID)
+          else expect(updates[field]).toBeNull()
+        }
+      })
+    }
+  }
+
+  it('leaves the subtype fields alone on a partial edit that keeps the type', async () => {
+    h.existing = { deposit_group_id: null, asset_type: 'bank' }
+    await put({ notes: 'renamed' })
+    const updates = h.updates ?? {}
+    for (const field of EXCLUSIVE) expect(updates).not.toHaveProperty(field)
+    expect(updates).toMatchObject({ notes: 'renamed' })
+  })
+
+  it('leaves the subtype fields alone when the edit restates the same type', async () => {
+    h.existing = { deposit_group_id: null, asset_type: 'bank' }
+    await put({ asset_type: 'bank', amount_vnd: 2_000_000 })
+    const updates = h.updates ?? {}
+    for (const field of EXCLUSIVE) expect(updates).not.toHaveProperty(field)
+    expect(updates).toMatchObject({ asset_type: 'bank', amount_vnd: 2_000_000 })
+  })
+
+  it('still scopes a stray bank_code to bank deposits on a same-type edit', async () => {
+    h.existing = { deposit_group_id: null, asset_type: 'fund' }
+    await put({ bank_code: 'VCB' })
+    expect(h.updates).toMatchObject({ bank_code: null })
+  })
+
+  it('refuses to change the asset type of an accumulating deposit book', async () => {
+    // A book is a group of bank tranches; converting one row would leave the
+    // rest of the group describing a deposit that no longer exists.
+    h.existing = { deposit_group_id: 'book-1', asset_type: 'bank' }
+    const res = await put({ asset_type: 'gold', amount_vnd: 1_000_000 })
+    expect(res.status).toBe(400)
+    expect(h.rpcCalls).toHaveLength(0)
+    expect(h.updates).toBeNull()
+  })
+
+  it('still edits an accumulating book through the atomic RPC when the type is unchanged', async () => {
+    h.existing = { deposit_group_id: 'book-1', asset_type: 'bank' }
+    const res = await put({ asset_type: 'bank', amount_vnd: 1_000_000 })
+    expect(res.status).toBe(200)
+    expect(h.rpcCalls.map((c) => c.name)).toEqual(['update_deposit_book'])
+  })
+
+  it('does not normalize a legacy row whose asset type is unknown', async () => {
+    h.existing = { deposit_group_id: null, asset_type: null }
+    await put({ asset_type: 'fund', fund_id: FUND_ID, amount_vnd: 1_000_000 })
+    const updates = h.updates ?? {}
+    expect(updates).toMatchObject({ asset_type: 'fund', fund_id: FUND_ID })
+    expect(updates).not.toHaveProperty('interest_rate')
+  })
+})

--- a/app/api/v1/investment-transactions/[id]/__tests__/route.put.subtype.test.ts
+++ b/app/api/v1/investment-transactions/[id]/__tests__/route.put.subtype.test.ts
@@ -186,6 +186,21 @@ describe('PUT /api/v1/investment-transactions/[id] — subtype normalization (#5
     expect(h.rpcCalls.map((c) => c.name)).toEqual(['update_deposit_book'])
   })
 
+  it('reports a book the database refused to convert as a conflict, not a missing row', async () => {
+    // The route's own guard reads deposit_group_id before it writes, so a
+    // deposit that becomes a book in between (a recurring top-up self-groups its
+    // anchor) is refused by the trigger instead. 404 would describe that as a
+    // row that isn't there.
+    h.existing = { deposit_group_id: null, asset_type: 'bank' }
+    h.updateResult = {
+      data: null,
+      error: { message: 'deposit book: a tranche of an accumulating book cannot change asset type' },
+    }
+    const res = await put({ asset_type: 'gold', amount_vnd: 1_000_000 })
+    expect(res.status).toBe(400)
+    expect(await res.json()).toMatchObject({ code: 'book_type_change' })
+  })
+
   it('does not normalize a legacy row whose asset type is unknown', async () => {
     h.existing = { deposit_group_id: null, asset_type: null }
     await put({ asset_type: 'fund', fund_id: FUND_ID, amount_vnd: 1_000_000 })

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -3,6 +3,7 @@ import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateBankCode, validateDate, validateEnum, validateNotes, validateRate, validateUUID } from '@/lib/validation'
 import { readJsonBody } from '@/lib/apiBody'
 import { isFutureInvestmentDate } from '@/lib/dates'
+import { subtypeResetFields } from '@/lib/assetTypeFields'
 
 const ASSET_TYPES = ['fund', 'bank', 'stock', 'gold'] as const
 
@@ -145,6 +146,19 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     .single()
   if (!existing) return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
 
+  const changesAssetType = Boolean(cleanAssetType && existing.asset_type && cleanAssetType !== existing.asset_type)
+
+  // A book is a group of bank tranches sharing a goal, a maturity and a bank.
+  // Converting one row out of `bank` would leave its siblings describing a
+  // deposit that no longer exists — and the book RPC has no asset_type argument,
+  // so the change would silently do nothing. Refuse it instead (#593).
+  if (existing.deposit_group_id && changesAssetType) {
+    return NextResponse.json(
+      { error: 'An accumulating deposit book cannot be changed to another asset type.', code: 'book_type_change' },
+      { status: 400 },
+    )
+  }
+
   if (existing.deposit_group_id) {
     const { data: row, error: bookErr } = await supabase
       .rpc('update_deposit_book', {
@@ -167,6 +181,13 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   }
 
   const updates: Record<string, unknown> = { updated_at: new Date().toISOString() }
+  // A type change drops the previous subtype's columns FIRST, so anything the
+  // request restates for the new type overwrites the null below and anything it
+  // omits is genuinely gone (#593). Without this the row kept contradictory
+  // metadata — a "fund" holding still carrying a maturity and a bank code.
+  if (changesAssetType && cleanAssetType) {
+    Object.assign(updates, subtypeResetFields(existing.asset_type, cleanAssetType))
+  }
   if (goal_id !== undefined) updates.goal_id = cleanGoalId
   if (cleanAssetType) updates.asset_type = cleanAssetType
   if (cleanInvestmentDate) updates.investment_date = cleanInvestmentDate

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -220,6 +220,17 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   // the pool (#588). A conflict the user resolves — "Bỏ chờ gộp" removes the
   // settlement and restores the deposit — not a missing row, so 404 would
   // misdescribe it. The prefix marks a rule this codebase authored.
+  // The book rules the table enforces (20260802000002). The guard above reads
+  // deposit_group_id before the write, so a deposit that becomes a book in
+  // between — a recurring top-up self-groups its anchor — is caught here
+  // instead. It is the same refusal, and 404 would call it a missing row.
+  if (error?.message?.startsWith('deposit book: ')) {
+    return NextResponse.json(
+      { error: 'An accumulating deposit book cannot be changed to another asset type.', code: 'book_type_change' },
+      { status: 400 },
+    )
+  }
+
   if (error?.message?.startsWith('held settlement: ')) {
     return NextResponse.json(
       {

--- a/lib/__tests__/assetTypeFields.test.ts
+++ b/lib/__tests__/assetTypeFields.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import {
+  ASSET_SUBTYPE_FIELDS,
+  SUBTYPE_EXCLUSIVE_FIELDS,
+  subtypeResetFields,
+  type SubtypeAssetType,
+} from '../assetTypeFields'
+
+const TYPES: SubtypeAssetType[] = ['fund', 'bank', 'gold', 'stock']
+
+describe('ASSET_SUBTYPE_FIELDS (#593)', () => {
+  it('gives each asset type a field set drawn from the exclusive columns', () => {
+    for (const type of TYPES) {
+      for (const field of ASSET_SUBTYPE_FIELDS[type]) {
+        expect(SUBTYPE_EXCLUSIVE_FIELDS).toContain(field)
+      }
+    }
+  })
+
+  it('keeps the deposit-only columns out of every non-bank type', () => {
+    for (const field of ['interest_rate', 'expiry_date', 'bank_code', 'interest_earned_vnd', 'deposit_group_id']) {
+      expect(ASSET_SUBTYPE_FIELDS.bank).toContain(field)
+      expect(ASSET_SUBTYPE_FIELDS.fund).not.toContain(field)
+      expect(ASSET_SUBTYPE_FIELDS.gold).not.toContain(field)
+      expect(ASSET_SUBTYPE_FIELDS.stock).not.toContain(field)
+    }
+  })
+
+  it('keeps fund_id to funds, and unit columns off bank deposits', () => {
+    expect(ASSET_SUBTYPE_FIELDS.fund).toContain('fund_id')
+    expect(ASSET_SUBTYPE_FIELDS.gold).not.toContain('fund_id')
+    expect(ASSET_SUBTYPE_FIELDS.bank).not.toContain('fund_id')
+    expect(ASSET_SUBTYPE_FIELDS.bank).not.toContain('units')
+    expect(ASSET_SUBTYPE_FIELDS.bank).not.toContain('unit_price')
+    for (const type of ['fund', 'gold', 'stock'] as const) {
+      expect(ASSET_SUBTYPE_FIELDS[type]).toContain('units')
+      expect(ASSET_SUBTYPE_FIELDS[type]).toContain('unit_price')
+    }
+  })
+})
+
+describe('subtypeResetFields (#593)', () => {
+  it('resets nothing when the type is unchanged', () => {
+    for (const type of TYPES) {
+      expect(subtypeResetFields(type, type)).toEqual({})
+    }
+  })
+
+  it('resets nothing when the previous type is unknown', () => {
+    // A legacy row with a null asset_type has no old subtype to clear.
+    expect(subtypeResetFields(null, 'fund')).toEqual({})
+    expect(subtypeResetFields(undefined, 'bank')).toEqual({})
+  })
+
+  // Every transition, in both directions: the whole exclusive set is nulled, so
+  // no field of the old subtype can survive the change.
+  for (const from of TYPES) {
+    for (const to of TYPES) {
+      if (from === to) continue
+      it(`clears every subtype column on ${from} -> ${to}`, () => {
+        const reset = subtypeResetFields(from, to)
+        expect(Object.keys(reset).sort()).toEqual([...SUBTYPE_EXCLUSIVE_FIELDS].sort())
+        expect(Object.values(reset).every((v) => v === null)).toBe(true)
+      })
+    }
+  }
+
+  it('clears the bank metadata a bank -> fund/gold change leaves behind', () => {
+    for (const to of ['fund', 'gold'] as const) {
+      const reset = subtypeResetFields('bank', to)
+      expect(reset).toMatchObject({
+        interest_rate: null, expiry_date: null, bank_code: null,
+        interest_earned_vnd: null, deposit_group_id: null,
+      })
+    }
+  })
+
+  it('clears the units a gold -> bank change leaves behind', () => {
+    expect(subtypeResetFields('gold', 'bank')).toMatchObject({ units: null, unit_price: null })
+  })
+
+  it('clears the fund link a fund -> bank/gold change leaves behind', () => {
+    expect(subtypeResetFields('fund', 'bank')).toMatchObject({ fund_id: null })
+    expect(subtypeResetFields('fund', 'gold')).toMatchObject({ fund_id: null })
+  })
+
+  it('returns a fresh object each call', () => {
+    const a = subtypeResetFields('bank', 'fund')
+    a.units = 1 as unknown as null
+    expect(subtypeResetFields('bank', 'fund').units).toBeNull()
+  })
+})

--- a/lib/assetTypeFields.ts
+++ b/lib/assetTypeFields.ts
@@ -1,0 +1,63 @@
+/**
+ * Which columns of `investment_transactions` belong to which asset type (#593).
+ *
+ * The table is one wide row shared by every kind of holding, so a fund's NAV
+ * columns, a deposit's rate/maturity/bank and gold's units all sit side by side
+ * and are all nullable. Editing a transaction can change its type, and the edit
+ * payload only ever carried the NEW type's fields — so Bank -> Fund kept the
+ * interest rate, maturity and bank code, and Gold -> Bank kept units and unit
+ * price. The row then claimed to be two kinds of holding at once, which every
+ * later reader (valuation, reports, migrations) has to guess its way through.
+ *
+ * This module is the single definition of the allowed shape. The edit route
+ * clears the old subtype from it, and the DB CHECK constraint added in
+ * 20260802000001 enforces the same table.
+ */
+
+export type SubtypeAssetType = 'fund' | 'bank' | 'gold' | 'stock'
+
+/**
+ * The subtype-specific columns each asset type may carry on an *investment* row.
+ * Columns shared by every type (amount_vnd, investment_date, goal_id, notes …)
+ * are not listed: they are never contradictory.
+ *
+ * - fund  — the linked fund plus the NAV pair the units are priced at.
+ * - gold  — quantity in chỉ and the price per chỉ; no fund, no deposit terms.
+ * - stock — legacy, priced like gold (quantity × price), never a deposit.
+ * - bank  — the deposit terms; a deposit has no units, no NAV and no fund.
+ *   `deposit_group_id` ties an accumulating book's tranches together, and
+ *   `interest_earned_vnd` is what a renewal booked.
+ */
+export const ASSET_SUBTYPE_FIELDS: Record<SubtypeAssetType, readonly string[]> = {
+  fund: ['fund_id', 'units', 'unit_price'],
+  gold: ['units', 'unit_price'],
+  stock: ['units', 'unit_price'],
+  bank: ['interest_rate', 'expiry_date', 'bank_code', 'interest_earned_vnd', 'deposit_group_id'],
+}
+
+/** Every column that belongs to at least one asset type but not to all of them. */
+export const SUBTYPE_EXCLUSIVE_FIELDS: readonly string[] = [
+  ...new Set(Object.values(ASSET_SUBTYPE_FIELDS).flat()),
+]
+
+/**
+ * The `{ column: null }` patch that clears the previous subtype when a
+ * transaction changes asset type.
+ *
+ * It nulls the WHOLE exclusive set, not merely the columns exclusive to `from`.
+ * Two types can share a column and still disagree about what it means — gold
+ * `units` are chỉ while fund `units` are shares — so carrying one over would
+ * value the new holding off the old quantity. Whatever the new type legitimately
+ * has is re-applied afterwards from the request itself, so a caller that sends
+ * the new type's fields loses nothing.
+ *
+ * Returns an empty patch when the type is unchanged, or when the row's previous
+ * type is unknown (a legacy row with a null `asset_type` has no subtype to clear).
+ */
+export function subtypeResetFields(
+  from: SubtypeAssetType | string | null | undefined,
+  to: SubtypeAssetType,
+): Record<string, null> {
+  if (!from || from === to) return {}
+  return Object.fromEntries(SUBTYPE_EXCLUSIVE_FIELDS.map((field) => [field, null]))
+}

--- a/supabase/migrations/20260802000001_normalize_asset_subtype_fields.sql
+++ b/supabase/migrations/20260802000001_normalize_asset_subtype_fields.sql
@@ -1,0 +1,96 @@
+-- One row per holding, one subtype's fields in it (#593).
+--
+-- investment_transactions is a single wide table shared by every kind of
+-- holding: a fund's fund_id/units/unit_price, a deposit's
+-- interest_rate/expiry_date/bank_code/interest_earned_vnd/deposit_group_id and
+-- gold's units/unit_price all sit side by side, all nullable. Editing a
+-- transaction can change its asset type, and the edit payload only ever carried
+-- the NEW type's fields — nothing cleared the old ones. So Bank -> Fund/Gold
+-- kept the rate, the maturity and the bank code, and Gold -> Bank kept units and
+-- unit price. The row then describes two kinds of holding at once and every
+-- later reader — valuation, reports, the next migration — has to guess which
+-- half is true.
+--
+-- The edit route now clears the previous subtype (lib/assetTypeFields.ts), but a
+-- route is only one writer: RPCs, service-role scripts and psql all reach this
+-- table too. The shape belongs on the table, for the same reason the withdrawal
+-- balance does (20260730000002).
+--
+--   asset_type | may carry
+--   -----------|--------------------------------------------------------------
+--   fund       | fund_id, units, unit_price
+--   gold       | units, unit_price
+--   stock      | units, unit_price            (legacy; priced like gold)
+--   bank       | interest_rate, expiry_date, bank_code, interest_earned_vnd,
+--              | deposit_group_id
+--
+-- Scope: INVESTMENT rows. A withdrawal is a movement, not a holding — it is
+-- keyed by parent_transaction_id and carries principal_withdrawn/units_withdrawn
+-- whose shape the withdrawal invariant already owns (20260730000002) — so
+-- constraining it here would duplicate one contract across two places and
+-- disagree with it eventually. Rows with a null asset_type (legacy) are left
+-- alone: there is no subtype to check.
+--
+-- Covered by supabase/tests/asset_subtype_shape.test.sql (`npm run test:db`).
+
+begin;
+
+-- ── Normalize what is already contradictory ─────────────────────────────────
+-- These columns cannot be recovered — a bank code on a gold row was never read
+-- by anything — so clearing them loses no information, and it is what makes the
+-- constraint below addable as VALID rather than deferred to the next write.
+
+-- Deposits carry no fund link and no units.
+update public.investment_transactions
+set fund_id = null, units = null, unit_price = null
+where transaction_type = 'investment'
+  and asset_type = 'bank'
+  and (fund_id is not null or units is not null or unit_price is not null);
+
+-- Funds carry no deposit terms.
+update public.investment_transactions
+set interest_rate = null, expiry_date = null, bank_code = null,
+    interest_earned_vnd = null, deposit_group_id = null
+where transaction_type = 'investment'
+  and asset_type = 'fund'
+  and (interest_rate is not null or expiry_date is not null or bank_code is not null
+       or interest_earned_vnd is not null or deposit_group_id is not null);
+
+-- Gold and stock carry neither a fund link nor deposit terms.
+update public.investment_transactions
+set fund_id = null, interest_rate = null, expiry_date = null, bank_code = null,
+    interest_earned_vnd = null, deposit_group_id = null
+where transaction_type = 'investment'
+  and asset_type in ('gold', 'stock')
+  and (fund_id is not null or interest_rate is not null or expiry_date is not null
+       or bank_code is not null or interest_earned_vnd is not null
+       or deposit_group_id is not null);
+
+-- ── Enforce it from here on ─────────────────────────────────────────────────
+alter table public.investment_transactions
+  drop constraint if exists investment_transactions_subtype_shape;
+
+alter table public.investment_transactions
+  add constraint investment_transactions_subtype_shape check (
+    transaction_type <> 'investment'
+    or asset_type is null
+    or case asset_type
+         when 'bank' then
+           fund_id is null and units is null and unit_price is null
+         when 'fund' then
+           interest_rate is null and expiry_date is null and bank_code is null
+           and interest_earned_vnd is null and deposit_group_id is null
+         when 'gold' then
+           fund_id is null and interest_rate is null and expiry_date is null
+           and bank_code is null and interest_earned_vnd is null and deposit_group_id is null
+         when 'stock' then
+           fund_id is null and interest_rate is null and expiry_date is null
+           and bank_code is null and interest_earned_vnd is null and deposit_group_id is null
+         else true
+       end
+  );
+
+comment on constraint investment_transactions_subtype_shape on public.investment_transactions is
+  'An investment row carries only its own asset type''s fields (#593). See lib/assetTypeFields.ts for the same table in application code.';
+
+commit;

--- a/supabase/migrations/20260802000002_guard_deposit_book_tranche.sql
+++ b/supabase/migrations/20260802000002_guard_deposit_book_tranche.sql
@@ -1,0 +1,98 @@
+-- A tranche stays in its book, as the kind of holding the book is made of (#593).
+--
+-- 20260802000001 fixed the row shape: an investment carries only its own asset
+-- type's columns. That alone still leaves one way to strand a book. RLS lets
+-- `authenticated` UPDATE its own investment_transactions rows straight through
+-- PostgREST — the browser holds that session — so a direct write can flip a
+-- tranche to gold/fund AND clear deposit_group_id in the same statement. The
+-- subtype CHECK sees a perfectly clean gold row and passes; the remaining
+-- tranches are left in a book whose principal no longer adds up, and renewal,
+-- collapse and book withdrawal each read a different holding than the user has.
+--
+-- The API refuses the conversion (PUT /api/v1/investment-transactions/[id]), but
+-- an API guard only binds callers who go through the API. The invariant belongs
+-- on the table, for the same reason the withdrawal balance does (20260730000002).
+--
+-- Three rules, and what each one leaves alone:
+--
+--   1. While a row is in a book, its asset_type is fixed. Nothing legitimate
+--      converts a tranche; a book is bank deposits by definition.
+--   2. A tranche cannot be moved into a different book. Nothing legitimate
+--      re-parents one, and a moved tranche would be double-counted in one book
+--      and missing from the other.
+--   3. A tranche may LEAVE a book only when the book is dissolved with it —
+--      checked at the end of the statement, because that is the shape of the two
+--      flows that legitimately do it: `withdraw_book_close_group` clears the
+--      whole group in one UPDATE, and `collapse_accumulating_book` deletes the
+--      other tranches first and then clears the anchor. Both leave nothing
+--      behind, which is precisely the condition.
+--
+-- Rule 3 is a statement-end check rather than a row-level one because a book is
+-- dissolved as a set, not row by row. It cannot be a role check: those RPCs are
+-- SECURITY INVOKER, so they run as `authenticated` too — the database cannot
+-- tell them apart from a direct PATCH by who is asking, only by what is left.
+--
+-- Covered by supabase/tests/deposit_book_tranche_guard.test.sql (`npm run test:db`).
+
+begin;
+
+create or replace function public.enforce_deposit_book_tranche_shape()
+returns trigger
+language plpgsql
+as $$
+begin
+  if new.asset_type is distinct from old.asset_type then
+    raise exception 'deposit book: a tranche of an accumulating book cannot change asset type'
+      using errcode = 'check_violation';
+  end if;
+
+  if new.deposit_group_id is not null and new.deposit_group_id <> old.deposit_group_id then
+    raise exception 'deposit book: a tranche cannot be moved into another book'
+      using errcode = 'check_violation';
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.enforce_deposit_book_tranche_shape() is
+  'A booked deposit keeps its asset type and its book (#593).';
+
+drop trigger if exists investment_transactions_book_tranche_shape on public.investment_transactions;
+create trigger investment_transactions_book_tranche_shape
+  before update of asset_type, deposit_group_id on public.investment_transactions
+  for each row
+  when (old.deposit_group_id is not null)
+  execute function public.enforce_deposit_book_tranche_shape();
+
+create or replace function public.enforce_deposit_book_dissolved_whole()
+returns trigger
+language plpgsql
+as $$
+begin
+  if exists (
+    select 1 from public.investment_transactions
+     where deposit_group_id = old.deposit_group_id
+  ) then
+    raise exception 'deposit book: a tranche cannot leave a book that still has members'
+      using errcode = 'check_violation';
+  end if;
+  return null;
+end;
+$$;
+
+comment on function public.enforce_deposit_book_dissolved_whole() is
+  'A tranche leaves a book only when the whole book is dissolved with it, checked at the end of the statement (#593).';
+
+drop trigger if exists investment_transactions_book_dissolved_whole on public.investment_transactions;
+create constraint trigger investment_transactions_book_dissolved_whole
+  after update of deposit_group_id on public.investment_transactions
+  -- INITIALLY IMMEDIATE on a constraint trigger means "at the end of the
+  -- statement", which is where a whole-book dissolve becomes visible. A caller
+  -- that genuinely needs several statements can still SET CONSTRAINTS DEFERRED.
+  deferrable initially immediate
+  for each row
+  when (old.deposit_group_id is not null and new.deposit_group_id is null)
+  execute function public.enforce_deposit_book_dissolved_whole();
+
+commit;

--- a/supabase/tests/asset_subtype_shape.test.sql
+++ b/supabase/tests/asset_subtype_shape.test.sql
@@ -1,0 +1,174 @@
+-- An investment row may carry only its own asset type's fields (#593).
+--
+-- The edit route clears the previous subtype on a type change, but the table has
+-- other writers (RPCs, service-role scripts, psql), so the shape is a constraint
+-- too — investment_transactions_subtype_shape, added in 20260802000001. This
+-- pins both halves: every contradictory shape is refused, and every legitimate
+-- one still lands.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_user  uuid;
+  v_goal  uuid;
+  v_fund  uuid;
+  v_bank  uuid;
+  v_gold  uuid;
+  v_gold2 uuid;
+  v_fundtx uuid;
+  -- Each attempt catches ONLY 23514 (check_violation): a null violation or a
+  -- foreign-key error must fail the test, not count as "refused".
+  v_ok    boolean;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'subtype-shape@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Test Fund', 'TSF', 'equity', 20000) returning id into v_fund;
+
+  -- ── The legitimate shapes all land ────────────────────────────────────────
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     interest_rate, expiry_date)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000, 5.5, '2027-01-01')
+  returning transaction_id into v_bank;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, units, unit_price)
+  values (v_user, v_goal, 'fund', 'investment', '2026-01-01', 10000000, v_fund, 500, 20000)
+  returning transaction_id into v_fundtx;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 7000000, 2, 3500000)
+  returning transaction_id into v_gold;
+
+  -- ── Contradictory shapes are refused ──────────────────────────────────────
+
+  -- Bank with a fund link.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id)
+    values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 1000000, v_fund);
+    raise exception 'a bank deposit carrying fund_id must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Bank with units / unit price (the Gold -> Bank leftover).
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+    values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 1000000, 2, 3500000);
+    raise exception 'a bank deposit carrying units must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Fund with deposit terms (the Bank -> Fund leftover).
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, interest_rate)
+    values (v_user, v_goal, 'fund', 'investment', '2026-01-01', 1000000, v_fund, 5.5);
+    raise exception 'a fund carrying an interest rate must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, expiry_date)
+    values (v_user, v_goal, 'fund', 'investment', '2026-01-01', 1000000, v_fund, '2027-01-01');
+    raise exception 'a fund carrying a maturity date must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Gold with bank metadata (the Bank -> Gold leftover).
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, bank_code)
+    values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 1000000, 2, 3500000, 'VCB');
+    raise exception 'gold carrying a bank code must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, interest_earned_vnd)
+    values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 1000000, 2, 50000);
+    raise exception 'gold carrying renewal interest must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── The bug itself: a type change that leaves the old fields behind ───────
+  begin
+    update public.investment_transactions
+    set asset_type = 'fund', fund_id = v_fund
+    where transaction_id = v_bank;
+    raise exception 'converting a deposit to a fund without clearing rate/maturity must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  begin
+    update public.investment_transactions
+    set asset_type = 'bank'
+    where transaction_id = v_gold;
+    raise exception 'converting gold to a deposit without clearing units must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  begin
+    update public.investment_transactions
+    set asset_type = 'gold'
+    where transaction_id = v_fundtx;
+    raise exception 'converting a fund to gold without clearing fund_id must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- The same conversions, done the way the route does them — old subtype
+  -- cleared in the same statement — are accepted.
+  update public.investment_transactions
+  set asset_type = 'fund', fund_id = v_fund, units = 500, unit_price = 20000,
+      interest_rate = null, expiry_date = null, bank_code = null,
+      interest_earned_vnd = null, deposit_group_id = null
+  where transaction_id = v_bank;
+
+  update public.investment_transactions
+  set asset_type = 'bank', units = null, unit_price = null, fund_id = null,
+      interest_rate = 5.5, expiry_date = '2027-06-01'
+  where transaction_id = v_gold;
+
+  select exists (
+    select 1 from public.investment_transactions
+    where transaction_id = v_bank and asset_type = 'fund' and interest_rate is null and expiry_date is null
+  ) into v_ok;
+  if not v_ok then raise exception 'the converted deposit should now be a clean fund row'; end if;
+
+  select exists (
+    select 1 from public.investment_transactions
+    where transaction_id = v_gold and asset_type = 'bank' and units is null and unit_price is null
+  ) into v_ok;
+  if not v_ok then raise exception 'the converted gold row should now be a clean deposit'; end if;
+
+  -- ── Out of scope, and staying that way ───────────────────────────────────
+
+  -- A withdrawal is a movement, not a holding: its shape is the withdrawal
+  -- invariant's contract (20260730000002), so this constraint must not touch it.
+  -- A gold sell legitimately carries units_withdrawn against its parent.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 7000000, 2, 3500000)
+  returning transaction_id into v_gold2;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 4000000, v_gold2, 1, 3500000);
+
+  -- (A null asset_type needs no case of its own: require_asset_type_for_investments
+  -- already forbids it on an investment row, and withdrawals are out of scope.)
+
+  raise notice 'asset subtype shape: OK';
+end $$;
+
+rollback;

--- a/supabase/tests/deposit_book_tranche_guard.test.sql
+++ b/supabase/tests/deposit_book_tranche_guard.test.sql
@@ -1,0 +1,157 @@
+-- A tranche cannot be converted out of its accumulating book (#593).
+--
+-- The edit route refuses an asset_type change on a booked deposit, but the route
+-- is not the only writer: RLS lets `authenticated` UPDATE its own
+-- investment_transactions rows straight through PostgREST, and the browser holds
+-- that session. A direct write could flip one tranche to gold/fund — clearing
+-- every bank-only column on the way, so the subtype CHECK is satisfied — and
+-- strand the remaining tranches in a book whose principal no longer adds up.
+-- Renewal, collapse and book withdrawal all read the book by deposit_group_id
+-- and would each see a different holding than the user has.
+--
+-- So the rule lives on the table:
+--   • while a row is in a book, its asset_type is fixed;
+--   • a tranche cannot be moved into a different book;
+--   • a tranche may leave a book only when the whole book is dissolved in the
+--     same statement — which is exactly what collapse and a full close do.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_user    uuid;
+  v_goal    uuid;
+  v_fund    uuid;
+  v_anchor  uuid;
+  v_tranche uuid;
+  v_other   uuid;
+  v_plain   uuid;
+  v_left    int;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'book-guard@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Guard Fund', 'GRD', 'equity', 20000) returning id into v_fund;
+
+  -- A book: the anchor self-groups, the tranche points at it.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, interest_rate)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 50000000, 5.5)
+  returning transaction_id into v_anchor;
+  update public.investment_transactions set deposit_group_id = v_anchor where transaction_id = v_anchor;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, interest_rate, deposit_group_id)
+  values (v_user, v_goal, 'bank', 'investment', '2026-02-01', 20000000, 5.5, v_anchor)
+  returning transaction_id into v_tranche;
+
+  -- A second book, to try to move a tranche into.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 30000000)
+  returning transaction_id into v_other;
+  update public.investment_transactions set deposit_group_id = v_other where transaction_id = v_other;
+
+  -- ── The bypass: a raw UPDATE that satisfies the subtype CHECK ─────────────
+
+  -- Every stale bank column cleared, so investment_transactions_subtype_shape is
+  -- happy — and the book is still left short a tranche.
+  begin
+    update public.investment_transactions
+    set asset_type = 'gold', units = 2, unit_price = 3500000,
+        interest_rate = null, expiry_date = null, bank_code = null,
+        interest_earned_vnd = null
+    where transaction_id = v_tranche;
+    raise exception 'a booked tranche must not be converted to gold';
+  exception when sqlstate '23514' then null;
+  end;
+
+  begin
+    update public.investment_transactions
+    set asset_type = 'fund', fund_id = v_fund, units = 100, unit_price = 20000,
+        interest_rate = null, expiry_date = null, bank_code = null,
+        interest_earned_vnd = null
+    where transaction_id = v_tranche;
+    raise exception 'a booked tranche must not be converted to a fund';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- The same write that also drops out of the book in one statement: still the
+  -- anchor's book losing a member, so still refused.
+  begin
+    update public.investment_transactions
+    set asset_type = 'gold', units = 2, unit_price = 3500000, deposit_group_id = null,
+        interest_rate = null, expiry_date = null, bank_code = null,
+        interest_earned_vnd = null
+    where transaction_id = v_tranche;
+    raise exception 'a booked tranche must not be converted while leaving the book';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- The anchor itself is a tranche too.
+  begin
+    update public.investment_transactions
+    set asset_type = 'gold', units = 5, unit_price = 3500000,
+        interest_rate = null, expiry_date = null, bank_code = null,
+        interest_earned_vnd = null
+    where transaction_id = v_anchor;
+    raise exception 'a book anchor must not be converted to gold';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── Moving between books, and leaving one behind ─────────────────────────
+  begin
+    update public.investment_transactions set deposit_group_id = v_other where transaction_id = v_tranche;
+    raise exception 'a tranche must not be moved into another book';
+  exception when sqlstate '23514' then null;
+  end;
+
+  begin
+    update public.investment_transactions set deposit_group_id = null where transaction_id = v_tranche;
+    raise exception 'a tranche must not leave a book that still has members';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── What must still work ─────────────────────────────────────────────────
+
+  -- An ordinary book edit: the fields update_deposit_book cascades, with the
+  -- type and the group untouched.
+  update public.investment_transactions
+  set interest_rate = 6.1, expiry_date = '2027-01-01', goal_id = v_goal, notes = 'edited'
+  where deposit_group_id = v_anchor;
+
+  -- Dissolving the WHOLE book in one statement — what a full close does.
+  update public.investment_transactions
+  set deposit_group_id = null, updated_at = now()
+  where deposit_group_id = v_anchor;
+
+  select count(*) into v_left from public.investment_transactions where deposit_group_id = v_anchor;
+  if v_left <> 0 then raise exception 'the book should have been dissolved'; end if;
+
+  -- Collapse's shape: delete the other tranches first, then clear the anchor.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, deposit_group_id)
+  values (v_user, v_goal, 'bank', 'investment', '2026-02-01', 20000000, v_other)
+  returning transaction_id into v_tranche;
+
+  delete from public.investment_transactions where transaction_id = v_tranche;
+  update public.investment_transactions set deposit_group_id = null where transaction_id = v_other;
+
+  -- And a deposit that was never in a book can still change type, provided the
+  -- old subtype goes with it.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, interest_rate)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 5000000, 5.5)
+  returning transaction_id into v_plain;
+
+  update public.investment_transactions
+  set asset_type = 'gold', units = 1, unit_price = 3500000, interest_rate = null
+  where transaction_id = v_plain;
+
+  raise notice 'deposit book tranche guard: OK';
+end $$;
+
+rollback;

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -428,14 +428,25 @@ begin
   insert into public.funds (user_id, name, code, fund_type, nav)
   values (v_user, 'Bucket2 Fund', 'BK2', 'equity', 20000) returning id into v_fund;
 
-  -- A fund purchase whose asset_type is edited to 'bank' keeps its fund_id (the
-  -- PUT route clears fund_id only when that field is sent). The dashboard then
-  -- values it as a bank holding — so its units are no longer fund inventory and
-  -- must not back a fund sell.
+  -- A fund purchase edited to 'bank' is no longer valued as fund inventory, so
+  -- its units must not back a fund sell.
   insert into public.investment_transactions (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
   values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000) returning transaction_id into v_buy;
 
-  update public.investment_transactions set asset_type = 'bank' where transaction_id = v_buy;
+  -- Such a row used to keep its fund_id and units — the PUT route cleared
+  -- fund_id only when that field was sent — which is the contradiction #593
+  -- closed. The subtype constraint now refuses the half-done conversion outright.
+  begin
+    update public.investment_transactions set asset_type = 'bank' where transaction_id = v_buy;
+    raise exception 'a fund converted to a deposit must not keep its fund_id and units';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Done properly — old subtype cleared in the same statement, as the route does
+  -- it — the conversion lands, and the bucket it left is empty from then on.
+  update public.investment_transactions
+  set asset_type = 'bank', fund_id = null, units = null, unit_price = null
+  where transaction_id = v_buy;
 
   begin
     insert into public.investment_transactions


### PR DESCRIPTION
Closes #593.

## Problem

`investment_transactions` is one wide table shared by every kind of holding — a fund's `fund_id/units/unit_price`, a deposit's `interest_rate/expiry_date/bank_code/interest_earned_vnd/deposit_group_id`, gold's `units/unit_price` — all nullable, side by side.

Editing a transaction can change its asset type, but the payload only ever carried the **new** type's fields and the route only updated fields present in the request. So Bank → Fund/Gold kept the rate, maturity and bank code; Gold → Bank kept units and unit price. The row then claimed to be two kinds of holding at once, and nothing in the schema said otherwise.

## Fix

**`lib/assetTypeFields.ts`** — the allowed field set per asset type, in one place, plus `subtypeResetFields(from, to)`.

**PUT `/api/v1/investment-transactions/[id]`** — on a type change it nulls the whole subtype-exclusive set *before* applying the request, so what the caller restates for the new type wins and what it omits is genuinely gone. Two types can share a column and still disagree about it (gold `units` are chỉ, fund `units` are shares), which is why the reset isn't limited to columns exclusive to the old type. Partial edits that keep the type are untouched, and a row with a legacy null `asset_type` has no subtype to clear.

Converting an **accumulating deposit book** is refused with 400: `update_deposit_book` has no `asset_type` argument, so the change silently did nothing, and converting one tranche would strand its siblings.

**Migration `20260802000001`** — normalizes rows that are already contradictory, then adds the `investment_transactions_subtype_shape` CHECK. Scoped to investment rows: a withdrawal is a movement whose shape the withdrawal invariant already owns (20260730000002).

## Tests (TDD, red first)

- `lib/__tests__/assetTypeFields.test.ts` — the field table, and every transition in both directions.
- `app/api/v1/investment-transactions/[id]/__tests__/route.put.subtype.test.ts` — every transition both ways over the real handler, plus: partial edit untouched, same-type edit untouched, stray `bank_code` still scoped, book type change refused, book same-type edit still takes the atomic RPC, legacy null type not normalized.
- `supabase/tests/asset_subtype_shape.test.sql` — every contradictory shape refused, every legitimate one accepted, half-done conversions refused and properly-cleared ones accepted, withdrawals out of scope.
- `supabase/tests/withdrawal_balance.test.sql` — **updated**: it built the exact contradictory row this issue is about (a fund flipped to `bank` keeping `fund_id` + `units`). It now asserts that half-done conversion is refused, then does it properly and keeps its original assertion that the emptied bucket can't back a fund sell.

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test -- --run` ✅ 1967 tests
- `npm run test:db` ✅ all 14 SQL suites
- `npm run test:e2e` ✅ 274 passed (11.1m) — full suite, since this adds a migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)