### PR TITLE
fix(ledger): a source cannot be edited or deleted below what it owes (#608)

### DIFF
--- a/app/api/v1/investment-transactions/[id]/__tests__/route.delete.test.ts
+++ b/app/api/v1/investment-transactions/[id]/__tests__/route.delete.test.ts
@@ -195,6 +195,30 @@ describe('DELETE /api/v1/investment-transactions/[id]', () => {
     expect(body.error).toMatch(/settlement/i)
   })
 
+  // Deleting a holding that a withdrawal still draws on is refused by the source
+  // side of the withdrawal invariant (#608): the cash would be left filed under no
+  // holding, which is silent and permanent. Like the settlement above it arrives as
+  // a check violation rather than the 23503 this handler was built around, so
+  // without its own branch an ordinary conflict reads as a server fault.
+  it('returns 409 when a withdrawal still draws on the holding', async () => {
+    h.deleteResult = {
+      data: null,
+      error: {
+        code: '23514',
+        message: 'withdrawal invariant: holding abc cannot be deleted while this withdrawal still draws 60000000 on it',
+      },
+    }
+
+    const res = await call()
+
+    expect(res.status).toBe(409)
+    const body = await res.json()
+    expect(body.code).toBe('withdrawal_invariant')
+    expect(body.error).toMatch(/withdrawal/i)
+    // The database's own sentence, with the row ids in it, is not the user's.
+    expect(JSON.stringify(body)).not.toContain('60000000')
+  })
+
   it('returns a generic 409 for an unrecognised foreign-key reference', async () => {
     h.deleteResult = {
       data: null,

--- a/app/api/v1/investment-transactions/[id]/__tests__/route.put.subtype.test.ts
+++ b/app/api/v1/investment-transactions/[id]/__tests__/route.put.subtype.test.ts
@@ -20,6 +20,7 @@ const h = vi.hoisted(() => ({
   updates: null as Record<string, unknown> | null,
   updateResult: { data: { transaction_id: '11111111-1111-4111-8111-111111111111' } as unknown, error: null as unknown },
   rpcCalls: [] as { name: string; args: Record<string, unknown> }[],
+  rpcResult: { data: { transaction_id: '11111111-1111-4111-8111-111111111111' } as unknown, error: null as unknown },
 }))
 
 vi.mock('@/lib/supabase-server', () => {
@@ -44,7 +45,7 @@ vi.mock('@/lib/supabase-server', () => {
       from: (table: string) => chainFor(table),
       rpc: (name: string, args: Record<string, unknown>) => {
         h.rpcCalls.push({ name, args })
-        return { single: async () => ({ data: { transaction_id: TX_ID }, error: null }) }
+        return { single: async () => h.rpcResult }
       },
     }),
   }
@@ -73,6 +74,7 @@ beforeEach(() => {
   h.updates = null
   h.updateResult = { data: { transaction_id: TX_ID }, error: null }
   h.rpcCalls = []
+  h.rpcResult = { data: { transaction_id: TX_ID }, error: null }
   vi.spyOn(console, 'error').mockImplementation(() => {})
 })
 
@@ -199,6 +201,34 @@ describe('PUT /api/v1/investment-transactions/[id] — subtype normalization (#5
     const res = await put({ asset_type: 'gold', amount_vnd: 1_000_000 })
     expect(res.status).toBe(400)
     expect(await res.json()).toMatchObject({ code: 'book_type_change' })
+  })
+
+  // A book tranche takes the RPC path, which returns before the plain-update
+  // branch's `withdrawal invariant:` mapping ever runs. Left to the generic
+  // handler, shrinking a tranche below what has been withdrawn from it (#608)
+  // answered 500 — the app looking broken — while the identical conflict on an
+  // ordinary deposit answered 400 with something the user can act on.
+  it('maps the withdrawal invariant to a 400 on the book path too', async () => {
+    h.existing = { deposit_group_id: 'book-1', asset_type: 'bank' }
+    h.rpcResult = {
+      data: null,
+      error: { message: 'withdrawal invariant: holding abc would be left owing 30000000 it does not hold' },
+    }
+
+    const res = await put({ amount_vnd: 1_000_000 })
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toMatchObject({ code: 'withdrawal_invariant' })
+  })
+
+  it('still reports an unrecognised book failure as a server error', async () => {
+    h.existing = { deposit_group_id: 'book-1', asset_type: 'bank' }
+    h.rpcResult = { data: null, error: { message: 'deadlock detected' } }
+
+    const res = await put({ amount_vnd: 1_000_000 })
+
+    expect(res.status).toBe(500)
+    expect(JSON.stringify(await res.json())).not.toContain('deadlock')
   })
 
   it('does not normalize a legacy row whose asset type is unknown', async () => {

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -173,6 +173,20 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
         p_set_bank: bank_code !== undefined, p_bank_code: cleanBankCode ?? null,
       })
       .single()
+    // A tranche is a holding like any other, so shrinking one below what has been
+    // withdrawn from it is refused at the table (#608) — and this branch returns
+    // before the mapping further down ever runs. Without its own check the same
+    // conflict answers 400 for a plain deposit and 500 for a book tranche, which
+    // tells the user the app broke rather than what to do about it.
+    if (bookErr?.message?.includes('withdrawal invariant:')) {
+      return NextResponse.json(
+        {
+          error: 'A withdrawal is recorded against this deposit. Remove it before changing the deposit this way.',
+          code: 'withdrawal_invariant',
+        },
+        { status: 400 },
+      )
+    }
     if (bookErr || !row) {
       console.error('update_deposit_book: atomic book edit failed', bookErr?.message)
       return NextResponse.json({ error: 'Failed to update deposit book' }, { status: 500 })

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -349,6 +349,21 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
         { status: 409 },
       )
     }
+    // A withdrawal is still drawn on this holding (#608). Deleting it would leave
+    // that cash filed under no holding at all — the ledger owes what nothing backs
+    // — so the invariant refuses it. A conflict the user resolves by removing the
+    // withdrawal first, not a fault, and 500 would call it one. Matched on the
+    // family prefix exactly as PUT and POST do, so a refusal added later cannot
+    // fall through as the wrong status.
+    if (error.message?.includes('withdrawal invariant:')) {
+      return NextResponse.json(
+        {
+          error: 'A withdrawal is recorded against this holding. Remove it before deleting the holding.',
+          code: 'withdrawal_invariant',
+        },
+        { status: 409 },
+      )
+    }
     console.error('investment-transactions delete: statement failed', error.message)
     return NextResponse.json({ error: 'Failed to delete transaction', code: 'delete_failed' }, { status: 500 })
   }

--- a/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
+++ b/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
@@ -102,6 +102,7 @@ describe('TransactionLedgerSheet — a refused delete says why', () => {
     ['settlement_consumed'],
     ['settlement_pending'],
     ['merge_target'],
+    ['withdrawal_invariant'],
   ])('surfaces the %s refusal', async (code) => {
     mockWithDelete({ ok: false, status: 409, body: { error: 'nope', code } })
     render(<TransactionLedgerSheet open desktop locale="en" onClose={() => {}} />)

--- a/app/assets/components/__tests__/deleteTransaction.test.ts
+++ b/app/assets/components/__tests__/deleteTransaction.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest'
-import { deleteTransaction } from '../deleteTransaction'
+import { deleteTransaction, DELETE_FAILURE_CODES } from '../deleteTransaction'
 
 // DELETE /api/v1/investment-transactions/:id refuses for several distinct,
 // user-actionable reasons — a settlement already merged, one still waiting to
@@ -33,6 +33,7 @@ describe('deleteTransaction', () => {
     ['merge_target'],
     ['settlement_pending'],
     ['referenced'],
+    ['withdrawal_invariant'],
     ['not_found'],
     ['delete_failed'],
   ])('passes through the %s code unchanged', async (code) => {
@@ -58,5 +59,23 @@ describe('deleteTransaction', () => {
       new Response('<html>502 Bad Gateway</html>', { status: 502 }),
     )
     await expect(deleteTransaction('tx-1')).resolves.toEqual({ ok: false, code: 'unknown' })
+  })
+
+  // The gap that let withdrawal_invariant ship half-done: the route mapped the
+  // refusal, the client did not list it, and it fell through to "couldn't delete
+  // this transaction" — the generic sentence, in place of the instruction the
+  // refusal exists to give. Pinning the three lists to each other catches the next
+  // one at the point it is added rather than in a bug report.
+  it('has a translation for every code the client accepts, in every language', async () => {
+    const en = (await import('@/messages/en.json')).default.deleteTransaction as Record<string, string>
+    const vi = (await import('@/messages/vi.json')).default.deleteTransaction as Record<string, string>
+
+    for (const code of DELETE_FAILURE_CODES) {
+      expect(en[code], `messages/en.json is missing deleteTransaction.${code}`).toBeTruthy()
+      expect(vi[code], `messages/vi.json is missing deleteTransaction.${code}`).toBeTruthy()
+    }
+    // And nothing translated that the client can never produce.
+    expect(Object.keys(en).sort()).toEqual([...DELETE_FAILURE_CODES].sort())
+    expect(Object.keys(vi).sort()).toEqual([...DELETE_FAILURE_CODES].sort())
   })
 })

--- a/app/assets/components/deleteTransaction.ts
+++ b/app/assets/components/deleteTransaction.ts
@@ -6,6 +6,7 @@ export type DeleteFailureCode =
   | 'merge_target'          // another settlement has been merged INTO this deposit
   | 'settlement_pending'    // a settlement is held, waiting to merge into this one
   | 'referenced'            // some other record still points at this row
+  | 'withdrawal_invariant'  // a withdrawal still draws on this holding (#608)
   | 'not_found'             // already gone
   | 'delete_failed'         // the server tried and failed
   | 'network'               // the request never got an answer
@@ -42,11 +43,16 @@ export async function deleteTransaction(txId: string): Promise<DeleteResult> {
   }
 }
 
-const CODES: readonly DeleteFailureCode[] = [
+// Keep in step with DeleteFailureCode AND with messages/*.json: a code the route
+// returns but this list omits falls through to 'unknown', so the toast says
+// "couldn't delete this transaction" in place of the instruction the refusal was
+// added to give. That is how withdrawal_invariant arrived — the route mapped it,
+// the client did not, and the actionable half of the change was invisible.
+export const DELETE_FAILURE_CODES: readonly DeleteFailureCode[] = [
   'settlement_consumed', 'merge_target', 'settlement_pending',
-  'referenced', 'not_found', 'delete_failed', 'network', 'unknown',
+  'referenced', 'withdrawal_invariant', 'not_found', 'delete_failed', 'network', 'unknown',
 ]
 
 function isFailureCode(v: unknown): v is DeleteFailureCode {
-  return typeof v === 'string' && (CODES as readonly string[]).includes(v)
+  return typeof v === 'string' && (DELETE_FAILURE_CODES as readonly string[]).includes(v)
 }

--- a/e2e/withdrawal-balance.spec.ts
+++ b/e2e/withdrawal-balance.spec.ts
@@ -94,22 +94,56 @@ test.describe('withdrawal balance enforcement (#587)', () => {
     expect(outgoing[0].principal_withdrawn).toBe(100_000_000)
   })
 
-  // The guard sits on a BEFORE UPDATE too, and parent_transaction_id is
-  // ON DELETE SET NULL — so deleting a partially withdrawn deposit orphans its
-  // children through an update that lands on the trigger. An early version of
-  // this change refused that update and turned an ordinary delete into a 500.
-  // The suite missed it because the test helpers delete children first; the route
-  // does not, so drive the route.
-  test('a source that has been partly withdrawn can still be deleted', async ({ request }) => {
+  // parent_transaction_id is ON DELETE SET NULL, so deleting a partly withdrawn
+  // deposit orphans its children through an update that lands on the trigger.
+  // That used to be permitted, and the cash stayed in history filed under no
+  // holding at all — #607. #608 refuses it from both ends: an edit may not take a
+  // source below what has left it, and a delete is that edit taken all the way.
+  //
+  // This is the one path that has to be driven through the ROUTE rather than a
+  // helper: the helpers delete children first, so they never produce the orphan,
+  // and it is the route that has to turn the refusal into a 409 the user can act
+  // on instead of a 500.
+  test('a source that has been partly withdrawn cannot be deleted under its withdrawal', async ({ request }) => {
     expect((await request.post('/api/v1/investment-transactions', { data: withdraw(30_000_000) })).status()).toBe(201)
 
-    const del = await request.delete(`/api/v1/investment-transactions/${depositId}`)
-    expect(del.status()).toBe(200)
+    const refused = await request.delete(`/api/v1/investment-transactions/${depositId}`)
+    expect(refused.status()).toBe(409)
+    expect((await refused.json()).code).toBe('withdrawal_invariant')
 
-    const listed = await (await request.get(
+    // Still there, and still whole.
+    let listed = await (await request.get(
       `/api/v1/investment-transactions?goal_id=${goalId}&limit=100`)).json()
-    const rows = listed.transactions as Array<{ transaction_id: string }>
+    let rows = listed.transactions as Array<{ transaction_id: string; transaction_type: string }>
+    expect(rows.find((t) => t.transaction_id === depositId)).toBeDefined()
+
+    // The remedy is the ledger's own: remove the withdrawal, then the holding.
+    const wd = rows.find((t) => t.transaction_type === 'withdrawal')!
+    expect((await request.delete(`/api/v1/investment-transactions/${wd.transaction_id}`)).status()).toBe(200)
+    expect((await request.delete(`/api/v1/investment-transactions/${depositId}`)).status()).toBe(200)
+
+    listed = await (await request.get(
+      `/api/v1/investment-transactions?goal_id=${goalId}&limit=100`)).json()
+    rows = listed.transactions as Array<{ transaction_id: string; transaction_type: string }>
     expect(rows.find((t) => t.transaction_id === depositId)).toBeUndefined()
+  })
+
+  // The edit half of the same rule, through the route: PUT already maps the
+  // family to a 400, so shrinking a deposit under what has left it must read as a
+  // refused edit rather than a 404 or a server fault.
+  test('a source cannot be edited below what has been withdrawn from it', async ({ request }) => {
+    expect((await request.post('/api/v1/investment-transactions', { data: withdraw(80_000_000) })).status()).toBe(201)
+
+    const refused = await request.put(`/api/v1/investment-transactions/${depositId}`, {
+      data: { amount_vnd: 50_000_000 },
+    })
+    expect(refused.status()).toBe(400)
+    expect((await refused.json()).code).toBe('withdrawal_invariant')
+
+    // Down to exactly what is left is an ordinary correction, not an overdraw.
+    expect((await request.put(`/api/v1/investment-transactions/${depositId}`, {
+      data: { amount_vnd: 80_000_000 },
+    })).status()).toBe(200)
   })
 
   // Selling a gold lot whose principal doesn't divide evenly by its units: the

--- a/e2e/withdrawal-balance.spec.ts
+++ b/e2e/withdrawal-balance.spec.ts
@@ -174,6 +174,55 @@ test.describe('withdrawal balance enforcement (#587)', () => {
   // fund_id is ON DELETE SET NULL too, so deleting a fund orphans its sells
   // through the same kind of update as deleting a deposit. Same failure mode, a
   // different route — and the helpers hide it the same way.
+  // The source side has its own race, and it is not the sells' one: two edits
+  // shrinking DIFFERENT purchases of the SAME bucket. Each locks only its own row,
+  // so each read the other at full size and both passed — two 50-unit purchases
+  // and a 60-unit sale, edited to 20 each, left 40 units backing 60 with no error.
+  // The bucket check now takes a lock on the bucket itself, which only a real
+  // stack with two connections can show.
+  test('two edits racing to shrink the same fund bucket: exactly one wins', async ({ request }) => {
+    const fund = await api.createFund({
+      name: `E2E WdBalance Race ${Date.now()}`,
+      code: `WBR${Math.random().toString(36).slice(2, 6).toUpperCase()}`,
+      fund_type: 'equity',
+      nav: 20_000,
+    })
+    const buys = await Promise.all([1, 2].map((n) => api.createTransaction({
+      asset_type: 'fund', fund_id: fund.id, goal_id: goalId,
+      amount_vnd: 1_000_000, units: 50, unit_price: 20_000,
+      investment_date: `2026-01-0${n}`, notes: 'E2E wd balance race',
+    })))
+    const sell = await request.post('/api/v1/investment-transactions', {
+      data: {
+        transaction_type: 'withdrawal', asset_type: 'fund', fund_id: fund.id,
+        investment_date: '2026-02-01', amount_vnd: 1_200_000,
+        units_withdrawn: 60, principal_withdrawn: 1_200_000, goal_id: goalId,
+        notes: 'E2E wd balance race',
+      },
+    })
+    expect(sell.status()).toBe(201)
+
+    try {
+      // Either edit alone leaves 70 units backing 60 and is fine. Both together
+      // leave 40, so exactly one may land.
+      const shrink = (id: string) => request.put(`/api/v1/investment-transactions/${id}`,
+        { data: { amount_vnd: 400_000, units: 20 } })
+      const [a, b] = await Promise.all([shrink(buys[0].transaction_id), shrink(buys[1].transaction_id)])
+      expect([a.status(), b.status()].sort()).toEqual([200, 400])
+
+      // And the bucket agrees: 70 units still held against the 60 sold.
+      const listed = await (await request.get(
+        `/api/v1/investment-transactions?goal_id=${goalId}&limit=100`)).json()
+      const held = (listed.transactions as Array<{ transaction_type: string; units: number | null }>)
+        .filter((t) => t.transaction_type === 'investment')
+        .reduce((sum, t) => sum + (t.units ?? 0), 0)
+      expect(held).toBe(70)
+    } finally {
+      await api.deleteAllTransactionsByNotes('E2E wd balance race')
+      await api.deleteFund(fund.id)
+    }
+  })
+
   test('a fund that has been sold from can still be deleted', async ({ request }) => {
     const fund = await api.createFund({
       name: `E2E WdBalance Del ${Date.now()}`,

--- a/messages/en.json
+++ b/messages/en.json
@@ -890,6 +890,7 @@
     "merge_target": "Another settlement has been merged into this deposit, so it can’t be removed.",
     "settlement_pending": "A settlement is waiting to be merged into this deposit. Cancel that pending settlement first.",
     "referenced": "Another record still references this transaction. Remove that reference before deleting it.",
+    "withdrawal_invariant": "A withdrawal or sale is recorded against this holding. Remove it before deleting the holding.",
     "not_found": "This transaction no longer exists.",
     "delete_failed": "Couldn’t delete this transaction. Please try again.",
     "network": "Connection problem — the transaction wasn’t deleted.",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -890,6 +890,7 @@
     "merge_target": "Đã có khoản tất toán được gộp vào sổ này nên không thể xoá.",
     "settlement_pending": "Có khoản tất toán đang chờ gộp vào sổ này. Hãy huỷ khoản chờ gộp trước.",
     "referenced": "Bản ghi khác vẫn tham chiếu tới giao dịch này. Hãy gỡ tham chiếu đó trước khi xoá.",
+    "withdrawal_invariant": "Có khoản rút/bán ghi nhận trên khoản này. Hãy xoá khoản rút/bán đó trước khi xoá.",
     "not_found": "Giao dịch này không còn tồn tại.",
     "delete_failed": "Không xoá được giao dịch. Vui lòng thử lại.",
     "network": "Lỗi kết nối — giao dịch chưa được xoá.",

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/supabase/migrations/20260804000001_source_must_back_its_claims.sql
+++ b/supabase/migrations/20260804000001_source_must_back_its_claims.sql
@@ -1,0 +1,303 @@
+-- A source may not be edited or deleted below what has already been withdrawn
+-- from it (#608).
+--
+-- 20260730000002 measures a WITHDRAWAL against its holding every time the
+-- withdrawal is written or moved, and says so in its own header: "lowering a
+-- source's amount_vnd below what has already been withdrawn is the mirror hole
+-- and wants its own guard". This is that guard. Nothing fired when the SOURCE
+-- shrank, so
+--
+--   buy 100,000,000 → sell 80,000,000 → edit the buy down to 50,000,000
+--
+-- was accepted in silence. dashboard/overview then does
+-- `totalInvested -= Σ principal_withdrawn` against a basis that no longer covers
+-- it: invested capital goes negative, the goal's progress bar with it, and there
+-- is no error and no screen that shows the inconsistency. You find it months
+-- later from a number that looks wrong.
+--
+-- ─── One question, asked from the other end ──────────────────────────────────
+--
+-- The balances are the same two the withdrawal invariant already measures, and
+-- the branch order is the same one lib/withdrawalProgress uses to decide which
+-- bucket a claim draws on. Restating the arithmetic here would be a second
+-- implementation of a decision table that must have exactly one, so this reuses
+-- what is there:
+--
+--   • fund purchase (asset_type='fund', a fund, units > 0) — its bucket is
+--     measured by check_fund_bucket_solvent, which since #606 counts every claim
+--     the dashboard counts: fund-keyed sells AND withdrawals parented to a
+--     purchase in the bucket.
+--   • everything else (bank / gold / stock, and a fund row with no units, which
+--     is no bucket) — one source row: amount_vnd and units must cover the claims
+--     parented to it, summed exactly as check_withdrawal_balance's parent branch
+--     sums them.
+--
+-- ─── Why the edit check is DEFERRED to commit ────────────────────────────────
+--
+-- Not a preference — renew_term_deposit_with_merge makes it necessary. It rolls
+-- the deposit forward FIRST (`update ... set amount_vnd = p_amount_vnd +
+-- v_merge_total`) and only two statements later re-parents that deposit's partial
+-- withdrawals onto the history snapshot it just wrote (#585). Renewing a
+-- 100,000,000 deposit that has 60,000,000 withdrawn from it at its remaining
+-- balance leaves the row holding 41,000,000 against a 60,000,000 claim for the
+-- length of two statements — legitimately insolvent in the middle, sound at the
+-- end. A row-level or end-of-statement check refuses every such renewal.
+--
+-- So the edit is asked at COMMIT, which is the only boundary where a
+-- multi-statement rewrite is a finished thought. That is the same reasoning
+-- 20260731000001 already applies to the held-settlement source check, and the
+-- price is the same: the error arrives at commit rather than at the statement.
+-- For the single-statement writes the API makes, they are the same moment.
+--
+-- ─── Why deleting is guarded from the CHILD's side ───────────────────────────
+--
+-- Deleting a source could not be measured at commit the way an edit is: both
+-- links a withdrawal hangs on are ON DELETE SET NULL, so by commit the child no
+-- longer names the holding that went, and there is nothing left to measure
+-- against. The tell has to be read while it is still there — during the FK's own
+-- SET NULL update, which is the last moment anything knows what this row drew on.
+-- enforce_withdrawal_within_balance already stands there and already tells
+-- "detached by hand" (refused) from "orphaned by the FK" (waved through); the
+-- refusal below is a trigger beside it, sorted to run first, so that function is
+-- not copied a third time to gain four lines. That is the delete half of #607,
+-- answered the same way as the edit because it is the same question.
+--
+-- The one shape that must still be let through is the account cascade: deleting a
+-- user removes holdings and withdrawals in an order Postgres picks, so a child can
+-- be orphaned by a parent that is on its way out too. The tell is the same one
+-- that branch already uses for the parent — by the time the FK action fires, the
+-- referenced auth.users row is deleted and invisible.
+--
+-- A fund purchase is different again: its sells name no parent, so deleting it
+-- fires no FK update at all and there is nothing to catch. Its bucket answers
+-- instead, at commit, where the deleted row has already left the sums.
+
+-- ── the measurement ─────────────────────────────────────────────────────────
+create or replace function public.check_source_backs_claims(src public.investment_transactions)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  -- The units tolerance the rest of this family uses — clients round
+  -- units_withdrawn to four decimals, so a FULL sell can post a hair more than
+  -- the holding and the source is allowed to be restated at exactly that.
+  -- Principal has NO tolerance, matching check_withdrawal_balance's parent branch:
+  -- it compares `principal_withdrawn > v_left` outright, and a source that covers
+  -- a đồng less than what left it is owing a đồng.
+  c_units_epsilon constant numeric := 0.0001;
+  v_out_principal bigint;
+  v_out_units     numeric;
+  v_have          bigint;
+  v_have_units    numeric;
+begin
+  -- A fund purchase IS its bucket, and the bucket is what claims draw on. `units
+  -- > 0` mirrors lib/withdrawalProgress exactly: a purchase with none is no
+  -- bucket — the dashboard values it as an ordinary holding — so it falls through
+  -- to the parent axis below, where its claims actually sit.
+  if src.transaction_type = 'investment' and src.asset_type = 'fund'
+     and src.fund_id is not null and coalesce(src.units, 0) > 0 then
+    perform public.check_fund_bucket_solvent(src.user_id, src.fund_id, src.goal_id);
+    return;
+  end if;
+
+  -- What is drawn on this row, summed the way check_withdrawal_balance's parent
+  -- branch sums it — a fund-keyed sibling draws on its own bucket whatever it
+  -- names as a parent, so counting it here would charge it twice.
+  select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
+    into v_out_principal, v_out_units
+    from public.investment_transactions w
+   where w.parent_transaction_id = src.transaction_id
+     and w.transaction_type = 'withdrawal'
+     and not coalesce(w.asset_type = 'fund' and w.fund_id is not null, false);
+
+  if v_out_principal = 0 and v_out_units = 0 then return; end if;
+
+  -- A row that is no longer an investment holds nothing at all: the dashboard
+  -- values no balance for it, so every claim parented to it is unbacked. That is
+  -- the same hole reached through transaction_type instead of amount_vnd, which
+  -- is why the trigger watches that column too.
+  v_have       := case when src.transaction_type = 'investment' then coalesce(src.amount_vnd, 0) else 0 end;
+  v_have_units := case when src.transaction_type = 'investment' then coalesce(src.units, 0) else 0 end;
+
+  if v_out_principal > v_have then
+    raise exception 'withdrawal invariant: holding % would be left owing % it does not hold (% withdrawn against a balance of %)',
+      src.transaction_id, v_out_principal - v_have, v_out_principal, v_have
+      using errcode = 'check_violation';
+  end if;
+
+  if v_out_units > v_have_units + c_units_epsilon then
+    raise exception 'withdrawal invariant: holding % would be left owing % units it does not hold (% units withdrawn against % held)',
+      src.transaction_id, v_out_units - v_have_units, v_out_units, v_have_units
+      using errcode = 'check_violation';
+  end if;
+end;
+$$;
+
+comment on function public.check_source_backs_claims(public.investment_transactions) is
+  'Raises when a holding no longer covers the withdrawals drawn on it — the source side of the withdrawal invariant (#608).';
+
+-- SECURITY DEFINER and PUBLIC-executable by default, which would make it an
+-- oracle: hand it a row naming someone else''s holding and the refusal reports
+-- that holding''s exact balance, RLS bypassed. Same reasoning, same revoke, as
+-- check_withdrawal_balance.
+revoke all on function public.check_source_backs_claims(public.investment_transactions) from public;
+revoke all on function public.check_source_backs_claims(public.investment_transactions) from anon, authenticated;
+
+-- ── an edit, measured once the transaction is a finished thought ────────────
+create or replace function public.enforce_source_backs_claims()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_row public.investment_transactions;
+begin
+  -- Re-read rather than trust the queued image: between the statement and commit
+  -- the row may have been edited again or deleted outright, and the question is
+  -- about what is actually there now. Gone means the delete triggers own it.
+  select * into v_row from public.investment_transactions t
+   where t.transaction_id = new.transaction_id;
+  if not found then return null; end if;
+
+  perform public.check_source_backs_claims(v_row);
+
+  -- A purchase that LEFT a bucket — its fund cleared, its asset_type changed, its
+  -- goal moved — shrinks the bucket it came from by everything it held, and the
+  -- row above no longer knows anything about that bucket. Measure the old one too.
+  -- Deleting the fund itself needs no exemption here: it clears fund_id on the
+  -- purchases and the sells alike, so the old bucket is empty on both sides and
+  -- the check is 0 against 0.
+  if old.transaction_type = 'investment' and old.asset_type = 'fund'
+     and old.fund_id is not null and coalesce(old.units, 0) > 0
+     and (old.fund_id is distinct from new.fund_id
+          or old.asset_type is distinct from new.asset_type
+          or old.goal_id is distinct from new.goal_id
+          or old.transaction_type is distinct from new.transaction_type) then
+    perform public.check_fund_bucket_solvent(old.user_id, old.fund_id, old.goal_id);
+  end if;
+
+  return null;
+end;
+$$;
+
+comment on function public.enforce_source_backs_claims() is
+  'Re-measures a holding against the withdrawals drawn on it after an edit, at commit so a multi-statement rewrite (renewal, collapse) is seen finished (#608).';
+
+revoke all on function public.enforce_source_backs_claims() from public, anon, authenticated;
+
+drop trigger if exists investment_transactions_source_backs_claims on public.investment_transactions;
+create constraint trigger investment_transactions_source_backs_claims
+  after update of transaction_type, asset_type, amount_vnd, units, fund_id, goal_id
+  on public.investment_transactions
+  -- INITIALLY DEFERRED, not IMMEDIATE: renewal is insolvent between its own
+  -- statements (see the header). A caller that needs the answer sooner can SET
+  -- CONSTRAINTS IMMEDIATE, which is how the tests force it.
+  deferrable initially deferred
+  for each row
+  -- Either side: a row that STOPS being an investment takes its balance away just
+  -- as surely as one that shrinks.
+  when (old.transaction_type = 'investment' or new.transaction_type = 'investment')
+  execute function public.enforce_source_backs_claims();
+
+-- ── deleting a fund purchase: the bucket answers ────────────────────────────
+create or replace function public.enforce_source_delete_backs_claims()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  -- At commit the deleted row has already left both sums, so the bucket is
+  -- measured as it will actually be read. An account cascade is 0 against 0 and
+  -- passes; a goal delete moves purchases and sells to the unallocated bucket
+  -- together and passes; what is refused is a delete that genuinely leaves sales
+  -- with less behind them than they claim.
+  perform public.check_fund_bucket_solvent(old.user_id, old.fund_id, old.goal_id);
+  return null;
+end;
+$$;
+
+comment on function public.enforce_source_delete_backs_claims() is
+  'Re-measures a fund bucket at commit after one of its purchases is deleted — a fund sell names no parent, so nothing else catches it (#608).';
+
+revoke all on function public.enforce_source_delete_backs_claims() from public, anon, authenticated;
+
+drop trigger if exists investment_transactions_source_deleted on public.investment_transactions;
+create constraint trigger investment_transactions_source_deleted
+  after delete on public.investment_transactions
+  deferrable initially deferred
+  for each row
+  when (old.transaction_type = 'investment' and old.asset_type = 'fund'
+        and old.fund_id is not null and coalesce(old.units, 0) > 0)
+  execute function public.enforce_source_delete_backs_claims();
+
+-- ── deleting any other holding: caught as its children are orphaned ─────────
+--
+-- A trigger of its own rather than another branch inside
+-- enforce_withdrawal_within_balance: that function has already been re-issued
+-- once (20260803000002) and copying it again to add four lines makes a third
+-- copy that drifts from the other two. This asks one question, and the ordering
+-- it needs it gets for free — same-timing triggers fire in name order, and
+-- `..._source_not_deletable...` sorts before `..._withdrawal_balance`, so the
+-- refusal below happens before that function reaches the branch that waves an
+-- FK orphan through.
+create or replace function public.refuse_orphaning_a_claim()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  -- Detaching a withdrawal from a holding that is STILL THERE is a different act
+  -- with a different message, and enforce_withdrawal_within_balance already owns
+  -- it. Only the FK's own orphaning reaches past here.
+  if exists (select 1 from public.investment_transactions t
+              where t.transaction_id = old.parent_transaction_id) then
+    return new;
+  end if;
+
+  -- The source was deleted while this row still draws on it. #608 refuses the
+  -- shrinking edit; deleting is that edit taken all the way, so it is refused the
+  -- same way rather than left to orphan the claim in silence (#607). This is the
+  -- only moment it can be caught — at commit the FK has already erased which
+  -- holding the row drew on.
+  --
+  -- Three carve-outs, each a shape where nothing is left owing:
+  --   • the account cascade — the whole ledger is going, and the auth.users row is
+  --     already invisible by the time this FK action fires, exactly as the deleted
+  --     parent above is. Without this, an account with any sell in it could not be
+  --     deleted at all.
+  --   • a fund-keyed sell — it draws on its (goal, fund) bucket whatever it names
+  --     as a parent, so the parent leaving costs it nothing.
+  --   • a held-for-merge settlement — 20260731000001 owns that case and answers it
+  --     with something the user can act on ("remove the settlement first"); firing
+  --     here first would replace that with a vaguer sentence about a balance.
+  if (coalesce(new.principal_withdrawn, 0) > 0 or coalesce(new.units_withdrawn, 0) > 0)
+     and not new.held_for_merge
+     and not coalesce(new.asset_type = 'fund' and new.fund_id is not null, false)
+     and exists (select 1 from auth.users u where u.id = old.user_id) then
+    raise exception 'withdrawal invariant: holding % cannot be deleted while this withdrawal still draws % on it',
+      old.parent_transaction_id, coalesce(new.principal_withdrawn, 0)
+      using errcode = 'check_violation';
+  end if;
+
+  return new;
+end;
+$$;
+
+comment on function public.refuse_orphaning_a_claim() is
+  'Refuses deleting a holding that a withdrawal still draws on, caught as the FK orphans the child because that is the last moment the link is readable (#607, #608).';
+
+revoke all on function public.refuse_orphaning_a_claim() from public, anon, authenticated;
+
+drop trigger if exists investment_transactions_source_not_deletable on public.investment_transactions;
+create trigger investment_transactions_source_not_deletable
+  before update of parent_transaction_id on public.investment_transactions
+  for each row
+  when (old.transaction_type = 'withdrawal'
+        and old.parent_transaction_id is not null
+        and new.parent_transaction_id is null)
+  execute function public.refuse_orphaning_a_claim();

--- a/supabase/migrations/20260804000001_source_must_back_its_claims.sql
+++ b/supabase/migrations/20260804000001_source_must_back_its_claims.sql
@@ -179,13 +179,27 @@ security definer
 set search_path = ''
 as $$
 declare
-  -- The units tolerance the rest of this family uses — clients round
-  -- units_withdrawn to four decimals, so a FULL sell can post a hair more than
-  -- the holding and the source is allowed to be restated at exactly that.
-  -- Principal has NO tolerance, matching check_withdrawal_balance's parent branch:
-  -- it compares `principal_withdrawn > v_left` outright, and a source that covers
-  -- a đồng less than what left it is owing a đồng.
+  -- The tolerances are PER SALE, and this side sums many of them, so they are
+  -- counted rather than taken flat.
+  --
+  -- A bank withdrawal is bounded outright (`principal_withdrawn > v_left`), so its
+  -- claims can never sum past the holding and it gets no slack at all — a deposit
+  -- covering a đồng less than what left it is owing a đồng.
+  --
+  -- A QUANTITY-valued sale is different, and gold is the case: its principal is the
+  -- proportional share of the remaining basis, and check_withdrawal_balance accepts
+  -- it a đồng either way because that is what rounding a slice produces. Four such
+  -- sales, each accepted, can therefore claim 101 against a basis of 100 — reproduced
+  -- on the local stack. Measured with a flat đồng, that ledger became UNEDITABLE:
+  -- restating the same amount, or correcting the units upward, was refused for a
+  -- drift the invariant itself licensed and nothing about the edit made worse. So
+  -- the allowance is one đồng per sale that moved units, and 0.0001 units likewise
+  -- (clients round units_withdrawn to four decimals). Zero such sales, zero slack,
+  -- which is what keeps a plain deposit's boundary exact.
   c_units_epsilon constant numeric := 0.0001;
+  v_priced        int;
+  v_allow         bigint  := 0;
+  v_allow_units   numeric := 0;
   v_out_principal bigint;
   v_out_units     numeric;
   v_have          bigint;
@@ -204,8 +218,9 @@ begin
   -- What is drawn on this row, summed the way check_withdrawal_balance's parent
   -- branch sums it — a fund-keyed sibling draws on its own bucket whatever it
   -- names as a parent, so counting it here would charge it twice.
-  select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
-    into v_out_principal, v_out_units
+  select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0),
+         count(*) filter (where coalesce(w.units_withdrawn, 0) > 0)
+    into v_out_principal, v_out_units, v_priced
     from public.investment_transactions w
    where w.parent_transaction_id = src.transaction_id
      and w.transaction_type = 'withdrawal'
@@ -220,13 +235,23 @@ begin
   v_have       := case when src.transaction_type = 'investment' then coalesce(src.amount_vnd, 0) else 0 end;
   v_have_units := case when src.transaction_type = 'investment' then coalesce(src.units, 0) else 0 end;
 
-  if v_out_principal > v_have then
+  -- The allowance rounds a real balance; it never creates one. A holding with
+  -- nothing left is measured exactly, the same carve-out check_withdrawal_balance
+  -- makes for its units epsilon, so a sold-out source cannot be handed đồng it
+  -- never had.
+  if v_have > 0 then v_allow := v_priced; end if;
+  if v_have_units > 0 then v_allow_units := v_priced * c_units_epsilon; end if;
+
+  -- The balances the messages report are the REAL ones, not the allowance-inflated
+  -- figures the comparison uses: "a balance of 101" for a 100 đồng holding sends
+  -- the reader looking for a đồng that was never there.
+  if v_out_principal > v_have + v_allow then
     raise exception 'withdrawal invariant: holding % would be left owing % it does not hold (% withdrawn against a balance of %)',
       src.transaction_id, v_out_principal - v_have, v_out_principal, v_have
       using errcode = 'check_violation';
   end if;
 
-  if v_out_units > v_have_units + c_units_epsilon then
+  if v_out_units > v_have_units + v_allow_units then
     raise exception 'withdrawal invariant: holding % would be left owing % units it does not hold (% units withdrawn against % held)',
       src.transaction_id, v_out_units - v_have_units, v_out_units, v_have_units
       using errcode = 'check_violation';

--- a/supabase/migrations/20260804000001_source_must_back_its_claims.sql
+++ b/supabase/migrations/20260804000001_source_must_back_its_claims.sql
@@ -133,6 +133,14 @@ declare
   v_par_units  numeric;
   v_par_basis  bigint;
   v_key        bigint;
+  -- One đồng per sale, for the reason the parent axis needs it: the proportional
+  -- allocation is checked per sale with no running total and no carve-out once the
+  -- remaining basis rounds to nothing, so a 1 đồng / 5 unit purchase legally
+  -- carries three 1-đồng sales. A flat đồng refused every later edit of such a
+  -- bucket, including one that only GREW the purchase. Units stay flat: that bound
+  -- withholds its epsilon at zero, so it cannot accumulate.
+  v_sales      int;
+  v_par_count  int;
 begin
   v_key := pg_catalog.hashtextextended(
     p_user::text || ':' || p_fund::text || ':' || coalesce(p_goal::text, ''), 0);
@@ -155,8 +163,8 @@ begin
      and t.renewed_from_transaction_id is null
      and t.units is not null;
 
-  select coalesce(sum(w.units_withdrawn), 0), coalesce(sum(w.principal_withdrawn), 0)
-    into v_out_units, v_out_basis
+  select coalesce(sum(w.units_withdrawn), 0), coalesce(sum(w.principal_withdrawn), 0), count(*)
+    into v_out_units, v_out_basis, v_sales
     from public.investment_transactions w
    where w.user_id = p_user and w.fund_id = p_fund and w.asset_type = 'fund'
      and w.transaction_type = 'withdrawal'
@@ -168,8 +176,8 @@ begin
   select coalesce(sum(case when coalesce(w.units_withdrawn, 0) > 0 then w.units_withdrawn
                            else least(p.units, p.units * coalesce(w.principal_withdrawn, 0) / p.amount_vnd)
                       end), 0),
-         coalesce(sum(coalesce(w.principal_withdrawn, 0)), 0)
-    into v_par_units, v_par_basis
+         coalesce(sum(coalesce(w.principal_withdrawn, 0)), 0), count(*)
+    into v_par_units, v_par_basis, v_par_count
     from public.investment_transactions w
     join public.investment_transactions p
       on p.transaction_id = w.parent_transaction_id
@@ -185,8 +193,17 @@ begin
 
   v_out_units := v_out_units + v_par_units;
   v_out_basis := v_out_basis + v_par_basis;
+  -- Deliberately NOT gated on the bucket still holding something, unlike the
+  -- parent axis. The flat đồng this replaces was ungated too, and a purchase-less
+  -- bucket is a real state a relocation can leave (#587) — withdrawal_ledger_audit
+  -- has a fixture standing on exactly that tolerance, and REPORTS such a bucket
+  -- rather than having the invariant refuse it. This change makes the allowance
+  -- per sale instead of flat; tightening the empty case is a different decision
+  -- and not this issue's to take. The units bound still catches what matters:
+  -- emptying a bucket that has sold units is refused there whatever the basis says.
+  v_sales     := v_sales + v_par_count;
 
-  if v_out_units > v_units + 0.0001 or v_out_basis > v_basis + 1 then
+  if v_out_units > v_units + 0.0001 or v_out_basis > v_basis + v_sales then
     raise exception 'withdrawal invariant: this fund bucket would be left owing % units / % of basis it does not hold',
       v_out_units - v_units, v_out_basis - v_basis using errcode = 'check_violation';
   end if;
@@ -287,7 +304,13 @@ begin
   -- claim vanished together, which is worse than the overdraw this file exists to
   -- refuse. `units = 0` is NOT this case: that row is still valued, just as an
   -- ordinary holding rather than a fund bucket.
+  -- And a row stamped as renewal HISTORY is out of active_investment_transactions
+  -- altogether, so the dashboard has no holding left for these claims to apply to.
+  -- Stamping a live 100,000,000 deposit carrying a 60,000,000 withdrawal took both
+  -- out of the totals at once — the fund half of this was already refused through
+  -- the bucket, this is the same act on the parent axis.
   if src.transaction_type is distinct from 'investment'
+     or src.renewed_from_transaction_id is not null
      or (src.asset_type = 'fund' and src.units is null) then
     v_have       := 0;
     v_have_units := 0;
@@ -343,7 +366,16 @@ begin
    where t.transaction_id = new.transaction_id;
   if not found then return null; end if;
 
-  perform public.check_source_backs_claims(v_row);
+  -- A row that was ALREADY history before this statement is not something this
+  -- edit took away, and the renewal RPCs write exactly that shape on purpose: the
+  -- snapshot is inserted as history and partial withdrawals are re-parented onto it
+  -- (#585), which is how a renewed deposit stops double-counting them. Those claims
+  -- are inert by design — the snapshot is not an active holding — so measuring them
+  -- against it would refuse the renewal itself. What is measured is a LIVE holding
+  -- becoming history, which is a balance leaving.
+  if old.renewed_from_transaction_id is null then
+    perform public.check_source_backs_claims(v_row);
+  end if;
 
   -- A purchase that LEFT a bucket — its fund cleared, its asset_type changed, its
   -- goal moved — shrinks the bucket it came from by everything it held, and the

--- a/supabase/migrations/20260804000001_source_must_back_its_claims.sql
+++ b/supabase/migrations/20260804000001_source_must_back_its_claims.sql
@@ -203,7 +203,14 @@ begin
   -- emptying a bucket that has sold units is refused there whatever the basis says.
   v_sales     := v_sales + v_par_count;
 
-  if v_out_units > v_units + 0.0001 or v_out_basis > v_basis + v_sales then
+  -- The units epsilon is WITHHELD when the bucket holds none, the same carve-out
+  -- check_withdrawal_balance makes for its own: it forgives a client's rounding of
+  -- a real balance, it does not conjure one. Flat, it let a 0.0001-unit purchase
+  -- backing a 0.0001-unit sale be edited to zero units — the purchase then leaves
+  -- the fund accumulator and is valued as an ordinary holding, so its whole
+  -- principal reappears on the dashboard while the sale has nothing left to reduce.
+  if v_out_units > v_units + (case when v_units > 0 then 0.0001 else 0 end)
+     or v_out_basis > v_basis + v_sales then
     raise exception 'withdrawal invariant: this fund bucket would be left owing % units / % of basis it does not hold',
       v_out_units - v_units, v_out_basis - v_basis using errcode = 'check_violation';
   end if;

--- a/supabase/migrations/20260804000001_source_must_back_its_claims.sql
+++ b/supabase/migrations/20260804000001_source_must_back_its_claims.sql
@@ -181,32 +181,39 @@ as $$
 declare
   -- ── how much rounding this side must forgive, and no more ────────────────
   --
-  -- The withdrawal side's tolerances are per sale, so summing many claims looks at
-  -- first like it should sum many tolerances. It does not, and getting that wrong
-  -- is over-permissive in a way that reopens this migration's own hole. Each sale
-  -- is measured against the balance EARLIER SALES LEFT, so every allowance after
-  -- the first is granted against an already-inflated remainder: u₂ ≤ (held − u₁) +
-  -- ε gives u₁ + u₂ ≤ held + ε, whatever the count. The aggregate can exceed the
-  -- holding by exactly ONE epsilon. (The four-sale gold ledger below drifts by one
-  -- đồng, not four — which is the same statement from the other direction.)
+  -- The withdrawal side's tolerances are per sale, and whether they ACCUMULATE
+  -- across a ledger turns on one detail that differs between the two: what happens
+  -- when the holding runs out. Getting it wrong is over-permissive one way and
+  -- makes legal ledgers uneditable the other, and this file has now been wrong in
+  -- both directions.
   --
-  -- WHO gets the đồng: gold, and only gold. check_withdrawal_balance runs the
-  -- proportional branch for a quantity-valued holding — where the principal is the
-  -- rounded share of the remaining basis and may land a đồng either way — and caps
-  -- bank and stock outright at `principal_withdrawn > v_left`. Claims on those can
-  -- never sum past the holding, so slack there is not forgiveness of rounding, it
-  -- is a đồng of real overdraw: a 100 stock holding with an 80 withdrawal was
-  -- editable down to 79, and the dashboard values that at −1.
+  -- UNITS do not accumulate. The bound is `v_left_units + (case when v_left_units >
+  -- 0 then ε else 0)` — the epsilon is WITHHELD at zero, so it never rounds an
+  -- empty holding upward. Each sale is measured against what earlier sales left,
+  -- so u₂ ≤ (held − u₁) + ε gives u₁ + u₂ ≤ held + ε whatever the count. Counting
+  -- them let a 10-unit sold gold holding be restated at 9.99985.
   --
-  -- The units epsilon is not asset-keyed, because the units bound it comes from is
-  -- not either: clients round units_withdrawn to four decimals, so a full sell of
-  -- any quantity-valued holding can post a hair more than it holds.
+  -- PRINCIPAL does accumulate, and only for gold. The proportional branch has no
+  -- running total at all — it checks `abs(principal − round(share)) ≤ 1`, with no
+  -- carve-out at zero. So when the remaining basis rounds to nothing every further
+  -- sale may still take its đồng: the audit suite's own legal fixture is a 1 đồng /
+  -- 5 chỉ holding sold in three 1-unit slices, three đồng out of one, every write
+  -- accepted (withdrawal_ledger_audit.test.sql — "'Σ principal ≤ basis' was never
+  -- the invariant's rule for gold"). A flat đồng made that holding uneditable: even
+  -- GROWING its units was refused. So the principal allowance is one đồng per
+  -- quantity-valued sale.
   --
-  -- Both round a REAL balance and never create one — applied to a holding emptied
-  -- to nothing they would hand it slack it never had, the same carve-out the
-  -- withdrawal side makes for its own epsilon.
+  -- And gold ALONE. check_withdrawal_balance caps bank and stock outright at
+  -- `principal_withdrawn > v_left`, so their claims can never sum past the holding
+  -- and slack there forgives no rounding — it is a đồng of real overdraw. A 100
+  -- stock holding with an 80 withdrawal was editable down to 79, which the
+  -- dashboard values at minus one.
+  --
+  -- Both round a REAL balance and never create one: applied to a holding emptied to
+  -- nothing they would hand it slack it never had, the same carve-out the units
+  -- bound above makes for itself.
   c_units_epsilon constant numeric := 0.0001;
-  c_dong_epsilon  constant bigint  := 1;
+  v_priced        int;
   v_allow         bigint  := 0;
   v_allow_units   numeric := 0;
   v_out_principal bigint;
@@ -230,8 +237,9 @@ begin
   -- What is drawn on this row, summed the way check_withdrawal_balance's parent
   -- branch sums it — a fund-keyed sibling draws on its own bucket whatever it
   -- names as a parent, so counting it here would charge it twice.
-  select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
-    into v_out_principal, v_out_units
+  select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0),
+         count(*) filter (where coalesce(w.units_withdrawn, 0) > 0)
+    into v_out_principal, v_out_units, v_priced
     from public.investment_transactions w
    where w.parent_transaction_id = src.transaction_id
      and w.transaction_type = 'withdrawal'
@@ -243,10 +251,24 @@ begin
   -- values no balance for it, so every claim parented to it is unbacked. That is
   -- the same hole reached through transaction_type instead of amount_vnd, which
   -- is why the trigger watches that column too.
-  v_have       := case when src.transaction_type = 'investment' then coalesce(src.amount_vnd, 0) else 0 end;
-  v_have_units := case when src.transaction_type = 'investment' then coalesce(src.units, 0) else 0 end;
+  -- A fund row with NULL units is the same statement in the dashboard's own words:
+  -- lib/dashboardOverview drops it from `investments` outright (the pending-DCA
+  -- exclusion), so it is valued at nothing whatever its amount_vnd says. Nulling
+  -- the units of a purchase carrying a legacy parented claim therefore took BOTH
+  -- out of the dashboard at once — no overdraw to find, because the holding and its
+  -- claim vanished together, which is worse than the overdraw this file exists to
+  -- refuse. `units = 0` is NOT this case: that row is still valued, just as an
+  -- ordinary holding rather than a fund bucket.
+  if src.transaction_type is distinct from 'investment'
+     or (src.asset_type = 'fund' and src.units is null) then
+    v_have       := 0;
+    v_have_units := 0;
+  else
+    v_have       := coalesce(src.amount_vnd, 0);
+    v_have_units := coalesce(src.units, 0);
+  end if;
 
-  if v_have > 0 and src.asset_type = 'gold' then v_allow := c_dong_epsilon; end if;
+  if v_have > 0 and src.asset_type = 'gold' then v_allow := v_priced; end if;
   if v_have_units > 0 then v_allow_units := c_units_epsilon; end if;
 
   -- The balances the messages report are the REAL ones, not the allowance-inflated

--- a/supabase/migrations/20260804000001_source_must_back_its_claims.sql
+++ b/supabase/migrations/20260804000001_source_must_back_its_claims.sql
@@ -179,25 +179,34 @@ security definer
 set search_path = ''
 as $$
 declare
-  -- The tolerances are PER SALE, and this side sums many of them, so they are
-  -- counted rather than taken flat.
+  -- ── how much rounding this side must forgive, and no more ────────────────
   --
-  -- A bank withdrawal is bounded outright (`principal_withdrawn > v_left`), so its
-  -- claims can never sum past the holding and it gets no slack at all — a deposit
-  -- covering a đồng less than what left it is owing a đồng.
+  -- The withdrawal side's tolerances are per sale, so summing many claims looks at
+  -- first like it should sum many tolerances. It does not, and getting that wrong
+  -- is over-permissive in a way that reopens this migration's own hole. Each sale
+  -- is measured against the balance EARLIER SALES LEFT, so every allowance after
+  -- the first is granted against an already-inflated remainder: u₂ ≤ (held − u₁) +
+  -- ε gives u₁ + u₂ ≤ held + ε, whatever the count. The aggregate can exceed the
+  -- holding by exactly ONE epsilon. (The four-sale gold ledger below drifts by one
+  -- đồng, not four — which is the same statement from the other direction.)
   --
-  -- A QUANTITY-valued sale is different, and gold is the case: its principal is the
-  -- proportional share of the remaining basis, and check_withdrawal_balance accepts
-  -- it a đồng either way because that is what rounding a slice produces. Four such
-  -- sales, each accepted, can therefore claim 101 against a basis of 100 — reproduced
-  -- on the local stack. Measured with a flat đồng, that ledger became UNEDITABLE:
-  -- restating the same amount, or correcting the units upward, was refused for a
-  -- drift the invariant itself licensed and nothing about the edit made worse. So
-  -- the allowance is one đồng per sale that moved units, and 0.0001 units likewise
-  -- (clients round units_withdrawn to four decimals). Zero such sales, zero slack,
-  -- which is what keeps a plain deposit's boundary exact.
+  -- WHO gets the đồng: gold, and only gold. check_withdrawal_balance runs the
+  -- proportional branch for a quantity-valued holding — where the principal is the
+  -- rounded share of the remaining basis and may land a đồng either way — and caps
+  -- bank and stock outright at `principal_withdrawn > v_left`. Claims on those can
+  -- never sum past the holding, so slack there is not forgiveness of rounding, it
+  -- is a đồng of real overdraw: a 100 stock holding with an 80 withdrawal was
+  -- editable down to 79, and the dashboard values that at −1.
+  --
+  -- The units epsilon is not asset-keyed, because the units bound it comes from is
+  -- not either: clients round units_withdrawn to four decimals, so a full sell of
+  -- any quantity-valued holding can post a hair more than it holds.
+  --
+  -- Both round a REAL balance and never create one — applied to a holding emptied
+  -- to nothing they would hand it slack it never had, the same carve-out the
+  -- withdrawal side makes for its own epsilon.
   c_units_epsilon constant numeric := 0.0001;
-  v_priced        int;
+  c_dong_epsilon  constant bigint  := 1;
   v_allow         bigint  := 0;
   v_allow_units   numeric := 0;
   v_out_principal bigint;
@@ -208,9 +217,12 @@ begin
   -- A fund purchase IS its bucket, and the bucket is what claims draw on. `units
   -- > 0` mirrors lib/withdrawalProgress exactly: a purchase with none is no
   -- bucket — the dashboard values it as an ordinary holding — so it falls through
-  -- to the parent axis below, where its claims actually sit.
+  -- to the parent axis below, where its claims actually sit. A renewal snapshot is
+  -- history rather than a holding, and check_fund_bucket_solvent leaves it out of
+  -- the sums for that reason, so it is not this bucket either.
   if src.transaction_type = 'investment' and src.asset_type = 'fund'
-     and src.fund_id is not null and coalesce(src.units, 0) > 0 then
+     and src.fund_id is not null and coalesce(src.units, 0) > 0
+     and src.renewed_from_transaction_id is null then
     perform public.check_fund_bucket_solvent(src.user_id, src.fund_id, src.goal_id);
     return;
   end if;
@@ -218,9 +230,8 @@ begin
   -- What is drawn on this row, summed the way check_withdrawal_balance's parent
   -- branch sums it — a fund-keyed sibling draws on its own bucket whatever it
   -- names as a parent, so counting it here would charge it twice.
-  select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0),
-         count(*) filter (where coalesce(w.units_withdrawn, 0) > 0)
-    into v_out_principal, v_out_units, v_priced
+  select coalesce(sum(w.principal_withdrawn), 0), coalesce(sum(w.units_withdrawn), 0)
+    into v_out_principal, v_out_units
     from public.investment_transactions w
    where w.parent_transaction_id = src.transaction_id
      and w.transaction_type = 'withdrawal'
@@ -235,12 +246,8 @@ begin
   v_have       := case when src.transaction_type = 'investment' then coalesce(src.amount_vnd, 0) else 0 end;
   v_have_units := case when src.transaction_type = 'investment' then coalesce(src.units, 0) else 0 end;
 
-  -- The allowance rounds a real balance; it never creates one. A holding with
-  -- nothing left is measured exactly, the same carve-out check_withdrawal_balance
-  -- makes for its units epsilon, so a sold-out source cannot be handed đồng it
-  -- never had.
-  if v_have > 0 then v_allow := v_priced; end if;
-  if v_have_units > 0 then v_allow_units := v_priced * c_units_epsilon; end if;
+  if v_have > 0 and src.asset_type = 'gold' then v_allow := c_dong_epsilon; end if;
+  if v_have_units > 0 then v_allow_units := c_units_epsilon; end if;
 
   -- The balances the messages report are the REAL ones, not the allowance-inflated
   -- figures the comparison uses: "a balance of 101" for a 100 đồng holding sends
@@ -303,12 +310,20 @@ begin
   -- dashboard dropped the purchase (it keys a fund holding on `units`), and the
   -- sale stayed. The row itself is measured on the parent axis by then, where a
   -- fund-keyed sell does not appear at all, so nothing else was going to catch it.
+  --
+  -- renewed_from_transaction_id is the second one, and it leaves no trace at all:
+  -- stamping it on a LIVE purchase files it as history, which every reader and
+  -- check_fund_bucket_solvent alike exclude from the sums. A 100-unit purchase
+  -- backing a 60-unit sale left a bucket the reader counts as 0 units against 60.
+  -- Watched in the trigger's `update of` list for the same reason.
   if old.transaction_type = 'investment' and old.asset_type = 'fund'
      and old.fund_id is not null and coalesce(old.units, 0) > 0
+     and old.renewed_from_transaction_id is null
      and not (new.transaction_type = 'investment' and new.asset_type = 'fund'
               and new.fund_id is not distinct from old.fund_id
               and new.goal_id is not distinct from old.goal_id
-              and coalesce(new.units, 0) > 0) then
+              and coalesce(new.units, 0) > 0
+              and new.renewed_from_transaction_id is null) then
     perform public.check_fund_bucket_solvent(old.user_id, old.fund_id, old.goal_id);
   end if;
 
@@ -323,7 +338,11 @@ revoke all on function public.enforce_source_backs_claims() from public, anon, a
 
 drop trigger if exists investment_transactions_source_backs_claims on public.investment_transactions;
 create constraint trigger investment_transactions_source_backs_claims
-  after update of transaction_type, asset_type, amount_vnd, units, fund_id, goal_id
+  -- Every column that can change what this row CONTRIBUTES to a balance, which
+  -- includes renewed_from_transaction_id: stamping it files a live purchase as
+  -- history, and history is left out of the bucket sums.
+  after update of transaction_type, asset_type, amount_vnd, units, fund_id, goal_id,
+                  renewed_from_transaction_id
   on public.investment_transactions
   -- INITIALLY DEFERRED, not IMMEDIATE: renewal is insolvent between its own
   -- statements (see the header). A caller that needs the answer sooner can SET
@@ -363,8 +382,11 @@ create constraint trigger investment_transactions_source_deleted
   after delete on public.investment_transactions
   deferrable initially deferred
   for each row
+  -- A renewal snapshot was never in the bucket's sums, so removing one cannot
+  -- leave it short.
   when (old.transaction_type = 'investment' and old.asset_type = 'fund'
-        and old.fund_id is not null and coalesce(old.units, 0) > 0)
+        and old.fund_id is not null and coalesce(old.units, 0) > 0
+        and old.renewed_from_transaction_id is null)
   execute function public.enforce_source_delete_backs_claims();
 
 -- ── deleting any other holding: caught as its children are orphaned ─────────

--- a/supabase/migrations/20260804000001_source_must_back_its_claims.sql
+++ b/supabase/migrations/20260804000001_source_must_back_its_claims.sql
@@ -72,6 +72,105 @@
 -- fires no FK update at all and there is nothing to catch. Its bucket answers
 -- instead, at commit, where the deleted row has already left the sums.
 
+-- ─── Why the bucket check takes a lock ───────────────────────────────────────
+--
+-- check_fund_bucket_solvent reads its two sums unlocked, which was enough while a
+-- relocation was the only thing that called it. Measuring EDITS through it opens
+-- an interleaving nothing serializes: two transactions shrinking DIFFERENT
+-- purchases of one bucket each lock only their own row, each reads the other at
+-- its old size, and both pass. Verified against the local stack — two 50-unit
+-- purchases and a 60-unit sale, each purchase edited to 20 in a concurrent
+-- session: both committed, 40 units left backing 60, no error.
+--
+-- The row lock the withdrawal side uses (SELECT ... FOR UPDATE over the bucket in
+-- transaction_id order) cannot be reused here. It works there because the sale
+-- takes every lock itself, in one order; an EDIT already holds the lock on the row
+-- it is changing before any check runs, so two edits enter with locks held in
+-- opposite orders and would deadlock instead of serialising.
+--
+-- So the bucket takes ONE lock, on the bucket itself, keyed by (user, fund, goal)
+-- — a transaction-scoped advisory lock, released at commit like any other. The
+-- loser waits, and its next statement then reads a fresh snapshot containing the
+-- winner's committed edit, which is exactly the balance it should be measured
+-- against. Edits against SALES need nothing new: a sale locks the purchase rows,
+-- an edit holds one of them, so those two already serialise.
+--
+-- A hash collision costs a wait between two unrelated buckets and nothing else.
+-- A statement that touches two buckets (a relocation measures both ends) takes two
+-- of these locks, so two simultaneous and opposite relocations of one fund can
+-- still deadlock; Postgres aborts one of them, and the invariant holds either way.
+-- Re-issued rather than wrapped: the arithmetic below is verbatim from
+-- 20260803000004 and stays the only copy, with the lock taken ahead of it.
+create or replace function public.check_fund_bucket_solvent(p_user uuid, p_fund uuid, p_goal uuid)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_units      numeric;
+  v_out_units  numeric;
+  v_basis      bigint;
+  v_out_basis  bigint;
+  v_par_units  numeric;
+  v_par_basis  bigint;
+begin
+  perform pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(p_user::text || ':' || p_fund::text || ':' || coalesce(p_goal::text, ''), 0));
+
+  select coalesce(sum(t.units), 0), coalesce(sum(t.amount_vnd), 0)
+    into v_units, v_basis
+    from public.investment_transactions t
+   where t.user_id = p_user and t.fund_id = p_fund and t.asset_type = 'fund'
+     and t.transaction_type = 'investment'
+     and t.goal_id is not distinct from p_goal
+     and t.renewed_from_transaction_id is null
+     and t.units is not null;
+
+  select coalesce(sum(w.units_withdrawn), 0), coalesce(sum(w.principal_withdrawn), 0)
+    into v_out_units, v_out_basis
+    from public.investment_transactions w
+   where w.user_id = p_user and w.fund_id = p_fund and w.asset_type = 'fund'
+     and w.transaction_type = 'withdrawal'
+     and w.goal_id is not distinct from p_goal;
+
+  -- The legacy claims, priced the way the reader prices them: recorded units when
+  -- there are any, the capped pro-rata share of the named purchase when there are
+  -- not. Keyed by the PURCHASE's goal, because that is the bucket it draws on.
+  select coalesce(sum(case when coalesce(w.units_withdrawn, 0) > 0 then w.units_withdrawn
+                           else least(p.units, p.units * coalesce(w.principal_withdrawn, 0) / p.amount_vnd)
+                      end), 0),
+         coalesce(sum(coalesce(w.principal_withdrawn, 0)), 0)
+    into v_par_units, v_par_basis
+    from public.investment_transactions w
+    join public.investment_transactions p
+      on p.transaction_id = w.parent_transaction_id
+   where w.user_id = p_user
+     and w.transaction_type = 'withdrawal'
+     and (w.asset_type is distinct from 'fund' or w.fund_id is null)
+     and p.transaction_type = 'investment'
+     and p.asset_type = 'fund'
+     and p.fund_id = p_fund
+     and p.goal_id is not distinct from p_goal
+     and coalesce(p.units, 0) > 0
+     and coalesce(p.amount_vnd, 0) > 0;
+
+  v_out_units := v_out_units + v_par_units;
+  v_out_basis := v_out_basis + v_par_basis;
+
+  if v_out_units > v_units + 0.0001 or v_out_basis > v_basis + 1 then
+    raise exception 'withdrawal invariant: this fund bucket would be left owing % units / % of basis it does not hold',
+      v_out_units - v_units, v_out_basis - v_basis using errcode = 'check_violation';
+  end if;
+end;
+$$;
+
+comment on function public.check_fund_bucket_solvent(uuid, uuid, uuid) is
+  'Raises when a (goal, fund) bucket would be left owing more units or basis than its purchases hold, under a lock on the bucket so two concurrent edits of it cannot both pass (#587, #606, #608).';
+
+revoke all on function public.check_fund_bucket_solvent(uuid, uuid, uuid) from public;
+revoke all on function public.check_fund_bucket_solvent(uuid, uuid, uuid) from anon, authenticated;
+
 -- ── the measurement ─────────────────────────────────────────────────────────
 create or replace function public.check_source_backs_claims(src public.investment_transactions)
 returns void
@@ -170,12 +269,21 @@ begin
   -- Deleting the fund itself needs no exemption here: it clears fund_id on the
   -- purchases and the sells alike, so the old bucket is empty on both sides and
   -- the check is 0 against 0.
+  --
+  -- Stated as "was a bucket, and is not still THAT bucket" rather than as a list
+  -- of the columns that can move it. As a list it missed the quietest way out:
+  -- clearing `units` alone. The PUT route accepts both 0 and null there, and
+  -- neither the fund, the asset type, the goal nor the transaction type changes —
+  -- so a 100-unit purchase backing a 60-unit sale was emptied and committed, the
+  -- dashboard dropped the purchase (it keys a fund holding on `units`), and the
+  -- sale stayed. The row itself is measured on the parent axis by then, where a
+  -- fund-keyed sell does not appear at all, so nothing else was going to catch it.
   if old.transaction_type = 'investment' and old.asset_type = 'fund'
      and old.fund_id is not null and coalesce(old.units, 0) > 0
-     and (old.fund_id is distinct from new.fund_id
-          or old.asset_type is distinct from new.asset_type
-          or old.goal_id is distinct from new.goal_id
-          or old.transaction_type is distinct from new.transaction_type) then
+     and not (new.transaction_type = 'investment' and new.asset_type = 'fund'
+              and new.fund_id is not distinct from old.fund_id
+              and new.goal_id is not distinct from old.goal_id
+              and coalesce(new.units, 0) > 0) then
     perform public.check_fund_bucket_solvent(old.user_id, old.fund_id, old.goal_id);
   end if;
 

--- a/supabase/migrations/20260804000001_source_must_back_its_claims.sql
+++ b/supabase/migrations/20260804000001_source_must_back_its_claims.sql
@@ -99,6 +99,24 @@
 -- A statement that touches two buckets (a relocation measures both ends) takes two
 -- of these locks, so two simultaneous and opposite relocations of one fund can
 -- still deadlock; Postgres aborts one of them, and the invariant holds either way.
+--
+-- WAITING FOR THE LOCK IS NOT ENOUGH ON ITS OWN, and the reason is the isolation
+-- level. Under READ COMMITTED the loser's next statement takes a fresh snapshot, so
+-- it measures the winner's committed edit and refuses — that is the whole mechanism.
+-- Under REPEATABLE READ the snapshot is frozen at the first statement, so the loser
+-- waits, reads its own stale view, and passes: verified, the two-purchase scenario
+-- above still ends at 40 units backing 60. So the lock is TRIED rather than waited
+-- for, and a contended bucket outside READ COMMITTED is answered with a
+-- serialization failure — the class such a caller is already written to retry, and
+-- the retry gets the fresh snapshot it needs. Nothing changes under READ COMMITTED,
+-- which is what PostgREST and every RPC here run at, and what 20260730000002's own
+-- header reasons in.
+--
+-- One gap remains, stated rather than papered over: a REPEATABLE READ transaction
+-- whose snapshot predates a bucket edit that COMMITTED before this check runs sees
+-- no contention to detect and measures the stale view. Closing that needs a fresh
+-- read inside a frozen transaction, which is not something a trigger can do. No
+-- writer in this codebase runs at that level.
 -- Re-issued rather than wrapped: the arithmetic below is verbatim from
 -- 20260803000004 and stays the only copy, with the lock taken ahead of it.
 create or replace function public.check_fund_bucket_solvent(p_user uuid, p_fund uuid, p_goal uuid)
@@ -114,9 +132,19 @@ declare
   v_out_basis  bigint;
   v_par_units  numeric;
   v_par_basis  bigint;
+  v_key        bigint;
 begin
-  perform pg_catalog.pg_advisory_xact_lock(
-    pg_catalog.hashtextextended(p_user::text || ':' || p_fund::text || ':' || coalesce(p_goal::text, ''), 0));
+  v_key := pg_catalog.hashtextextended(
+    p_user::text || ':' || p_fund::text || ':' || coalesce(p_goal::text, ''), 0);
+  if not pg_catalog.pg_try_advisory_xact_lock(v_key) then
+    -- Someone else is measuring this bucket. Waiting only helps if the sums below
+    -- will then be read fresh, which is a READ COMMITTED promise (see the header).
+    if pg_catalog.current_setting('transaction_isolation') <> 'read committed' then
+      raise exception 'withdrawal invariant: this fund bucket is being edited concurrently and cannot be measured against a frozen snapshot — retry the transaction'
+        using errcode = 'serialization_failure';
+    end if;
+    perform pg_catalog.pg_advisory_xact_lock(v_key);
+  end if;
 
   select coalesce(sum(t.units), 0), coalesce(sum(t.amount_vnd), 0)
     into v_units, v_basis

--- a/supabase/tests/source_backs_claims.test.sql
+++ b/supabase/tests/source_backs_claims.test.sql
@@ -1,0 +1,400 @@
+-- A source may never be edited or deleted below what has already been withdrawn
+-- from it (#608).
+--
+-- 20260730000002 measures a WITHDRAWAL against its holding whenever the
+-- withdrawal is written or relocated. Nothing measured the holding when the
+-- HOLDING moved: editing a purchase down, or deleting one, left the ledger owing
+-- more than it holds and raised nothing. That migration's own header names this
+-- as the mirror hole; this is the other half.
+--
+--   buy 100,000,000 → sell 80,000,000 → edit the buy down to 50,000,000
+--
+-- was accepted, and dashboard/overview then does `totalInvested -= 80,000,000`
+-- against a 50,000,000 basis: invested capital goes negative, the goal's progress
+-- bar with it, and nothing on screen says so.
+--
+-- The two balances are the same two the withdrawal invariant measures, so the
+-- source-side check asks the same question from the other end:
+--   • bank / gold / stock — one source row: amount_vnd and units must cover every
+--     claim parented to it.
+--   • fund — the (goal, fund) bucket, measured by check_fund_bucket_solvent, which
+--     since #606 counts fund-keyed sells AND claims parented to a purchase in it.
+--
+-- The edit check is DEFERRED to commit, because renewal rewrites a source's
+-- amount_vnd before it re-parents that source's withdrawals onto the history
+-- snapshot — a transaction that is legitimately insolvent in the middle and sound
+-- at the end. Every refusal below therefore forces it with `set constraints all
+-- immediate`, which is what a real transaction does by committing.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+-- ── one source row: bank and gold ───────────────────────────────────────────
+do $$
+declare
+  v_user  uuid;
+  v_goal  uuid;
+  v_bank  uuid;
+  v_gold  uuid;
+  v_msg   text;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'src-parent@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_bank;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 80000000, v_bank, 80000000);
+
+  -- The issue's repro.
+  begin
+    update public.investment_transactions set amount_vnd = 50000000 where transaction_id = v_bank;
+    set constraints all immediate;
+    raise exception 'shrinking a deposit below what has been withdrawn from it must be refused';
+  exception when sqlstate '23514' then
+    v_msg := sqlerrm;
+  end;
+  set constraints all deferred;
+  -- The routes map this whole family to a 400 on the prefix, so the wording is a
+  -- contract, not a detail (see PUT /api/v1/investment-transactions/[id]).
+  if v_msg not like '%withdrawal invariant:%' or v_msg not like '%owing%' then
+    raise exception 'the refusal must be a withdrawal-invariant "left owing" message, got: %', v_msg;
+  end if;
+
+  -- Exactly what is out: the boundary is allowed, not off by one. A deposit worth
+  -- nothing left is a real end state — everything was withdrawn.
+  update public.investment_transactions set amount_vnd = 80000000 where transaction_id = v_bank;
+  set constraints all immediate;
+  set constraints all deferred;
+
+  -- One đồng under it is not.
+  begin
+    update public.investment_transactions set amount_vnd = 79999999 where transaction_id = v_bank;
+    set constraints all immediate;
+    raise exception 'one đồng below the withdrawn total must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
+  -- Growing a holding is never in question.
+  update public.investment_transactions set amount_vnd = 120000000 where transaction_id = v_bank;
+  set constraints all immediate;
+  set constraints all deferred;
+
+  -- A holding that stops being one takes its whole balance away — the same hole
+  -- through a different column, and the reason transaction_type is watched.
+  begin
+    update public.investment_transactions set transaction_type = 'withdrawal' where transaction_id = v_bank;
+    set constraints all immediate;
+    raise exception 'turning a holding into a withdrawal under a claim must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
+  -- ── gold: the quantity is a balance too ───────────────────────────────────
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 80000000, 10, 8000000) returning transaction_id into v_gold;
+
+  -- 6 chỉ out, at the proportional share of the basis the invariant requires.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 50000000, v_gold, 48000000, 6);
+
+  -- Re-stating the holding at 4 chỉ leaves 6 sold out of 4 — refused on units
+  -- even though the principal below would still fit.
+  begin
+    update public.investment_transactions set units = 4 where transaction_id = v_gold;
+    set constraints all immediate;
+    raise exception 'shrinking gold below the units already sold must be refused';
+  exception when sqlstate '23514' then
+    v_msg := sqlerrm;
+  end;
+  set constraints all deferred;
+  if v_msg not like '%units%' then
+    raise exception 'the units refusal must name units, got: %', v_msg;
+  end if;
+
+  -- And on principal, with the units untouched.
+  begin
+    update public.investment_transactions set amount_vnd = 40000000 where transaction_id = v_gold;
+    set constraints all immediate;
+    raise exception 'shrinking gold below the basis already taken must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
+  -- Exactly what is out, on both axes at once.
+  update public.investment_transactions set units = 6, amount_vnd = 48000000 where transaction_id = v_gold;
+  set constraints all immediate;
+  set constraints all deferred;
+
+  raise notice 'one-source shrink: ok';
+end;
+$$;
+
+-- ── the (goal, fund) bucket ─────────────────────────────────────────────────
+do $$
+declare
+  v_user  uuid;
+  v_goal  uuid;
+  v_fund  uuid;
+  v_buy   uuid;
+  v_buy_b uuid;
+  v_msg   text;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'src-fund@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Test Fund', 'TFX', 'equity', 20000) returning id into v_fund;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000) returning transaction_id into v_buy;
+
+  -- 60 of the 100 units, at the basis the allocation rule requires.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-03-01', 1200000, 1200000, 60);
+
+  -- The issue's fund shape: re-price the purchase to 40 units and the bucket owes
+  -- 60 out of 40.
+  begin
+    update public.investment_transactions set units = 40, amount_vnd = 800000 where transaction_id = v_buy;
+    set constraints all immediate;
+    raise exception 'shrinking a fund purchase below what the bucket has sold must be refused';
+  exception when sqlstate '23514' then
+    v_msg := sqlerrm;
+  end;
+  set constraints all deferred;
+  if v_msg not like '%withdrawal invariant:%' or v_msg not like '%bucket%' then
+    raise exception 'the refusal must name the bucket, got: %', v_msg;
+  end if;
+
+  -- Exactly what the bucket has sold: allowed.
+  update public.investment_transactions set units = 60, amount_vnd = 1200000 where transaction_id = v_buy;
+  set constraints all immediate;
+  set constraints all deferred;
+
+  -- Leaving the fund takes the purchase out of the bucket entirely, which is the
+  -- same subtraction as shrinking it to nothing.
+  begin
+    update public.investment_transactions set asset_type = 'bank', fund_id = null where transaction_id = v_buy;
+    set constraints all immediate;
+    raise exception 'moving a purchase out of a fund whose bucket has sold units must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
+  -- ── a claim parented to a purchase, the legacy shape #606 values ──────────
+  -- Nothing writes one any more (20260803000002 refuses it), so it is produced
+  -- the way the ledger already contains it: written before the guard existed.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-05', 1000000, 50, 20000) returning transaction_id into v_buy_b;
+
+  alter table public.investment_transactions disable trigger user;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-03-05', 400000, v_buy_b, 400000, 20);
+  alter table public.investment_transactions enable trigger user;
+
+  -- The bucket now holds 60 + 50 units against 60 fund-keyed + 20 parented. Take
+  -- the second purchase down to 20 units and 80 units are claimed on 80 held —
+  -- the boundary, allowed.
+  update public.investment_transactions set units = 20, amount_vnd = 400000 where transaction_id = v_buy_b;
+  set constraints all immediate;
+  set constraints all deferred;
+
+  -- One unit further and the parented claim is what tips it: 60 fund-keyed units
+  -- would still fit inside the 79 left. Before #606 this claim was invisible to
+  -- the bucket, so the edit passed.
+  begin
+    update public.investment_transactions set units = 19, amount_vnd = 380000 where transaction_id = v_buy_b;
+    set constraints all immediate;
+    raise exception 'a parented claim must count when its purchase is shrunk';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
+  raise notice 'fund-bucket shrink: ok';
+end;
+$$;
+
+-- ── deleting a source ───────────────────────────────────────────────────────
+do $$
+declare
+  v_user  uuid;
+  v_goal  uuid;
+  v_fund  uuid;
+  v_bank  uuid;
+  v_snap  uuid;
+  v_buy   uuid;
+  v_buy_b uuid;
+  v_msg   text;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'src-delete@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Test Fund', 'TFX', 'equity', 20000) returning id into v_fund;
+
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_bank;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 60000000, v_bank, 60000000);
+
+  -- parent_transaction_id is ON DELETE SET NULL, so deleting the deposit used to
+  -- orphan its withdrawal in silence (#607): the cash stays in history, filed
+  -- under no holding, and nothing subtracts it from anything ever again.
+  begin
+    delete from public.investment_transactions where transaction_id = v_bank;
+    raise exception 'deleting a holding that still has withdrawals must be refused';
+  exception when sqlstate '23514' then
+    v_msg := sqlerrm;
+  end;
+  if v_msg not like '%withdrawal invariant:%' then
+    raise exception 'the delete refusal must join the withdrawal-invariant family, got: %', v_msg;
+  end if;
+
+  -- The remedy is the ledger's own: remove the withdrawal, then the holding.
+  delete from public.investment_transactions
+   where parent_transaction_id = v_bank and transaction_type = 'withdrawal';
+  delete from public.investment_transactions where transaction_id = v_bank;
+
+  -- Renewal and collapse re-parent partial withdrawals onto the history snapshot
+  -- BEFORE removing the row they came from (#585). That order still deletes.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_bank;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 60000000, v_bank, 60000000);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, renewed_from_transaction_id)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000, v_bank) returning transaction_id into v_snap;
+  update public.investment_transactions
+     set parent_transaction_id = v_snap
+   where parent_transaction_id = v_bank and transaction_type = 'withdrawal';
+  delete from public.investment_transactions where transaction_id = v_bank;
+  set constraints all immediate;
+  set constraints all deferred;
+
+  -- ── a fund purchase: the bucket decides, not the row ──────────────────────
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000) returning transaction_id into v_buy;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-05', 1000000, 50, 20000) returning transaction_id into v_buy_b;
+  -- 60 of the 150 units in the bucket.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-03-01', 1200000, 1200000, 60);
+
+  -- The smaller purchase can go: 100 units still back the 60 sold. A fund sell
+  -- names no parent, so nothing about this row's deletion is refusable on its
+  -- own — only the bucket it leaves behind can answer.
+  delete from public.investment_transactions where transaction_id = v_buy_b;
+  set constraints all immediate;
+  set constraints all deferred;
+
+  -- The larger one cannot: 50 units would be left backing 60.
+  begin
+    delete from public.investment_transactions where transaction_id = v_buy;
+    set constraints all immediate;
+    raise exception 'deleting a purchase the bucket still needs must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
+  raise notice 'source delete: ok';
+end;
+$$;
+
+-- ── what must still go through ──────────────────────────────────────────────
+-- Every cascade and RPC that legitimately rewrites a source. A guard that stops
+-- any of these is worse than the hole it closes.
+do $$
+declare
+  v_user  uuid;
+  v_goal  uuid;
+  v_fund  uuid;
+  v_bank  uuid;
+  v_snap  uuid;
+  v_buy   uuid;
+  v_left  bigint;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'src-carveout@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Test Fund', 'TFX', 'equity', 20000) returning id into v_fund;
+
+  -- ── renewal's statement order ─────────────────────────────────────────────
+  -- renew_term_deposit_with_merge rewrites the source's amount_vnd FIRST and only
+  -- then re-parents its withdrawals onto the snapshot, so the row is genuinely
+  -- insolvent between the two statements. This is the whole reason the edit check
+  -- is deferred to commit rather than measured at the end of each statement.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_bank;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 60000000, v_bank, 60000000);
+
+  -- 1) roll the deposit forward at its remaining balance plus interest
+  update public.investment_transactions set amount_vnd = 41000000 where transaction_id = v_bank;
+  -- 2) append the history snapshot of the closed cycle
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, renewed_from_transaction_id)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000, v_bank) returning transaction_id into v_snap;
+  -- 3) move the partial withdrawals onto it
+  update public.investment_transactions
+     set parent_transaction_id = v_snap
+   where parent_transaction_id = v_bank and transaction_type = 'withdrawal';
+  -- Sound at the end, which is the only place it is asked.
+  set constraints all immediate;
+  set constraints all deferred;
+
+  -- ── deleting the fund ─────────────────────────────────────────────────────
+  -- funds.id is ON DELETE SET NULL on this table, so the whole bucket — purchases
+  -- and sells — loses its fund at once. An ordinary fund delete must not fail
+  -- (the same cascade broke the withdrawal invariant once, fixed in #599).
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000) returning transaction_id into v_buy;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-03-01', 1200000, 1200000, 60);
+
+  delete from public.funds where id = v_fund;
+  set constraints all immediate;
+  set constraints all deferred;
+
+  -- ── deleting the goal ─────────────────────────────────────────────────────
+  -- goal_id is ON DELETE SET NULL too: everything in the goal moves to the
+  -- unallocated bucket together, so nothing is separated from what backs it.
+  delete from public.savings_goals where goal_id = v_goal;
+  set constraints all immediate;
+  set constraints all deferred;
+
+  -- ── deleting the user ─────────────────────────────────────────────────────
+  -- The account cascade removes holdings and withdrawals in an order Postgres
+  -- picks. A guard that reads a half-removed ledger as an overdraw would make an
+  -- account undeletable.
+  delete from auth.users where id = v_user;
+  set constraints all immediate;
+  set constraints all deferred;
+
+  select count(*) into v_left from public.investment_transactions where user_id = v_user;
+  if v_left <> 0 then
+    raise exception 'the account cascade left % rows behind', v_left;
+  end if;
+
+  raise notice 'carve-outs: ok';
+end;
+$$;
+
+rollback;

--- a/supabase/tests/source_backs_claims.test.sql
+++ b/supabase/tests/source_backs_claims.test.sql
@@ -274,6 +274,8 @@ declare
   v_other uuid;
   v_fund_t uuid;
   v_buy_t uuid;
+  v_fund_e uuid;
+  v_buy_e uuid;
   i       int;
   v_msg   text;
 begin
@@ -333,6 +335,29 @@ begin
     update public.investment_transactions set units = null where transaction_id = v_buy;
     set constraints all immediate;
     raise exception 'nulling a fund purchase''s units under a sale must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
+  -- The units epsilon is withheld when the bucket holds none. Flat, it forgave the
+  -- one edit that empties a bucket whose whole quantity IS an epsilon: a
+  -- 0.0001-unit purchase backing a 0.0001-unit sale, taken to zero units, passed
+  -- because 0.0001 > 0 + 0.0001 is false. The purchase then leaves the fund
+  -- accumulator, is valued as an ordinary holding, and its whole principal
+  -- reappears on the dashboard while the sale has nothing left to reduce.
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Epsilon Fund', 'EPSF', 'equity', 20000) returning id into v_fund_e;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund_e, 'fund', 'investment', '2026-01-01', 1000000, 0.0001, 20000) returning transaction_id into v_buy_e;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, v_fund_e, 'fund', 'withdrawal', '2026-02-01', 1000000, 1000000, 0.0001);
+
+  begin
+    update public.investment_transactions set units = 0 where transaction_id = v_buy_e;
+    set constraints all immediate;
+    raise exception 'an epsilon-sized bucket must not be emptied on the epsilon';
   exception when sqlstate '23514' then null;
   end;
   set constraints all deferred;

--- a/supabase/tests/source_backs_claims.test.sql
+++ b/supabase/tests/source_backs_claims.test.sql
@@ -39,7 +39,9 @@ declare
   v_bank  uuid;
   v_gold  uuid;
   v_drift uuid;
+  v_tiny  uuid;
   v_stock uuid;
+  i       int;
   v_claimed bigint;
   v_msg   text;
 begin
@@ -168,33 +170,39 @@ begin
   set constraints all immediate;
   set constraints all deferred;
 
-  -- The allowance is ONE đồng however many sales there are, not one per sale.
-  -- Each sale is measured against the balance earlier sales left, so every
-  -- allowance after the first is granted against an already-inflated remainder and
-  -- the aggregate can only ever drift by one — which is why the four sales above
-  -- land on 101 rather than 104. Counting them would buy real overdraw.
+  -- The allowance is a đồng PER SALE, because the proportional branch has no
+  -- running total and no carve-out at zero: once the remaining basis rounds to
+  -- nothing, every further sale may still take its đồng. The audit suite's own
+  -- legal fixture is the extreme of it — a 1 đồng / 5 chỉ holding sold in three
+  -- 1-unit slices, three đồng out of one, every write accepted. Measured with a
+  -- flat đồng that holding could not even have its units GROWN.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 1, 5, 1) returning transaction_id into v_tiny;
+  for i in 1..3 loop
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+    values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 1, v_tiny, 1, 1);
+  end loop;
+  update public.investment_transactions set units = 6 where transaction_id = v_tiny;
+  set constraints all immediate;
+  set constraints all deferred;
+
+  -- Per sale is not unbounded, and it still rounds a real balance rather than
+  -- creating one: emptied to nothing, the holding gets no đồng at all.
   begin
