### PR TITLE
ci: gate merges on DB tests, lint, build, and coverage thresholds (#596)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   push:
     branches: [main, feature/redesign-desktop]
 
+# Every gate is its own job so the PR page reports unit, lint, build, DB and
+# smoke-E2E status independently — a red X names the thing that broke instead of
+# hiding it behind one "Unit Tests" check (#596).
 jobs:
   test:
     name: Unit Tests
@@ -25,8 +28,99 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
-      - name: Run unit tests
-        run: npm test -- --run
+      # Coverage thresholds live in vitest.config.ts and are enforced here: the
+      # run fails when a gated module drops below its floor.
+      - name: Run unit tests with coverage
+        run: npm run test:coverage
+
+      - name: Upload the coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/
+          retention-days: 7
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+  build:
+    name: Production Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      # Placeholder Supabase credentials: `next build` only needs the public env
+      # vars to exist so the client bundle compiles and the static routes
+      # prerender. Nothing in the build talks to the database, and placeholders
+      # keep this gate runnable on fork PRs, where secrets aren't available. The
+      # build against a real stack happens in the E2E lane.
+      - name: Build
+        run: npm run build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: https://placeholder.supabase.co
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: placeholder-anon-key
+
+  # Migration + SQL-trigger gate. `supabase start` provisions an empty Postgres
+  # and replays every migration in supabase/migrations from scratch, so this job
+  # fails on a migration that can't apply to a clean database — the case a
+  # long-lived local stack never exercises. The suite in supabase/tests then
+  # asserts the constraints and triggers those migrations install (withdrawal
+  # balance, FK ownership, held-for-merge settlement, the refresh rate limits,
+  # …). Each test runs as the `postgres` superuser inside a rolled-back
+  # transaction, so ordering between files doesn't matter.
+  db:
+    name: DB Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - uses: supabase/setup-cli@v2
+        with:
+          version: latest
+
+      # Only Postgres (and the auth stack the migrations reference) is needed —
+      # skip the containers the SQL suite never touches so the job stays quick.
+      # The tests connect over psql as `postgres`; no API layer is involved.
+      - name: Start a local Supabase stack (applies every migration from scratch)
+        run: supabase start -x studio,imgproxy,edge-runtime,logflare,vector,mailpit,supavisor
+
+      - name: Run the SQL test suite
+        run: npm run test:db
+
+      - name: Dump the stack status on failure
+        if: failure()
+        run: supabase status || true
 
   # Browser gate on every PR: the ~19 `@smoke`-tagged tests only (#595). The
   # full suite stays off the PR path — it takes ~7.6 min serial and runs nightly
@@ -48,10 +142,14 @@ jobs:
   # main, so schema changes ship automatically instead of needing a manual
   # `supabase db push`. `supabase db push` is idempotent (only applies migrations
   # not yet in the remote history), so re-runs are safe.
+  #
+  # This writes to the production schema, so it waits on *every* gate, not just
+  # unit tests: a migration that can't apply to a clean database, code that
+  # doesn't build, or a broken smoke path must not reach production.
   migrate:
     name: Apply DB migrations (production)
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, lint, build, db, e2e-smoke]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,16 @@ jobs:
       - name: Start a local Supabase stack (applies every migration from scratch)
         run: supabase start -x studio,imgproxy,edge-runtime,logflare,vector,mailpit,supavisor
 
