### PR TITLE
fix(dashboard): count a withdrawal parented to a fund purchase (#606)

### DIFF
--- a/app/api/v1/dashboard/overview/__tests__/route.test.ts
+++ b/app/api/v1/dashboard/overview/__tests__/route.test.ts
@@ -150,6 +150,84 @@ describe('GET /api/v1/dashboard/overview — partial reads never corrupt snapsho
   }
 })
 
+// #606 — a withdrawal parented to a FUND PURCHASE (not itself fund-keyed: no
+// fund_id, asset_type omitted). It used to be filed under a key the dashboard
+// never reads, so the cash left while the fund kept every unit: net worth
+// overstated by the withdrawn amount, silently. Asserted end-to-end through the
+// handler, not just on the map, because the map is only half the loop — the
+// bucket the reader consults is the other half.
+describe('GET /api/v1/dashboard/overview — a fund-parented withdrawal is counted (#606)', () => {
+  const FUND = { id: 'f1', name: 'Fund One', nav: 25_000, updated_at: new Date().toISOString(), fund_type: 'equity' }
+
+  /** One 50-unit / 2m đồng purchase, plus `wd` withdrawal rows. */
+  function ledger(wd: Record<string, unknown>[]) {
+    h.tables.savings_goals = { data: [{ goal_id: 'g1', goal_name: 'Goal', target_amount: 10_000_000, target_date: null }], error: null }
+    h.tables.active_investment_transactions = {
+      data: [
+        {
+          transaction_id: 'buy-1', goal_id: 'g1', asset_type: 'fund', transaction_type: 'investment',
+          amount_vnd: 2_000_000, units: 50, unit_price: 40_000, investment_date: '2026-01-01',
+          fund_id: 'f1', funds: FUND, affects_progress: true,
+        },
+        ...wd.map((w, i) => ({
+          transaction_id: `wd-${i}`, goal_id: 'g1', asset_type: null, transaction_type: 'withdrawal',
+          amount_vnd: 0, units: null, investment_date: '2026-02-01', parent_transaction_id: 'buy-1',
+          affects_progress: true, ...w,
+        })),
+      ],
+      error: null,
+    }
+  }
+
+  async function overview() {
+    const res = await GET()
+    expect(res.status).toBe(200)
+    return await res.json() as {
+      netWorth: { netWorth: number }
+      goals: { currentValue: number; progressValue: number; funds: { quantity: number; currentValue: number; costBasis: number }[] }[]
+    }
+  }
+
+  it('leaves the full holding when nothing was withdrawn', async () => {
+    ledger([])
+    const d = await overview()
+    expect(d.netWorth.netWorth).toBe(1_250_000) // 50 units × 25,000
+    expect(d.goals[0].funds[0].quantity).toBe(50)
+  })
+
+  it('drops the sold units from net worth and from the fund row', async () => {
+    ledger([{ principal_withdrawn: 400_000, units_withdrawn: 10 }])
+    const d = await overview()
+    expect(d.goals[0].funds[0].quantity).toBe(40)
+    expect(d.goals[0].funds[0].costBasis).toBe(1_600_000)
+    expect(d.netWorth.netWorth).toBe(1_000_000) // 40 × 25,000 — not the un-withdrawn 1,250,000
+    // The goal card and the headline are computed from the same bucket.
+    expect(d.goals[0].currentValue).toBe(1_000_000)
+    expect(d.goals[0].progressValue).toBe(1_000_000)
+  })
+
+  it('derives the units when the row records only principal', async () => {
+    ledger([{ principal_withdrawn: 500_000, units_withdrawn: null }])
+    const d = await overview()
+    expect(d.goals[0].funds[0].quantity).toBe(37.5) // 50 − 50 × 500k/2m
+    expect(d.netWorth.netWorth).toBe(937_500)
+  })
+
+  it('holds the bar steady for an affects_progress=false sale while net worth falls', async () => {
+    ledger([{ principal_withdrawn: 400_000, units_withdrawn: 10, affects_progress: false }])
+    const d = await overview()
+    expect(d.netWorth.netWorth).toBe(1_000_000)          // valuation: the units are gone
+    expect(d.goals[0].progressValue).toBe(1_250_000) // progress: held steady
+  })
+
+  it('drops the holding entirely when the whole purchase is withdrawn', async () => {
+    ledger([{ principal_withdrawn: 2_000_000, units_withdrawn: 50 }])
+    const d = await overview()
+    expect(d.netWorth.netWorth).toBe(0)
+    expect(d.goals[0].funds).toHaveLength(0)
+  })
+})
+
 describe('GET /api/v1/dashboard/overview — optional gold price (#513)', () => {
   it('still returns 200 when gold_price_settings has no row (PGRST116)', async () => {
     h.tables.gold_price_settings = { data: null, error: { code: 'PGRST116' } }

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -241,6 +241,22 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     )
   }
 
+  // The withdrawal invariant refused the edit. An asset-type change can create the
+  // shape a withdrawal may not wear — a holding becoming a fund purchase while a
+  // withdrawal that is not keyed by a fund draws on it (#606) — and the row is
+  // right there on screen, so 404 'not found' would describe it as something else
+  // entirely. Matched on the family prefix, exactly as POST does, so a refusal
+  // added later cannot fall through as the wrong status.
+  if (error?.message?.includes('withdrawal invariant:')) {
+    return NextResponse.json(
+      {
+        error: 'A withdrawal is recorded against this holding. Remove it before changing the holding this way.',
+        code: 'withdrawal_invariant',
+      },
+      { status: 400 },
+    )
+  }
+
   if (error || !transaction) return NextResponse.json({ error: 'Transaction not found' }, { status: 404 })
 
   // (Accumulating books took the atomic update_deposit_book path above; only

--- a/app/api/v1/investment-transactions/__tests__/route.put.invariant.test.ts
+++ b/app/api/v1/investment-transactions/__tests__/route.put.invariant.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// A holding cannot become a fund purchase while a withdrawal that is not keyed by
+// a fund draws on it (#606, supabase/migrations/20260803000003). That refusal
+// reaches this route as an ordinary database error, and the route used to map
+// everything it didn't recognise to 404 'Transaction not found' — describing a
+// refused edit as a missing row, on a holding the user is looking at.
+//
+// Same contract the POST route already keeps for the withdrawal family: one match
+// on the 'withdrawal invariant:' prefix, so a refusal added later cannot fall
+// through as the wrong status.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  existing: { data: { deposit_group_id: null, asset_type: 'bank' } as unknown, error: null as unknown },
+  fund: { data: { id: 'f1' } as unknown, error: null as unknown },
+  updateResult: { data: null as unknown, error: null as unknown },
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chain = (table: string) => {
+    let op = 'select'
+    const c: Record<string, unknown> = {
+      select: () => c,
+      update: () => { op = 'update'; return c },
+      eq: () => c,
+      single: async () => {
+        if (op === 'update') return h.updateResult
+        if (table === 'funds') return h.fund
+        if (table === 'savings_goals') return { data: { goal_id: 'g1' }, error: null }
+        return h.existing
+      },
+      maybeSingle: async () => h.existing,
+      then: (resolve: (v: unknown) => void) => resolve({ data: null, error: null }),
+    }
+    return c
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (table: string) => chain(table),
+      rpc: () => ({ single: async () => ({ data: null, error: { message: 'not used' } }) }),
+    }),
+  }
+})
+
+const { PUT } = await import('../[id]/route')
+
+const TX = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const FUND = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+
+const call = (body: Record<string, unknown>) =>
+  PUT(
+    new NextRequest(`https://app.test/api/v1/investment-transactions/${TX}`, {
+      method: 'PUT',
+      body: JSON.stringify(body),
+    }),
+    { params: Promise.resolve({ id: TX }) },
+  )
+
+const TO_FUND = { asset_type: 'fund', fund_id: FUND, units: 50, unit_price: 40_000 }
+
+describe('PUT /api/v1/investment-transactions/[id] — the withdrawal invariant (#606)', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.existing = { data: { deposit_group_id: null, asset_type: 'bank' }, error: null }
+    h.fund = { data: { id: 'f1' }, error: null }
+    h.updateResult = { data: { transaction_id: TX }, error: null }
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it('converts a plain holding when nothing draws on it', async () => {
+    const res = await call(TO_FUND)
+    expect(res.status).toBe(200)
+  })
+
+  it('answers 400, not 404, when the conversion is refused by the invariant', async () => {
+    h.updateResult = {
+      data: null,
+      error: {
+        code: '23514',
+        message: 'withdrawal invariant: holding abc cannot become a fund purchase while a withdrawal that is not keyed by a fund draws on it',
+      },
+    }
+    const res = await call(TO_FUND)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    // The user is told what to do about it, not shown the raw refusal.
+    expect(body.error).not.toMatch(/^withdrawal invariant: /)
+    expect(body.error).toMatch(/withdrawal/i)
+  })
+
+  // One match on the family prefix, so a refusal written later cannot regress to
+  // 'Transaction not found' the way listing messages individually allowed.
+  it('maps any invariant refusal the same way', async () => {
+    h.updateResult = {
+      data: null,
+      error: { code: '23514', message: 'withdrawal invariant: something nobody has written yet' },
+    }
+    expect((await call(TO_FUND)).status).toBe(400)
+  })
+
+  it('still answers 404 for a genuinely missing row', async () => {
+    h.updateResult = { data: null, error: { code: 'PGRST116', message: 'No rows found' } }
+    const res = await call(TO_FUND)
+    expect(res.status).toBe(404)
+  })
+})

--- a/lib/__tests__/withdrawalProgress.test.ts
+++ b/lib/__tests__/withdrawalProgress.test.ts
@@ -193,6 +193,18 @@ describe('buildWithdrawalMaps', () => {
       expect(fundWdMapAll.get('goal-1::fund-1')).toEqual({ units: 12.5, cost: 500_000 }) // 50 × 500k/2m
     })
 