-    update public.investment_transactions set amount_vnd = 99 where transaction_id = v_drift;
+    update public.investment_transactions set amount_vnd = 0 where transaction_id = v_tiny;
     set constraints all immediate;
-    raise exception 'the đồng of rounding is one in total, not one per sale';
+    raise exception 'an emptied holding must not inherit the rounding allowance';
   exception when sqlstate '23514' then null;
   end;
   set constraints all deferred;
 
+  -- Back on the four-sale ledger: four sales buy four đồng and no more.
   begin
     update public.investment_transactions set amount_vnd = 96 where transaction_id = v_drift;
     set constraints all immediate;
     raise exception 'shrinking past the per-sale rounding allowance must be refused';
-  exception when sqlstate '23514' then null;
-  end;
-  set constraints all deferred;
-
-  -- And it rounds a real balance rather than creating one: a holding emptied to
-  -- nothing is measured exactly, with no đồng of slack to spend.
-  begin
-    update public.investment_transactions set amount_vnd = 0, units = 0 where transaction_id = v_drift;
-    set constraints all immediate;
-    raise exception 'an emptied holding must not inherit the rounding allowance';
   exception when sqlstate '23514' then null;
   end;
   set constraints all deferred;
@@ -341,6 +349,21 @@ begin
   -- One unit further and the parented claim is what tips it: 60 fund-keyed units
   -- would still fit inside the 79 left. Before #606 this claim was invisible to
   -- the bucket, so the edit passed.