+      - name: Restore the hosted-project DML baseline
+        # Same reason as the E2E lane: a hosted project grants anon/authenticated/
+        # service_role full DML on `public` through default privileges, so the
+        # app's migrations carry no GRANTs. The CLI's local stack grants only the
+        # non-DML part, so a test that runs an RPC as `service_role` fails with
+        # `42501 permission denied for table …`. The script tops up DML only for
+        # roles still present in an object's ACL, so migration-level revocations
+        # survive it.
+        run: npm run db:baseline
+
       - name: Run the SQL test suite
         run: npm run test:db
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,13 @@ the wrong month (#591). An eslint `no-restricted-syntax` rule blocks both idioms
 
 ## What to run before opening a PR
 
-CI runs unit tests plus the **E2E smoke lane** (~19 `@smoke` tests, ~3 min, against a
-local Supabase stack started in the runner — #595). The **full** suite still runs
-locally and nightly, never on the PR path. Scale the checks to the change:
+CI reports five independent gates on every PR (#596): **Unit Tests** (typecheck +
+Vitest with coverage thresholds), **Lint**, **Production Build**, **DB Tests** (the
+`supabase/tests` SQL suite against a stack started from scratch, which also proves
+every migration applies to an empty database), and the **E2E smoke lane** (~19
+`@smoke` tests, ~3 min, against a local Supabase stack started in the runner — #595).
+The production `supabase db push` job waits on all five. The **full** E2E suite still
+runs locally and nightly, never on the PR path. Scale the checks to the change:
 
 - **Always:** `npm run typecheck`, `npm test -- --run` (Vitest unit tests), and
   `npm run lint`. Fast, every PR. Don't skip the typecheck because the tests are
@@ -70,6 +74,16 @@ locally and nightly, never on the PR path. Scale the checks to the change:
   handler with a signature it no longer has passes locally and fails CI. CI runs
   `typecheck` inside the "Unit Tests" job, so a red X there is often `tsc`, not a
   failing assertion (#614).
+- **Coverage** (`npm run test:coverage`) — when you delete or rewrite tests, or add a
+  server route. Thresholds live in `vitest.config.ts`: a repo-wide floor set just
+  under today's numbers, `lines: 100` on the money modules in `lib/`, and per-file
+  floors on the transaction/dashboard routes. They are a ratchet — raise them as
+  tests land, never lower one to turn a red build green.
+- **DB tests** (`npm run test:db`) — after touching a migration, trigger, RPC, or
+  constraint. Needs the local Supabase stack running.
+- **Production build** (`npm run build`) — after touching config, env usage, or
+  anything that only fails under `next build` (it type-checks the whole repo,
+  including `vitest.config.ts`).
 - **Targeted E2E** — when the change touches a feature area, run that area's specs,
   e.g. `npx playwright test e2e/planning.spec.ts --project=chromium`. This is the
   common case.

--- a/__tests__/ci-gates.test.ts
+++ b/__tests__/ci-gates.test.ts
@@ -1,0 +1,84 @@
+import { readFileSync } from 'fs'
+import path from 'path'
+import { describe, it, expect } from 'vitest'
+
+// Guard for #596: CI used to gate merges on typecheck + unit tests alone, so a
+// broken migration, a lint error, a build failure, or a dead smoke path could
+// merge — and the production migration job shipped on that same thin signal.
+// These assertions lock in the shape of the gate: five independently-reported
+// jobs, and a production deploy that waits on all of them.
+//
+// Read the workflow as text rather than parsing YAML — the repo has no YAML
+// parser dependency, and the questions here ("is there a job called X", "what
+// does migrate need") are answerable structurally without one.
+const root = path.resolve(__dirname, '..')
+const ci = readFileSync(path.join(root, '.github/workflows/ci.yml'), 'utf8')
+
+/** Top-level job ids: keys indented exactly two spaces under `jobs:`. */
+function jobIds(workflow: string): string[] {
+  const jobs = workflow.slice(workflow.indexOf('\njobs:'))
+  return [...jobs.matchAll(/^ {2}([a-z0-9][a-z0-9-]*):$/gm)].map((m) => m[1])
+}
+
+/** The `needs:` entries of a job, whether written inline or as a list. */
+function needsOf(workflow: string, job: string): string[] {
+  const start = workflow.indexOf(`\n  ${job}:\n`)
+  expect(start, `job "${job}" not found`).toBeGreaterThan(-1)
+  const block = workflow.slice(start + 1)
+  const inline = block.match(/^ {4}needs:\s*\[([^\]]*)\]/m)
+  if (inline) return inline[1].split(',').map((s) => s.trim()).filter(Boolean)
+  const single = block.match(/^ {4}needs:\s*([a-z0-9-]+)\s*$/m)
+  return single ? [single[1]] : []
+}
+
+describe('CI quality gates (#596)', () => {
+  it('reports unit, lint, build, DB and smoke-E2E status as independent jobs', () => {
+    // One job per gate: a red X on the PR names the thing that broke instead of
+    // collapsing every check into "Unit Tests".
+    expect(jobIds(ci)).toEqual(expect.arrayContaining(['test', 'lint', 'build', 'db', 'e2e-smoke']))
+  })
+
+  it('runs lint and a production build on every PR', () => {
+    expect(ci).toMatch(/npm run lint/)
+    expect(ci).toMatch(/npm run build/)
+  })
+
+  it('exercises the SQL suite against a Supabase stack started from scratch', () => {
+    // `supabase start` on a fresh runner replays every migration onto an empty
+    // database, so this is also the "migrations apply cleanly" gate.
+    expect(ci).toMatch(/supabase start/)
+    expect(ci).toMatch(/npm run test:db/)
+  })
+
+  it('enforces unit-test coverage rather than running bare vitest', () => {
+    expect(ci).toMatch(/npm run test:coverage/)
+  })
+
+  it('gates the production migration push on every check, not just unit tests', () => {
+    // The migrate job writes to the production schema. Anything that can fail
+    // must be able to stop it.
+    expect(needsOf(ci, 'migrate')).toEqual(
+      expect.arrayContaining(['test', 'lint', 'build', 'db', 'e2e-smoke']),
+    )
+    expect(ci).toMatch(/supabase db push/)
+  })
+})
+
+describe('coverage configuration (#596)', () => {
+  const cfg = readFileSync(path.join(root, 'vitest.config.ts'), 'utf8')
+
+  it('measures every application/server source file, not only imported ones', () => {
+    // The include patterns are what pull untested files into the report as 0%
+    // instead of leaving them out and overstating the global percentage.
+    expect(cfg).toMatch(/include:\s*\[[^\]]*app\/\*\*/)
+    expect(cfg).toMatch(/include:\s*\[[^\]]*lib\/\*\*/)
+    expect(cfg).toMatch(/include:\s*\[[^\]]*components\/\*\*/)
+  })
+
+  it('sets thresholds for the critical money routes, not just a global number', () => {
+    expect(cfg).toMatch(/thresholds:/)
+    expect(cfg).toMatch(/app\/api\/v1\/investment-transactions\/route\.ts/)
+    expect(cfg).toMatch(/app\/api\/v1\/investment-transactions\/\[id\]\/route\.ts/)
+    expect(cfg).toMatch(/app\/api\/v1\/dashboard\/overview\/route\.ts/)
+  })
+})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -15,6 +15,9 @@ const eslintConfig = defineConfig([
     // Gitignored local git worktrees (stale repo copies checked out by other
     // Claude sessions) — don't lint their sources as if they were ours (#469).
     ".claude/**",
+    // Generated v8/istanbul coverage report (#596) — its bundled HTML viewer
+    // scripts are not our source.
+    "coverage/**",
   ]),
   {
     rules: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,6 +32,13 @@ export default defineConfig({
         // the only application source at the repo root, and it runs on every
         // page navigation, so it belongs in the report like any route.
         'proxy.ts',
+        // Deliberately NOT here: public/sw.js. lib/__tests__/serviceWorker.test.ts
+        // does exercise the real worker, but it loads the file as text and runs
+        // it through `new Function(...)`, which v8 cannot attribute back to the
+        // source. Adding it reports a flat 0% across 140 statements — measured —
+        // so it would drag the global floor down while labelling a well-tested
+        // file untested. Attributing it properly means reworking that harness to
+        // load the worker through the module pipeline.
       ],
       exclude: [
         '**/__tests__/**',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,61 @@ export default defineConfig({
     // files, which vitest would otherwise discover and run — reporting failures
     // from a stale checkout, not this one (#469).
     exclude: ['**/node_modules/**', '**/e2e/**', '**/.claude/**'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text-summary', 'html', 'lcov'],
+      reportsDirectory: './coverage',
+      // Count every application/server source file, not just the ones a test
+      // happens to import — an untested route must show up as 0%, not vanish
+      // from the report and leave the global number overstating the repo (#596).
+      // Vitest 4 reports every file matching `include` regardless of imports, so
+      // the explicit patterns below are what makes that true (the old `all` flag
+      // is gone).
+      include: [
+        'app/**/*.{ts,tsx}',
+        'lib/**/*.{ts,tsx}',
+        'components/**/*.{ts,tsx}',
+        'i18n/**/*.{ts,tsx}',
+      ],
+      exclude: [
+        '**/__tests__/**',
+        '**/*.test.{ts,tsx}',
+        '**/*.d.ts',
+        // Framework manifests and metadata: declarative config with no branches
+        // worth gating on.
+        'app/layout.tsx',
+        'app/manifest.ts',
+        'app/robots.ts',
+        'app/sitemap.ts',
+        'app/**/layout.tsx',
+        'app/**/loading.tsx',
+        'app/**/not-found.tsx',
+      ],
+      // Ratchet, not aspiration: the globals sit just under today's numbers so a
+      // regression fails CI while nothing fails on day one. The per-file entries
+      // guard the money paths the audit called out — raise them as tests land,
+      // never lower them to make a red build green.
+      thresholds: {
+        // Repo-wide floor, measured 2026-08-03 at 61.13 / 57.99 / 59.68 / 64.51.
+        statements: 60,
+        branches: 56,
+        functions: 58,
+        lines: 63,
+
+        // The money math. These modules are the ones that have actually shipped
+        // bugs, and they are fully covered today — hold them there.
+        'lib/{accumulating,bankWithdrawal,dates,depositValuation,finance,fundWithdrawal,goldWithdrawal,heldForMerge,maturity,mergeCluster,mergeEligibility,planning,recurringLink,snapshots,validation,withdrawalProgress}.ts':
+          { lines: 100, functions: 100, branches: 80 },
+
+        // The server routes the audit flagged as thin. Floors sit just under
+        // today's numbers: they fail on a regression, and they are meant to be
+        // raised as tests land — never lowered to turn a red build green.
+        'app/api/v1/investment-transactions/route.ts': { lines: 65, branches: 57, functions: 50 },
+        'app/api/v1/investment-transactions/[id]/route.ts': { lines: 78, branches: 72, functions: 65 },
+        'app/api/v1/dashboard/overview/route.ts': { lines: 95, branches: 72, functions: 90 },
+        'lib/dashboardOverview.ts': { lines: 35, branches: 15, functions: 20 },
+      },
+    },
   },
   resolve: {
     alias: { '@': path.resolve(__dirname, '.') },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -28,6 +28,10 @@ export default defineConfig({
         'lib/**/*.{ts,tsx}',
         'components/**/*.{ts,tsx}',
         'i18n/**/*.{ts,tsx}',
+        // The Next.js middleware — auth redirects, session refresh, CSP. It's
+        // the only application source at the repo root, and it runs on every
+        // page navigation, so it belongs in the report like any route.
+        'proxy.ts',
       ],
       exclude: [
         '**/__tests__/**',
@@ -48,7 +52,7 @@ export default defineConfig({
       // guard the money paths the audit called out — raise them as tests land,
       // never lower them to make a red build green.
       thresholds: {
-        // Repo-wide floor, measured 2026-08-03 at 61.13 / 57.99 / 59.68 / 64.51.
+        // Repo-wide floor, measured 2026-08-03 at 60.88 / 57.91 / 59.38 / 64.22.
         statements: 60,
         branches: 56,
         functions: 58,


### PR DESCRIPTION
Closes #596.

## Problem

CI gated merges on `typecheck` + unit tests alone. A migration that couldn't apply to a clean database, a lint error, a build that didn't compile, or an untested route could all merge — and the production `supabase db push` job shipped on that same thin signal, because it only needed the unit-test job.

Coverage existed as a number (`npm run test:coverage`) but nothing enforced it, and it measured only files some test happened to import — so an untested route was *absent* from the report rather than 0%, and the global percentage read healthier than the repo was.

## What changed

Five gates, each its own job, so a red X on the PR names the thing that broke:

| Job | What it runs |
| --- | --- |
| **Unit Tests** | `typecheck` + `npm run test:coverage` (thresholds enforced), uploads the report |
| **Lint** | `npm run lint` |
| **Production Build** | `npm run build` with placeholder Supabase env — no secrets, so it works on fork PRs too |
| **DB Tests** | `supabase start` on a fresh runner (replays every migration onto an empty database) then the `supabase/tests` SQL suite |
| **E2E Smoke** | unchanged from #595 |

`migrate` (production `supabase db push`) now `needs: [test, lint, build, db, e2e-smoke]`.

### Coverage as a ratchet

`vitest.config.ts` gains explicit `include` patterns (`app/`, `lib/`, `components/`, `i18n/`) so untested files count as 0% instead of vanishing, and thresholds in three tiers:

- **Repo-wide floor** just under today's measurement — 60 / 56 / 58 / 63 against 61.06 / 57.99 / 59.54 / 64.42.
- **`lines: 100, functions: 100, branches: 80`** on the money modules in `lib/` (finance, planning, validation, maturity, the withdrawal set, …) — they're fully covered today, so hold them there.
- **Per-file floors** on the routes the audit called out: the transaction POST route, the transaction `[id]` route, the dashboard overview route, and `lib/dashboardOverview.ts`.

Nothing fails on day one; a regression does. Raise them as tests land — never lower one to turn a red build green.

`__tests__/ci-gates.test.ts` locks the wiring in place: the five jobs exist, `migrate` waits on all of them, and the coverage config still carries include patterns and the critical-route thresholds.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run build` (placeholder env) — all pass.
- `npm run test:coverage` — 178 files, 2029 tests, thresholds green.
- `npm run test:db` — full SQL suite against the local stack, exit 0.
- Every new threshold was **probed by raising it** and confirming the run fails with the expected `ERROR: Coverage for … does not meet …` line, so each glob is proven to match something rather than silently gating nothing.

The `db` job's `supabase start` on a clean runner is the one thing that can only be verified here — watch that job on this PR.

## Note

`next build` type-checks `vitest.config.ts` too, which is how the now-removed Vitest 3 `coverage.all` flag was caught: Vitest 4 dropped it and reports every file matching `include` by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)