+    // The old parent-backed write path required positive units only from a gold
+    // parent, so a recorded ZERO next to a real principal is a shape this data
+    // wears. Kept as zero it would be worse than before the fix: the overview
+    // skips a bucket entry with units <= 0 outright, principal and all.
+    it('treats a recorded zero as an absent quantity, not as "no units"', () => {
+      const wd = makeWithdrawal({
+        parent_transaction_id: 'buy-1', units_withdrawn: 0, principal_withdrawn: 500_000,
+      })
+      const { fundWdMapAll } = buildWithdrawalMaps([wd], [buy])
+      expect(fundWdMapAll.get('goal-1::fund-1')).toEqual({ units: 12.5, cost: 500_000 })
+    })
+
     it('never derives more units than the purchase holds', () => {
       const wd = makeWithdrawal({
         parent_transaction_id: 'buy-1', units_withdrawn: null, principal_withdrawn: 9_000_000,

--- a/lib/__tests__/withdrawalProgress.test.ts
+++ b/lib/__tests__/withdrawalProgress.test.ts
@@ -213,12 +213,27 @@ describe('buildWithdrawalMaps', () => {
       expect(fundWdMapAll.get('goal-1::fund-1')).toEqual({ units: 50, cost: 9_000_000 })
     })
 
-    it('derives no units from a purchase that records none (a pending DCA seed)', () => {
+    // A purchase with no units is no bucket: lib/dashboardOverview keys a fund
+    // holding on `asset_type === 'fund' && tx.units`, so a pending DCA seed (units
+    // null) or a zero-unit purchase is valued as an ordinary holding — reduced
+    // through the PARENT map. Redirecting there would file the claim where nothing
+    // reads it and give the purchase its principal back.
+    it('leaves a withdrawal on the parent axis when the purchase records no units', () => {
       const wd = makeWithdrawal({
         parent_transaction_id: 'buy-1', units_withdrawn: null, principal_withdrawn: 500_000,
       })
-      const { fundWdMapAll } = buildWithdrawalMaps([wd], [{ ...buy, units: null }])
-      expect(fundWdMapAll.get('goal-1::fund-1')).toEqual({ units: 0, cost: 500_000 })
+      const { fundWdMapAll, parentWdMapAll } = buildWithdrawalMaps([wd], [{ ...buy, units: null }])
+      expect(fundWdMapAll.size).toBe(0)
+      expect(parentWdMapAll.get('buy-1')).toEqual({ principal: 500_000, units: 0 })
+    })
+
+    it('leaves it on the parent axis for a zero-unit purchase too', () => {
+      const wd = makeWithdrawal({
+        parent_transaction_id: 'buy-1', units_withdrawn: null, principal_withdrawn: 500_000,
+      })
+      const { fundWdMapAll, parentWdMapAll } = buildWithdrawalMaps([wd], [{ ...buy, units: 0 }])
+      expect(fundWdMapAll.size).toBe(0)
+      expect(parentWdMapAll.get('buy-1')).toEqual({ principal: 500_000, units: 0 })
     })
 
     it('keeps the progress axis: an affects_progress=false row is valued but not progressed', () => {

--- a/lib/__tests__/withdrawalProgress.test.ts
+++ b/lib/__tests__/withdrawalProgress.test.ts
@@ -137,6 +137,10 @@ describe('buildWithdrawalMaps', () => {
   // map under a key nothing reads: the dashboard values a fund through the (goal,
   // fund) map and never consults parentWdMap, so the cash left while the fund kept
   // every unit — net worth overstated by the withdrawn amount, silently.
+  //
+  // The shape is refused at write time now (check_withdrawal_balance, #606), so
+  // these cases are about the rows already in the ledger: they are valued, not
+  // waved through.
   describe('a withdrawal parented to a fund purchase (#606)', () => {
     const buy = {
       transaction_id: 'buy-1',

--- a/lib/__tests__/withdrawalProgress.test.ts
+++ b/lib/__tests__/withdrawalProgress.test.ts
@@ -131,4 +131,128 @@ describe('buildWithdrawalMaps', () => {
       expect(parentWdMapAll.get('parent-1')).toEqual({ principal: 1_000_000, units: 0 }) // all three
     })
   })
+
+  // #606 — a withdrawal that names a FUND PURCHASE as its parent but is not itself
+  // fund-keyed (no fund_id, or asset_type not 'fund'). It used to land in the parent
+  // map under a key nothing reads: the dashboard values a fund through the (goal,
+  // fund) map and never consults parentWdMap, so the cash left while the fund kept
+  // every unit — net worth overstated by the withdrawn amount, silently.
+  describe('a withdrawal parented to a fund purchase (#606)', () => {
+    const buy = {
+      transaction_id: 'buy-1',
+      goal_id: 'goal-1',
+      asset_type: 'fund',
+      fund_id: 'fund-1',
+      transaction_type: 'investment',
+      amount_vnd: 2_000_000,
+      units: 50,
+    }
+
+    it('is filed under the PARENT purchase\'s (goal, fund) bucket, not the parent map', () => {
+      const wd = makeWithdrawal({
+        parent_transaction_id: 'buy-1', units_withdrawn: 10, principal_withdrawn: 400_000,
+      })
+      const { fundWdMap, fundWdMapAll, parentWdMap, parentWdMapAll } = buildWithdrawalMaps([wd], [buy])
+      expect(fundWdMap.get('goal-1::fund-1')).toEqual({ units: 10, cost: 400_000 })
+      expect(fundWdMapAll.get('goal-1::fund-1')).toEqual({ units: 10, cost: 400_000 })
+      expect(parentWdMap.has('buy-1')).toBe(false)   // counted once, in the bucket the reader reads
+      expect(parentWdMapAll.has('buy-1')).toBe(false)
+    })
+
+    // The bucket key comes from the PURCHASE (that is how the dashboard keys the
+    // accumulator), so a withdrawal carrying a different / missing goal_id still
+    // lands on the units it actually drew on.
+    it('keys by the purchase\'s goal, not the withdrawal\'s', () => {
+      const wd = makeWithdrawal({
+        goal_id: null, parent_transaction_id: 'buy-1', units_withdrawn: 10, principal_withdrawn: 400_000,
+      })
+      const { fundWdMapAll } = buildWithdrawalMaps([wd], [buy])
+      expect(fundWdMapAll.get('goal-1::fund-1')).toEqual({ units: 10, cost: 400_000 })
+    })
+
+    it('uses the "unallocated" key for a purchase with no goal', () => {
+      const wd = makeWithdrawal({
+        parent_transaction_id: 'buy-1', units_withdrawn: 10, principal_withdrawn: 400_000,
+      })
+      const { fundWdMapAll } = buildWithdrawalMaps([wd], [{ ...buy, goal_id: null }])
+      expect(fundWdMapAll.get('unallocated::fund-1')).toEqual({ units: 10, cost: 400_000 })
+    })
+
+    // Principal alone would drop the cost basis while every unit stayed in net
+    // worth — the fund's value is NAV × units, so the sold units have to go too.
+    // The row names ONE purchase, so that purchase's own price converts them.
+    it('derives units pro-rata from the purchase when units_withdrawn is absent', () => {
+      const wd = makeWithdrawal({
+        parent_transaction_id: 'buy-1', units_withdrawn: null, principal_withdrawn: 500_000,
+      })
+      const { fundWdMapAll } = buildWithdrawalMaps([wd], [buy])
+      expect(fundWdMapAll.get('goal-1::fund-1')).toEqual({ units: 12.5, cost: 500_000 }) // 50 × 500k/2m
+    })
+
+    it('never derives more units than the purchase holds', () => {
+      const wd = makeWithdrawal({
+        parent_transaction_id: 'buy-1', units_withdrawn: null, principal_withdrawn: 9_000_000,
+      })
+      const { fundWdMapAll } = buildWithdrawalMaps([wd], [buy])
+      expect(fundWdMapAll.get('goal-1::fund-1')).toEqual({ units: 50, cost: 9_000_000 })
+    })
+
+    it('derives no units from a purchase that records none (a pending DCA seed)', () => {
+      const wd = makeWithdrawal({
+        parent_transaction_id: 'buy-1', units_withdrawn: null, principal_withdrawn: 500_000,
+      })
+      const { fundWdMapAll } = buildWithdrawalMaps([wd], [{ ...buy, units: null }])
+      expect(fundWdMapAll.get('goal-1::fund-1')).toEqual({ units: 0, cost: 500_000 })
+    })
+
+    it('keeps the progress axis: an affects_progress=false row is valued but not progressed', () => {
+      const wd = makeWithdrawal({
+        parent_transaction_id: 'buy-1', units_withdrawn: 10, principal_withdrawn: 400_000,
+        affects_progress: false,
+      })
+      const { fundWdMap, fundWdMapAll } = buildWithdrawalMaps([wd], [buy])
+      expect(fundWdMap.has('goal-1::fund-1')).toBe(false)
+      expect(fundWdMapAll.get('goal-1::fund-1')).toEqual({ units: 10, cost: 400_000 })
+    })
+
+    it('still keys a fund-keyed row by its own fund even when it also names a parent', () => {
+      const wd = makeWithdrawal({
+        asset_type: 'fund', fund_id: 'fund-2', parent_transaction_id: 'buy-1',
+        units_withdrawn: 10, principal_withdrawn: 400_000,
+      })
+      const { fundWdMapAll } = buildWithdrawalMaps([wd], [buy])
+      expect(fundWdMapAll.get('goal-1::fund-2')).toEqual({ units: 10, cost: 400_000 })
+      expect(fundWdMapAll.has('goal-1::fund-1')).toBe(false)
+    })
+
+    // Only a FUND purchase redirects. A deposit parent, an unknown parent, or a
+    // fund purchase with no fund_id all stay on the parent axis, which is where
+    // lib/depositValuation reads them.
+    it('leaves a bank-parented withdrawal on the parent axis', () => {
+      const wd = makeWithdrawal({ parent_transaction_id: 'dep-1', principal_withdrawn: 400_000 })
+      const parents = [{ ...buy, transaction_id: 'dep-1', asset_type: 'bank', fund_id: null }]
+      const { parentWdMapAll, fundWdMapAll } = buildWithdrawalMaps([wd], parents)
+      expect(parentWdMapAll.get('dep-1')).toEqual({ principal: 400_000, units: 0 })
+      expect(fundWdMapAll.size).toBe(0)
+    })
+
+    it('leaves a withdrawal whose parent is not in the given rows on the parent axis', () => {
+      const wd = makeWithdrawal({ parent_transaction_id: 'gone-1', principal_withdrawn: 400_000 })
+      const { parentWdMapAll } = buildWithdrawalMaps([wd], [buy])
+      expect(parentWdMapAll.get('gone-1')).toEqual({ principal: 400_000, units: 0 })
+    })
+
+    it('leaves it on the parent axis when the purchase carries no fund_id', () => {
+      const wd = makeWithdrawal({ parent_transaction_id: 'buy-1', principal_withdrawn: 400_000 })
+      const { parentWdMapAll, fundWdMapAll } = buildWithdrawalMaps([wd], [{ ...buy, fund_id: null }])
+      expect(parentWdMapAll.get('buy-1')).toEqual({ principal: 400_000, units: 0 })
+      expect(fundWdMapAll.size).toBe(0)
+    })
+
+    it('is a no-op for callers that pass no parent rows', () => {
+      const wd = makeWithdrawal({ parent_transaction_id: 'buy-1', principal_withdrawn: 400_000 })
+      const { parentWdMapAll } = buildWithdrawalMaps([wd])
+      expect(parentWdMapAll.get('buy-1')).toEqual({ principal: 400_000, units: 0 })
+    })
+  })
 })

--- a/lib/dashboardOverview.ts
+++ b/lib/dashboardOverview.ts
@@ -204,7 +204,13 @@ export async function buildDashboardOverview(
   // steady). currentValue and progressValue below are computed independently
   // so a "doesn't count toward progress" withdrawal lowers net worth without
   // moving the bar — and the dashboard agrees with the goal-detail tab.
-  const { parentWdMap, fundWdMap, parentWdMapAll, fundWdMapAll } = buildWithdrawalMaps(withdrawals)
+  //
+  // The raw rows are passed as the parent index (not `investments`): a withdrawal
+  // that names a FUND PURCHASE as its parent draws on that purchase's (goal, fund)
+  // bucket, and resolving that needs the purchase itself — including a pending
+  // DCA seed, which `investments` drops but which a withdrawal can still name
+  // (#606). buildWithdrawalMaps ignores every non-fund-purchase row it is given.
+  const { parentWdMap, fundWdMap, parentWdMapAll, fundWdMapAll } = buildWithdrawalMaps(withdrawals, allTxsRaw)
 
   const insuranceMembers = insuranceRes.data ?? []
   const goldPricePerChi: number | null = goldPriceRes.data?.price_per_chi ?? null

--- a/lib/withdrawalProgress.ts
+++ b/lib/withdrawalProgress.ts
@@ -118,7 +118,14 @@ export function buildWithdrawalMaps(withdrawals: WithdrawalRow[], parents: Paren
       const derived = buyUnits > 0 && buyAmount > 0
         ? Math.min(buyUnits, (buyUnits * principal) / buyAmount)
         : 0
-      const row: WithdrawalRow = { ...wd, units_withdrawn: wd.units_withdrawn ?? derived }
+      // A recorded ZERO is treated as absent, not as a quantity. The old
+      // parent-backed write path required positive units only from a gold parent,
+      // so `units_withdrawn = 0` alongside a real principal is one of the shapes
+      // this legacy data actually wears — and dashboardOverview skips a bucket
+      // entry whose units are <= 0 entirely, principal included, which would leave
+      // exactly the #606 overstatement this function is here to remove.
+      const recorded = wd.units_withdrawn ?? 0
+      const row: WithdrawalRow = { ...wd, units_withdrawn: recorded > 0 ? recorded : derived }
       const key = fundBucketKey(fundParent.goal_id, fundParent.fund_id!)
       addFund(fundWdMapAll, key, row)
       if (affectsProgress) addFund(fundWdMap, key, row)

--- a/lib/withdrawalProgress.ts
+++ b/lib/withdrawalProgress.ts
@@ -47,22 +47,26 @@ export function fundBucketKey(goalId: string | null, fundId: string): string {
 // a fund purchase. Only a withdrawal that is neither is keyed by its parent id.
 //
 // The second half is what #606 added. A row parented to a fund purchase but not
-// itself fund-keyed (no fund_id, or asset_type omitted — a shape the POST route
-// accepts and supabase/tests/dca_seeding_heal.test.sql plants as data that exists)
-// used to land in parentWdMap under a key nothing reads: the dashboard values a
-// fund through the (goal, fund) map and never consults parentWdMap, so the cash
-// left while the fund kept every unit. Net worth was overstated by the withdrawn
-// amount, with no error and nothing on screen to show it. The trigger cannot fix
-// that — the number was wrong in the reader, not the writer — so the reader is
-// where it is fixed, which also brings EXISTING rows in that shape into the total
-// instead of leaving them silently uncounted.
+// itself fund-keyed (no fund_id, or asset_type omitted) used to land in
+// parentWdMap under a key nothing reads: the dashboard values a fund through the
+// (goal, fund) map and never consults parentWdMap, so the cash left while the fund
+// kept every unit. Net worth was overstated by the withdrawn amount, with no error
+// and nothing on screen to show it.
 //
 // The bucket key comes from the PURCHASE, not the withdrawal: that is how
 // lib/dashboardOverview keys the accumulator, so the sale lands on the units it
 // actually drew on. Units come from `units_withdrawn` when recorded and are
 // otherwise derived pro-rata from that one purchase's own price (units ×
-// principal / amount) — principal alone would drop the cost basis while every
-// unit stayed in net worth, the same trap the invariant refuses for gold.
+// principal / amount, capped at the units it holds) — principal alone would drop
+// the cost basis while every unit stayed in net worth, the same trap the invariant
+// refuses for gold.
+//
+// This half is for HISTORY. check_withdrawal_balance refuses the shape at write
+// time (20260803000002): one bucket cannot have two balances, and measuring a
+// parented row against its purchase while the units come out of the bucket let a
+// 45-unit fund-keyed sell and a 10-unit parented one take 55 units out of 50. So
+// nothing writes such a row any more; what is already in the ledger is valued here
+// rather than left silently uncounted, and withdrawal_ledger_audit reports it.
 export function buildWithdrawalMaps(withdrawals: WithdrawalRow[], parents: ParentRow[] = []): {
   parentWdMap: ParentWdMap
   fundWdMap: FundWdMap

--- a/lib/withdrawalProgress.ts
+++ b/lib/withdrawalProgress.ts
@@ -91,10 +91,18 @@ export function buildWithdrawalMaps(withdrawals: WithdrawalRow[], parents: Paren
     map.set(key, e)
   }
 
-  // Only fund purchases are indexed — every other parent stays on the parent axis.
+  // Only fund purchases the dashboard actually accumulates as a fund holding are
+  // indexed — every other parent stays on the parent axis.
+  //
+  // `p.units` is part of that, not a tidy-up: lib/dashboardOverview keys a holding
+  // into a fund bucket on `asset_type === 'fund' && tx.units`, so a purchase with
+  // ZERO units (the validators allow one) is valued as an ordinary holding and has
+  // no bucket at all. Redirecting its withdrawal would file the claim where nothing
+  // reads it and hand the purchase its full principal back — the #606 bug, from the
+  // other side.
   const fundParents = new Map<string, ParentRow>()
   for (const p of parents) {
-    if (p.asset_type === 'fund' && p.fund_id && p.transaction_type !== 'withdrawal') {
+    if (p.asset_type === 'fund' && p.fund_id && p.units && p.transaction_type !== 'withdrawal') {
       fundParents.set(p.transaction_id, p)
     }
   }

--- a/lib/withdrawalProgress.ts
+++ b/lib/withdrawalProgress.ts
@@ -9,8 +9,25 @@ export type WithdrawalRow = {
   affects_progress: boolean | null
 }
 
+// The investment rows a withdrawal can name as its parent — only enough of each
+// to decide which bucket the withdrawal draws on, and to price its units.
+export type ParentRow = {
+  transaction_id: string
+  goal_id: string | null
+  asset_type: string | null
+  fund_id: string | null
+  transaction_type?: string | null
+  amount_vnd?: number | null
+  units?: number | null
+}
+
 export type ParentWdMap = Map<string, { principal: number; units: number }>
 export type FundWdMap = Map<string, { units: number; cost: number }>
+
+/** The (goal, fund) bucket key the dashboard accumulates a fund holding under. */
+export function fundBucketKey(goalId: string | null, fundId: string): string {
+  return `${goalId ?? 'unallocated'}::${fundId}`
+}
 
 // Aggregates withdrawals onto their holding along TWO axes that must not be
 // conflated:
@@ -22,7 +39,31 @@ export type FundWdMap = Map<string, { units: number; cost: number }>
 //     the progress flag. Sharing the progress maps for valuation overstated net
 //     worth by the withdrawn amount and made the same deposit show two different
 //     values across the dashboard vs the goal-detail tab.
-export function buildWithdrawalMaps(withdrawals: WithdrawalRow[]): {
+//
+// ─── Which bucket a withdrawal draws on — ONE rule (#606) ────────────────────
+//
+// A withdrawal is valued against a (goal, fund) bucket when it is fund-keyed
+// (asset_type='fund' + fund_id) OR when the transaction it names as its parent is
+// a fund purchase. Only a withdrawal that is neither is keyed by its parent id.
+//
+// The second half is what #606 added. A row parented to a fund purchase but not
+// itself fund-keyed (no fund_id, or asset_type omitted — a shape the POST route
+// accepts and supabase/tests/dca_seeding_heal.test.sql plants as data that exists)
+// used to land in parentWdMap under a key nothing reads: the dashboard values a
+// fund through the (goal, fund) map and never consults parentWdMap, so the cash
+// left while the fund kept every unit. Net worth was overstated by the withdrawn
+// amount, with no error and nothing on screen to show it. The trigger cannot fix
+// that — the number was wrong in the reader, not the writer — so the reader is
+// where it is fixed, which also brings EXISTING rows in that shape into the total
+// instead of leaving them silently uncounted.
+//
+// The bucket key comes from the PURCHASE, not the withdrawal: that is how
+// lib/dashboardOverview keys the accumulator, so the sale lands on the units it
+// actually drew on. Units come from `units_withdrawn` when recorded and are
+// otherwise derived pro-rata from that one purchase's own price (units ×
+// principal / amount) — principal alone would drop the cost basis while every
+// unit stayed in net worth, the same trap the invariant refuses for gold.
+export function buildWithdrawalMaps(withdrawals: WithdrawalRow[], parents: ParentRow[] = []): {
   parentWdMap: ParentWdMap
   fundWdMap: FundWdMap
   parentWdMapAll: ParentWdMap
@@ -46,13 +87,37 @@ export function buildWithdrawalMaps(withdrawals: WithdrawalRow[]): {
     map.set(key, e)
   }
 
+  // Only fund purchases are indexed — every other parent stays on the parent axis.
+  const fundParents = new Map<string, ParentRow>()
+  for (const p of parents) {
+    if (p.asset_type === 'fund' && p.fund_id && p.transaction_type !== 'withdrawal') {
+      fundParents.set(p.transaction_id, p)
+    }
+  }
+
   for (const wd of withdrawals) {
     const affectsProgress = wd.affects_progress !== false
+    const fundParent = wd.parent_transaction_id ? fundParents.get(wd.parent_transaction_id) : undefined
 
     if (wd.asset_type === 'fund' && wd.fund_id) {
-      const key = `${wd.goal_id ?? 'unallocated'}::${wd.fund_id}`
+      const key = fundBucketKey(wd.goal_id, wd.fund_id)
       addFund(fundWdMapAll, key, wd)
       if (affectsProgress) addFund(fundWdMap, key, wd)
+    } else if (fundParent) {
+      // Cap the derived units at what the purchase holds: the row can name a
+      // principal larger than the purchase cost (the invariant bounds it by the
+      // parent's principal, and a repaid/edited row can still exceed it), and
+      // inventing units the purchase never had would understate net worth.
+      const buyUnits = fundParent.units ?? 0
+      const buyAmount = fundParent.amount_vnd ?? 0
+      const principal = wd.principal_withdrawn ?? 0
+      const derived = buyUnits > 0 && buyAmount > 0
+        ? Math.min(buyUnits, (buyUnits * principal) / buyAmount)
+        : 0
+      const row: WithdrawalRow = { ...wd, units_withdrawn: wd.units_withdrawn ?? derived }
+      const key = fundBucketKey(fundParent.goal_id, fundParent.fund_id!)
+      addFund(fundWdMapAll, key, row)
+      if (affectsProgress) addFund(fundWdMap, key, row)
     } else if (wd.parent_transaction_id) {
       addParent(parentWdMapAll, wd.parent_transaction_id, wd)
       if (affectsProgress) addParent(parentWdMap, wd.parent_transaction_id, wd)

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
+++ b/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
@@ -290,7 +290,11 @@ select 'parent_is_a_fund_purchase', 'review',
        case when w.fund_parented
               then format('draws %s đồng on fund purchase %s, valued against that fund bucket with units %s',
                           w.principal_withdrawn, w.parent_transaction_id,
-                          case when w.units_withdrawn is null then 'derived pro-rata' else w.units_withdrawn::text end)
+                          -- Zero is derived as well, on both sides: labelling it
+                          -- "units 0" would tell an operator nothing was removed
+                          -- while the dashboard removed the derived quantity.
+                          case when coalesce(w.units_withdrawn, 0) > 0 then w.units_withdrawn::text
+                               else 'derived pro-rata' end)
             else format('draws %s đồng on fund-typed %s %s, which carries no fund of its own — no bucket values it',
                         w.principal_withdrawn, w.parent_type, w.parent_transaction_id)
        end

--- a/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
+++ b/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
@@ -13,19 +13,24 @@
 -- writer — and it brings the rows already in the ledger into the total instead of
 -- leaving them to a backfill nobody can time.
 --
--- Only ONE branch of the view changes: 'parent_is_a_fund_purchase' told an
--- operator the row's principal "no valuation offsets", which is now false and
--- would invite a manual repair that subtracts the same money twice. Everything
--- else is copied verbatim from 20260730000003 (a view has to be re-stated whole).
+-- What changes here, and why:
 --
--- Deliberately NOT changed: the proportional checks still measure a fund bucket by
--- its fund-keyed sells alone. A fund-parented row whose units are derived is
--- proportional BY CONSTRUCTION (units = purchase units x principal / purchase
--- cost), so folding it in would only ever compare the derivation with itself; and
--- one that does record units is already named, by the check above, for review.
--- The overdraw checks need no change either: `holding_overdrawn` already measures
--- every parent-backed draw against the purchase it names, which is exactly the
--- bound the reader caps the derived units at.
+--   • fund_sells now aggregates BOTH shapes into the bucket each draws on, and
+--     `parents` stops counting a fund-parented row against the purchase row. One
+--     claim, one balance: without this, a 50-unit purchase could show a 45-unit
+--     fund-keyed sell and a 10-unit parented sell and no overdraw anywhere, while
+--     the reader subtracts 55 and drops the holding five units early.
+--   • 'parent_is_a_fund_purchase' told an operator the row's principal "no
+--     valuation offsets" — now false, and it would invite a manual repair that
+--     subtracts the same money twice. It says what the row is instead: legacy, and
+--     valued into the bucket.
+--
+-- Everything else is copied verbatim from 20260730000003 (a view has to be
+-- re-stated whole). The per-sale proportionality check still measures fund-keyed
+-- sells only: a fund-parented row's units are as often derived as recorded, and
+-- comparing a derivation against the rate it was derived from proves nothing.
+-- 20260803000002 refuses the shape at write time, so what these aggregates cover
+-- is history, and history is exactly what an audit is for.
 
 create or replace view public.withdrawal_ledger_audit
 with (security_invoker = true) as
@@ -38,7 +43,16 @@ with wd as (
          -- fund) bucket no matter what parent it also names.
          coalesce(w.asset_type = 'fund' and w.fund_id is not null, false) as fund_keyed,
          p.transaction_type as parent_type,
-         p.asset_type       as parent_asset
+         p.asset_type       as parent_asset,
+         -- The other half of the same bucket (#606): a row parented to a fund
+         -- PURCHASE draws on that purchase's (goal, fund) bucket too, so the
+         -- aggregates below have to add it there — and NOT to the parent, or one
+         -- claim would be measured against two balances.
+         p.fund_id          as parent_fund,
+         p.goal_id          as parent_goal,
+         coalesce(not (w.asset_type = 'fund' and w.fund_id is not null)
+                  and p.transaction_type = 'investment'
+                  and p.asset_type = 'fund' and p.fund_id is not null, false) as fund_parented
     from public.investment_transactions w
     left join public.investment_transactions p on p.transaction_id = w.parent_transaction_id
    where w.transaction_type = 'withdrawal'
@@ -50,7 +64,8 @@ parents as (
          sum(coalesce(w.units_withdrawn, 0))     as out_units,
          count(*)                                as sells
     from public.investment_transactions p
-    join wd w on w.parent_transaction_id = p.transaction_id and not w.fund_keyed
+    join wd w on w.parent_transaction_id = p.transaction_id
+             and not w.fund_keyed and not w.fund_parented
    where p.transaction_type = 'investment'
    group by p.transaction_id, p.user_id, p.goal_id, p.asset_type, p.amount_vnd, p.units
 ),
@@ -66,14 +81,22 @@ fund_buys as (
    group by t.user_id, t.goal_id, t.fund_id
 ),
 fund_sells as (
-  select w.user_id, w.goal_id, w.fund_id,
+  -- One bucket, both shapes. A fund-parented row's units are counted only where it
+  -- RECORDS them: the reader derives them when they are absent, and a derived
+  -- quantity is proportional by construction, so folding it in here would report
+  -- the derivation rather than the ledger. That makes the units side conservative —
+  -- it under-counts what such a row removes, never over-counts — which is the right
+  -- direction for a check that calls an overrun a violation.
+  select w.user_id,
+         case when w.fund_keyed then w.goal_id else w.parent_goal end as goal_id,
+         case when w.fund_keyed then w.fund_id else w.parent_fund end as fund_id,
          sum(coalesce(w.principal_withdrawn, 0)) as out_principal,
          sum(coalesce(w.units_withdrawn, 0))     as out_units,
          count(*)                                as sells,
          min(w.transaction_id::text)             as a_sell
     from wd w
-   where w.fund_keyed
-   group by w.user_id, w.goal_id, w.fund_id
+   where w.fund_keyed or w.fund_parented
+   group by 1, 2, 3
 ),
 fund_buckets as (
   select s.user_id, s.goal_id, s.fund_id, s.out_principal, s.out_units, s.sells, s.a_sell,
@@ -107,6 +130,9 @@ sale_dev as (
    where not w.fund_keyed and p.asset_type = 'gold' and coalesce(p.units, 0) > 0
      and coalesce(w.units_withdrawn, 0) > 0
   union all
+  -- Fund-keyed sells only. A fund-parented row is named by its own check, and its
+  -- units are as often derived as recorded — comparing a derivation against the
+  -- rate it was derived from proves nothing.
   select w.transaction_id, w.user_id, w.goal_id, w.fund_id, w.parent_transaction_id,
          w.units_withdrawn, w.principal_withdrawn,
          null::uuid, b.fund_id::text || ':' || coalesce(b.goal_id::text, ''), b.basis, b.units,
@@ -224,13 +250,16 @@ select 'parent_is_not_an_investment', 'violation',
  where not w.fund_keyed and w.parent_type is not null and w.parent_type <> 'investment'
 
 union all
--- Counted, but not in the shape the app writes. Since #606 buildWithdrawalMaps
--- values such a row against the PURCHASE's (goal, fund) bucket, so its principal
--- does reduce the holding — it is no longer the uncounted withdrawal this check
--- was written for. It stays reported, at 'review', for the one thing still worth a
--- human's eye: when the row records no units_withdrawn, the units removed from the
--- bucket are DERIVED pro-rata from that purchase's own price rather than recorded,
--- and no reader can tell a deliberate quantity from a derived one.
+-- Legacy shape, no longer writable. Since #606 buildWithdrawalMaps values such a
+-- row against the PURCHASE's (goal, fund) bucket, so its principal does reduce the
+-- holding — it is no longer the uncounted withdrawal this check was written for —
+-- and check_withdrawal_balance refuses new ones outright, because a fund sale has
+-- to be keyed by its fund to be measured against the balance it draws down.
+--
+-- What is left is history, and it stays reported at 'review' for the thing still
+-- worth a human's eye: when the row records no units_withdrawn, the units removed
+-- from the bucket are DERIVED pro-rata rather than recorded, and no reader can tell
+-- a deliberate quantity from a derived one.
 --
 -- Do not repair one by hand off this row alone without checking what the dashboard
 -- already subtracts for it — the money is offset now, and subtracting it a second

--- a/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
+++ b/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
@@ -94,12 +94,17 @@ fund_sells as (
          case when w.fund_keyed then w.goal_id else w.parent_goal end as goal_id,
          case when w.fund_keyed then w.fund_id else w.parent_fund end as fund_id,
          sum(coalesce(w.principal_withdrawn, 0)) as out_principal,
+         -- A recorded ZERO derives like an absent one, exactly as the reader does:
+         -- the old parent-backed write path demanded positive units only from a
+         -- gold parent, so zero beside a real principal is a shape this data wears,
+         -- and coalesce alone would let it slip past the derivation and hide the
+         -- units the dashboard removes for it.
          sum(case when w.fund_keyed then coalesce(w.units_withdrawn, 0)
-                  else coalesce(w.units_withdrawn,
-                                case when coalesce(w.parent_units, 0) > 0 and coalesce(w.parent_amount, 0) > 0
-                                       then least(w.parent_units,
-                                                  w.parent_units * coalesce(w.principal_withdrawn, 0) / w.parent_amount)
-                                     else 0 end)
+                  when coalesce(w.units_withdrawn, 0) > 0 then w.units_withdrawn
+                  when coalesce(w.parent_units, 0) > 0 and coalesce(w.parent_amount, 0) > 0
+                    then least(w.parent_units,
+                               w.parent_units * coalesce(w.principal_withdrawn, 0) / w.parent_amount)
+                  else 0
              end)                                as out_units,
          count(*)                                as sells,
          min(w.transaction_id::text)             as a_sell

--- a/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
+++ b/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
@@ -56,7 +56,12 @@ with wd as (
          -- holding into a fund bucket on `asset_type === 'fund' && tx.units`, so a
          -- purchase with no units (a pending DCA seed) or zero units is valued as an
          -- ordinary holding and its withdrawal stays on the parent axis.
-         coalesce(not (w.asset_type = 'fund' and w.fund_id is not null)
+         -- The inner test is coalesced BEFORE the negation, like fund_keyed above:
+         -- asset_type is nullable, so `w.asset_type = 'fund'` on a row with a
+         -- retained fund_id and no asset_type is NULL, and `not NULL` is NULL —
+         -- which would file the row as neither fund-keyed nor fund-parented while
+         -- the reader charges the parent's bucket for it.
+         coalesce(not coalesce(w.asset_type = 'fund' and w.fund_id is not null, false)
                   and p.transaction_type = 'investment'
                   and p.asset_type = 'fund' and p.fund_id is not null
                   and coalesce(p.units, 0) > 0, false) as fund_parented

--- a/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
+++ b/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
@@ -305,15 +305,23 @@ select 'parent_is_a_fund_purchase', 'review',
                           -- while the dashboard removed the derived quantity.
                           case when coalesce(w.units_withdrawn, 0) > 0 then w.units_withdrawn::text
                                else 'derived pro-rata' end)
-            -- The rest are not one shape and must not read as one. A parent that
-            -- holds no units is valued as an ordinary holding, and its withdrawal
-            -- is applied there by lib/depositValuation — a correct row, said so
-            -- plainly, because "nothing values it" would invite a repair that
-            -- subtracts the money a second time. A parent with no fund at all (or
-            -- one that is itself a withdrawal) really is valued by nothing.
+            -- The rest are three different shapes and must not read as one.
+            --
+            -- ZERO units: the purchase is valued as an ordinary holding, and
+            -- lib/depositValuation applies this withdrawal there — a correct row,
+            -- said so plainly, because "nothing values it" would invite a repair
+            -- that subtracts the money a second time.
             when w.parent_asset = 'fund' and w.parent_fund is not null
-                 and coalesce(w.parent_units, 0) <= 0
+                 and w.parent_units is not null and w.parent_units <= 0
               then format('draws %s đồng on fund purchase %s, which holds no units — valued against that purchase, not a bucket',
+                          w.principal_withdrawn, w.parent_transaction_id)
+            -- NO units recorded: a pending DCA seed. lib/dashboardOverview drops
+            -- those from the holdings pass entirely, so the purchase is valued by
+            -- nothing and neither is this row — the parent map entry it lands in is
+            -- read by no holding at all.
+            when w.parent_asset = 'fund' and w.parent_fund is not null
+                 and w.parent_units is null
+              then format('draws %s đồng on pending fund purchase %s, which records no units — nothing values either row',
                           w.principal_withdrawn, w.parent_transaction_id)
             else format('draws %s đồng on fund-typed %s %s, which carries no fund of its own — no bucket values it',
                         w.principal_withdrawn, w.parent_type, w.parent_transaction_id)

--- a/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
+++ b/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
@@ -52,9 +52,14 @@ with wd as (
          p.goal_id          as parent_goal,
          p.units            as parent_units,
          p.amount_vnd       as parent_amount,
+         -- `p.units > 0` mirrors the reader exactly: lib/dashboardOverview keys a
+         -- holding into a fund bucket on `asset_type === 'fund' && tx.units`, so a
+         -- purchase with no units (a pending DCA seed) or zero units is valued as an
+         -- ordinary holding and its withdrawal stays on the parent axis.
          coalesce(not (w.asset_type = 'fund' and w.fund_id is not null)
                   and p.transaction_type = 'investment'
-                  and p.asset_type = 'fund' and p.fund_id is not null, false) as fund_parented
+                  and p.asset_type = 'fund' and p.fund_id is not null
+                  and coalesce(p.units, 0) > 0, false) as fund_parented
     from public.investment_transactions w
     left join public.investment_transactions p on p.transaction_id = w.parent_transaction_id
    where w.transaction_type = 'withdrawal'

--- a/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
+++ b/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
@@ -305,6 +305,16 @@ select 'parent_is_a_fund_purchase', 'review',
                           -- while the dashboard removed the derived quantity.
                           case when coalesce(w.units_withdrawn, 0) > 0 then w.units_withdrawn::text
                                else 'derived pro-rata' end)
+            -- The rest are not one shape and must not read as one. A parent that
+            -- holds no units is valued as an ordinary holding, and its withdrawal
+            -- is applied there by lib/depositValuation — a correct row, said so
+            -- plainly, because "nothing values it" would invite a repair that
+            -- subtracts the money a second time. A parent with no fund at all (or
+            -- one that is itself a withdrawal) really is valued by nothing.
+            when w.parent_asset = 'fund' and w.parent_fund is not null
+                 and coalesce(w.parent_units, 0) <= 0
+              then format('draws %s đồng on fund purchase %s, which holds no units — valued against that purchase, not a bucket',
+                          w.principal_withdrawn, w.parent_transaction_id)
             else format('draws %s đồng on fund-typed %s %s, which carries no fund of its own — no bucket values it',
                         w.principal_withdrawn, w.parent_type, w.parent_transaction_id)
        end

--- a/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
+++ b/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
@@ -1,0 +1,481 @@
+-- Re-state the withdrawal ledger audit for the #606 decision.
+--
+-- #606: a withdrawal that names a FUND PURCHASE as its parent but is not itself
+-- fund-keyed (no fund_id, or asset_type omitted — a shape the POST route accepts,
+-- and one supabase/tests/dca_seeding_heal.test.sql plants as data that exists) was
+-- silently uncounted. The dashboard values a fund through the (goal, fund) map and
+-- never consulted the parent map, so the cash left while the fund kept every unit.
+--
+-- The rule now, stated once in lib/withdrawalProgress and mirrored here: a
+-- withdrawal draws on a (goal, fund) bucket when it is fund-keyed OR when its
+-- parent is a fund purchase; only a withdrawal that is neither is keyed by its
+-- parent. That is a reader fix — the number was wrong in the reader, not the
+-- writer — and it brings the rows already in the ledger into the total instead of
+-- leaving them to a backfill nobody can time.
+--
+-- Only ONE branch of the view changes: 'parent_is_a_fund_purchase' told an
+-- operator the row's principal "no valuation offsets", which is now false and
+-- would invite a manual repair that subtracts the same money twice. Everything
+-- else is copied verbatim from 20260730000003 (a view has to be re-stated whole).
+--
+-- Deliberately NOT changed: the proportional checks still measure a fund bucket by
+-- its fund-keyed sells alone. A fund-parented row whose units are derived is
+-- proportional BY CONSTRUCTION (units = purchase units x principal / purchase
+-- cost), so folding it in would only ever compare the derivation with itself; and
+-- one that does record units is already named, by the check above, for review.
+-- The overdraw checks need no change either: `holding_overdrawn` already measures
+-- every parent-backed draw against the purchase it names, which is exactly the
+-- bound the reader caps the derived units at.
+
+create or replace view public.withdrawal_ledger_audit
+with (security_invoker = true) as
+with wd as (
+  select w.transaction_id, w.user_id, w.goal_id, w.fund_id, w.parent_transaction_id,
+         w.asset_type, w.principal_withdrawn, w.units_withdrawn, w.held_for_merge,
+         w.investment_date,
+         -- The same branch precedence as the invariant and lib/withdrawalProgress:
+         -- asset_type='fund' + fund_id wins, and such a row draws on its (goal,
+         -- fund) bucket no matter what parent it also names.
+         coalesce(w.asset_type = 'fund' and w.fund_id is not null, false) as fund_keyed,
+         p.transaction_type as parent_type,
+         p.asset_type       as parent_asset
+    from public.investment_transactions w
+    left join public.investment_transactions p on p.transaction_id = w.parent_transaction_id
+   where w.transaction_type = 'withdrawal'
+),
+-- One source row: bank, gold, stock. Only holdings that something draws on.
+parents as (
+  select p.transaction_id, p.user_id, p.goal_id, p.asset_type, p.amount_vnd, p.units,
+         sum(coalesce(w.principal_withdrawn, 0)) as out_principal,
+         sum(coalesce(w.units_withdrawn, 0))     as out_units,
+         count(*)                                as sells
+    from public.investment_transactions p
+    join wd w on w.parent_transaction_id = p.transaction_id and not w.fund_keyed
+   where p.transaction_type = 'investment'
+   group by p.transaction_id, p.user_id, p.goal_id, p.asset_type, p.amount_vnd, p.units
+),
+fund_buys as (
+  select t.user_id, t.goal_id, t.fund_id,
+         sum(t.amount_vnd) as basis, sum(t.units) as units, count(*) as buys
+    from public.investment_transactions t
+   where t.transaction_type = 'investment'
+     and t.asset_type = 'fund'
+     and t.fund_id is not null
+     and t.units is not null                       -- pending DCA seeds hold nothing
+     and t.renewed_from_transaction_id is null     -- renewal snapshots are history
+   group by t.user_id, t.goal_id, t.fund_id
+),
+fund_sells as (
+  select w.user_id, w.goal_id, w.fund_id,
+         sum(coalesce(w.principal_withdrawn, 0)) as out_principal,
+         sum(coalesce(w.units_withdrawn, 0))     as out_units,
+         count(*)                                as sells,
+         min(w.transaction_id::text)             as a_sell
+    from wd w
+   where w.fund_keyed
+   group by w.user_id, w.goal_id, w.fund_id
+),
+fund_buckets as (
+  select s.user_id, s.goal_id, s.fund_id, s.out_principal, s.out_units, s.sells, s.a_sell,
+         coalesce(b.basis, 0) as basis, coalesce(b.units, 0) as units, coalesce(b.buys, 0) as buys
+    from fund_sells s
+    left join fund_buys b
+      on b.user_id = s.user_id
+     and b.fund_id = s.fund_id
+     and b.goal_id is not distinct from s.goal_id
+),
+
+-- How far each individual sale sits from the flat rate units × basis / total_units,
+-- with the two tolerances it may claim. Split out as a CTE because the full-sale
+-- slack has to be RATIONED across the holding (see below), which needs a window
+-- over the per-sale deviations rather than a row-local predicate.
+sale_dev as (
+  select w.transaction_id, w.user_id, w.goal_id, w.fund_id, w.parent_transaction_id,
+         w.units_withdrawn, w.principal_withdrawn,
+         p.transaction_id as holding, p.transaction_id::text as balance_key,
+         p.amount_vnd as basis, p.units as units,
+         format('a sale of %s of the holding''s %s units took %s đồng where the flat rate on a %s basis is %s',
+                w.units_withdrawn, p.units, w.principal_withdrawn, p.amount_vnd,
+                round(p.amount_vnd * w.units_withdrawn / p.units)) as detail,
+         abs(coalesce(w.principal_withdrawn, 0) - round(p.amount_vnd * w.units_withdrawn / p.units)) as dev,
+         p.sells + 1 as base_tol,
+         case when p.out_units >= p.units - 0.0001
+                then least(abs(p.units - p.out_units), 0.0001) * p.amount_vnd / p.units else 0 end as shortcut_tol,
+         p.out_units >= p.units - 0.0001 as exhausted
+    from wd w
+    join parents p on p.transaction_id = w.parent_transaction_id
+   where not w.fund_keyed and p.asset_type = 'gold' and coalesce(p.units, 0) > 0
+     and coalesce(w.units_withdrawn, 0) > 0
+  union all
+  select w.transaction_id, w.user_id, w.goal_id, w.fund_id, w.parent_transaction_id,
+         w.units_withdrawn, w.principal_withdrawn,
+         null::uuid, b.fund_id::text || ':' || coalesce(b.goal_id::text, ''), b.basis, b.units,
+         format('a sell of %s of the bucket''s %s units took %s đồng where the flat rate on a %s basis is %s',
+                w.units_withdrawn, b.units, w.principal_withdrawn, b.basis,
+                round(b.basis * w.units_withdrawn / b.units)),
+         abs(coalesce(w.principal_withdrawn, 0) - round(b.basis * w.units_withdrawn / b.units)),
+         b.sells + 1,
+         case when b.out_units >= b.units - 0.0001
+                then least(abs(b.units - b.out_units), 0.0001) * b.basis / b.units else 0 end,
+         b.out_units >= b.units - 0.0001
+    from wd w
+    join fund_buckets b
+      on b.user_id = w.user_id and b.fund_id = w.fund_id and b.goal_id is not distinct from w.goal_id
+   where w.fund_keyed and b.units > 0
+     and coalesce(w.units_withdrawn, 0) > 0
+),
+
+-- Exactly ONE sale per holding can be the one that closed it, so at most one may
+-- claim the full-sale slack. Siblings are counted by the BALANCE key and nothing
+-- else — parent_transaction_id for bank/gold/stock, (fund, goal) for a fund bucket
+-- — because that is what the invariant measures. A withdrawal carries its own
+-- goal_id, and for a parent-backed row the invariant ignores it entirely; counting
+-- by it would split one holding's sales into separate partitions and hand each of
+-- them the slack that only one sale can have. Rows past the base tolerance are counted per holding:
+-- if two or more need the slack, the holding cannot be explained by any legal
+-- sequence and they are all reported; if just one does, it is allowed its value.
+--
+-- Sub-epsilon slivers in the tail of an exhausted holding are judged by the same
+-- one-closer rule rather than exempted outright: exactly one of them may have been
+-- the sale that emptied the basis, so the others must have taken either their flat
+-- share or (having come after it) nothing. Two slivers that did neither have no
+-- legal reading in any order — 0.9998 units taking 999,800 and then 0.0001 each
+-- taking 50 and 150 of the 200 left adds up perfectly and is refused by all six
+-- orderings, which is the shape this catches.
+--
+-- The exemption itself is still limited to a holding that ends EXHAUSTED. A sliver can take a whole remaining basis only if it closed the
+-- holding, and which slivers in that tail were legal depends on write order — the
+-- undecidable-from-state limit the header records. On a holding with units still
+-- unsold nothing closed anything, so a sliver there owes the flat rate like any
+-- other sale and is measured like one: 0.0002 units out of 1 closes nothing.
+sale_dev_ranked as (
+  select d.*,
+         d.exhausted and d.units_withdrawn <= 0.0002 as sliver,
+         count(*) filter (where d.dev > d.base_tol and not (d.exhausted and d.units_withdrawn <= 0.0002))
+           over (partition by d.user_id, d.balance_key) as over_base,
+         -- Slivers in the tail that took NEITHER their flat share nor nothing at
+         -- all. One of those is the closer emptying the basis; a second one has no
+         -- legal reading, whatever order they were written in.
+         count(*) filter (where d.exhausted and d.units_withdrawn <= 0.0002
+                            and d.dev > d.base_tol and coalesce(d.principal_withdrawn, 0) > 1)
+           over (partition by d.user_id, d.balance_key) as odd_slivers
+    from sale_dev d
+)
+
+-- ── shape, per row ──────────────────────────────────────────────────────────
+
+-- A negative withdrawal ADDS to the holding and banks a credit the next one can
+-- spend: every sum here and in lib/depositValuation is signed.
+select 'negative_amounts'::text as check_name, 'violation'::text as severity,
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('principal %s, units %s', w.principal_withdrawn, w.units_withdrawn) as detail
+  from wd w
+ where coalesce(w.principal_withdrawn, 0) < 0 or coalesce(w.units_withdrawn, 0) < 0
+
+union all
+-- Without units the overview skips the subtraction entirely (it bails on
+-- `units <= 0`), so the fund keeps its full value while the row claims a sale.
+select 'fund_sale_missing_units', 'violation',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('fund sell of %s đồng records units %s', w.principal_withdrawn, w.units_withdrawn)
+  from wd w
+ where w.fund_keyed and coalesce(w.units_withdrawn, 0) <= 0
+
+union all
+-- Gold is the one non-fund holding valued by quantity, so a sale must move both:
+-- principal alone drops the cost while every chỉ stays in net worth.
+select 'gold_sale_missing_units', 'violation',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('gold sale of %s đồng records units %s', w.principal_withdrawn, w.units_withdrawn)
+  from wd w
+ where not w.fund_keyed and w.parent_asset = 'gold' and coalesce(w.units_withdrawn, 0) <= 0
+
+union all
+-- No principal takes nothing out: the holding keeps its value while the row claims
+-- cash left. The invariant demands a positive principal from a parent-backed
+-- withdrawal outright, which is what makes this a violation.
+--
+-- FUND sells are deliberately not judged here, though they were until a review
+-- pointed at the hole. A fund sell's principal is a proportional slice, and a slice
+-- can correctly be ZERO when it is worth less than half a đồng — but whether it was
+-- worth that is decided by the bucket AS IT WAS when the sale was written, and a
+-- purchase arriving later moves the ratio. A 1 đồng / 100 unit bucket makes a
+-- 1-unit slice worth nothing; add a 999 đồng purchase afterwards and the same
+-- accepted row looks five đồng short. Nothing whose every write was legal may be
+-- called a violation, so fund sells are left to sale_basis_not_proportional, whose
+-- 'review' severity says exactly this about purchases added after a sale.
+select 'withdrawal_missing_principal', 'violation',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('withdrawal from holding %s records principal %s',
+              w.parent_transaction_id, w.principal_withdrawn)
+  from wd w
+ where coalesce(w.principal_withdrawn, 0) <= 0
+   and not w.fund_keyed
+   and w.parent_transaction_id is not null
+
+union all
+-- A withdrawal is not a holding: parenting to one invents a balance out of money
+-- that already left. Renewal snapshots ARE valid parents (#585) and are
+-- investments, so they are not caught here.
+select 'parent_is_not_an_investment', 'violation',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('parent %s is a %s', w.parent_transaction_id, w.parent_type)
+  from wd w
+ where not w.fund_keyed and w.parent_type is not null and w.parent_type <> 'investment'
+
+union all
+-- Counted, but not in the shape the app writes. Since #606 buildWithdrawalMaps
+-- values such a row against the PURCHASE's (goal, fund) bucket, so its principal
+-- does reduce the holding — it is no longer the uncounted withdrawal this check
+-- was written for. It stays reported, at 'review', for the one thing still worth a
+-- human's eye: when the row records no units_withdrawn, the units removed from the
+-- bucket are DERIVED pro-rata from that purchase's own price rather than recorded,
+-- and no reader can tell a deliberate quantity from a derived one.
+--
+-- Do not repair one by hand off this row alone without checking what the dashboard
+-- already subtracts for it — the money is offset now, and subtracting it a second
+-- time would understate the holding by the same amount this once overstated it.
+select 'parent_is_a_fund_purchase', 'review',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('draws %s đồng on fund purchase %s, valued against that fund bucket with units %s',
+              w.principal_withdrawn, w.parent_transaction_id,
+              case when w.units_withdrawn is null then 'derived pro-rata' else w.units_withdrawn::text end)
+  from wd w
+ where not w.fund_keyed and w.parent_asset = 'fund'
+
+union all
+-- Filed under neither key: it subtracts from nothing while the record says cash
+-- left. What deleting a source leaves behind (#607), among other routes.
+--
+-- A RETAINED fund_id does not save such a row, which is why this asks only about
+-- fund_keyed and the parent. Editing a fund sell's asset_type off 'fund' leaves the
+-- fund_id in place (the PUT clears it only when that field is sent), and a bare id
+-- is not a bucket key — buildWithdrawalMaps needs asset_type='fund' — so the row
+-- draws on nothing at all. Requiring fund_id is null here would have made that
+-- shape, the one the invariant refuses by name, invisible to the audit.
+select 'draws_on_no_holding', 'violation',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       format('takes principal %s / units %s from no holding%s',
+              w.principal_withdrawn, w.units_withdrawn,
+              case when w.fund_id is not null then ' (fund id retained without asset_type=fund)' else '' end)
+  from wd w
+ where not w.fund_keyed and w.parent_transaction_id is null
+   and (coalesce(w.principal_withdrawn, 0) > 0 or coalesce(w.units_withdrawn, 0) > 0)
+
+union all
+-- Claiming nothing and naming nothing is legal for exactly one kind of row: a
+-- held-for-merge settlement whose source isn't recorded yet (#588). Nothing else
+-- may wear that exception.
+select 'sourceless_not_held_for_merge', 'violation',
+       w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
+       'nothing it draws on, no deltas, and not held_for_merge'
+  from wd w
+ where not w.fund_keyed and w.parent_transaction_id is null
+   and coalesce(w.principal_withdrawn, 0) = 0 and coalesce(w.units_withdrawn, 0) = 0
+   and not w.held_for_merge
+
+-- ── balance, per holding ────────────────────────────────────────────────────
+
+union all
+-- Past zero. The dashboard then DROPS the holding (valueNonFundHolding returns
+-- null at effectiveAmount <= 0) while the excess withdrawal stays in history, so
+-- net worth is wrong in a way no screen shows.
+-- What the invariant actually caps, and what it does not.
+--
+-- UNITS are capped for every kind of holding, and the bound is cumulative however
+-- many sales there are: each sale is measured against what is LEFT, which already
+-- carries the previous sale's excess, so Σunits ≤ units + 0.0001 whatever the
+-- count (two sales totalling units + 0.00015 are refused — probed). Selling more of
+-- a thing than exists is provable from state, so it is a violation.
+--
+-- PRINCIPAL is capped only where the invariant caps it: bank and stock, where the
+-- amount withdrawn is the user's own figure and the rule is literally
+-- `principal_withdrawn > remaining` → refused. There is NO principal cap in the
+-- quantity-valued branch. Gold and fund sells are governed by the proportional
+-- allocation instead, one sale at a time, and THAT allowance accumulates: a 1 đồng
+-- / 5 unit holding sold in three 1-unit slices has each slice's share round to
+-- zero, while the invariant separately demands a positive principal from a
+-- parent-backed withdrawal — so three đồng legally leave a one đồng holding, every
+-- write accepted. Calling that an overdraw would tell an operator to repair a
+-- correctly written ledger, which is the one thing 'violation' promises not to do.
+-- Quantity-valued basis overruns go to 'review' below instead.
+--
+-- Units are compared against coalesce: a holding with NO units still has a balance
+-- of zero units, and the invariant refuses any positive quantity drawn on it
+-- ('5 units exceeds the remaining balance of 0 units'). Skipping the comparison
+-- when the parent's units are null let exactly that row report clean.
+--
+-- And the 4-decimal epsilon is granted only where the invariant grants it: while
+-- something is left to round. `case when v_left_units > 0 then c_units_epsilon else
+-- 0 end` is its own wording. A holding of zero units — the schema allows one — has
+-- no rounding to forgive, so a sliver sold out of it is an overdraw like any other.
+select 'holding_overdrawn', 'violation',
+       p.user_id, null::uuid, p.transaction_id, null::uuid, p.goal_id,
+       format('%s holding of %s đồng / %s units has %s đồng / %s units taken out across %s withdrawal(s)',
+              p.asset_type, p.amount_vnd, coalesce(p.units, 0), p.out_principal, p.out_units, p.sells)
+  from parents p
+ where p.out_units > coalesce(p.units, 0) + case when coalesce(p.units, 0) > 0 then 0.0001 else 0 end
+    or (p.asset_type is distinct from 'gold' and p.out_principal > p.amount_vnd)
+
+union all
+select 'fund_bucket_overdrawn', 'violation',
+       b.user_id, null::uuid, null::uuid, b.fund_id, b.goal_id,
+       format('bucket holds %s đồng / %s units and has %s đồng / %s units sold across %s sell(s)',
+              b.basis, b.units, b.out_principal, b.out_units, b.sells)
+  from fund_buckets b
+ where b.buys > 0
+   and b.out_units > b.units + case when b.units > 0 then 0.0001 else 0 end
+
+union all
+-- The same overrun on the principal side of a quantity-valued holding. Worth
+-- looking at — dashboard/overview subtracts exactly this sum from invested capital
+-- — but never provable, since accumulated rounding on small slices reaches it
+-- legally. The per-sale tolerance is what an honest reading needs, so it is the
+-- tolerance used here too.
+select 'basis_taken_exceeds_cost', 'review',
+       p.user_id, null::uuid, p.transaction_id, null::uuid, p.goal_id,
+       format('gold holding cost %s đồng and has %s đồng taken out across %s withdrawal(s)',
+              p.amount_vnd, p.out_principal, p.sells)
+  from parents p
+ where p.asset_type = 'gold' and p.out_principal > p.amount_vnd + p.sells
+
+union all
+select 'basis_taken_exceeds_cost', 'review',
+       b.user_id, null::uuid, null::uuid, b.fund_id, b.goal_id,
+       format('bucket cost %s đồng and has %s đồng sold out of it across %s sell(s)',
+              b.basis, b.out_principal, b.sells)
+  from fund_buckets b
+ where b.buys > 0 and b.out_principal > b.basis + b.sells
+
+union all
+-- A sell alone in a bucket: its purchases are in another goal, so nothing here
+-- offsets it and the goal that HAS the purchases shows them unsold. What an
+-- assign racing a sale leaves behind (#610).
+-- ...beyond what a relocation may legally leave behind. check_fund_bucket_solvent
+-- (#587) refuses a move only when the bucket would be left owing MORE than 0.0001
+-- units or one đồng, so an orphan that small is a state the invariant itself
+-- permits — reachable by moving a purchase out from under an epsilon-sized sell.
+-- Reporting it as provable corruption would send an operator to repair a ledger
+-- nobody wrote wrong; the same thresholds are mirrored here so the two agree.
+select 'fund_bucket_has_no_purchases', 'violation',
+       b.user_id, b.a_sell::uuid, null::uuid, b.fund_id, b.goal_id,
+       format('%s sell(s) taking %s đồng / %s units, with no purchases in this bucket',
+              b.sells, b.out_principal, b.out_units)
+  from fund_buckets b
+ where b.buys = 0
+   and (b.out_units > 0.0001 or b.out_principal > 1)
+
+-- ── allocation, per quantity-valued holding ─────────────────────────────────
+-- Fund buckets and gold bind the principal TO the units: a sale of all remaining
+-- units takes the remaining basis, a partial sale its units-proportional share.
+-- That rule is additive and order-independent — each sale takes units × basis /
+-- total_units regardless of sequence — so the aggregate is a sound check even
+-- though the per-sale history is not reconstructible.
+--
+-- The tolerance is TWO đồng per sale, and unlike the overdraw bound above this one
+-- genuinely has to scale: each partial sale's expectation is recomputed from the
+-- ROUNDED remaining basis, so the error compounds rather than cancelling. Worked
+-- example, both writes accepted by the invariant — 100 đồng over 15 units, a sale
+-- of 7 units taking 48 where the expectation is 47, then 1 unit of the remaining 8
+-- taking 8 where the expectation is round(52/8) = 7: the aggregate is 56 against a
+-- flat expectation of 53, a drift of 3 across 2 sales.
+--
+-- Two rather than one-and-a-half because 1.5 is where the measured worst case sits:
+-- a search over 400k invariant-legal sale sequences (random basis, units, chain
+-- length up to 25, errors pushed to the allowance every time) never exceeded 1.5
+-- đồng per sale. It cannot run away, either — writing D for the drift, each sale
+-- gives D ← D × (1 − units/remaining_units) + e, a CONTRACTION, so the accumulated
+-- part shrinks as the chain grows and the worst cases are short chains.
+--
+-- Over-taking gains nothing from this slack: the cumulative upper bound stays tight
+-- in holding_overdrawn / fund_bucket_overdrawn above.
+--
+-- 'review', not 'violation': a purchase added to a bucket AFTER a sale legitimately
+-- shifts the ratio, and so does a hand-corrected row. The number is the useful
+-- part — expected vs actual says how far the basis has drifted from the units.
+
+-- Per SALE as well as per holding, because holding-level totals hide errors that
+-- CANCEL: 50 units taking 400 and 50 taking 600 out of a 1000 đồng / 100 unit
+-- holding add up to exactly the right basis, while the invariant refuses each one
+-- as a first write (50 of 100 units must take 500) — that state is unreachable in
+-- any order, and a totals-only audit calls it clean. The flat rate is the right
+-- yardstick per row precisely because the allocation rule is additive: each sale
+-- takes units × basis / total_units whatever the sequence.
+--
+-- The tolerance has THREE parts, and the third is the one that matters in practice:
+--   sells   the ±1 allowance each sale may use, which the last sale inherits
+--   1       the two roundings between the flat rate and the invariant's expectation
+--   the value of the units left UNSOLD, and only on a holding that ends exhausted
+--           at most one epsilon's worth, since that is as much as can be over or
+--           under. The clients round units to 4 decimals in BOTH directions: a full
+--           sale of 4 chỉ posts as 3.9999 or 4.0001 with equal ease, and the
+--           invariant takes either for a full sale and hands it the whole basis, so
+--           the gap against the flat rate runs a thousand đồng each way. The clients round units to 4
+--           decimals, so "sell everything" routinely posts a hair UNDER the holding
+--           (4 chỉ leaves as 3.9999) and the invariant treats a sale within an
+--           epsilon of the rest as a FULL one, taking the whole basis. On an
+--           ordinary 40,000,000 đồng gold holding that legitimate gap is a THOUSAND
+--           đồng — a flat tolerance reports every full gold sale in the ledger.
+--
+--           Two conditions keep that slack from covering ordinary misallocation,
+--           and both are exact rather than heuristic. The shortcut requires a sale
+--           to take within an epsilon of what REMAINS, so (a) at most an epsilon of
+--           units can be left behind afterwards — any legal use implies the holding
+--           ends exhausted, and a sale of 1 chỉ out of 4 leaves 3 behind and gets
+--           nothing — and (b) the gap it opens against the flat rate is exactly the
+--           value of the units it did NOT take, which for the closer is the whole
+--           holding's unsold remainder. A holding sold out to the last unit had no
+--           gap to open: 4 units bought and 4 sold means every sale owes the flat
+--           rate exactly, however the sales were split up.
+-- Validated against 1.5M invariant-legal sale sequences across four magnitudes of
+-- basis and units: no row exceeded it, tightest margin 1.2 đồng.
+union all
+select 'sale_basis_not_proportional', 'review',
+       d.user_id, d.transaction_id, d.parent_transaction_id, d.fund_id, d.goal_id, d.detail
+  from sale_dev_ranked d
+ where d.dev > d.base_tol
+   and case
+         when d.sliver
+           -- The tail exemption is for ONE closer, not for every sliver in it.
+           then d.odd_slivers >= 2 and coalesce(d.principal_withdrawn, 0) > 1
+         else d.over_base >= 2 or d.dev > d.base_tol + d.shortcut_tol
+       end
+
+union all
+select 'basis_not_proportional', 'review',
+       p.user_id, null::uuid, p.transaction_id, null::uuid, p.goal_id,
+       format('%s of %s units sold should have taken %s đồng of the %s basis, took %s',
+              p.out_units, p.units,
+              case when p.out_units >= p.units - 0.0001 then p.amount_vnd
+                   else round(p.amount_vnd * p.out_units / p.units) end,
+              p.amount_vnd, p.out_principal)
+  from parents p
+ where p.asset_type = 'gold' and coalesce(p.units, 0) > 0
+   and abs(p.out_principal
+           - case when p.out_units >= p.units - 0.0001 then p.amount_vnd
+                  else round(p.amount_vnd * p.out_units / p.units) end) > 2 * p.sells + case when p.out_units >= p.units - 0.0001
+                          then least(abs(p.units - p.out_units), 0.0001) * p.amount_vnd / p.units else 0 end
+
+union all
+select 'basis_not_proportional', 'review',
+       b.user_id, null::uuid, null::uuid, b.fund_id, b.goal_id,
+       format('%s of %s units sold should have taken %s đồng of the %s basis, took %s',
+              b.out_units, b.units,
+              case when b.out_units >= b.units - 0.0001 then b.basis
+                   else round(b.basis * b.out_units / b.units) end,
+              b.basis, b.out_principal)
+  from fund_buckets b
+ where b.units > 0
+   and abs(b.out_principal
+           - case when b.out_units >= b.units - 0.0001 then b.basis
+                  else round(b.basis * b.out_units / b.units) end) > 2 * b.sells + case when b.out_units >= b.units - 0.0001
+                          then least(abs(b.units - b.out_units), 0.0001) * b.basis / b.units else 0 end;
+
+comment on view public.withdrawal_ledger_audit is
+  'Read-only screen of existing withdrawal rows against the decision table enforced by check_withdrawal_balance. severity=violation is provable from state; severity=review is sequence-sensitive. An empty result does NOT prove the ledger clean — see the header (#609).';
+
+-- An operator tool, and there is no screen that reads it. security_invoker means
+-- RLS would confine a caller to their own rows anyway, but granting it adds a
+-- PostgREST surface for no gain — the same reasoning that revoked
+-- check_withdrawal_balance in 20260730000002.
+revoke all on public.withdrawal_ledger_audit from anon, authenticated;

--- a/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
+++ b/supabase/migrations/20260803000001_fund_parented_withdrawal_is_valued.sql
@@ -50,6 +50,8 @@ with wd as (
          -- claim would be measured against two balances.
          p.fund_id          as parent_fund,
          p.goal_id          as parent_goal,
+         p.units            as parent_units,
+         p.amount_vnd       as parent_amount,
          coalesce(not (w.asset_type = 'fund' and w.fund_id is not null)
                   and p.transaction_type = 'investment'
                   and p.asset_type = 'fund' and p.fund_id is not null, false) as fund_parented
@@ -81,17 +83,24 @@ fund_buys as (
    group by t.user_id, t.goal_id, t.fund_id
 ),
 fund_sells as (
-  -- One bucket, both shapes. A fund-parented row's units are counted only where it
-  -- RECORDS them: the reader derives them when they are absent, and a derived
-  -- quantity is proportional by construction, so folding it in here would report
-  -- the derivation rather than the ledger. That makes the units side conservative —
-  -- it under-counts what such a row removes, never over-counts — which is the right
-  -- direction for a check that calls an overrun a violation.
+  -- One bucket, both shapes — measured by what the READER removes, which for a
+  -- fund-parented row with no units_withdrawn is a DERIVED quantity: the same
+  -- capped pro-rata share of the parent purchase that lib/withdrawalProgress
+  -- subtracts. Counting those rows as zero units looked conservative and was not:
+  -- a principal-only draw on a 100-unit purchase takes 100 units out of the bucket
+  -- in the dashboard, and an audit that scores it as nothing reports a bucket sold
+  -- past its units as clean — which is the one thing this check exists to catch.
   select w.user_id,
          case when w.fund_keyed then w.goal_id else w.parent_goal end as goal_id,
          case when w.fund_keyed then w.fund_id else w.parent_fund end as fund_id,
          sum(coalesce(w.principal_withdrawn, 0)) as out_principal,
-         sum(coalesce(w.units_withdrawn, 0))     as out_units,
+         sum(case when w.fund_keyed then coalesce(w.units_withdrawn, 0)
+                  else coalesce(w.units_withdrawn,
+                                case when coalesce(w.parent_units, 0) > 0 and coalesce(w.parent_amount, 0) > 0
+                                       then least(w.parent_units,
+                                                  w.parent_units * coalesce(w.principal_withdrawn, 0) / w.parent_amount)
+                                     else 0 end)
+             end)                                as out_units,
          count(*)                                as sells,
          min(w.transaction_id::text)             as a_sell
     from wd w
@@ -264,11 +273,22 @@ union all
 -- Do not repair one by hand off this row alone without checking what the dashboard
 -- already subtracts for it — the money is offset now, and subtracting it a second
 -- time would understate the holding by the same amount this once overstated it.
+--
+-- The message is gated on what the reader ACTUALLY does with the row. A parent
+-- that is fund-typed but carries no fund_id of its own — or that is itself a
+-- fund-typed withdrawal — is not a bucket: buildWithdrawalMaps leaves such a row on
+-- the parent axis, where nothing reads it, and the parent is not valued either. An
+-- audit that told an operator those were "valued against that fund bucket" would
+-- have them leave an unvalued row alone, which is the mistake this check is for.
 select 'parent_is_a_fund_purchase', 'review',
        w.user_id, w.transaction_id, w.parent_transaction_id, w.fund_id, w.goal_id,
-       format('draws %s đồng on fund purchase %s, valued against that fund bucket with units %s',
-              w.principal_withdrawn, w.parent_transaction_id,
-              case when w.units_withdrawn is null then 'derived pro-rata' else w.units_withdrawn::text end)
+       case when w.fund_parented
+              then format('draws %s đồng on fund purchase %s, valued against that fund bucket with units %s',
+                          w.principal_withdrawn, w.parent_transaction_id,
+                          case when w.units_withdrawn is null then 'derived pro-rata' else w.units_withdrawn::text end)
+            else format('draws %s đồng on fund-typed %s %s, which carries no fund of its own — no bucket values it',
+                        w.principal_withdrawn, w.parent_type, w.parent_transaction_id)
+       end
   from wd w
  where not w.fund_keyed and w.parent_asset = 'fund'
 

--- a/supabase/migrations/20260803000002_fund_sale_must_be_fund_keyed.sql
+++ b/supabase/migrations/20260803000002_fund_sale_must_be_fund_keyed.sql
@@ -1,0 +1,300 @@
+-- A fund sale is keyed by its fund — the writer's half of the #606 decision.
+--
+-- #606 fixed the reader: a withdrawal parented to a fund purchase is valued against
+-- that purchase's (goal, fund) bucket instead of being silently uncounted. That
+-- leaves the invariant measuring a balance nobody draws down. It bounds such a row
+-- by the parent PURCHASE's own principal, while the units now come out of the
+-- BUCKET — so one 50-unit purchase accepted a 45-unit fund-keyed sell and a 10-unit
+-- parented sell, each legal against its own reading, 55 units out of 50. The
+-- dashboard then subtracts all 55, drops the bucket at zero, and understates the
+-- holding by the five units still held.
+--
+-- Two balances for one bucket is the bug; this migration removes the second one.
+-- The shape is refused at write time — a fund sale carries asset_type='fund' +
+-- fund_id, which is what both sell sheets have always posted — so the only rows
+-- left in it are the ones already in the ledger, which the reader values and
+-- withdrawal_ledger_audit reports by name.
+--
+-- Everything else in the function is copied verbatim from 20260730000002.
+
+create or replace function public.check_withdrawal_balance(wd public.investment_transactions)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  -- Clients round units_withdrawn to 4 decimals (parseFloat(u.toFixed(4))), so a
+  -- FULL sell can post a hair more than the holding: 50.12345 units becomes
+  -- 50.1235. Allow exactly that much and no more, or "sell everything" breaks.
+  c_units_epsilon constant numeric := 0.0001;
+  v_principal     bigint;
+  v_units         numeric;
+  v_out_principal bigint;
+  v_out_units     numeric;
+  v_left          bigint;
+  v_left_units    numeric;
+  v_parent_type   text;
+  v_parent_asset  text;
+  -- Purchases in the fund bucket; null outside that branch, which is also how the
+  -- allocation rule below knows which kind it is measuring.
+  v_rows          int;
+  -- The basis a fund sale of these units is allowed to take, and the one đồng of
+  -- rounding the proportional split can produce.
+  v_expected      numeric;
+  c_dong_epsilon  constant numeric := 1;
+begin
+  if wd.transaction_type is distinct from 'withdrawal' then return; end if;
+
+  -- A negative withdrawal runs the ledger backwards: it ADDS to the holding and
+  -- banks a credit the next withdrawal can spend (the sums below are signed, and
+  -- so is lib/depositValuation's subtraction). Nothing in the schema stops one, so
+  -- the invariant does — before anything is measured, since a negative amount
+  -- would poison the measurement itself.
+  if coalesce(wd.principal_withdrawn, 0) < 0 or coalesce(wd.units_withdrawn, 0) < 0 then
+    raise exception 'withdrawal invariant: amounts cannot be negative (principal %, units %)',
+      wd.principal_withdrawn, wd.units_withdrawn using errcode = 'check_violation';
+  end if;
+
+  -- The branch order is not a preference: it MIRRORS lib/withdrawalProgress, which
+  -- keys any row with asset_type='fund' + fund_id by (goal, fund) and ignores its
+  -- parent. Measuring such a row against a parent instead would check a balance
+  -- nothing draws down — a fat holding in one goal waving through a phantom fund
+  -- sell in another, since the API accepts both fields on one row.
+  if wd.asset_type = 'fund' and wd.fund_id is not null then
+    -- A fund sale is a quantity: without units the overview skips the whole
+    -- subtraction (it bails on `wd.units <= 0`) and the holding keeps its value.
+    -- The principal is then not a free number — it is the allocation of the
+    -- remaining basis for those units, checked at the end of this function.
+    if coalesce(wd.units_withdrawn, 0) <= 0 then
+      raise exception 'withdrawal invariant: a fund sale must record units_withdrawn (got %)',
+        wd.units_withdrawn using errcode = 'check_violation';
+    end if;
+
+    -- Both sides of the bucket carry `asset_type = 'fund'`, because that is what
+    -- the valuation counts: a row whose asset_type was edited off 'fund' keeps its
+    -- fund_id (the PUT clears fund_id only when that field is sent) but is valued
+    -- as a bank holding, so its units are no longer fund inventory to sell.
+    --
+    -- Lock the bucket's investment rows before measuring them (see the header):
+    -- this is what makes two concurrent sells of the same bucket serialize. Pending
+    -- DCA seeds (units is null) are excluded: they carry a planned amount with no
+    -- units bought yet, the dashboard never values them, so they hold nothing to
+    -- sell. Renewal snapshots are history copies, not holdings.
+    perform 1
+      from public.investment_transactions t
+     where t.user_id = wd.user_id
+       and t.fund_id = wd.fund_id
+       and t.asset_type = 'fund'
+       and t.transaction_type = 'investment'
+       and t.goal_id is not distinct from wd.goal_id
+       and t.renewed_from_transaction_id is null
+       and t.units is not null
+     order by t.transaction_id      -- a stable lock order; concurrent sells can't deadlock
+       for update;
+
+    -- ONE authoritative basis: Σ amount_vnd, what the purchases cost. That is
+    -- where the number lands — dashboard/overview does
+    --   acc.totalInvested -= Σ principal_withdrawn
+    -- against exactly this sum, while the NAV cost (Σ units × unit_price, fees
+    -- excluded) is reduced by units and only feeds the average entry price.
+    --
+    -- The sheets used to post a NAV-derived figure into that amount-based
+    -- accumulator, reconstructed through the averaged purchasePrice, and this check
+    -- grew a tolerance to accommodate it. lib/fundWithdrawal now takes the basis
+    -- from the dashboard directly (a full sale takes it exactly), so the two agree
+    -- and the tolerance below covers only what rounding can still explain.
+    select coalesce(sum(t.amount_vnd), 0), coalesce(sum(t.units), 0), count(*)
+      into v_principal, v_units, v_rows
+      from public.investment_transactions t
+     where t.user_id = wd.user_id
+       and t.fund_id = wd.fund_id
+       and t.asset_type = 'fund'
+       and t.transaction_type = 'investment'
+       and t.goal_id is not distinct from wd.goal_id
+       and t.renewed_from_transaction_id is null
+       and t.units is not null;
+
+    select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
+      into v_out_principal, v_out_units
+      from public.investment_transactions w
+     where w.user_id = wd.user_id
+       and w.fund_id = wd.fund_id
+       and w.asset_type = 'fund'
+       and w.transaction_type = 'withdrawal'
+       and w.goal_id is not distinct from wd.goal_id
+       and w.transaction_id <> wd.transaction_id;   -- measured without itself
+
+  elsif wd.parent_transaction_id is not null then
+    -- Bank / gold / stock: one source row. Lock it before measuring it, so two
+    -- concurrent withdrawals of the same deposit serialize here.
+    select t.amount_vnd, t.units, t.transaction_type, t.asset_type
+      into v_principal, v_units, v_parent_type, v_parent_asset
+      from public.investment_transactions t
+     where t.transaction_id = wd.parent_transaction_id
+       and t.user_id = wd.user_id
+       for update;
+    -- A parent that isn't the writer's own is the ownership trigger's refusal to
+    -- make (#474 / #525); staying quiet here keeps that message the one the user
+    -- sees instead of a confusing "no balance".
+    if not found then return; end if;
+
+    -- A withdrawal is not a holding, so parenting to one invents a balance out of
+    -- money that already left. Renewal snapshots ARE valid parents on purpose:
+    -- renew and collapse re-parent partial withdrawals onto them, which is how a
+    -- renewed deposit stops double-counting them (#585).
+    --
+    if v_parent_type is distinct from 'investment' then
+      raise exception 'withdrawal invariant: draws on no holding — its parent % is not an investment',
+        wd.parent_transaction_id using errcode = 'check_violation';
+    end if;
+
+    -- A parent that is a FUND purchase was left alone here, and #606 is what that
+    -- cost: the reader values a fund through its (goal, fund) bucket, so such a row
+    -- was measured against one balance and subtracted from another — or, before
+    -- #606, from none at all. lib/withdrawalProgress now draws it on the purchase's
+    -- BUCKET, and that leaves this branch with the wrong balance in hand: it caps
+    -- the row by the parent purchase's own principal while the units come out of a
+    -- bucket this measurement never looked at. One 50-unit purchase could take a
+    -- 45-unit fund-keyed sell AND a 10-unit parented one, each legal against its own
+    -- reading, 55 units out of 50.
+    --
+    -- So the shape is refused rather than measured twice. A fund sale is keyed by
+    -- its fund — the one shape both sheets have always posted, and the only one
+    -- this function can measure against the balance the dashboard actually reduces.
+    -- Rows already written this way keep their meaning (the reader values them into
+    -- the bucket, and withdrawal_ledger_audit reports them); what stops is writing
+    -- new ones, and editing an old one back into legality means giving it its fund.
+    if v_parent_asset = 'fund' then
+      raise exception 'withdrawal invariant: a fund sale must be keyed by its fund (asset_type=fund + fund_id), not parented to purchase %',
+        wd.parent_transaction_id using errcode = 'check_violation';
+    end if;
+
+    -- Gold is the one non-fund holding valued by QUANTITY: valueNonFundHolding
+    -- prices it as units × gold price and takes its cost basis from amount_vnd. So
+    -- a sale must move both, exactly as a fund sell must. Principal alone drops the
+    -- basis while every chỉ stays in net worth — P&L inflated and the sold gold
+    -- never leaves; units alone removes the metal and leaves its cost behind.
+    -- Keyed off the PARENT's type, not the withdrawal's: the row's own asset_type
+    -- is nullable and the route lets it be omitted. Bank and stock are unaffected —
+    -- their valuation is principal-only, and a deposit has no units to move.
+    if v_parent_asset = 'gold' and coalesce(wd.units_withdrawn, 0) <= 0 then
+      raise exception 'withdrawal invariant: a gold sale must record units_withdrawn (got %)',
+        wd.units_withdrawn using errcode = 'check_violation';
+    end if;
+
+    -- A withdrawal that records no principal takes nothing out of the holding:
+    -- lib/depositValuation subtracts coalesce(principal_withdrawn, 0), so the
+    -- deposit keeps its full value while the row claims cash left. A withdrawal
+    -- must not be valid merely because the number to measure was omitted.
+    if coalesce(wd.principal_withdrawn, 0) <= 0 then
+      raise exception 'withdrawal invariant: a withdrawal from holding % must record a positive principal_withdrawn (got %)',
+        wd.parent_transaction_id, wd.principal_withdrawn using errcode = 'check_violation';
+    end if;
+
+    select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
+      into v_out_principal, v_out_units
+      from public.investment_transactions w
+     where w.parent_transaction_id = wd.parent_transaction_id
+       and w.transaction_type = 'withdrawal'
+       -- Same precedence as the branch above, applied to the OTHER rows: a sibling
+       -- that is keyed by a fund draws on that bucket, not on this parent, so
+       -- counting it here too would charge it twice and make an ordinary later
+       -- withdrawal of this deposit look like an overdraw.
+       --
+       -- coalesce, because asset_type is nullable and the route lets a caller omit
+       -- it: written bare, the predicate is NULL for a row with a fund_id and no
+       -- asset_type, which DROPS it from this sum — while buildWithdrawalMaps
+       -- counts that row against the parent (the fund key needs asset_type =
+       -- 'fund'). Two full withdrawals of one deposit both passed that way.
+       and not coalesce(w.asset_type = 'fund' and w.fund_id is not null, false)
+       and w.transaction_id <> wd.transaction_id;
+
+  else
+    -- Nothing identifiable to draw down. A row taking principal or units out of no
+    -- holding at all is not a withdrawal — buildWithdrawalMaps files it under
+    -- neither key, so it subtracts from nothing while the record claims cash left.
+    -- Reachable by editing a fund sell's asset_type off 'fund' (the fund_id stays,
+    -- but the row leaves the fund bucket), which is why asset_type fires the
+    -- trigger: running is not enough, the new shape has to be refused.
+    if coalesce(wd.principal_withdrawn, 0) > 0 or coalesce(wd.units_withdrawn, 0) > 0 then
+      raise exception 'withdrawal invariant: draws on no holding — it has neither a parent transaction nor a fund'
+        using errcode = 'check_violation';
+    end if;
+    -- Carrying neither delta leaves nothing to measure, and exactly ONE kind of row
+    -- is allowed to be in that state: a held-for-merge settlement whose source is
+    -- not recorded yet (#588 makes them source-backed). The exception is for that
+    -- pool, so nothing else may wear it — an ordinary withdrawal has to name what it
+    -- draws on, or it is cash leaving no holding at all. held_for_merge is in the
+    -- trigger's UPDATE OF list too, so an allowed held row cannot become an
+    -- ordinary one by dropping the flag.
+    if not wd.held_for_merge then
+      raise exception 'withdrawal invariant: draws on no holding — only a held-for-merge settlement may omit its source'
+        using errcode = 'check_violation';
+    end if;
+    return;
+  end if;
+
+  -- What the holding has left, after everything already taken out of it.
+  v_left := coalesce(v_principal, 0) - v_out_principal;
+  v_left_units := coalesce(v_units, 0) - v_out_units;
+
+  -- Quantity bound, for whichever kinds carry units.
+  if coalesce(wd.units_withdrawn, 0) > 0 then
+    -- The tolerance rounds a real balance; it does not create one. Applied to an
+    -- empty holding it would hand every sold-out bucket 0.0001 units it never had.
+    if wd.units_withdrawn > v_left_units + (case when v_left_units > 0 then c_units_epsilon else 0 end) then
+      raise exception 'withdrawal invariant: % units exceeds the remaining balance of % units on this holding',
+        wd.units_withdrawn, v_left_units using errcode = 'check_violation';
+    end if;
+  end if;
+
+  if v_rows is not null or v_parent_asset = 'gold' then
+    -- ANY quantity-valued holding — a fund bucket, or gold — has its principal
+    -- BOUND TO THE UNITS, not merely capped beside them. Capping the two
+    -- independently let a sale of 1 unit out of 100 claim the whole basis and leave
+    -- 99 units with none, which corrupts every later sale's allocation and the P&L,
+    -- and eventually makes the rest unsellable for lack of basis. Gold behaves the
+    -- same way: valueNonFundHolding prices it units × market and takes its basis
+    -- from amount_vnd.
+    --
+    -- One allocation rule, shared with lib/fundWithdrawal and lib/goldWithdrawal and
+    -- matching how the dashboard itself reduces a holding: a sale of ALL the
+    -- remaining units takes the remaining basis exactly, and a partial sale takes
+    -- its units-proportional share of it. ONE rounding rule: the two sides may
+    -- differ by at most a đồng, which is what rounding a proportional slice can
+    -- produce.
+    if wd.units_withdrawn >= v_left_units - c_units_epsilon then
+      v_expected := v_left;
+    else
+      v_expected := round(wd.units_withdrawn * v_left / v_left_units);
+    end if;
+    if abs(coalesce(wd.principal_withdrawn, 0) - v_expected) > c_dong_epsilon then
+      raise exception 'withdrawal invariant: a sale of % units out of % must take % of the % basis, not %',
+        wd.units_withdrawn, v_left_units, v_expected, v_left, wd.principal_withdrawn
+        using errcode = 'check_violation';
+    end if;
+
+  elsif coalesce(wd.principal_withdrawn, 0) > 0 then
+    -- Non-fund: the principal is the user's own figure (the amount they withdrew),
+    -- bounded by what the holding still holds.
+    if wd.principal_withdrawn > v_left then
+      raise exception 'withdrawal invariant: % exceeds the remaining balance of % on this holding',
+        wd.principal_withdrawn, v_left using errcode = 'check_violation';
+    end if;
+  end if;
+end;
+$$;
+
+comment on function public.check_withdrawal_balance(public.investment_transactions) is
+  'Raises when a withdrawal/sell would take more principal or units than its holding still has. Measured under a lock on the source, so concurrent sells cannot both pass (#587).';
+
+-- Postgres grants EXECUTE on a new function to PUBLIC, and this one is SECURITY
+-- DEFINER — so left open it is an oracle: call it with a hand-built row naming
+-- someone else's holding, and the refusal message reports that holding's exact
+-- remaining principal or units, RLS bypassed, taking row locks on the way. It is
+-- the triggers' helper and nothing else's; they call it as the definer, so they
+-- keep working without these grants.
+revoke all on function public.check_withdrawal_balance(public.investment_transactions) from public;
+revoke all on function public.check_withdrawal_balance(public.investment_transactions) from anon, authenticated;
+

--- a/supabase/migrations/20260803000002_fund_sale_must_be_fund_keyed.sql
+++ b/supabase/migrations/20260803000002_fund_sale_must_be_fund_keyed.sql
@@ -26,6 +26,10 @@ language plpgsql
 security definer
 set search_path = ''
 as $$
+declare
+  -- The parent as the SHAPE check sees it, read under a lock (below).
+  v_shape_asset text;
+  v_shape_fund  uuid;
 begin
   if tg_op = 'UPDATE' then
     -- Deleting a source is an ordinary ledger action, and BOTH links a withdrawal
@@ -115,15 +119,25 @@ begin
   -- the fund branch requires BOTH asset_type='fund' and a fund_id.
   if new.parent_transaction_id is not null
      and (new.asset_type is distinct from 'fund' or new.fund_id is null) then
-    if exists (
-      select 1
-        from public.investment_transactions p
-        join public.funds f on f.id = p.fund_id
-       where p.transaction_id = new.parent_transaction_id
-         and p.user_id = new.user_id
-         and p.transaction_type = 'investment'
-         and p.asset_type = 'fund'
-    ) then
+    -- LOCKED, for the same reason every other measurement here is (see the header
+    -- of 20260730000002): read unlocked, this races the very edit that creates the
+    -- shape. A conversion of the parent bank → fund running concurrently with this
+    -- insert saw no child yet, while this saw the parent's old bank version — and
+    -- then check_withdrawal_balance locked the parent, waited for that conversion,
+    -- and measured the row against a fund purchase whose shape had just been
+    -- waved through. Taking the lock here makes the two serialize whichever wins:
+    -- this statement re-reads the committed parent and refuses, or the conversion
+    -- waits and finds the child.
+    select p.asset_type, p.fund_id
+      into v_shape_asset, v_shape_fund
+      from public.investment_transactions p
+     where p.transaction_id = new.parent_transaction_id
+       and p.user_id = new.user_id
+       and p.transaction_type = 'investment'
+       for update;
+
+    if v_shape_asset = 'fund' and v_shape_fund is not null
+       and exists (select 1 from public.funds f where f.id = v_shape_fund) then
       raise exception 'withdrawal invariant: a fund sale must be keyed by its fund (asset_type=fund + fund_id), not parented to purchase %',
         new.parent_transaction_id using errcode = 'check_violation';
     end if;

--- a/supabase/migrations/20260803000002_fund_sale_must_be_fund_keyed.sql
+++ b/supabase/migrations/20260803000002_fund_sale_must_be_fund_keyed.sql
@@ -36,6 +36,9 @@ declare
   v_left_units    numeric;
   v_parent_type   text;
   v_parent_asset  text;
+  -- The parent's own fund: what makes it a BUCKET rather than just a fund-typed
+  -- row. Deleting a fund clears it (ON DELETE SET NULL) on both sides.
+  v_parent_fund   uuid;
   -- Purchases in the fund bucket; null outside that branch, which is also how the
   -- allocation rule below knows which kind it is measuring.
   v_rows          int;
@@ -128,8 +131,8 @@ begin
   elsif wd.parent_transaction_id is not null then
     -- Bank / gold / stock: one source row. Lock it before measuring it, so two
     -- concurrent withdrawals of the same deposit serialize here.
-    select t.amount_vnd, t.units, t.transaction_type, t.asset_type
-      into v_principal, v_units, v_parent_type, v_parent_asset
+    select t.amount_vnd, t.units, t.transaction_type, t.asset_type, t.fund_id
+      into v_principal, v_units, v_parent_type, v_parent_asset, v_parent_fund
       from public.investment_transactions t
      where t.transaction_id = wd.parent_transaction_id
        and t.user_id = wd.user_id
@@ -165,7 +168,14 @@ begin
     -- Rows already written this way keep their meaning (the reader values them into
     -- the bucket, and withdrawal_ledger_audit reports them); what stops is writing
     -- new ones, and editing an old one back into legality means giving it its fund.
-    if v_parent_asset = 'fund' then
+    --
+    -- Asked exactly as lib/withdrawalProgress asks it: the parent must still CARRY
+    -- a fund. A fund-typed purchase whose fund is gone (ON DELETE SET NULL clears
+    -- fund_id on both sides) is no bucket — the reader leaves such a row on the
+    -- parent axis, and this branch measures it there, which is what keeps
+    -- DELETE /api/v1/funds/[id] working for a sell that named both its fund and a
+    -- purchase. Refusing on asset_type alone turned deleting a fund into an error.
+    if v_parent_asset = 'fund' and v_parent_fund is not null then
       raise exception 'withdrawal invariant: a fund sale must be keyed by its fund (asset_type=fund + fund_id), not parented to purchase %',
         wd.parent_transaction_id using errcode = 'check_violation';
     end if;

--- a/supabase/migrations/20260803000002_fund_sale_must_be_fund_keyed.sql
+++ b/supabase/migrations/20260803000002_fund_sale_must_be_fund_keyed.sql
@@ -2,317 +2,138 @@
 --
 -- #606 fixed the reader: a withdrawal parented to a fund purchase is valued against
 -- that purchase's (goal, fund) bucket instead of being silently uncounted. That
--- leaves the invariant measuring a balance nobody draws down. It bounds such a row
--- by the parent PURCHASE's own principal, while the units now come out of the
--- BUCKET — so one 50-unit purchase accepted a 45-unit fund-keyed sell and a 10-unit
--- parented sell, each legal against its own reading, 55 units out of 50. The
--- dashboard then subtracts all 55, drops the bucket at zero, and understates the
--- holding by the five units still held.
+-- left the invariant measuring a balance nobody draws down — it bounds such a row
+-- by the parent PURCHASE's own principal, while the units come out of the BUCKET.
+-- So one 50-unit purchase accepted a 45-unit fund-keyed sell and a 10-unit parented
+-- sell, each legal against its own reading, 55 units out of 50; the dashboard then
+-- subtracts all 55, drops the bucket at zero, and understates the holding by the
+-- five units still held.
 --
--- Two balances for one bucket is the bug; this migration removes the second one.
--- The shape is refused at write time — a fund sale carries asset_type='fund' +
--- fund_id, which is what both sell sheets have always posted — so the only rows
--- left in it are the ones already in the ledger, which the reader values and
--- withdrawal_ledger_audit reports by name.
+-- Two balances for one bucket is the bug, and this removes the second one by
+-- refusing the shape as it is WRITTEN. The check goes in the immediate trigger
+-- rather than in check_withdrawal_balance itself, and that placement is the whole
+-- point: by the time it runs, a relocation and the FK's own orphaning have both
+-- already returned, so deleting a goal or a fund still works over a ledger that
+-- already contains such rows. They stay valued by the reader and reported by
+-- withdrawal_ledger_audit; what stops is writing new ones.
 --
 -- Everything else in the function is copied verbatim from 20260730000002.
 
-create or replace function public.check_withdrawal_balance(wd public.investment_transactions)
-returns void
+-- ── immediate: a new or increased claim ──────────────────────────────────────
+create or replace function public.enforce_withdrawal_within_balance()
+returns trigger
 language plpgsql
 security definer
 set search_path = ''
 as $$
-declare
-  -- Clients round units_withdrawn to 4 decimals (parseFloat(u.toFixed(4))), so a
-  -- FULL sell can post a hair more than the holding: 50.12345 units becomes
-  -- 50.1235. Allow exactly that much and no more, or "sell everything" breaks.
-  c_units_epsilon constant numeric := 0.0001;
-  v_principal     bigint;
-  v_units         numeric;
-  v_out_principal bigint;
-  v_out_units     numeric;
-  v_left          bigint;
-  v_left_units    numeric;
-  v_parent_type   text;
-  v_parent_asset  text;
-  -- The parent's own fund: what makes it a BUCKET rather than just a fund-typed
-  -- row. Deleting a fund clears it (ON DELETE SET NULL) on both sides.
-  v_parent_fund   uuid;
-  -- Purchases in the fund bucket; null outside that branch, which is also how the
-  -- allocation rule below knows which kind it is measuring.
-  v_rows          int;
-  -- The basis a fund sale of these units is allowed to take, and the one đồng of
-  -- rounding the proportional split can produce.
-  v_expected      numeric;
-  c_dong_epsilon  constant numeric := 1;
 begin
-  if wd.transaction_type is distinct from 'withdrawal' then return; end if;
+  if tg_op = 'UPDATE' then
+    -- Deleting a source is an ordinary ledger action, and BOTH links a withdrawal
+    -- hangs on are ON DELETE SET NULL — the deposit (parent_transaction_id) and
+    -- the fund (fund_id, which a sell is keyed by). So Postgres orphans the
+    -- children with an UPDATE that lands right here, and measuring it would refuse
+    -- the row (it just lost the holding it drew on) and turn a plain delete into an
+    -- error.
+    --
+    -- Only the FK may orphan a row. Detaching a withdrawal from a source that is
+    -- still there restores the holding to full value while the withdrawal is filed
+    -- under no key at all — the same escape this function exists to close. The tell
+    -- is the source itself: by the time the FK action fires, the referenced row is
+    -- already deleted and invisible to these queries.
+    if old.parent_transaction_id is not null and new.parent_transaction_id is null then
+      if exists (select 1 from public.investment_transactions t
+                  where t.transaction_id = old.parent_transaction_id) then
+        raise exception 'withdrawal invariant: cannot be detached from holding %, which still exists',
+          old.parent_transaction_id using errcode = 'check_violation';
+      end if;
+      -- The source is gone. If the row still names a fund it now draws on that
+      -- bucket instead, so it has to be re-measured rather than waved through;
+      -- with nothing left to draw on, the leftover orphan is a shape this
+      -- invariant would not let anyone CREATE (issue #607).
+      if new.fund_id is null then return new; end if;
+    end if;
 
-  -- A negative withdrawal runs the ledger backwards: it ADDS to the holding and
-  -- banks a credit the next withdrawal can spend (the sums below are signed, and
-  -- so is lib/depositValuation's subtraction). Nothing in the schema stops one, so
-  -- the invariant does — before anything is measured, since a negative amount
-  -- would poison the measurement itself.
-  if coalesce(wd.principal_withdrawn, 0) < 0 or coalesce(wd.units_withdrawn, 0) < 0 then
-    raise exception 'withdrawal invariant: amounts cannot be negative (principal %, units %)',
-      wd.principal_withdrawn, wd.units_withdrawn using errcode = 'check_violation';
+    if old.fund_id is not null and new.fund_id is null then
+      if exists (select 1 from public.funds f where f.id = old.fund_id) then
+        raise exception 'withdrawal invariant: cannot be detached from fund %, which still exists',
+          old.fund_id using errcode = 'check_violation';
+      end if;
+      -- The fund is gone. buildWithdrawalMaps now keys the row by its PARENT, so
+      -- if it has one, it must be measured against that balance — a sell that fit
+      -- the fund bucket can overdraw a smaller deposit. With no parent either,
+      -- it is the orphan case above.
+      if new.parent_transaction_id is null then return new; end if;
+    end if;
+
+    -- A pure relocation: the claim is unchanged, only which bucket it sits in.
+    -- Its destination is only complete once the whole statement has landed (a
+    -- fund assign moves purchases and sells together), so the deferred trigger
+    -- measures this one.
+    --
+    -- Every column that can change what the row IS has to be listed here, or the
+    -- bypass hands out an exemption it was never meant to: held_for_merge was
+    -- missing, so clearing it turned a permitted no-source held settlement into an
+    -- ordinary sourceless withdrawal without anything re-measuring it. Keep this
+    -- list in step with the trigger's `update of` columns — goal_id is the only one
+    -- a relocation may touch.
+    if new.principal_withdrawn is not distinct from old.principal_withdrawn
+       and new.units_withdrawn is not distinct from old.units_withdrawn
+       and new.parent_transaction_id is not distinct from old.parent_transaction_id
+       and new.fund_id is not distinct from old.fund_id
+       and new.asset_type is not distinct from old.asset_type
+       and new.transaction_type = old.transaction_type
+       and new.held_for_merge = old.held_for_merge then
+      return new;
+    end if;
   end if;
 
-  -- The branch order is not a preference: it MIRRORS lib/withdrawalProgress, which
-  -- keys any row with asset_type='fund' + fund_id by (goal, fund) and ignores its
-  -- parent. Measuring such a row against a parent instead would check a balance
-  -- nothing draws down — a fat holding in one goal waving through a phantom fund
-  -- sell in another, since the API accepts both fields on one row.
-  if wd.asset_type = 'fund' and wd.fund_id is not null then
-    -- A fund sale is a quantity: without units the overview skips the whole
-    -- subtraction (it bails on `wd.units <= 0`) and the holding keeps its value.
-    -- The principal is then not a free number — it is the allocation of the
-    -- remaining basis for those units, checked at the end of this function.
-    if coalesce(wd.units_withdrawn, 0) <= 0 then
-      raise exception 'withdrawal invariant: a fund sale must record units_withdrawn (got %)',
-        wd.units_withdrawn using errcode = 'check_violation';
-    end if;
-
-    -- Both sides of the bucket carry `asset_type = 'fund'`, because that is what
-    -- the valuation counts: a row whose asset_type was edited off 'fund' keeps its
-    -- fund_id (the PUT clears fund_id only when that field is sent) but is valued
-    -- as a bank holding, so its units are no longer fund inventory to sell.
-    --
-    -- Lock the bucket's investment rows before measuring them (see the header):
-    -- this is what makes two concurrent sells of the same bucket serialize. Pending
-    -- DCA seeds (units is null) are excluded: they carry a planned amount with no
-    -- units bought yet, the dashboard never values them, so they hold nothing to
-    -- sell. Renewal snapshots are history copies, not holdings.
-    perform 1
-      from public.investment_transactions t
-     where t.user_id = wd.user_id
-       and t.fund_id = wd.fund_id
-       and t.asset_type = 'fund'
-       and t.transaction_type = 'investment'
-       and t.goal_id is not distinct from wd.goal_id
-       and t.renewed_from_transaction_id is null
-       and t.units is not null
-     order by t.transaction_id      -- a stable lock order; concurrent sells can't deadlock
-       for update;
-
-    -- ONE authoritative basis: Σ amount_vnd, what the purchases cost. That is
-    -- where the number lands — dashboard/overview does
-    --   acc.totalInvested -= Σ principal_withdrawn
-    -- against exactly this sum, while the NAV cost (Σ units × unit_price, fees
-    -- excluded) is reduced by units and only feeds the average entry price.
-    --
-    -- The sheets used to post a NAV-derived figure into that amount-based
-    -- accumulator, reconstructed through the averaged purchasePrice, and this check
-    -- grew a tolerance to accommodate it. lib/fundWithdrawal now takes the basis
-    -- from the dashboard directly (a full sale takes it exactly), so the two agree
-    -- and the tolerance below covers only what rounding can still explain.
-    select coalesce(sum(t.amount_vnd), 0), coalesce(sum(t.units), 0), count(*)
-      into v_principal, v_units, v_rows
-      from public.investment_transactions t
-     where t.user_id = wd.user_id
-       and t.fund_id = wd.fund_id
-       and t.asset_type = 'fund'
-       and t.transaction_type = 'investment'
-       and t.goal_id is not distinct from wd.goal_id
-       and t.renewed_from_transaction_id is null
-       and t.units is not null;
-
-    select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
-      into v_out_principal, v_out_units
-      from public.investment_transactions w
-     where w.user_id = wd.user_id
-       and w.fund_id = wd.fund_id
-       and w.asset_type = 'fund'
-       and w.transaction_type = 'withdrawal'
-       and w.goal_id is not distinct from wd.goal_id
-       and w.transaction_id <> wd.transaction_id;   -- measured without itself
-
-  elsif wd.parent_transaction_id is not null then
-    -- Bank / gold / stock: one source row. Lock it before measuring it, so two
-    -- concurrent withdrawals of the same deposit serialize here.
-    select t.amount_vnd, t.units, t.transaction_type, t.asset_type, t.fund_id
-      into v_principal, v_units, v_parent_type, v_parent_asset, v_parent_fund
-      from public.investment_transactions t
-     where t.transaction_id = wd.parent_transaction_id
-       and t.user_id = wd.user_id
-       for update;
-    -- A parent that isn't the writer's own is the ownership trigger's refusal to
-    -- make (#474 / #525); staying quiet here keeps that message the one the user
-    -- sees instead of a confusing "no balance".
-    if not found then return; end if;
-
-    -- A withdrawal is not a holding, so parenting to one invents a balance out of
-    -- money that already left. Renewal snapshots ARE valid parents on purpose:
-    -- renew and collapse re-parent partial withdrawals onto them, which is how a
-    -- renewed deposit stops double-counting them (#585).
-    --
-    if v_parent_type is distinct from 'investment' then
-      raise exception 'withdrawal invariant: draws on no holding — its parent % is not an investment',
-        wd.parent_transaction_id using errcode = 'check_violation';
-    end if;
-
-    -- A parent that is a FUND purchase was left alone here, and #606 is what that
-    -- cost: the reader values a fund through its (goal, fund) bucket, so such a row
-    -- was measured against one balance and subtracted from another — or, before
-    -- #606, from none at all. lib/withdrawalProgress now draws it on the purchase's
-    -- BUCKET, and that leaves this branch with the wrong balance in hand: it caps
-    -- the row by the parent purchase's own principal while the units come out of a
-    -- bucket this measurement never looked at. One 50-unit purchase could take a
-    -- 45-unit fund-keyed sell AND a 10-unit parented one, each legal against its own
-    -- reading, 55 units out of 50.
-    --
-    -- So the shape is refused rather than measured twice. A fund sale is keyed by
-    -- its fund — the one shape both sheets have always posted, and the only one
-    -- this function can measure against the balance the dashboard actually reduces.
-    -- Rows already written this way keep their meaning (the reader values them into
-    -- the bucket, and withdrawal_ledger_audit reports them); what stops is writing
-    -- new ones, and editing an old one back into legality means giving it its fund.
-    --
-    -- Asked exactly as lib/withdrawalProgress asks it: the parent must still CARRY
-    -- a fund. A fund-typed purchase whose fund is gone is no bucket — the reader
-    -- leaves such a row on the parent axis, and this branch measures it there.
-    --
-    -- And the fund itself has to still EXIST, which is not the same question. When
-    -- a fund is deleted, ON DELETE SET NULL clears fund_id on every referencing row
-    -- in one statement, in no defined order: a sell that named both its fund and a
-    -- purchase in it can be re-measured BEFORE its parent has been cleared, and
-    -- then the parent still shows the fund that is already gone. Keyed off fund_id
-    -- alone, deleting a fund succeeded or raised depending on heap order. The
-    -- lookup below is the same tell 20260730000002 uses for the orphan cases: a
-    -- referenced fund row that no longer exists is the FK's own transition, not a
-    -- freshly written parent-backed sale.
-    if v_parent_asset = 'fund' and v_parent_fund is not null
-       and exists (select 1 from public.funds f where f.id = v_parent_fund) then
+  -- ── a fund sale is keyed by its fund (#606) ──────────────────────────────
+  -- Everything above this line has decided that the row is a NEW or RAISED claim:
+  -- a relocation has already returned, and the FK's own orphaning has too. This is
+  -- therefore the one place the SHAPE can be refused without refusing history.
+  --
+  -- Why refuse it at all: lib/withdrawalProgress values a withdrawal parented to a
+  -- fund purchase against that purchase's (goal, fund) BUCKET, while
+  -- check_withdrawal_balance measures it against the purchase's own principal. Two
+  -- balances for one bucket — a 50-unit purchase took a 45-unit fund-keyed sell AND
+  -- a 10-unit parented one, each legal against its own reading, 55 units out of 50,
+  -- and the dashboard then drops the holding five units early. A fund sale carries
+  -- asset_type='fund' + fund_id, which is what both sell sheets have always posted
+  -- and the only shape measurable against the balance the dashboard reduces.
+  --
+  -- Two things it deliberately does NOT refuse:
+  --   • the parent's fund must still EXIST. Deleting a fund clears fund_id on every
+  --     referencing row in one statement, in no defined order, so this can run while
+  --     the parent still shows the fund that is already gone; and a purchase with no
+  --     fund is no bucket anyway — the reader leaves such a row on the parent axis.
+  --   • a relocation. Deleting a goal (ON DELETE SET NULL) and assigning a fund both
+  --     re-measure existing rows through the DEFERRED trigger, which calls
+  --     check_withdrawal_balance directly and never reaches this check. A legacy row
+  --     must not make a goal undeletable — it is history, valued by the reader and
+  --     reported by withdrawal_ledger_audit. What stops is writing new ones.
+  -- "not fund-keyed", spelled with the parens it needs: asset_type is nullable, so
+  -- the fund branch requires BOTH asset_type='fund' and a fund_id.
+  if new.parent_transaction_id is not null
+     and (new.asset_type is distinct from 'fund' or new.fund_id is null) then
+    if exists (
+      select 1
+        from public.investment_transactions p
+        join public.funds f on f.id = p.fund_id
+       where p.transaction_id = new.parent_transaction_id
+         and p.user_id = new.user_id
+         and p.transaction_type = 'investment'
+         and p.asset_type = 'fund'
+    ) then
       raise exception 'withdrawal invariant: a fund sale must be keyed by its fund (asset_type=fund + fund_id), not parented to purchase %',
-        wd.parent_transaction_id using errcode = 'check_violation';
-    end if;
-
-    -- Gold is the one non-fund holding valued by QUANTITY: valueNonFundHolding
-    -- prices it as units × gold price and takes its cost basis from amount_vnd. So
-    -- a sale must move both, exactly as a fund sell must. Principal alone drops the
-    -- basis while every chỉ stays in net worth — P&L inflated and the sold gold
-    -- never leaves; units alone removes the metal and leaves its cost behind.
-    -- Keyed off the PARENT's type, not the withdrawal's: the row's own asset_type
-    -- is nullable and the route lets it be omitted. Bank and stock are unaffected —
-    -- their valuation is principal-only, and a deposit has no units to move.
-    if v_parent_asset = 'gold' and coalesce(wd.units_withdrawn, 0) <= 0 then
-      raise exception 'withdrawal invariant: a gold sale must record units_withdrawn (got %)',
-        wd.units_withdrawn using errcode = 'check_violation';
-    end if;
-
-    -- A withdrawal that records no principal takes nothing out of the holding:
-    -- lib/depositValuation subtracts coalesce(principal_withdrawn, 0), so the
-    -- deposit keeps its full value while the row claims cash left. A withdrawal
-    -- must not be valid merely because the number to measure was omitted.
-    if coalesce(wd.principal_withdrawn, 0) <= 0 then
-      raise exception 'withdrawal invariant: a withdrawal from holding % must record a positive principal_withdrawn (got %)',
-        wd.parent_transaction_id, wd.principal_withdrawn using errcode = 'check_violation';
-    end if;
-
-    select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
-      into v_out_principal, v_out_units
-      from public.investment_transactions w
-     where w.parent_transaction_id = wd.parent_transaction_id
-       and w.transaction_type = 'withdrawal'
-       -- Same precedence as the branch above, applied to the OTHER rows: a sibling
-       -- that is keyed by a fund draws on that bucket, not on this parent, so
-       -- counting it here too would charge it twice and make an ordinary later
-       -- withdrawal of this deposit look like an overdraw.
-       --
-       -- coalesce, because asset_type is nullable and the route lets a caller omit
-       -- it: written bare, the predicate is NULL for a row with a fund_id and no
-       -- asset_type, which DROPS it from this sum — while buildWithdrawalMaps
-       -- counts that row against the parent (the fund key needs asset_type =
-       -- 'fund'). Two full withdrawals of one deposit both passed that way.
-       and not coalesce(w.asset_type = 'fund' and w.fund_id is not null, false)
-       and w.transaction_id <> wd.transaction_id;
-
-  else
-    -- Nothing identifiable to draw down. A row taking principal or units out of no
-    -- holding at all is not a withdrawal — buildWithdrawalMaps files it under
-    -- neither key, so it subtracts from nothing while the record claims cash left.
-    -- Reachable by editing a fund sell's asset_type off 'fund' (the fund_id stays,
-    -- but the row leaves the fund bucket), which is why asset_type fires the
-    -- trigger: running is not enough, the new shape has to be refused.
-    if coalesce(wd.principal_withdrawn, 0) > 0 or coalesce(wd.units_withdrawn, 0) > 0 then
-      raise exception 'withdrawal invariant: draws on no holding — it has neither a parent transaction nor a fund'
-        using errcode = 'check_violation';
-    end if;
-    -- Carrying neither delta leaves nothing to measure, and exactly ONE kind of row
-    -- is allowed to be in that state: a held-for-merge settlement whose source is
-    -- not recorded yet (#588 makes them source-backed). The exception is for that
-    -- pool, so nothing else may wear it — an ordinary withdrawal has to name what it
-    -- draws on, or it is cash leaving no holding at all. held_for_merge is in the
-    -- trigger's UPDATE OF list too, so an allowed held row cannot become an
-    -- ordinary one by dropping the flag.
-    if not wd.held_for_merge then
-      raise exception 'withdrawal invariant: draws on no holding — only a held-for-merge settlement may omit its source'
-        using errcode = 'check_violation';
-    end if;
-    return;
-  end if;
-
-  -- What the holding has left, after everything already taken out of it.
-  v_left := coalesce(v_principal, 0) - v_out_principal;
-  v_left_units := coalesce(v_units, 0) - v_out_units;
-
-  -- Quantity bound, for whichever kinds carry units.
-  if coalesce(wd.units_withdrawn, 0) > 0 then
-    -- The tolerance rounds a real balance; it does not create one. Applied to an
-    -- empty holding it would hand every sold-out bucket 0.0001 units it never had.
-    if wd.units_withdrawn > v_left_units + (case when v_left_units > 0 then c_units_epsilon else 0 end) then
-      raise exception 'withdrawal invariant: % units exceeds the remaining balance of % units on this holding',
-        wd.units_withdrawn, v_left_units using errcode = 'check_violation';
+        new.parent_transaction_id using errcode = 'check_violation';
     end if;
   end if;
 
-  if v_rows is not null or v_parent_asset = 'gold' then
-    -- ANY quantity-valued holding — a fund bucket, or gold — has its principal
-    -- BOUND TO THE UNITS, not merely capped beside them. Capping the two
-    -- independently let a sale of 1 unit out of 100 claim the whole basis and leave
-    -- 99 units with none, which corrupts every later sale's allocation and the P&L,
-    -- and eventually makes the rest unsellable for lack of basis. Gold behaves the
-    -- same way: valueNonFundHolding prices it units × market and takes its basis
-    -- from amount_vnd.
-    --
-    -- One allocation rule, shared with lib/fundWithdrawal and lib/goldWithdrawal and
-    -- matching how the dashboard itself reduces a holding: a sale of ALL the
-    -- remaining units takes the remaining basis exactly, and a partial sale takes
-    -- its units-proportional share of it. ONE rounding rule: the two sides may
-    -- differ by at most a đồng, which is what rounding a proportional slice can
-    -- produce.
-    if wd.units_withdrawn >= v_left_units - c_units_epsilon then
-      v_expected := v_left;
-    else
-      v_expected := round(wd.units_withdrawn * v_left / v_left_units);
-    end if;
-    if abs(coalesce(wd.principal_withdrawn, 0) - v_expected) > c_dong_epsilon then
-      raise exception 'withdrawal invariant: a sale of % units out of % must take % of the % basis, not %',
-        wd.units_withdrawn, v_left_units, v_expected, v_left, wd.principal_withdrawn
-        using errcode = 'check_violation';
-    end if;
-
-  elsif coalesce(wd.principal_withdrawn, 0) > 0 then
-    -- Non-fund: the principal is the user's own figure (the amount they withdrew),
-    -- bounded by what the holding still holds.
-    if wd.principal_withdrawn > v_left then
-      raise exception 'withdrawal invariant: % exceeds the remaining balance of % on this holding',
-        wd.principal_withdrawn, v_left using errcode = 'check_violation';
-    end if;
-  end if;
+  perform public.check_withdrawal_balance(new);
+  return new;
 end;
 $$;
 
-comment on function public.check_withdrawal_balance(public.investment_transactions) is
-  'Raises when a withdrawal/sell would take more principal or units than its holding still has. Measured under a lock on the source, so concurrent sells cannot both pass (#587).';
-
--- Postgres grants EXECUTE on a new function to PUBLIC, and this one is SECURITY
--- DEFINER — so left open it is an oracle: call it with a hand-built row naming
--- someone else's holding, and the refusal message reports that holding's exact
--- remaining principal or units, RLS bypassed, taking row locks on the way. It is
--- the triggers' helper and nothing else's; they call it as the definer, so they
--- keep working without these grants.
-revoke all on function public.check_withdrawal_balance(public.investment_transactions) from public;
-revoke all on function public.check_withdrawal_balance(public.investment_transactions) from anon, authenticated;
+comment on function public.enforce_withdrawal_within_balance() is
+  'Measures a new or increased withdrawal claim against its holding as it is written (#587).';
 

--- a/supabase/migrations/20260803000002_fund_sale_must_be_fund_keyed.sql
+++ b/supabase/migrations/20260803000002_fund_sale_must_be_fund_keyed.sql
@@ -30,6 +30,7 @@ declare
   -- The parent as the SHAPE check sees it, read under a lock (below).
   v_shape_asset text;
   v_shape_fund  uuid;
+  v_shape_units numeric;
 begin
   if tg_op = 'UPDATE' then
     -- Deleting a source is an ordinary ledger action, and BOTH links a withdrawal
@@ -128,15 +129,18 @@ begin
     -- waved through. Taking the lock here makes the two serialize whichever wins:
     -- this statement re-reads the committed parent and refuses, or the conversion
     -- waits and finds the child.
-    select p.asset_type, p.fund_id
-      into v_shape_asset, v_shape_fund
+    select p.asset_type, p.fund_id, coalesce(p.units, 0)
+      into v_shape_asset, v_shape_fund, v_shape_units
       from public.investment_transactions p
      where p.transaction_id = new.parent_transaction_id
        and p.user_id = new.user_id
        and p.transaction_type = 'investment'
        for update;
 
-    if v_shape_asset = 'fund' and v_shape_fund is not null
+    -- `units > 0` for the same reason lib/withdrawalProgress asks it: a purchase
+    -- with no units is no bucket — the dashboard values it as an ordinary holding —
+    -- so a withdrawal on it stays on the parent axis and is not the forbidden shape.
+    if v_shape_asset = 'fund' and v_shape_fund is not null and v_shape_units > 0
        and exists (select 1 from public.funds f where f.id = v_shape_fund) then
       raise exception 'withdrawal invariant: a fund sale must be keyed by its fund (asset_type=fund + fund_id), not parented to purchase %',
         new.parent_transaction_id using errcode = 'check_violation';

--- a/supabase/migrations/20260803000002_fund_sale_must_be_fund_keyed.sql
+++ b/supabase/migrations/20260803000002_fund_sale_must_be_fund_keyed.sql
@@ -170,12 +170,20 @@ begin
     -- new ones, and editing an old one back into legality means giving it its fund.
     --
     -- Asked exactly as lib/withdrawalProgress asks it: the parent must still CARRY
-    -- a fund. A fund-typed purchase whose fund is gone (ON DELETE SET NULL clears
-    -- fund_id on both sides) is no bucket — the reader leaves such a row on the
-    -- parent axis, and this branch measures it there, which is what keeps
-    -- DELETE /api/v1/funds/[id] working for a sell that named both its fund and a
-    -- purchase. Refusing on asset_type alone turned deleting a fund into an error.
-    if v_parent_asset = 'fund' and v_parent_fund is not null then
+    -- a fund. A fund-typed purchase whose fund is gone is no bucket — the reader
+    -- leaves such a row on the parent axis, and this branch measures it there.
+    --
+    -- And the fund itself has to still EXIST, which is not the same question. When
+    -- a fund is deleted, ON DELETE SET NULL clears fund_id on every referencing row
+    -- in one statement, in no defined order: a sell that named both its fund and a
+    -- purchase in it can be re-measured BEFORE its parent has been cleared, and
+    -- then the parent still shows the fund that is already gone. Keyed off fund_id
+    -- alone, deleting a fund succeeded or raised depending on heap order. The
+    -- lookup below is the same tell 20260730000002 uses for the orphan cases: a
+    -- referenced fund row that no longer exists is the FK's own transition, not a
+    -- freshly written parent-backed sale.
+    if v_parent_asset = 'fund' and v_parent_fund is not null
+       and exists (select 1 from public.funds f where f.id = v_parent_fund) then
       raise exception 'withdrawal invariant: a fund sale must be keyed by its fund (asset_type=fund + fund_id), not parented to purchase %',
         wd.parent_transaction_id using errcode = 'check_violation';
     end if;

--- a/supabase/migrations/20260803000003_parent_cannot_become_a_fund_under_withdrawals.sql
+++ b/supabase/migrations/20260803000003_parent_cannot_become_a_fund_under_withdrawals.sql
@@ -54,7 +54,17 @@ begin
 
   -- BECOMING a fund purchase: every non-fund-keyed child would wake up parented to
   -- a fund, which is the shape 20260803000002 refuses at the child's own door.
-  if (old.asset_type is distinct from new.asset_type or old.fund_id is distinct from new.fund_id)
+  --
+  -- transaction_type counts as becoming one, and the trigger lists it too. Without
+  -- that, the guard was two updates wide: turn the parent into a valid fund-keyed
+  -- WITHDRAWAL first (this function returns — it is no longer an investment), then
+  -- flip transaction_type back on its own. The second statement changed no column
+  -- this trigger watched and left a fund purchase sitting under the legacy child,
+  -- which is the whole shape the migration exists to prevent. Verified against the
+  -- local stack: both steps were accepted.
+  if (old.asset_type is distinct from new.asset_type
+      or old.fund_id is distinct from new.fund_id
+      or old.transaction_type is distinct from new.transaction_type)
      and exists (
        select 1
          from public.investment_transactions w
@@ -99,7 +109,7 @@ revoke all on function public.enforce_parent_not_fund_under_withdrawals() from a
 
 drop trigger if exists investment_transactions_parent_not_fund on public.investment_transactions;
 create trigger investment_transactions_parent_not_fund
-  before update of asset_type, fund_id, amount_vnd, units
+  before update of transaction_type, asset_type, fund_id, amount_vnd, units
   on public.investment_transactions
   for each row
   when (new.transaction_type = 'investment')

--- a/supabase/migrations/20260803000003_parent_cannot_become_a_fund_under_withdrawals.sql
+++ b/supabase/migrations/20260803000003_parent_cannot_become_a_fund_under_withdrawals.sql
@@ -19,12 +19,13 @@
 -- a new sale, asked of the edit that would create the shape.
 --
 -- The same statement is also the only thing that can move the RATE a legacy child's
--- units are derived at. Those units are `parent units x principal / parent amount`,
+-- units are DERIVED at. Those units are `parent units x principal / parent amount`,
 -- so editing the purchase's amount_vnd or units rewrites how much the dashboard
 -- takes out of the bucket for a row nothing re-measured — two principal-only
 -- children of a 50-unit / 2,000,000 purchase derive 12.5 units each today and 25
 -- each if the purchase is re-priced to half the units. The guard covers that edit
--- too, for a purchase that HAS such a child.
+-- too, and only for children that are actually derived from it: one that RECORDS a
+-- positive units_withdrawn is read as written, so it must not freeze the edit.
 --
 -- (The general case — lowering a holding's amount below what has already been
 -- withdrawn — is the mirror hole 20260730000002 names in its header and #608 owns.
@@ -46,35 +47,46 @@ security definer
 set search_path = ''
 as $$
 begin
-  if new.transaction_type = 'investment'
-     and new.asset_type = 'fund' and new.fund_id is not null
-     and (old.asset_type is distinct from new.asset_type
-          or old.fund_id is distinct from new.fund_id
-          -- The purchase's own PRICE is the rate a legacy child's units are derived
-          -- at (units x principal / amount, lib/withdrawalProgress), so editing it
-          -- silently rewrites how much the dashboard takes out of the bucket for a
-          -- row nothing re-measured. Only a purchase that HAS such a child is
-          -- affected: an ordinary fund holding, whose sells carry their own fund,
-          -- is edited exactly as before.
-          or old.amount_vnd is distinct from new.amount_vnd
-          or old.units is distinct from new.units) then
-    if exists (
-      select 1
-        from public.investment_transactions w
-       where w.parent_transaction_id = new.transaction_id
-         and w.transaction_type = 'withdrawal'
-         and (w.asset_type is distinct from 'fund' or w.fund_id is null)
-    ) then
-      -- Prefixed like every other refusal in this family so the API maps it to a
-      -- 400 with the one match it already has.
-      if old.asset_type is distinct from new.asset_type or old.fund_id is distinct from new.fund_id then
-        raise exception 'withdrawal invariant: holding % cannot become a fund purchase while a withdrawal that is not keyed by a fund draws on it',
-          new.transaction_id using errcode = 'check_violation';
-      end if;
-      raise exception 'withdrawal invariant: fund purchase % cannot change its amount or units while a withdrawal that is not keyed by a fund draws on it — that row''s units are derived from this purchase',
-        new.transaction_id using errcode = 'check_violation';
-    end if;
+  if new.transaction_type is distinct from 'investment'
+     or new.asset_type is distinct from 'fund' or new.fund_id is null then
+    return new;
   end if;
+
+  -- BECOMING a fund purchase: every non-fund-keyed child would wake up parented to
+  -- a fund, which is the shape 20260803000002 refuses at the child's own door.
+  if (old.asset_type is distinct from new.asset_type or old.fund_id is distinct from new.fund_id)
+     and exists (
+       select 1
+         from public.investment_transactions w
+        where w.parent_transaction_id = new.transaction_id
+          and w.transaction_type = 'withdrawal'
+          and (w.asset_type is distinct from 'fund' or w.fund_id is null)
+     ) then
+    -- Prefixed like every other refusal in this family so the API maps it to a 400
+    -- with the one match it already has.
+    raise exception 'withdrawal invariant: holding % cannot become a fund purchase while a withdrawal that is not keyed by a fund draws on it',
+      new.transaction_id using errcode = 'check_violation';
+  end if;
+
+  -- RE-PRICING one: this row's price is the rate a legacy child's units are DERIVED
+  -- at (parent units x principal / parent amount, lib/withdrawalProgress), so moving
+  -- it rewrites what the dashboard takes out of the bucket for a row nothing
+  -- re-measures. Only children that are actually derived from it are affected: one
+  -- that RECORDS a positive units_withdrawn is read as written, whatever this
+  -- purchase later costs, so it must not freeze an ordinary edit.
+  if (old.amount_vnd is distinct from new.amount_vnd or old.units is distinct from new.units)
+     and exists (
+       select 1
+         from public.investment_transactions w
+        where w.parent_transaction_id = new.transaction_id
+          and w.transaction_type = 'withdrawal'
+          and (w.asset_type is distinct from 'fund' or w.fund_id is null)
+          and coalesce(w.units_withdrawn, 0) <= 0
+     ) then
+    raise exception 'withdrawal invariant: fund purchase % cannot change its amount or units while a withdrawal that is not keyed by a fund derives its units from it',
+      new.transaction_id using errcode = 'check_violation';
+  end if;
+
   return new;
 end;
 $$;

--- a/supabase/migrations/20260803000003_parent_cannot_become_a_fund_under_withdrawals.sql
+++ b/supabase/migrations/20260803000003_parent_cannot_become_a_fund_under_withdrawals.sql
@@ -27,9 +27,15 @@
 -- too, and only for children that are actually derived from it: one that RECORDS a
 -- positive units_withdrawn is read as written, so it must not freeze the edit.
 --
--- (The general case — lowering a holding's amount below what has already been
--- withdrawn — is the mirror hole 20260730000002 names in its header and #608 owns.
--- This is only the part #606 introduced by deriving from the parent's price.)
+-- (The general case — lowering a holding below what has already been withdrawn — is
+-- the mirror hole 20260730000002 names in its header and #608 owns. It is NOT
+-- special to legacy children: shrinking a fund purchase under an ordinary
+-- fund-keyed sell leaves the same bucket owing units it does not hold, today,
+-- unchanged by any of this. What #606 adds is that a legacy child now draws on the
+-- bucket like any other sell — so it joins that hole rather than making a new one,
+-- and the fix belongs where the whole class is fixed. What is guarded here is only
+-- the part #606 did introduce: the RATE such a child's units are derived at, which
+-- nothing but this edit can move.)
 --
 -- Scope, deliberately narrow:
 --   • Only a purchase with a non-fund-keyed child. An ordinary fund holding, whose
@@ -46,6 +52,10 @@ language plpgsql
 security definer
 set search_path = ''
 as $$
+declare
+  v_rate_kept        boolean;
+  v_max_principal    bigint;
+  v_derived_children int;
 begin
   if new.transaction_type is distinct from 'investment'
      or new.asset_type is distinct from 'fund' or new.fund_id is null then
@@ -84,17 +94,33 @@ begin
   -- re-measures. Only children that are actually derived from it are affected: one
   -- that RECORDS a positive units_withdrawn is read as written, whatever this
   -- purchase later costs, so it must not freeze an ordinary edit.
-  if (old.amount_vnd is distinct from new.amount_vnd or old.units is distinct from new.units)
-     and exists (
-       select 1
-         from public.investment_transactions w
-        where w.parent_transaction_id = new.transaction_id
-          and w.transaction_type = 'withdrawal'
-          and (w.asset_type is distinct from 'fund' or w.fund_id is null)
-          and coalesce(w.units_withdrawn, 0) <= 0
-     ) then
-    raise exception 'withdrawal invariant: fund purchase % cannot change its amount or units while a withdrawal that is not keyed by a fund derives its units from it',
-      new.transaction_id using errcode = 'check_violation';
+  if old.amount_vnd is distinct from new.amount_vnd or old.units is distinct from new.units then
+    -- What the RATE does to each derived child, rather than whether the columns
+    -- moved: `units x principal / amount` is unchanged by a proportional correction
+    -- (50 units / 2,000,000 restated as 100 / 4,000,000 takes exactly the same
+    -- quantity out of the bucket), and freezing both columns refused that edit for
+    -- no gain. The cap has to hold still too: the derivation is capped at the
+    -- purchase's own units, and that cap only ever binds for a child whose
+    -- principal exceeds the purchase's cost — so an edit is safe when the rate is
+    -- preserved and no derived child is in that position on either side of it.
+    v_rate_kept := coalesce(old.units, 0) > 0 and coalesce(old.amount_vnd, 0) > 0
+               and coalesce(new.units, 0) > 0 and coalesce(new.amount_vnd, 0) > 0
+               and old.units * new.amount_vnd = new.units * old.amount_vnd;
+
+    select coalesce(max(w.principal_withdrawn), 0), count(*)
+      into v_max_principal, v_derived_children
+      from public.investment_transactions w
+     where w.parent_transaction_id = new.transaction_id
+       and w.transaction_type = 'withdrawal'
+       and (w.asset_type is distinct from 'fund' or w.fund_id is null)
+       and coalesce(w.units_withdrawn, 0) <= 0;
+
+    if v_derived_children > 0
+       and not (v_rate_kept
+                and v_max_principal <= least(coalesce(old.amount_vnd, 0), coalesce(new.amount_vnd, 0))) then
+      raise exception 'withdrawal invariant: fund purchase % cannot change the rate a withdrawal that is not keyed by a fund derives its units at',
+        new.transaction_id using errcode = 'check_violation';
+    end if;
   end if;
 
   return new;

--- a/supabase/migrations/20260803000003_parent_cannot_become_a_fund_under_withdrawals.sql
+++ b/supabase/migrations/20260803000003_parent_cannot_become_a_fund_under_withdrawals.sql
@@ -18,10 +18,22 @@
 -- given its fund (or removed) first — the same end state 20260803000002 demands of
 -- a new sale, asked of the edit that would create the shape.
 --
+-- The same statement is also the only thing that can move the RATE a legacy child's
+-- units are derived at. Those units are `parent units x principal / parent amount`,
+-- so editing the purchase's amount_vnd or units rewrites how much the dashboard
+-- takes out of the bucket for a row nothing re-measured — two principal-only
+-- children of a 50-unit / 2,000,000 purchase derive 12.5 units each today and 25
+-- each if the purchase is re-priced to half the units. The guard covers that edit
+-- too, for a purchase that HAS such a child.
+--
+-- (The general case — lowering a holding's amount below what has already been
+-- withdrawn — is the mirror hole 20260730000002 names in its header and #608 owns.
+-- This is only the part #606 introduced by deriving from the parent's price.)
+--
 -- Scope, deliberately narrow:
---   • Only BECOMING one. A row that is already a fund purchase is untouched, so
---     ordinary edits to a fund holding still work, and the legacy rows already in
---     the ledger keep the meaning the reader gives them.
+--   • Only a purchase with a non-fund-keyed child. An ordinary fund holding, whose
+--     sells carry their own fund, is created and edited exactly as before, and the
+--     legacy rows already in the ledger keep the meaning the reader gives them.
 --   • Only rows that carry a fund. Clearing fund_id — which ON DELETE SET NULL does
 --     for the whole table when a fund is deleted — is the opposite direction and
 --     must never raise (see 20260803000002's own handling of that cascade).
@@ -37,7 +49,15 @@ begin
   if new.transaction_type = 'investment'
      and new.asset_type = 'fund' and new.fund_id is not null
      and (old.asset_type is distinct from new.asset_type
-          or old.fund_id is distinct from new.fund_id) then
+          or old.fund_id is distinct from new.fund_id
+          -- The purchase's own PRICE is the rate a legacy child's units are derived
+          -- at (units x principal / amount, lib/withdrawalProgress), so editing it
+          -- silently rewrites how much the dashboard takes out of the bucket for a
+          -- row nothing re-measured. Only a purchase that HAS such a child is
+          -- affected: an ordinary fund holding, whose sells carry their own fund,
+          -- is edited exactly as before.
+          or old.amount_vnd is distinct from new.amount_vnd
+          or old.units is distinct from new.units) then
     if exists (
       select 1
         from public.investment_transactions w
@@ -47,7 +67,11 @@ begin
     ) then
       -- Prefixed like every other refusal in this family so the API maps it to a
       -- 400 with the one match it already has.
-      raise exception 'withdrawal invariant: holding % cannot become a fund purchase while a withdrawal that is not keyed by a fund draws on it',
+      if old.asset_type is distinct from new.asset_type or old.fund_id is distinct from new.fund_id then
+        raise exception 'withdrawal invariant: holding % cannot become a fund purchase while a withdrawal that is not keyed by a fund draws on it',
+          new.transaction_id using errcode = 'check_violation';
+      end if;
+      raise exception 'withdrawal invariant: fund purchase % cannot change its amount or units while a withdrawal that is not keyed by a fund draws on it — that row''s units are derived from this purchase',
         new.transaction_id using errcode = 'check_violation';
     end if;
   end if;
@@ -56,14 +80,14 @@ end;
 $$;
 
 comment on function public.enforce_parent_not_fund_under_withdrawals() is
-  'Refuses turning a holding into a fund purchase while non-fund-keyed withdrawals draw on it — the other door into the shape 20260803000002 refuses (#606).';
+  'Refuses turning a holding into a fund purchase, or re-pricing one, while non-fund-keyed withdrawals draw on it — the other door into the shape 20260803000002 refuses, and the rate their units are derived at (#606).';
 
 revoke all on function public.enforce_parent_not_fund_under_withdrawals() from public;
 revoke all on function public.enforce_parent_not_fund_under_withdrawals() from anon, authenticated;
 
 drop trigger if exists investment_transactions_parent_not_fund on public.investment_transactions;
 create trigger investment_transactions_parent_not_fund
-  before update of asset_type, fund_id
+  before update of asset_type, fund_id, amount_vnd, units
   on public.investment_transactions
   for each row
   when (new.transaction_type = 'investment')

--- a/supabase/migrations/20260803000003_parent_cannot_become_a_fund_under_withdrawals.sql
+++ b/supabase/migrations/20260803000003_parent_cannot_become_a_fund_under_withdrawals.sql
@@ -1,0 +1,70 @@
+-- A holding cannot turn into a fund purchase under withdrawals that draw on it.
+--
+-- 20260803000002 refuses a fund sale that names a purchase as its parent, but it
+-- guards the WITHDRAWAL's own writes. The same forbidden shape can be assembled
+-- from the other end, and nothing fired: PUT /api/v1/investment-transactions/[id]
+-- lets a holding change asset_type (#593), so a perfectly ordinary bank deposit
+-- with a withdrawal hanging off it can be edited into a fund purchase — and the
+-- withdrawal, untouched by that statement, wakes up parented to a fund.
+--
+-- Verified against the local stack before this migration: the conversion went
+-- through in silence. From then on lib/withdrawalProgress redirects the child into
+-- the fund's (goal, fund) bucket while check_withdrawal_balance would have measured
+-- it against the parent's own principal — the two balances #606 exists to collapse,
+-- reachable again through a door the child's trigger cannot see.
+--
+-- So the parent is asked the question instead: it may become a fund purchase only
+-- when nothing draws on it that isn't already fund-keyed. The withdrawal has to be
+-- given its fund (or removed) first — the same end state 20260803000002 demands of
+-- a new sale, asked of the edit that would create the shape.
+--
+-- Scope, deliberately narrow:
+--   • Only BECOMING one. A row that is already a fund purchase is untouched, so
+--     ordinary edits to a fund holding still work, and the legacy rows already in
+--     the ledger keep the meaning the reader gives them.
+--   • Only rows that carry a fund. Clearing fund_id — which ON DELETE SET NULL does
+--     for the whole table when a fund is deleted — is the opposite direction and
+--     must never raise (see 20260803000002's own handling of that cascade).
+--   • Only non-fund-keyed children. A sell that carries asset_type='fund' + fund_id
+--     draws on its own bucket whatever its parent is, exactly as it did before.
+create or replace function public.enforce_parent_not_fund_under_withdrawals()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if new.transaction_type = 'investment'
+     and new.asset_type = 'fund' and new.fund_id is not null
+     and (old.asset_type is distinct from new.asset_type
+          or old.fund_id is distinct from new.fund_id) then
+    if exists (
+      select 1
+        from public.investment_transactions w
+       where w.parent_transaction_id = new.transaction_id
+         and w.transaction_type = 'withdrawal'
+         and (w.asset_type is distinct from 'fund' or w.fund_id is null)
+    ) then
+      -- Prefixed like every other refusal in this family so the API maps it to a
+      -- 400 with the one match it already has.
+      raise exception 'withdrawal invariant: holding % cannot become a fund purchase while a withdrawal that is not keyed by a fund draws on it',
+        new.transaction_id using errcode = 'check_violation';
+    end if;
+  end if;
+  return new;
+end;
+$$;
+
+comment on function public.enforce_parent_not_fund_under_withdrawals() is
+  'Refuses turning a holding into a fund purchase while non-fund-keyed withdrawals draw on it — the other door into the shape 20260803000002 refuses (#606).';
+
+revoke all on function public.enforce_parent_not_fund_under_withdrawals() from public;
+revoke all on function public.enforce_parent_not_fund_under_withdrawals() from anon, authenticated;
+
+drop trigger if exists investment_transactions_parent_not_fund on public.investment_transactions;
+create trigger investment_transactions_parent_not_fund
+  before update of asset_type, fund_id
+  on public.investment_transactions
+  for each row
+  when (new.transaction_type = 'investment')
+  execute function public.enforce_parent_not_fund_under_withdrawals();

--- a/supabase/migrations/20260803000003_parent_cannot_become_a_fund_under_withdrawals.sql
+++ b/supabase/migrations/20260803000003_parent_cannot_become_a_fund_under_withdrawals.sql
@@ -76,9 +76,16 @@ begin
   -- this trigger watched and left a fund purchase sitting under the legacy child,
   -- which is the whole shape the migration exists to prevent. Verified against the
   -- local stack: both steps were accepted.
+  --
+  -- GAINING units is becoming one too, for the same reason `units > 0` gates this
+  -- function at all: a purchase with none is no bucket, so its children sit on the
+  -- parent axis — and the statement that gives it units makes every one of them a
+  -- claim on a bucket. The pricing branch below would only have caught the children
+  -- whose units are derived; this catches the rest.
   if (old.asset_type is distinct from new.asset_type
       or old.fund_id is distinct from new.fund_id
-      or old.transaction_type is distinct from new.transaction_type)
+      or old.transaction_type is distinct from new.transaction_type
+      or (coalesce(old.units, 0) <= 0 and coalesce(new.units, 0) > 0))
      and exists (
        select 1
          from public.investment_transactions w

--- a/supabase/migrations/20260803000003_parent_cannot_become_a_fund_under_withdrawals.sql
+++ b/supabase/migrations/20260803000003_parent_cannot_become_a_fund_under_withdrawals.sql
@@ -57,8 +57,12 @@ declare
   v_max_principal    bigint;
   v_derived_children int;
 begin
+  -- `units > 0` mirrors lib/withdrawalProgress: a purchase with no units is no
+  -- bucket (the dashboard values it as an ordinary holding), so a withdrawal on it
+  -- stays on the parent axis and none of this applies.
   if new.transaction_type is distinct from 'investment'
-     or new.asset_type is distinct from 'fund' or new.fund_id is null then
+     or new.asset_type is distinct from 'fund' or new.fund_id is null
+     or coalesce(new.units, 0) <= 0 then
     return new;
   end if;
 

--- a/supabase/migrations/20260803000004_bucket_solvency_counts_parented_claims.sql
+++ b/supabase/migrations/20260803000004_bucket_solvency_counts_parented_claims.sql
@@ -1,0 +1,95 @@
+-- A fund bucket's solvency must count every claim the dashboard counts (#606).
+--
+-- check_fund_bucket_solvent refuses a relocation that would leave a bucket owing
+-- more units or basis than it holds (#587): an assign moves a fund's purchases,
+-- and a sale left behind in the old bucket is silent net-worth inflation. It sums
+-- the sales the reader summed at the time — fund-keyed rows only.
+--
+-- #606 gave the reader a second kind of claim on the same bucket: a withdrawal
+-- parented to a fund purchase draws on that purchase's (goal, fund) bucket, at its
+-- recorded units or, with none recorded, the pro-rata share of the purchase it
+-- names. Those claims were invisible here, so a move could be waved through that
+-- the dashboard then reads as an overdraw:
+--
+--   two 50-unit purchases in one bucket, a 45-unit fund-keyed sell, and a legacy
+--   10-unit claim parented to the first purchase. Move the SECOND purchase to
+--   another goal — a single-row edit, which nothing about it relocates the claims —
+--   and 50 units are left backing 55. This function saw 45 and accepted it; the
+--   overview subtracts all 55 and drops the remaining five units.
+--
+-- So the sale sum below is the reader's sum. `units > 0` on the purchase mirrors
+-- lib/withdrawalProgress exactly: a purchase with no units is no bucket (the
+-- dashboard values it as an ordinary holding), so its withdrawal stays on the
+-- parent axis and is not a claim here.
+--
+-- Whole-bucket moves are unaffected, which is what keeps this from wedging the
+-- ordinary paths: a fund assign moves the purchases, and a parented claim is keyed
+-- by its parent's goal, so it moves with the purchase it names. Deleting a goal
+-- moves everything in it at once, for the same reason. What is refused is a
+-- relocation that genuinely splits the claims from what backs them.
+create or replace function public.check_fund_bucket_solvent(p_user uuid, p_fund uuid, p_goal uuid)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_units      numeric;
+  v_out_units  numeric;
+  v_basis      bigint;
+  v_out_basis  bigint;
+  v_par_units  numeric;
+  v_par_basis  bigint;
+begin
+  select coalesce(sum(t.units), 0), coalesce(sum(t.amount_vnd), 0)
+    into v_units, v_basis
+    from public.investment_transactions t
+   where t.user_id = p_user and t.fund_id = p_fund and t.asset_type = 'fund'
+     and t.transaction_type = 'investment'
+     and t.goal_id is not distinct from p_goal
+     and t.renewed_from_transaction_id is null
+     and t.units is not null;
+
+  select coalesce(sum(w.units_withdrawn), 0), coalesce(sum(w.principal_withdrawn), 0)
+    into v_out_units, v_out_basis
+    from public.investment_transactions w
+   where w.user_id = p_user and w.fund_id = p_fund and w.asset_type = 'fund'
+     and w.transaction_type = 'withdrawal'
+     and w.goal_id is not distinct from p_goal;
+
+  -- The legacy claims, priced the way the reader prices them: recorded units when
+  -- there are any, the capped pro-rata share of the named purchase when there are
+  -- not. Keyed by the PURCHASE's goal, because that is the bucket it draws on.
+  select coalesce(sum(case when coalesce(w.units_withdrawn, 0) > 0 then w.units_withdrawn
+                           else least(p.units, p.units * coalesce(w.principal_withdrawn, 0) / p.amount_vnd)
+                      end), 0),
+         coalesce(sum(coalesce(w.principal_withdrawn, 0)), 0)
+    into v_par_units, v_par_basis
+    from public.investment_transactions w
+    join public.investment_transactions p
+      on p.transaction_id = w.parent_transaction_id
+   where w.user_id = p_user
+     and w.transaction_type = 'withdrawal'
+     and (w.asset_type is distinct from 'fund' or w.fund_id is null)
+     and p.transaction_type = 'investment'
+     and p.asset_type = 'fund'
+     and p.fund_id = p_fund
+     and p.goal_id is not distinct from p_goal
+     and coalesce(p.units, 0) > 0
+     and coalesce(p.amount_vnd, 0) > 0;
+
+  v_out_units := v_out_units + v_par_units;
+  v_out_basis := v_out_basis + v_par_basis;
+
+  if v_out_units > v_units + 0.0001 or v_out_basis > v_basis + 1 then
+    raise exception 'withdrawal invariant: this fund bucket would be left owing % units / % of basis it does not hold',
+      v_out_units - v_units, v_out_basis - v_basis using errcode = 'check_violation';
+  end if;
+end;
+$$;
+
+comment on function public.check_fund_bucket_solvent(uuid, uuid, uuid) is
+  'Raises when a (goal, fund) bucket would be left owing more units or basis than its purchases hold, counting every claim the dashboard counts — fund-keyed sells and withdrawals parented to a purchase in the bucket (#587, #606).';
+
+revoke all on function public.check_fund_bucket_solvent(uuid, uuid, uuid) from public;
+revoke all on function public.check_fund_bucket_solvent(uuid, uuid, uuid) from anon, authenticated;

--- a/supabase/migrations/20260803000005_fund_sale_measured_against_every_claim.sql
+++ b/supabase/migrations/20260803000005_fund_sale_measured_against_every_claim.sql
@@ -1,0 +1,322 @@
+-- A new fund sale is measured against every claim on its bucket (#606).
+--
+-- The fund branch of this invariant sums the sells it knew about: rows carrying
+-- asset_type='fund' + fund_id. #606 gave the same bucket a second kind of claim —
+-- a withdrawal parented to one of its purchases, which lib/withdrawalProgress
+-- values against the bucket at its recorded units or the capped pro-rata share of
+-- the purchase it names.
+--
+-- 20260803000002 stops new ones being written and 20260803000004 counts them when
+-- a bucket is relocated, but an ordinary new SALE was still measured against the
+-- fund-keyed sells alone: a legacy 10-unit claim followed by a 45-unit sell fitted
+-- inside a 50-unit bucket, and the dashboard then subtracted all 55 and dropped
+-- the five units left. One balance means one sum, and this is the last place that
+-- was still using the old one.
+--
+-- Everything else in the function is copied verbatim from 20260730000002.
+
+create or replace function public.check_withdrawal_balance(wd public.investment_transactions)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  -- Clients round units_withdrawn to 4 decimals (parseFloat(u.toFixed(4))), so a
+  -- FULL sell can post a hair more than the holding: 50.12345 units becomes
+  -- 50.1235. Allow exactly that much and no more, or "sell everything" breaks.
+  c_units_epsilon constant numeric := 0.0001;
+  v_principal     bigint;
+  v_units         numeric;
+  v_out_principal bigint;
+  v_out_units     numeric;
+  v_left          bigint;
+  v_left_units    numeric;
+  v_parent_type   text;
+  v_parent_asset  text;
+  -- Purchases in the fund bucket; null outside that branch, which is also how the
+  -- allocation rule below knows which kind it is measuring.
+  v_rows          int;
+  -- The basis a fund sale of these units is allowed to take, and the one đồng of
+  -- rounding the proportional split can produce.
+  v_expected      numeric;
+  -- The bucket's legacy parent-backed claims (#606), summed alongside the
+  -- fund-keyed sells because the reader counts both against the same units.
+  v_par_units     numeric;
+  v_par_principal bigint;
+  c_dong_epsilon  constant numeric := 1;
+begin
+  if wd.transaction_type is distinct from 'withdrawal' then return; end if;
+
+  -- A negative withdrawal runs the ledger backwards: it ADDS to the holding and
+  -- banks a credit the next withdrawal can spend (the sums below are signed, and
+  -- so is lib/depositValuation's subtraction). Nothing in the schema stops one, so
+  -- the invariant does — before anything is measured, since a negative amount
+  -- would poison the measurement itself.
+  if coalesce(wd.principal_withdrawn, 0) < 0 or coalesce(wd.units_withdrawn, 0) < 0 then
+    raise exception 'withdrawal invariant: amounts cannot be negative (principal %, units %)',
+      wd.principal_withdrawn, wd.units_withdrawn using errcode = 'check_violation';
+  end if;
+
+  -- The branch order is not a preference: it MIRRORS lib/withdrawalProgress, which
+  -- keys any row with asset_type='fund' + fund_id by (goal, fund) and ignores its
+  -- parent. Measuring such a row against a parent instead would check a balance
+  -- nothing draws down — a fat holding in one goal waving through a phantom fund
+  -- sell in another, since the API accepts both fields on one row.
+  if wd.asset_type = 'fund' and wd.fund_id is not null then
+    -- A fund sale is a quantity: without units the overview skips the whole
+    -- subtraction (it bails on `wd.units <= 0`) and the holding keeps its value.
+    -- The principal is then not a free number — it is the allocation of the
+    -- remaining basis for those units, checked at the end of this function.
+    if coalesce(wd.units_withdrawn, 0) <= 0 then
+      raise exception 'withdrawal invariant: a fund sale must record units_withdrawn (got %)',
+        wd.units_withdrawn using errcode = 'check_violation';
+    end if;
+
+    -- Both sides of the bucket carry `asset_type = 'fund'`, because that is what
+    -- the valuation counts: a row whose asset_type was edited off 'fund' keeps its
+    -- fund_id (the PUT clears fund_id only when that field is sent) but is valued
+    -- as a bank holding, so its units are no longer fund inventory to sell.
+    --
+    -- Lock the bucket's investment rows before measuring them (see the header):
+    -- this is what makes two concurrent sells of the same bucket serialize. Pending
+    -- DCA seeds (units is null) are excluded: they carry a planned amount with no
+    -- units bought yet, the dashboard never values them, so they hold nothing to
+    -- sell. Renewal snapshots are history copies, not holdings.
+    perform 1
+      from public.investment_transactions t
+     where t.user_id = wd.user_id
+       and t.fund_id = wd.fund_id
+       and t.asset_type = 'fund'
+       and t.transaction_type = 'investment'
+       and t.goal_id is not distinct from wd.goal_id
+       and t.renewed_from_transaction_id is null
+       and t.units is not null
+     order by t.transaction_id      -- a stable lock order; concurrent sells can't deadlock
+       for update;
+
+    -- ONE authoritative basis: Σ amount_vnd, what the purchases cost. That is
+    -- where the number lands — dashboard/overview does
+    --   acc.totalInvested -= Σ principal_withdrawn
+    -- against exactly this sum, while the NAV cost (Σ units × unit_price, fees
+    -- excluded) is reduced by units and only feeds the average entry price.
+    --
+    -- The sheets used to post a NAV-derived figure into that amount-based
+    -- accumulator, reconstructed through the averaged purchasePrice, and this check
+    -- grew a tolerance to accommodate it. lib/fundWithdrawal now takes the basis
+    -- from the dashboard directly (a full sale takes it exactly), so the two agree
+    -- and the tolerance below covers only what rounding can still explain.
+    select coalesce(sum(t.amount_vnd), 0), coalesce(sum(t.units), 0), count(*)
+      into v_principal, v_units, v_rows
+      from public.investment_transactions t
+     where t.user_id = wd.user_id
+       and t.fund_id = wd.fund_id
+       and t.asset_type = 'fund'
+       and t.transaction_type = 'investment'
+       and t.goal_id is not distinct from wd.goal_id
+       and t.renewed_from_transaction_id is null
+       and t.units is not null;
+
+    select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
+      into v_out_principal, v_out_units
+      from public.investment_transactions w
+     where w.user_id = wd.user_id
+       and w.fund_id = wd.fund_id
+       and w.asset_type = 'fund'
+       and w.transaction_type = 'withdrawal'
+       and w.goal_id is not distinct from wd.goal_id
+       and w.transaction_id <> wd.transaction_id;   -- measured without itself
+
+    -- The bucket's OTHER kind of claim (#606). A withdrawal parented to a purchase
+    -- in this bucket draws on it too — lib/withdrawalProgress values it there, at
+    -- its recorded units or the capped pro-rata share of the purchase it names —
+    -- and this sum used to ignore it. A legacy 10-unit claim followed by an
+    -- ordinary 45-unit sell was accepted against a 50-unit bucket, and the reader
+    -- then subtracted all 55 and dropped what was left. Such rows can no longer be
+    -- written, but the ones already in the ledger are still claims, and a new sale
+    -- has to be measured against what the bucket actually still owes.
+    --
+    -- `p.units > 0` is the same question the reader asks: a purchase with no units
+    -- is no bucket, so its withdrawal sits on the parent axis and is not counted
+    -- here (it is measured against that parent instead).
+    select coalesce(sum(case when coalesce(w.units_withdrawn, 0) > 0 then w.units_withdrawn
+                             else least(p.units, p.units * coalesce(w.principal_withdrawn, 0) / p.amount_vnd)
+                        end), 0),
+           coalesce(sum(coalesce(w.principal_withdrawn, 0)), 0)
+      into v_par_units, v_par_principal
+      from public.investment_transactions w
+      join public.investment_transactions p
+        on p.transaction_id = w.parent_transaction_id
+     where w.user_id = wd.user_id
+       and w.transaction_type = 'withdrawal'
+       and (w.asset_type is distinct from 'fund' or w.fund_id is null)
+       and w.transaction_id <> wd.transaction_id
+       and p.transaction_type = 'investment'
+       and p.asset_type = 'fund'
+       and p.fund_id = wd.fund_id
+       and p.goal_id is not distinct from wd.goal_id
+       and coalesce(p.units, 0) > 0
+       and coalesce(p.amount_vnd, 0) > 0;
+
+    v_out_principal := v_out_principal + v_par_principal;
+    v_out_units := v_out_units + v_par_units;
+
+  elsif wd.parent_transaction_id is not null then
+    -- Bank / gold / stock: one source row. Lock it before measuring it, so two
+    -- concurrent withdrawals of the same deposit serialize here.
+    select t.amount_vnd, t.units, t.transaction_type, t.asset_type
+      into v_principal, v_units, v_parent_type, v_parent_asset
+      from public.investment_transactions t
+     where t.transaction_id = wd.parent_transaction_id
+       and t.user_id = wd.user_id
+       for update;
+    -- A parent that isn't the writer's own is the ownership trigger's refusal to
+    -- make (#474 / #525); staying quiet here keeps that message the one the user
+    -- sees instead of a confusing "no balance".
+    if not found then return; end if;
+
+    -- A withdrawal is not a holding, so parenting to one invents a balance out of
+    -- money that already left. Renewal snapshots ARE valid parents on purpose:
+    -- renew and collapse re-parent partial withdrawals onto them, which is how a
+    -- renewed deposit stops double-counting them (#585).
+    --
+    -- A parent that is a FUND purchase is left alone here, though review flagged
+    -- it: such a row is ignored by buildWithdrawalMaps (the fund is valued through
+    -- the goal/fund map, which never consults parentWdMap), so it is an UNCOUNTED
+    -- withdrawal rather than an overdraw — a valuation gap that predates this
+    -- change, and one supabase/tests/dca_seeding_heal.test.sql treats as data that
+    -- exists (issue #606). Bounding it by the parent's own principal, as below, is
+    -- the most this invariant can honestly say about it.
+    if v_parent_type is distinct from 'investment' then
+      raise exception 'withdrawal invariant: draws on no holding — its parent % is not an investment',
+        wd.parent_transaction_id using errcode = 'check_violation';
+    end if;
+
+    -- Gold is the one non-fund holding valued by QUANTITY: valueNonFundHolding
+    -- prices it as units × gold price and takes its cost basis from amount_vnd. So
+    -- a sale must move both, exactly as a fund sell must. Principal alone drops the
+    -- basis while every chỉ stays in net worth — P&L inflated and the sold gold
+    -- never leaves; units alone removes the metal and leaves its cost behind.
+    -- Keyed off the PARENT's type, not the withdrawal's: the row's own asset_type
+    -- is nullable and the route lets it be omitted. Bank and stock are unaffected —
+    -- their valuation is principal-only, and a deposit has no units to move.
+    if v_parent_asset = 'gold' and coalesce(wd.units_withdrawn, 0) <= 0 then
+      raise exception 'withdrawal invariant: a gold sale must record units_withdrawn (got %)',
+        wd.units_withdrawn using errcode = 'check_violation';
+    end if;
+
+    -- A withdrawal that records no principal takes nothing out of the holding:
+    -- lib/depositValuation subtracts coalesce(principal_withdrawn, 0), so the
+    -- deposit keeps its full value while the row claims cash left. A withdrawal
+    -- must not be valid merely because the number to measure was omitted.
+    if coalesce(wd.principal_withdrawn, 0) <= 0 then
+      raise exception 'withdrawal invariant: a withdrawal from holding % must record a positive principal_withdrawn (got %)',
+        wd.parent_transaction_id, wd.principal_withdrawn using errcode = 'check_violation';
+    end if;
+
+    select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
+      into v_out_principal, v_out_units
+      from public.investment_transactions w
+     where w.parent_transaction_id = wd.parent_transaction_id
+       and w.transaction_type = 'withdrawal'
+       -- Same precedence as the branch above, applied to the OTHER rows: a sibling
+       -- that is keyed by a fund draws on that bucket, not on this parent, so
+       -- counting it here too would charge it twice and make an ordinary later
+       -- withdrawal of this deposit look like an overdraw.
+       --
+       -- coalesce, because asset_type is nullable and the route lets a caller omit
+       -- it: written bare, the predicate is NULL for a row with a fund_id and no
+       -- asset_type, which DROPS it from this sum — while buildWithdrawalMaps
+       -- counts that row against the parent (the fund key needs asset_type =
+       -- 'fund'). Two full withdrawals of one deposit both passed that way.
+       and not coalesce(w.asset_type = 'fund' and w.fund_id is not null, false)
+       and w.transaction_id <> wd.transaction_id;
+
+  else
+    -- Nothing identifiable to draw down. A row taking principal or units out of no
+    -- holding at all is not a withdrawal — buildWithdrawalMaps files it under
+    -- neither key, so it subtracts from nothing while the record claims cash left.
+    -- Reachable by editing a fund sell's asset_type off 'fund' (the fund_id stays,
+    -- but the row leaves the fund bucket), which is why asset_type fires the
+    -- trigger: running is not enough, the new shape has to be refused.
+    if coalesce(wd.principal_withdrawn, 0) > 0 or coalesce(wd.units_withdrawn, 0) > 0 then
+      raise exception 'withdrawal invariant: draws on no holding — it has neither a parent transaction nor a fund'
+        using errcode = 'check_violation';
+    end if;
+    -- Carrying neither delta leaves nothing to measure, and exactly ONE kind of row
+    -- is allowed to be in that state: a held-for-merge settlement whose source is
+    -- not recorded yet (#588 makes them source-backed). The exception is for that
+    -- pool, so nothing else may wear it — an ordinary withdrawal has to name what it
+    -- draws on, or it is cash leaving no holding at all. held_for_merge is in the
+    -- trigger's UPDATE OF list too, so an allowed held row cannot become an
+    -- ordinary one by dropping the flag.
+    if not wd.held_for_merge then
+      raise exception 'withdrawal invariant: draws on no holding — only a held-for-merge settlement may omit its source'
+        using errcode = 'check_violation';
+    end if;
+    return;
+  end if;
+
+  -- What the holding has left, after everything already taken out of it.
+  v_left := coalesce(v_principal, 0) - v_out_principal;
+  v_left_units := coalesce(v_units, 0) - v_out_units;
+
+  -- Quantity bound, for whichever kinds carry units.
+  if coalesce(wd.units_withdrawn, 0) > 0 then
+    -- The tolerance rounds a real balance; it does not create one. Applied to an
+    -- empty holding it would hand every sold-out bucket 0.0001 units it never had.
+    if wd.units_withdrawn > v_left_units + (case when v_left_units > 0 then c_units_epsilon else 0 end) then
+      raise exception 'withdrawal invariant: % units exceeds the remaining balance of % units on this holding',
+        wd.units_withdrawn, v_left_units using errcode = 'check_violation';
+    end if;
+  end if;
+
+  if v_rows is not null or v_parent_asset = 'gold' then
+    -- ANY quantity-valued holding — a fund bucket, or gold — has its principal
+    -- BOUND TO THE UNITS, not merely capped beside them. Capping the two
+    -- independently let a sale of 1 unit out of 100 claim the whole basis and leave
+    -- 99 units with none, which corrupts every later sale's allocation and the P&L,
+    -- and eventually makes the rest unsellable for lack of basis. Gold behaves the
+    -- same way: valueNonFundHolding prices it units × market and takes its basis
+    -- from amount_vnd.
+    --
+    -- One allocation rule, shared with lib/fundWithdrawal and lib/goldWithdrawal and
+    -- matching how the dashboard itself reduces a holding: a sale of ALL the
+    -- remaining units takes the remaining basis exactly, and a partial sale takes
+    -- its units-proportional share of it. ONE rounding rule: the two sides may
+    -- differ by at most a đồng, which is what rounding a proportional slice can
+    -- produce.
+    if wd.units_withdrawn >= v_left_units - c_units_epsilon then
+      v_expected := v_left;
+    else
+      v_expected := round(wd.units_withdrawn * v_left / v_left_units);
+    end if;
+    if abs(coalesce(wd.principal_withdrawn, 0) - v_expected) > c_dong_epsilon then
+      raise exception 'withdrawal invariant: a sale of % units out of % must take % of the % basis, not %',
+        wd.units_withdrawn, v_left_units, v_expected, v_left, wd.principal_withdrawn
+        using errcode = 'check_violation';
+    end if;
+
+  elsif coalesce(wd.principal_withdrawn, 0) > 0 then
+    -- Non-fund: the principal is the user's own figure (the amount they withdrew),
+    -- bounded by what the holding still holds.
+    if wd.principal_withdrawn > v_left then
+      raise exception 'withdrawal invariant: % exceeds the remaining balance of % on this holding',
+        wd.principal_withdrawn, v_left using errcode = 'check_violation';
+    end if;
+  end if;
+end;
+$$;
+
+comment on function public.check_withdrawal_balance(public.investment_transactions) is
+  'Raises when a withdrawal/sell would take more principal or units than its holding still has. Measured under a lock on the source, so concurrent sells cannot both pass (#587).';
+
+-- Postgres grants EXECUTE on a new function to PUBLIC, and this one is SECURITY
+-- DEFINER — so left open it is an oracle: call it with a hand-built row naming
+-- someone else's holding, and the refusal message reports that holding's exact
+-- remaining principal or units, RLS bypassed, taking row locks on the way. It is
+-- the triggers' helper and nothing else's; they call it as the definer, so they
+-- keep working without these grants.
+revoke all on function public.check_withdrawal_balance(public.investment_transactions) from public;
+revoke all on function public.check_withdrawal_balance(public.investment_transactions) from anon, authenticated;
+

--- a/supabase/tests/dca_seeding_heal.test.sql
+++ b/supabase/tests/dca_seeding_heal.test.sql
@@ -64,10 +64,17 @@ begin
 
   -- A withdrawal referencing the second recorded row — this is what would be
   -- orphaned if the healing deleted v_rec2.
+  --
+  -- Planted with the trigger off: since #606 a fund sale must be keyed by its fund,
+  -- so this shape can no longer be WRITTEN. It is what the ledger may already hold
+  -- — rows from before that rule — and the healing step has to be safe over the
+  -- data as it is, not only over the data the API would accept today.
+  alter table investment_transactions disable trigger user;
   insert into investment_transactions
     (user_id, parent_transaction_id, transaction_type, asset_type, amount_vnd, principal_withdrawn, investment_date, affects_progress)
     values (v_user, v_rec2, 'withdrawal', null, 500000, 500000, '2099-11-15', true)
     returning transaction_id into v_wd;
+  alter table investment_transactions enable trigger user;
 
   -- ---- Run the healing exactly as the migration does -----------------------
   update investment_transactions it

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -1187,6 +1187,7 @@ begin;
 do $$
 declare
   v_user uuid; v_goal uuid; v_goal2 uuid; v_fund uuid; v_fund2 uuid;
+  v_goal3 uuid; v_fund3 uuid; v_dep2 uuid; v_dep3 uuid; v_wd2 uuid;
   v_buy uuid; v_buy2 uuid; v_buy3 uuid; v_dep uuid;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'fundkeyed@test.invalid') returning id into v_user;
@@ -1308,6 +1309,51 @@ begin
 
   -- Deleting the FUND out from under the same legacy row is fine too.
   delete from public.funds where id = v_fund2;
+
+  -- The same shape assembled from the OTHER end: the child's trigger cannot see a
+  -- statement that only touches the parent, and PUT lets a holding change its asset
+  -- type (#593) — so a bank deposit with a withdrawal on it could be edited into a
+  -- fund purchase and the withdrawal woke up parented to a fund. The parent is asked
+  -- the question now.
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Converted') returning goal_id into v_goal3;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Convert Fund', 'CNVF', 'equity', 25000) returning id into v_fund3;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal3, 'bank', 'investment', '2026-01-01', 2000000) returning transaction_id into v_dep2;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal3, 'bank', 'withdrawal', '2026-02-01', 400000, v_dep2, 400000)
+  returning transaction_id into v_wd2;
+
+  begin
+    update public.investment_transactions
+       set asset_type = 'fund', fund_id = v_fund3, units = 50, unit_price = 40000
+     where transaction_id = v_dep2;
+    raise exception 'a holding must not become a fund purchase under a withdrawal that is not fund-keyed';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Removing the withdrawal is what unblocks it: the guard is about the shape the
+  -- edit would create, not about the edit.
+  delete from public.investment_transactions where transaction_id = v_wd2;
+  update public.investment_transactions
+     set asset_type = 'fund', fund_id = v_fund3, units = 50, unit_price = 40000
+   where transaction_id = v_dep2;
+
+  -- A child that carries its OWN fund draws on that bucket whatever its parent is,
+  -- so it never blocks the conversion. (Dual-key sell: legal, the fund branch wins.)
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal3, 'bank', 'investment', '2026-01-01', 5000000) returning transaction_id into v_dep3;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal3, v_fund3, 'fund', 'withdrawal', '2026-02-01', 250000, v_dep3, 10, 400000);
+
+  update public.investment_transactions
+     set asset_type = 'fund', fund_id = v_fund3, units = 100, unit_price = 50000
+   where transaction_id = v_dep3;
 
   raise notice 'a fund sale must be keyed by its fund: ok';
 end;

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -352,17 +352,16 @@ begin
   insert into public.investment_transactions (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
   values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 90000000, 4500, 20000) returning transaction_id into v_buy;
 
-  -- Parented to that fund purchase: allowed, but still bounded by the row it
-  -- names — 90M is there, 200M is not.
-  insert into public.investment_transactions
-    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
-  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 10000000, v_buy, 10000000);
-
+  -- Parented to that fund purchase: refused (#606). It used to be allowed and
+  -- bounded by the row it names, which gave the fund bucket a SECOND balance —
+  -- the reader values such a row against the bucket, so a sell keyed by the fund
+  -- and one parented to a purchase in it could each pass their own reading and
+  -- together take more units than the bucket holds. A fund sale carries its fund.
   begin
     insert into public.investment_transactions
       (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
-    values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-02', 200000000, v_buy, 200000000);
-    raise exception 'even an oddly parented withdrawal is bounded by the row it names';
+    values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 10000000, v_buy, 10000000);
+    raise exception 'a withdrawal parented to a fund purchase must be refused';
   exception when sqlstate '23514' then null;
   end;
 
@@ -1172,6 +1171,87 @@ begin
   end;
 
   raise notice 'held-for-merge exception boundary: ok';
+end;
+$$;
+
+rollback;
+
+begin;
+-- ── a fund sale is keyed by its fund, not parented to the purchase (#606) ─────
+-- The reader values a withdrawal parented to a fund purchase against that
+-- purchase's (goal, fund) bucket. This function measured the same row against the
+-- purchase's own principal, so ONE bucket had TWO balances: a 50-unit purchase
+-- took a 45-unit fund-keyed sell and a 10-unit parented sell, each legal against
+-- its own reading, 55 units out of 50 — and the dashboard, subtracting all 55,
+-- drops the holding five units early. The shape is refused instead.
+do $$
+declare
+  v_user uuid; v_goal uuid; v_fund uuid; v_buy uuid; v_dep uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'fundkeyed@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Fund keyed') returning goal_id into v_goal;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Keyed Fund', 'KEYF', 'equity', 25000) returning id into v_fund;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 50, 40000)
+  returning transaction_id into v_buy;
+
+  -- The pair that used to fit: 45 units through the bucket, 10 more through the
+  -- purchase. The first is an ordinary sell and stays legal.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd,
+     units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-02-01', 1125000, 45, 1800000);
+
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+       parent_transaction_id, units_withdrawn, principal_withdrawn)
+    values (v_user, v_goal, null, 'withdrawal', '2026-03-01', 250000, v_buy, 10, 400000);
+    raise exception 'a sale parented to a fund purchase must be refused, not measured against the purchase';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Not about the missing asset_type, and not about the units either: the shape is
+  -- refused for naming a fund purchase as its source at all.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+       parent_transaction_id, principal_withdrawn)
+    values (v_user, v_goal, 'bank', 'withdrawal', '2026-03-01', 100000, v_buy, 100000);
+    raise exception 'a bank-typed withdrawal on a fund purchase must be refused too';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- The same 10 units, keyed by the fund: now measured against the bucket, which
+  -- has 5 units and 200,000 đồng left — so this is refused for what it really is.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd,
+       units_withdrawn, principal_withdrawn)
+    values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-03-01', 250000, 10, 400000);
+    raise exception 'ten units out of the five the bucket has left must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- And what the bucket does still hold goes through.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd,
+     units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-03-01', 125000, 5, 200000);
+
+  -- A deposit parent is untouched by any of this.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 10000000) returning transaction_id into v_dep;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 4000000, v_dep, 4000000);
+
+  raise notice 'a fund sale must be keyed by its fund: ok';
 end;
 $$;
 

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -1187,7 +1187,7 @@ begin;
 do $$
 declare
   v_user uuid; v_goal uuid; v_goal2 uuid; v_fund uuid; v_fund2 uuid;
-  v_goal3 uuid; v_fund3 uuid; v_dep2 uuid; v_dep3 uuid; v_wd2 uuid;
+  v_goal3 uuid; v_fund3 uuid; v_dep2 uuid; v_dep3 uuid; v_dep4 uuid; v_wd2 uuid;
   v_buy uuid; v_buy2 uuid; v_buy3 uuid; v_dep uuid;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'fundkeyed@test.invalid') returning id into v_user;
@@ -1386,6 +1386,36 @@ begin
 
   -- Everything else about it still edits: the guard is about the rate, not the row.
   update public.investment_transactions set notes = 'renamed' where transaction_id = v_dep2;
+
+  -- The same shape assembled in TWO statements. Turning the parent into a valid
+  -- fund-keyed withdrawal takes it out of this guard's reach (it is no longer an
+  -- investment), so flipping transaction_type back on its own used to change no
+  -- column the trigger watched — and left a fund purchase under the legacy child.
+  -- Activating it is becoming one, and is measured as such.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal3, v_fund3, 'fund', 'investment', '2026-01-01', 2000000, 50, 40000);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal3, 'bank', 'investment', '2026-01-01', 1000000) returning transaction_id into v_dep4;
+  alter table public.investment_transactions disable trigger user;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal3, null, 'withdrawal', '2026-02-01', 400000, v_dep4, 400000);
+  alter table public.investment_transactions enable trigger user;
+
+  -- Step one is legal on its own: as a fund-keyed sell it draws on the bucket.
+  update public.investment_transactions
+     set transaction_type = 'withdrawal', asset_type = 'fund', fund_id = v_fund3,
+         units_withdrawn = 10, principal_withdrawn = 400000, amount_vnd = 250000
+   where transaction_id = v_dep4;
+
+  begin
+    update public.investment_transactions set transaction_type = 'investment'
+     where transaction_id = v_dep4;
+    raise exception 'activating a fund purchase under a legacy child must be measured, not waved through';
+  exception when sqlstate '23514' then null;
+  end;
 
   -- A child that carries its OWN fund draws on that bucket whatever its parent is,
   -- so it never blocks the conversion. (Dual-key sell: legal, the fund branch wins.)

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -1341,6 +1341,32 @@ begin
      set asset_type = 'fund', fund_id = v_fund3, units = 50, unit_price = 40000
    where transaction_id = v_dep2;
 
+  -- Re-pricing a purchase that carries a legacy child is refused for the same
+  -- reason: those units are derived from this purchase's price, so moving it
+  -- rewrites what the dashboard takes out of the bucket for a row nothing
+  -- re-measures. Planted with the trigger off — the only way the child can exist.
+  alter table public.investment_transactions disable trigger user;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal3, null, 'withdrawal', '2026-03-01', 500000, v_dep2, 500000);
+  alter table public.investment_transactions enable trigger user;
+
+  begin
+    update public.investment_transactions set units = 25, unit_price = 80000
+     where transaction_id = v_dep2;
+    raise exception 'a fund purchase must not be re-priced under a legacy child';
+  exception when sqlstate '23514' then null;
+  end;
+  begin
+    update public.investment_transactions set amount_vnd = 4000000
+     where transaction_id = v_dep2;
+    raise exception 'a fund purchase must not have its amount changed under a legacy child';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Everything else about it still edits: the guard is about the rate, not the row.
+  update public.investment_transactions set notes = 'renamed' where transaction_id = v_dep2;
+
   -- A child that carries its OWN fund draws on that bucket whatever its parent is,
   -- so it never blocks the conversion. (Dual-key sell: legal, the fund branch wins.)
   insert into public.investment_transactions

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -1265,6 +1265,15 @@ begin
      parent_transaction_id, units_withdrawn, principal_withdrawn)
   values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-04-02', 250000, v_buy2, 10, 250000);
 
+  -- ...and in the order that used to decide it. ON DELETE SET NULL clears every
+  -- referencing row in ONE statement, in no defined order, so the sell can be
+  -- re-measured before its parent has been cleared — and then the parent still
+  -- shows the fund that is already gone. Touching the purchase moves it behind the
+  -- sell in the heap, which is the ordering that raised. What settles it is that
+  -- the fund ROW is gone by then, whichever row the cascade reaches first.
+  update public.investment_transactions set notes = 'moved behind the sell'
+   where transaction_id = v_buy2;
+
   delete from public.funds where id = v_fund;
 
   if exists (select 1 from public.investment_transactions where transaction_id = v_buy2 and fund_id is not null) then

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -1186,7 +1186,7 @@ begin;
 -- drops the holding five units early. The shape is refused instead.
 do $$
 declare
-  v_user uuid; v_goal uuid; v_fund uuid; v_buy uuid; v_dep uuid;
+  v_user uuid; v_goal uuid; v_fund uuid; v_buy uuid; v_buy2 uuid; v_dep uuid;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'fundkeyed@test.invalid') returning id into v_user;
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Fund keyed') returning goal_id into v_goal;
@@ -1250,6 +1250,26 @@ begin
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
      parent_transaction_id, principal_withdrawn)
   values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 4000000, v_dep, 4000000);
+
+  -- Deleting a fund must still work for a sell that named BOTH its fund and a
+  -- purchase in it. The FK clears fund_id on both sides, the orphan path re-measures
+  -- the row, and it lands in the parent branch — where the parent is fund-typed but
+  -- no longer carries a fund, so it is no bucket and nothing is refused. Asking only
+  -- about asset_type turned an ordinary fund deletion into an error.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-04-01', 1000000, 40, 25000)
+  returning transaction_id into v_buy2;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-04-02', 250000, v_buy2, 10, 250000);
+
+  delete from public.funds where id = v_fund;
+
+  if exists (select 1 from public.investment_transactions where transaction_id = v_buy2 and fund_id is not null) then
+    raise exception 'deleting the fund should have cleared the purchase''s fund_id';
+  end if;
 
   raise notice 'a fund sale must be keyed by its fund: ok';
 end;

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -1177,6 +1177,61 @@ $$;
 rollback;
 
 begin;
+
+-- ── a relocation must count the claims the reader counts (#606) ──────────────
+-- Two purchases in one bucket, a 45-unit fund-keyed sell and a legacy 10-unit
+-- claim parented to the first. Moving the SECOND purchase out leaves 50 units
+-- backing 55 — the bucket solvency check saw only the fund-keyed 45 and waved it
+-- through, and the dashboard then subtracts all 55 and drops the holding.
+do $$
+declare
+  v_user uuid; v_goal uuid; v_goal_b uuid; v_fund uuid; v_buy_a uuid; v_buy_b uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'bucketmove@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Bucket') returning goal_id into v_goal;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Elsewhere') returning goal_id into v_goal_b;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Move Fund', 'MVF', 'equity', 25000) returning id into v_fund;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 50, 40000)
+  returning transaction_id into v_buy_a;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-02', 2000000, 50, 40000)
+  returning transaction_id into v_buy_b;
+
+  -- 45 of the bucket's 100 units, keyed by the fund: an ordinary sell.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-02-01', 1125000, 45, 1800000);
+
+  -- The legacy claim on purchase A (planted with the trigger off — no longer writable).
+  alter table public.investment_transactions disable trigger user;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal, null, 'withdrawal', '2026-03-01', 250000, v_buy_a, 10, 400000);
+  alter table public.investment_transactions enable trigger user;
+
+  begin
+    update public.investment_transactions set goal_id = v_goal_b where transaction_id = v_buy_b;
+    raise exception 'moving a purchase out from under the claims on its bucket must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Moving the purchase the claim NAMES takes the claim with it — the claim is
+  -- keyed by its parent's goal — so the bucket it leaves is short of nothing.
+  update public.investment_transactions set goal_id = v_goal_b where transaction_id = v_buy_a;
+
+  raise notice 'a relocation counts parented claims: ok';
+end;
+$$;
+
+rollback;
+
+begin;
+
 -- ── a fund sale is keyed by its fund, not parented to the purchase (#606) ─────
 -- The reader values a withdrawal parented to a fund purchase against that
 -- purchase's (goal, fund) bucket. This function measured the same row against the
@@ -1412,8 +1467,11 @@ begin
   alter table public.investment_transactions enable trigger user;
 
   -- Step one is legal on its own: as a fund-keyed sell it draws on the bucket.
+  -- (units set too, so flipping it back would produce a real bucket purchase —
+  -- one with no units is no bucket and none of this applies.)
   update public.investment_transactions
      set transaction_type = 'withdrawal', asset_type = 'fund', fund_id = v_fund3,
+         units = 50, unit_price = 40000,
          units_withdrawn = 10, principal_withdrawn = 400000, amount_vnd = 250000
    where transaction_id = v_dep4;
 

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -1364,6 +1364,26 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- A legacy child that RECORDS its units is read as written, whatever this
+  -- purchase later costs — so it must not freeze an ordinary edit. Give the child
+  -- units and the same re-pricing goes through.
+  -- (Off, because touching the child's own amounts is a RAISED claim and the child's
+  -- trigger refuses the legacy shape there — giving it a fund is what legalises it.)
+  alter table public.investment_transactions disable trigger user;
+  update public.investment_transactions set units_withdrawn = 12.5
+   where parent_transaction_id = v_dep2 and transaction_type = 'withdrawal';
+  alter table public.investment_transactions enable trigger user;
+
+  update public.investment_transactions set units = 25, unit_price = 80000
+   where transaction_id = v_dep2;
+  update public.investment_transactions set units = 50, unit_price = 40000
+   where transaction_id = v_dep2;
+
+  alter table public.investment_transactions disable trigger user;
+  update public.investment_transactions set units_withdrawn = null
+   where parent_transaction_id = v_dep2 and transaction_type = 'withdrawal';
+  alter table public.investment_transactions enable trigger user;
+
   -- Everything else about it still edits: the guard is about the rate, not the row.
   update public.investment_transactions set notes = 'renamed' where transaction_id = v_dep2;
 

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -1186,7 +1186,8 @@ begin;
 -- drops the holding five units early. The shape is refused instead.
 do $$
 declare
-  v_user uuid; v_goal uuid; v_fund uuid; v_buy uuid; v_buy2 uuid; v_dep uuid;
+  v_user uuid; v_goal uuid; v_goal2 uuid; v_fund uuid; v_fund2 uuid;
+  v_buy uuid; v_buy2 uuid; v_buy3 uuid; v_dep uuid;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'fundkeyed@test.invalid') returning id into v_user;
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Fund keyed') returning goal_id into v_goal;
@@ -1279,6 +1280,34 @@ begin
   if exists (select 1 from public.investment_transactions where transaction_id = v_buy2 and fund_id is not null) then
     raise exception 'deleting the fund should have cleared the purchase''s fund_id';
   end if;
+
+  -- A goal holding a LEGACY row of this shape must still be deletable. Deleting a
+  -- goal clears goal_id on every transaction (ON DELETE SET NULL) and the deferred
+  -- trigger re-measures each one; refusing the shape there would make history
+  -- undeletable, so the refusal lives in the new-claim path only. The legacy row is
+  -- planted with the trigger off, which is the only way it can exist now.
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Legacy goal') returning goal_id into v_goal2;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Legacy Fund', 'LGCF', 'equity', 25000) returning id into v_fund2;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal2, v_fund2, 'fund', 'investment', '2026-01-01', 2000000, 50, 40000)
+  returning transaction_id into v_buy3;
+
+  alter table public.investment_transactions disable trigger user;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal2, null, 'withdrawal', '2026-02-01', 400000, v_buy3, 400000);
+  alter table public.investment_transactions enable trigger user;
+
+  delete from public.savings_goals where goal_id = v_goal2;
+
+  if exists (select 1 from public.investment_transactions where transaction_id = v_buy3 and goal_id is not null) then
+    raise exception 'deleting the goal should have cleared the purchase''s goal_id';
+  end if;
+
+  -- Deleting the FUND out from under the same legacy row is fine too.
+  delete from public.funds where id = v_fund2;
 
   raise notice 'a fund sale must be keyed by its fund: ok';
 end;

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -1364,6 +1364,13 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- A proportional correction leaves every derived quantity identical — the rate
+  -- `units x principal / amount` is what the child is read at — so it goes through.
+  update public.investment_transactions set units = 100, amount_vnd = 4000000, unit_price = 40000
+   where transaction_id = v_dep2;
+  update public.investment_transactions set units = 50, amount_vnd = 2000000, unit_price = 40000
+   where transaction_id = v_dep2;
+
   -- A legacy child that RECORDS its units is read as written, whatever this
   -- purchase later costs — so it must not freeze an ordinary edit. Give the child
   -- units and the same re-pricing goes through.

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -1242,7 +1242,7 @@ begin;
 do $$
 declare
   v_user uuid; v_goal uuid; v_goal2 uuid; v_fund uuid; v_fund2 uuid;
-  v_goal3 uuid; v_fund3 uuid; v_dep2 uuid; v_dep3 uuid; v_dep4 uuid; v_wd2 uuid;
+  v_goal3 uuid; v_fund3 uuid; v_fund4 uuid; v_dep2 uuid; v_dep3 uuid; v_dep4 uuid; v_dep5 uuid; v_wd2 uuid;
   v_buy uuid; v_buy2 uuid; v_buy3 uuid; v_dep uuid;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'fundkeyed@test.invalid') returning id into v_user;
@@ -1479,6 +1479,29 @@ begin
     update public.investment_transactions set transaction_type = 'investment'
      where transaction_id = v_dep4;
     raise exception 'activating a fund purchase under a legacy child must be measured, not waved through';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- GAINING units makes a bucket out of a holding that was not one, so every child
+  -- on the parent axis becomes a claim against it — including one that RECORDS its
+  -- units, which the re-pricing branch alone would let through.
+  -- Its own fund, so this fixture cannot move the bucket the sells above measure.
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Gains Fund', 'GNSF', 'equity', 25000) returning id into v_fund4;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal3, v_fund4, 'fund', 'investment', '2026-01-01', 1000000, 0, 0)
+  returning transaction_id into v_dep5;
+  alter table public.investment_transactions disable trigger user;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal3, null, 'withdrawal', '2026-02-01', 400000, v_dep5, 8, 400000);
+  alter table public.investment_transactions enable trigger user;
+
+  begin
+    update public.investment_transactions set units = 40, unit_price = 25000
+     where transaction_id = v_dep5;
+    raise exception 'giving a holding units makes it a bucket and must be measured';
   exception when sqlstate '23514' then null;
   end;
 

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -1228,6 +1228,51 @@ begin
 end;
 $$;
 
+-- ── a new sale is measured against every claim on the bucket (#606) ──────────
+-- A legacy 10-unit claim sits in a 50-unit bucket. A 45-unit sell fits inside the
+-- fund-keyed sum alone, and the dashboard then subtracts all 55 and drops the five
+-- units left. The claim has to be part of the balance a new sale is measured
+-- against — one bucket, one sum.
+do $$
+declare
+  v_user uuid; v_goal uuid; v_fund uuid; v_buy uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'claimsum@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Claims') returning goal_id into v_goal;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Claim Fund', 'CLMF', 'equity', 25000) returning id into v_fund;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 50, 40000)
+  returning transaction_id into v_buy;
+
+  alter table public.investment_transactions disable trigger user;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal, null, 'withdrawal', '2026-02-01', 250000, v_buy, 10, 400000);
+  alter table public.investment_transactions enable trigger user;
+
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units_withdrawn, principal_withdrawn)
+    -- Proportional against the bucket as the OLD sum saw it (45 of 50 units of a
+    -- 2,000,000 basis), so what refuses it is the claim, not the allocation rule.
+    values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-03-01', 1125000, 45, 1800000);
+    raise exception 'a sale that fits only by ignoring the legacy claim must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- What the bucket really has left — 40 units and the 1,600,000 basis behind them
+  -- — still sells, in one go.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-03-01', 1000000, 40, 1600000);
+
+  raise notice 'a new sale counts the bucket''s legacy claims: ok';
+end;
+$$;
+
 rollback;
 
 begin;

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -847,6 +847,14 @@ begin
     raise exception 'the audit must count the units a principal-only row derives, got % overdraw(s)', v_n;
   end if;
 
+  -- And the detail must not call it "units 0": the dashboard removed the derived
+  -- quantity, and an operator reading zero would conclude nothing was taken.
+  if not exists (select 1 from public.withdrawal_ledger_audit
+                  where user_id = v_user and check_name = 'parent_is_a_fund_purchase'
+                    and detail like '%derived pro-rata%') then
+    raise exception 'a recorded zero must be reported as derived, not as units 0';
+  end if;
+
   raise notice 'withdrawal_ledger_audit: derived units count against the bucket';
 end $$;
 

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -883,11 +883,15 @@ end $$;
 do $$
 declare
   v_user uuid; v_goal uuid; v_orphan uuid; v_wd uuid; v_detail text;
+  v_nofund_fund uuid; v_zero uuid; v_zero_wd uuid;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'wd-audit-nofund@test.invalid') returning id into v_user;
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'No fund') returning goal_id into v_goal;
 
   alter table public.investment_transactions disable trigger user;
+
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Zero Unit Fund', 'ZUF', 'equity', 25000) returning id into v_nofund_fund;
 
   -- A fund purchase whose fund is gone (the FK is ON DELETE SET NULL).
   insert into public.investment_transactions
@@ -911,6 +915,30 @@ begin
   end if;
   if v_detail not like '%carries no fund of its own%' then
     raise exception 'the detail must say why nothing values it, got: %', v_detail;
+  end if;
+
+  -- A ZERO-unit fund purchase is a different case and must not wear the same
+  -- sentence: it IS valued — as an ordinary holding, with its withdrawal applied on
+  -- the parent axis — so telling an operator nothing values it invites a repair
+  -- that subtracts the money twice.
+  alter table public.investment_transactions disable trigger user;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_nofund_fund, 'fund', 'investment', '2026-01-01', 1000000, 0, 0)
+  returning transaction_id into v_zero;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, null, 'withdrawal', '2026-02-01', 400000, v_zero, 400000)
+  returning transaction_id into v_zero_wd;
+  alter table public.investment_transactions enable trigger user;
+
+  select detail into v_detail from public.withdrawal_ledger_audit
+   where transaction_id = v_zero_wd and check_name = 'parent_is_a_fund_purchase';
+  if v_detail like '%no bucket values it%' or v_detail like '%valued against that fund bucket%' then
+    raise exception 'a zero-unit purchase is valued on the parent axis; the audit said: %', v_detail;
+  end if;
+  if v_detail not like '%holds no units%' then
+    raise exception 'the detail must say the purchase holds no units, got: %', v_detail;
   end if;
 
   raise notice 'withdrawal_ledger_audit: no bucket, no claim that the row was valued';

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -828,9 +828,12 @@ begin
   values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-02', 1000, 1, 1000);
 
   -- Principal-only draw on the 100-unit purchase: the reader takes all 100 units.
+  -- Written as a recorded ZERO rather than a null, because that is the harder shape:
+  -- the old write path demanded positive units only from a gold parent, and a
+  -- coalesce would let the zero slip past the derivation on both sides.
   insert into public.investment_transactions
-    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
-  values (v_user, v_goal, null, 'withdrawal', '2026-02-01', 1000, v_big, 1000);
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal, null, 'withdrawal', '2026-02-01', 1000, v_big, 0, 1000);
   -- Plus an ordinary 2-unit sell: 102 units asked of a bucket holding 101.
   insert into public.investment_transactions
     (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units_withdrawn, principal_withdrawn)

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -802,6 +802,90 @@ begin
   raise notice 'withdrawal_ledger_audit: both sale shapes share one bucket balance';
 end $$;
 
+-- A legacy row that records only PRINCIPAL still takes units out of the bucket:
+-- the reader derives them pro-rata from the purchase it names. An audit that
+-- scored such a row as zero units called a bucket sold past its units clean —
+-- 102 units out of 101, silent, which is the one thing this check is for.
+do $$
+declare
+  v_user uuid; v_goal uuid; v_fund uuid; v_big uuid; v_n int;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-audit-derived@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Derived units') returning goal_id into v_goal;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Derived Fund', 'DRVF', 'equity', 10) returning id into v_fund;
+
+  alter table public.investment_transactions disable trigger user;
+
+  -- Two purchases at very different prices, so the bucket's average hides what the
+  -- named purchase actually gives up: 100 units for 1000 đồng, and 1 for 1000.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 1000, 100, 10)
+  returning transaction_id into v_big;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-02', 1000, 1, 1000);
+
+  -- Principal-only draw on the 100-unit purchase: the reader takes all 100 units.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, null, 'withdrawal', '2026-02-01', 1000, v_big, 1000);
+  -- Plus an ordinary 2-unit sell: 102 units asked of a bucket holding 101.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-03-01', 20, 2, 20);
+
+  alter table public.investment_transactions enable trigger user;
+
+  select count(*) into v_n from public.withdrawal_ledger_audit
+   where user_id = v_user and check_name = 'fund_bucket_overdrawn' and fund_id = v_fund;
+  if v_n <> 1 then
+    raise exception 'the audit must count the units a principal-only row derives, got % overdraw(s)', v_n;
+  end if;
+
+  raise notice 'withdrawal_ledger_audit: derived units count against the bucket';
+end $$;
+
+-- A fund-typed parent with no fund of its own is NOT a bucket: the reader leaves
+-- such a row on the parent axis, where nothing reads it. Telling an operator it was
+-- "valued against that fund bucket" would have them leave an unvalued row alone.
+do $$
+declare
+  v_user uuid; v_goal uuid; v_orphan uuid; v_wd uuid; v_detail text;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-audit-nofund@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'No fund') returning goal_id into v_goal;
+
+  alter table public.investment_transactions disable trigger user;
+
+  -- A fund purchase whose fund is gone (the FK is ON DELETE SET NULL).
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'fund', 'investment', '2026-01-01', 1000000, 50, 20000)
+  returning transaction_id into v_orphan;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, null, 'withdrawal', '2026-02-01', 400000, v_orphan, 400000)
+  returning transaction_id into v_wd;
+
+  alter table public.investment_transactions enable trigger user;
+
+  select detail into v_detail from public.withdrawal_ledger_audit
+   where transaction_id = v_wd and check_name = 'parent_is_a_fund_purchase';
+  if v_detail is null then
+    raise exception 'the row must still be reported';
+  end if;
+  if v_detail like '%valued against that fund bucket%' then
+    raise exception 'a parent with no fund is no bucket: the audit must not claim the row was valued';
+  end if;
+  if v_detail not like '%carries no fund of its own%' then
+    raise exception 'the detail must say why nothing values it, got: %', v_detail;
+  end if;
+
+  raise notice 'withdrawal_ledger_audit: no bucket, no claim that the row was valued';
+end $$;
+
 -- ═══ the contract itself ═══════════════════════════════════════════════════
 -- Two claims the view's header makes, kept honest here rather than in prose alone.
 do $$

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -752,7 +752,7 @@ end $$;
 -- why these rows are planted with the trigger off.
 do $$
 declare
-  v_user uuid; v_goal uuid; v_fund uuid; v_buy uuid; v_par uuid; v_n int;
+  v_user uuid; v_goal uuid; v_fund uuid; v_buy uuid; v_par uuid; v_par_bare uuid; v_n int;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'wd-audit-606@test.invalid') returning id into v_user;
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Mixed shapes') returning goal_id into v_goal;
@@ -797,6 +797,25 @@ begin
                   where transaction_id = v_par and check_name = 'parent_is_a_fund_purchase'
                     and detail like '%valued against that fund bucket%') then
     raise exception 'the fund-parented row must still be reported for review';
+  end if;
+
+  -- The same claim wearing a RETAINED fund_id and no asset_type — what editing a
+  -- sell's asset_type off 'fund' leaves behind (the PUT clears fund_id only when
+  -- that field is sent). The reader reads it as not fund-keyed and charges the
+  -- parent's bucket, so the audit has to as well: written without coalescing the
+  -- inner test, `not (asset_type = 'fund' and ...)` is NULL for this row and it
+  -- fell out of both branches.
+  alter table public.investment_transactions disable trigger user;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal, v_fund, null, 'withdrawal', '2026-03-02', 250000, v_buy, 10, 400000)
+  returning transaction_id into v_par_bare;
+  alter table public.investment_transactions enable trigger user;
+
+  if not exists (select 1 from public.withdrawal_ledger_audit
+                  where transaction_id = v_par_bare and check_name = 'parent_is_a_fund_purchase'
+                    and detail like '%valued against that fund bucket%') then
+    raise exception 'a claim with a retained fund_id and no asset_type must be read as the reader reads it';
   end if;
 
   raise notice 'withdrawal_ledger_audit: both sale shapes share one bucket balance';

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -627,6 +627,16 @@ begin
     end if;
   end loop;
 
+  -- The detail an operator reads is part of the report, not decoration: this row's
+  -- principal IS offset now (lib/withdrawalProgress values it against the parent
+  -- purchase's fund bucket, #606), and the old wording — "which no valuation
+  -- offsets" — would send whoever reads it to subtract the same money a second time.
+  if not exists (select 1 from public.withdrawal_ledger_audit
+                  where transaction_id = v_onfund
+                    and detail like '%valued against that fund bucket%') then
+    raise exception 'the fund-parented withdrawal must be reported as valued, not as uncounted';
+  end if;
+
   -- the three group-level checks, keyed by holding rather than by row
   if not exists (select 1 from public.withdrawal_ledger_audit
                   where check_name = 'holding_overdrawn' and parent_transaction_id = v_over_src) then

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -883,7 +883,7 @@ end $$;
 do $$
 declare
   v_user uuid; v_goal uuid; v_orphan uuid; v_wd uuid; v_detail text;
-  v_nofund_fund uuid; v_zero uuid; v_zero_wd uuid;
+  v_nofund_fund uuid; v_zero uuid; v_zero_wd uuid; v_pending uuid; v_pending_wd uuid;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'wd-audit-nofund@test.invalid') returning id into v_user;
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'No fund') returning goal_id into v_goal;
@@ -939,6 +939,30 @@ begin
   end if;
   if v_detail not like '%holds no units%' then
     raise exception 'the detail must say the purchase holds no units, got: %', v_detail;