+  -- NULLING the units is not the same as zeroing them, and it is worse: the
+  -- dashboard drops a fund row with null units outright (the pending-DCA
+  -- exclusion), so the purchase stops being valued at all. With a legacy claim
+  -- parented to it, BOTH leave the dashboard together — no overdraw to find,
+  -- because the holding and what draws on it vanish at the same time. The bucket
+  -- recheck cannot see it either: its join excludes a purchase with no units, and
+  -- so excludes that purchase's claim with it.
+  begin
+    update public.investment_transactions set units = null where transaction_id = v_buy_b;
+    set constraints all immediate;
+    raise exception 'nulling the units of a purchase carrying a claim must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
   begin
     update public.investment_transactions set units = 19, amount_vnd = 380000 where transaction_id = v_buy_b;
     set constraints all immediate;

--- a/supabase/tests/source_backs_claims.test.sql
+++ b/supabase/tests/source_backs_claims.test.sql
@@ -180,6 +180,29 @@ begin
   set constraints all immediate;
   set constraints all deferred;
 
+  -- Clearing the UNITS is the quietest way out of a bucket, and the one a
+  -- column-by-column guard misses: the fund, the asset type, the goal and the
+  -- transaction type are all untouched, so nothing about the row says it moved —
+  -- but the dashboard keys a fund holding on `units`, so the purchase disappears
+  -- from the bucket and the sale stays. The row is measured on the parent axis by
+  -- then, where a fund-keyed sell does not appear at all.
+  begin
+    update public.investment_transactions set units = 0 where transaction_id = v_buy;
+    set constraints all immediate;
+    raise exception 'clearing a fund purchase''s units under a sale must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
+  -- Null is the same act spelled differently, and the PUT route accepts both.
+  begin
+    update public.investment_transactions set units = null where transaction_id = v_buy;
+    set constraints all immediate;
+    raise exception 'nulling a fund purchase''s units under a sale must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
   -- Leaving the fund takes the purchase out of the bucket entirely, which is the
   -- same subtraction as shrinking it to nothing.
   begin

