### PR TITLE
refactor(funds): share the fund-library list model between desktop and mobile (#603)

### DIFF
--- a/app/(app)/funds/components/DesktopFundLibraryView.tsx
+++ b/app/(app)/funds/components/DesktopFundLibraryView.tsx
@@ -19,28 +19,10 @@ import { useFundMutations } from './useFundMutations'
 // ─── Types ────────────────────────────────────────────────────────────────────
 // Fund/Goal/FundType are shared with the mobile view via useFundsData.
 
-type SortKey = 'code' | 'nav' | 'name'
-type TypeFilter = 'all' | 'equity' | 'debt' | 'balanced'
+import type { SortKey, TypeFilter } from '@/features/funds/contracts'
+import { TYPE_META, TYPE_FILTERS, FORM_TYPES, filterAndSortFunds, nextSort } from '@/features/funds/fundListModel'
 
 // ─── Design constants ─────────────────────────────────────────────────────────
-
-const TYPE_META: Record<FundType, { label: string; labelVi: string; color: string; bg: string }> = {
-  equity:   { label: 'Stock',    labelVi: 'Cổ phiếu',   color: 'var(--c-fund-equity)',   bg: 'var(--c-fund-equity-bg)' },
-  debt:     { label: 'Bond',     labelVi: 'Trái phiếu', color: 'var(--c-fund-debt)',     bg: 'var(--c-fund-debt-bg)' },
-  balanced: { label: 'Balanced', labelVi: 'Cân bằng',   color: 'var(--c-fund-balanced)', bg: 'var(--c-fund-balanced-bg)' },
-  gold:     { label: 'Gold',     labelVi: 'Vàng',       color: 'var(--c-fund-gold)',     bg: 'var(--c-fund-gold-bg)' },
-}
-
-const TYPE_FILTERS: { v: TypeFilter; label: string; labelVi: string }[] = [
-  { v: 'all',      label: 'All',      labelVi: 'Tất cả' },
-  { v: 'equity',   label: 'Stock',    labelVi: 'Cổ phiếu' },
-  { v: 'debt',     label: 'Bond',     labelVi: 'Trái phiếu' },
-  { v: 'balanced', label: 'Balanced', labelVi: 'Cân bằng' },
-]
-
-// Selectable fund types in the create/edit form. Gold is excluded (handled
-// separately via byType) to match MobileFundLibraryView's FORM_TYPES.
-const FORM_TYPES = (Object.keys(TYPE_META) as FundType[]).filter(ft => ft !== 'gold')
 
 // ─── Small components ─────────────────────────────────────────────────────────
 
@@ -364,25 +346,15 @@ export default function DesktopFundLibraryView({ funds, setFunds, goals, loading
 
   // Sorting
   const handleSort = (key: SortKey) => {
-    if (sortKey === key) setSortAsc(a => !a)
-    else { setSortKey(key); setSortAsc(true) }
+    const next = nextSort({ sortKey, sortAsc }, key)
+    setSortKey(next.sortKey); setSortAsc(next.sortAsc)
   }
 
   // Filtered + sorted funds
-  const displayFunds = useMemo(() => {
-    let f = funds
-    if (typeFilter !== 'all') f = f.filter(x => x.fund_type === typeFilter)
-    if (query) {
-      const q = query.toLowerCase()
-      f = f.filter(x => x.code.toLowerCase().includes(q) || x.name.toLowerCase().includes(q))
-    }
-    return [...f].sort((a, b) => {
-      let cmp = 0
-      if (sortKey === 'nav') cmp = a.nav - b.nav
-      else cmp = a[sortKey].localeCompare(b[sortKey])
-      return sortAsc ? cmp : -cmp
-    })
-  }, [funds, typeFilter, query, sortKey, sortAsc])
+  const displayFunds = useMemo(
+    () => filterAndSortFunds(funds, { query, typeFilter, sortKey, sortAsc }),
+    [funds, typeFilter, query, sortKey, sortAsc],
+  )
 
   // Refresh NAV
   async function handleRefreshNav() {

--- a/app/(app)/funds/components/MobileFundLibraryView.tsx
+++ b/app/(app)/funds/components/MobileFundLibraryView.tsx
@@ -10,6 +10,8 @@ import { fmtNav, fmtCompact } from '@/lib/formatters'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 // Shared dialog a11y (Esc-to-close + focus trap + focus restore). Lives under
 // the Plan feature today; reused here so Funds sheets behave the same.
+import { TYPE_META, TYPE_FILTERS, FORM_TYPES, filterAndSortFunds, nextSort } from '@/features/funds/fundListModel'
+import type { TypeFilter } from '@/features/funds/contracts'
 import { useDialogA11y } from '@/components/ui/useDialogA11y'
 import { FundsEmptyState } from './FundsEmptyState'
 import { FundNavAge } from './FundNavAge'
@@ -36,20 +38,6 @@ type Toast = { id: number; message: string; type: 'success' | 'error' }
 type SortKey = 'code' | 'nav' | 'name'
 
 // ─── Constants ───────────────────────────────────────────────────────────────
-
-const TYPE_META: Record<FundType, { label: string; labelVi: string; color: string; bg: string }> = {
-  equity:   { label: 'Stock',    labelVi: 'Cổ phiếu',   color: 'var(--c-fund-equity)',   bg: 'var(--c-fund-equity-bg)' },
-  debt:     { label: 'Bond',     labelVi: 'Trái phiếu', color: 'var(--c-fund-debt)',     bg: 'var(--c-fund-debt-bg)' },
-  balanced: { label: 'Balanced', labelVi: 'Cân bằng',   color: 'var(--c-fund-balanced)', bg: 'var(--c-fund-balanced-bg)' },
-  gold:     { label: 'Gold',     labelVi: 'Vàng',       color: 'var(--c-fund-gold)',     bg: 'var(--c-fund-gold-bg)' },
-}
-
-const TYPE_FILTERS: Array<{ v: 'all' | FundType; label: string; labelVi: string }> = [
-  { v: 'all',      label: 'All',      labelVi: 'Tất cả' },
-  { v: 'equity',   label: 'Stock',    labelVi: 'Cổ phiếu' },
-  { v: 'debt',     label: 'Bond',     labelVi: 'Trái phiếu' },
-  { v: 'balanced', label: 'Balanced', labelVi: 'Cân bằng' },
-]
 
 // i18n key (in the `funds` namespace) for each sort option's label.
 const SORT_OPTIONS: Array<{ v: SortKey; key: 'colCode' | 'colNav' | 'colName' }> = [
@@ -107,7 +95,6 @@ function SortDropdown({ sortKey, sortAsc, onSort }: { sortKey: SortKey; sortAsc:
 
 // ─── Type dropdown ────────────────────────────────────────────────────────────
 
-const FORM_TYPES = (Object.keys(TYPE_META) as FundType[]).filter((ft) => ft !== 'gold')
 
 function TypeDropdown({ value, onChange }: { value: FundType; onChange: (v: FundType) => void }) {
   const locale = useLocale()
@@ -459,7 +446,7 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
 
   // ── UI state ──────────────────────────────────────────────────────────────
   const [query, setQuery] = useState('')
-  const [filter, setFilter] = useState<'all' | FundType>('all')
+  const [filter, setFilter] = useState<TypeFilter>('all')
   const [sortKey, setSortKey] = useState<SortKey>('code')
   const [sortAsc, setSortAsc] = useState(true)
 
@@ -551,28 +538,16 @@ export default function MobileFundLibraryView({ funds, setFunds, goals, loading,
 
   // ── Sorted/filtered list ──────────────────────────────────────────────────
 
-  const sortedFunds = useMemo(() => {
-    let list = [...funds]
-    if (filter !== 'all') list = list.filter((f) => f.fund_type === filter)
-    if (query) {
-      const q = query.toLowerCase()
-      list = list.filter((f) => f.code.toLowerCase().includes(q) || f.name.toLowerCase().includes(q))
-    }
-    list.sort((a, b) => {
-      let cmp = 0
-      if (sortKey === 'nav') cmp = a.nav - b.nav
-      else if (sortKey === 'code') cmp = a.code.localeCompare(b.code)
-      else cmp = a.name.localeCompare(b.name)
-      return sortAsc ? cmp : -cmp
-    })
-    return list
-  }, [funds, filter, query, sortKey, sortAsc])
+  const sortedFunds = useMemo(
+    () => filterAndSortFunds(funds, { query, typeFilter: filter, sortKey, sortAsc }),
+    [funds, filter, query, sortKey, sortAsc],
+  )
 
   // ── Actions ───────────────────────────────────────────────────────────────
 
   function handleSort(key: SortKey) {
-    if (sortKey === key) setSortAsc((v) => !v)
-    else { setSortKey(key); setSortAsc(true) }
+    const next = nextSort({ sortKey, sortAsc }, key)
+    setSortKey(next.sortKey); setSortAsc(next.sortAsc)
   }
 
   async function handleSave(data: SavePayload, existingId?: string) {

--- a/app/(app)/funds/components/useFundsData.ts
+++ b/app/(app)/funds/components/useFundsData.ts
@@ -6,23 +6,8 @@ import { useAdoptCacheOnce } from '@/lib/useHydrated'
 
 // ─── Shared types ─────────────────────────────────────────────────────────────
 
-export type FundType = 'balanced' | 'equity' | 'debt' | 'gold'
-
-export type Fund = {
-  id: string
-  name: string
-  code: string
-  fund_type: FundType
-  nav: number
-  nav_source_url: string | null
-  is_dca: boolean
-  dca_monthly_amount_vnd: number | null
-  dca_goal_id: string | null
-  created_at: string
-  updated_at: string
-}
-
-export type Goal = { goal_id: string; goal_name: string }
+export type { FundType, Fund, Goal } from '@/features/funds/contracts'
+import type { Fund, Goal } from '@/features/funds/contracts'
 
 export interface FundsData {
   funds: Fund[]

--- a/app/__tests__/darkModeNavyFill.test.tsx
+++ b/app/__tests__/darkModeNavyFill.test.tsx
@@ -87,17 +87,14 @@ describe('issue #264 — fund-type chips are theme-tokenized', () => {
   // colours from hardcoded light-pastel hex, which stayed light on the dark
   // canvas. Both the surface and the accent text must come from flipping
   // tokens instead.
-  for (const rel of [
-    '(app)/funds/components/MobileFundLibraryView.tsx',
-    '(app)/funds/components/DesktopFundLibraryView.tsx',
-  ]) {
-    it(`${rel} TYPE_META uses CSS tokens, not hardcoded hex`, () => {
-      const src = readFileSync(path.join(APP_DIR, rel), 'utf8')
-      const block = src.match(/const TYPE_META[^=]*=\s*\{([\s\S]*?)\n\}/)
-      expect(block, 'TYPE_META block not found').not.toBeNull()
-      expect(block![1], 'TYPE_META still has a hardcoded hex colour').not.toMatch(/#[0-9a-fA-F]{6}/)
-    })
-  }
+  // One palette now, shared by both views (#603) — so there is one place to
+  // check, and no way for the two copies to drift apart on a re-tokenisation.
+  it('TYPE_META uses CSS tokens, not hardcoded hex', () => {
+    const src = readFileSync(path.resolve(process.cwd(), 'features/funds/fundListModel.ts'), 'utf8')
+    const block = src.match(/TYPE_META[^=]*=\s*\{([\s\S]*?)\n\}/)
+    expect(block, 'TYPE_META block not found').not.toBeNull()
+    expect(block![1], 'TYPE_META still has a hardcoded hex colour').not.toMatch(/#[0-9a-fA-F]{6}/)
+  })
 
   it('globals.css defines fund-type tokens with dark-mode overrides', () => {
     const css = readFileSync(path.join(process.cwd(), 'app/globals.css'), 'utf8')

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -34,7 +34,6 @@ import {
   depositMaturityState,
   addMonths,
   monthsBetween,
-  allocateCumulative,
   type RenewMode,
 } from '@/lib/maturity'
 import { maturityResolveStrings } from '@/features/dashboard/maturity/strings'

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -66,6 +66,9 @@ Done:
 - Maturity resolve decomposed (#602): the merge rules and picker state
   (`features/dashboard/maturity/`) and the sheet's 121-line copy block are out
   of `MaturityResolveBody`, 1,021 → ~818 lines.
+- Fund Library desktop/mobile drift (#603): one filter+sort rule and one
+  fund-type palette in `features/funds/`, replacing a byte-identical copy in
+  each view. The table and the card list stay separate — they genuinely differ.
 - One component root: `app/components/` folded into `components/{ui,layout,navigation}`
   and `features/landing/`. The app shell no longer imports a screen — the
   add-transaction sheet reaches it as an opaque `overlays` node from the route
@@ -75,6 +78,6 @@ Still open — incremental, as files are touched, not as a repo-wide rename:
 
 - `app/assets/` split into `features/dashboard`, `features/investments`,
   `features/goals`, `features/insurance`.
-- Fund Library, Planning and Settings desktop/mobile drift (#603). Keep the
-  shells separate where the UX genuinely differs; extract the shared models,
-  actions and form fields.
+- Planning and Settings desktop/mobile drift (#603) — Fund Library is done.
+  Keep the shells separate where the UX genuinely differs; extract the shared
+  models, actions and form fields.

--- a/features/funds/__tests__/fundListModel.test.ts
+++ b/features/funds/__tests__/fundListModel.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import type { Fund } from '../contracts'
+import { filterAndSortFunds, nextSort, TYPE_META, TYPE_FILTERS, FORM_TYPES } from '../fundListModel'
+
+// The fund library's list derivation (#603). Desktop and mobile each had their
+// own copy of the filter+sort — same behavior, written twice, free to drift.
+// Extracted so the rule is stated once and tested once, while the two views
+// keep their own (genuinely different) table and card layouts.
+
+const fund = (over: Partial<Fund> = {}): Fund => ({
+  id: 'f1', name: 'VESAF', code: 'VESAF', fund_type: 'equity', nav: 20_000,
+  nav_source_url: null, is_dca: false, dca_monthly_amount_vnd: null, dca_goal_id: null,
+  created_at: '2026-01-01', updated_at: '2026-01-01', ...over,
+})
+
+const funds = [
+  fund({ id: '1', code: 'VESAF', name: 'VinaCapital Equity', fund_type: 'equity', nav: 30_000 }),
+  fund({ id: '2', code: 'TCBF', name: 'Techcom Bond', fund_type: 'debt', nav: 10_000 }),
+  fund({ id: '3', code: 'BALAN', name: 'Alpha Balanced', fund_type: 'balanced', nav: 20_000 }),
+]
+
+const codes = (list: Fund[]) => list.map((f) => f.code)
+const all = { query: '', typeFilter: 'all' as const, sortKey: 'code' as const, sortAsc: true }
+
+describe('filterAndSortFunds', () => {
+  it('sorts by code ascending by default', () => {
+    expect(codes(filterAndSortFunds(funds, all))).toEqual(['BALAN', 'TCBF', 'VESAF'])
+  })
+
+  it('reverses on descending', () => {
+    expect(codes(filterAndSortFunds(funds, { ...all, sortAsc: false }))).toEqual(['VESAF', 'TCBF', 'BALAN'])
+  })
+
+  it('sorts NAV numerically, not as text', () => {
+    // '10000' < '20000' < '30000' happens to agree as strings; 9,000 would not.
+    const withSmall = [...funds, fund({ id: '4', code: 'SMALL', nav: 9_000 })]
+    expect(filterAndSortFunds(withSmall, { ...all, sortKey: 'nav' }).map((f) => f.nav))
+      .toEqual([9_000, 10_000, 20_000, 30_000])
+  })
+
+  it('sorts by name', () => {
+    expect(codes(filterAndSortFunds(funds, { ...all, sortKey: 'name' }))).toEqual(['BALAN', 'TCBF', 'VESAF'])
+  })
+
+  it('filters by fund type', () => {
+    expect(codes(filterAndSortFunds(funds, { ...all, typeFilter: 'debt' }))).toEqual(['TCBF'])
+  })
+
+  it('searches code and name, case-insensitively', () => {
+    expect(codes(filterAndSortFunds(funds, { ...all, query: 'vesaf' }))).toEqual(['VESAF'])
+    expect(codes(filterAndSortFunds(funds, { ...all, query: 'bond' }))).toEqual(['TCBF'])
+    expect(codes(filterAndSortFunds(funds, { ...all, query: 'BOND' }))).toEqual(['TCBF'])
+  })
+
+  it('applies the type filter and the search together', () => {
+    expect(filterAndSortFunds(funds, { ...all, typeFilter: 'equity', query: 'bond' })).toEqual([])
+  })
+
+  it('does not mutate the input list', () => {
+    const input = [...funds]
+    filterAndSortFunds(input, { ...all, sortKey: 'nav', sortAsc: false })
+    expect(codes(input)).toEqual(['VESAF', 'TCBF', 'BALAN'])
+  })
+
+  it('handles an empty library', () => {
+    expect(filterAndSortFunds([], all)).toEqual([])
+  })
+})
+
+describe('nextSort', () => {
+  it('flips direction when the same column is clicked again', () => {
+    expect(nextSort({ sortKey: 'code', sortAsc: true }, 'code')).toEqual({ sortKey: 'code', sortAsc: false })
+    expect(nextSort({ sortKey: 'code', sortAsc: false }, 'code')).toEqual({ sortKey: 'code', sortAsc: true })
+  })
+
+  it('starts a new column ascending', () => {
+    // Not "keep the previous direction" — a fresh column always reads top-down.
+    expect(nextSort({ sortKey: 'code', sortAsc: false }, 'nav')).toEqual({ sortKey: 'nav', sortAsc: true })
+  })
+})
+
+describe('type metadata', () => {
+  it('offers every fund type except gold in the create/edit form', () => {
+    // Gold is tracked via byType, not as a user-created fund.
+    expect(FORM_TYPES).not.toContain('gold')
+    expect(FORM_TYPES.sort()).toEqual(['balanced', 'debt', 'equity'])
+  })
+
+  it('has a label and colours for every fund type', () => {
+    const types = Object.keys(TYPE_META)
+    expect(types.sort()).toEqual(['balanced', 'debt', 'equity', 'gold'])
+    types.forEach((t) => {
+      const meta = TYPE_META[t as keyof typeof TYPE_META]
+      expect(meta.label).toBeTruthy()
+      expect(meta.labelVi).toBeTruthy()
+      expect(meta.color).toBeTruthy()
+      expect(meta.bg).toBeTruthy()
+    })
+  })
+
+  it('offers "all" plus the non-gold types as filters', () => {
+    expect(TYPE_FILTERS.map((f) => f.v)).toEqual(['all', 'equity', 'debt', 'balanced'])
+  })
+})

--- a/features/funds/contracts.ts
+++ b/features/funds/contracts.ts
@@ -1,0 +1,30 @@
+// The fund library's contracts (#603).
+//
+// Declared here rather than in `useFundsData.ts` so the shared list model can
+// read them without importing from `app/` — the layer rule in
+// docs/architecture.md. `useFundsData` re-exports them, so existing imports
+// keep working.
+
+export type FundType = 'balanced' | 'equity' | 'debt' | 'gold'
+
+export type Fund = {
+  id: string
+  name: string
+  code: string
+  fund_type: FundType
+  nav: number
+  nav_source_url: string | null
+  is_dca: boolean
+  dca_monthly_amount_vnd: number | null
+  dca_goal_id: string | null
+  created_at: string
+  updated_at: string
+}
+
+export type Goal = { goal_id: string; goal_name: string }
+
+/** Column the fund table/list is ordered by. */
+export type SortKey = 'code' | 'nav' | 'name'
+
+/** Fund-type filter chip; 'all' clears the filter. */
+export type TypeFilter = 'all' | 'equity' | 'debt' | 'balanced'

--- a/features/funds/fundListModel.ts
+++ b/features/funds/fundListModel.ts
@@ -1,0 +1,72 @@
+// The fund library's list derivation and type metadata (#603).
+//
+// Desktop and mobile each carried their own copy of the filter+sort and a
+// byte-identical TYPE_META / TYPE_FILTERS / FORM_TYPES. Same behavior, written
+// twice, free to drift — and neither copy was reachable by a test without
+// rendering a whole 830-line view.
+//
+// Deliberately NOT shared: the table and the card list. Those genuinely differ,
+// and merging them would trade real duplication for a component full of
+// breakpoint conditionals.
+
+import type { Fund, FundType, SortKey, TypeFilter } from './contracts'
+
+export const TYPE_META: Record<FundType, { label: string; labelVi: string; color: string; bg: string }> = {
+  equity:   { label: 'Stock',    labelVi: 'Cổ phiếu',   color: 'var(--c-fund-equity)',   bg: 'var(--c-fund-equity-bg)' },
+  debt:     { label: 'Bond',     labelVi: 'Trái phiếu', color: 'var(--c-fund-debt)',     bg: 'var(--c-fund-debt-bg)' },
+  balanced: { label: 'Balanced', labelVi: 'Cân bằng',   color: 'var(--c-fund-balanced)', bg: 'var(--c-fund-balanced-bg)' },
+  gold:     { label: 'Gold',     labelVi: 'Vàng',       color: 'var(--c-fund-gold)',     bg: 'var(--c-fund-gold-bg)' },
+}
+
+export const TYPE_FILTERS: { v: TypeFilter; label: string; labelVi: string }[] = [
+  { v: 'all',      label: 'All',      labelVi: 'Tất cả' },
+  { v: 'equity',   label: 'Stock',    labelVi: 'Cổ phiếu' },
+  { v: 'debt',     label: 'Bond',     labelVi: 'Trái phiếu' },
+  { v: 'balanced', label: 'Balanced', labelVi: 'Cân bằng' },
+]
+
+/**
+ * Selectable fund types in the create/edit form. Gold is excluded — it is
+ * tracked via byType, not created as a user fund.
+ */
+export const FORM_TYPES = (Object.keys(TYPE_META) as FundType[]).filter((ft) => ft !== 'gold')
+
+export interface FundListControls {
+  query: string
+  typeFilter: TypeFilter
+  sortKey: SortKey
+  sortAsc: boolean
+}
+
+/**
+ * The funds a view should render, in order. Filter by type, then by the search
+ * over code and name, then sort. NAV sorts numerically; the rest compare as
+ * text. Never mutates the input.
+ */
+export function filterAndSortFunds(funds: Fund[], controls: FundListControls): Fund[] {
+  const { query, typeFilter, sortKey, sortAsc } = controls
+  let list = funds
+  if (typeFilter !== 'all') list = list.filter((f) => f.fund_type === typeFilter)
+  if (query) {
+    const q = query.toLowerCase()
+    list = list.filter((f) => f.code.toLowerCase().includes(q) || f.name.toLowerCase().includes(q))
+  }
+  return [...list].sort((a, b) => {
+    const cmp = sortKey === 'nav' ? a.nav - b.nav : a[sortKey].localeCompare(b[sortKey])
+    return sortAsc ? cmp : -cmp
+  })
+}
+
+/**
+ * Clicking a column header: the same column flips direction, a new one starts
+ * ascending (a fresh column should always read top-down, not inherit the
+ * previous column's direction).
+ */
+export function nextSort(
+  current: { sortKey: SortKey; sortAsc: boolean },
+  key: SortKey,
+): { sortKey: SortKey; sortAsc: boolean } {
+  return current.sortKey === key
+    ? { sortKey: key, sortAsc: !current.sortAsc }
+    : { sortKey: key, sortAsc: true }
+}


### PR DESCRIPTION
Part of #603 — **Fund Library only**, the first of the issue's three prioritized areas. No product behavior changes.

## The duplication

`DesktopFundLibraryView` and `MobileFundLibraryView` each carried:

- a **byte-identical** `TYPE_META`, `TYPE_FILTERS` and `FORM_TYPES`
- their own copy of the filter + sort derivation

Not drifted yet — but nothing stopped it, and neither copy was reachable by a test without rendering an 800-line view.

## What's shared now

| Module | What it owns |
| --- | --- |
| `features/funds/contracts.ts` | `Fund`, `FundType`, `Goal`, plus `SortKey`/`TypeFilter` — so the model doesn't import from `app/`. `useFundsData` re-exports them, existing imports untouched |
| `features/funds/fundListModel.ts` | One `filterAndSortFunds`, one `nextSort`, one fund-type palette. 14 tests |

## What is deliberately NOT shared

The desktop **table** and the mobile **card list**. Per the issue — don't force shared JSX to reduce line count. Those layouts genuinely differ, and merging them would trade real duplication for a component full of breakpoint conditionals.

## Two things that fell out

1. **A latent type mismatch.** Mobile's filter state was typed `'all' | FundType`, which admits `'gold'` — a value `TYPE_FILTERS` never offers and the desktop's `TypeFilter` excludes. Both are `TypeFilter` now. No behavior change (the chips can't produce `'gold'`); the type just no longer permits a state the UI can't reach.
2. **The #264 theme-token guard** asserted `TYPE_META` uses CSS tokens in *each* view file. It now checks the single shared palette — one place to verify, and no way for two copies to diverge on a re-tokenisation.

Also drops a dead `allocateCumulative` import left behind by #631.

## Verified

`npm run typecheck` · `npm test -- --run` (2141 passing) · `npm run test:coverage` · `npm run lint` · `npm run build` · full E2E suite (236 passed, 6m 11s — includes both the desktop and mobile funds specs)

## Follow-up

Planning and Settings are the other two areas in #603. I'd rather ship them as separate PRs than put three large view refactors in one diff, so **#603 stays open** after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)