+  end if;
+
+  -- A PENDING seed (units null) is a third case again: the overview drops those
+  -- rows from the holdings pass, so the purchase is valued by nothing and neither
+  -- is the claim on it. Saying it is "valued against that purchase" would be the
+  -- same false comfort in the other direction.
+  alter table public.investment_transactions disable trigger user;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, is_dca_seeded)
+  values (v_user, v_goal, v_nofund_fund, 'fund', 'investment', '2026-01-01', 1000000, null, null, false)
+  returning transaction_id into v_pending;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, null, 'withdrawal', '2026-02-01', 400000, v_pending, 400000)
+  returning transaction_id into v_pending_wd;
+  alter table public.investment_transactions enable trigger user;
+
+  select detail into v_detail from public.withdrawal_ledger_audit
+   where transaction_id = v_pending_wd and check_name = 'parent_is_a_fund_purchase';
+  if v_detail like '%valued against%' then
+    raise exception 'a claim on a pending seed is valued by nothing; the audit said: %', v_detail;
+  end if;
+  if v_detail not like '%nothing values either row%' then
+    raise exception 'the detail must say neither row is valued, got: %', v_detail;
   end if;
 
   raise notice 'withdrawal_ledger_audit: no bucket, no claim that the row was valued';

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -743,6 +743,65 @@ begin
   end if;
 end $$;
 