--- a/supabase/tests/source_backs_claims.test.sql
+++ b/supabase/tests/source_backs_claims.test.sql
@@ -38,6 +38,8 @@ declare
   v_goal  uuid;
   v_bank  uuid;
   v_gold  uuid;
+  v_drift uuid;
+  v_claimed bigint;
   v_msg   text;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'src-parent@test.invalid') returning id into v_user;
@@ -131,6 +133,58 @@ begin
   -- Exactly what is out, on both axes at once.
   update public.investment_transactions set units = 6, amount_vnd = 48000000 where transaction_id = v_gold;
   set constraints all immediate;
+  set constraints all deferred;
+
+  -- ── a ledger the invariant's own rounding put over the line ───────────────
+  -- A quantity-valued sale takes the proportional share of the remaining basis,
+  -- and check_withdrawal_balance accepts it a đồng either way because that is what
+  -- rounding a slice produces. So a run of sales it ACCEPTS can sum past the
+  -- holding: four below claim 101 against a basis of 100. Measured with a flat
+  -- đồng, that ledger became uneditable — the drift is the invariant's own, and no
+  -- edit that leaves the balance alone makes it worse.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 100, 4, 25) returning transaction_id into v_drift;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 1, v_drift, 26, 1),
+         (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 1, v_drift, 26, 1),
+         (v_user, v_goal, 'gold', 'withdrawal', '2026-04-01', 1, v_drift, 25, 1),
+         (v_user, v_goal, 'gold', 'withdrawal', '2026-05-01', 1, v_drift, 24, 1);
+
+  select coalesce(sum(w.principal_withdrawn), 0) into v_claimed
+    from public.investment_transactions w where w.parent_transaction_id = v_drift;
+  if v_claimed <= 100 then
+    raise exception 'the fixture must actually drift over the basis, got %', v_claimed;
+  end if;
+
+  -- Restating the same amount, and correcting the units upward: neither takes
+  -- anything away, so neither may be refused.
+  update public.investment_transactions set amount_vnd = 100 where transaction_id = v_drift;
+  set constraints all immediate;
+  set constraints all deferred;
+  update public.investment_transactions set units = 5 where transaction_id = v_drift;
+  set constraints all immediate;
+  set constraints all deferred;
+
+  -- The allowance is one đồng per sale that moved units, not a blank cheque: four
+  -- sales buy four đồng, and a real shrink is still refused.
+  begin
+    update public.investment_transactions set amount_vnd = 96 where transaction_id = v_drift;
+    set constraints all immediate;
+    raise exception 'shrinking past the per-sale rounding allowance must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
+  -- And it rounds a real balance rather than creating one: a holding emptied to
+  -- nothing is measured exactly, with no đồng of slack to spend.
+  begin
+    update public.investment_transactions set amount_vnd = 0, units = 0 where transaction_id = v_drift;
+    set constraints all immediate;
+    raise exception 'an emptied holding must not inherit the rounding allowance';
+  exception when sqlstate '23514' then null;
+  end;
   set constraints all deferred;
 
   raise notice 'one-source shrink: ok';

