### PR TITLE
test(e2e): add a fast PR smoke lane and isolate the full suite from CI limits (#595)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,12 +28,21 @@ jobs:
       - name: Run unit tests
         run: npm test -- --run
 
-  # E2E (Playwright) runs LOCALLY, not in CI. The dedicated test Supabase project
-  # is a small NANO instance whose Disk IO budget can't sustain the suite's write
-  # load — CI runs throttled and timed out (~72 min, cascading failures). Run E2E
-  # locally against a local Supabase stack instead — see "Running E2E locally" in
-  # the README. Unit tests remain the CI gate, and the guard in e2e/helpers/guard.ts
-  # still prevents E2E from ever targeting production.
+  # Browser gate on every PR: the ~19 `@smoke`-tagged tests only (#595). The
+  # full suite stays off the PR path — it takes ~7.6 min serial and runs nightly
+  # via .github/workflows/e2e.yml (also dispatchable on demand).
+  #
+  # Both lanes run against a local Supabase stack started inside the runner. The
+  # shared test project is a NANO instance whose Disk IO budget can't sustain the
+  # suite's write load — pointing CI at it throttled and timed out (~72 min,
+  # cascading failures), which is why E2E was pulled from CI in #313. The guard in
+  # e2e/helpers/guard.ts still prevents E2E from ever targeting production.
+  e2e-smoke:
+    name: E2E Smoke
+    needs: test
+    uses: ./.github/workflows/e2e.yml
+    with:
+      lane: smoke
 
   # Apply pending migrations to the production Supabase project on every merge to
   # main, so schema changes ship automatically instead of needing a manual

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,6 +59,21 @@ jobs:
       - name: Start a local Supabase stack
         run: supabase start
 
+      - name: Grant the API roles access to public
+        # A hosted Supabase project grants anon/authenticated/service_role on
+        # everything in `public` through its default privileges, so the app's
+        # migrations never carry GRANTs. Migrations applied by `supabase start`
+        # in the runner don't pick those up, and every seeded row failed with
+        # `42501 permission denied for table …`. Grant them explicitly so the
+        # ephemeral CI database matches a real project. RLS still applies.
+        run: |
+          psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -v ON_ERROR_STOP=1 <<'SQL'
+          GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+          GRANT ALL ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;
+          GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO anon, authenticated, service_role;
+          GRANT ALL ON ALL ROUTINES IN SCHEMA public TO anon, authenticated, service_role;
+          SQL
+
       - name: Point the app and the E2E setup at the local stack
         # `supabase status -o env` prints the local stack's URL and keys. These
         # are the CLI's well-known local development keys — not secrets.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -59,19 +59,45 @@ jobs:
       - name: Start a local Supabase stack
         run: supabase start
 
-      - name: Grant the API roles access to public
-        # A hosted Supabase project grants anon/authenticated/service_role on
-        # everything in `public` through its default privileges, so the app's
-        # migrations never carry GRANTs. Migrations applied by `supabase start`
-        # in the runner don't pick those up, and every seeded row failed with
-        # `42501 permission denied for table …`. Grant them explicitly so the
-        # ephemeral CI database matches a real project. RLS still applies.
+      - name: Restore the hosted-project DML baseline
+        # A hosted Supabase project grants anon/authenticated/service_role full
+        # DML on everything in `public` through its default privileges, so the
+        # app's migrations carry no GRANTs of their own. The CLI's local stack
+        # grants only the non-DML part (`Dxtm` — truncate/references/trigger/
+        # maintain), so every seeded row failed with `42501 permission denied
+        # for table …`.
+        #
+        # Top up DML *only for roles still present in an object's ACL*. That is
+        # the difference that matters: a migration's `revoke all on <table> from
+        # anon, authenticated` removes the role from the ACL entirely, so those
+        # deliberate revocations survive this step instead of being handed back.
+        # Functions are untouched for the same reason — migrations manage their
+        # EXECUTE grants explicitly (e.g. refresh_gold_price_all is service_role
+        # only), and the 20 that carry no explicit ACL already get PUBLIC
+        # EXECUTE exactly as they do in production.
+        #
+        # Caveat: this restores the full DML set, so a *partial* revoke (say,
+        # revoking only INSERT) would be undone. The schema has none today — all
+        # revocations are `revoke all`.
         run: |
           psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -v ON_ERROR_STOP=1 <<'SQL'
-          GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
-          GRANT ALL ON ALL TABLES IN SCHEMA public TO anon, authenticated, service_role;
-          GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO anon, authenticated, service_role;
-          GRANT ALL ON ALL ROUTINES IN SCHEMA public TO anon, authenticated, service_role;
+          DO $$
+          DECLARE obj record;
+          BEGIN
+            FOR obj IN
+              SELECT DISTINCT c.oid::regclass::text AS rel,
+                              pg_get_userbyid(a.grantee) AS grantee
+              FROM pg_class c
+              JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+              CROSS JOIN LATERAL aclexplode(c.relacl) a
+              WHERE c.relkind IN ('r', 'p', 'v', 'm')
+                AND pg_get_userbyid(a.grantee) IN ('anon', 'authenticated', 'service_role')
+            LOOP
+              EXECUTE format(
+                'GRANT SELECT, INSERT, UPDATE, DELETE ON %s TO %I', obj.rel, obj.grantee);
+            END LOOP;
+          END
+          $$;
           SQL
 
       - name: Point the app and the E2E setup at the local stack

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,97 @@
+name: E2E
+
+# Playwright lanes (#595).
+#
+#   smoke — ~19 high-value tests (auth, cross-user ownership, API validation,
+#           the core transaction flow, one maturity/merge money path, the report
+#           download, navigation). Called by CI on every pull request.
+#   full  — the whole suite (~258 tests, ~7.6 min serial). Runs nightly and on
+#           demand, never on the PR path.
+#
+# Both lanes run against a **local Supabase stack started inside the runner**,
+# not the shared test project. That project is a NANO instance whose Disk IO
+# budget could not sustain the suite (throttled, ~72 min, cascading failures),
+# which is why E2E was pulled from CI in the first place (#313). A per-run local
+# stack is isolated, fast, and free — and the production guard in
+# e2e/helpers/guard.ts still refuses to run against production either way.
+
+on:
+  workflow_call:
+    inputs:
+      lane:
+        description: 'smoke or full'
+        type: string
+        default: full
+  workflow_dispatch:
+    inputs:
+      lane:
+        description: 'Which lane to run'
+        type: choice
+        options: [full, smoke]
+        default: full
+  schedule:
+    # 18:00 UTC = 01:00 Asia/Ho_Chi_Minh — the nightly full-suite run.
+    - cron: '0 18 * * *'
+
+jobs:
+  e2e:
+    name: E2E (${{ inputs.lane || 'full' }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      LANE: ${{ inputs.lane || 'full' }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - uses: supabase/setup-cli@v2
+        with:
+          version: latest
+
+      - name: Start a local Supabase stack
+        run: supabase start
+
+      - name: Point the app and the E2E setup at the local stack
+        # `supabase status -o env` prints the local stack's URL and keys. These
+        # are the CLI's well-known local development keys — not secrets.
+        run: |
+          eval "$(supabase status -o env)"
+          {
+            echo "NEXT_PUBLIC_SUPABASE_URL=$API_URL"
+            echo "NEXT_PUBLIC_SUPABASE_ANON_KEY=$ANON_KEY"
+            echo "SUPABASE_SERVICE_ROLE_KEY=$SERVICE_ROLE_KEY"
+            echo "E2E_SUPABASE_URL=$API_URL"
+            echo "E2E_SUPABASE_SERVICE_ROLE_KEY=$SERVICE_ROLE_KEY"
+          } >> "$GITHUB_ENV"
+
+      - name: Build the app
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run the ${{ inputs.lane || 'full' }} lane
+        run: |
+          if [ "$LANE" = "smoke" ]; then
+            npm run test:e2e:smoke
+          else
+            npm run test:e2e
+          fi
+
+      - name: Upload the Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ inputs.lane || 'full' }}
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -60,45 +60,14 @@ jobs:
         run: supabase start
 
       - name: Restore the hosted-project DML baseline
-        # A hosted Supabase project grants anon/authenticated/service_role full
-        # DML on everything in `public` through its default privileges, so the
-        # app's migrations carry no GRANTs of their own. The CLI's local stack
-        # grants only the non-DML part (`Dxtm` — truncate/references/trigger/
-        # maintain), so every seeded row failed with `42501 permission denied
-        # for table …`.
-        #
-        # Top up DML *only for roles still present in an object's ACL*. That is
-        # the difference that matters: a migration's `revoke all on <table> from
-        # anon, authenticated` removes the role from the ACL entirely, so those
-        # deliberate revocations survive this step instead of being handed back.
-        # Functions are untouched for the same reason — migrations manage their
-        # EXECUTE grants explicitly (e.g. refresh_gold_price_all is service_role
-        # only), and the 20 that carry no explicit ACL already get PUBLIC
-        # EXECUTE exactly as they do in production.
-        #
-        # Caveat: this restores the full DML set, so a *partial* revoke (say,
-        # revoking only INSERT) would be undone. The schema has none today — all
-        # revocations are `revoke all`.
-        run: |
-          psql "postgresql://postgres:postgres@127.0.0.1:54322/postgres" -v ON_ERROR_STOP=1 <<'SQL'
-          DO $$
-          DECLARE obj record;
-          BEGIN
-            FOR obj IN
-              SELECT DISTINCT c.oid::regclass::text AS rel,
-                              pg_get_userbyid(a.grantee) AS grantee
-              FROM pg_class c
-              JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
-              CROSS JOIN LATERAL aclexplode(c.relacl) a
-              WHERE c.relkind IN ('r', 'p', 'v', 'm')
-                AND pg_get_userbyid(a.grantee) IN ('anon', 'authenticated', 'service_role')
-            LOOP
-              EXECUTE format(
-                'GRANT SELECT, INSERT, UPDATE, DELETE ON %s TO %I', obj.rel, obj.grantee);
-            END LOOP;
-          END
-          $$;
-          SQL
+        # A hosted project grants anon/authenticated/service_role full DML on
+        # `public` through default privileges, so the app's migrations carry no
+        # GRANTs. The CLI's local stack grants only the non-DML part, so seeding
+        # fails with `42501 permission denied for table …`. The script tops up
+        # DML only for roles still present in an object's ACL, so migration-level
+        # revocations survive it — see the comments in the file. Same script the
+        # local setup in docs/e2e.md runs, so CI and local can't drift.
+        run: npm run db:baseline
 
       - name: Point the app and the E2E setup at the local stack
         # `supabase status -o env` prints the local stack's URL and keys. These

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,9 @@ the wrong month (#591). An eslint `no-restricted-syntax` rule blocks both idioms
 
 ## What to run before opening a PR
 
-E2E was removed from CI (PR #313) and runs **locally only** — so local checks are
-the only automated gate before the Vercel preview. Scale the checks to the change:
+CI runs unit tests plus the **E2E smoke lane** (~19 `@smoke` tests, ~3 min, against a
+local Supabase stack started in the runner — #595). The **full** suite still runs
+locally and nightly, never on the PR path. Scale the checks to the change:
 
 - **Always:** `npm run typecheck`, `npm test -- --run` (Vitest unit tests), and
   `npm run lint`. Fast, every PR. Don't skip the typecheck because the tests are
@@ -72,13 +73,16 @@ the only automated gate before the Vercel preview. Scale the checks to the chang
 - **Targeted E2E** — when the change touches a feature area, run that area's specs,
   e.g. `npx playwright test e2e/planning.spec.ts --project=chromium`. This is the
   common case.
+- **Smoke lane** (`npm run test:e2e:smoke`, ~3 min) — the same lane CI runs on the PR.
+  Cheap way to catch a break before pushing.
 - **Full E2E** (`npm run test:e2e`, ~8 min serial) — before merging anything broad or
   risky: auth, layout, the dashboard overview API, shared components, a DB migration,
   or env/config changes. Also run it after touching E2E selectors / DOM attributes /
   i18n strings (grep `e2e/` for the old value first).
 
 Keep the local Supabase stack running for the session so spec runs are instant — see
-[Running E2E locally](README.md#running-e2e-locally). A few specs key off the current
+[docs/e2e.md](docs/e2e.md) for lanes, tagging, the smoke budget, and the infra-vs-product
+failure classification. A few specs key off the current
 real date (e.g. planning's June-2026 fixtures), so they can fail as the calendar moves
 — unrelated to your change.
 

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -54,6 +54,14 @@ layer; it doesn't fail the run.
 - **product** — everything else, including a plain locator timeout (that is an
   element that never appeared, i.e. a real regression).
 
+Ambiguity resolves to *product* by design. A bare assertion diff
+(`Expected: 400 / Received: 503`) is **not** treated as infra: the reporter only
+receives the diff — `TestResult.errors[]` carries no code snippet — so a
+throttled gateway and a money-value regression are textually identical there.
+Calling a genuine regression "infra" is the failure mode this classifier exists
+to prevent. Real throttling nearly always also carries a socket error, a
+statement timeout, or the status phrase itself.
+
 A run whose failures are *all* infra prints an explicit note. Re-run it against
 a healthy stack before chasing the app.
 

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -64,8 +64,18 @@ session so spec runs are instant:
 
 ```bash
 supabase start                     # local stack on :54321 / :54322
+npm run db:baseline                # restore the hosted-project DML baseline
 supabase status -o env             # copy API_URL / ANON_KEY / SERVICE_ROLE_KEY
 ```
+
+`npm run db:baseline` is not optional on a stack created by a recent Supabase
+CLI. A hosted project grants `anon`/`authenticated`/`service_role` full DML on
+`public` through default privileges, so no migration carries a `GRANT`; the
+local stack grants only the non-DML part, and seeding fails with
+`42501 permission denied for table …`. The script tops up DML *only for roles
+still present in an object's ACL*, so migration-level revocations survive it —
+see `supabase/scripts/restore-dml-baseline.sql`. It is idempotent, a no-op on a
+stack that already has the grants, and CI runs the very same script.
 
 Put those in `.env.e2e` (gitignored):
 
@@ -96,15 +106,11 @@ production project, in CI and locally alike.
 - Both start a **local Supabase stack inside the runner**. The shared NANO test
   project throttles under the suite's write load — that is what made CI E2E
   unusable in #313 — so nothing points at it.
-- After the stack starts, one SQL step restores the **hosted-project DML
-  baseline**. A hosted project grants `anon`/`authenticated`/`service_role` full
-  DML on `public` through default privileges (which is why no migration carries
-  a `GRANT`); the CLI's local stack grants only the non-DML part, so seeding
-  fails with `42501 permission denied`. The step tops up DML *only for roles
-  still present in an object's ACL*, so a migration's
-  `revoke all on <table> from anon, authenticated` survives it — the revoked
-  tables stay revoked and function `EXECUTE` grants are left alone. Verified
-  against a stack reproduced locally with the same CLI version.
+- After the stack starts, CI runs `npm run db:baseline` — the same script the
+  local setup above uses, so the two can't drift. It restores the hosted-project
+  DML baseline while leaving migration-level revocations (and every function
+  `EXECUTE` grant) alone. Verified against a stack reproduced locally with the
+  same CLI version CI installs.
 - The Playwright HTML report and `test-results/` are uploaded as artifacts on
   failure.
 

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -1,0 +1,104 @@
+# E2E lanes
+
+Playwright runs in two lanes (#595). Pick the lane by what you're guarding, not
+by habit — and remember that most behaviors belong in a `lib/` or component unit
+test, not here (see CLAUDE.md).
+
+| Lane      | What runs                        | Size | Budget            | Where                                        |
+| --------- | -------------------------------- | ---- | ----------------- | -------------------------------------------- |
+| **smoke** | tests tagged `@smoke`            | ~19  | **3 min**         | every PR (CI) + `npm run test:e2e:smoke`      |
+| **full**  | every spec                       | ~258 | ~7.6 min (serial) | nightly + on demand + `npm run test:e2e`      |
+
+The lanes are mutually exclusive Playwright projects selected by `E2E_LANE`, so
+a bare `npx playwright test` runs the full suite and never double-runs a smoke
+test.
+
+## The smoke lane
+
+It is a regression *gate*, not coverage. It keeps one or a few tests per area
+that would be catastrophic to break and that no lower layer can catch:
+
+- **auth / session** — login, wrong password, unauthenticated redirect, stale cookie
+- **cross-user ownership** — 403 on a foreign FK, 2xx on your own
+- **API validation** — non-finite amount, malformed UUID, malformed date, invalid JSON
+- **core transaction flow** — dashboard renders, net worth card, sell an unallocated fund
+- **add-transaction entry point** — the sheet opens
+- **maturity / merge money path** — merge a sibling deposit, no double-count
+- **report download** — the PDF actually downloads
+- **navigation** — sidebar routing
+
+Those areas are listed in `e2e/helpers/lanes.ts` (`SMOKE_COVERAGE_AREAS`) and a
+Vitest unit test (`lib/__tests__/e2eSmokeLane.test.ts`) fails if the lane drifts
+outside 15–30 tests or if an area loses its tags. Adding a test to the lane is
+one edit:
+
+```ts
+test('something critical', { tag: '@smoke' }, async ({ page }) => { … })
+```
+
+### The budget
+
+`SMOKE_BUDGET_MS` (3 minutes, in `e2e/helpers/lanes.ts`) covers the whole run —
+setup project included. The lane reporter prints the run's wall-clock time and
+warns when it overruns. An overrun means trim the lane or move the test down a
+layer; it doesn't fail the run.
+
+## Infra failures vs. product failures
+
+`e2e/reporters/laneReporter.ts` classifies every failure with
+`e2e/helpers/failureClass.ts`:
+
+- **infra** — socket errors, `fetch failed`, Postgres connection exhaustion or
+  statement timeouts, Disk IO throttling, 429/5xx from the API gateway, a
+  webServer that never came up, a dead browser.
+- **product** — everything else, including a plain locator timeout (that is an
+  element that never appeared, i.e. a real regression).
+
+A run whose failures are *all* infra prints an explicit note. Re-run it against
+a healthy stack before chasing the app.
+
+## Running locally
+
+Both lanes need a Supabase stack and the app. Keep a local stack running for the
+session so spec runs are instant:
+
+```bash
+supabase start                     # local stack on :54321 / :54322
+supabase status -o env             # copy API_URL / ANON_KEY / SERVICE_ROLE_KEY
+```
+
+Put those in `.env.e2e` (gitignored):
+
+```bash
+NEXT_PUBLIC_SUPABASE_URL=http://127.0.0.1:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=<local anon key>
+E2E_SUPABASE_URL=http://127.0.0.1:54321
+E2E_SUPABASE_SERVICE_ROLE_KEY=<local service role key>
+```
+
+Then:
+
+```bash
+npm run test:e2e:smoke                                   # the PR gate, ~3 min
+npm run test:e2e                                         # everything, ~7.6 min
+npx playwright test e2e/planning.spec.ts --project=chromium   # one area
+```
+
+`e2e/helpers/guard.ts` aborts the run if the target Supabase URL is the
+production project, in CI and locally alike.
+
+## In CI
+
+- **Every PR** — `.github/workflows/ci.yml` runs the smoke lane after the unit
+  tests, via the reusable `.github/workflows/e2e.yml`.
+- **Nightly (01:00 Vietnam) and on demand** — the same reusable workflow runs
+  the full suite; `workflow_dispatch` lets you pick the lane.
+- Both start a **local Supabase stack inside the runner**. The shared NANO test
+  project throttles under the suite's write load — that is what made CI E2E
+  unusable in #313 — so nothing points at it.
+- The Playwright HTML report and `test-results/` are uploaded as artifacts on
+  failure.
+
+Sharding is deliberately not enabled: the suite shares a single authenticated
+user (one `storageState`), so parallel workers race on per-user rows. Isolated
+users/storage state per worker come first.

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -54,6 +54,14 @@ layer; it doesn't fail the run.
 - **product** — everything else, including a plain locator timeout (that is an
   element that never appeared, i.e. a real regression).
 
+The gateway *wording* signals (`Service Unavailable`, `Too many requests`, …)
+don't count when the failure is a text or locator expectation — Playwright
+echoes a locator's expected text into the message, so
+`expect(getByText('Network error')).toBeVisible()` failing means the banner
+never rendered, which is a regression. Transport-level signals (socket codes,
+`net::ERR_*`, `fetch failed`) still count everywhere, including inside a locator
+assertion, because there the page genuinely failed to load.
+
 Ambiguity resolves to *product* by design. A bare assertion diff
 (`Expected: 400 / Received: 503`) is **not** treated as infra: the reporter only
 receives the diff — `TestResult.errors[]` carries no code snippet — so a

--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -96,6 +96,15 @@ production project, in CI and locally alike.
 - Both start a **local Supabase stack inside the runner**. The shared NANO test
   project throttles under the suite's write load — that is what made CI E2E
   unusable in #313 — so nothing points at it.
+- After the stack starts, one SQL step restores the **hosted-project DML
+  baseline**. A hosted project grants `anon`/`authenticated`/`service_role` full
+  DML on `public` through default privileges (which is why no migration carries
+  a `GRANT`); the CLI's local stack grants only the non-DML part, so seeding
+  fails with `42501 permission denied`. The step tops up DML *only for roles
+  still present in an object's ACL*, so a migration's
+  `revoke all on <table> from anon, authenticated` survives it — the revoked
+  tables stay revoked and function `EXECUTE` grants are left alone. Verified
+  against a stack reproduced locally with the same CLI version.
 - The Playwright HTML report and `test-results/` are uploaded as artifacts on
   failure.
 

--- a/e2e/add-transaction.spec.ts
+++ b/e2e/add-transaction.spec.ts
@@ -40,7 +40,7 @@ test('add button is visible on funds page', async ({ page }) => {
 
 // ─── Sheet open / close ──────────────────────────────────────────────────────
 
-test('clicking the add button opens Add transaction sheet', async ({ page }) => {
+test('clicking the add button opens Add transaction sheet', { tag: '@smoke' }, async ({ page }) => {
   await page.goto('/dashboard')
   await page.waitForLoadState('networkidle')
   await page.getByRole('button', { name: /add transaction/i }).click()

--- a/e2e/api-validation.spec.ts
+++ b/e2e/api-validation.spec.ts
@@ -8,7 +8,7 @@ import * as api from './helpers/api'
 // lib/__tests__/validation.test.ts.
 
 test.describe('API input validation', () => {
-  test('POST /api/v1/savings-goals rejects amount with Infinity (400)', async ({ request }) => {
+  test('POST /api/v1/savings-goals rejects amount with Infinity (400)', { tag: '@smoke' }, async ({ request }) => {
     const res = await request.post('/api/v1/savings-goals', {
       data: {
         goal_name: 'Test',
@@ -37,7 +37,7 @@ test.describe('API input validation', () => {
     expect(res.status()).toBe(400)
   })
 
-  test('GET /api/v1/savings-goals/<bad-uuid> rejects malformed UUID (400)', async ({ request }) => {
+  test('GET /api/v1/savings-goals/<bad-uuid> rejects malformed UUID (400)', { tag: '@smoke' }, async ({ request }) => {
     const res = await request.get('/api/v1/savings-goals/not-a-uuid')
     expect(res.status()).toBe(400)
   })
@@ -68,7 +68,7 @@ test.describe('API input validation', () => {
     expect(res.status()).toBe(400)
   })
 
-  test('POST /api/v1/investment-transactions rejects malformed investment_date (400)', async ({ request }) => {
+  test('POST /api/v1/investment-transactions rejects malformed investment_date (400)', { tag: '@smoke' }, async ({ request }) => {
     const res = await request.post('/api/v1/investment-transactions', {
       data: {
         asset_type: 'bank',
@@ -237,7 +237,7 @@ test.describe('API input validation', () => {
       data: Buffer.from(raw),
     })
 
-  test('POST /api/v1/savings-goals rejects a syntactically invalid body (400)', async ({ request }) => {
+  test('POST /api/v1/savings-goals rejects a syntactically invalid body (400)', { tag: '@smoke' }, async ({ request }) => {
     const res = await rawPost(request, '{"goal_name": ')
     expect(res.status()).toBe(400)
   })

--- a/e2e/auth.spec.ts
+++ b/e2e/auth.spec.ts
@@ -47,7 +47,7 @@ test('login page h1 says Welcome back', async ({ page }) => {
 
 // ─── Login behaviour ────────────────────────────────────────────────────────
 
-test('valid login redirects to /dashboard', async ({ page }) => {
+test('valid login redirects to /dashboard', { tag: '@smoke' }, async ({ page }) => {
   const { email, password } = getTestCredentials()
   await page.goto('/auth/login')
   await page.locator('#email').fill(email)
@@ -57,7 +57,7 @@ test('valid login redirects to /dashboard', async ({ page }) => {
   await expect(page).toHaveURL(/dashboard/)
 })
 
-test('wrong password shows error and stays on login page', async ({ page }) => {
+test('wrong password shows error and stays on login page', { tag: '@smoke' }, async ({ page }) => {
   const { email } = getTestCredentials()
   await page.goto('/auth/login')
   await page.locator('#email').fill(email)
@@ -67,7 +67,7 @@ test('wrong password shows error and stays on login page', async ({ page }) => {
   await expect(page).toHaveURL(/auth\/login/)
 })
 
-test('unauthenticated access to /dashboard redirects to /auth/login', async ({ page }) => {
+test('unauthenticated access to /dashboard redirects to /auth/login', { tag: '@smoke' }, async ({ page }) => {
   await page.goto('/dashboard')
   await page.waitForURL('**/auth/login', { timeout: 10_000 })
   await expect(page).toHaveURL(/auth\/login/)
@@ -79,7 +79,7 @@ test('unauthenticated access to /dashboard redirects to /auth/login', async ({ p
 // "Invalid Refresh Token: Refresh Token Not Found", and a soft router.push()
 // after sign-in bounced straight back to /auth/login — the button stuck on
 // "redirecting", never reaching Overview. See fix in app/auth/login/page.tsx.
-test('login succeeds even when a stale/invalid session cookie is present', async ({ page }) => {
+test('login succeeds even when a stale/invalid session cookie is present', { tag: '@smoke' }, async ({ page }) => {
   const adminUrl = process.env.E2E_SUPABASE_URL
   const serviceRoleKey = process.env.E2E_SUPABASE_SERVICE_ROLE_KEY
   test.skip(!adminUrl || !serviceRoleKey, 'requires E2E Supabase admin credentials')

--- a/e2e/dashboard.spec.ts
+++ b/e2e/dashboard.spec.ts
@@ -45,13 +45,13 @@ async function gotoFreshDashboard(page: Page) {
   ])
 }
 
-test('dashboard page loads with main layout', async ({ page }) => {
+test('dashboard page loads with main layout', { tag: '@smoke' }, async ({ page }) => {
   await page.goto('/dashboard')
   await expect(page.locator('nav, [role="navigation"]').first()).toBeVisible()
   await expect(page).toHaveURL(/dashboard/)
 })
 
-test('dashboard shows net worth card when data exists', async ({ page }) => {
+test('dashboard shows net worth card when data exists', { tag: '@smoke' }, async ({ page }) => {
   await page.goto('/dashboard')
   await page.waitForLoadState('networkidle')
   // Net worth card shows the net worth or total assets label in EN or VI
@@ -148,7 +148,7 @@ test('assign unallocated fund to a goal via action sheet', async ({ page }) => {
   await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 8_000 })
 })
 
-test('sell unallocated fund via action sheet', async ({ page }) => {
+test('sell unallocated fund via action sheet', { tag: '@smoke' }, async ({ page }) => {
   const fund = await api.createFund({ name: 'E2E Test Fund', code: 'E2ETESTFUND', fund_type: 'equity', nav: 10000 })
   cleanup.add(() => api.deleteFund(fund.id))
 

--- a/e2e/fk-ownership.spec.ts
+++ b/e2e/fk-ownership.spec.ts
@@ -32,14 +32,14 @@ test.describe('FK ownership enforcement (#474)', () => {
   })
 
   // ---- investment-transactions: fund_id ------------------------------------
-  test('POST /api/v1/investment-transactions rejects a cross-user fund_id (403)', async ({ request }) => {
+  test('POST /api/v1/investment-transactions rejects a cross-user fund_id (403)', { tag: '@smoke' }, async ({ request }) => {
     const res = await request.post('/api/v1/investment-transactions', {
       data: { asset_type: 'fund', fund_id: foreign.fundId, amount_vnd: 1_000_000, investment_date: '2026-01-01', unit_price: 20000, units: 50 },
     })
     expect(res.status()).toBe(403)
   })
 
-  test('POST /api/v1/investment-transactions accepts the caller’s own fund_id', async ({ request }) => {
+  test('POST /api/v1/investment-transactions accepts the caller’s own fund_id', { tag: '@smoke' }, async ({ request }) => {
     const res = await request.post('/api/v1/investment-transactions', {
       data: { asset_type: 'fund', fund_id: ownFundId, amount_vnd: 1_000_000, investment_date: '2026-01-01', unit_price: 20000, units: 50, notes: 'E2E own-fund FK' },
     })
@@ -205,7 +205,7 @@ test.describe('FK ownership enforcement — plan-scoped and user-scoped (#525)',
     expect(res.status()).toBe(403)
   })
 
-  test('recurring-savings rejects a cross-user goal_id (403)', async ({ request }) => {
+  test('recurring-savings rejects a cross-user goal_id (403)', { tag: '@smoke' }, async ({ request }) => {
     const res = await request.post('/api/v1/recurring-savings', {
       data: { name: `E2E FK Recurring ${Date.now()}`, amount_vnd: 1_000_000, goal_id: foreign.goalId },
     })
@@ -231,7 +231,7 @@ test.describe('FK ownership enforcement — plan-scoped and user-scoped (#525)',
   })
 
   // The same guard must not get in the way of a legitimate write.
-  test('a plan override against the caller’s own record still succeeds', async ({ request }) => {
+  test('a plan override against the caller’s own record still succeeds', { tag: '@smoke' }, async ({ request }) => {
     const member = await api.createInsuranceMember({
       member_name: `E2E FK Own Member ${Date.now()}`,
       relationship: 'self',

--- a/e2e/global.setup.ts
+++ b/e2e/global.setup.ts
@@ -49,7 +49,7 @@ setup('authenticate', async ({ page }) => {
   await page.context().storageState({ path: AUTH_FILE })
 
   // Seed one bank transaction so the dashboard isn't empty
-  await admin.from('investment_transactions').insert({
+  const seededTransaction = await admin.from('investment_transactions').insert({
     user_id: userId,
     asset_type: 'bank',
     amount_vnd: 10_000_000,
@@ -59,11 +59,19 @@ setup('authenticate', async ({ page }) => {
   })
 
   // Seed one insurance member so the insurance section is always visible
-  await admin.from('insurance_members').insert({
+  const seededMember = await admin.from('insurance_members').insert({
     user_id: userId,
     member_name: 'E2e Member',
     relationship: 'Self',
     annual_payment_vnd: 5_000_000,
     payment_date: '2026-06-01',
   })
+
+  // Fail loudly if seeding didn't land. Swallowing these errors made a database
+  // the suite couldn't write to look like a setup that succeeded — every spec
+  // then failed later, far from the cause (#595).
+  const seedError = seededTransaction.error ?? seededMember.error
+  if (seedError) {
+    throw new Error(`Failed to seed the E2E fixtures: ${seedError.message}`)
+  }
 })

--- a/e2e/helpers/failureClass.ts
+++ b/e2e/helpers/failureClass.ts
@@ -1,0 +1,89 @@
+// Tell infrastructure trouble apart from real product regressions (#595).
+//
+// The E2E suite historically went red in CI because the shared Supabase Nano
+// instance throttled (Disk IO budget, connection exhaustion, 5xx from the API
+// gateway) — not because the app broke. A red lane that mixes those two causes
+// trains everyone to ignore it. The lane reporter uses this classifier to print
+// them in separate buckets, so "20 infra failures, 0 product failures" reads as
+// "the database gave up", not "the app regressed".
+//
+// Dependency-free on purpose: imported by the Playwright reporter and by the
+// Vitest unit test (which lives outside the e2e/ tree Vitest excludes).
+
+export type FailureKind = 'infra' | 'product'
+
+export type FailureInput = {
+  title?: string
+  message?: string
+  status?: string
+}
+
+/**
+ * Signals that the environment — network, database, browser process — failed,
+ * rather than an assertion about the product.
+ *
+ * Deliberately *not* here: a bare "Timed out"/"Test timeout exceeded". That is
+ * the suite's most common *product* failure (an element never appeared), so a
+ * timeout only counts as infra when it carries one of these markers too.
+ */
+const INFRA_PATTERNS: RegExp[] = [
+  // Socket / DNS level
+  /\b(ECONNREFUSED|ECONNRESET|ETIMEDOUT|EPIPE|EAI_AGAIN|ENOTFOUND|EHOSTUNREACH)\b/,
+  /socket hang up/i,
+  /fetch failed/i,
+  /network error/i,
+  /net::ERR_[A-Z_]+/,
+  // Postgres / Supabase throttling and exhaustion
+  /too many connections/i,
+  /remaining connection slots/i,
+  /statement timeout/i,
+  /canceling statement due to/i,
+  /disk io/i,
+  /resource exhausted/i,
+  // Gateway and rate-limit responses
+  /\b(429|502|503|504)\b/,
+  /too many requests/i,
+  /service unavailable/i,
+  /gateway timeout/i,
+  /bad gateway/i,
+  // The app server never came up at all
+  /from config\.webServer to start/i,
+  // Browser / worker died under us
+  /browser has been closed/i,
+  /browser closed unexpectedly/i,
+  /target crashed/i,
+  /page crashed/i,
+]
+
+/** Classify one failed test as infrastructure trouble or a product regression. */
+export function classifyFailure(failure: FailureInput): FailureKind {
+  const message = failure.message ?? ''
+  if (!message) return 'product'
+  return INFRA_PATTERNS.some((p) => p.test(message)) ? 'infra' : 'product'
+}
+
+export type FailureSummary<T extends FailureInput> = {
+  infra: T[]
+  product: T[]
+  total: number
+  /** True when there was at least one failure and every one of them was infra. */
+  infraOnly: boolean
+}
+
+/** Split a run's failures into infra and product buckets. */
+export function summarizeFailures<T extends FailureInput>(failures: T[]): FailureSummary<T> {
+  const infra: T[] = []
+  const product: T[] = []
+
+  for (const failure of failures) {
+    if (classifyFailure(failure) === 'infra') infra.push(failure)
+    else product.push(failure)
+  }
+
+  return {
+    infra,
+    product,
+    total: failures.length,
+    infraOnly: failures.length > 0 && product.length === 0,
+  }
+}

--- a/e2e/helpers/failureClass.ts
+++ b/e2e/helpers/failureClass.ts
@@ -49,7 +49,6 @@ const INFRA_PATTERNS: RegExp[] = [
   /gateway timeout/i,
   /bad gateway/i,
   /\b(?:status(?:[ _]?code)?|http)\b\W{0,3}(?:429|50[234])\b/i,
-  /\breceived\s*:?\s+(?:429|50[234])\b/i,
   // The app server never came up at all. Playwright words this several ways
   // ("Timed out waiting … from config.webServer.", "Process from
   // config.webServer was not able to start."), so match the config key itself.
@@ -61,9 +60,29 @@ const INFRA_PATTERNS: RegExp[] = [
   /page crashed/i,
 ]
 
+/**
+ * Playwright colours its errors, so a real diff arrives as
+ * `Received: <ESC>[31m503<ESC>[39m` — the escape sits between the label and the
+ * number and defeats any pattern spanning the two. Strip them before matching.
+ */
+const ANSI = /\u001b\[[0-9;]*m/g
+
+/**
+ * Deliberately *not* a signal: an assertion diff of the form
+ * `Expected: 400 / Received: 503`. When a throttled gateway answers a status the
+ * test asserted on, that diff is all the reporter gets — `TestResult.errors[]`
+ * carries no code snippet (verified by instrumenting a real run), so there is no
+ * HTTP context to key on, and the identical text is what a money-value
+ * regression prints. Such a run is reported as a *product* failure: calling a
+ * genuine regression "infra" is the failure mode this classifier exists to
+ * prevent, so ambiguity resolves that way. Real throttling nearly always also
+ * carries one of the signals above — a socket error, a statement timeout, or
+ * the status phrase itself.
+ */
+
 /** Classify one failed test as infrastructure trouble or a product regression. */
 export function classifyFailure(failure: FailureInput): FailureKind {
-  const message = failure.message ?? ''
+  const message = (failure.message ?? '').replace(ANSI, '')
   if (!message) return 'product'
   return INFRA_PATTERNS.some((p) => p.test(message)) ? 'infra' : 'product'
 }

--- a/e2e/helpers/failureClass.ts
+++ b/e2e/helpers/failureClass.ts
@@ -31,7 +31,6 @@ const INFRA_PATTERNS: RegExp[] = [
   /\b(ECONNREFUSED|ECONNRESET|ETIMEDOUT|EPIPE|EAI_AGAIN|ENOTFOUND|EHOSTUNREACH)\b/,
   /socket hang up/i,
   /fetch failed/i,
-  /network error/i,
   /net::ERR_[A-Z_]+/,
   // Postgres / Supabase throttling and exhaustion
   /too many connections/i,
@@ -40,15 +39,6 @@ const INFRA_PATTERNS: RegExp[] = [
   /canceling statement due to/i,
   /disk io/i,
   /resource exhausted/i,
-  // Gateway and rate-limit responses. The classifier sees the message *and* the
-  // stack, so a bare number is not enough — `dashboard.spec.ts:503:11` and an
-  // expected value of 429 are ordinary product failures. Require either the
-  // status phrase or an explicit HTTP-status context.
-  /too many requests/i,
-  /service unavailable/i,
-  /gateway timeout/i,
-  /bad gateway/i,
-  /\b(?:status(?:[ _]?code)?|http)\b\W{0,3}(?:429|50[234])\b/i,
   // The app server never came up at all. Playwright words this several ways
   // ("Timed out waiting … from config.webServer.", "Process from
   // config.webServer was not able to start."), so match the config key itself.
@@ -59,6 +49,28 @@ const INFRA_PATTERNS: RegExp[] = [
   /target crashed/i,
   /page crashed/i,
 ]
+
+/**
+ * Wording-only signals. A gateway announces itself in prose, but prose is also
+ * what a UI renders — and Playwright echoes a locator's expected text into the
+ * failure message, so `expect(getByText('Network error')).toBeVisible()` failing
+ * because the banner never appeared would otherwise read as infrastructure. The
+ * suite has ~120 text assertions, so these count only when the failure is not a
+ * text/locator expectation. (`network error` was dropped outright: as a phrase
+ * it is almost purely UI copy, and a genuine transport failure always carries a
+ * socket code, `fetch failed`, or `net::ERR_*` above.)
+ */
+const INFRA_WORDING: RegExp[] = [
+  /too many requests/i,
+  /service unavailable/i,
+  /gateway timeout/i,
+  /bad gateway/i,
+  /\b(?:status(?:[ _]?code)?|http)\b\W{0,3}(?:429|50[234])\b/i,
+]
+
+/** The failure is an expectation about rendered text, so its wording is the test's, not the server's. */
+const TEXT_EXPECTATION =
+  /getBy(?:Text|Role|Label|Placeholder|Title|AltText)\(|toContainText\(|toHaveText\(|Locator:|locator\(/
 
 /**
  * Playwright colours its errors, so a real diff arrives as
@@ -84,7 +96,9 @@ const ANSI = /\u001b\[[0-9;]*m/g
 export function classifyFailure(failure: FailureInput): FailureKind {
   const message = (failure.message ?? '').replace(ANSI, '')
   if (!message) return 'product'
-  return INFRA_PATTERNS.some((p) => p.test(message)) ? 'infra' : 'product'
+  if (INFRA_PATTERNS.some((p) => p.test(message))) return 'infra'
+  if (TEXT_EXPECTATION.test(message)) return 'product'
+  return INFRA_WORDING.some((p) => p.test(message)) ? 'infra' : 'product'
 }
 
 export type FailureSummary<T extends FailureInput> = {

--- a/e2e/helpers/failureClass.ts
+++ b/e2e/helpers/failureClass.ts
@@ -46,8 +46,10 @@ const INFRA_PATTERNS: RegExp[] = [
   /service unavailable/i,
   /gateway timeout/i,
   /bad gateway/i,
-  // The app server never came up at all
-  /from config\.webServer to start/i,
+  // The app server never came up at all. Playwright words this several ways
+  // ("Timed out waiting … from config.webServer.", "Process from
+  // config.webServer was not able to start."), so match the config key itself.
+  /config\.webServer/i,
   // Browser / worker died under us
   /browser has been closed/i,
   /browser closed unexpectedly/i,

--- a/e2e/helpers/failureClass.ts
+++ b/e2e/helpers/failureClass.ts
@@ -40,12 +40,16 @@ const INFRA_PATTERNS: RegExp[] = [
   /canceling statement due to/i,
   /disk io/i,
   /resource exhausted/i,
-  // Gateway and rate-limit responses
-  /\b(429|502|503|504)\b/,
+  // Gateway and rate-limit responses. The classifier sees the message *and* the
+  // stack, so a bare number is not enough — `dashboard.spec.ts:503:11` and an
+  // expected value of 429 are ordinary product failures. Require either the
+  // status phrase or an explicit HTTP-status context.
   /too many requests/i,
   /service unavailable/i,
   /gateway timeout/i,
   /bad gateway/i,
+  /\b(?:status(?:[ _]?code)?|http)\b\W{0,3}(?:429|50[234])\b/i,
+  /\breceived\s*:?\s+(?:429|50[234])\b/i,
   // The app server never came up at all. Playwright words this several ways
   // ("Timed out waiting … from config.webServer.", "Process from
   // config.webServer was not able to start."), so match the config key itself.

--- a/e2e/helpers/lanes.ts
+++ b/e2e/helpers/lanes.ts
@@ -1,0 +1,60 @@
+// The two E2E lanes (#595).
+//
+//  - **smoke** — a small, high-value subset tagged `@smoke`, fast enough to run
+//    on every pull request. It is a regression *gate*, not coverage: auth,
+//    cross-user ownership, API validation, the core transaction flow, one
+//    maturity/merge money path, and the report download.
+//  - **full**  — every spec (~258 tests, ~7.6 min serial). Runs nightly and on
+//    demand, never on the PR path.
+//
+// This module is intentionally dependency-free so it can be imported by the
+// Playwright config, the lane reporter, and the Vitest unit test (which lives
+// outside the e2e/ tree Vitest otherwise excludes).
+
+/** Playwright tag marking a test as part of the PR smoke lane. */
+export const SMOKE_TAG = '@smoke'
+
+/**
+ * Documented wall-clock budget for the smoke lane, covering the whole
+ * Playwright run (setup project + tests). The full suite takes ~7.6 min; the
+ * smoke lane must stay a small fraction of that or it stops being a PR gate.
+ * The lane reporter prints a warning when a run overruns this.
+ */
+export const SMOKE_BUDGET_MS = 3 * 60_000
+
+/** The lane is only useful inside this size band — see #595. */
+export const SMOKE_MIN_TESTS = 15
+export const SMOKE_MAX_TESTS = 30
+
+/**
+ * Areas the smoke lane must keep guarding, and the spec that carries them.
+ * A unit test fails if any area loses its `@smoke` tags, so shrinking the lane
+ * can't silently drop a whole category of regression.
+ */
+export const SMOKE_COVERAGE_AREAS = [
+  { name: 'auth / session', spec: 'auth.spec.ts' },
+  { name: 'cross-user ownership', spec: 'fk-ownership.spec.ts' },
+  { name: 'API validation', spec: 'api-validation.spec.ts' },
+  { name: 'core transaction flow', spec: 'dashboard.spec.ts' },
+  { name: 'add-transaction entry point', spec: 'add-transaction.spec.ts' },
+  { name: 'maturity / merge money path', spec: 'maturity-combine-merge.spec.ts' },
+  { name: 'report download', spec: 'report.spec.ts' },
+  { name: 'navigation', spec: 'navigation.spec.ts' },
+] as const
+
+export type SmokeBudgetVerdict = {
+  withinBudget: boolean
+  /** Milliseconds over the budget; 0 when within it. */
+  overByMs: number
+  budgetMs: number
+  durationMs: number
+}
+
+/** Compare a finished run's wall-clock duration against the documented budget. */
+export function checkSmokeBudget(
+  durationMs: number,
+  budgetMs: number = SMOKE_BUDGET_MS,
+): SmokeBudgetVerdict {
+  const overByMs = Math.max(0, durationMs - budgetMs)
+  return { withinBudget: overByMs === 0, overByMs, budgetMs, durationMs }
+}

--- a/e2e/maturity-combine-merge.spec.ts
+++ b/e2e/maturity-combine-merge.spec.ts
@@ -41,7 +41,7 @@ async function goalSnapshot(page: Page, goalId: string): Promise<{ progressValue
 }
 
 test.describe('Term-deposit maturity — merge a sibling deposit into the re-deposit', () => {
-  test('settles the sibling early and folds its cash into the renewed principal, no double-count', async ({ page }) => {
+  test('settles the sibling early and folds its cash into the renewed principal, no double-count', { tag: '@smoke' }, async ({ page }) => {
     test.slow()
     const goal = await api.createGoal({ goal_name: 'E2E Merge Goal', target_amount: 200_000_000 })
     // D: matured term deposit (rolls forward on renewal). S: an active sibling

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test'
 
-test('sidebar links navigate to correct routes', async ({ page }) => {
+test('sidebar links navigate to correct routes', { tag: '@smoke' }, async ({ page }) => {
   await page.goto('/dashboard')
   await page.waitForLoadState('networkidle')
 

--- a/e2e/report.spec.ts
+++ b/e2e/report.spec.ts
@@ -23,7 +23,7 @@ test.describe('PDF Report download', () => {
     await expect(exportBtn(page)).toBeVisible({ timeout: 5_000 })
   })
 
-  test('clicking the button downloads a PDF file with the correct filename', async ({ page }) => {
+  test('clicking the button downloads a PDF file with the correct filename', { tag: '@smoke' }, async ({ page }) => {
     await reportBtn(page).click()
     await expect(exportBtn(page)).toBeVisible({ timeout: 5_000 })
     const [download] = await Promise.all([

--- a/e2e/reporters/laneReporter.ts
+++ b/e2e/reporters/laneReporter.ts
@@ -1,0 +1,96 @@
+import type { Reporter, TestCase, TestResult, FullResult } from '@playwright/test/reporter'
+import { summarizeFailures, type FailureInput } from '../helpers/failureClass'
+import { checkSmokeBudget, SMOKE_BUDGET_MS } from '../helpers/lanes'
+
+type Failure = FailureInput & { title: string }
+
+/**
+ * Prints a run summary that separates infrastructure trouble (database
+ * throttling, socket errors, a browser that died) from product regressions, and
+ * — on the smoke lane — checks the run against its documented time budget
+ * (#595).
+ *
+ * It never changes the exit code: a red run stays red. The point is that the
+ * *reason* is legible at a glance, so a throttled database is not mistaken for
+ * an app regression.
+ */
+class LaneReporter implements Reporter {
+  private failures: Failure[] = []
+  private startedAt = 0
+  private finished = 0
+  private lane = process.env.E2E_LANE ?? 'full'
+
+  onBegin() {
+    this.startedAt = Date.now()
+  }
+
+  onTestEnd(test: TestCase, result: TestResult) {
+    this.finished += 1
+    if (result.status === 'passed' || result.status === 'skipped') return
+    if (result.status === test.expectedStatus) return
+    // Retries: only the final attempt matters.
+    if (result.retry < test.retries) return
+
+    this.failures.push({
+      title: test.titlePath().filter(Boolean).join(' › '),
+      status: result.status,
+      message: [result.error?.message, result.error?.stack, ...result.errors.map((e) => e.message)]
+        .filter(Boolean)
+        .join('\n'),
+    })
+  }
+
+  onEnd(result: FullResult) {
+    // Nothing ran — e.g. `playwright test --list`. Stay quiet.
+    if (this.finished === 0 && this.failures.length === 0) return
+
+    const durationMs = Date.now() - this.startedAt
+    const lines: string[] = ['', `E2E lane: ${this.lane} — ${formatDuration(durationMs)}`]
+
+    if (this.lane === 'smoke') {
+      const verdict = checkSmokeBudget(durationMs)
+      lines.push(
+        verdict.withinBudget
+          ? `  ✓ within the ${formatDuration(SMOKE_BUDGET_MS)} smoke budget`
+          : `  ! over the ${formatDuration(SMOKE_BUDGET_MS)} smoke budget by ${formatDuration(
+              verdict.overByMs,
+            )} — trim the lane or move a test down a layer`,
+      )
+    }
+
+    const summary = summarizeFailures(this.failures)
+    if (summary.total > 0) {
+      lines.push(
+        `  ${summary.product.length} product failure(s), ${summary.infra.length} infra failure(s)`,
+      )
+      for (const failure of summary.product) lines.push(`    ✗ product: ${failure.title}`)
+      for (const failure of summary.infra) lines.push(`    ~ infra:   ${failure.title}`)
+      if (summary.infraOnly) {
+        lines.push(
+          '  Every failure looks like infrastructure (database throttling, network, browser),',
+          '  not a product regression. Re-run against a healthy stack before chasing the app.',
+        )
+      }
+    } else if (result.status === 'passed') {
+      lines.push('  no failures')
+    }
+
+    console.log(lines.join('\n'))
+
+    if (process.env.GITHUB_STEP_SUMMARY && summary.total > 0) {
+      const marker = summary.infraOnly ? 'warning' : 'error'
+      console.log(
+        `::${marker} title=E2E ${this.lane} lane::${summary.product.length} product failure(s), ` +
+          `${summary.infra.length} infra failure(s)`,
+      )
+    }
+  }
+}
+
+function formatDuration(ms: number): string {
+  const seconds = Math.round(ms / 1000)
+  const minutes = Math.floor(seconds / 60)
+  return minutes > 0 ? `${minutes}m ${seconds % 60}s` : `${seconds}s`
+}
+
+export default LaneReporter

--- a/e2e/reporters/laneReporter.ts
+++ b/e2e/reporters/laneReporter.ts
@@ -32,7 +32,10 @@ class LaneReporter implements Reporter {
 
   onTestEnd(test: TestCase, result: TestResult) {
     this.finished += 1
-    if (result.status === 'passed' || result.status === 'skipped') return
+    if (result.status === 'skipped') return
+    // Compare against the *expected* status, not against 'passed': a test.fail()
+    // that passes turns the run red, and an expected failure does not. Checking
+    // `status === 'passed'` first would drop the former from the summary.
     if (result.status === test.expectedStatus) return
     // Retries: only the final attempt matters.
     if (result.retry < test.retries) return

--- a/e2e/reporters/laneReporter.ts
+++ b/e2e/reporters/laneReporter.ts
@@ -1,4 +1,10 @@
-import type { Reporter, TestCase, TestResult, FullResult } from '@playwright/test/reporter'
+import type {
+  Reporter,
+  TestCase,
+  TestResult,
+  TestError,
+  FullResult,
+} from '@playwright/test/reporter'
 import { summarizeFailures, type FailureInput } from '../helpers/failureClass'
 import { checkSmokeBudget, SMOKE_BUDGET_MS } from '../helpers/lanes'
 
@@ -40,14 +46,29 @@ class LaneReporter implements Reporter {
     })
   }
 
+  /**
+   * Global errors never reach `onTestEnd` — a webServer that won't start, a
+   * config that won't load, a worker that died before any test ran. Without
+   * this, exactly the failure the infra classifier is best at spotting would be
+   * missing from the summary.
+   */
+  onError(error: TestError) {
+    this.failures.push({
+      title: 'global error (no test)',
+      status: 'failed',
+      message: [error.message, error.stack, error.value].filter(Boolean).join('\n'),
+    })
+  }
+
   onEnd(result: FullResult) {
-    // Nothing ran — e.g. `playwright test --list`. Stay quiet.
+    // Nothing ran and nothing failed — e.g. `playwright test --list`. Stay quiet.
     if (this.finished === 0 && this.failures.length === 0) return
 
     const durationMs = Date.now() - this.startedAt
     const lines: string[] = ['', `E2E lane: ${this.lane} — ${formatDuration(durationMs)}`]
 
-    if (this.lane === 'smoke') {
+    // A run that never got as far as a test says nothing about the budget.
+    if (this.lane === 'smoke' && this.finished > 0) {
       const verdict = checkSmokeBudget(durationMs)
       lines.push(
         verdict.withinBudget

--- a/lib/__tests__/e2eFailureClass.test.ts
+++ b/lib/__tests__/e2eFailureClass.test.ts
@@ -27,6 +27,22 @@ describe('classifyFailure', () => {
     )
     expect(classifyFailure({ message: 'request failed with 504 Gateway Timeout' })).toBe('infra')
     expect(classifyFailure({ message: 'HTTP 429 Too Many Requests' })).toBe('infra')
+    expect(classifyFailure({ message: 'apiResponse.json: status 502' })).toBe('infra')
+    expect(classifyFailure({ message: 'Received: 429' })).toBe('infra')
+  })
+
+  it('does not read a bare number in a stack frame or a value as a status code', () => {
+    // The classifier sees message + stack. A line number, an amount, or a goal
+    // id containing 503 must not turn a real regression into "infra".
+    expect(
+      classifyFailure({
+        message: 'expect(received).toBe(expected)\n    at e2e/dashboard.spec.ts:503:11',
+      }),
+    ).toBe('product')
+    expect(
+      classifyFailure({ message: 'expect(received).toBe(expected)\n\nExpected: 429\nReceived: 0' }),
+    ).toBe('product')
+    expect(classifyFailure({ message: 'amount_vnd 502000 did not match' })).toBe('product')
   })
 
   it('classifies a webServer that never came up as infra', () => {

--- a/lib/__tests__/e2eFailureClass.test.ts
+++ b/lib/__tests__/e2eFailureClass.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest'
+import { classifyFailure, summarizeFailures } from '../../e2e/helpers/failureClass'
+
+describe('classifyFailure', () => {
+  it('classifies socket-level errors as infra', () => {
+    expect(classifyFailure({ message: 'connect ECONNREFUSED 127.0.0.1:54321' })).toBe('infra')
+    expect(classifyFailure({ message: 'read ECONNRESET' })).toBe('infra')
+    expect(classifyFailure({ message: 'socket hang up' })).toBe('infra')
+    expect(classifyFailure({ message: 'TypeError: fetch failed' })).toBe('infra')
+    expect(classifyFailure({ message: 'page.goto: net::ERR_CONNECTION_REFUSED' })).toBe('infra')
+  })
+
+  it('classifies database throttling and exhaustion as infra', () => {
+    expect(classifyFailure({ message: 'FATAL: remaining connection slots are reserved' })).toBe(
+      'infra',
+    )
+    expect(classifyFailure({ message: 'too many connections for role "postgres"' })).toBe('infra')
+    expect(
+      classifyFailure({ message: 'canceling statement due to statement timeout' }),
+    ).toBe('infra')
+    expect(classifyFailure({ message: 'Disk IO budget exhausted for this project' })).toBe('infra')
+  })
+
+  it('classifies gateway/rate-limit responses as infra', () => {
+    expect(classifyFailure({ message: 'Expected 400 but received 503 Service Unavailable' })).toBe(
+      'infra',
+    )
+    expect(classifyFailure({ message: 'request failed with 504 Gateway Timeout' })).toBe('infra')
+    expect(classifyFailure({ message: 'HTTP 429 Too Many Requests' })).toBe('infra')
+  })
+
+  it('classifies a webServer that never came up as infra', () => {
+    expect(
+      classifyFailure({
+        message: 'Timed out waiting 120000ms from config.webServer to start at http://localhost:3000',
+      }),
+    ).toBe('infra')
+  })
+
+  it('classifies browser/worker crashes as infra', () => {
+    expect(
+      classifyFailure({ message: 'Target page, context or browser has been closed' }),
+    ).toBe('infra')
+    expect(classifyFailure({ message: 'browserType.launch: Browser closed unexpectedly' })).toBe(
+      'infra',
+    )
+  })
+
+  it('classifies assertion failures as product failures', () => {
+    expect(
+      classifyFailure({
+        message: 'expect(received).toBe(expected)\n\nExpected: 400\nReceived: 200',
+      }),
+    ).toBe('product')
+    expect(
+      classifyFailure({
+        message: 'expect(locator).toBeVisible() failed\n\nLocator resolved to 0 elements',
+      }),
+    ).toBe('product')
+  })
+
+  it('treats a plain locator timeout as a product failure, not infra', () => {
+    // The suite's most common failure: an element never appeared. "Timed out"
+    // alone must not be read as infrastructure trouble.
+    expect(
+      classifyFailure({
+        status: 'timedOut',
+        message: 'Timed out 5000ms waiting for expect(locator).toBeVisible()',
+      }),
+    ).toBe('product')
+    expect(
+      classifyFailure({
+        status: 'timedOut',
+        message: 'Test timeout of 30000ms exceeded.',
+      }),
+    ).toBe('product')
+  })
+
+  it('lets an infra marker win even when the test timed out', () => {
+    expect(
+      classifyFailure({
+        status: 'timedOut',
+        message: 'Test timeout of 30000ms exceeded.\nError: connect ETIMEDOUT db.supabase.co:5432',
+      }),
+    ).toBe('infra')
+  })
+
+  it('defaults to a product failure when there is no message at all', () => {
+    expect(classifyFailure({})).toBe('product')
+    expect(classifyFailure({ message: '' })).toBe('product')
+  })
+})
+
+describe('summarizeFailures', () => {
+  it('splits failures into infra and product buckets', () => {
+    const summary = summarizeFailures([
+      { title: 'a', message: 'connect ECONNREFUSED 127.0.0.1:54321' },
+      { title: 'b', message: 'expect(received).toBe(expected)' },
+      { title: 'c', message: 'HTTP 429 Too Many Requests' },
+    ])
+
+    expect(summary.infra.map((f) => f.title)).toEqual(['a', 'c'])
+    expect(summary.product.map((f) => f.title)).toEqual(['b'])
+  })
+
+  it('reports an all-infra run so a red lane is not read as a regression', () => {
+    const summary = summarizeFailures([
+      { title: 'a', message: 'socket hang up' },
+      { title: 'b', message: 'too many connections' },
+    ])
+
+    expect(summary.infraOnly).toBe(true)
+    expect(summary.total).toBe(2)
+  })
+
+  it('is not infra-only when a single product failure is present', () => {
+    const summary = summarizeFailures([
+      { title: 'a', message: 'socket hang up' },
+      { title: 'b', message: 'expect(locator).toBeVisible() failed' },
+    ])
+
+    expect(summary.infraOnly).toBe(false)
+  })
+
+  it('reports no failures as an empty, non-infra-only summary', () => {
+    const summary = summarizeFailures([])
+    expect(summary.total).toBe(0)
+    expect(summary.infraOnly).toBe(false)
+  })
+})

--- a/lib/__tests__/e2eFailureClass.test.ts
+++ b/lib/__tests__/e2eFailureClass.test.ts
@@ -28,7 +28,28 @@ describe('classifyFailure', () => {
     expect(classifyFailure({ message: 'request failed with 504 Gateway Timeout' })).toBe('infra')
     expect(classifyFailure({ message: 'HTTP 429 Too Many Requests' })).toBe('infra')
     expect(classifyFailure({ message: 'apiResponse.json: status 502' })).toBe('infra')
-    expect(classifyFailure({ message: 'Received: 429' })).toBe('infra')
+  })
+
+  it('sees through the ANSI colour codes Playwright actually emits', () => {
+    const esc = '\u001b'
+    expect(
+      classifyFailure({
+        message: `Error: apiResponse: ${esc}[31mstatus 503${esc}[39m`,
+      }),
+    ).toBe('infra')
+  })
+
+  it('reports a bare status diff as a product failure — the honest default', () => {
+    // Instrumenting a real run showed the reporter receives only the diff:
+    // `TestResult.errors[]` carries no code snippet, so a throttled gateway and
+    // a money-value regression are textually identical here. Ambiguity resolves
+    // to 'product' so a genuine regression is never dismissed as infra.
+    const esc = '\u001b'
+    const real =
+      `Error: ${esc}[2mexpect(${esc}[22m${esc}[31mreceived${esc}[39m${esc}[2m).${esc}[22mtoBe${esc}[2m(${esc}[22m${esc}[32mexpected${esc}[39m${esc}[2m) // Object.is equality${esc}[22m\n\n` +
+      `Expected: ${esc}[32m400${esc}[39m\nReceived: ${esc}[31m503${esc}[39m`
+
+    expect(classifyFailure({ message: real })).toBe('product')
   })
 
   it('does not read a bare number in a stack frame or a value as a status code', () => {
@@ -43,6 +64,13 @@ describe('classifyFailure', () => {
       classifyFailure({ message: 'expect(received).toBe(expected)\n\nExpected: 429\nReceived: 0' }),
     ).toBe('product')
     expect(classifyFailure({ message: 'amount_vnd 502000 did not match' })).toBe('product')
+    expect(
+      classifyFailure({
+        message:
+          'expect(received).toBe(expected)\n\nExpected: 0\nReceived: 503\n    at e2e/planning.spec.ts:88:20',
+      }),
+    ).toBe('product')
+    expect(classifyFailure({ message: 'Received: 429' })).toBe('product')
   })
 
   it('classifies a webServer that never came up as infra', () => {

--- a/lib/__tests__/e2eFailureClass.test.ts
+++ b/lib/__tests__/e2eFailureClass.test.ts
@@ -90,6 +90,44 @@ describe('classifyFailure', () => {
     ).toBe('infra')
   })
 
+  it('does not let a text assertion about an error state count as infra', () => {
+    // The suite has ~120 text/locator assertions. If the UI asserts on an error
+    // banner, Playwright echoes that text into the failure message — a missing
+    // error state is a product regression, not a throttled gateway.
+    expect(
+      classifyFailure({
+        message:
+          "expect(locator).toBeVisible() failed\n\nLocator: getByText('Network error')\nExpected: visible\nReceived: <element(s) not found>",
+      }),
+    ).toBe('product')
+    expect(
+      classifyFailure({
+        message:
+          "expect(locator).toContainText('Service Unavailable') failed\n\nLocator: locator('#banner')",
+      }),
+    ).toBe('product')
+    expect(
+      classifyFailure({
+        message: "expect(locator).toBeVisible() failed\n\nLocator: getByText('Too many requests')",
+      }),
+    ).toBe('product')
+  })
+
+  it('still calls a real transport failure infra even inside a locator assertion', () => {
+    // The page genuinely failed to load — not a text expectation about wording.
+    expect(
+      classifyFailure({
+        message:
+          "expect(locator).toBeVisible() failed\n\nCall log:\n  - page.goto: net::ERR_CONNECTION_REFUSED at http://localhost:3000",
+      }),
+    ).toBe('infra')
+    expect(
+      classifyFailure({
+        message: "expect(locator).toBeVisible() failed\n\nError: connect ECONNREFUSED 127.0.0.1:54321",
+      }),
+    ).toBe('infra')
+  })
+
   it('classifies browser/worker crashes as infra', () => {
     expect(
       classifyFailure({ message: 'Target page, context or browser has been closed' }),

--- a/lib/__tests__/e2eFailureClass.test.ts
+++ b/lib/__tests__/e2eFailureClass.test.ts
@@ -30,6 +30,15 @@ describe('classifyFailure', () => {
   })
 
   it('classifies a webServer that never came up as infra', () => {
+    // Playwright words this several ways; all of them mention config.webServer.
+    expect(
+      classifyFailure({ message: 'Timed out waiting 120000ms from config.webServer.' }),
+    ).toBe('infra')
+    expect(
+      classifyFailure({
+        message: 'Process from config.webServer was not able to start. Exit code: 1',
+      }),
+    ).toBe('infra')
     expect(
       classifyFailure({
         message: 'Timed out waiting 120000ms from config.webServer to start at http://localhost:3000',

--- a/lib/__tests__/e2eLaneReporter.test.ts
+++ b/lib/__tests__/e2eLaneReporter.test.ts
@@ -70,6 +70,41 @@ describe('LaneReporter', () => {
     expect(output()).not.toContain('Every failure looks like infrastructure')
   })
 
+  it('records an unexpected pass — a test.fail() that passed makes the run red', () => {
+    const { reporter, output } = makeReporter()
+    const unexpectedPass = {
+      expectedStatus: 'failed',
+      retries: 0,
+      titlePath: () => ['', 'smoke', 'a.spec.ts', 'known-broken test'],
+    } as unknown as TestCase
+
+    reporter.onBegin()
+    reporter.onTestEnd(unexpectedPass, {
+      status: 'passed',
+      retry: 0,
+      errors: [],
+    } as unknown as TestResult)
+    reporter.onEnd(failedRun)
+
+    expect(output()).toContain('1 product failure(s)')
+    expect(output()).toContain('known-broken test')
+  })
+
+  it('does not record an expected failure', () => {
+    const { reporter, output } = makeReporter()
+    const expectedFailure = {
+      expectedStatus: 'failed',
+      retries: 0,
+      titlePath: () => ['', 'smoke', 'a.spec.ts', 'known-broken test'],
+    } as unknown as TestCase
+
+    reporter.onBegin()
+    reporter.onTestEnd(expectedFailure, failedResult)
+    reporter.onEnd(passedRun)
+
+    expect(output()).toContain('no failures')
+  })
+
   it('stays quiet when nothing ran and nothing failed — e.g. `--list`', () => {
     const { reporter, output } = makeReporter()
 

--- a/lib/__tests__/e2eLaneReporter.test.ts
+++ b/lib/__tests__/e2eLaneReporter.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import type { FullResult, TestCase, TestResult } from '@playwright/test/reporter'
+import LaneReporter from '../../e2e/reporters/laneReporter'
+
+/**
+ * The reporter's job is to make a red run legible. The case that matters most
+ * here is the one Playwright never routes through `onTestEnd`: a global error
+ * (the webServer failing to start), which otherwise vanishes from the summary.
+ */
+
+function makeReporter() {
+  const reporter = new LaneReporter()
+  const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+  return { reporter, output: () => log.mock.calls.map((c) => String(c[0])).join('\n') }
+}
+
+const failedResult = {
+  status: 'failed',
+  retry: 0,
+  errors: [],
+  error: { message: 'expect(received).toBe(expected)' },
+} as unknown as TestResult
+
+const failedTest = {
+  expectedStatus: 'passed',
+  retries: 0,
+  titlePath: () => ['', 'smoke', 'a.spec.ts', 'some test'],
+} as unknown as TestCase
+
+const passedRun = { status: 'passed' } as FullResult
+const failedRun = { status: 'failed' } as FullResult
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('LaneReporter', () => {
+  it('reports a webServer that never started as an infra failure', () => {
+    const { reporter, output } = makeReporter()
+
+    reporter.onBegin()
+    reporter.onError({ message: 'Timed out waiting 120000ms from config.webServer.' })
+    reporter.onEnd(failedRun)
+
+    expect(output()).toContain('1 infra failure(s)')
+    expect(output()).toContain('0 product failure(s)')
+    expect(output()).toContain('Every failure looks like infrastructure')
+  })
+
+  it('still summarizes when the only failure is global — no test ever ran', () => {
+    const { reporter, output } = makeReporter()
+
+    reporter.onBegin()
+    reporter.onError({ message: 'connect ECONNREFUSED 127.0.0.1:54321' })
+    reporter.onEnd(failedRun)
+
+    expect(output()).not.toBe('')
+    expect(output()).toContain('infra')
+  })
+
+  it('counts a global error alongside test failures', () => {
+    const { reporter, output } = makeReporter()
+
+    reporter.onBegin()
+    reporter.onTestEnd(failedTest, failedResult)
+    reporter.onError({ message: 'socket hang up' })
+    reporter.onEnd(failedRun)
+
+    expect(output()).toContain('1 product failure(s), 1 infra failure(s)')
+    expect(output()).not.toContain('Every failure looks like infrastructure')
+  })
+
+  it('stays quiet when nothing ran and nothing failed — e.g. `--list`', () => {
+    const { reporter, output } = makeReporter()
+
+    reporter.onBegin()
+    reporter.onEnd(passedRun)
+
+    expect(output()).toBe('')
+  })
+})

--- a/lib/__tests__/e2eSmokeLane.test.ts
+++ b/lib/__tests__/e2eSmokeLane.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'fs'
+import path from 'path'
+import {
+  SMOKE_TAG,
+  SMOKE_BUDGET_MS,
+  SMOKE_MIN_TESTS,
+  SMOKE_MAX_TESTS,
+  SMOKE_COVERAGE_AREAS,
+  checkSmokeBudget,
+} from '../../e2e/helpers/lanes'
+
+const E2E_DIR = path.join(__dirname, '..', '..', 'e2e')
+
+function specFiles(): string[] {
+  return fs
+    .readdirSync(E2E_DIR)
+    .filter((f) => f.endsWith('.spec.ts'))
+    .map((f) => path.join(E2E_DIR, f))
+}
+
+/** Count `{ tag: '@smoke' }` annotations in a spec file. */
+function countSmokeTags(file: string): number {
+  const source = fs.readFileSync(file, 'utf8')
+  return source.split(SMOKE_TAG).length - 1
+}
+
+describe('checkSmokeBudget', () => {
+  it('passes a run that finishes inside the documented budget', () => {
+    const verdict = checkSmokeBudget(SMOKE_BUDGET_MS - 1_000)
+    expect(verdict.withinBudget).toBe(true)
+    expect(verdict.overByMs).toBe(0)
+  })
+
+  it('flags a run that overruns the budget, with the overrun', () => {
+    const verdict = checkSmokeBudget(SMOKE_BUDGET_MS + 30_000)
+    expect(verdict.withinBudget).toBe(false)
+    expect(verdict.overByMs).toBe(30_000)
+  })
+
+  it('treats hitting the budget exactly as within budget', () => {
+    expect(checkSmokeBudget(SMOKE_BUDGET_MS).withinBudget).toBe(true)
+  })
+
+  it('documents a budget that is a small fraction of the full suite (~7.6 min)', () => {
+    expect(SMOKE_BUDGET_MS).toBeGreaterThan(60_000)
+    expect(SMOKE_BUDGET_MS).toBeLessThanOrEqual(4 * 60_000)
+  })
+})
+
+describe('the @smoke lane inventory', () => {
+  it('tags roughly 15–30 tests — enough to gate a PR, small enough to stay fast', () => {
+    const total = specFiles().reduce((sum, f) => sum + countSmokeTags(f), 0)
+    expect(total).toBeGreaterThanOrEqual(SMOKE_MIN_TESTS)
+    expect(total).toBeLessThanOrEqual(SMOKE_MAX_TESTS)
+  })
+
+  it('covers every high-value area the lane is meant to guard', () => {
+    const missing = SMOKE_COVERAGE_AREAS.filter(
+      (area) => countSmokeTags(path.join(E2E_DIR, area.spec)) === 0,
+    )
+    expect(missing.map((a) => a.name)).toEqual([])
+  })
+
+  it('names a spec file that actually exists for every covered area', () => {
+    const absent = SMOKE_COVERAGE_AREAS.filter(
+      (area) => !fs.existsSync(path.join(E2E_DIR, area.spec)),
+    )
+    expect(absent.map((a) => a.spec)).toEqual([])
+  })
+})

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
+    "test:e2e:smoke": "E2E_LANE=smoke playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:db": "for f in supabase/tests/*.sql; do echo \"» $f\"; psql \"${DATABASE_URL:-postgresql://postgres:postgres@127.0.0.1:54322/postgres}\" -v ON_ERROR_STOP=1 -f \"$f\" || exit 1; done"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
+    "db:baseline": "psql \"${DATABASE_URL:-postgresql://postgres:postgres@127.0.0.1:54322/postgres}\" -v ON_ERROR_STOP=1 -f supabase/scripts/restore-dml-baseline.sql",
     "test:e2e": "playwright test",
     "test:e2e:smoke": "E2E_LANE=smoke playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,7 @@
-import { defineConfig, devices } from '@playwright/test'
+import { defineConfig, devices, type Project, type ReporterDescription } from '@playwright/test'
 import { config as dotenvConfig } from 'dotenv'
 import { existsSync } from 'fs'
+import { SMOKE_TAG } from './e2e/helpers/lanes'
 
 // Load .env.e2e for local runs (ignored in CI where env vars come from secrets)
 if (!process.env.CI && existsSync('.env.e2e')) {
@@ -14,6 +15,61 @@ const baseURL = process.env.PLAYWRIGHT_BASE_URL ?? 'http://localhost:3000'
 // a system-installed browser instead. Unset => Playwright's bundled Chromium.
 const channel = process.env.PLAYWRIGHT_CHANNEL || undefined
 
+// Which lane to run (#595):
+//   E2E_LANE=smoke → only the `@smoke`-tagged tests (the PR gate, ~3 min budget)
+//   anything else  → the full suite (nightly / manual, ~7.6 min serial)
+// The lanes are mutually exclusive projects, so a bare `npx playwright test`
+// never runs the smoke tests twice.
+const lane = process.env.E2E_LANE === 'smoke' ? 'smoke' : 'full'
+
+const reporter: ReporterDescription[] = process.env.CI
+  ? [['github'], ['html', { open: 'never' }]]
+  : [['list'], ['html', { open: 'on-failure' }]]
+// Splits failures into infra (database throttling, network, a dead browser) vs.
+// product regressions, and checks the smoke lane against its documented budget.
+reporter.push(['./e2e/reporters/laneReporter.ts'])
+
+const setupProject: Project = {
+  name: 'setup',
+  testMatch: /global\.setup\.ts/,
+  use: { channel },
+}
+
+const desktopUse = {
+  ...devices['Desktop Chrome'],
+  channel,
+  storageState: 'e2e/.auth/session.json',
+}
+
+const smokeProject: Project = {
+  name: 'smoke',
+  use: desktopUse,
+  // Every `@smoke` test is a desktop-viewport test; funds.spec.ts is the
+  // mobile-only spec and carries no smoke tags.
+  testIgnore: ['**/funds.spec.ts'],
+  grep: new RegExp(SMOKE_TAG),
+  dependencies: ['setup'],
+}
+
+const fullProjects: Project[] = [
+  {
+    name: 'chromium',
+    use: desktopUse,
+    testIgnore: ['**/funds.spec.ts'],
+    dependencies: ['setup'],
+  },
+  {
+    name: 'mobile',
+    use: {
+      channel,
+      viewport: { width: 390, height: 844 },
+      storageState: 'e2e/.auth/session.json',
+    },
+    testMatch: ['**/funds.spec.ts'],
+    dependencies: ['setup'],
+  },
+]
+
 export default defineConfig({
   testDir: './e2e',
   globalTeardown: './e2e/global.teardown.ts',
@@ -26,9 +82,7 @@ export default defineConfig({
   // unique constraint. CI already used 1 worker; E2E now runs locally too, so
   // keep it serial everywhere rather than relying on the CI default.
   workers: 1,
-  reporter: process.env.CI
-    ? [['github'], ['html', { open: 'never' }]]
-    : [['list'], ['html', { open: 'on-failure' }]],
+  reporter,
 
   use: {
     baseURL,
@@ -38,33 +92,7 @@ export default defineConfig({
     video: channel ? 'off' : 'retain-on-failure',
   },
 
-  projects: [
-    {
-      name: 'setup',
-      testMatch: /global\.setup\.ts/,
-      use: { channel },
-    },
-    {
-      name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome'],
-        channel,
-        storageState: 'e2e/.auth/session.json',
-      },
-      testIgnore: ['**/funds.spec.ts'],
-      dependencies: ['setup'],
-    },
-    {
-      name: 'mobile',
-      use: {
-        channel,
-        viewport: { width: 390, height: 844 },
-        storageState: 'e2e/.auth/session.json',
-      },
-      testMatch: ['**/funds.spec.ts'],
-      dependencies: ['setup'],
-    },
-  ],
+  projects: [setupProject, ...(lane === 'smoke' ? [smokeProject] : fullProjects)],
 
   webServer: {
     command: process.env.CI ? 'npm start' : 'npm run dev',

--- a/supabase/scripts/restore-dml-baseline.sql
+++ b/supabase/scripts/restore-dml-baseline.sql
@@ -1,0 +1,41 @@
+-- Restore the hosted-project DML baseline on a local Supabase stack (#595).
+--
+-- A hosted Supabase project grants anon/authenticated/service_role full DML on
+-- everything in `public` through its default privileges, which is why none of
+-- this app's migrations carry a GRANT. Recent Supabase CLI versions grant the
+-- local stack only the non-DML part of that default (`Dxtm` —
+-- truncate/references/trigger/maintain), so seeding an E2E fixture fails with
+-- `42501 permission denied for table …`.
+--
+-- Top up DML *only for roles still present in an object's ACL*. That is the
+-- distinction that matters: a migration's `revoke all on <table> from anon,
+-- authenticated` removes the role from the ACL entirely, so those deliberate
+-- revocations survive this script instead of being handed back (e.g.
+-- withdrawal_ledger_audit, report_render_rate_limit). Functions are left alone
+-- for the same reason — migrations manage their EXECUTE grants explicitly
+-- (refresh_gold_price_all is service_role only), and functions with no explicit
+-- ACL already get PUBLIC EXECUTE exactly as they do in production.
+--
+-- Caveat: this restores the full DML set, so a *partial* revoke (revoking only
+-- INSERT, say) would be undone. The schema has none today — every revocation is
+-- `revoke all`.
+--
+-- Safe to re-run, and a no-op on a stack that already has the full grants.
+-- Run it with `npm run db:baseline` after `supabase start`.
+
+DO $$
+DECLARE obj record;
+BEGIN
+  FOR obj IN
+    SELECT DISTINCT c.oid::regclass::text AS rel,
+                    pg_get_userbyid(a.grantee) AS grantee
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+    CROSS JOIN LATERAL aclexplode(c.relacl) a
+    WHERE c.relkind IN ('r', 'p', 'v', 'm')
+      AND pg_get_userbyid(a.grantee) IN ('anon', 'authenticated', 'service_role')
+  LOOP
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON %s TO %I', obj.rel, obj.grantee);
+  END LOOP;
+END
+$$;


### PR DESCRIPTION
Closes #595.

## Why

E2E has had no CI gate since #313 — the shared Supabase test project is a NANO instance whose Disk IO budget can't sustain the suite, so CI ran throttled (~72 min, cascading failures). The fix isn't "run everything in CI" or "run nothing": it's two lanes plus a database that doesn't throttle.

## What

**Two mutually exclusive lanes**, selected by `E2E_LANE` (so a bare `npx playwright test` runs the full suite and never double-runs a smoke test):

| Lane | Tests | Budget | Where |
| --- | --- | --- | --- |
| `smoke` | 19 tagged `@smoke` | **3 min** (measured 46s locally) | every PR + `npm run test:e2e:smoke` |
| `full` | 274 | ~7.6 min serial | nightly 01:00 VN, `workflow_dispatch`, `npm run test:e2e` |

Smoke coverage: auth/session (4), cross-user ownership (4), API validation (4), core transaction flow (3), add-transaction entry point, one maturity/merge money path, report download, navigation.

**CI runs against a local Supabase stack started inside the runner** (`supabase start`), for both lanes — isolated per run, no NANO throttling, no shared-project contention. `e2e/helpers/guard.ts` still refuses to target production. Sharding stays off until each worker has its own user/storage state (today the suite shares one `storageState`).

**Infra vs. product failure classification** — a new lane reporter buckets failures: socket errors, `fetch failed`, Postgres connection exhaustion / statement timeouts, Disk IO throttling, 429/5xx, a webServer that never came up, a dead browser → *infra*; everything else → *product*. A plain locator timeout stays a **product** failure (an element that never appeared). An all-infra run says so explicitly, so a throttled database never reads as an app regression.

**Tests** (TDD, all at the unit layer — no new E2E):
- `lib/__tests__/e2eFailureClass.test.ts` — the classifier, including the timeout distinction.
- `lib/__tests__/e2eSmokeLane.test.ts` — the budget helper, plus the lane inventory itself: 15–30 tagged tests and every documented coverage area still tagged, so the lane can't silently rot.

Docs in `docs/e2e.md`; CLAUDE.md's pre-PR checklist updated (its old README anchor didn't exist).

## Verification

- `npm run test:e2e:smoke` → **20 passed (46.0s)**, within budget.
- Reporter checked against a scratch spec with one product and one infra failure — bucketed correctly.
- `npx playwright test --list`: full 274 / smoke 20 — no duplicates.
- `npm run typecheck`, `npx vitest run` (2011 tests, 176 files), `npx eslint .` — all clean.

The one thing not verified locally is the GitHub-side `supabase start` job; that runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)