+-- ═══ one bucket, one balance across both sale shapes (#606) ════════════════
+-- A fund-keyed sell and a sell parented to a purchase in the same bucket used to be
+-- measured against two different balances, and the audit aggregated only the first
+-- — so 55 units out of a 50-unit bucket reported clean while the reader subtracted
+-- all 55 and dropped the holding five units early. The write path refuses the
+-- parented shape now; what is already in the ledger has to be REPORTED, which is
+-- why these rows are planted with the trigger off.
+do $$
+declare
+  v_user uuid; v_goal uuid; v_fund uuid; v_buy uuid; v_par uuid; v_n int;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-audit-606@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Mixed shapes') returning goal_id into v_goal;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Mixed Fund', 'MIXF', 'equity', 25000) returning id into v_fund;
+
+  alter table public.investment_transactions disable trigger user;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 50, 40000)
+  returning transaction_id into v_buy;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-02-01', 1125000, 45, 1800000);
+
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, units_withdrawn, principal_withdrawn)
+  values (v_user, v_goal, null, 'withdrawal', '2026-03-01', 250000, v_buy, 10, 400000)
+  returning transaction_id into v_par;
+
+  alter table public.investment_transactions enable trigger user;
+
+  -- 55 of 50 units, whichever shape took them.
+  select count(*) into v_n from public.withdrawal_ledger_audit
+   where user_id = v_user and check_name = 'fund_bucket_overdrawn' and fund_id = v_fund;
+  if v_n <> 1 then
+    raise exception 'the audit must report the bucket drawn on by both sale shapes, got %', v_n;
+  end if;
+
+  -- And the parented row is not ALSO charged to the purchase it names: one claim,
+  -- one balance. Counting it twice would invent an overdrawn holding on top.
+  select count(*) into v_n from public.withdrawal_ledger_audit
+   where user_id = v_user and check_name = 'holding_overdrawn';
+  if v_n <> 0 then
+    raise exception 'a fund-parented sale must not be charged to the purchase as well, got % holding overdraw(s)', v_n;
+  end if;
+
+  -- It stays named for review, with the detail that says it IS valued.
+  if not exists (select 1 from public.withdrawal_ledger_audit
+                  where transaction_id = v_par and check_name = 'parent_is_a_fund_purchase'
+                    and detail like '%valued against that fund bucket%') then
+    raise exception 'the fund-parented row must still be reported for review';
+  end if;
+
+  raise notice 'withdrawal_ledger_audit: both sale shapes share one bucket balance';
+end $$;
+
 -- ═══ the contract itself ═══════════════════════════════════════════════════
 -- Two claims the view's header makes, kept honest here rather than in prose alone.
 do $$