--- a/supabase/tests/source_backs_claims.test.sql
+++ b/supabase/tests/source_backs_claims.test.sql
@@ -37,6 +37,8 @@ declare
   v_user  uuid;
   v_goal  uuid;
   v_bank  uuid;
+  v_bank_b uuid;
+  v_snap  uuid;
   v_gold  uuid;
   v_drift uuid;
   v_tiny  uuid;
@@ -50,6 +52,9 @@ begin
 
   insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
   values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_bank;
+  -- Something for a renewal stamp to point at, further down.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 1) returning transaction_id into v_bank_b;
 
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
@@ -98,6 +103,33 @@ begin
     raise exception 'turning a holding into a withdrawal under a claim must be refused';
   exception when sqlstate '23514' then null;
   end;
+  set constraints all deferred;
+
+  -- Stamping a LIVE deposit as renewal history takes its whole balance away
+  -- without touching a single number on it: active_investment_transactions
+  -- excludes history, so the dashboard has no holding left for the claim to apply
+  -- to and both leave the totals together. The fund half of this is refused
+  -- through the bucket; this is the same act on the parent axis.
+  begin
+    update public.investment_transactions set renewed_from_transaction_id = v_bank_b
+     where transaction_id = v_bank;
+    set constraints all immediate;
+    raise exception 'filing a live holding as renewal history under a claim must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
+  -- But a snapshot the renewal RPCs actually wrote must keep working: it is
+  -- INSERTED as history and partial withdrawals are re-parented onto it (#585),
+  -- which is how a renewed deposit stops double-counting them. Those claims are
+  -- inert by design, so measuring them against it would refuse the renewal itself.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, renewed_from_transaction_id)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000, v_bank_b) returning transaction_id into v_snap;
+  update public.investment_transactions set parent_transaction_id = v_snap
+   where parent_transaction_id = v_bank and transaction_type = 'withdrawal';
+  update public.investment_transactions set amount_vnd = 100000001 where transaction_id = v_snap;
+  set constraints all immediate;
   set constraints all deferred;
 
   -- ── gold: the quantity is a balance too ───────────────────────────────────
