### PR TITLE
refactor(planning): share the per-row model between desktop and mobile (#603)

### DIFF
--- a/__tests__/architecture.test.ts
+++ b/__tests__/architecture.test.ts
@@ -107,10 +107,15 @@ describe('layer boundaries (#600)', () => {
     expect(sourceFiles('app/components')).toEqual([])
   })
 
-  it('exports no types from DashboardClient', () => {
-    // The concrete instance of all of the above: the dashboard's DTOs live in a
+  it.each([
+    'app/assets/DashboardClient.tsx',
+    'app/(app)/planning/PlanningClient.tsx',
+  ])('exports no types from %s', (file) => {
+    // The concrete instance of all of the above: a screen's DTOs live in a
     // layer-neutral contract module, not in the component that renders them.
-    const src = readFileSync(path.join(root, 'app/assets/DashboardClient.tsx'), 'utf8')
+    // Both of these declared theirs inline, so every shared model, hook and
+    // route that needed one had to import it back out of `'use client'` code.
+    const src = readFileSync(path.join(root, file), 'utf8')
     expect(src).not.toMatch(/^export (interface|type) /m)
   })
 })

--- a/app/(app)/planning/PlanningClient.tsx
+++ b/app/(app)/planning/PlanningClient.tsx
@@ -9,98 +9,14 @@ import MobilePlanningView from './components/MobilePlanningView'
 import DesktopPlanningView from './components/DesktopPlanningView'
 import { useAdoptCacheOnce } from '@/lib/useHydrated'
 import { businessYearMonth } from '@/lib/dates'
-
-export interface MonthlyPlan {
-  id: string
-  month: number
-  year: number
-  salary_vnd: number
-}
-
-export interface FundInvestment {
-  transaction_id: string
-  plan_id: string
-  fund_id: string
-  goal_id: string | null
-  amount_vnd: number
-  units: number | null
-  unit_price: number | null
-  investment_date: string | null
-  is_dca_seeded: boolean
-  funds: { name: string; nav: number } | null
-  savings_goals: { goal_name: string } | null
-}
-
-export interface DirectSaving {
-  transaction_id: string
-  plan_id: string
-  goal_id: string | null
-  amount_vnd: number
-  interest_rate: number | null
-  expiry_date: string | null
-  investment_date: string
-  savings_goals: { goal_name: string } | null
-}
-
-export interface FixedExpense {
-  expense_id: string
-  expense_name: string
-  amount_vnd: number
-  override?: number // overridden monthly amount if set
-}
-
-export interface InsuranceMember {
-  member_id: string
-  member_name: string
-  relationship: string
-  annual_payment_vnd: number
-  payment_date: string | null
-  excluded?: boolean
-  monthlyOverride?: number
-}
-
-export interface OtherExpense {
-  id: string
-  plan_id: string
-  description: string
-  amount_vnd: number
-  created_at: string
-}
-
-export interface RecurringSaving {
-  saving_id: string
-  name: string
-  goal_id: string | null
-  amount_vnd: number
-  effective_from: string | null
-  effective_to: string | null
-  linked_deposit_tx_id?: string | null
-  savings_goals: { goal_name: string } | null
-}
-
-export interface RecurringSavingOverride {
-  recurring_saving_id: string
-  monthly_amount_override_vnd: number
-}
-
-// A recurring recorded this month via maturity-combine / book top-up. amount_vnd
-// is what was fulfilled; source distinguishes whether a plan-scoped deposit was
-// also logged (book top-up) so contributed isn't double-counted.
-export interface RecurringFulfillment {
-  recurring_saving_id: string
-  amount_vnd: number
-  source: string
-}
-
-export interface Fund {
-  id: string; name: string; nav: number
-  is_dca?: boolean
-  dca_monthly_amount_vnd?: number | null
-  dca_goal_id?: string | null
-}
-
-export interface DcaSkip { fund_id: string }
-export interface Goal { goal_id: string; goal_name: string }
+import { monthLabel } from '@/features/planning/planModel'
+// The plan's data shapes live in a layer-neutral contract module (#603) so the
+// shared derivations, actions and row model don't have to import a type out of
+// this `'use client'` component.
+import type {
+  MonthlyPlan, FundInvestment, DirectSaving, FixedExpense, InsuranceMember,
+  OtherExpense, RecurringSaving, RecurringSavingOverride, RecurringFulfillment, DcaSkip, Fund, Goal,
+} from '@/features/planning/contracts'
 
 const PLAN_CACHE_TTL = 2 * 60 * 1000
 function getPlanCache(month: number, year: number) {
@@ -121,9 +37,6 @@ function bustPlanCache(month: number, year: number) {
 
 function prevMonth(m: number, y: number) { return m === 1 ? { m: 12, y: y - 1 } : { m: m - 1, y } }
 function nextMonth(m: number, y: number) { return m === 12 ? { m: 1, y: y + 1 } : { m: m + 1, y } }
-
-const SHORT_MONTHS_EN = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
-const SHORT_MONTHS_VI = ['Th1','Th2','Th3','Th4','Th5','Th6','Th7','Th8','Th9','Th10','Th11','Th12']
 
 export default function PlanningClient() {
   const t = useTranslations('planning')
@@ -316,8 +229,7 @@ export default function PlanningClient() {
   }, [])
 
   useEffect(() => {
-    const shortMonths = isVI ? SHORT_MONTHS_VI : SHORT_MONTHS_EN
-    const shortLabel = `${shortMonths[month - 1]} ${year}`
+    const shortLabel = monthLabel(month, year, isVI, { short: true })
     setMobileTopBar({
       title: isVI ? 'Kế hoạch Tháng' : 'Monthly Plan',
       subtitle: isVI ? 'Kế hoạch' : 'Planning',

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -22,20 +22,14 @@ import { DModal, PlanTable, THead, AllocationCard } from './desktopPlanningCards
 import { type GoalItem } from '@/lib/planning'
 import { usePlanningDerivations } from '../usePlanningDerivations'
 import { usePlanningActions, buildBuyEdit, buildContributionPrefill } from '../usePlanningActions'
+import { monthLabel as formatMonthLabel, goalProgress, fixedExpenseRow, insuranceRow, savedPercent } from '@/features/planning/planModel'
 import { saveIncome, deletePlan, saveOtherExpense } from '../planActions'
 import { relationshipLabel } from '@/app/assets/components/insuranceShared'
 import { businessYearMonth } from '@/lib/dates'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
   InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, RecurringFulfillment, DcaSkip, Fund, Goal,
-} from '../PlanningClient'
-
-// ─── Pure helpers ─────────────────────────────────────────────────────────────
-
-const SHORT_MONTHS_EN = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
-const SHORT_MONTHS_VI = ['Th1','Th2','Th3','Th4','Th5','Th6','Th7','Th8','Th9','Th10','Th11','Th12']
-const LONG_MONTHS_EN  = ['January','February','March','April','May','June','July','August','September','October','November','December']
-const LONG_MONTHS_VI  = ['Tháng 1','Tháng 2','Tháng 3','Tháng 4','Tháng 5','Tháng 6','Tháng 7','Tháng 8','Tháng 9','Tháng 10','Tháng 11','Tháng 12']
+} from '@/features/planning/contracts'
 
 // ─── Shared button style ──────────────────────────────────────────────────────
 
@@ -125,12 +119,10 @@ export default function DesktopPlanningView({
     plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,
     recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, isVI,
   })
-  const savedPct = plan && plan.salary_vnd > 0 ? Math.round(totalGoalAmount / plan.salary_vnd * 100) : 0
+  const savedPct = (plan && savedPercent(totalGoalAmount, plan.salary_vnd)) ?? 0
 
-  const shortMonths = isVI ? SHORT_MONTHS_VI : SHORT_MONTHS_EN
-  const longMonths  = isVI ? LONG_MONTHS_VI  : LONG_MONTHS_EN
-  const monthLabel  = `${longMonths[month - 1]} ${year}`
-  const shortLabel  = `${shortMonths[month - 1]} ${year}`
+  const monthLabel = formatMonthLabel(month, year, isVI)
+  const shortLabel = formatMonthLabel(month, year, isVI, { short: true })
   const today       = businessYearMonth()
   const isCurrentMonth = month === today.month && year === today.year
 
@@ -413,8 +405,7 @@ export default function DesktopPlanningView({
                   {byGoal.length === 0 ? (
                     <tr><td colSpan={3} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có phân bổ nào' : 'No allocations yet'}</td></tr>
                   ) : byGoal.map(g => {
-                    const pct = g.totalAllocated > 0 ? Math.min(100, Math.round(g.contributed / g.totalAllocated * 100)) : (g.contributed > 0 ? 100 : 0)
-                    const met = g.totalAllocated > 0 && g.contributed >= g.totalAllocated
+                    const { pct, met } = goalProgress(g)
                     return (
                     <React.Fragment key={g.goalId}>
                       <tr style={{ background: 'var(--c-card-2)', borderBottom: '1px solid var(--c-line)' }}>
@@ -498,21 +489,19 @@ export default function DesktopPlanningView({
                   {fixedExpenses.length === 0 ? (
                     <tr><td colSpan={3} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có chi phí cố định nào' : 'No fixed expenses yet'}</td></tr>
                   ) : fixedExpenses.map((fe, i) => {
-                    const skipped    = fe.override === 0
-                    const isOverridden = !skipped && fe.override != null && fe.override !== fe.amount_vnd
-                    const amount     = skipped ? 0 : (fe.override ?? fe.amount_vnd)
+                    const row = fixedExpenseRow(fe)
                     return (
                       <DPlanRow
                         key={fe.expense_id}
                         primary={fe.expense_name}
-                        secondary={skipped ? (isVI ? 'Bỏ qua tháng này' : 'Skipped') : isOverridden ? (isVI ? '(đã ghi đè)' : '(overridden)') : null}
-                        amount={amount}
-                        muted={skipped}
+                        secondary={row.skipped ? (isVI ? 'Bỏ qua tháng này' : 'Skipped') : row.overridden ? (isVI ? '(đã ghi đè)' : '(overridden)') : null}
+                        amount={row.amount}
+                        muted={row.skipped}
                         last={i === fixedExpenses.length - 1}
                         isVI={isVI}
                         onSkip={() => handleFESkip(fe)}
-                        onRestore={fe.override != null ? () => handleFERestore(fe) : undefined}
-                        onOverride={() => { setOverrideModal({ id: fe.expense_id, name: fe.expense_name, defaultAmount: fe.amount_vnd, type: 'fe' }); setOverrideVal(String(fe.override ?? fe.amount_vnd)) }}
+                        onRestore={row.hasStoredOverride ? () => handleFERestore(fe) : undefined}
+                        onOverride={() => { setOverrideModal({ id: fe.expense_id, name: fe.expense_name, defaultAmount: fe.amount_vnd, type: 'fe' }); setOverrideVal(String(row.overrideDefault)) }}
                       />
                     )
                   })}
@@ -546,23 +535,21 @@ export default function DesktopPlanningView({
                   {insuranceMembers.length === 0 ? (
                     <tr><td colSpan={5} style={{ padding: '16px', textAlign: 'center', color: 'var(--c-muted)', fontSize: 12 }}>{isVI ? 'Chưa có thành viên bảo hiểm nào' : 'No insurance members yet'}</td></tr>
                   ) : insuranceMembers.map((m, i) => {
-                    const defaultMonthly = Math.round(m.annual_payment_vnd / 12)
-                    const monthly    = m.monthlyOverride ?? defaultMonthly
-                    const isOverridden = !m.excluded && m.monthlyOverride != null
+                    const row = insuranceRow(m)
                     return (
                       <DPlanRow
                         key={m.member_id}
                         primary={m.member_name}
                         relationship={relationshipLabel(m.relationship, isVI)}
-                        defaultAmount={defaultMonthly}
-                        secondary={m.excluded ? (isVI ? 'Bỏ qua tháng này' : 'Skipped') : isOverridden ? (isVI ? '(đã ghi đè)' : '(overridden)') : null}
-                        amount={m.excluded ? 0 : monthly}
-                        muted={m.excluded}
+                        defaultAmount={row.defaultMonthly}
+                        secondary={row.excluded ? (isVI ? 'Bỏ qua tháng này' : 'Skipped') : row.overridden ? (isVI ? '(đã ghi đè)' : '(overridden)') : null}
+                        amount={row.amount}
+                        muted={row.excluded}
                         last={i === insuranceMembers.length - 1}
                         isVI={isVI}
                         onSkip={() => handleInsSkip(m)}
-                        onRestore={m.excluded || m.monthlyOverride != null ? () => handleInsRestore(m) : undefined}
-                        onOverride={() => { setOverrideModal({ id: m.member_id, name: m.member_name, defaultAmount: defaultMonthly, type: 'ins' }); setOverrideVal(String(m.monthlyOverride ?? defaultMonthly)) }}
+                        onRestore={row.excluded || row.hasStoredOverride ? () => handleInsRestore(m) : undefined}
+                        onOverride={() => { setOverrideModal({ id: m.member_id, name: m.member_name, defaultAmount: row.defaultMonthly, type: 'ins' }); setOverrideVal(String(row.overrideDefault)) }}
                       />
                     )
                   })}

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -16,12 +16,13 @@ import { Sheet, SalarySheet, DeletePlanSheet, OtherExpenseSheet, SimpleOverrideS
 import { type GoalRow, type GoalItem } from '@/lib/planning'
 import { usePlanningDerivations } from '../usePlanningDerivations'
 import { usePlanningActions, buildBuyEdit, buildContributionPrefill } from '../usePlanningActions'
+import { monthLabel as formatMonthLabel, fixedExpenseRow, insuranceRow, savedPercent } from '@/features/planning/planModel'
 import { relationshipLabel } from '@/app/assets/components/insuranceShared'
 import { MobilePlanningSkeleton } from './PlanningSkeleton'
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense,
   InsuranceMember, OtherExpense, RecurringSaving, RecurringSavingOverride, RecurringFulfillment, DcaSkip, Fund, Goal,
-} from '../PlanningClient'
+} from '@/features/planning/contracts'
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -60,17 +61,6 @@ type SheetState =
   | { type: 'manage-fixed' }
   | { type: 'manage-recurring'; editId?: string }
 
-// ─── Helpers ─────────────────────────────────────────────────────────────────
-
-const SHORT_MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
-const LONG_MONTHS = ['January','February','March','April','May','June','July','August','September','October','November','December']
-
-function getMonthLabel(month: number, year: number, short = false) {
-  const names = short ? SHORT_MONTHS : LONG_MONTHS
-  return `${names[month - 1]} ${year}`
-}
-
-
 // ─── Main MobilePlanningView ──────────────────────────────────────────────────
 
 export default function MobilePlanningView({
@@ -90,7 +80,8 @@ export default function MobilePlanningView({
   const [showAddInsurance, setShowAddInsurance] = useState(false)
   const [overrideTarget, setOverrideTarget] = useState<{ type: 'fe' | 'ins' | 'rec'; id: string; name: string; defaultAmount: number } | null>(null)
 
-  const monthLabel = getMonthLabel(month, year)
+  const monthLabel = formatMonthLabel(month, year, isVI)
+
 
   // ─── Computed totals ────────────────────────────────────────────────────────
 
@@ -102,6 +93,7 @@ export default function MobilePlanningView({
     plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,
     recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, isVI,
   })
+  const savedPct = plan ? savedPercent(totalGoals, plan.salary_vnd) : null
 
   // ─── Skip/restore handlers ─────────────────────────────────────────────────
   // Shared with the desktop view via usePlanningActions so both surfaces stay
@@ -145,14 +137,12 @@ export default function MobilePlanningView({
   // ─── Override sheet helpers ────────────────────────────────────────────────
 
   function openOverrideFE(expense: FixedExpense) {
-    const defaultAmt = (expense.override != null && expense.override > 0) ? expense.override : expense.amount_vnd
-    setOverrideTarget({ type: 'fe', id: expense.expense_id, name: expense.expense_name, defaultAmount: defaultAmt })
+    setOverrideTarget({ type: 'fe', id: expense.expense_id, name: expense.expense_name, defaultAmount: fixedExpenseRow(expense).overrideDefault })
     setSheet({ type: 'override-fe', expense })
   }
 
   function openOverrideIns(member: InsuranceMember) {
-    const defaultAmt = member.monthlyOverride ?? Math.round(member.annual_payment_vnd / 12)
-    setOverrideTarget({ type: 'ins', id: member.member_id, name: member.member_name, defaultAmount: defaultAmt })
+    setOverrideTarget({ type: 'ins', id: member.member_id, name: member.member_name, defaultAmount: insuranceRow(member).overrideDefault })
     setSheet({ type: 'override-ins', member })
   }
 
@@ -195,7 +185,7 @@ export default function MobilePlanningView({
               {[
                 { l: isVI ? 'Tổng chi' : 'Outflow', v: fmtCompact(totalOutflow), c: 'var(--c-ink)' },
                 { l: isVI ? 'Còn lại' : 'Remaining', v: fmtCompact(remaining), c: remaining >= 0 ? 'var(--c-pos)' : 'var(--c-neg)' },
-                { l: isVI ? '% Tiết kiệm' : 'Saved %', v: plan.salary_vnd > 0 ? `${Math.round((totalGoals / plan.salary_vnd) * 100)}%` : '—', c: 'var(--c-navy)' },
+                { l: isVI ? '% Tiết kiệm' : 'Saved %', v: savedPct != null ? `${savedPct}%` : '—', c: 'var(--c-navy)' },
               ].map((k, i) => (
                 <div key={i} style={{ background: 'var(--c-card)', padding: '10px 12px' }}>
                   <div style={{ fontSize: 10, color: 'var(--c-muted)' }}>{k.l}</div>
@@ -287,20 +277,18 @@ export default function MobilePlanningView({
                   </div>
                 )}
                 {fixedExpenses.map((fe, i) => {
-                  const isSkipped = fe.override === 0
-                  const hasOverride = fe.override != null && fe.override > 0 && fe.override !== fe.amount_vnd
-                  const thisMonth = isSkipped ? 0 : (fe.override ?? fe.amount_vnd)
-                  const secondary = isSkipped
+                  const row = fixedExpenseRow(fe)
+                  const secondary = row.skipped
                     ? (isVI ? 'Bỏ qua tháng này' : 'Skipped')
-                    : hasOverride ? (isVI ? '(đã ghi đè)' : '(overridden)') : null
+                    : row.overridden ? (isVI ? '(đã ghi đè)' : '(overridden)') : null
                   return (
                     <PlanLineItem
                       key={fe.expense_id}
                       primary={fe.expense_name}
                       secondary={secondary}
-                      amount={thisMonth}
-                      muted={isSkipped}
-                      overridden={hasOverride}
+                      amount={row.amount}
+                      muted={row.skipped}
+                      overridden={row.overridden}
                       last={i === fixedExpenses.length - 1}
                       isVI={isVI}
                       onSkip={() => handleSkipFE(fe)}
@@ -340,26 +328,24 @@ export default function MobilePlanningView({
                   </div>
                 )}
                 {insuranceMembers.map((m, i) => {
-                  const defaultMonthly = Math.round(m.annual_payment_vnd / 12)
-                  const hasOverride = m.monthlyOverride != null && m.monthlyOverride !== defaultMonthly
-                  const thisMonth = m.excluded ? 0 : (m.monthlyOverride ?? defaultMonthly)
+                  const row = insuranceRow(m)
                   // A phone has no room for Relationship/Default columns (the desktop
                   // table carries those), so the relationship rides the subtitle line.
                   // When overridden, append the default so the user still sees it.
                   const rel = relationshipLabel(m.relationship, isVI)
-                  const secondary = m.excluded
+                  const secondary = row.excluded
                     ? (isVI ? 'Bỏ qua tháng này' : 'Skipped')
-                    : hasOverride
-                      ? `${rel ? rel + ' · ' : ''}${isVI ? 'mặc định ' : 'default '}${fmt(defaultMonthly)}`
+                    : row.overridden
+                      ? `${rel ? rel + ' · ' : ''}${isVI ? 'mặc định ' : 'default '}${fmt(row.defaultMonthly)}`
                       : (rel || (isVI ? 'Đóng góp tháng' : 'Monthly contribution'))
                   return (
                     <PlanLineItem
                       key={m.member_id}
                       primary={m.member_name}
                       secondary={secondary}
-                      amount={thisMonth}
-                      muted={m.excluded}
-                      overridden={hasOverride}
+                      amount={row.amount}
+                      muted={row.excluded}
+                      overridden={row.overridden}
                       last={i === insuranceMembers.length - 1}
                       isVI={isVI}
                       onSkip={() => handleSkipIns(m)}

--- a/app/(app)/planning/components/RecurringSavingManager.tsx
+++ b/app/(app)/planning/components/RecurringSavingManager.tsx
@@ -6,7 +6,7 @@ import { toast } from 'sonner'
 import { Plus, ChevronLeft } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import { formatIntVN, parseIntVN } from '@/lib/numberFormat'
-import type { Goal } from '../PlanningClient'
+import type { Goal } from '@/features/planning/contracts'
 
 interface Saving {
   saving_id: string

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, within, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import DesktopPlanningView from '../DesktopPlanningView'
-import type { MonthlyPlan, FundInvestment, DirectSaving, RecurringSaving, RecurringFulfillment, InsuranceMember, FixedExpense } from '../../PlanningClient'
+import type { MonthlyPlan, FundInvestment, DirectSaving, RecurringSaving, RecurringFulfillment, InsuranceMember, FixedExpense } from '@/features/planning/contracts'
 
 const { toastErrorMock } = vi.hoisted(() => ({ toastErrorMock: vi.fn() }))
 vi.mock('sonner', () => ({ toast: Object.assign(vi.fn(), { error: toastErrorMock, success: vi.fn() }) }))

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, within, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import MobilePlanningView from '../MobilePlanningView'
-import type { MonthlyPlan, FixedExpense, InsuranceMember, OtherExpense, FundInvestment, DirectSaving, RecurringFulfillment } from '../../PlanningClient'
+import type { MonthlyPlan, FixedExpense, InsuranceMember, OtherExpense, FundInvestment, DirectSaving, RecurringFulfillment } from '@/features/planning/contracts'
 
 const { toastErrorMock } = vi.hoisted(() => ({ toastErrorMock: vi.fn() }))
 vi.mock('sonner', () => ({ toast: Object.assign(vi.fn(), { error: toastErrorMock, success: vi.fn() }) }))

--- a/app/(app)/planning/components/desktopPlanningRows.tsx
+++ b/app/(app)/planning/components/desktopPlanningRows.tsx
@@ -9,6 +9,7 @@ import { Check, Plus, RefreshCw, TrendingUp, MoreHorizontal, X } from 'lucide-re
 import { fmt } from '@/lib/formatters'
 import { type GoalItem } from '@/lib/planning'
 import { useCloseOnScroll } from '@/components/ui/useDialogA11y'
+import { goalItemSublabel } from '@/features/planning/planModel'
 import { EditIcon } from './planningIcons'
 
 function MenuBtn({ icon, label, onClick, danger, noBorder }: {
@@ -99,15 +100,7 @@ export function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit
   const skipped = !!item.skipped
   const recorded = !!item.recorded
 
-  const sublabel = skipped
-    ? (isVI ? 'Bỏ qua tháng này' : 'Skipped this month')
-    : item.overridden
-      ? (isVI ? 'Đã ghi đè tháng này' : 'Overridden this month')
-      : recorded
-        ? item.type === 'bank' ? (isVI ? 'Đã gửi tháng này' : 'Deposited this month') : (isVI ? 'Đã mua' : 'Recorded')
-        : item.type === 'fund'
-          ? 'Fund'
-          : item.isRecurring ? (isVI ? 'Tiết kiệm định kỳ' : 'Recurring saving') : (isVI ? 'Tiết kiệm' : 'Direct saving')
+  const sublabel = goalItemSublabel(item, isVI)
 
   function openMenu() {
     if (btnRef.current) {

--- a/app/(app)/planning/components/planningRows.tsx
+++ b/app/(app)/planning/components/planningRows.tsx
@@ -9,6 +9,7 @@ import { Check, ChevronDown, ChevronUp, MoreHorizontal, Plus, RefreshCw, Target,
 import { fmt } from '@/lib/formatters'
 import { type GoalRow, type GoalItem } from '@/lib/planning'
 import { useCloseOnScroll } from '@/components/ui/useDialogA11y'
+import { goalItemSublabel, goalProgress } from '@/features/planning/planModel'
 import { EditIcon } from './planningIcons'
 
 export function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride, onRecEdit, onRecordBuy, onRecordDeposit, onLogContribution, onDcaSkip, onDcaRestore }: {
@@ -24,8 +25,7 @@ export function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecO
   onDcaRestore: (item: GoalItem) => void
 }) {
   const [open, setOpen] = useState(false)
-  const pct = entry.totalAllocated > 0 ? Math.min(100, Math.round(entry.contributed / entry.totalAllocated * 100)) : (entry.contributed > 0 ? 100 : 0)
-  const met = entry.totalAllocated > 0 && entry.contributed >= entry.totalAllocated
+  const { pct, met } = goalProgress(entry)
   return (
     <div>
       <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '12px 14px', borderTop: '1px solid var(--c-line)' }}>
@@ -115,15 +115,7 @@ function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onReco
   const skipped = !!item.skipped
   const recorded = !!item.recorded
 
-  const sublabel = skipped
-    ? (isVI ? 'Bỏ qua tháng này' : 'Skipped this month')
-    : item.overridden
-      ? (isVI ? 'Đã ghi đè tháng này' : 'Overridden this month')
-      : recorded
-        ? item.type === 'bank' ? (isVI ? 'Đã gửi tháng này' : 'Deposited this month') : (isVI ? 'Đã mua' : 'Recorded')
-        : item.type === 'fund'
-          ? 'Fund'
-          : item.isRecurring ? (isVI ? 'Tiết kiệm định kỳ' : 'Recurring saving') : (isVI ? 'Tiết kiệm' : 'Direct saving')
+  const sublabel = goalItemSublabel(item, isVI)
 
   function openMenu() {
     if (btnRef.current) {

--- a/app/(app)/planning/components/planningSheets.tsx
+++ b/app/(app)/planning/components/planningSheets.tsx
@@ -11,7 +11,7 @@ import { fmtCompact } from '@/lib/formatters'
 import { useDialogA11y } from '@/components/ui/useDialogA11y'
 import { TrashIcon } from './planningIcons'
 import { saveIncome, deletePlan, saveOtherExpense } from '../planActions'
-import type { MonthlyPlan, OtherExpense } from '../PlanningClient'
+import type { MonthlyPlan, OtherExpense } from '@/features/planning/contracts'
 import { useDialogMount, useResetOnOpen } from '@/components/ui/useDialogMount'
 
 export function Sheet({ open, onClose, title, children }: { open: boolean; onClose: () => void; title: string; children: React.ReactNode }) {

--- a/app/(app)/planning/usePlanningActions.ts
+++ b/app/(app)/planning/usePlanningActions.ts
@@ -3,7 +3,7 @@ import { todayIso } from '@/lib/dates'
 import type { GoalItem, GoalRow } from '@/lib/planning'
 import type { EditableTransaction, PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import type { BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
-import type { MonthlyPlan, FixedExpense, InsuranceMember, FundInvestment } from './PlanningClient'
+import type { MonthlyPlan, FixedExpense, InsuranceMember, FundInvestment } from '@/features/planning/contracts'
 
 export type OverrideType = 'fe' | 'rec' | 'ins'
 

--- a/app/(app)/planning/usePlanningDerivations.ts
+++ b/app/(app)/planning/usePlanningDerivations.ts
@@ -8,7 +8,7 @@ import {
 import type {
   MonthlyPlan, FundInvestment, DirectSaving, FixedExpense, InsuranceMember,
   OtherExpense, RecurringSaving, RecurringSavingOverride, RecurringFulfillment, DcaSkip, Fund, Goal,
-} from './PlanningClient'
+} from '@/features/planning/contracts'
 
 // Effective monthly totals. A `override === 0` fixed expense is skipped for the
 // month; an `excluded` insurance member is skipped; otherwise the override (if

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -49,7 +49,8 @@ type, that type is in the wrong place — extract it to a contract module.
 [`__tests__/architecture.test.ts`](../__tests__/architecture.test.ts) fails the
 build on: an import from `app/` in any lower layer, a route handler or the
 navigation chrome importing feature UI, and a type exported from
-`DashboardClient.tsx`. Add a rule there when you establish one here.
+`DashboardClient.tsx` or `PlanningClient.tsx`. Add a rule there when you
+establish one here.
 
 ## Migration status (#600)
 
@@ -69,6 +70,12 @@ Done:
 - Fund Library desktop/mobile drift (#603): one filter+sort rule and one
   fund-type palette in `features/funds/`, replacing a byte-identical copy in
   each view. The table and the card list stay separate — they genuinely differ.
+- Planning desktop/mobile drift (#603): the plan's DTOs are out of
+  `PlanningClient.tsx` and into `features/planning/contracts.ts`, and the
+  per-row derivations (month labels, goal progress, an allocation's sublabel,
+  the skipped/overridden/amount rules for a fixed expense and an insurance
+  member) into `features/planning/planModel.ts`. Three of those copies had
+  already drifted. The table and the card stack stay separate.
 - One component root: `app/components/` folded into `components/{ui,layout,navigation}`
   and `features/landing/`. The app shell no longer imports a screen — the
   add-transaction sheet reaches it as an opaque `overlays` node from the route
@@ -78,6 +85,6 @@ Still open — incremental, as files are touched, not as a repo-wide rename:
 
 - `app/assets/` split into `features/dashboard`, `features/investments`,
   `features/goals`, `features/insurance`.
-- Planning and Settings desktop/mobile drift (#603) — Fund Library is done.
+- Settings desktop/mobile drift (#603) — Fund Library and Planning are done.
   Keep the shells separate where the UX genuinely differs; extract the shared
   models, actions and form fields.

--- a/features/planning/__tests__/planModel.test.ts
+++ b/features/planning/__tests__/planModel.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest'
+import {
+  monthLabel,
+  goalItemSublabel,
+  goalProgress,
+  fixedExpenseRow,
+  insuranceRow,
+  savedPercent,
+} from '../planModel'
+import type { FixedExpense, InsuranceMember } from '../contracts'
+import type { GoalItem, GoalRow } from '@/lib/planning'
+
+const goalRow = (over: Partial<GoalRow> = {}): GoalRow => ({
+  goalId: 'g1', goalName: 'Emergency', totalAllocated: 0, contributed: 0,
+  isUnallocated: false, items: [], ...over,
+})
+
+const item = (over: Partial<GoalItem> = {}): GoalItem => ({
+  name: 'VESAF', type: 'fund', amount: 1_000_000, ...over,
+})
+
+const expense = (over: Partial<FixedExpense> = {}): FixedExpense => ({
+  expense_id: 'fe1', expense_name: 'Rent', amount_vnd: 5_000_000, ...over,
+})
+
+const member = (over: Partial<InsuranceMember> = {}): InsuranceMember => ({
+  member_id: 'm1', member_name: 'Minh', relationship: 'self',
+  annual_payment_vnd: 12_000_000, payment_date: null, ...over,
+})
+
+describe('monthLabel', () => {
+  it('renders the long month in each locale', () => {
+    expect(monthLabel(6, 2026, false)).toBe('June 2026')
+    expect(monthLabel(6, 2026, true)).toBe('Tháng 6 2026')
+  })
+
+  it('renders the short month in each locale', () => {
+    expect(monthLabel(6, 2026, false, { short: true })).toBe('Jun 2026')
+    expect(monthLabel(6, 2026, true, { short: true })).toBe('Th6 2026')
+  })
+
+  // The mobile view carried an English-only copy of the month names, so a
+  // Vietnamese user saw "January 2026" in the delete-plan sheet and the empty
+  // state while the desktop said "Tháng 1 2026". One table, both surfaces.
+  it('covers all twelve months in both locales', () => {
+    for (let m = 1; m <= 12; m++) {
+      expect(monthLabel(m, 2026, false)).not.toMatch(/undefined/)
+      expect(monthLabel(m, 2026, true)).toMatch(/^Tháng \d{1,2} 2026$/)
+      expect(monthLabel(m, 2026, true, { short: true })).toMatch(/^Th\d{1,2} 2026$/)
+    }
+  })
+})
+
+describe('goalItemSublabel', () => {
+  it('reports a skipped item before anything else', () => {
+    const skipped = item({ skipped: true, overridden: true, recorded: true })
+    expect(goalItemSublabel(skipped, false)).toBe('Skipped this month')
+    expect(goalItemSublabel(skipped, true)).toBe('Bỏ qua tháng này')
+  })
+
+  it('reports an override ahead of a recorded contribution', () => {
+    const overridden = item({ overridden: true, recorded: true })
+    expect(goalItemSublabel(overridden, false)).toBe('Overridden this month')
+    expect(goalItemSublabel(overridden, true)).toBe('Đã ghi đè tháng này')
+  })
+
+  it('distinguishes a recorded deposit from a recorded buy', () => {
+    expect(goalItemSublabel(item({ type: 'bank', recorded: true }), false)).toBe('Deposited this month')
+    expect(goalItemSublabel(item({ type: 'bank', recorded: true }), true)).toBe('Đã gửi tháng này')
+    expect(goalItemSublabel(item({ type: 'fund', recorded: true }), false)).toBe('Recorded')
+    expect(goalItemSublabel(item({ type: 'fund', recorded: true }), true)).toBe('Đã mua')
+  })
+
+  it('falls back to the item kind', () => {
+    expect(goalItemSublabel(item({ type: 'fund' }), true)).toBe('Fund')
+    expect(goalItemSublabel(item({ type: 'bank', isRecurring: true }), false)).toBe('Recurring saving')
+    expect(goalItemSublabel(item({ type: 'bank', isRecurring: true }), true)).toBe('Tiết kiệm định kỳ')
+    expect(goalItemSublabel(item({ type: 'bank' }), false)).toBe('Direct saving')
+    expect(goalItemSublabel(item({ type: 'bank' }), true)).toBe('Tiết kiệm')
+  })
+})
+
+describe('goalProgress', () => {
+  it('is the contributed share of what was planned', () => {
+    expect(goalProgress(goalRow({ totalAllocated: 4_000_000, contributed: 1_000_000 })))
+      .toEqual({ pct: 25, met: false })
+  })
+
+  it('caps the bar at 100% but still marks the goal met', () => {
+    expect(goalProgress(goalRow({ totalAllocated: 1_000_000, contributed: 3_000_000 })))
+      .toEqual({ pct: 100, met: true })
+  })
+
+  it('marks an exactly-funded goal met', () => {
+    expect(goalProgress(goalRow({ totalAllocated: 1_000_000, contributed: 1_000_000 })))
+      .toEqual({ pct: 100, met: true })
+  })
+
+  // An unplanned goal that received money is full, not 0/0 — but it isn't "met",
+  // since there was no target to meet.
+  it('shows an unplanned contribution as full and not met', () => {
+    expect(goalProgress(goalRow({ totalAllocated: 0, contributed: 500_000 })))
+      .toEqual({ pct: 100, met: false })
+  })
+
+  it('is empty when nothing is planned and nothing given', () => {
+    expect(goalProgress(goalRow())).toEqual({ pct: 0, met: false })
+  })
+})
+
+describe('fixedExpenseRow', () => {
+  it('uses the base amount when there is no override', () => {
+    expect(fixedExpenseRow(expense())).toEqual({
+      skipped: false, overridden: false, amount: 5_000_000,
+      hasStoredOverride: false, overrideDefault: 5_000_000,
+    })
+  })
+
+  it('treats a zero override as skipped for the month', () => {
+    expect(fixedExpenseRow(expense({ override: 0 }))).toMatchObject({
+      skipped: true, overridden: false, amount: 0,
+    })
+  })
+
+  // Desktop pre-filled the override input from `override ?? amount_vnd`, so
+  // opening "Override amount" on a *skipped* expense offered 0 — a value the
+  // sheet refuses to save. Both surfaces now offer the base amount.
+  it('offers the base amount as the override default on a skipped expense', () => {
+    expect(fixedExpenseRow(expense({ override: 0 })).overrideDefault).toBe(5_000_000)
+  })
+
+  it('uses the override when it differs from the base amount', () => {
+    expect(fixedExpenseRow(expense({ override: 6_000_000 }))).toEqual({
+      skipped: false, overridden: true, amount: 6_000_000,
+      hasStoredOverride: true, overrideDefault: 6_000_000,
+    })
+  })
+
+  // An override stored at exactly the base amount changes nothing the user can
+  // see, so it isn't announced — but it is still restorable.
+  it('does not announce an override equal to the base amount', () => {
+    expect(fixedExpenseRow(expense({ override: 5_000_000 }))).toMatchObject({
+      overridden: false, hasStoredOverride: true, amount: 5_000_000,
+    })
+  })
+})
+
+describe('insuranceRow', () => {
+  it('spreads the annual payment over twelve months', () => {
+    expect(insuranceRow(member())).toEqual({
+      excluded: false, overridden: false, hasStoredOverride: false,
+      defaultMonthly: 1_000_000, amount: 1_000_000, overrideDefault: 1_000_000,
+    })
+  })
+
+  it('rounds the monthly default', () => {
+    expect(insuranceRow(member({ annual_payment_vnd: 10_000_000 })).defaultMonthly).toBe(833_333)
+  })
+
+  it('zeroes an excluded member but keeps the default visible', () => {
+    expect(insuranceRow(member({ excluded: true }))).toMatchObject({
+      excluded: true, amount: 0, defaultMonthly: 1_000_000, overrideDefault: 1_000_000,
+    })
+  })
+
+  it('uses the override when set', () => {
+    expect(insuranceRow(member({ monthlyOverride: 1_500_000 }))).toMatchObject({
+      overridden: true, hasStoredOverride: true, amount: 1_500_000, overrideDefault: 1_500_000,
+    })
+  })
+
+  // Desktop announced "(overridden)" for any stored override, mobile only when
+  // it differed from the default — the same member read differently on the two
+  // surfaces. Announce it only when the amount actually changed, matching how
+  // fixed expenses already behaved on both.
+  it('does not announce an override equal to the monthly default', () => {
+    expect(insuranceRow(member({ monthlyOverride: 1_000_000 }))).toMatchObject({
+      overridden: false, hasStoredOverride: true, amount: 1_000_000,
+    })
+  })
+
+  it('never announces an override on an excluded member', () => {
+    expect(insuranceRow(member({ excluded: true, monthlyOverride: 1_500_000 }))).toMatchObject({
+      excluded: true, overridden: false, hasStoredOverride: true, amount: 0,
+    })
+  })
+})
+
+describe('savedPercent', () => {
+  it('is the planned-goal share of income', () => {
+    expect(savedPercent(9_000_000, 30_000_000)).toBe(30)
+  })
+
+  it('rounds to a whole percent', () => {
+    expect(savedPercent(1_000_000, 3_000_000)).toBe(33)
+  })
+
+  it('is null without income to divide by', () => {
+    expect(savedPercent(1_000_000, 0)).toBeNull()
+  })
+})

--- a/features/planning/contracts.ts
+++ b/features/planning/contracts.ts
@@ -1,0 +1,100 @@
+// The monthly plan's contracts (#603).
+//
+// These are the shapes `/api/v1/monthly-plans?full=true` returns and the two
+// planning views render. They were declared inside `PlanningClient.tsx` — a
+// `'use client'` component — which meant the shared derivations, actions and
+// row model all had to import a type out of `app/`, the wrong direction under
+// docs/architecture.md. `PlanningClient` re-exports them, so existing imports
+// keep working.
+
+export interface MonthlyPlan {
+  id: string
+  month: number
+  year: number
+  salary_vnd: number
+}
+
+export interface FundInvestment {
+  transaction_id: string
+  plan_id: string
+  fund_id: string
+  goal_id: string | null
+  amount_vnd: number
+  units: number | null
+  unit_price: number | null
+  investment_date: string | null
+  is_dca_seeded: boolean
+  funds: { name: string; nav: number } | null
+  savings_goals: { goal_name: string } | null
+}
+
+export interface DirectSaving {
+  transaction_id: string
+  plan_id: string
+  goal_id: string | null
+  amount_vnd: number
+  interest_rate: number | null
+  expiry_date: string | null
+  investment_date: string
+  savings_goals: { goal_name: string } | null
+}
+
+export interface FixedExpense {
+  expense_id: string
+  expense_name: string
+  amount_vnd: number
+  override?: number // overridden monthly amount if set
+}
+
+export interface InsuranceMember {
+  member_id: string
+  member_name: string
+  relationship: string
+  annual_payment_vnd: number
+  payment_date: string | null
+  excluded?: boolean
+  monthlyOverride?: number
+}
+
+export interface OtherExpense {
+  id: string
+  plan_id: string
+  description: string
+  amount_vnd: number
+  created_at: string
+}
+
+export interface RecurringSaving {
+  saving_id: string
+  name: string
+  goal_id: string | null
+  amount_vnd: number
+  effective_from: string | null
+  effective_to: string | null
+  linked_deposit_tx_id?: string | null
+  savings_goals: { goal_name: string } | null
+}
+
+export interface RecurringSavingOverride {
+  recurring_saving_id: string
+  monthly_amount_override_vnd: number
+}
+
+// A recurring recorded this month via maturity-combine / book top-up. amount_vnd
+// is what was fulfilled; source distinguishes whether a plan-scoped deposit was
+// also logged (book top-up) so contributed isn't double-counted.
+export interface RecurringFulfillment {
+  recurring_saving_id: string
+  amount_vnd: number
+  source: string
+}
+
+export interface Fund {
+  id: string; name: string; nav: number
+  is_dca?: boolean
+  dca_monthly_amount_vnd?: number | null
+  dca_goal_id?: string | null
+}
+
+export interface DcaSkip { fund_id: string }
+export interface Goal { goal_id: string; goal_name: string }

--- a/features/planning/planModel.ts
+++ b/features/planning/planModel.ts
@@ -1,0 +1,143 @@
+// The planning page's per-row derivations (#603).
+//
+// The desktop table and the mobile card stack each carried their own copy of
+// these: the month-name tables, the by-goal progress bar, an allocation line's
+// sublabel (byte-identical in both row files), and the skipped/overridden/amount
+// arithmetic for a fixed expense and an insurance member. Same rules, written
+// twice, and three of them had already drifted — see the tests.
+//
+// Deliberately NOT shared: the table rows and the card rows themselves. A phone
+// has no room for the Relationship and Default columns, so the two layouts
+// genuinely differ; what they must agree on is the *state* each row is in, not
+// the markup that shows it.
+
+import type { GoalItem, GoalRow } from '@/lib/planning'
+import type { FixedExpense, InsuranceMember } from './contracts'
+
+// ─── Month labels ────────────────────────────────────────────────────────────
+
+const SHORT_MONTHS_EN = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec']
+const SHORT_MONTHS_VI = ['Th1','Th2','Th3','Th4','Th5','Th6','Th7','Th8','Th9','Th10','Th11','Th12']
+const LONG_MONTHS_EN  = ['January','February','March','April','May','June','July','August','September','October','November','December']
+const LONG_MONTHS_VI  = ['Tháng 1','Tháng 2','Tháng 3','Tháng 4','Tháng 5','Tháng 6','Tháng 7','Tháng 8','Tháng 9','Tháng 10','Tháng 11','Tháng 12']
+
+/**
+ * The month a plan is for, as the user reads it. `short` is the compact form
+ * the month pickers use.
+ */
+export function monthLabel(month: number, year: number, isVI: boolean, opts?: { short?: boolean }): string {
+  const names = opts?.short
+    ? (isVI ? SHORT_MONTHS_VI : SHORT_MONTHS_EN)
+    : (isVI ? LONG_MONTHS_VI : LONG_MONTHS_EN)
+  return `${names[month - 1]} ${year}`
+}
+
+// ─── By-goal rows ────────────────────────────────────────────────────────────
+
+/** The line under an allocation: what happened to it this month, or what it is. */
+export function goalItemSublabel(item: GoalItem, isVI: boolean): string {
+  if (item.skipped) return isVI ? 'Bỏ qua tháng này' : 'Skipped this month'
+  if (item.overridden) return isVI ? 'Đã ghi đè tháng này' : 'Overridden this month'
+  if (item.recorded) {
+    return item.type === 'bank'
+      ? (isVI ? 'Đã gửi tháng này' : 'Deposited this month')
+      : (isVI ? 'Đã mua' : 'Recorded')
+  }
+  if (item.type === 'fund') return 'Fund'
+  return item.isRecurring
+    ? (isVI ? 'Tiết kiệm định kỳ' : 'Recurring saving')
+    : (isVI ? 'Tiết kiệm' : 'Direct saving')
+}
+
+/**
+ * A goal's progress bar: how much of what was planned has actually been logged.
+ * The bar caps at 100%, and a goal with nothing planned but money in reads as
+ * full — there is no shortfall to show — without being "met", since it had no
+ * target to meet.
+ */
+export function goalProgress(entry: Pick<GoalRow, 'totalAllocated' | 'contributed'>): { pct: number; met: boolean } {
+  const { totalAllocated, contributed } = entry
+  if (totalAllocated > 0) {
+    return {
+      pct: Math.min(100, Math.round((contributed / totalAllocated) * 100)),
+      met: contributed >= totalAllocated,
+    }
+  }
+  return { pct: contributed > 0 ? 100 : 0, met: false }
+}
+
+// ─── Fixed expense / insurance rows ──────────────────────────────────────────
+
+export interface PlanLineState {
+  /** An override is stored *and* it changes the amount, so it's worth announcing. */
+  overridden: boolean
+  /** An override row exists at all — what "Restore default" is offered for. */
+  hasStoredOverride: boolean
+  /** What this month costs. */
+  amount: number
+  /** What the override input opens on. */
+  overrideDefault: number
+}
+
+/** A fixed expense line. A skip is stored as `override === 0`. */
+export interface FixedExpenseLine extends PlanLineState {
+  skipped: boolean
+}
+
+/** An insurance line. A skip is stored as its own exclusion row. */
+export interface InsuranceLine extends PlanLineState {
+  excluded: boolean
+  /** The annual premium's monthly share — shown even when overridden. */
+  defaultMonthly: number
+}
+
+/**
+ * A fixed expense this month. `override === 0` is how a skip is stored; any
+ * other override wins over the base amount.
+ *
+ * `overrideDefault` is deliberately never 0: opening "Override amount" on a
+ * skipped expense used to offer 0 on desktop, which the sheet refuses to save.
+ */
+export function fixedExpenseRow(expense: FixedExpense): FixedExpenseLine {
+  const { override, amount_vnd } = expense
+  const skipped = override === 0
+  const hasStoredOverride = override != null
+  const amount = skipped ? 0 : (override ?? amount_vnd)
+  return {
+    skipped,
+    overridden: !skipped && hasStoredOverride && override !== amount_vnd,
+    hasStoredOverride,
+    amount,
+    overrideDefault: skipped ? amount_vnd : (override ?? amount_vnd),
+  }
+}
+
+/**
+ * An insurance member this month. The plan spreads the annual premium over
+ * twelve months; `excluded` skips the member, and an override replaces the
+ * monthly share.
+ */
+export function insuranceRow(member: InsuranceMember): InsuranceLine {
+  const { excluded, monthlyOverride, annual_payment_vnd } = member
+  const defaultMonthly = Math.round(annual_payment_vnd / 12)
+  const hasStoredOverride = monthlyOverride != null
+  return {
+    excluded: !!excluded,
+    overridden: !excluded && hasStoredOverride && monthlyOverride !== defaultMonthly,
+    hasStoredOverride,
+    defaultMonthly,
+    amount: excluded ? 0 : (monthlyOverride ?? defaultMonthly),
+    overrideDefault: monthlyOverride ?? defaultMonthly,
+  }
+}
+
+// ─── Summary ─────────────────────────────────────────────────────────────────
+
+/**
+ * The share of income the month plans to save. Null when there is no income to
+ * divide by — the views show a dash rather than a misleading 0%.
+ */
+export function savedPercent(totalGoals: number, salaryVnd: number): number | null {
+  if (salaryVnd <= 0) return null
+  return Math.round((totalGoals / salaryVnd) * 100)
+}


### PR DESCRIPTION
Part of #603 (parent #600). Fund Library shipped in #632; this is Planning. Settings is the remaining area.

## What was duplicated

Both planning views carried their own copy of the month-name tables, the by-goal progress bar, an allocation line's sublabel (byte-identical in the two row files), and the skipped/overridden/amount rules for a fixed expense and an insurance member. None of it was reachable by a test without rendering a 500–770-line view.

**Three of those copies had already drifted**, so this is not a pure no-op refactor:

| | Before | After |
| --- | --- | --- |
| Mobile month labels | English-only — a Vietnamese user saw "January 2026" in the delete-plan sheet and the empty state while desktop said "Tháng 1 2026" | one table, both locales, both surfaces |
| Insurance "(overridden)" | desktop announced it for *any* stored override; mobile only when it differed from the monthly default | announced only when the amount actually changed — matching how fixed expenses already behaved on both |
| Override input on a *skipped* fixed expense | desktop pre-filled `0`, which the sheet refuses to save | both offer the base amount |

## What moved

- **`features/planning/planModel.ts`** — `monthLabel`, `goalProgress`, `goalItemSublabel`, `fixedExpenseRow`, `insuranceRow`, `savedPercent`. 26 tests.
- **`features/planning/contracts.ts`** — the plan's 12 DTOs, out of `PlanningClient.tsx`. The shared derivations, actions, sheets and both row files were importing a type back out of a `'use client'` component — the wrong direction under `docs/architecture.md`. The architecture test now asserts no exported types on `PlanningClient` alongside `DashboardClient`.

Net −118 lines across the views; the table and the card stack stay separate, per the issue.

## Checks

`typecheck`, `lint` (0 errors), `build` clean. 2,168 unit tests pass; coverage 63.08% statements, above the 63.07 floor. Targeted E2E green: `planning`, `planning-desktop`, `expenses`, `insurance-override` (11 passed).

## Worth checking on the preview

The plan page on both breakpoints: skip / restore / override on a fixed expense and an insurance member (including opening the override sheet on an already-skipped expense), the by-goal progress bars, recording a DCA buy and a recurring deposit, and — in Vietnamese — the month label in the header, the empty state and the delete-plan confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)