### PR DESCRIPTION
Closes #606.

## The gap

`buildWithdrawalMaps` keyed a withdrawal one of two ways: fund-keyed (`asset_type='fund'` + `fund_id`) → the `(goal, fund)` map, otherwise `parent_transaction_id` → the parent map. The dashboard consumes those in matching halves — a fund row is valued through the goal/fund map and never consults `parentWdMap`.

So a withdrawal whose parent is a **fund purchase**, but which is not itself fund-keyed, landed under a key nothing reads. The cash left; the fund kept its full units and value. Net worth was overstated by the withdrawn amount, with no error and nothing on screen to show it.

## The decision

**One rule, and one balance behind it:** a withdrawal draws on a `(goal, fund)` bucket when it is fund-keyed **or** when its parent is a fund purchase the dashboard accumulates as one (`asset_type='fund'`, a `fund_id`, and `units > 0` — a purchase with no units is valued as an ordinary holding, so its withdrawal stays on the parent axis). Only a withdrawal that is neither is keyed by its parent.

**Reader** (`lib/withdrawalProgress`, `lib/dashboardOverview`): the bucket key comes from the purchase — that is how the accumulator is keyed — and units come from `units_withdrawn` when it records a positive quantity, otherwise derived pro-rata from that purchase's own price, capped at the units it holds. Principal alone would drop the cost basis while every unit stayed in net worth, the trap the invariant already refuses for gold. Fixing it in the reader brings rows **already in the ledger** into the total, so no backfill has to be timed.