@@ -240,6 +272,9 @@ declare
   v_buy   uuid;
   v_buy_b uuid;
   v_other uuid;
+  v_fund_t uuid;
+  v_buy_t uuid;
+  i       int;
   v_msg   text;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'src-fund@test.invalid') returning id into v_user;
@@ -298,6 +333,34 @@ begin
     update public.investment_transactions set units = null where transaction_id = v_buy;
     set constraints all immediate;
     raise exception 'nulling a fund purchase''s units under a sale must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
+  -- The bucket forgives the same per-sale rounding the parent axis does, and for
+  -- the same reason: the fund allocation rule is checked per sale with no running
+  -- total. The fund twin of the audit suite's tiny ledger — a 1 đồng / 5 unit
+  -- purchase carrying three legal 1-đồng sales — was refused every later edit,
+  -- including one that only GREW the purchase.
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Tiny Fund', 'TNYF', 'equity', 1) returning id into v_fund_t;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, v_fund_t, 'fund', 'investment', '2026-01-01', 1, 5, 1) returning transaction_id into v_buy_t;
+  for i in 1..3 loop
+    insert into public.investment_transactions
+      (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, principal_withdrawn, units_withdrawn)
+    values (v_user, v_goal, v_fund_t, 'fund', 'withdrawal', '2026-02-01', 1, 1, 1);
+  end loop;
+  update public.investment_transactions set units = 6 where transaction_id = v_buy_t;
+  set constraints all immediate;
+  set constraints all deferred;
+
+  -- Per sale, not unbounded: emptying that bucket is still refused.
+  begin
+    update public.investment_transactions set units = 0.1, amount_vnd = 0 where transaction_id = v_buy_t;
+    set constraints all immediate;
+    raise exception 'emptying a bucket must not be forgiven as rounding';
   exception when sqlstate '23514' then null;
   end;
   set constraints all deferred;

