### PR TITLE
refactor(settings): share the option tables and profile editor (#603)

### DIFF
--- a/app/(app)/settings/components/DesktopSettingsView.tsx
+++ b/app/(app)/settings/components/DesktopSettingsView.tsx
@@ -2,25 +2,14 @@
 
 import { useState, useRef } from 'react'
 import { useLocale, useTranslations } from 'next-intl'
-import { type ThemeChoice } from '@/components/layout/ThemeProvider'
 import { useDialogA11y } from '@/components/ui/useDialogA11y'
-import {
-  Sun, Moon, Settings, RefreshCw, TrendingUp,
-  Coins, LogOut, Download, X, Check, Edit2,
-} from 'lucide-react'
+import { RefreshCw, LogOut, Download, X, Check, Edit2 } from 'lucide-react'
 import DownloadReportSheet from '@/app/assets/components/DownloadReportSheet'
 import { useSettingsController } from '../useSettingsController'
-import { useManagedTimeout } from '../useManagedTimeout'
-
-interface Props {
-  email: string
-  initials: string
-  displayName: string
-}
-
-// How long the "Saved" success flash stays up before the modal closes.
-// Kept in sync with MobileSettingsView so both views feel identical.
-const SAVE_FLASH_MS = 1400
+import { useProfileEditor } from '@/features/settings/useProfileEditor'
+import {
+  themeOptions, localeOptions, priceSources, type SettingsViewProps,
+} from '@/features/settings/settingsOptions'
 
 // ─── Desktop Modal ─────────────────────────────────────────────────────────────
 
@@ -128,41 +117,22 @@ function SettingRow({ icon, label, onClick, last = false }: {
 
 // ─── Main component ────────────────────────────────────────────────────────────
 
-export default function DesktopSettingsView({ email, initials, displayName }: Props) {
+export default function DesktopSettingsView({ email, initials, displayName }: SettingsViewProps) {
   const locale = useLocale()
   const t = useTranslations('settings')
   const c = useSettingsController({ initials, displayName })
 
-  // Modal state — the desktop's own chrome. The editor lives inline here rather
-  // than in a child component (mobile's ProfileSheet), so its draft and its
-  // success flash stay with the modal.
+  // Modal state — the desktop's own chrome. The editor's draft and save-flash
+  // sequence is the shared hook; what lives here is the modal that wraps it.
   const [showProfile, setShowProfile] = useState(false)
-  const [profileSaved, setProfileSaved] = useState(false)
-  const [profileName, setProfileName] = useState(displayName)
-  const scheduleSaveFlashReset = useManagedTimeout()
+  const profile = useProfileEditor(c.displayName, c.saveProfile, () => setShowProfile(false))
 
   function handleOpenProfile() {
-    setProfileName(c.displayName)
-    setProfileSaved(false)
+    profile.reset()
     setShowProfile(true)
   }
 
-  async function handleSaveProfile() {
-    // Only flash "Saved" and close once the persist succeeded — a failed update
-    // surfaces a toast (from saveProfile) and keeps the modal open.
-    const ok = await c.saveProfile(profileName)
-    if (!ok) return
-    setProfileSaved(true)
-    scheduleSaveFlashReset(() => { setProfileSaved(false); setShowProfile(false) }, SAVE_FLASH_MS)
-  }
-
   const isSyncing = c.syncStatus === 'syncing'
-
-  const themeOptions: { v: ThemeChoice; icon: React.ReactNode; label: string }[] = [
-    { v: 'light',  icon: <Sun size={13} color="currentColor" />,      label: t('appearanceLight')  },
-    { v: 'dark',   icon: <Moon size={13} color="currentColor" />,     label: t('appearanceDark')   },
-    { v: 'system', icon: <Settings size={13} color="currentColor" />, label: t('appearanceSystem') },
-  ]
 
   return (
     <div data-testid="desktop-settings-view" className="hidden md:flex" style={{ flex: 1, flexDirection: 'column', minHeight: 0, overflow: 'hidden' }}>
@@ -223,19 +193,19 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
                   {t('language')}
                 </div>
                 <div style={{ display: 'flex', gap: 8 }}>
-                  {[{ v: 'en', l: t('languageEnglish') }, { v: 'vi', l: t('languageVietnamese') }].map(o => (
+                  {localeOptions(t).map(o => (
                     <button
-                      key={o.v}
-                      onClick={() => c.switchLocale(o.v)}
+                      key={o.value}
+                      onClick={() => c.switchLocale(o.value)}
                       style={{
                         padding: '7px 14px', borderRadius: 8, fontSize: 12, fontWeight: 500,
-                        background: locale === o.v ? 'var(--c-btn-primary)' : 'var(--c-card-2)',
-                        color: locale === o.v ? '#fff' : 'var(--c-muted)',
-                        border: `1px solid ${locale === o.v ? 'var(--c-btn-primary)' : 'var(--c-line)'}`,
+                        background: locale === o.value ? 'var(--c-btn-primary)' : 'var(--c-card-2)',
+                        color: locale === o.value ? '#fff' : 'var(--c-muted)',
+                        border: `1px solid ${locale === o.value ? 'var(--c-btn-primary)' : 'var(--c-line)'}`,
                         cursor: 'pointer', fontFamily: 'inherit', transition: 'all 120ms',
                       }}
                     >
-                      {o.l}
+                      {o.label}
                     </button>
                   ))}
                 </div>
@@ -247,20 +217,20 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
                   {t('appearance')}
                 </div>
                 <div style={{ display: 'flex', gap: 8 }}>
-                  {themeOptions.map(o => (
+                  {themeOptions(t).map(o => (
                     <button
-                      key={o.v}
-                      onClick={() => c.selectTheme(o.v)}
+                      key={o.value}
+                      onClick={() => c.selectTheme(o.value)}
                       style={{
                         display: 'flex', alignItems: 'center', gap: 6,
                         padding: '7px 14px', borderRadius: 8, fontSize: 12, fontWeight: 500,
-                        background: c.themeChoice === o.v ? 'var(--c-navy-tint)' : 'var(--c-card-2)',
-                        color: c.themeChoice === o.v ? 'var(--c-navy)' : 'var(--c-muted)',
-                        border: `1px solid ${c.themeChoice === o.v ? 'var(--c-navy)' : 'var(--c-line)'}`,
+                        background: c.themeChoice === o.value ? 'var(--c-navy-tint)' : 'var(--c-card-2)',
+                        color: c.themeChoice === o.value ? 'var(--c-navy)' : 'var(--c-muted)',
+                        border: `1px solid ${c.themeChoice === o.value ? 'var(--c-navy)' : 'var(--c-line)'}`,
                         cursor: 'pointer', fontFamily: 'inherit', transition: 'all 120ms',
                       }}
                     >
-                      {o.icon}
+                      <o.Icon size={13} color="currentColor" />
                       {o.label}
                     </button>
                   ))}
@@ -324,13 +294,10 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
                 </button>
               </div>
               <div style={{ display: 'grid', gap: 10, paddingTop: 12, borderTop: '1px solid var(--c-line)' }}>
-                {[
-                  { icon: <TrendingUp size={13} />, color: '#2563eb', label: t('fundNav'),   note: t('fundNavNote') },
-                  { icon: <Coins size={13} />, color: 'var(--c-fund-gold)', label: t('goldPrice'), note: t('goldNote') },
-                ].map((row, i) => (
-                  <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                {priceSources(t).map((row) => (
+                  <div key={row.key} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                     <div style={{ width: 28, height: 28, borderRadius: 7, background: 'var(--c-card-2)', color: row.color, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
-                      {row.icon}
+                      <row.Icon size={13} />
                     </div>
                     <div style={{ flex: 1 }}>
                       <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-ink)' }}>{row.label}</div>
@@ -357,8 +324,8 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
       </div>
 
       {/* ─── Edit profile modal ─────────────────────────────────────────────── */}
-      <DModal open={showProfile} onClose={() => { setShowProfile(false); setProfileSaved(false) }} title={t('profileModalTitle')} dismissOnBackdrop={false}>
-        {profileSaved ? (
+      <DModal open={showProfile} onClose={() => { setShowProfile(false); profile.reset() }} title={t('profileModalTitle')} dismissOnBackdrop={false}>
+        {profile.saved ? (
           <div style={{ padding: '28px 0', textAlign: 'center' }}>
             <div style={{ width: 52, height: 52, borderRadius: 26, background: 'var(--c-pos-tint)', color: 'var(--c-pos)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 12px' }}>
               <Check size={26} strokeWidth={2.5} />
@@ -372,8 +339,8 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
                 {t('fullName')}
               </label>
               <input
-                value={profileName}
-                onChange={e => setProfileName(e.target.value)}
+                value={profile.name}
+                onChange={e => profile.setName(e.target.value)}
                 autoFocus
                 style={{
                   width: '100%', padding: '9px 12px', fontSize: 13,
@@ -413,7 +380,7 @@ export default function DesktopSettingsView({ email, initials, displayName }: Pr
                 {t('cancel')}
               </button>
               <button
-                onClick={handleSaveProfile}
+                onClick={profile.save}
                 className="cn-btn primary"
                 style={{ flex: 2, justifyContent: 'center' }}
               >

--- a/app/(app)/settings/components/MobileSettingsView.tsx
+++ b/app/(app)/settings/components/MobileSettingsView.tsx
@@ -4,25 +4,16 @@ import { useState, useEffect, useRef } from 'react'
 import { useLocale, useTranslations } from 'next-intl'
 import { type ThemeChoice } from '@/components/layout/ThemeProvider'
 import { useDialogA11y } from '@/components/ui/useDialogA11y'
-import {
-  Globe, Sun, Moon, Settings, Download, RefreshCw,
-  TrendingUp, Coins, LogOut, ChevronRight, Check,
-} from 'lucide-react'
+import { Globe, Sun, Download, RefreshCw, LogOut, ChevronRight, Check } from 'lucide-react'
 import { useNavigation } from '@/components/navigation/NavigationContext'
 import DownloadReportSheet from '@/app/assets/components/DownloadReportSheet'
 import { useSettingsController } from '../useSettingsController'
-import { useManagedTimeout } from '../useManagedTimeout'
+import { useProfileEditor } from '@/features/settings/useProfileEditor'
+import {
+  themeOptions, themeLabel, localeOptions, localeLabel, priceSources,
+  type SettingsViewProps,
+} from '@/features/settings/settingsOptions'
 import { useDialogMount, useResetOnOpen } from '@/components/ui/useDialogMount'
-
-interface Props {
-  email: string
-  initials: string
-  displayName: string
-}
-
-// How long the "Saved" success flash stays up before the sheet/modal closes.
-// Kept in sync with DesktopSettingsView so both views feel identical.
-const SAVE_FLASH_MS = 1400
 
 // ─── Bottom sheet wrapper ──────────────────────────────────────────────────────
 
@@ -94,20 +85,9 @@ function ProfileSheet({ open, onClose, onSave, displayName, email }: {
   email: string
 }) {
   const t = useTranslations('settings')
-  const [name, setName] = useState(displayName)
-  const [saved, setSaved] = useState(false)
-  const scheduleTimeout = useManagedTimeout()
+  const { name, setName, saved, save, reset } = useProfileEditor(displayName, onSave, onClose)
 
-  useResetOnOpen(open, () => { setName(displayName); setSaved(false) }, displayName)
-
-  async function handleSave() {
-    // Only flash "Saved" and close once the persist actually succeeded — a
-    // failed update surfaces a toast (from onSave) and keeps the form open.
-    const ok = await onSave(name)
-    if (!ok) return
-    setSaved(true)
-    scheduleTimeout(() => { setSaved(false); onClose() }, SAVE_FLASH_MS)
-  }
+  useResetOnOpen(open, reset, displayName)
 
   return (
     <BottomSheet open={open} onClose={onClose} title={t('profileModalTitle')} dismissOnBackdrop={false}>
@@ -173,7 +153,7 @@ function ProfileSheet({ open, onClose, onSave, displayName, email }: {
               {t('cancel')}
             </button>
             <button
-              onClick={handleSave}
+              onClick={save}
               style={{
                 flex: 2, padding: '10px 0', fontSize: 13, fontWeight: 600,
                 minHeight: 44, display: 'flex', alignItems: 'center', justifyContent: 'center',
@@ -208,11 +188,7 @@ function AppearanceSheet({ open, onClose, onApply, current }: {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
 
-  const options: { v: ThemeChoice; icon: React.ReactNode; label: string }[] = [
-    { v: 'light',  icon: <Sun size={18} />,      label: t('appearanceLight')  },
-    { v: 'dark',   icon: <Moon size={18} />,     label: t('appearanceDark')   },
-    { v: 'system', icon: <Settings size={18} />, label: t('appearanceSystem') },
-  ]
+  const options = themeOptions(t)
 
   // onApply is the controller's selectTheme — it both persists the choice and
   // hands it to the theme provider, so the sheet doesn't touch either directly.
@@ -226,21 +202,21 @@ function AppearanceSheet({ open, onClose, onApply, current }: {
       <div style={{ display: 'grid', gap: 8, marginBottom: 14 }}>
         {options.map(opt => (
           <button
-            key={opt.v}
-            onClick={() => setSelected(opt.v)}
+            key={opt.value}
+            onClick={() => setSelected(opt.value)}
             style={{
               width: '100%', textAlign: 'left', padding: '14px 16px',
-              background: selected === opt.v ? 'var(--c-navy-tint)' : 'var(--c-card)',
-              border: `1.5px solid ${selected === opt.v ? 'var(--c-navy)' : 'var(--c-line)'}`,
+              background: selected === opt.value ? 'var(--c-navy-tint)' : 'var(--c-card)',
+              border: `1.5px solid ${selected === opt.value ? 'var(--c-navy)' : 'var(--c-line)'}`,
               borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit',
               display: 'flex', alignItems: 'center', gap: 12, transition: 'all 120ms',
             }}
           >
-            <span style={{ color: selected === opt.v ? 'var(--c-navy)' : 'var(--c-muted)' }}>{opt.icon}</span>
-            <span style={{ fontSize: 13, fontWeight: 600, color: selected === opt.v ? 'var(--c-navy)' : 'var(--c-ink)', flex: 1 }}>
+            <span style={{ color: selected === opt.value ? 'var(--c-navy)' : 'var(--c-muted)' }}><opt.Icon size={18} /></span>
+            <span style={{ fontSize: 13, fontWeight: 600, color: selected === opt.value ? 'var(--c-navy)' : 'var(--c-ink)', flex: 1 }}>
               {opt.label}
             </span>
-            {selected === opt.v && (
+            {selected === opt.value && (
               <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-btn-primary)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                 <Check size={12} strokeWidth={2.5} color="#fff" />
               </div>
@@ -283,10 +259,7 @@ function LanguageSheet({ open, onClose, onApply, currentLocale }: {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open])
 
-  const options = [
-    { v: 'en', label: t('languageEnglish') },
-    { v: 'vi', label: t('languageVietnamese') },
-  ]
+  const options = localeOptions(t)
 
   function handleApply() {
     onApply(selected)
@@ -298,21 +271,21 @@ function LanguageSheet({ open, onClose, onApply, currentLocale }: {
       <div style={{ display: 'grid', gap: 8, marginBottom: 14 }}>
         {options.map(opt => (
           <button
-            key={opt.v}
-            onClick={() => setSelected(opt.v)}
+            key={opt.value}
+            onClick={() => setSelected(opt.value)}
             style={{
               width: '100%', textAlign: 'left', padding: '14px 16px', minHeight: 44,
-              background: selected === opt.v ? 'var(--c-navy-tint)' : 'var(--c-card)',
-              border: `1.5px solid ${selected === opt.v ? 'var(--c-navy)' : 'var(--c-line)'}`,
+              background: selected === opt.value ? 'var(--c-navy-tint)' : 'var(--c-card)',
+              border: `1.5px solid ${selected === opt.value ? 'var(--c-navy)' : 'var(--c-line)'}`,
               borderRadius: 12, cursor: 'pointer', fontFamily: 'inherit',
               display: 'flex', alignItems: 'center', gap: 12, transition: 'all 120ms',
             }}
           >
-            <span style={{ color: selected === opt.v ? 'var(--c-navy)' : 'var(--c-muted)' }}><Globe size={18} /></span>
-            <span style={{ fontSize: 13, fontWeight: 600, color: selected === opt.v ? 'var(--c-navy)' : 'var(--c-ink)', flex: 1 }}>
+            <span style={{ color: selected === opt.value ? 'var(--c-navy)' : 'var(--c-muted)' }}><opt.Icon size={18} /></span>
+            <span style={{ fontSize: 13, fontWeight: 600, color: selected === opt.value ? 'var(--c-navy)' : 'var(--c-ink)', flex: 1 }}>
               {opt.label}
             </span>
-            {selected === opt.v && (
+            {selected === opt.value && (
               <div style={{ width: 20, height: 20, borderRadius: 10, background: 'var(--c-btn-primary)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                 <Check size={12} strokeWidth={2.5} color="#fff" />
               </div>
@@ -375,7 +348,7 @@ function SettingsRow({ icon, label, value, onClick, last = false }: {
 
 // ─── Main component ────────────────────────────────────────────────────────────
 
-export default function MobileSettingsView({ email, initials, displayName }: Props) {
+export default function MobileSettingsView({ email, initials, displayName }: SettingsViewProps) {
   const locale = useLocale()
   const t = useTranslations('settings')
   const { setMobileTopBar } = useNavigation()
@@ -396,12 +369,10 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
 
   const isSyncing = c.syncStatus === 'syncing'
 
-  const localeLabel = locale === 'vi' ? t('languageVietnamese') : t('languageEnglish')
-  const appearanceLabel = c.themeChoice === 'dark'
-    ? t('appearanceDark')
-    : c.themeChoice === 'light'
-    ? t('appearanceLight')
-    : t('appearanceSystem')
+  // Both summaries read off the same option lists the sheets render, so a new
+  // choice can't appear in the picker and be missing from the row.
+  const currentLocaleLabel = localeLabel(locale, t)
+  const appearanceLabel = themeLabel(c.themeChoice, t)
 
   return (
     <>
@@ -444,7 +415,7 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
             <SettingsRow
               icon={<Globe size={16} />}
               label={t('language')}
-              value={localeLabel}
+              value={currentLocaleLabel}
               onClick={() => setShowLanguage(true)}
             />
             <SettingsRow
@@ -498,26 +469,13 @@ export default function MobileSettingsView({ email, initials, displayName }: Pro
 
             {/* Source rows */}
             <div style={{ display: 'grid', gap: 8, padding: '12px 0 0', borderTop: '1px solid var(--c-line)' }}>
-              {[
-                {
-                  icon: <TrendingUp size={14} />,
-                  color: '#2563eb',
-                  label: t('fundNav'),
-                  note: t('fundNavNote'),
-                },
-                {
-                  icon: <Coins size={14} />,
-                  color: 'var(--c-fund-gold)',
-                  label: t('goldPrice'),
-                  note: t('goldNote'),
-                },
-              ].map((row, i) => (
-                <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              {priceSources(t).map((row) => (
+                <div key={row.key} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
                   <div style={{
                     width: 28, height: 28, borderRadius: 7, background: 'var(--c-card-2)',
                     color: row.color, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0,
                   }}>
-                    {row.icon}
+                    <row.Icon size={14} />
                   </div>
                   <div style={{ flex: 1, minWidth: 0 }}>
                     <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-ink)' }}>{row.label}</div>

--- a/app/(app)/settings/useSettingsController.ts
+++ b/app/(app)/settings/useSettingsController.ts
@@ -8,7 +8,7 @@ import { toast } from 'sonner'
 import { useTheme, type ThemeChoice } from '@/components/layout/ThemeProvider'
 import { useNavigation } from '@/components/navigation/NavigationContext'
 import type { DashboardData } from '@/features/dashboard/contracts'
-import { useManagedTimeout } from './useManagedTimeout'
+import { useManagedTimeout } from '@/components/ui/useManagedTimeout'
 import {
   clearAppCaches, setLocaleCookie, refreshPrices, fetchOverview,
   exportPortfolioReport, fetchLastSync, formatLastSync,

--- a/components/ui/useManagedTimeout.ts
+++ b/components/ui/useManagedTimeout.ts
@@ -9,7 +9,9 @@ import { useCallback, useEffect, useRef } from 'react'
 // stacking a second one.
 //
 // Lived inside MobileSettingsView; desktop used a bare setTimeout and leaked
-// (#570). Shared so both views get the cleanup.
+// (#570). Shared so both views get the cleanup, and moved here from the settings
+// route when the profile editor became a feature module (#603) — it knows
+// nothing about settings, so under docs/architecture.md it is a UI primitive.
 export function useManagedTimeout() {
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,15 +76,23 @@ Done:
   the skipped/overridden/amount rules for a fixed expense and an insurance
   member) into `features/planning/planModel.ts`. Three of those copies had
   already drifted. The table and the card stack stay separate.
+- Settings desktop/mobile drift (#603): the theme, language and price-source
+  tables in `features/settings/settingsOptions.ts` — each had been declared
+  twice, with a third hand-written chain on mobile to summarise the current
+  choice in the row — and the profile editor's draft + save-flash sequence in
+  `useProfileEditor`, replacing a copy in each view that carried its own
+  `SAVE_FLASH_MS`. `useManagedTimeout` moved to `components/ui/`; it knows
+  nothing about settings.
 - One component root: `app/components/` folded into `components/{ui,layout,navigation}`
   and `features/landing/`. The app shell no longer imports a screen — the
   add-transaction sheet reaches it as an opaque `overlays` node from the route
   group, with its open flag in `NavigationContext`.
 
+All three drift areas in #603 are done: Fund Library, Planning, Settings.
+
 Still open — incremental, as files are touched, not as a repo-wide rename:
 
 - `app/assets/` split into `features/dashboard`, `features/investments`,
-  `features/goals`, `features/insurance`.
-- Settings desktop/mobile drift (#603) — Fund Library and Planning are done.
-  Keep the shells separate where the UX genuinely differs; extract the shared
-  models, actions and form fields.
+  `features/goals`, `features/insurance`. This is the standing rule for new
+  work, not a migration anyone should schedule: move a file the first time you
+  have a reason to open it.

--- a/features/settings/__tests__/settingsOptions.test.ts
+++ b/features/settings/__tests__/settingsOptions.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { Sun, Moon, Settings, Globe, TrendingUp, Coins } from 'lucide-react'
+import {
+  themeOptions, themeLabel, localeOptions, localeLabel, priceSources,
+} from '../settingsOptions'
+
+// The views pass next-intl's `t`; echoing the key is enough to prove which
+// message each option asks for, without pulling the catalogue in.
+const t = (key: string) => key
+
+describe('themeOptions', () => {
+  it('offers light, dark and system, in that order', () => {
+    expect(themeOptions(t).map(o => o.value)).toEqual(['light', 'dark', 'system'])
+  })
+
+  it('labels each choice from the settings catalogue', () => {
+    expect(themeOptions(t).map(o => o.label))
+      .toEqual(['appearanceLight', 'appearanceDark', 'appearanceSystem'])
+  })
+
+  // The icon travels as a component, not an element: desktop renders it at 13px
+  // and the mobile sheet at 18px, and that is the only thing they differed on.
+  it('carries the icon as a component the caller sizes', () => {
+    expect(themeOptions(t).map(o => o.Icon)).toEqual([Sun, Moon, Settings])
+  })
+})
+
+describe('themeLabel', () => {
+  it('is the label of the matching option', () => {
+    expect(themeLabel('dark', t)).toBe('appearanceDark')
+    expect(themeLabel('light', t)).toBe('appearanceLight')
+    expect(themeLabel('system', t)).toBe('appearanceSystem')
+  })
+
+  // Mobile's row summary was a hand-written if/else chain beside the sheet's own
+  // option list — two places to update to add a choice. Reading it off the list
+  // is what keeps them from disagreeing.
+  it('agrees with the option list for every choice', () => {
+    for (const option of themeOptions(t)) {
+      expect(themeLabel(option.value, t)).toBe(option.label)
+    }
+  })
+})
+
+describe('localeOptions', () => {
+  it('offers English and Vietnamese', () => {
+    expect(localeOptions(t).map(o => o.value)).toEqual(['en', 'vi'])
+    expect(localeOptions(t).map(o => o.label)).toEqual(['languageEnglish', 'languageVietnamese'])
+  })
+
+  it('carries the globe icon for each', () => {
+    expect(localeOptions(t).map(o => o.Icon)).toEqual([Globe, Globe])
+  })
+})
+
+describe('localeLabel', () => {
+  it('is the label of the matching option', () => {
+    expect(localeLabel('vi', t)).toBe('languageVietnamese')
+    expect(localeLabel('en', t)).toBe('languageEnglish')
+  })
+
+  // The app only ever serves 'en' and 'vi'; anything else is a misconfiguration,
+  // and English is what the rest of the app falls back to.
+  it('falls back to English for an unknown locale', () => {
+    expect(localeLabel('fr', t)).toBe('languageEnglish')
+  })
+})
+
+describe('priceSources', () => {
+  it('lists what a sync refreshes, with its label and note', () => {
+    expect(priceSources(t)).toEqual([
+      { key: 'nav',  label: 'fundNav',   note: 'fundNavNote', color: '#2563eb',            Icon: TrendingUp },
+      { key: 'gold', label: 'goldPrice', note: 'goldNote',    color: 'var(--c-fund-gold)', Icon: Coins },
+    ])
+  })
+
+  // #264: colours come from theme tokens, not hard-coded hex — except this one
+  // blue, which predates the token set and is checked here so the exception is
+  // visible rather than silently copied into a third place.
+  it('uses the gold token for the gold row', () => {
+    expect(priceSources(t).find(s => s.key === 'gold')?.color).toMatch(/^var\(--/)
+  })
+})

--- a/features/settings/__tests__/useProfileEditor.test.tsx
+++ b/features/settings/__tests__/useProfileEditor.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useProfileEditor } from '../useProfileEditor'
+import { SAVE_FLASH_MS } from '../settingsOptions'
+
+describe('useProfileEditor', () => {
+  beforeEach(() => { vi.useFakeTimers() })
+  afterEach(() => { vi.useRealTimers() })
+
+  function setup(saveProfile: (name: string) => Promise<boolean>, onDone = vi.fn()) {
+    const view = renderHook(() => useProfileEditor('Minh Tran', saveProfile, onDone))
+    return { ...view, onDone }
+  }
+
+  it('opens on the current display name', () => {
+    const { result } = setup(vi.fn())
+    expect(result.current.name).toBe('Minh Tran')
+    expect(result.current.saved).toBe(false)
+  })
+
+  it('edits the draft without touching the account', async () => {
+    const saveProfile = vi.fn()
+    const { result } = setup(saveProfile)
+    act(() => result.current.setName('Minh'))
+    expect(result.current.name).toBe('Minh')
+    expect(saveProfile).not.toHaveBeenCalled()
+  })
+
+  it('persists the draft, flashes Saved, then closes', async () => {
+    const saveProfile = vi.fn().mockResolvedValue(true)
+    const { result, onDone } = setup(saveProfile)
+
+    act(() => result.current.setName('Minh'))
+    await act(async () => { await result.current.save() })
+
+    expect(saveProfile).toHaveBeenCalledWith('Minh')
+    expect(result.current.saved).toBe(true)
+    expect(onDone).not.toHaveBeenCalled()
+
+    act(() => { vi.advanceTimersByTime(SAVE_FLASH_MS) })
+    expect(result.current.saved).toBe(false)
+    expect(onDone).toHaveBeenCalledTimes(1)
+  })
+
+  // A failed write surfaces its own toast from saveProfile. Flashing "Saved" and
+  // closing over it would tell the user their name was stored when it wasn't.
+  it('neither flashes nor closes when the write fails', async () => {
+    const { result, onDone } = setup(vi.fn().mockResolvedValue(false))
+
+    await act(async () => { await result.current.save() })
+
+    expect(result.current.saved).toBe(false)
+    act(() => { vi.advanceTimersByTime(SAVE_FLASH_MS * 2) })
+    expect(onDone).not.toHaveBeenCalled()
+  })
+
+  it('reopens on the latest saved name after an edit is abandoned', () => {
+    const { result } = setup(vi.fn())
+    act(() => result.current.setName('typed but never saved'))
+    act(() => result.current.reset())
+    expect(result.current.name).toBe('Minh Tran')
+    expect(result.current.saved).toBe(false)
+  })
+
+  // The desktop view used a bare setTimeout here and leaked a setState past
+  // unmount (#570). The shared editor schedules through useManagedTimeout.
+  it('does not fire the flash reset after unmount', async () => {
+    const onDone = vi.fn()
+    const { result, unmount } = renderHook(() =>
+      useProfileEditor('Minh Tran', () => Promise.resolve(true), onDone))
+
+    await act(async () => { await result.current.save() })
+    unmount()
+    act(() => { vi.advanceTimersByTime(SAVE_FLASH_MS * 2) })
+
+    expect(onDone).not.toHaveBeenCalled()
+  })
+
+  it('tracks a display name that changes underneath it', async () => {
+    const { result, rerender } = renderHook(
+      ({ name }) => useProfileEditor(name, () => Promise.resolve(true), vi.fn()),
+      { initialProps: { name: 'Minh Tran' } },
+    )
+    rerender({ name: 'Minh T' })
+    act(() => result.current.reset())
+    expect(result.current.name).toBe('Minh T')
+  })
+})

--- a/features/settings/settingsOptions.ts
+++ b/features/settings/settingsOptions.ts
@@ -1,0 +1,75 @@
+// The settings page's option tables (#603).
+//
+// Desktop rendered the theme and language choices as inline chips, mobile as
+// bottom-sheet pickers, and each declared its own copy of what the choices are
+// — plus a third hand-written if/else on mobile to summarise the current one in
+// the row. The price-source rows (fund NAV, gold) were duplicated outright. One
+// table each, here, so adding or renaming a choice is a single edit.
+//
+// Deliberately NOT shared: the chips and the picker rows themselves. Desktop
+// applies a choice on click; the mobile sheets are select-then-Apply, which is
+// the right shape for a thumb and the wrong one for a settings pane.
+
+import { Sun, Moon, Settings, Globe, TrendingUp, Coins, type LucideIcon } from 'lucide-react'
+import type { ThemeChoice } from '@/components/layout/ThemeProvider'
+
+/** next-intl's `t` for the 'settings' namespace, as the views already hold it. */
+export type Translate = (key: string) => string
+
+/** What both views need to render a user: passed down from the server page. */
+export interface SettingsViewProps {
+  email: string
+  initials: string
+  displayName: string
+}
+
+/** How long the "Saved" flash stays up before the profile editor closes. */
+export const SAVE_FLASH_MS = 1400
+
+export interface ChoiceOption<T> {
+  value: T
+  label: string
+  /** The icon as a *component* — desktop renders it at 13px, mobile at 18px. */
+  Icon: LucideIcon
+}
+
+export function themeOptions(t: Translate): ChoiceOption<ThemeChoice>[] {
+  return [
+    { value: 'light',  label: t('appearanceLight'),  Icon: Sun },
+    { value: 'dark',   label: t('appearanceDark'),   Icon: Moon },
+    { value: 'system', label: t('appearanceSystem'), Icon: Settings },
+  ]
+}
+
+/** The current theme, as the mobile Appearance row summarises it. */
+export function themeLabel(choice: ThemeChoice, t: Translate): string {
+  return themeOptions(t).find(o => o.value === choice)?.label ?? t('appearanceSystem')
+}
+
+export function localeOptions(t: Translate): ChoiceOption<string>[] {
+  return [
+    { value: 'en', label: t('languageEnglish'),    Icon: Globe },
+    { value: 'vi', label: t('languageVietnamese'), Icon: Globe },
+  ]
+}
+
+/** The current language, as the mobile Language row summarises it. */
+export function localeLabel(locale: string, t: Translate): string {
+  return localeOptions(t).find(o => o.value === locale)?.label ?? t('languageEnglish')
+}
+
+export interface PriceSource {
+  key: 'nav' | 'gold'
+  label: string
+  note: string
+  color: string
+  Icon: LucideIcon
+}
+
+/** What a price sync refreshes, as listed under the Sync now button. */
+export function priceSources(t: Translate): PriceSource[] {
+  return [
+    { key: 'nav',  label: t('fundNav'),   note: t('fundNavNote'), color: '#2563eb',            Icon: TrendingUp },
+    { key: 'gold', label: t('goldPrice'), note: t('goldNote'),    color: 'var(--c-fund-gold)', Icon: Coins },
+  ]
+}

--- a/features/settings/useProfileEditor.ts
+++ b/features/settings/useProfileEditor.ts
@@ -1,0 +1,51 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { useManagedTimeout } from '@/components/ui/useManagedTimeout'
+import { SAVE_FLASH_MS } from './settingsOptions'
+
+// The profile editor's draft state and its save sequence (#603).
+//
+// Desktop kept this inline in the modal, mobile in a ProfileSheet — the same
+// six lines twice, each with a local `SAVE_FLASH_MS = 1400` and a comment
+// promising to keep it in step with the other. The chrome around it genuinely
+// differs (a centred modal vs a bottom sheet), the sequence does not.
+
+export interface ProfileEditor {
+  /** The draft name, which can be ahead of what the account holds. */
+  name: string
+  setName: (name: string) => void
+  /** True while the success flash is showing. */
+  saved: boolean
+  /** Persist the draft; on success flash, then call `onDone`. */
+  save: () => Promise<void>
+  /** Re-open on the current display name, discarding an abandoned edit. */
+  reset: () => void
+}
+
+export function useProfileEditor(
+  displayName: string,
+  saveProfile: (name: string) => Promise<boolean>,
+  onDone: () => void,
+): ProfileEditor {
+  const [name, setName] = useState(displayName)
+  const [saved, setSaved] = useState(false)
+  const scheduleFlashReset = useManagedTimeout()
+
+  const reset = useCallback(() => {
+    setName(displayName)
+    setSaved(false)
+  }, [displayName])
+
+  const save = useCallback(async () => {
+    // Only flash "Saved" and close once the write succeeded — a failed update
+    // surfaces its own toast from saveProfile and keeps the form open over the
+    // name the user typed.
+    const ok = await saveProfile(name)
+    if (!ok) return
+    setSaved(true)
+    scheduleFlashReset(() => { setSaved(false); onDone() }, SAVE_FLASH_MS)
+  }, [saveProfile, name, onDone, scheduleFlashReset])
+
+  return { name, setName, saved, save, reset }
+}


### PR DESCRIPTION
The last of #603's three drift areas (parent #600). Fund Library shipped in #632, Planning in #633.

Settings already shared its network calls (`settingsShared`) and its React orchestration (`useSettingsController`, #570). What was left duplicated was the **data behind the choices**, and the one flow each view had re-implemented.

## What was duplicated

| | Before | After |
| --- | --- | --- |
| Theme + language choices | declared once per view, **plus** a third hand-written if/else on mobile to summarise the current choice in its row — three places to edit to add a theme, and the row free to disagree with the picker it opens | one table each; both summaries read off the list the sheets render |
| Price-source rows (fund NAV, gold) | duplicated outright, differing only in icon size | one table; the icon travels as a *component*, so each view sizes it (13px / 14px / 18px) |
| Profile save + "Saved" flash | the same six lines twice, each with its own `SAVE_FLASH_MS = 1400` and a comment promising to keep it in step with the other | `useProfileEditor` owns the draft and the sequence |

`useManagedTimeout` moves to `components/ui/` — the shared editor needs it and it knows nothing about settings, which is the rule in `docs/architecture.md`.

**Deliberately not shared:** the chips and the picker rows. Desktop applies a choice on click; the mobile sheets are select-then-Apply, which is right for a thumb and wrong for a settings pane.

## Checks

`typecheck`, `lint` (0 errors), `build` clean. 2,186 unit tests pass (18 new); coverage 63.11% statements, above the 63.07 floor. Targeted E2E green: `settings`, `settings-desktop`, `report` (9 passed).

## Worth checking on the preview

Settings on both breakpoints: switching language and theme (desktop chips apply on click, mobile sheets on Apply), the mobile Language/Appearance rows showing the current choice, editing and saving the display name — including that a failed save keeps the form open — and the Sync now card with its two source rows.

## After this

All three areas of #603 are done, and I believe #600's acceptance criteria are met — see the issue for the rundown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)