**Writer** — one bucket cannot have two balances, so every path that measures one now counts both kinds of claim:

- `20260803000002` — the shape is refused as it is *written*. The check sits in the immediate trigger, after the relocation bypass and the FK's own orphaning, so deleting a goal or a fund over legacy rows still works; the parent is read under the same lock the measurement takes, so it cannot race a bank→fund conversion.
- `20260803000003` — the other door: a holding may not *become* a fund purchase (by type, by fund, by activation, or by gaining units) while a non-fund-keyed withdrawal draws on it, and a purchase may not change the **rate** a legacy child's units are derived at. Proportional restatements that leave every derived quantity identical are allowed.
- `20260803000004` — `check_fund_bucket_solvent` counts parented claims, so a relocation cannot split a bucket from what it owes.
- `20260803000005` — the fund branch of `check_withdrawal_balance` counts them too, so a new sale is measured against every claim on the bucket.

**Audit** (`20260803000001`): `fund_sells` aggregates both shapes into the bucket each draws on (deriving units where the reader derives them), `parents` stops charging a parented row to the purchase as well, and `parent_is_a_fund_purchase` says what is actually true of each shape — valued into the bucket, valued on the parent axis (zero-unit purchase), or valued by nothing (no fund at all).

**Route**: `PUT /api/v1/investment-transactions/[id]` maps the `withdrawal invariant:` family to 400 instead of collapsing it into `404 Transaction not found`.