--- a/supabase/tests/source_backs_claims.test.sql
+++ b/supabase/tests/source_backs_claims.test.sql
@@ -39,6 +39,7 @@ declare
   v_bank  uuid;
   v_gold  uuid;
   v_drift uuid;
+  v_stock uuid;
   v_claimed bigint;
   v_msg   text;
 begin
@@ -139,9 +140,9 @@ begin
   -- A quantity-valued sale takes the proportional share of the remaining basis,
   -- and check_withdrawal_balance accepts it a đồng either way because that is what
   -- rounding a slice produces. So a run of sales it ACCEPTS can sum past the
-  -- holding: four below claim 101 against a basis of 100. Measured with a flat
-  -- đồng, that ledger became uneditable — the drift is the invariant's own, and no
-  -- edit that leaves the balance alone makes it worse.
+  -- holding: the four below claim 101 against a basis of 100. Measured with NO
+  -- tolerance at all, that ledger became uneditable — restating the same amount was
+  -- refused for a drift the invariant itself licensed and no edit made worse.
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
   values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 100, 4, 25) returning transaction_id into v_drift;
@@ -167,8 +168,19 @@ begin
   set constraints all immediate;
   set constraints all deferred;
 
-  -- The allowance is one đồng per sale that moved units, not a blank cheque: four
-  -- sales buy four đồng, and a real shrink is still refused.
+  -- The allowance is ONE đồng however many sales there are, not one per sale.
+  -- Each sale is measured against the balance earlier sales left, so every
+  -- allowance after the first is granted against an already-inflated remainder and
+  -- the aggregate can only ever drift by one — which is why the four sales above
+  -- land on 101 rather than 104. Counting them would buy real overdraw.
+  begin
+    update public.investment_transactions set amount_vnd = 99 where transaction_id = v_drift;
+    set constraints all immediate;
+    raise exception 'the đồng of rounding is one in total, not one per sale';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
   begin
     update public.investment_transactions set amount_vnd = 96 where transaction_id = v_drift;
     set constraints all immediate;
@@ -187,6 +199,26 @@ begin
   end;
   set constraints all deferred;
 
+  -- And the đồng is GOLD's, because gold is the only parent-axis holding whose
+  -- principal is a rounded proportional share. check_withdrawal_balance caps bank
+  -- and stock outright, so their claims can never sum past the holding and slack
+  -- there is not forgiveness of rounding — it is a đồng of real overdraw the
+  -- dashboard values at minus one. Units recorded on the sale must not buy it.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal, 'stock', 'investment', '2026-01-01', 100, 10, 10) returning transaction_id into v_stock;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn, units_withdrawn)
+  values (v_user, v_goal, 'stock', 'withdrawal', '2026-02-01', 80, v_stock, 80, 8);
+
+  begin
+    update public.investment_transactions set amount_vnd = 79 where transaction_id = v_stock;
+    set constraints all immediate;
+    raise exception 'a stock holding must not inherit gold''s rounding allowance';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
   raise notice 'one-source shrink: ok';
 end;
 $$;
@@ -199,6 +231,7 @@ declare
   v_fund  uuid;
   v_buy   uuid;
   v_buy_b uuid;
+  v_other uuid;
   v_msg   text;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'src-fund@test.invalid') returning id into v_user;
@@ -209,6 +242,10 @@ begin
   insert into public.investment_transactions
     (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
   values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000) returning transaction_id into v_buy;
+  -- Something for a renewal stamp to point at, further down.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 1) returning transaction_id into v_other;
 
   -- 60 of the 100 units, at the basis the allocation rule requires.
   insert into public.investment_transactions
@@ -253,6 +290,20 @@ begin
     update public.investment_transactions set units = null where transaction_id = v_buy;
     set constraints all immediate;
     raise exception 'nulling a fund purchase''s units under a sale must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints all deferred;
+
+  -- Stamping a LIVE purchase as renewal history is the same subtraction again, and
+  -- the one that leaves no trace on the row's own shape: it stays a fund purchase
+  -- with its units, but every reader — and check_fund_bucket_solvent — leaves
+  -- history out of the sums, so the bucket the dashboard counts drops to nothing
+  -- while the sale stays. Watched because nothing about the columns above moves.
+  begin
+    update public.investment_transactions set renewed_from_transaction_id = v_other
+     where transaction_id = v_buy;
+    set constraints all immediate;
+    raise exception 'filing a live purchase as renewal history under a sale must be refused';
   exception when sqlstate '23514' then null;
   end;
   set constraints all deferred;
@@ -312,6 +363,7 @@ declare
   v_snap  uuid;
   v_buy   uuid;
   v_buy_b uuid;
+  v_other uuid;
   v_msg   text;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'src-delete@test.invalid') returning id into v_user;

--- a/supabase/tests/withdrawal_balance.test.sql
+++ b/supabase/tests/withdrawal_balance.test.sql
@@ -399,13 +399,24 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
-  -- Deleting a source that has withdrawals is an ordinary ledger action. The FK
-  -- is ON DELETE SET NULL, so Postgres orphans the children — an UPDATE that
-  -- lands on this trigger. It must not turn a delete into an error.
+  -- Deleting a source that still has withdrawals USED to be an ordinary ledger
+  -- action: the FK is ON DELETE SET NULL, so Postgres orphaned the children and
+  -- the cash stayed in history filed under no holding at all — silent, and the
+  -- open half of #607. #608 refuses the shrinking edit, and a delete is that edit
+  -- taken all the way, so it is refused by the same rule (20260804000001). The
+  -- remedy is the ledger's own: remove the withdrawal, then the holding.
+  begin
+    delete from public.investment_transactions where transaction_id = v_snap;
+    raise exception 'deleting a source that still has withdrawals must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  delete from public.investment_transactions where transaction_id = v_wd;
   delete from public.investment_transactions where transaction_id = v_snap;
 
-  if (select parent_transaction_id from public.investment_transactions where transaction_id = v_wd) is not null then
-    raise exception 'the orphaned withdrawal should have lost its parent';
+  if exists (select 1 from public.investment_transactions
+              where transaction_id in (v_wd, v_snap)) then
+    raise exception 'the withdrawal and its source should both be gone';
   end if;
 
   raise notice 'withdrawal parent kinds + source deletion: ok';
@@ -1208,11 +1219,20 @@ begin
   values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-02-01', 1125000, 45, 1800000);
 
   -- The legacy claim on purchase A (planted with the trigger off — no longer writable).
+  -- ALTER TABLE refuses to run while a constraint trigger has events queued, and
+  -- the #608 source checks are DEFERRED (renewal is insolvent between its own
+  -- statements, so they can only be asked at the end). Flushing just those two —
+  -- not ALL — leaves every other deferrable trigger in this file at the timing it
+  -- was written for. Restored after the plant, so the rest of the block still sees
+  -- them the way a real transaction does. Same pair either side of every
+  -- disable/enable below.
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
   alter table public.investment_transactions disable trigger user;
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, units_withdrawn, principal_withdrawn)
   values (v_user, v_goal, null, 'withdrawal', '2026-03-01', 250000, v_buy_a, 10, 400000);
   alter table public.investment_transactions enable trigger user;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   begin
     update public.investment_transactions set goal_id = v_goal_b where transaction_id = v_buy_b;
@@ -1247,11 +1267,14 @@ begin
   values (v_user, v_goal, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 50, 40000)
   returning transaction_id into v_buy;
 
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
+
   alter table public.investment_transactions disable trigger user;
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, units_withdrawn, principal_withdrawn)
   values (v_user, v_goal, null, 'withdrawal', '2026-02-01', 250000, v_buy, 10, 400000);
   alter table public.investment_transactions enable trigger user;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   begin
     insert into public.investment_transactions
@@ -1395,11 +1418,14 @@ begin
   values (v_user, v_goal2, v_fund2, 'fund', 'investment', '2026-01-01', 2000000, 50, 40000)
   returning transaction_id into v_buy3;
 
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
+
   alter table public.investment_transactions disable trigger user;
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
   values (v_user, v_goal2, null, 'withdrawal', '2026-02-01', 400000, v_buy3, 400000);
   alter table public.investment_transactions enable trigger user;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   delete from public.savings_goals where goal_id = v_goal2;
 
@@ -1445,11 +1471,13 @@ begin
   -- reason: those units are derived from this purchase's price, so moving it
   -- rewrites what the dashboard takes out of the bucket for a row nothing
   -- re-measures. Planted with the trigger off — the only way the child can exist.
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
   alter table public.investment_transactions disable trigger user;
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
   values (v_user, v_goal3, null, 'withdrawal', '2026-03-01', 500000, v_dep2, 500000);
   alter table public.investment_transactions enable trigger user;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   begin
     update public.investment_transactions set units = 25, unit_price = 80000
@@ -1476,20 +1504,25 @@ begin
   -- units and the same re-pricing goes through.
   -- (Off, because touching the child's own amounts is a RAISED claim and the child's
   -- trigger refuses the legacy shape there — giving it a fund is what legalises it.)
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
   alter table public.investment_transactions disable trigger user;
   update public.investment_transactions set units_withdrawn = 12.5
    where parent_transaction_id = v_dep2 and transaction_type = 'withdrawal';
   alter table public.investment_transactions enable trigger user;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   update public.investment_transactions set units = 25, unit_price = 80000
    where transaction_id = v_dep2;
   update public.investment_transactions set units = 50, unit_price = 40000
    where transaction_id = v_dep2;
 
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
+
   alter table public.investment_transactions disable trigger user;
   update public.investment_transactions set units_withdrawn = null
    where parent_transaction_id = v_dep2 and transaction_type = 'withdrawal';
   alter table public.investment_transactions enable trigger user;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   -- Everything else about it still edits: the guard is about the rate, not the row.
   update public.investment_transactions set notes = 'renamed' where transaction_id = v_dep2;
@@ -1505,20 +1538,43 @@ begin
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
   values (v_user, v_goal3, 'bank', 'investment', '2026-01-01', 1000000) returning transaction_id into v_dep4;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
   alter table public.investment_transactions disable trigger user;
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
   values (v_user, v_goal3, null, 'withdrawal', '2026-02-01', 400000, v_dep4, 400000);
   alter table public.investment_transactions enable trigger user;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
-  -- Step one is legal on its own: as a fund-keyed sell it draws on the bucket.
-  -- (units set too, so flipping it back would produce a real bucket purchase —
-  -- one with no units is no bucket and none of this applies.)
+  -- Step one used to be legal on its own — as a fund-keyed sell the converted row
+  -- draws on the bucket. #608 closes that door first: turning the holding into a
+  -- withdrawal takes its balance away while the legacy child still draws 400,000
+  -- on it, which is the same refusal as shrinking it to nothing.
+  begin
+    update public.investment_transactions
+       set transaction_type = 'withdrawal', asset_type = 'fund', fund_id = v_fund3,
+           units = 50, unit_price = 40000,
+           units_withdrawn = 10, principal_withdrawn = 400000, amount_vnd = 250000
+     where transaction_id = v_dep4;
+    set constraints investment_transactions_source_backs_claims immediate;
+    raise exception 'converting a holding into a withdrawal under a claim must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  set constraints investment_transactions_source_backs_claims deferred;
+
+  -- The shape is still reachable as HISTORY, so step two must go on being guarded
+  -- on its own account: a ledger written before either guard existed contains it,
+  -- and activating such a row is what 20260803000003 refuses. Planted with the
+  -- user triggers off, which is the only way in now.
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
+  alter table public.investment_transactions disable trigger user;
   update public.investment_transactions
      set transaction_type = 'withdrawal', asset_type = 'fund', fund_id = v_fund3,
          units = 50, unit_price = 40000,
          units_withdrawn = 10, principal_withdrawn = 400000, amount_vnd = 250000
    where transaction_id = v_dep4;
+  alter table public.investment_transactions enable trigger user;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   begin
     update public.investment_transactions set transaction_type = 'investment'
@@ -1537,11 +1593,13 @@ begin
     (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
   values (v_user, v_goal3, v_fund4, 'fund', 'investment', '2026-01-01', 1000000, 0, 0)
   returning transaction_id into v_dep5;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
   alter table public.investment_transactions disable trigger user;
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, units_withdrawn, principal_withdrawn)
   values (v_user, v_goal3, null, 'withdrawal', '2026-02-01', 400000, v_dep5, 8, 400000);
   alter table public.investment_transactions enable trigger user;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   begin
     update public.investment_transactions set units = 40, unit_price = 25000

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -280,6 +280,14 @@ begin
   -- ═══ the planted violations ════════════════════════════════════════════════
   -- Disabling the user triggers is the only way in: these are precisely the shapes
   -- the invariant refuses, which is why they can only exist as HISTORY.
+  --
+  -- ALTER TABLE refuses to run while a constraint trigger has events queued, and
+  -- the #608 source checks are DEFERRED (renewal is insolvent between its own
+  -- statements, so they can only be asked at the end). Flushing just those two —
+  -- not ALL — leaves every other deferrable trigger in this file at the timing it
+  -- was written for, and they are restored after the plant. Same pair either side
+  -- of every disable/enable below.
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
   alter table public.investment_transactions disable trigger user;
 
   -- A held-for-merge row with no source. #588 requires one, through a DEFERRED
@@ -590,6 +598,8 @@ begin
 
   alter table public.investment_transactions enable trigger user;
 
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
+
   -- ═══ every planted row must be named, by the right check ═══════════════════
   -- Asserting the CHECK NAME and not merely "something was reported": a row caught
   -- by the wrong check sends whoever reads the report after the wrong repair.
@@ -759,6 +769,8 @@ begin
   insert into public.funds (user_id, name, code, fund_type, nav)
   values (v_user, 'Mixed Fund', 'MIXF', 'equity', 25000) returning id into v_fund;
 
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
+
   alter table public.investment_transactions disable trigger user;
 
   insert into public.investment_transactions
@@ -776,6 +788,8 @@ begin
   returning transaction_id into v_par;
 
   alter table public.investment_transactions enable trigger user;
+
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   -- 55 of 50 units, whichever shape took them.
   select count(*) into v_n from public.withdrawal_ledger_audit
@@ -805,12 +819,14 @@ begin
   -- parent's bucket, so the audit has to as well: written without coalescing the
   -- inner test, `not (asset_type = 'fund' and ...)` is NULL for this row and it
   -- fell out of both branches.
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
   alter table public.investment_transactions disable trigger user;
   insert into public.investment_transactions
     (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, units_withdrawn, principal_withdrawn)
   values (v_user, v_goal, v_fund, null, 'withdrawal', '2026-03-02', 250000, v_buy, 10, 400000)
   returning transaction_id into v_par_bare;
   alter table public.investment_transactions enable trigger user;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   if not exists (select 1 from public.withdrawal_ledger_audit
                   where transaction_id = v_par_bare and check_name = 'parent_is_a_fund_purchase'
@@ -833,6 +849,8 @@ begin
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Derived units') returning goal_id into v_goal;
   insert into public.funds (user_id, name, code, fund_type, nav)
   values (v_user, 'Derived Fund', 'DRVF', 'equity', 10) returning id into v_fund;
+
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
 
   alter table public.investment_transactions disable trigger user;
 
@@ -859,6 +877,8 @@ begin
   values (v_user, v_goal, v_fund, 'fund', 'withdrawal', '2026-03-01', 20, 2, 20);
 
   alter table public.investment_transactions enable trigger user;
+
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   select count(*) into v_n from public.withdrawal_ledger_audit
    where user_id = v_user and check_name = 'fund_bucket_overdrawn' and fund_id = v_fund;
@@ -888,6 +908,8 @@ begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'wd-audit-nofund@test.invalid') returning id into v_user;
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'No fund') returning goal_id into v_goal;
 
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
+
   alter table public.investment_transactions disable trigger user;
 
   insert into public.funds (user_id, name, code, fund_type, nav)
@@ -905,6 +927,8 @@ begin
 
   alter table public.investment_transactions enable trigger user;
 
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
+
   select detail into v_detail from public.withdrawal_ledger_audit
    where transaction_id = v_wd and check_name = 'parent_is_a_fund_purchase';
   if v_detail is null then
@@ -921,6 +945,7 @@ begin
   -- sentence: it IS valued — as an ordinary holding, with its withdrawal applied on
   -- the parent axis — so telling an operator nothing values it invites a repair
   -- that subtracts the money twice.
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
   alter table public.investment_transactions disable trigger user;
   insert into public.investment_transactions
     (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
@@ -931,6 +956,7 @@ begin
   values (v_user, v_goal, null, 'withdrawal', '2026-02-01', 400000, v_zero, 400000)
   returning transaction_id into v_zero_wd;
   alter table public.investment_transactions enable trigger user;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   select detail into v_detail from public.withdrawal_ledger_audit
    where transaction_id = v_zero_wd and check_name = 'parent_is_a_fund_purchase';
@@ -945,6 +971,7 @@ begin
   -- rows from the holdings pass, so the purchase is valued by nothing and neither
   -- is the claim on it. Saying it is "valued against that purchase" would be the
   -- same false comfort in the other direction.
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
   alter table public.investment_transactions disable trigger user;
   insert into public.investment_transactions
     (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, is_dca_seeded)
@@ -955,6 +982,7 @@ begin
   values (v_user, v_goal, null, 'withdrawal', '2026-02-01', 400000, v_pending, 400000)
   returning transaction_id into v_pending_wd;
   alter table public.investment_transactions enable trigger user;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   select detail into v_detail from public.withdrawal_ledger_audit
    where transaction_id = v_pending_wd and check_name = 'parent_is_a_fund_purchase';
@@ -986,6 +1014,7 @@ begin
   -- audit CANNOT see it, and this test exists so that silence is never mistaken for
   -- a guarantee: if someone later makes this ledger report, the header's claim has
   -- changed and both must be revisited together.
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
   alter table public.investment_transactions disable trigger user;
   insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
   values (v_user, v_g, 'gold', 'investment', '2026-01-01', 1000, 100, 10) returning transaction_id into v_s;
@@ -994,6 +1023,8 @@ begin
          (v_user, v_g, 'gold', 'withdrawal', '2026-03-01', 1, v_s, 503, 50);
 
   alter table public.investment_transactions enable trigger user;
+
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   select count(*) into v_any from public.withdrawal_ledger_audit where user_id = v_user;
   if v_any <> 0 then

--- a/supabase/tests/withdrawal_ledger_audit.test.sql
+++ b/supabase/tests/withdrawal_ledger_audit.test.sql
@@ -261,12 +261,21 @@ begin
   insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id)
   values (v_user, v_goal_b, 'fund', 'investment', '2026-03-01', 999, 100, 10, v_late_fund);
 
-  -- An orphan bucket the invariant itself allows. A 0.0001-unit sell worth a đồng
-  -- is left behind when its purchase moves to another goal: check_fund_bucket_solvent
-  -- (#587) refuses a relocation only when the bucket would be left owing MORE than
-  -- 0.0001 units or one đồng, so this state is reachable with every trigger enabled.
-  -- A purchase-less bucket is therefore not corrupt by itself, and calling it one
-  -- would hand an operator a repair to make on a ledger nobody wrote wrong.
+  -- An orphan bucket: a 0.0001-unit sell worth a đồng, left behind when its
+  -- purchase moved to another goal. A purchase-less bucket is not corrupt by
+  -- itself, and calling it one would hand an operator a repair to make on a ledger
+  -- nobody wrote wrong — which is what this fixture is here to prove.
+  --
+  -- It used to be reachable with every trigger enabled, because
+  -- check_fund_bucket_solvent's units epsilon was flat: a bucket left owing
+  -- EXACTLY 0.0001 units passed. #608 withholds that epsilon when the bucket holds
+  -- no units, the same carve-out check_withdrawal_balance always made for its own —
+  -- it forgives a client's rounding of a real balance, it does not conjure one.
+  -- Flat, it also let a 0.0001-unit purchase backing a 0.0001-unit sale be edited
+  -- to zero units, after which the purchase left the fund accumulator and its whole
+  -- principal reappeared on the dashboard. So the relocation is refused now, and
+  -- the bucket is planted the way every other unreachable shape in this file is.
+  -- What the audit must say about it is unchanged.
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Orphan target') returning goal_id into v_orphan_goal;
   insert into public.funds (user_id, name, code, fund_type, nav)
   values (v_user, 'Orphan Fund', 'ORPH', 'equity', 1) returning id into v_orphan_fund;
@@ -275,7 +284,11 @@ begin
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id, principal_withdrawn, units_withdrawn)
   values (v_user, v_goal_b, 'fund', 'withdrawal', '2026-02-01', 1, v_orphan_fund, 1, 0.0001);
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
+  alter table public.investment_transactions disable trigger user;
   update public.investment_transactions set goal_id = v_orphan_goal where transaction_id = v_orphan_buy;
+  alter table public.investment_transactions enable trigger user;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
   -- ═══ the planted violations ════════════════════════════════════════════════
   -- Disabling the user triggers is the only way in: these are precisely the shapes


### PR DESCRIPTION
Closes #608. Closes #607.

## The hole

`20260730000002_enforce_withdrawal_balance.sql` measures a **withdrawal** against its holding every time the withdrawal is written or relocated. Nothing fired when the **source** shrank — its own header names this as the mirror hole and leaves it for #608.

```
buy  a deposit of 100,000,000
sell 80,000,000 from it          -- allowed, 20,000,000 left
edit the buy down to 50,000,000  -- allowed, and now the holding owes 80,000,000 against 50,000,000
```

`dashboard/overview` then does `totalInvested -= Σ principal_withdrawn` against a basis that no longer covers it: invested capital goes negative and drags the goal's progress bar with it. Silent — no error, and no screen that surfaces the inconsistency.

Same shape for a fund bucket (buy 100 units, sell 60, re-price the buy to 40), and — since #606 (PR #636) — for a bucket carrying a claim parented to one of its purchases.

## The fix

One question, asked from the other end, reusing the measurements that already exist rather than restating the decision table:

| source | measured by |
|---|---|
| fund purchase (`asset_type='fund'`, a fund, `units > 0`) | `check_fund_bucket_solvent` — since #636 it already counts fund-keyed sells **and** parented claims, i.e. everything the dashboard counts |
| bank / gold / stock (and a fund row with no units, which is no bucket) | the claims parented to it, summed exactly as `check_withdrawal_balance`'s parent branch sums them |

The branch order mirrors `lib/withdrawalProgress`, same as the withdrawal side.

### Why the edit check is deferred to commit

Not a preference — `renew_term_deposit_with_merge` makes it necessary. It rolls the deposit forward first and only two statements later re-parents that deposit's partial withdrawals onto the history snapshot (#585). Renewing a 100,000,000 deposit with 60,000,000 withdrawn leaves the row holding 41,000,000 against a 60,000,000 claim for the length of two statements — legitimately insolvent in the middle, sound at the end. An end-of-statement check refuses every such renewal.

Commit is the only boundary at which a multi-statement rewrite is a finished thought. `20260731000001` reached the same conclusion for the held-settlement source check.

### Why deleting is guarded from the child's side

Deleting could not be measured at commit the way an edit is: both links a withdrawal hangs on are `ON DELETE SET NULL`, so by commit the child no longer names the holding that went. It is caught as the FK orphans the child — the last moment the link is readable — by a trigger sitting beside `enforce_withdrawal_within_balance`, named to sort before it. A separate trigger rather than a fourth branch inside that function, which has already been re-issued once (`20260803000002`); copying it again to gain four lines makes a third copy that drifts.

Three shapes still pass, each one where nothing is left owing:
- the **account cascade** — the whole ledger is going, and `auth.users` is already invisible by the time the FK action fires (the same tell that branch already uses for the parent). Without it, an account with any sell in it could not be deleted.
- a **fund-keyed sell** — it draws on its `(goal, fund)` bucket whatever it names as a parent.
- a **held-for-merge settlement** — `20260731000001` owns that case and answers it with something the user can act on.

A fund purchase is different again: its sells name no parent, so deleting one fires no FK update at all. Its bucket answers instead, at commit, where the deleted row has already left the sums.

## What changed in existing tests

Two tests asserted the behaviour this reverses, and now assert the refusal and the remedy:
- `withdrawal_balance.test.sql` — *"deleting a source that has withdrawals is an ordinary ledger action"*
- `e2e/withdrawal-balance.spec.ts` — the same, driven through the route (which is the point: the helpers delete children first, so only the route produces the orphan)

#636's two-statement fixture is now planted with the triggers off, because #608 closes its first step (converting a holding into a withdrawal under a claim).

Deferred constraint triggers block `ALTER TABLE`, and the SQL suites plant history with `disable trigger user`. Those sites flush **these two constraints by name** — not `ALL` — around each disable/enable, so every other deferrable trigger stays at the timing it was written for.

## API

`DELETE /api/v1/investment-transactions/[id]` maps the refusal to a 409 with `code: 'withdrawal_invariant'` — a conflict the user resolves by removing the withdrawal first, not a 500. PUT's 400 mapping from #636 already covers the edit; both match on the family prefix.

## Checks

- `npm run test:db` — full SQL suite green, from a `supabase db reset`, including a new `supabase/tests/source_backs_claims.test.sql` (shrink / boundary / grow / type-change / units, both balances, deletes, and every cascade that must still pass: renewal's statement order, fund delete, goal delete, account delete)
- `npm run typecheck` · `npm test -- --run` (2210 passed) · `npm run lint` (0 errors) · `npm run build` · `npm run test:coverage` (thresholds met)
- `npm run test:e2e` — **237 passed**, full suite

> ⚠️ Unrelated: `supabase/tests/gold_refresh_cron_atomic.test.sql` fails locally with `permission denied for table gold_price_settings`. It fails identically on plain `origin/main` with this migration removed — the local stack comes out of `supabase db reset` with no table-level DML grants for `anon`/`authenticated`/`service_role` at all. Not touched by this PR, but worth a look if CI's DB gate is red for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)