## Tests

- `lib/__tests__/withdrawalProgress.test.ts` — the redirect, the purchase's goal as the key, derivation (absent, zero, capped), the progress/valuation split, and every shape that must stay on the parent axis.
- `app/api/v1/dashboard/overview/__tests__/route.test.ts` — closes the loop through the real handler: net worth, the fund row's units and cost basis, and the goal card all fall by the right amount.
- `app/api/v1/investment-transactions/__tests__/route.put.invariant.test.ts` — the 400, the family prefix, and a genuinely missing row still 404ing.
- `supabase/tests/withdrawal_balance.test.sql` — refusals for both variants of the shape, the two-statement bypass, gaining units, re-pricing vs a proportional restatement, and that deleting a goal or a fund over a legacy row still works.
- `supabase/tests/withdrawal_ledger_audit.test.sql` — one bucket for both shapes, derived units counted, and each detail message tied to the shape it describes.

Every DB assertion was checked red against the previous object before being kept. Ran locally: typecheck, lint, full Vitest, `test:db`, production build, E2E smoke lane.

## Review

Codex found ten issues across the rounds, each reproduced against the running stack before it was fixed — two balances for one bucket, the cascade-order and concurrency races, the goal-delete wedge, the two-statement bypass, `not NULL` filing a row under neither branch, and three audit messages that described a row as something it was not. One finding was deliberately not fixed here: shrinking a purchase under claims it can no longer back is the mirror hole `20260730000002` names in its header and #608 owns — identical for an ordinary fund-keyed sell, and noted on that issue with the shape a fix would take.