### PR TITLE
feat(deposits): open a successor book when a bank stops taking top-ups (#638)

### DIFF
--- a/app/(app)/planning/__tests__/usePlanningActions.test.ts
+++ b/app/(app)/planning/__tests__/usePlanningActions.test.ts
@@ -5,6 +5,7 @@ vi.mock('sonner', () => ({ toast: Object.assign(vi.fn(), { error: toastErrorMock
 
 import { usePlanningActions, buildBuyEdit, buildContributionPrefill } from '../usePlanningActions'
 import type { GoalItem } from '@/lib/planning'
+import { addDaysIso, todayIso } from '@/lib/dates'
 
 // usePlanningActions uses no React hooks internally — it returns plain async
 // functions — so it can be exercised directly. It's the single implementation
@@ -133,9 +134,29 @@ describe('usePlanningActions (#467 shared planning actions)', () => {
       }
     })
 
-    it('toasts and returns matured for a matured book', async () => {
+    // #638 Phase 2: a book that cannot take this month is not a dead end — the
+    // month goes into the successor, prefilled from what the plan already knows.
+    it('steers a matured book to a successor, carrying the month with it', async () => {
+      const { actions } = setup()
+      mockFetch(() => ({ ok: true, body: { transaction_id: 'tx1', deposit_group_id: 'tx1', expiry_date: '2000-01-01', interest_rate: 6, notes: 'My book' } }))
+      const r = await actions.probeRecurringRecord(item)
+      expect(r.kind).toBe('successor')
+      if (r.kind === 'successor') {
+        expect(r.target).toMatchObject({ bookId: 'tx1', bookName: 'My book', amount: 1_000_000, savingId: 'r1', ym: '2026-06' })
+      }
+    })
+
+    it('steers a book inside its lock window the same way', async () => {
+      const { actions } = setup()
+      mockFetch(() => ({ ok: true, body: { transaction_id: 'tx1', deposit_group_id: 'tx1', expiry_date: addDaysIso(todayIso(), 10), top_up_lock_days: 30, interest_rate: 6 } }))
+      const r = await actions.probeRecurringRecord(item)
+      expect(r.kind).toBe('successor')
+      if (r.kind === 'successor') expect(r.target.lockDays).toBe(30)
+    })
+
+    it('a book that already handed over sends the user to the successor instead', async () => {
       const { actions, onToast } = setup()
-      mockFetch(() => ({ ok: true, body: { transaction_id: 'tx1', deposit_group_id: 'tx1', expiry_date: '2000-01-01' } }))
+      mockFetch(() => ({ ok: true, body: { transaction_id: 'tx1', deposit_group_id: 'tx1', expiry_date: '2000-01-01', successor_deposit_tx_id: 'tx2' } }))
       const r = await actions.probeRecurringRecord(item)
       expect(r.kind).toBe('matured')
       expect(onToast).toHaveBeenCalled()

--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -15,6 +15,7 @@ import FixedExpenseManager from './FixedExpenseManager'
 import RecurringSavingManager from './RecurringSavingManager'
 import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
+import SuccessorBookSheet, { type SuccessorTarget } from '@/app/assets/components/SuccessorBookSheet'
 import AddInsuranceMemberModal from '@/app/assets/components/AddInsuranceMemberModal'
 import { EditIcon, TrashIcon } from './planningIcons'
 import { DPlanRow, DGoalItemRow } from './desktopPlanningRows'
@@ -108,6 +109,7 @@ export default function DesktopPlanningView({
   // deposit, opens the same sheet in create mode (POST) pre-filled with the goal.
   const [prefillTx, setPrefillTx] = useState<PrefillTransaction | null>(null)
   const [bookTopUp, setBookTopUp] = useState<BookTopUpTarget | null>(null)
+  const [successor, setSuccessor] = useState<SuccessorTarget | null>(null)
 
   // ── Derived values ── (shared with the mobile view via usePlanningDerivations)
   const {
@@ -187,6 +189,7 @@ export default function DesktopPlanningView({
   async function recordRecurring(g: { goalId: string; isUnallocated: boolean }, item: GoalItem) {
     const result = await actions.probeRecurringRecord(item)
     if (result.kind === 'book-topup') setBookTopUp(result.target)
+    else if (result.kind === 'successor') setSuccessor(result.target)
     else if (result.kind === 'contribution') openContribution(g, { asset_type: 'bank', amount_vnd: item.amount })
   }
 
@@ -754,6 +757,12 @@ export default function DesktopPlanningView({
         isVi={isVI}
         onClose={() => setBookTopUp(null)}
         onDone={() => { onRefresh(); onToast(isVI ? 'Đã nạp vào sổ' : 'Topped up book') }}
+      />
+      <SuccessorBookSheet
+        target={successor}
+        isVi={isVI}
+        onClose={() => setSuccessor(null)}
+        onDone={() => { onRefresh(); onToast(isVI ? 'Đã mở sổ kế nhiệm' : 'Successor book opened') }}
       />
     </div>
   )

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -8,6 +8,7 @@ import FixedExpenseManager from './FixedExpenseManager'
 import RecurringSavingManager from './RecurringSavingManager'
 import AddTransactionSheet, { type EditableTransaction, type PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import RecurringBookTopUpSheet, { type BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
+import SuccessorBookSheet, { type SuccessorTarget } from '@/app/assets/components/SuccessorBookSheet'
 import AddInsuranceMemberModal from '@/app/assets/components/AddInsuranceMemberModal'
 import { EditIcon } from './planningIcons'
 import { GoalAllocationRow, PlanLineItem } from './planningRows'
@@ -77,6 +78,7 @@ export default function MobilePlanningView({
   const [buyEdit, setBuyEdit] = useState<EditableTransaction | null>(null)
   const [prefillTx, setPrefillTx] = useState<PrefillTransaction | null>(null)
   const [bookTopUp, setBookTopUp] = useState<BookTopUpTarget | null>(null)
+  const [successor, setSuccessor] = useState<SuccessorTarget | null>(null)
   const [showAddInsurance, setShowAddInsurance] = useState(false)
   const [overrideTarget, setOverrideTarget] = useState<{ type: 'fe' | 'ins' | 'rec'; id: string; name: string; defaultAmount: number } | null>(null)
 
@@ -126,6 +128,7 @@ export default function MobilePlanningView({
   async function recordRecurring(entry: GoalRow, item: GoalItem) {
     const result = await actions.probeRecurringRecord(item)
     if (result.kind === 'book-topup') setBookTopUp(result.target)
+    else if (result.kind === 'successor') setSuccessor(result.target)
     else if (result.kind === 'contribution') openContribution(entry, { asset_type: 'bank', amount_vnd: item.amount })
   }
 
@@ -497,6 +500,12 @@ export default function MobilePlanningView({
         isVi={isVI}
         onClose={() => setBookTopUp(null)}
         onDone={() => { onToast(isVI ? 'Đã nạp vào sổ' : 'Topped up book'); onRefresh() }}
+      />
+      <SuccessorBookSheet
+        target={successor}
+        isVi={isVI}
+        onClose={() => setSuccessor(null)}
+        onDone={() => { onToast(isVI ? 'Đã mở sổ kế nhiệm' : 'Successor book opened'); onRefresh() }}
       />
 
       <AddInsuranceMemberModal

--- a/app/(app)/planning/usePlanningActions.ts
+++ b/app/(app)/planning/usePlanningActions.ts
@@ -3,6 +3,8 @@ import { todayIso } from '@/lib/dates'
 import type { GoalItem, GoalRow } from '@/lib/planning'
 import type { EditableTransaction, PrefillTransaction } from '@/app/assets/components/AddTransactionSheet'
 import type { BookTopUpTarget } from '@/app/assets/components/RecurringBookTopUpSheet'
+import type { SuccessorTarget } from '@/app/assets/components/SuccessorBookSheet'
+import { classifyAccumulatingTopUp } from '@/lib/accumulatingTopUp'
 import type { MonthlyPlan, FixedExpense, InsuranceMember, FundInvestment } from '@/features/planning/contracts'
 
 export type OverrideType = 'fe' | 'rec' | 'ins'
@@ -10,6 +12,7 @@ export type OverrideType = 'fe' | 'rec' | 'ins'
 export type RecordRecurringResult =
   | { kind: 'matured' }
   | { kind: 'book-topup'; target: BookTopUpTarget }
+  | { kind: 'successor'; target: SuccessorTarget }
   | { kind: 'contribution' }
 
 // Build the Add-Transaction edit payload for recording a planned DCA buy. Pure —
@@ -199,10 +202,29 @@ export function usePlanningActions(ctx: PlanningActionsCtx) {
           const dep = await res.json()
           const isBookAnchor = dep.deposit_group_id && dep.deposit_group_id === dep.transaction_id
           if (isBookAnchor) {
-            const matured = dep.expiry_date && dep.expiry_date < todayIso()
-            if (matured) {
-              onToast(isVI ? 'Sổ đã đáo hạn — hãy xử lý đáo hạn trước.' : 'This book has matured — handle its maturity first.')
-              return { kind: 'matured' }
+            const date = todayIso()
+            // A book that will not take this month's contribution is not a dead
+            // end: the answer is the successor book, prefilled with the month
+            // that could not go in (#638). A book that already has one is simply
+            // done — the contribution belongs to whatever it was replaced by.
+            const eligibility = classifyAccumulatingTopUp({ topUpDate: date, expiryDate: dep.expiry_date ?? null, lockDays: dep.top_up_lock_days ?? null })
+            if (eligibility.status !== 'allowed') {
+              if (dep.successor_deposit_tx_id) {
+                onToast(isVI ? 'Sổ này đã có sổ kế nhiệm — hãy ghi khoản này vào sổ đó.' : 'This book already has a successor — record this into that one.')
+                return { kind: 'matured' }
+              }
+              return {
+                kind: 'successor',
+                target: {
+                  bookId: dep.transaction_id,
+                  bookName: dep.notes || (isVI ? 'Sổ ngân hàng' : 'Bank deposit'),
+                  amount: item.amount, date, rate: dep.interest_rate ?? null,
+                  lockDays: dep.top_up_lock_days ?? null,
+                  savingId: item.recurringId,
+                  ym: `${year}-${String(month).padStart(2, '0')}`,
+                  planId: plan.id,
+                },
+              }
             }
             return {
               kind: 'book-topup',

--- a/app/(app)/planning/usePlanningActions.ts
+++ b/app/(app)/planning/usePlanningActions.ts
@@ -220,6 +220,7 @@ export function usePlanningActions(ctx: PlanningActionsCtx) {
                   bookName: dep.notes || (isVI ? 'Sổ ngân hàng' : 'Bank deposit'),
                   amount: item.amount, date, rate: dep.interest_rate ?? null,
                   lockDays: dep.top_up_lock_days ?? null,
+                  sourceExpiry: dep.expiry_date ?? null,
                   savingId: item.recurringId,
                   ym: `${year}-${String(month).padStart(2, '0')}`,
                   planId: plan.id,

--- a/app/api/v1/investment-transactions/[id]/__tests__/route.delete.test.ts
+++ b/app/api/v1/investment-transactions/[id]/__tests__/route.delete.test.ts
@@ -219,6 +219,26 @@ describe('DELETE /api/v1/investment-transactions/[id]', () => {
     expect(JSON.stringify(body)).not.toContain('60000000')
   })
 
+  // A book promised to a successor is deliberately undeletable (#638) — losing
+  // the plan is the failure the link exists to prevent — so the answer has to
+  // say what to undo, not that the server broke.
+  it('returns 409 telling the user to cancel the handover first', async () => {
+    h.deleteResult = {
+      data: null,
+      error: {
+        code: '23514',
+        message: 'successor book: this book is promised to a successor, so cancel the handover before deleting it',
+      },
+    }
+
+    const res = await call()
+
+    expect(res.status).toBe(409)
+    const body = await res.json()
+    expect(body.code).toBe('successor_planned')
+    expect(body.error).toMatch(/cancel the handover/i)
+  })
+
   it('returns a generic 409 for an unrecognised foreign-key reference', async () => {
     h.deleteResult = {
       data: null,

--- a/app/api/v1/investment-transactions/[id]/__tests__/route.put.subtype.test.ts
+++ b/app/api/v1/investment-transactions/[id]/__tests__/route.put.subtype.test.ts
@@ -201,6 +201,19 @@ describe('PUT /api/v1/investment-transactions/[id] — subtype normalization (#5
     await expect(res.json()).resolves.toMatchObject({ code: 'top_up_locked_near_maturity' })
   })
 
+  it('reports a pairing the edit broke as a conflict the user can fix', async () => {
+    h.existing = { deposit_group_id: 'book-1', asset_type: 'bank' }
+    h.rpcResult = {
+      data: null,
+      error: { message: 'successor book: both books need a maturity while the handover stands' },
+    }
+
+    const res = await put({ expiry_date: null })
+
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toMatchObject({ code: 'successor_pairing' })
+  })
+
   it('reports a book the database refused to convert as a conflict, not a missing row', async () => {
     // The route's own guard reads deposit_group_id before it writes, so a
     // deposit that becomes a book in between (a recurring top-up self-groups its

--- a/app/api/v1/investment-transactions/[id]/collapse/route.ts
+++ b/app/api/v1/investment-transactions/[id]/collapse/route.ts
@@ -148,6 +148,15 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     if (rpcErr?.message?.includes('book changed since load')) {
       return NextResponse.json({ error: 'This deposit changed — please reload and try again.' }, { status: 409 })
     }
+    // Collapse is exactly when a promised book must NOT quietly become a plain
+    // deposit: the merge into its successor is what maturity is for (#638). The
+    // user has to withdraw the promise first, so say that rather than "failed".
+    if (rpcErr?.message?.startsWith('successor book: ')) {
+      return NextResponse.json(
+        { error: rpcErr.message.slice('successor book: '.length), code: 'successor_planned' },
+        { status: 409 },
+      )
+    }
     console.error('collapse: atomic collapse failed', rpcErr?.message)
     return NextResponse.json({ error: 'Failed to collapse book' }, { status: 500 })
   }

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -194,6 +194,15 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
           { status: 400 },
         )
       }
+      // An edit that breaks the handover — clearing a maturity, moving the
+      // source's past its successor's — is the user's to correct (#638), and
+      // the message says which rule it broke.
+      if (bookErr?.message?.startsWith('successor book: ')) {
+        return NextResponse.json(
+          { error: bookErr.message.slice('successor book: '.length), code: 'successor_pairing' },
+          { status: 409 },
+        )
+      }
       console.error('update_deposit_book: atomic book edit failed', bookErr?.message)
       return NextResponse.json({ error: 'Failed to update deposit book' }, { status: 500 })
     }
@@ -381,6 +390,15 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
           error: 'A withdrawal is recorded against this holding. Remove it before deleting the holding.',
           code: 'withdrawal_invariant',
         },
+        { status: 409 },
+      )
+    }
+    // A book promised to a successor is deliberately undeletable (#638): losing
+    // the plan is the failure the link exists to prevent. Say what to do about
+    // it rather than reporting a server fault.
+    if (error.message?.startsWith('successor book: ')) {
+      return NextResponse.json(
+        { error: error.message.slice('successor book: '.length), code: 'successor_planned' },
         { status: 409 },
       )
     }

--- a/app/api/v1/investment-transactions/[id]/successor/__tests__/route.test.ts
+++ b/app/api/v1/investment-transactions/[id]/successor/__tests__/route.test.ts
@@ -186,11 +186,14 @@ describe('POST /api/v1/investment-transactions/[id]/successor (#638)', () => {
         { params: Promise.resolve({ id: BOOK }) },
       )
 
-    it('clears the link and leaves the successor book alone', async () => {
+    it('cancels through the function that owns the column', async () => {
       const res = await del()
 
       expect(res.status).toBe(200)
-      expect(h.updates).toMatchObject({ successor_deposit_tx_id: null })
+      // The column is not writable by clients at all, so the route cannot
+      // update it directly — it asks the function that may.
+      expect(h.updates).toBeNull()
+      expect(h.rpcCalls[0]).toMatchObject({ name: 'cancel_successor_book', args: { p_source_book_id: BOOK } })
       await expect(res.json()).resolves.toMatchObject({ successor_deposit_tx_id: null })
     })
 
@@ -219,7 +222,7 @@ describe('POST /api/v1/investment-transactions/[id]/successor (#638)', () => {
     })
 
     it('answers 404 for a deposit that is not the caller\'s', async () => {
-      h.updateResult = { data: null, error: null }
+      h.rpcResult = { data: null, error: { message: 'successor book: deposit not found' } }
       expect((await del()).status).toBe(404)
     })
   })

--- a/app/api/v1/investment-transactions/[id]/successor/__tests__/route.test.ts
+++ b/app/api/v1/investment-transactions/[id]/successor/__tests__/route.test.ts
@@ -16,7 +16,7 @@ const PLAN = '44444444-4444-4444-8444-444444444444'
 const h = vi.hoisted(() => ({
   user: { id: 'user-1' } as { id: string } | null,
   saving: { linked_deposit_tx_id: '11111111-1111-4111-8111-111111111111' } as unknown,
-  plan: { id: '44444444-4444-4444-8444-444444444444' } as unknown,
+  plan: { id: '44444444-4444-4444-8444-444444444444', month: 8, year: 2026 } as unknown,
   rpcResult: { data: { transaction_id: '22222222-2222-4222-8222-222222222222' } as unknown, error: null as unknown },
   rpcCalls: [] as { name: string; args: Record<string, unknown> }[],
   updates: null as Record<string, unknown> | null,
@@ -70,7 +70,7 @@ const call = (body: Record<string, unknown> = BODY) =>
 beforeEach(() => {
   h.user = { id: 'user-1' }
   h.saving = { linked_deposit_tx_id: BOOK }
-  h.plan = { id: PLAN }
+  h.plan = { id: PLAN, month: 8, year: 2026 }
   h.rpcResult = { data: { transaction_id: NEW_BOOK }, error: null }
   h.rpcCalls = []
   h.updates = null
@@ -106,6 +106,25 @@ describe('POST /api/v1/investment-transactions/[id]/successor (#638)', () => {
     expect(h.rpcCalls[0].args).toMatchObject({
       p_saving_id: SAVING, p_ym: '2026-08', p_plan_id: PLAN,
     })
+  })
+
+  // The tranche carries the plan while the fulfillment is filed under ym; if
+  // they name different months, one month shows a contribution whose deposit it
+  // cannot find and the other counts a deposit it never planned.
+  it('refuses a plan from a different month than the contribution', async () => {
+    h.plan = { id: PLAN, month: 7, year: 2026 }
+
+    const res = await call({ ...BODY, saving_id: SAVING, ym: '2026-08', plan_id: PLAN })
+
+    expect(res.status).toBe(400)
+    expect(h.rpcCalls).toHaveLength(0)
+  })
+
+  it('accepts a plan for the same month', async () => {
+    const res = await call({ ...BODY, saving_id: SAVING, ym: '2026-08', plan_id: PLAN })
+
+    expect(res.status).toBe(201)
+    expect(h.rpcCalls[0].args).toMatchObject({ p_plan_id: PLAN, p_ym: '2026-08' })
   })
 
   it('rejects an anonymous caller', async () => {
@@ -175,7 +194,26 @@ describe('POST /api/v1/investment-transactions/[id]/successor (#638)', () => {
       await expect(res.json()).resolves.toMatchObject({ successor_deposit_tx_id: null })
     })
 
-    it('rejects an anonymous caller', async () => {
+    // The tranche carries the plan while the fulfillment is filed under ym; if
+  // they name different months, one month shows a contribution whose deposit it
+  // cannot find and the other counts a deposit it never planned.
+  it('refuses a plan from a different month than the contribution', async () => {
+    h.plan = { id: PLAN, month: 7, year: 2026 }
+
+    const res = await call({ ...BODY, saving_id: SAVING, ym: '2026-08', plan_id: PLAN })
+
+    expect(res.status).toBe(400)
+    expect(h.rpcCalls).toHaveLength(0)
+  })
+
+  it('accepts a plan for the same month', async () => {
+    const res = await call({ ...BODY, saving_id: SAVING, ym: '2026-08', plan_id: PLAN })
+
+    expect(res.status).toBe(201)
+    expect(h.rpcCalls[0].args).toMatchObject({ p_plan_id: PLAN, p_ym: '2026-08' })
+  })
+
+  it('rejects an anonymous caller', async () => {
       h.user = null
       expect((await del()).status).toBe(401)
     })

--- a/app/api/v1/investment-transactions/[id]/successor/__tests__/route.test.ts
+++ b/app/api/v1/investment-transactions/[id]/successor/__tests__/route.test.ts
@@ -19,18 +19,25 @@ const h = vi.hoisted(() => ({
   plan: { id: '44444444-4444-4444-8444-444444444444' } as unknown,
   rpcResult: { data: { transaction_id: '22222222-2222-4222-8222-222222222222' } as unknown, error: null as unknown },
   rpcCalls: [] as { name: string; args: Record<string, unknown> }[],
+  updates: null as Record<string, unknown> | null,
+  updateResult: { data: { transaction_id: '11111111-1111-4111-8111-111111111111' } as unknown, error: null as unknown },
 }))
 
 vi.mock('@/lib/supabase-server', () => ({
   createSupabaseServerClient: async () => ({
     auth: { getUser: async () => ({ data: { user: h.user } }) },
     from: (table: string) => {
+      let op: 'select' | 'update' = 'select'
       const c: Record<string, unknown> = {
         select: () => c,
         eq: () => c,
-        single: async () => (table === 'recurring_savings'
-          ? { data: h.saving, error: null }
-          : { data: h.plan, error: null }),
+        update: (payload: Record<string, unknown>) => { op = 'update'; h.updates = payload; return c },
+        single: async () => {
+          if (op === 'update') return h.updateResult
+          return table === 'recurring_savings'
+            ? { data: h.saving, error: null }
+            : { data: h.plan, error: null }
+        },
       }
       return c
     },
@@ -41,7 +48,7 @@ vi.mock('@/lib/supabase-server', () => ({
   }),
 }))
 
-const { POST } = await import('../route')
+const { POST, DELETE } = await import('../route')
 
 const BODY = {
   amount_vnd: 2_000_000,
@@ -66,6 +73,8 @@ beforeEach(() => {
   h.plan = { id: PLAN }
   h.rpcResult = { data: { transaction_id: NEW_BOOK }, error: null }
   h.rpcCalls = []
+  h.updates = null
+  h.updateResult = { data: { transaction_id: BOOK }, error: null }
   vi.spyOn(console, 'error').mockImplementation(() => {})
 })
 
@@ -147,5 +156,33 @@ describe('POST /api/v1/investment-transactions/[id]/successor (#638)', () => {
     h.rpcResult = { data: null, error: { message: 'successor book: accumulating book not found' } }
 
     expect((await call()).status).toBe(404)
+  })
+
+  // The database refuses to close a promised book, so the promise has to be
+  // withdrawable on purpose — otherwise the old deposit could never be closed.
+  describe('DELETE — cancelling the handover', () => {
+    const del = () =>
+      DELETE(
+        new Request(`https://app.test/api/v1/investment-transactions/${BOOK}/successor`, { method: 'DELETE' }) as unknown as NextRequest,
+        { params: Promise.resolve({ id: BOOK }) },
+      )
+
+    it('clears the link and leaves the successor book alone', async () => {
+      const res = await del()
+
+      expect(res.status).toBe(200)
+      expect(h.updates).toMatchObject({ successor_deposit_tx_id: null })
+      await expect(res.json()).resolves.toMatchObject({ successor_deposit_tx_id: null })
+    })
+
+    it('rejects an anonymous caller', async () => {
+      h.user = null
+      expect((await del()).status).toBe(401)
+    })
+
+    it('answers 404 for a deposit that is not the caller\'s', async () => {
+      h.updateResult = { data: null, error: null }
+      expect((await del()).status).toBe(404)
+    })
   })
 })

--- a/app/api/v1/investment-transactions/[id]/successor/__tests__/route.test.ts
+++ b/app/api/v1/investment-transactions/[id]/successor/__tests__/route.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// Opening the successor of a book that stopped accepting top-ups (#638). The
+// route is thin on purpose: everything that has to happen together — the new
+// book, the month's contribution, the fulfillment, the moved recurring link —
+// happens inside open_successor_book. What the route owes is validation, the
+// recurring's ownership, and turning the RPC's refusals into answers a user can
+// act on rather than a 500.
+
+const BOOK = '11111111-1111-4111-8111-111111111111'
+const NEW_BOOK = '22222222-2222-4222-8222-222222222222'
+const SAVING = '33333333-3333-4333-8333-333333333333'
+const PLAN = '44444444-4444-4444-8444-444444444444'
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  saving: { linked_deposit_tx_id: '11111111-1111-4111-8111-111111111111' } as unknown,
+  plan: { id: '44444444-4444-4444-8444-444444444444' } as unknown,
+  rpcResult: { data: { transaction_id: '22222222-2222-4222-8222-222222222222' } as unknown, error: null as unknown },
+  rpcCalls: [] as { name: string; args: Record<string, unknown> }[],
+}))
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: h.user } }) },
+    from: (table: string) => {
+      const c: Record<string, unknown> = {
+        select: () => c,
+        eq: () => c,
+        single: async () => (table === 'recurring_savings'
+          ? { data: h.saving, error: null }
+          : { data: h.plan, error: null }),
+      }
+      return c
+    },
+    rpc: (name: string, args: Record<string, unknown>) => {
+      h.rpcCalls.push({ name, args })
+      return { single: async () => h.rpcResult }
+    },
+  }),
+}))
+
+const { POST } = await import('../route')
+
+const BODY = {
+  amount_vnd: 2_000_000,
+  interest_rate: 4.2,
+  investment_date: '2026-08-04',
+  expiry_date: '2027-08-04',
+  top_up_lock_days: 30,
+}
+
+const call = (body: Record<string, unknown> = BODY) =>
+  POST(
+    new Request(`https://app.test/api/v1/investment-transactions/${BOOK}/successor`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest,
+    { params: Promise.resolve({ id: BOOK }) },
+  )
+
+beforeEach(() => {
+  h.user = { id: 'user-1' }
+  h.saving = { linked_deposit_tx_id: BOOK }
+  h.plan = { id: PLAN }
+  h.rpcResult = { data: { transaction_id: NEW_BOOK }, error: null }
+  h.rpcCalls = []
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('POST /api/v1/investment-transactions/[id]/successor (#638)', () => {
+  it('opens the successor through the atomic RPC', async () => {
+    const res = await call()
+
+    expect(res.status).toBe(201)
+    await expect(res.json()).resolves.toMatchObject({ transaction_id: NEW_BOOK })
+    expect(h.rpcCalls).toHaveLength(1)
+    expect(h.rpcCalls[0]).toMatchObject({
+      name: 'open_successor_book',
+      args: {
+        p_source_book_id: BOOK,
+        p_amount_vnd: 2_000_000,
+        p_interest_rate: 4.2,
+        p_investment_date: '2026-08-04',
+        p_expiry_date: '2027-08-04',
+        p_top_up_lock_days: 30,
+        p_saving_id: null,
+        p_ym: null,
+      },
+    })
+  })
+
+  it('carries the recurring saving and its month into the same call', async () => {
+    await call({ ...BODY, saving_id: SAVING, ym: '2026-08', plan_id: PLAN })
+
+    expect(h.rpcCalls[0].args).toMatchObject({
+      p_saving_id: SAVING, p_ym: '2026-08', p_plan_id: PLAN,
+    })
+  })
+
+  it('rejects an anonymous caller', async () => {
+    h.user = null
+    expect((await call()).status).toBe(401)
+  })
+
+  it('rejects a maturity that is not after the contribution', async () => {
+    const res = await call({ ...BODY, expiry_date: '2026-08-04' })
+
+    expect(res.status).toBe(400)
+    expect(h.rpcCalls).toHaveLength(0)
+  })
+
+  it('rejects a contribution dated in the future', async () => {
+    const res = await call({ ...BODY, investment_date: '2099-01-01' })
+
+    expect(res.status).toBe(400)
+    expect(h.rpcCalls).toHaveLength(0)
+  })
+
+  it('refuses to move a recurring saving that is linked to another book', async () => {
+    h.saving = { linked_deposit_tx_id: NEW_BOOK }
+
+    const res = await call({ ...BODY, saving_id: SAVING, ym: '2026-08' })
+
+    expect(res.status).toBe(400)
+    expect(h.rpcCalls).toHaveLength(0)
+  })
+
+  it('reports a book that already has a successor as a conflict, not a fault', async () => {
+    h.rpcResult = { data: null, error: { message: 'successor book: this book already has a successor' } }
+
+    const res = await call()
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: 'This book already has a successor.' })
+  })
+
+  it('reports a missing book as a 404', async () => {
+    h.rpcResult = { data: null, error: { message: 'successor book: accumulating book not found' } }
+
+    expect((await call()).status).toBe(404)
+  })
+})

--- a/app/api/v1/investment-transactions/[id]/successor/__tests__/route.test.ts
+++ b/app/api/v1/investment-transactions/[id]/successor/__tests__/route.test.ts
@@ -111,6 +111,13 @@ describe('POST /api/v1/investment-transactions/[id]/successor (#638)', () => {
     expect(h.rpcCalls).toHaveLength(0)
   })
 
+  it('rejects a book opened without a rate', async () => {
+    const res = await call({ ...BODY, interest_rate: null })
+
+    expect(res.status).toBe(400)
+    expect(h.rpcCalls).toHaveLength(0)
+  })
+
   it('rejects a contribution dated in the future', async () => {
     const res = await call({ ...BODY, investment_date: '2099-01-01' })
 

--- a/app/api/v1/investment-transactions/[id]/successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/successor/route.ts
@@ -85,11 +85,17 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   if (cleanPlanId) {
     const { data: plan } = await supabase
       .from('monthly_plans')
-      .select('id')
+      .select('id, month, year')
       .eq('id', cleanPlanId)
       .eq('user_id', user.id)
       .single()
     if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
+    // The tranche is tagged with the plan while the fulfillment is filed under
+    // `ym`. If those disagree, one month shows a contribution it cannot find the
+    // deposit for, and another counts a deposit it never planned.
+    if (cleanYm && `${plan.year}-${String(plan.month).padStart(2, '0')}` !== cleanYm) {
+      return NextResponse.json({ error: 'The plan and the contribution month must be the same month.' }, { status: 400 })
+    }
   }
 
   const { data: book, error } = await supabase

--- a/app/api/v1/investment-transactions/[id]/successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/successor/route.ts
@@ -127,3 +127,37 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
 
   return NextResponse.json(book, { status: 201 })
 }
+
+// Cancel a planned handover. The database will not let a promised book be closed
+// or collapsed — losing the plan at maturity is exactly the failure the link
+// exists to prevent — so the way out is to withdraw the promise on purpose.
+// The successor book itself stays: it holds real money and is nobody's to delete
+// from here.
+export async function DELETE(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  let bookId: string
+  try {
+    bookId = validateUUID(id, 'id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const { data: book, error } = await supabase
+    .from('investment_transactions')
+    .update({ successor_deposit_tx_id: null, updated_at: new Date().toISOString() })
+    .eq('transaction_id', bookId)
+    .eq('user_id', user.id)
+    .select('transaction_id')
+    .single()
+
+  if (error || !book) {
+    if (error) console.error('cancel successor failed', error.message)
+    return NextResponse.json({ error: 'Deposit not found' }, { status: 404 })
+  }
+  return NextResponse.json({ transaction_id: book.transaction_id, successor_deposit_tx_id: null })
+}

--- a/app/api/v1/investment-transactions/[id]/successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/successor/route.ts
@@ -1,0 +1,125 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateNotes, validateRate, validateUUID, validateYearMonth } from '@/lib/validation'
+import { isFutureInvestmentDate } from '@/lib/dates'
+import { readJsonBody } from '@/lib/apiBody'
+
+// Open the accumulating book that takes over from one the bank will no longer
+// top up (#638). The new book opens with the contribution that could not go into
+// the old one; the user supplies its maturity and rate, since those are the
+// bank's terms for a new deposit and nothing in the old book predicts them.
+//
+// When the contribution came from a recurring saving, the same call also files
+// the month and moves the saving's link — one RPC, because a half-applied
+// version of that is a plan that asks for the month again or a contribution
+// recorded in a book nothing points at.
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
+  const { amount_vnd, interest_rate, investment_date, expiry_date, top_up_lock_days, notes, saving_id, ym, plan_id } = body
+
+  let bookId: string
+  let cleanAmount: number
+  let cleanRate: number | null = null
+  let cleanDate: string
+  let cleanExpiry: string
+  let cleanLockDays: number | null = null
+  let cleanNotes: string | null = null
+  let cleanSavingId: string | null = null
+  let cleanYm: string | null = null
+  let cleanPlanId: string | null = null
+  try {
+    bookId = validateUUID(id, 'id')
+    cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
+    if (cleanAmount <= 0) throw new ValidationError('amount_vnd must be positive')
+    if (interest_rate != null && interest_rate !== '') cleanRate = validateRate(interest_rate, 'interest_rate')
+    cleanDate = validateDate(investment_date, 'investment_date')
+    cleanExpiry = validateDate(expiry_date, 'expiry_date')
+    if (cleanExpiry <= cleanDate) throw new ValidationError('expiry_date must be after investment_date')
+    if (top_up_lock_days != null && top_up_lock_days !== '') {
+      const lockDays = Number(top_up_lock_days)
+      if (!Number.isInteger(lockDays) || lockDays < 0 || lockDays > 3650) throw new ValidationError('top_up_lock_days must be a whole number from 0 to 3650')
+      cleanLockDays = lockDays
+    }
+    if (notes != null && notes !== '') cleanNotes = validateNotes(notes)
+    if (saving_id) {
+      cleanSavingId = validateUUID(saving_id, 'saving_id')
+      cleanYm = validateYearMonth(ym, 'ym')
+    }
+    if (plan_id) cleanPlanId = validateUUID(plan_id, 'plan_id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  if (isFutureInvestmentDate(cleanDate)) {
+    return NextResponse.json({ error: 'Contribution date cannot be in the future.' }, { status: 400 })
+  }
+
+  // The RPC checks this too — it has to, being the only thing a direct caller
+  // goes through — but a wrong link is a user-correctable mistake, so answer it
+  // here where it can be phrased as one.
+  if (cleanSavingId) {
+    const { data: saving } = await supabase
+      .from('recurring_savings')
+      .select('linked_deposit_tx_id')
+      .eq('saving_id', cleanSavingId)
+      .eq('user_id', user.id)
+      .single()
+    if (!saving) return NextResponse.json({ error: 'Recurring saving not found' }, { status: 404 })
+    if (saving.linked_deposit_tx_id !== bookId) {
+      return NextResponse.json({ error: 'This recurring saving is not linked to that book.' }, { status: 400 })
+    }
+  }
+
+  if (cleanPlanId) {
+    const { data: plan } = await supabase
+      .from('monthly_plans')
+      .select('id')
+      .eq('id', cleanPlanId)
+      .eq('user_id', user.id)
+      .single()
+    if (!plan) return NextResponse.json({ error: 'Plan not found' }, { status: 404 })
+  }
+
+  const { data: book, error } = await supabase
+    .rpc('open_successor_book', {
+      p_source_book_id: bookId,
+      p_amount_vnd: Math.round(cleanAmount),
+      p_interest_rate: cleanRate,
+      p_investment_date: cleanDate,
+      p_expiry_date: cleanExpiry,
+      p_top_up_lock_days: cleanLockDays,
+      p_notes: cleanNotes,
+      p_saving_id: cleanSavingId,
+      p_ym: cleanYm,
+      p_plan_id: cleanPlanId,
+    })
+    .single()
+
+  if (error || !book) {
+    const msg = error?.message ?? ''
+    if (msg.includes('accumulating book not found')) {
+      return NextResponse.json({ error: 'Accumulating book not found.' }, { status: 404 })
+    }
+    if (msg.includes('already has a successor')) {
+      return NextResponse.json({ error: 'This book already has a successor.', code: 'successor_exists' }, { status: 400 })
+    }
+    // Every other refusal this family raises is a rule the user can satisfy by
+    // changing what they typed, so the message goes back as-is rather than
+    // becoming an anonymous server fault.
+    if (msg.startsWith('successor book: ')) {
+      return NextResponse.json({ error: msg.slice('successor book: '.length), code: 'successor_refused' }, { status: 400 })
+    }
+    console.error('open_successor_book failed', msg)
+    return NextResponse.json({ error: 'Failed to open the successor book' }, { status: 500 })
+  }
+
+  return NextResponse.json(book, { status: 201 })
+}

--- a/app/api/v1/investment-transactions/[id]/successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/successor/route.ts
@@ -153,16 +153,15 @@ export async function DELETE(_request: NextRequest, { params }: { params: Promis
     throw e
   }
 
+  // Through the RPC, not a direct update: the column is not writable by clients
+  // at all (#638). The two functions that own it are the only places that know
+  // what a handover involves.
   const { data: book, error } = await supabase
-    .from('investment_transactions')
-    .update({ successor_deposit_tx_id: null, updated_at: new Date().toISOString() })
-    .eq('transaction_id', bookId)
-    .eq('user_id', user.id)
-    .select('transaction_id')
-    .single()
+    .rpc('cancel_successor_book', { p_source_book_id: bookId })
+    .single<{ transaction_id: string }>()
 
   if (error || !book) {
-    if (error) console.error('cancel successor failed', error.message)
+    if (error) console.error('cancel_successor_book failed', error.message)
     return NextResponse.json({ error: 'Deposit not found' }, { status: 404 })
   }
   return NextResponse.json({ transaction_id: book.transaction_id, successor_deposit_tx_id: null })

--- a/app/api/v1/investment-transactions/[id]/successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/successor/route.ts
@@ -38,7 +38,11 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     bookId = validateUUID(id, 'id')
     cleanAmount = validateAmount(amount_vnd, 'amount_vnd')
     if (cleanAmount <= 0) throw new ValidationError('amount_vnd must be positive')
-    if (interest_rate != null && interest_rate !== '') cleanRate = validateRate(interest_rate, 'interest_rate')
+    // The new book opens holding real money, so it needs the rate that money
+    // earns — and a rateless deposit is not a valid target for a recurring link.
+    if (interest_rate == null || interest_rate === '') throw new ValidationError('interest_rate is required')
+    cleanRate = validateRate(interest_rate, 'interest_rate')
+    if (!(cleanRate > 0)) throw new ValidationError('interest_rate must be positive')
     cleanDate = validateDate(investment_date, 'investment_date')
     cleanExpiry = validateDate(expiry_date, 'expiry_date')
     if (cleanExpiry <= cleanDate) throw new ValidationError('expiry_date must be after investment_date')

--- a/app/api/v1/investment-transactions/[id]/withdraw-book/route.ts
+++ b/app/api/v1/investment-transactions/[id]/withdraw-book/route.ts
@@ -62,6 +62,14 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     if (error.message?.includes('nothing to withdraw') || error.message?.includes('more than the book balance')) {
       return NextResponse.json({ error: 'Withdrawal exceeds the book balance.' }, { status: 400 })
     }
+    // A book promised to a successor is not closed behind the promise's back
+    // (#638). That is a decision to undo, not a fault — say which one.
+    if (error.message?.startsWith('successor book: ')) {
+      return NextResponse.json(
+        { error: error.message.slice('successor book: '.length), code: 'successor_planned' },
+        { status: 409 },
+      )
+    }
     console.error('withdraw_accumulating_book failed', error.message)
     return NextResponse.json({ error: 'Failed to withdraw book' }, { status: 500 })
   }

--- a/app/api/v1/investment-transactions/__tests__/route.get.ids.test.ts
+++ b/app/api/v1/investment-transactions/__tests__/route.get.ids.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// `ids` fetches a named set of transactions in one round trip (#638). Goal
+// detail uses it for the book anchors that fell outside its 200-row page: a
+// book's terms live on the anchor, and without them the page reads a tranche
+// that knows none of them. One request, not one per anchor.
+
+const ID_A = '11111111-1111-4111-8111-111111111111'
+const ID_B = '22222222-2222-4222-8222-222222222222'
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  inCalls: [] as { column: string; values: unknown }[],
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const q: Record<string, unknown> = {}
+  const chain = () => {
+    Object.assign(q, {
+      select: () => q, eq: () => q, is: () => q, gte: () => q, lte: () => q,
+      order: () => q, range: () => q,
+      in: (column: string, values: unknown) => { h.inCalls.push({ column, values }); return q },
+      then: (resolve: (v: unknown) => unknown) => resolve({ data: [], error: null, count: 0 }),
+    })
+    return q
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: () => chain(),
+    }),
+  }
+})
+
+const { GET } = await import('../route')
+
+const get = (query: string) =>
+  GET(new Request(`https://app.test/api/v1/investment-transactions?${query}`) as unknown as NextRequest)
+
+beforeEach(() => {
+  h.user = { id: 'user-1' }
+  h.inCalls = []
+})
+
+describe('GET /api/v1/investment-transactions — ids (#638)', () => {
+  it('filters to the requested set', async () => {
+    const res = await get(`ids=${ID_A},${ID_B}&include_history=true`)
+
+    expect(res.status).toBe(200)
+    expect(h.inCalls).toEqual([{ column: 'transaction_id', values: [ID_A, ID_B] }])
+  })
+
+  it('does not filter when ids is absent', async () => {
+    await get('goal_id=g1')
+
+    expect(h.inCalls).toHaveLength(0)
+  })
+
+  it('rejects a malformed id rather than filtering on garbage', async () => {
+    const res = await get('ids=not-a-uuid')
+
+    expect(res.status).toBe(400)
+    expect(h.inCalls).toHaveLength(0)
+  })
+
+  it('refuses an unbounded set', async () => {
+    const res = await get(`ids=${Array.from({ length: 101 }, () => ID_A).join(',')}`)
+
+    expect(res.status).toBe(400)
+    expect(h.inCalls).toHaveLength(0)
+  })
+})

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -44,7 +44,7 @@ export async function GET(request: NextRequest) {
 
   let query = supabase
     .from('investment_transactions')
-    .select('transaction_id, goal_id, asset_type, transaction_type, parent_transaction_id, renewed_from_transaction_id, deposit_group_id, interest_earned_vnd, investment_date, amount_vnd, unit_price, units, interest_rate, expiry_date, notes, fund_id, bank_code, currency, is_pledged, top_up_lock_days, principal_withdrawn, units_withdrawn, affects_progress, held_for_merge, consumed_by_inv_id, merge_anchor_inv_id, savings_goals(goal_name), funds(id, name, nav)', { count: 'exact' })
+    .select('transaction_id, goal_id, asset_type, transaction_type, parent_transaction_id, renewed_from_transaction_id, deposit_group_id, interest_earned_vnd, investment_date, amount_vnd, unit_price, units, interest_rate, expiry_date, notes, fund_id, bank_code, currency, is_pledged, top_up_lock_days, successor_deposit_tx_id, principal_withdrawn, units_withdrawn, affects_progress, held_for_merge, consumed_by_inv_id, merge_anchor_inv_id, savings_goals(goal_name), funds(id, name, nav)', { count: 'exact' })
     .eq('user_id', user.id)
     .order('investment_date', { ascending: false })
     .range(offset, offset + limit - 1)

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -31,7 +31,14 @@ export async function GET(request: NextRequest) {
   const includeHistory = searchParams.get('include_history') === 'true'
   let page: number
   let limit: number
+  let idFilter: string[] | null = null
   try {
+    const ids = searchParams.get('ids')
+    if (ids) {
+      const parts = ids.split(',').filter(Boolean)
+      if (parts.length > 100) throw new ValidationError('ids accepts at most 100 transaction ids')
+      idFilter = parts.map((v, i) => validateUUID(v, `ids[${i}]`))
+    }
     // Only finite positive integers; garbage (page=abc) is a 400, not a NaN
     // range call. limit is clamped to the documented ceiling of 1000.
     page = validatePositiveIntParam(searchParams.get('page'), 'page', { fallback: 1 })
@@ -58,6 +65,11 @@ export async function GET(request: NextRequest) {
   if (goal_id) query = query.eq('goal_id', goal_id)
   if (plan_id) query = query.eq('plan_id', plan_id)
   if (unassigned === 'true') query = query.is('goal_id', null)
+  // `ids` fetches a named set in one round trip. Goal detail uses it to pull the
+  // few book anchors that fell outside its page — a book's terms live on the
+  // anchor, and a page of tranches knows none of them (#638). Capped, because
+  // the point is one small request instead of one request per id.
+  if (idFilter) query = query.in('transaction_id', idFilter)
 
   const { data: transactions, error, count } = await query
 

--- a/app/api/v1/recurring-savings/linkValidation.ts
+++ b/app/api/v1/recurring-savings/linkValidation.ts
@@ -18,7 +18,7 @@ export async function validateLinkedDeposit(
 ): Promise<string | null> {
   const { data, error } = await supabase
     .from('investment_transactions')
-    .select('asset_type, interest_rate, expiry_date, goal_id, transaction_type, deposit_group_id')
+    .select('asset_type, interest_rate, expiry_date, goal_id, transaction_type, deposit_group_id, successor_deposit_tx_id')
     .eq('transaction_id', txId)
     .eq('user_id', userId)
     .single()
@@ -38,6 +38,12 @@ export async function validateLinkedDeposit(
   // surviving anchor). A non-anchor tranche is not a linkable target.
   if (data.deposit_group_id != null && data.deposit_group_id !== txId) {
     return 'Link an accumulating book via its anchor deposit.'
+  }
+  // A book that has handed over refuses every contribution from here on (#638),
+  // so a link pointing at it could never be funded — and the monthly plan would
+  // answer the Saved pill with "it already has a successor" and nothing else.
+  if (data.successor_deposit_tx_id) {
+    return 'That book has handed over to a successor — link the successor instead.'
   }
   if ((data.goal_id ?? null) !== (recurringGoalId ?? null)) {
     return 'Linked deposit must belong to the same goal as the recurring saving.'

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -117,6 +117,10 @@ export function MaturityResolveBody({
   const [maturityOverride, setMaturityOverride] = useState<string | null>(null)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
+  // A book promised to a successor cannot be collapsed (#638) — the merge into
+  // that successor is what its maturity is for. Until that merge exists, the way
+  // out has to be reachable from here, or the refusal is a dead end.
+  const [handoverBlocked, setHandoverBlocked] = useState(false)
   const [done, setDone] = useState<null | { newPrincipal: number; newMaturity: string; sources: string[] }>(null)
   // Settle-with-hold success: the deposit was parked in the pool (no re-deposit).
   const [heldDone, setHeldDone] = useState<null | { anchorName: string }>(null)
@@ -406,6 +410,7 @@ export function MaturityResolveBody({
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))
         setError(body.error ?? (isVi ? 'Không thể tái tục' : 'Could not renew'))
+        if (body.code === 'successor_planned') setHandoverBlocked(true)
         setSaving(false)
         return
       }
@@ -690,6 +695,20 @@ export function MaturityResolveBody({
       )}
 
       {error && <p style={{ margin: 0, fontSize: 13, color: 'var(--c-neg)' }}>{error}</p>}
+      {handoverBlocked && (
+        <button type="button" data-testid="cancel-handover-btn" disabled={saving}
+          onClick={async () => {
+            setSaving(true)
+            try {
+              const res = await fetch(`/api/v1/investment-transactions/${inv.id}/successor`, { method: 'DELETE' })
+              if (res.ok) { setHandoverBlocked(false); setError('') }
+              else setError(isVi ? 'Không huỷ được bàn giao' : 'Could not cancel the handover')
+            } catch { setError(isVi ? 'Lỗi kết nối' : 'Connection error') } finally { setSaving(false) }
+          }}
+          style={{ alignSelf: 'flex-start', padding: 0, border: 'none', background: 'none', color: 'var(--c-navy)', fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', textDecoration: 'underline' }}>
+          {isVi ? 'Huỷ bàn giao rồi thử lại' : 'Cancel the handover and try again'}
+        </button>
+      )}
 
       {/* Where the new cycle is deposited. Shown for every renewal — a matured
           deposit moving to another bank is the ordinary case, and it used to be

--- a/app/assets/components/SuccessorBookSheet.tsx
+++ b/app/assets/components/SuccessorBookSheet.tsx
@@ -1,0 +1,140 @@
+'use client'
+
+// The way out of a book the bank will not top up (#638): open the next one and
+// put this contribution there. Everything that identifies the money — goal,
+// bank, currency — comes from the old book, so the form only asks for what the
+// bank decides fresh for a new deposit: its maturity and its rate.
+//
+// The same sheet serves both entry points. Opened from a book's own top-up
+// control it just moves the contribution; opened from the monthly plan it also
+// carries the recurring saving, whose month is filed and whose link moves to the
+// new book in the same request.
+
+import { useEffect, useState, type CSSProperties } from 'react'
+import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
+import { fmtCompact } from '@/lib/formatters'
+
+export interface SuccessorTarget {
+  bookId: string
+  bookName: string
+  amount: number
+  date: string
+  rate: number | null
+  lockDays: number | null
+  /** Set when the contribution is a recurring saving's month, not a one-off. */
+  savingId?: string | null
+  ym?: string | null
+  planId?: string | null
+}
+
+const field: CSSProperties = {
+  width: '100%', boxSizing: 'border-box', padding: '10px 12px', fontSize: 15, fontWeight: 600,
+  background: 'var(--c-canvas,#faf9f7)', border: '1.5px solid var(--c-line)', borderRadius: 10,
+  color: 'var(--c-ink)', outline: 'none', fontVariantNumeric: 'tabular-nums',
+}
+const lbl: CSSProperties = { fontSize: 11, fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--c-muted)', marginBottom: 6, display: 'block' }
+
+export default function SuccessorBookSheet({
+  target, isVi, onClose, onDone,
+}: {
+  target: SuccessorTarget | null
+  isVi: boolean
+  onClose: () => void
+  onDone: () => void
+}) {
+  const [amount, setAmount] = useState('')
+  const [rate, setRate] = useState('')
+  const [date, setDate] = useState('')
+  const [expiry, setExpiry] = useState('')
+  const [lockDays, setLockDays] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState('')
+
+  // Re-seed whenever a new target opens. The rate is only a suggestion: a new
+  // book is a new deposit, so its rate is whatever the bank quotes today.
+  useEffect(() => {
+    if (!target) return
+    setAmount(String(target.amount))
+    setRate(target.rate != null ? String(Math.round(target.rate * 10) / 10) : '')
+    setDate(target.date)
+    setExpiry('')
+    setLockDays(target.lockDays != null ? String(target.lockDays) : '')
+    setError('')
+  }, [target])
+
+  if (!target) return null
+  const amt = Number(amount)
+  const datesOk = !!expiry && !!date && expiry > date
+
+  async function submit() {
+    if (!target) return
+    if (!(amt > 0)) { setError(isVi ? 'Cần nhập số tiền' : 'Amount is required'); return }
+    if (!expiry) { setError(isVi ? 'Cần nhập ngày đáo hạn của sổ mới' : "The new book's maturity is required"); return }
+    if (!datesOk) { setError(isVi ? 'Ngày đáo hạn phải sau ngày nạp' : 'Maturity must come after the contribution'); return }
+    setSaving(true); setError('')
+    try {
+      const res = await fetch(`/api/v1/investment-transactions/${target.bookId}/successor`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          amount_vnd: Math.round(amt),
+          interest_rate: rate ? Number(rate) : null,
+          investment_date: date,
+          expiry_date: expiry,
+          top_up_lock_days: lockDays === '' ? null : Number(lockDays),
+          saving_id: target.savingId ?? null,
+          ym: target.ym ?? null,
+          plan_id: target.planId ?? null,
+        }),
+      })
+      if (!res.ok) { const d = await res.json().catch(() => ({})); setError(d.error ?? (isVi ? 'Lỗi' : 'Error')); setSaving(false); return }
+      onDone(); onClose()
+    } catch { setError(isVi ? 'Lỗi kết nối' : 'Connection error') } finally { setSaving(false) }
+  }
+
+  return (
+    <div onClick={() => !saving && onClose()} style={{ position: 'fixed', inset: 0, zIndex: 330, background: 'rgba(15,23,42,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+      <div onClick={(e) => e.stopPropagation()} data-testid="successor-modal" style={{ width: 400, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, display: 'grid', gap: 12, boxShadow: '0 20px 50px rgba(15,23,42,0.25)' }}>
+        <div>
+          <div style={{ fontSize: 15, fontWeight: 700 }}>{isVi ? 'Mở sổ kế nhiệm' : 'Open successor book'}</div>
+          <p style={{ margin: '6px 0 0', fontSize: 12, lineHeight: 1.5, color: 'var(--c-muted)' }}>
+            {isVi
+              ? `${target.bookName} không nhận nạp thêm nữa. Khoản ${fmtCompact(target.amount)} này sẽ vào sổ mới, và sổ cũ được ghi nhận sẽ gộp vào đây khi đáo hạn.`
+              : `${target.bookName} takes no more top-ups. This ${fmtCompact(target.amount)} opens the new book, and the old one is recorded as merging into it at maturity.`}
+          </p>
+        </div>
+        <div>
+          <label style={lbl}>{isVi ? 'Số tiền nạp (₫)' : 'Contribution (₫)'}</label>
+          <input data-testid="successor-amount" type="text" inputMode="numeric" value={formatIntVN(amount)} onChange={(e) => setAmount(parseIntVN(e.target.value))} style={field} />
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <div>
+            <label style={lbl}>{isVi ? 'Ngày nạp' : 'Contribution date'}</label>
+            <input data-testid="successor-date" type="date" value={date} onChange={(e) => setDate(e.target.value)} style={field} />
+          </div>
+          <div>
+            <label style={lbl}>{isVi ? 'Đáo hạn sổ mới' : 'New maturity'}</label>
+            <input data-testid="successor-expiry" type="date" value={expiry} onChange={(e) => setExpiry(e.target.value)} style={field} />
+          </div>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+          <div>
+            <label style={lbl}>{isVi ? 'Lãi suất (%)' : 'Rate (%)'}</label>
+            <input data-testid="successor-rate" type="text" inputMode="decimal" value={formatDecimalVN(rate)} onChange={(e) => setRate(parseDecimalVN(e.target.value))} placeholder="4,2" style={field} />
+          </div>
+          <div>
+            <label style={lbl}>{isVi ? 'Khoá nạp (ngày)' : 'Lock window (days)'}</label>
+            <input data-testid="successor-lock" type="text" inputMode="numeric" value={lockDays} onChange={(e) => setLockDays(e.target.value.replace(/\D/g, ''))} placeholder="30" style={field} />
+          </div>
+        </div>
+        {error && <p data-testid="successor-error" style={{ margin: 0, fontSize: 13, color: 'var(--c-neg)' }}>{error}</p>}
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button type="button" onClick={onClose} style={{ flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)', background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit' }}>{isVi ? 'Huỷ' : 'Cancel'}</button>
+          <button type="button" data-testid="successor-submit" onClick={submit} disabled={saving || !(amt > 0) || !datesOk}
+            style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit', opacity: saving || !(amt > 0) || !datesOk ? 0.6 : 1 }}>
+            {isVi ? 'Mở sổ mới' : 'Open the new book'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/assets/components/SuccessorBookSheet.tsx
+++ b/app/assets/components/SuccessorBookSheet.tsx
@@ -65,19 +65,22 @@ export default function SuccessorBookSheet({
   if (!target) return null
   const amt = Number(amount)
   const datesOk = !!expiry && !!date && expiry > date
+  // The new book opens holding money, so it needs the rate that money earns.
+  const rateOk = Number(rate) > 0
 
   async function submit() {
     if (!target) return
     if (!(amt > 0)) { setError(isVi ? 'Cần nhập số tiền' : 'Amount is required'); return }
     if (!expiry) { setError(isVi ? 'Cần nhập ngày đáo hạn của sổ mới' : "The new book's maturity is required"); return }
     if (!datesOk) { setError(isVi ? 'Ngày đáo hạn phải sau ngày nạp' : 'Maturity must come after the contribution'); return }
+    if (!rateOk) { setError(isVi ? 'Cần nhập lãi suất' : 'Rate is required'); return }
     setSaving(true); setError('')
     try {
       const res = await fetch(`/api/v1/investment-transactions/${target.bookId}/successor`, {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           amount_vnd: Math.round(amt),
-          interest_rate: rate ? Number(rate) : null,
+          interest_rate: Number(rate),
           investment_date: date,
           expiry_date: expiry,
           top_up_lock_days: lockDays === '' ? null : Number(lockDays),
@@ -129,8 +132,8 @@ export default function SuccessorBookSheet({
         {error && <p data-testid="successor-error" style={{ margin: 0, fontSize: 13, color: 'var(--c-neg)' }}>{error}</p>}
         <div style={{ display: 'flex', gap: 8 }}>
           <button type="button" onClick={onClose} style={{ flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)', background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit' }}>{isVi ? 'Huỷ' : 'Cancel'}</button>
-          <button type="button" data-testid="successor-submit" onClick={submit} disabled={saving || !(amt > 0) || !datesOk}
-            style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit', opacity: saving || !(amt > 0) || !datesOk ? 0.6 : 1 }}>
+          <button type="button" data-testid="successor-submit" onClick={submit} disabled={saving || !(amt > 0) || !datesOk || !rateOk}
+            style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit', opacity: saving || !(amt > 0) || !datesOk || !rateOk ? 0.6 : 1 }}>
             {isVi ? 'Mở sổ mới' : 'Open the new book'}
           </button>
         </div>

--- a/app/assets/components/SuccessorBookSheet.tsx
+++ b/app/assets/components/SuccessorBookSheet.tsx
@@ -13,6 +13,7 @@
 import { useEffect, useState, type CSSProperties } from 'react'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 import { fmtCompact } from '@/lib/formatters'
+import { classifyAccumulatingTopUp } from '@/lib/accumulatingTopUp'
 
 export interface SuccessorTarget {
   bookId: string
@@ -21,6 +22,9 @@ export interface SuccessorTarget {
   date: string
   rate: number | null
   lockDays: number | null
+  /** The old book's maturity. The contribution date is editable here, and a date
+   *  the old book still accepts is a top-up, not a reason to replace it. */
+  sourceExpiry: string | null
   /** Set when the contribution is a recurring saving's month, not a one-off. */
   savingId?: string | null
   ym?: string | null
@@ -67,6 +71,12 @@ export default function SuccessorBookSheet({
   const datesOk = !!expiry && !!date && expiry > date
   // The new book opens holding money, so it needs the rate that money earns.
   const rateOk = Number(rate) > 0
+  // The date is editable, so the reason for opening a successor can evaporate
+  // while the sheet is open: on a date the old book still accepts, this is an
+  // ordinary top-up — and the server would refuse the handover anyway.
+  const sourceStillOpen = classifyAccumulatingTopUp({
+    topUpDate: date, expiryDate: target.sourceExpiry, lockDays: target.lockDays,
+  }).status === 'allowed'
 
   async function submit() {
     if (!target) return
@@ -89,6 +99,28 @@ export default function SuccessorBookSheet({
           plan_id: target.planId ?? null,
         }),
       })
+      if (!res.ok) { const d = await res.json().catch(() => ({})); setError(d.error ?? (isVi ? 'Lỗi' : 'Error')); setSaving(false); return }
+      onDone(); onClose()
+    } catch { setError(isVi ? 'Lỗi kết nối' : 'Connection error') } finally { setSaving(false) }
+  }
+
+  // Record it where it actually belongs: the recurring endpoint when the month
+  // came from the plan (it files the fulfillment too), the ordinary top-up
+  // otherwise.
+  async function topUpInstead() {
+    if (!target) return
+    if (!(amt > 0)) { setError(isVi ? 'Cần nhập số tiền' : 'Amount is required'); return }
+    setSaving(true); setError('')
+    try {
+      const res = target.savingId
+        ? await fetch(`/api/v1/recurring-savings/${target.savingId}/topup`, {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ book_id: target.bookId, amount_vnd: Math.round(amt), interest_rate: Number(rate), investment_date: date, ym: target.ym, plan_id: target.planId ?? null }),
+          })
+        : await fetch('/api/v1/investment-transactions', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ tops_up_deposit_id: target.bookId, asset_type: 'bank', investment_date: date, amount_vnd: Math.round(amt), interest_rate: rate ? Number(rate) : null }),
+          })
       if (!res.ok) { const d = await res.json().catch(() => ({})); setError(d.error ?? (isVi ? 'Lỗi' : 'Error')); setSaving(false); return }
       onDone(); onClose()
     } catch { setError(isVi ? 'Lỗi kết nối' : 'Connection error') } finally { setSaving(false) }
@@ -129,11 +161,22 @@ export default function SuccessorBookSheet({
             <input data-testid="successor-lock" type="text" inputMode="numeric" value={lockDays} onChange={(e) => setLockDays(e.target.value.replace(/\D/g, ''))} placeholder="30" style={field} />
           </div>
         </div>
+        {sourceStillOpen && (
+          <div data-testid="successor-not-needed" style={{ margin: 0, padding: '9px 10px', borderRadius: 10, background: 'var(--c-warn-tint)', color: 'var(--c-warn)', fontSize: 12, lineHeight: 1.45 }}>
+            {isVi
+              ? `${target.bookName} vẫn nhận nạp vào ngày này, nên đây là một lần nạp thêm chứ chưa cần sổ mới.`
+              : `${target.bookName} still accepts a contribution on that date, so this is a top-up rather than a new book.`}
+            <button type="button" data-testid="record-topup-instead" disabled={saving} onClick={topUpInstead}
+              style={{ display: 'block', marginTop: 6, padding: 0, border: 'none', background: 'none', color: 'inherit', fontSize: 12, fontWeight: 700, cursor: 'pointer', fontFamily: 'inherit', textDecoration: 'underline' }}>
+              {isVi ? 'Ghi thành nạp thêm vào sổ cũ' : 'Record it as a top-up instead'}
+            </button>
+          </div>
+        )}
         {error && <p data-testid="successor-error" style={{ margin: 0, fontSize: 13, color: 'var(--c-neg)' }}>{error}</p>}
         <div style={{ display: 'flex', gap: 8 }}>
           <button type="button" onClick={onClose} style={{ flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)', background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit' }}>{isVi ? 'Huỷ' : 'Cancel'}</button>
-          <button type="button" data-testid="successor-submit" onClick={submit} disabled={saving || !(amt > 0) || !datesOk || !rateOk}
-            style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit', opacity: saving || !(amt > 0) || !datesOk || !rateOk ? 0.6 : 1 }}>
+          <button type="button" data-testid="successor-submit" onClick={submit} disabled={saving || !(amt > 0) || !datesOk || !rateOk || sourceStillOpen}
+            style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit', opacity: saving || !(amt > 0) || !datesOk || !rateOk || sourceStillOpen ? 0.6 : 1 }}>
             {isVi ? 'Mở sổ mới' : 'Open the new book'}
           </button>
         </div>

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -851,4 +851,36 @@ describe('MaturityResolveBody', () => {
     await waitFor(() => expect(onWithdraw).toHaveBeenCalled())
     expect(writeCalls(fetchMock)).toHaveLength(0)
   })
+
+  // A book promised to a successor cannot be collapsed: the merge into that
+  // successor is what its maturity is for (#638). Until that merge exists, the
+  // refusal has to carry its own way out, or it is a dead end.
+  it('offers to cancel the handover when the collapse is refused for one', async () => {
+    const user = userEvent.setup()
+    const calls: { url: string; method?: string }[] = []
+    global.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url)
+      calls.push({ url: u, method: init?.method })
+      if (init?.method === 'POST') {
+        return {
+          ok: false,
+          json: async () => ({ error: 'this book is promised to a successor, so cancel the handover before closing it', code: 'successor_planned' }),
+        } as Response
+      }
+      if (init?.method === 'DELETE') return { ok: true, json: async () => ({}) } as Response
+      return { ok: true, json: async () => ({ banks: [] }) } as Response
+    }) as unknown as typeof fetch
+
+    const book: InvRow = { ...maturedDeposit, depositGroupId: 'tx-bank-1', successorDepositTxId: 'book-2' }
+    render(
+      <MaturityResolveBody inv={book} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+
+    await user.click(screen.getByRole('button', { name: /Xác nhận tái tục|Confirm renewal/i }))
+    await waitFor(() => expect(screen.getByTestId('cancel-handover-btn')).toBeInTheDocument())
+
+    fireEvent.click(screen.getByTestId('cancel-handover-btn'))
+    await waitFor(() => expect(screen.queryByTestId('cancel-handover-btn')).not.toBeInTheDocument())
+    expect(calls.some(c => c.method === 'DELETE' && c.url.endsWith('/tx-bank-1/successor'))).toBe(true)
+  })
 })

--- a/app/assets/components/__tests__/TopUpControl.test.tsx
+++ b/app/assets/components/__tests__/TopUpControl.test.tsx
@@ -1,5 +1,5 @@
-import { describe, expect, it } from 'vitest'
-import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { TopUpControl, type InvRow } from '../goalDetailShared'
 import { addDaysIso, todayIso } from '@/lib/dates'
 
@@ -59,6 +59,30 @@ describe('TopUpControl', () => {
 
     expect(screen.getByTestId('top-up-submit')).toBeInTheDocument()
     expect(screen.queryByTestId('open-successor-btn')).not.toBeInTheDocument()
+  })
+
+  // The date is editable inside the successor sheet, so the reason for opening
+  // one can evaporate while it is open (#638).
+  it('offers a plain top-up when the date moves back to one the old book accepts', async () => {
+    const calls: string[] = []
+    global.fetch = vi.fn(async (url: string | URL | Request) => {
+      calls.push(String(url))
+      return { ok: true, json: async () => ({}) } as Response
+    }) as unknown as typeof fetch
+
+    render(<TopUpControl inv={lockedBook} isVi={false} onDone={() => {}} />)
+    await screen.getByTestId('top-up-btn').click()
+    fireEvent.change(screen.getByTestId('top-up-amount'), { target: { value: '2000000' } })
+    fireEvent.click(screen.getByTestId('open-successor-btn'))
+
+    // Inside the sheet, back to a date the book still takes.
+    fireEvent.change(screen.getByTestId('successor-date'), { target: { value: addDaysIso(todayIso(), -25) } })
+    expect(screen.getByTestId('successor-not-needed')).toBeInTheDocument()
+    expect(screen.getByTestId('successor-submit')).toBeDisabled()
+
+    fireEvent.click(screen.getByTestId('record-topup-instead'))
+    await waitFor(() => expect(calls).toHaveLength(1))
+    expect(calls[0]).toBe('/api/v1/investment-transactions')
   })
 
   it('a book that already handed over says so instead of taking more money', () => {

--- a/app/assets/components/__tests__/TopUpControl.test.tsx
+++ b/app/assets/components/__tests__/TopUpControl.test.tsx
@@ -23,4 +23,48 @@ describe('TopUpControl', () => {
     expect(screen.queryByTestId('top-up-locked')).not.toBeInTheDocument()
     expect(screen.getByTestId('top-up-submit')).toBeDisabled() // still needs an amount
   })
+
+  // #638 Phase 2: a book the bank has closed to top-ups is not a dead end.
+  it('offers the successor book while the entered date is inside the lock window', async () => {
+    const { container } = render(<TopUpControl inv={lockedBook} isVi={false} onDone={() => {}} />)
+
+    await screen.getByTestId('top-up-btn').click()
+    fireEvent.change(screen.getByTestId('top-up-amount'), { target: { value: '2000000' } })
+
+    // Locked today: the way forward is the next book, not a refused top-up.
+    expect(screen.queryByTestId('top-up-submit')).not.toBeInTheDocument()
+    fireEvent.click(screen.getByTestId('open-successor-btn'))
+
+    const sheet = screen.getByTestId('successor-modal')
+    expect(sheet).toBeInTheDocument()
+    // The contribution the user already typed carries over, and the old book's
+    // policy is the new book's default.
+    expect((screen.getByTestId('successor-amount') as HTMLInputElement).value).toBe('2.000.000')
+    expect((screen.getByTestId('successor-lock') as HTMLInputElement).value).toBe('30')
+    // The maturity is the bank's to quote, so it starts empty and gates submit.
+    expect((screen.getByTestId('successor-expiry') as HTMLInputElement).value).toBe('')
+    expect(screen.getByTestId('successor-submit')).toBeDisabled()
+
+    const dates = container.querySelectorAll('[data-testid="successor-expiry"]')
+    fireEvent.change(dates[0], { target: { value: addDaysIso(todayIso(), 365) } })
+    expect(screen.getByTestId('successor-submit')).toBeEnabled()
+  })
+
+  it('back to a date the book still accepts, the top-up itself returns', async () => {
+    const { container } = render(<TopUpControl inv={lockedBook} isVi={false} onDone={() => {}} />)
+
+    await screen.getByTestId('top-up-btn').click()
+    const date = container.querySelector('input[type="date"]') as HTMLInputElement
+    fireEvent.change(date, { target: { value: addDaysIso(todayIso(), -25) } })
+
+    expect(screen.getByTestId('top-up-submit')).toBeInTheDocument()
+    expect(screen.queryByTestId('open-successor-btn')).not.toBeInTheDocument()
+  })
+
+  it('a book that already handed over says so instead of taking more money', () => {
+    render(<TopUpControl inv={{ ...lockedBook, successorDepositTxId: 'book-2' }} isVi={false} onDone={() => {}} />)
+
+    expect(screen.getByTestId('successor-planned')).toBeInTheDocument()
+    expect(screen.queryByTestId('top-up-btn')).not.toBeInTheDocument()
+  })
 })

--- a/app/assets/components/__tests__/useGoalDetailData.test.tsx
+++ b/app/assets/components/__tests__/useGoalDetailData.test.tsx
@@ -38,8 +38,8 @@ describe('useGoalDetailData (#467)', () => {
     const urls: string[] = []
     mockFetch((url) => {
       urls.push(url)
-      if (url.includes('/investment-transactions/anchor-1')) {
-        return { ok: true, body: { transaction_id: 'anchor-1', deposit_group_id: 'anchor-1', investment_date: '2025-01-01', successor_deposit_tx_id: 'book-2' } }
+      if (url.includes('ids=anchor-1')) {
+        return { ok: true, body: { transactions: [{ transaction_id: 'anchor-1', deposit_group_id: 'anchor-1', investment_date: '2025-01-01', successor_deposit_tx_id: 'book-2' }] } }
       }
       if (url.includes('/investment-transactions?')) {
         return { ok: true, body: { transactions: [{ transaction_id: 't9', deposit_group_id: 'anchor-1', investment_date: '2026-05-01' }] } }
@@ -53,6 +53,8 @@ describe('useGoalDetailData (#467)', () => {
 
     const anchor = result.current.transactions.find(t => t.transaction_id === 'anchor-1')
     expect(anchor?.successor_deposit_tx_id).toBe('book-2')
+    // One request for the whole set, not one per anchor.
+    expect(urls.filter(u => u.includes('ids=')).length).toBe(1)
   })
 
   it('does not ask for anchors the page already has', async () => {
@@ -72,7 +74,7 @@ describe('useGoalDetailData (#467)', () => {
     const { result } = renderHook(() => useGoalDetailData({ goalId: 'g1', enabled: true, refreshKey: 0, txReload: 0 }))
     await waitFor(() => expect(result.current.txLoading).toBe(false))
 
-    expect(urls.some(u => /investment-transactions\/[^?]/.test(u))).toBe(false)
+    expect(urls.some(u => u.includes('ids='))).toBe(false)
   })
 
   it('does not fetch while disabled', async () => {

--- a/app/assets/components/__tests__/useGoalDetailData.test.tsx
+++ b/app/assets/components/__tests__/useGoalDetailData.test.tsx
@@ -31,6 +31,50 @@ describe('useGoalDetailData (#467)', () => {
     expect(result.current.txError).toBe(false)
   })
 
+  // A book's terms live on its anchor, and the page only holds the newest 200
+  // rows — so an old book with recent tranches would otherwise be read off a
+  // tranche and appear to still take top-ups after it handed over (#638).
+  it('fetches a book anchor that fell outside the page', async () => {
+    const urls: string[] = []
+    mockFetch((url) => {
+      urls.push(url)
+      if (url.includes('/investment-transactions/anchor-1')) {
+        return { ok: true, body: { transaction_id: 'anchor-1', deposit_group_id: 'anchor-1', investment_date: '2025-01-01', successor_deposit_tx_id: 'book-2' } }
+      }
+      if (url.includes('/investment-transactions?')) {
+        return { ok: true, body: { transactions: [{ transaction_id: 't9', deposit_group_id: 'anchor-1', investment_date: '2026-05-01' }] } }
+      }
+      if (url.includes('/recurring-contributions')) return { ok: true, body: { contributions: [] } }
+      return { ok: true, body: {} }
+    })
+
+    const { result } = renderHook(() => useGoalDetailData({ goalId: 'g1', enabled: true, refreshKey: 0, txReload: 0 }))
+    await waitFor(() => expect(result.current.transactions).toHaveLength(2))
+
+    const anchor = result.current.transactions.find(t => t.transaction_id === 'anchor-1')
+    expect(anchor?.successor_deposit_tx_id).toBe('book-2')
+  })
+
+  it('does not ask for anchors the page already has', async () => {
+    const urls: string[] = []
+    mockFetch((url) => {
+      urls.push(url)
+      if (url.includes('/investment-transactions?')) {
+        return { ok: true, body: { transactions: [
+          { transaction_id: 'anchor-1', deposit_group_id: 'anchor-1', investment_date: '2026-01-01' },
+          { transaction_id: 't9', deposit_group_id: 'anchor-1', investment_date: '2026-05-01' },
+        ] } }
+      }
+      if (url.includes('/recurring-contributions')) return { ok: true, body: { contributions: [] } }
+      return { ok: true, body: {} }
+    })
+
+    const { result } = renderHook(() => useGoalDetailData({ goalId: 'g1', enabled: true, refreshKey: 0, txReload: 0 }))
+    await waitFor(() => expect(result.current.txLoading).toBe(false))
+
+    expect(urls.some(u => /investment-transactions\/[^?]/.test(u))).toBe(false)
+  })
+
   it('does not fetch while disabled', async () => {
     const fetchSpy = vi.fn()
     global.fetch = fetchSpy as unknown as typeof fetch

--- a/app/assets/components/__tests__/useGoalDetailData.test.tsx
+++ b/app/assets/components/__tests__/useGoalDetailData.test.tsx
@@ -57,6 +57,30 @@ describe('useGoalDetailData (#467)', () => {
     expect(urls.filter(u => u.includes('ids=')).length).toBe(1)
   })
 
+  it('asks for every missing anchor, in batches', async () => {
+    const urls: string[] = []
+    const anchorIds = Array.from({ length: 150 }, (_, i) => `anchor-${i}`)
+    mockFetch((url) => {
+      urls.push(url)
+      if (url.includes('ids=')) {
+        const ids = new URL(url, 'https://app.test').searchParams.get('ids')!.split(',')
+        return { ok: true, body: { transactions: ids.map(id => ({ transaction_id: id, deposit_group_id: id, investment_date: '2025-01-01' })) } }
+      }
+      if (url.includes('/investment-transactions?')) {
+        return { ok: true, body: { transactions: anchorIds.map((id, i) => ({ transaction_id: `t${i}`, deposit_group_id: id, investment_date: '2026-05-01' })) } }
+      }
+      if (url.includes('/recurring-contributions')) return { ok: true, body: { contributions: [] } }
+      return { ok: true, body: {} }
+    })
+
+    const { result } = renderHook(() => useGoalDetailData({ goalId: 'g1', enabled: true, refreshKey: 0, txReload: 0 }))
+    await waitFor(() => expect(result.current.transactions).toHaveLength(300))
+
+    // 150 anchors over a 100-id cap: two requests, none of them dropped.
+    expect(urls.filter(u => u.includes('ids=')).length).toBe(2)
+    expect(result.current.transactions.filter(t => t.transaction_id.startsWith('anchor-'))).toHaveLength(150)
+  })
+
   it('does not ask for anchors the page already has', async () => {
     const urls: string[] = []
     mockFetch((url) => {

--- a/app/assets/components/__tests__/useGoalDetailData.test.tsx
+++ b/app/assets/components/__tests__/useGoalDetailData.test.tsx
@@ -81,6 +81,21 @@ describe('useGoalDetailData (#467)', () => {
     expect(result.current.transactions.filter(t => t.transaction_id.startsWith('anchor-'))).toHaveLength(150)
   })
 
+  it('fails the load when an anchor batch fails, rather than rendering a book without its terms', async () => {
+    mockFetch((url) => {
+      if (url.includes('ids=')) return { ok: false }
+      if (url.includes('/investment-transactions?')) {
+        return { ok: true, body: { transactions: [{ transaction_id: 't9', deposit_group_id: 'anchor-1', investment_date: '2026-05-01' }] } }
+      }
+      if (url.includes('/recurring-contributions')) return { ok: true, body: { contributions: [] } }
+      return { ok: true, body: {} }
+    })
+
+    const { result } = renderHook(() => useGoalDetailData({ goalId: 'g1', enabled: true, refreshKey: 0, txReload: 0 }))
+    await waitFor(() => expect(result.current.txError).toBe(true))
+    expect(result.current.transactions).toEqual([])
+  })
+
   it('does not ask for anchors the page already has', async () => {
     const urls: string[] = []
     mockFetch((url) => {

--- a/app/assets/components/goalDetailRows.ts
+++ b/app/assets/components/goalDetailRows.ts
@@ -171,6 +171,7 @@ export function buildInvRows(
       currency: anchor.currency ?? null,
       isPledged: anchor.is_pledged ?? false,
       topUpLockDays: anchor.top_up_lock_days ?? null,
+      successorDepositTxId: anchor.successor_deposit_tx_id ?? null,
       tranches,
     }
   }).filter((row): row is InvRow => row !== null)

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -325,10 +325,24 @@ export function TopUpControl({ inv, isVi, onDone }: { inv: InvRow; isVi: boolean
   // A book that has handed over is done taking money: its contributions go to
   // the successor now, and what is left here is folded in at maturity (#638).
   if (inv.successorDepositTxId) {
+    // The database will not close a promised book — losing the plan at maturity
+    // is the failure the link exists to prevent — so the promise has to be
+    // withdrawable on purpose, or the deposit could never be closed at all.
     return (
-      <p data-testid="successor-planned" style={{ margin: '0 0 4px', padding: '9px 10px', borderRadius: 10, background: 'var(--c-canvas,#faf9f7)', border: '1px solid var(--c-line)', color: 'var(--c-muted)', fontSize: 12, lineHeight: 1.45 }}>
+      <div data-testid="successor-planned" style={{ margin: '0 0 4px', padding: '9px 10px', borderRadius: 10, background: 'var(--c-canvas,#faf9f7)', border: '1px solid var(--c-line)', color: 'var(--c-muted)', fontSize: 12, lineHeight: 1.45 }}>
         {isVi ? 'Sẽ gộp vào sổ kế nhiệm khi đáo hạn.' : 'Will merge into its successor book at maturity.'}
-      </p>
+        <button type="button" data-testid="cancel-successor-btn" disabled={saving}
+          onClick={async () => {
+            setSaving(true)
+            try {
+              const res = await fetch(`/api/v1/investment-transactions/${inv.id}/successor`, { method: 'DELETE' })
+              if (res.ok) onDone()
+            } finally { setSaving(false) }
+          }}
+          style={{ display: 'block', marginTop: 6, padding: 0, border: 'none', background: 'none', color: 'var(--c-navy)', fontSize: 12, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', textDecoration: 'underline' }}>
+          {isVi ? 'Huỷ bàn giao' : 'Cancel the handover'}
+        </button>
+      </div>
     )
   }
 

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -405,7 +405,7 @@ export function TopUpControl({ inv, isVi, onDone }: { inv: InvRow; isVi: boolean
                   straight into it (#638). */}
               {eligibility.status !== 'allowed' ? (
                 <button type="button" data-testid="open-successor-btn" disabled={!(amt > 0)}
-                  onClick={() => setSuccessor({ bookId: inv.id, bookName: inv.name, amount: Math.round(amt), date, rate: inv.interestRate ?? null, lockDays: inv.topUpLockDays ?? null })}
+                  onClick={() => setSuccessor({ bookId: inv.id, bookName: inv.name, amount: Math.round(amt), date, rate: inv.interestRate ?? null, lockDays: inv.topUpLockDays ?? null, sourceExpiry: inv.expiryDate ?? null })}
                   style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', opacity: amt > 0 ? 1 : 0.6 }}>
                   {isVi ? 'Mở sổ kế nhiệm' : 'Open successor book'}
                 </button>

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -8,6 +8,7 @@ import { TrendingUp, Building, Coins, BarChart2, Target, RefreshCw, Plus } from 
 import { fmtCompact } from '@/lib/formatters'
 import { todayIso } from '@/lib/dates'
 import { classifyAccumulatingTopUp } from '@/lib/accumulatingTopUp'
+import SuccessorBookSheet, { type SuccessorTarget } from './SuccessorBookSheet'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 import { fmtTxDate } from './transactionUtils'
 import { fmtMaturity, type Maturity } from './goalDetailMaturity'
@@ -227,6 +228,8 @@ export interface GoalDetailTx {
   currency?: string | null
   is_pledged?: boolean | null
   top_up_lock_days?: number | null
+  // The book this one is planned to be folded into at maturity (#638).
+  successor_deposit_tx_id?: string | null
   // Set on the rows the recurring-contributions endpoint synthesizes for a
   // goal's recurring savings. They have no investment_transactions row behind
   // them — `transaction_id` is a `recurring:<savingId>:<date>` label, not an id
@@ -316,7 +319,18 @@ export function TopUpControl({ inv, isVi, onDone }: { inv: InvRow; isVi: boolean
   const [date, setDate] = useState(() => todayIso())
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState('')
+  const [successor, setSuccessor] = useState<SuccessorTarget | null>(null)
   if (!inv.depositGroupId) return null
+
+  // A book that has handed over is done taking money: its contributions go to
+  // the successor now, and what is left here is folded in at maturity (#638).
+  if (inv.successorDepositTxId) {
+    return (
+      <p data-testid="successor-planned" style={{ margin: '0 0 4px', padding: '9px 10px', borderRadius: 10, background: 'var(--c-canvas,#faf9f7)', border: '1px solid var(--c-line)', color: 'var(--c-muted)', fontSize: 12, lineHeight: 1.45 }}>
+        {isVi ? 'Sẽ gộp vào sổ kế nhiệm khi đáo hạn.' : 'Will merge into its successor book at maturity.'}
+      </p>
+    )
+  }
 
   // Eligibility follows the date the user is recording, not today's date: a
   // legitimate historical top-up can predate the book's lock window.
@@ -372,11 +386,23 @@ export function TopUpControl({ inv, isVi, onDone }: { inv: InvRow; isVi: boolean
             {error && <p style={{ margin: 0, fontSize: 13, color: 'var(--c-neg)' }}>{error}</p>}
             <div style={{ display: 'flex', gap: 8 }}>
               <button type="button" onClick={() => setOpen(false)} style={{ flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)', background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit' }}>{isVi ? 'Huỷ' : 'Cancel'}</button>
+              {/* A book the bank has closed to top-ups has one way forward: the
+                  next book. The amount and date the user already typed carry
+                  straight into it (#638). */}
+              {eligibility.status !== 'allowed' ? (
+                <button type="button" data-testid="open-successor-btn" disabled={!(amt > 0)}
+                  onClick={() => setSuccessor({ bookId: inv.id, bookName: inv.name, amount: Math.round(amt), date, rate: inv.interestRate ?? null, lockDays: inv.topUpLockDays ?? null })}
+                  style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', opacity: amt > 0 ? 1 : 0.6 }}>
+                  {isVi ? 'Mở sổ kế nhiệm' : 'Open successor book'}
+                </button>
+              ) : (
               <button type="button" data-testid="top-up-submit" onClick={submit} disabled={saving || !(amt > 0) || eligibility.status !== 'allowed'} style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit', opacity: saving || !(amt > 0) || eligibility.status !== 'allowed' ? 0.6 : 1 }}>{isVi ? 'Nạp thêm' : 'Top up'}</button>
+              )}
             </div>
           </div>
         </div>
       )}
+      <SuccessorBookSheet target={successor} isVi={isVi} onClose={() => setSuccessor(null)} onDone={() => { setOpen(false); setAmount(''); onDone() }} />
     </>
   )
 }

--- a/app/assets/components/useGoalDetailData.ts
+++ b/app/assets/components/useGoalDetailData.ts
@@ -108,11 +108,14 @@ export function useGoalDetailData(opts: {
         const CHUNK = 100
         const chunks: string[][] = []
         for (let i = 0; i < missingAnchors.length; i += CHUNK) chunks.push(missingAnchors.slice(i, i + CHUNK))
+        // A failed anchor batch fails the load. These are not supplementary like
+        // the recurring contributions: without an anchor a book renders off a
+        // tranche, which does not know the book has handed over — so it would
+        // offer actions the database then refuses. A retry beats a wrong page.
         const anchors: InvestmentTx[] = (await Promise.all(chunks.map((chunk) =>
           fetch(`/api/v1/investment-transactions?ids=${chunk.join(',')}&include_history=true&limit=${CHUNK}`, { cache: 'no-store' })
-            .then((r) => r.ok ? r.json() : null)
-            .then((res) => (res?.transactions ?? []) as InvestmentTx[])
-            .catch(() => [] as InvestmentTx[]),
+            .then((r) => { if (!r.ok) throw new Error('anchor load failed'); return r.json() })
+            .then((res) => (res?.transactions ?? []) as InvestmentTx[]),
         ))).flat()
 
         const merged: InvestmentTx[] = [...rows, ...anchors, ...(recRes.contributions ?? [])]

--- a/app/assets/components/useGoalDetailData.ts
+++ b/app/assets/components/useGoalDetailData.ts
@@ -102,11 +102,15 @@ export function useGoalDetailData(opts: {
         const missingAnchors = [...new Set(
           rows.map((r) => r.deposit_group_id).filter((id): id is string => !!id && !present.has(id)),
         )]
-        const anchors = missingAnchors.length === 0 ? [] : (await Promise.all(
-          missingAnchors.map((id) => fetch(`/api/v1/investment-transactions/${id}`, { cache: 'no-store' })
-            .then((r) => r.ok ? r.json() : null)
-            .catch(() => null)),
-        )).filter((a): a is InvestmentTx => !!a?.transaction_id)
+        // One request for all of them: a goal with many older books would
+        // otherwise open one connection per anchor before the page could render.
+        const anchors: InvestmentTx[] = missingAnchors.length === 0 ? [] : await fetch(
+          `/api/v1/investment-transactions?ids=${missingAnchors.slice(0, 100).join(',')}&include_history=true&limit=100`,
+          { cache: 'no-store' },
+        )
+          .then((r) => r.ok ? r.json() : null)
+          .then((res) => res?.transactions ?? [])
+          .catch(() => [])
 
         const merged: InvestmentTx[] = [...rows, ...anchors, ...(recRes.contributions ?? [])]
         merged.sort((a, b) => (a.investment_date < b.investment_date ? 1 : a.investment_date > b.investment_date ? -1 : 0))

--- a/app/assets/components/useGoalDetailData.ts
+++ b/app/assets/components/useGoalDetailData.ts
@@ -27,6 +27,9 @@ export interface InvestmentTx {
   consumed_by_inv_id?: string | null
   top_up_lock_days?: number | null
   successor_deposit_tx_id?: string | null
+  // Set on every row of an accumulating book; equals transaction_id on the
+  // anchor, which is the row that carries the book's terms.
+  deposit_group_id?: string | null
 }
 
 export interface UseGoalDetailData {
@@ -88,8 +91,24 @@ export function useGoalDetailData(opts: {
         .then((r) => r.ok ? r.json() : { contributions: [] })
         .catch(() => ({ contributions: [] })),
     ])
-      .then(([txRes, recRes]) => {
-        const merged: InvestmentTx[] = [...(txRes.transactions ?? []), ...(recRes.contributions ?? [])]
+      .then(async ([txRes, recRes]) => {
+        const rows: InvestmentTx[] = txRes.transactions ?? []
+        // A book's terms — maturity, bank, lock window, whether it has handed
+        // over to a successor — live on its ANCHOR, and this page holds only the
+        // newest 200 rows. An old book with recent tranches would otherwise be
+        // read off a tranche, which knows none of that, and would look like it
+        // still takes top-ups (#638). Ask for the few anchors that fell out.
+        const present = new Set(rows.map((r) => r.transaction_id))
+        const missingAnchors = [...new Set(
+          rows.map((r) => r.deposit_group_id).filter((id): id is string => !!id && !present.has(id)),
+        )]
+        const anchors = missingAnchors.length === 0 ? [] : (await Promise.all(
+          missingAnchors.map((id) => fetch(`/api/v1/investment-transactions/${id}`, { cache: 'no-store' })
+            .then((r) => r.ok ? r.json() : null)
+            .catch(() => null)),
+        )).filter((a): a is InvestmentTx => !!a?.transaction_id)
+
+        const merged: InvestmentTx[] = [...rows, ...anchors, ...(recRes.contributions ?? [])]
         merged.sort((a, b) => (a.investment_date < b.investment_date ? 1 : a.investment_date > b.investment_date ? -1 : 0))
         setTransactions(merged)
       })

--- a/app/assets/components/useGoalDetailData.ts
+++ b/app/assets/components/useGoalDetailData.ts
@@ -26,6 +26,7 @@ export interface InvestmentTx {
   held_for_merge?: boolean | null
   consumed_by_inv_id?: string | null
   top_up_lock_days?: number | null
+  successor_deposit_tx_id?: string | null
 }
 
 export interface UseGoalDetailData {

--- a/app/assets/components/useGoalDetailData.ts
+++ b/app/assets/components/useGoalDetailData.ts
@@ -102,15 +102,18 @@ export function useGoalDetailData(opts: {
         const missingAnchors = [...new Set(
           rows.map((r) => r.deposit_group_id).filter((id): id is string => !!id && !present.has(id)),
         )]
-        // One request for all of them: a goal with many older books would
-        // otherwise open one connection per anchor before the page could render.
-        const anchors: InvestmentTx[] = missingAnchors.length === 0 ? [] : await fetch(
-          `/api/v1/investment-transactions?ids=${missingAnchors.slice(0, 100).join(',')}&include_history=true&limit=100`,
-          { cache: 'no-store' },
-        )
-          .then((r) => r.ok ? r.json() : null)
-          .then((res) => res?.transactions ?? [])
-          .catch(() => [])
+        // Batched, because a goal holding many older books would otherwise open
+        // one connection per anchor before the page could render — and chunked
+        // rather than capped, so no book is quietly left reading a tranche.
+        const CHUNK = 100
+        const chunks: string[][] = []
+        for (let i = 0; i < missingAnchors.length; i += CHUNK) chunks.push(missingAnchors.slice(i, i + CHUNK))
+        const anchors: InvestmentTx[] = (await Promise.all(chunks.map((chunk) =>
+          fetch(`/api/v1/investment-transactions?ids=${chunk.join(',')}&include_history=true&limit=${CHUNK}`, { cache: 'no-store' })
+            .then((r) => r.ok ? r.json() : null)
+            .then((res) => (res?.transactions ?? []) as InvestmentTx[])
+            .catch(() => [] as InvestmentTx[]),
+        ))).flat()
 
         const merged: InvestmentTx[] = [...rows, ...anchors, ...(recRes.contributions ?? [])]
         merged.sort((a, b) => (a.investment_date < b.investment_date ? 1 : a.investment_date > b.investment_date ? -1 : 0))

--- a/features/dashboard/contracts.ts
+++ b/features/dashboard/contracts.ts
@@ -134,6 +134,9 @@ export interface InvRow {
   isPledged?: boolean | null
   /** Optional inclusive pre-maturity lock window for adding a new book tranche. */
   topUpLockDays?: number | null
+  // The book this one is planned to be folded into at maturity, once it stopped
+  // accepting top-ups and its contributions moved on (#638).
+  successorDepositTxId?: string | null
   // The book's tranches (top-ups), newest first, for the detail view. Each is one
   // underlying row; present only on an accumulating book row.
   tranches?: InvTranche[] | null

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -142,12 +142,18 @@ begin
   -- merge INTO it is a contribution: if B is promised to C, then A's promised
   -- merge into B can never be carried out. One promise at a time, in both
   -- directions — settle the incoming one first (Phase 3), or cancel it.
-  if v_source.successor_deposit_tx_id is not null and exists (
+  -- Both directions, and on every pairing change rather than only on a fresh
+  -- link: repointing an existing promise skips the new-link guards entirely.
+  if exists (
     select 1 from public.investment_transactions
      where successor_deposit_tx_id = v_source.transaction_id
        and user_id = v_source.user_id
   ) then
     raise exception 'successor book: this book is itself promised a merge, so settle that before handing over again'
+      using errcode = 'check_violation';
+  end if;
+  if v_successor.successor_deposit_tx_id is not null then
+    raise exception 'successor book: that book has already handed over, so it cannot receive this one'
       using errcode = 'check_violation';
   end if;
   -- The merge happens when the SOURCE matures, so both books need a maturity at

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -42,45 +42,106 @@ create trigger investment_transactions_successor_fk_ownership
 -- pairing that could never be: a successor must itself be a live accumulating
 -- book, in the same goal and currency, and it must not already point back at
 -- the source (a two-book cycle has no maturity order).
-create or replace function public.enforce_successor_book_pairing()
-returns trigger language plpgsql security definer set search_path = '' as $$
-declare v_successor public.investment_transactions;
+create or replace function public.assert_successor_book_pairing(p_source_id uuid)
+returns void language plpgsql security definer set search_path = '' as $$
+declare v_source public.investment_transactions; v_successor public.investment_transactions;
 begin
-  if new.successor_deposit_tx_id is null then return new; end if;
+  select * into v_source from public.investment_transactions where transaction_id = p_source_id;
+  if not found or v_source.successor_deposit_tx_id is null then return; end if;
 
   select * into v_successor from public.investment_transactions
-   where transaction_id = new.successor_deposit_tx_id and user_id = new.user_id;
+   where transaction_id = v_source.successor_deposit_tx_id and user_id = v_source.user_id;
   -- Ownership is the fk trigger's job; say nothing here about a row that is not
   -- the caller's, so a foreign book cannot be probed through these messages.
-  if not found then return new; end if;
+  if not found then return; end if;
 
   if v_successor.deposit_group_id is distinct from v_successor.transaction_id then
     raise exception 'successor book: a successor must itself be an accumulating book'
       using errcode = 'check_violation';
   end if;
-  if v_successor.goal_id is distinct from new.goal_id then
+  if v_successor.goal_id is distinct from v_source.goal_id then
     raise exception 'successor book: both books must belong to the same goal'
       using errcode = 'check_violation';
   end if;
-  if coalesce(v_successor.currency, 'VND') is distinct from coalesce(new.currency, 'VND') then
+  if coalesce(v_successor.currency, 'VND') is distinct from coalesce(v_source.currency, 'VND') then
     raise exception 'successor book: both books must be in the same currency'
       using errcode = 'check_violation';
   end if;
-  if v_successor.successor_deposit_tx_id = new.transaction_id then
+  if v_successor.successor_deposit_tx_id = v_source.transaction_id then
     raise exception 'successor book: two books cannot succeed each other'
       using errcode = 'check_violation';
   end if;
-  return new;
+end;
+$$;
+
+-- The pairing can be broken from EITHER end: by re-pointing the source, or by
+-- editing the successor out from under it — moving that book to another goal is
+-- an ordinary transaction edit, and it would leave the source promising a merge
+-- that can never happen. So the check runs from whichever row moved, and looks
+-- both ways.
+--
+-- Deferred, for the reason the top-up guard is (#638): update_deposit_book
+-- rewrites a book across several statements, and only the state the transaction
+-- ends in is the state the user asked for.
+create or replace function public.enforce_successor_book_pairing()
+returns trigger language plpgsql security definer set search_path = '' as $$
+declare v_id uuid;
+begin
+  perform public.assert_successor_book_pairing(new.transaction_id);
+  for v_id in
+    select transaction_id from public.investment_transactions
+     where successor_deposit_tx_id = new.transaction_id
+  loop
+    perform public.assert_successor_book_pairing(v_id);
+  end loop;
+  return null;
 end;
 $$;
 
 drop trigger if exists investment_transactions_successor_pairing on public.investment_transactions;
-create trigger investment_transactions_successor_pairing
-  before insert or update of successor_deposit_tx_id, goal_id, currency
+create constraint trigger investment_transactions_successor_pairing
+  after insert or update of successor_deposit_tx_id, goal_id, currency, deposit_group_id
   on public.investment_transactions
+  deferrable initially deferred
   for each row
-  when (new.successor_deposit_tx_id is not null)
+  -- Only two kinds of row can affect a pairing: one that names a successor, and
+  -- a book anchor, which is the only kind that can BE one. Narrow, because a
+  -- deferred event is queued until commit and pending events block ALTER TABLE
+  -- on this table — every unrelated edit would otherwise carry one.
+  when (new.successor_deposit_tx_id is not null
+        or new.deposit_group_id = new.transaction_id)
   execute function public.enforce_successor_book_pairing();
+
+-- ── A book that has handed over is closed to new money ──────────────────────
+--
+-- The lock window does not cover this on its own: a contribution dated before
+-- the window still clears it, so a stale modal or a deliberately historical
+-- date could keep feeding the old book after its recurring link has moved —
+-- splitting one month's saving across two books. The handover is the same kind
+-- of fact as maturity, so it belongs in the same guard every writer passes.
+create or replace function public.assert_accumulating_book_topup_allowed(p_book_id uuid, p_owner_id uuid, p_top_up_date date)
+returns void language plpgsql security definer set search_path = '' as $$
+declare v_anchor public.investment_transactions; v_days_left integer;
+begin
+  select * into v_anchor from public.investment_transactions
+   where transaction_id = p_book_id and deposit_group_id = p_book_id and user_id = p_owner_id for update;
+  if not found then raise exception 'accumulating top-up: accumulating book not found' using errcode = 'no_data_found'; end if;
+  if v_anchor.successor_deposit_tx_id is not null then
+    raise exception 'accumulating top-up: this book has handed over to a successor, so contributions belong there'
+      using errcode = 'check_violation';
+  end if;
+  if v_anchor.expiry_date is null then return; end if;
+  v_days_left := v_anchor.expiry_date - p_top_up_date;
+  if v_days_left <= 0 then
+    raise exception 'accumulating top-up: cannot top up a deposit on or after its maturity date' using errcode = 'check_violation';
+  end if;
+  if v_anchor.top_up_lock_days is not null and v_days_left <= v_anchor.top_up_lock_days then
+    raise exception 'accumulating top-up: this deposit no longer accepts top-ups: % days remain before maturity (its lock window is % days)', v_days_left, v_anchor.top_up_lock_days using errcode = 'check_violation';
+  end if;
+end;
+$$;
+
+revoke all on function public.assert_accumulating_book_topup_allowed(uuid, uuid, date) from public, anon, authenticated;
 
 -- ── Opening the successor ───────────────────────────────────────────────────
 --

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -1,0 +1,201 @@
+-- A book that stops accepting contributions hands them to a successor (#638).
+--
+-- Phase 1 taught the database when a bank refuses another tranche. That leaves
+-- the user holding a contribution the bank will not take: the real workflow is
+-- to open a NEW accumulating book and send the month there, then fold the old
+-- book into it when it matures (Phase 3).
+--
+-- The relationship is stored, not guessed. Matching two books later by bank,
+-- name and date would be a guess, and the whole point of the link is to steer
+-- money — the recurring saving's contributions now, the maturity action later.
+
+alter table public.investment_transactions
+  add column if not exists successor_deposit_tx_id uuid
+  references public.investment_transactions(transaction_id) on delete set null;
+
+-- Only a book anchor may name a successor, and never itself. `on delete set
+-- null` above handles a successor that is deleted outright: the plan is dropped
+-- and the user is asked to choose again, rather than the source row going with it.
+alter table public.investment_transactions
+  drop constraint if exists investment_transactions_successor_shape;
+alter table public.investment_transactions
+  add constraint investment_transactions_successor_shape check (
+    successor_deposit_tx_id is null
+    or (deposit_group_id = transaction_id and successor_deposit_tx_id <> transaction_id)
+  );
+
+create unique index if not exists investment_transactions_successor_unique
+  on public.investment_transactions (successor_deposit_tx_id)
+  where successor_deposit_tx_id is not null;
+
+comment on column public.investment_transactions.successor_deposit_tx_id is
+  'The accumulating book this one is planned to be folded into at maturity (#638).';
+
+-- The reference is a user-scoped one like every other (20260728000001).
+drop trigger if exists investment_transactions_successor_fk_ownership on public.investment_transactions;
+create trigger investment_transactions_successor_fk_ownership
+  before insert or update of successor_deposit_tx_id, user_id on public.investment_transactions
+  for each row execute function public.enforce_user_scoped_fk_ownership(
+    'successor_deposit_tx_id', 'investment_transactions', 'transaction_id');
+
+-- What the link promises is that the two books CAN be merged later, so refuse a
+-- pairing that could never be: a successor must itself be a live accumulating
+-- book, in the same goal and currency, and it must not already point back at
+-- the source (a two-book cycle has no maturity order).
+create or replace function public.enforce_successor_book_pairing()
+returns trigger language plpgsql security definer set search_path = '' as $$
+declare v_successor public.investment_transactions;
+begin
+  if new.successor_deposit_tx_id is null then return new; end if;
+
+  select * into v_successor from public.investment_transactions
+   where transaction_id = new.successor_deposit_tx_id and user_id = new.user_id;
+  -- Ownership is the fk trigger's job; say nothing here about a row that is not
+  -- the caller's, so a foreign book cannot be probed through these messages.
+  if not found then return new; end if;
+
+  if v_successor.deposit_group_id is distinct from v_successor.transaction_id then
+    raise exception 'successor book: a successor must itself be an accumulating book'
+      using errcode = 'check_violation';
+  end if;
+  if v_successor.goal_id is distinct from new.goal_id then
+    raise exception 'successor book: both books must belong to the same goal'
+      using errcode = 'check_violation';
+  end if;
+  if coalesce(v_successor.currency, 'VND') is distinct from coalesce(new.currency, 'VND') then
+    raise exception 'successor book: both books must be in the same currency'
+      using errcode = 'check_violation';
+  end if;
+  if v_successor.successor_deposit_tx_id = new.transaction_id then
+    raise exception 'successor book: two books cannot succeed each other'
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists investment_transactions_successor_pairing on public.investment_transactions;
+create trigger investment_transactions_successor_pairing
+  before insert or update of successor_deposit_tx_id, goal_id, currency
+  on public.investment_transactions
+  for each row
+  when (new.successor_deposit_tx_id is not null)
+  execute function public.enforce_successor_book_pairing();
+
+-- ── Opening the successor ───────────────────────────────────────────────────
+--
+-- One call, because the recurring-driven flow is four writes that are only
+-- correct together: create B, record the month's contribution in it, mark the
+-- month fulfilled so the plan does not ask for it twice, and move the recurring
+-- link off the book that can no longer receive it. Half of that, committed
+-- alone, is a plan that double-counts or a contribution filed nowhere.
+--
+-- B's opening tranche IS its anchor row: an accumulating book's anchor carries
+-- the first contribution, and every later top-up joins the group behind it.
+create or replace function public.open_successor_book(
+  p_source_book_id uuid,
+  p_amount_vnd bigint,
+  p_interest_rate numeric,
+  p_investment_date date,
+  p_expiry_date date,
+  p_top_up_lock_days integer,
+  p_notes text,
+  p_saving_id uuid default null,
+  p_ym text default null,
+  p_plan_id uuid default null
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_source public.investment_transactions;
+  v_book public.investment_transactions;
+  v_new_id uuid := gen_random_uuid();
+begin
+  select * into v_source
+    from public.investment_transactions
+   where transaction_id = p_source_book_id
+     and deposit_group_id = p_source_book_id
+   for update;
+  if not found then
+    raise exception 'successor book: accumulating book not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_source.asset_type is distinct from 'bank' then
+    raise exception 'successor book: not a bank book' using errcode = 'check_violation';
+  end if;
+  if v_source.successor_deposit_tx_id is not null then
+    raise exception 'successor book: this book already has a successor'
+      using errcode = 'check_violation';
+  end if;
+  if p_amount_vnd is null or p_amount_vnd <= 0 then
+    raise exception 'successor book: amount must be positive' using errcode = 'check_violation';
+  end if;
+  if p_expiry_date is null or p_investment_date is null or p_expiry_date <= p_investment_date then
+    raise exception 'successor book: the new maturity must come after the contribution'
+      using errcode = 'check_violation';
+  end if;
+  if p_investment_date > current_date + 1 then
+    raise exception 'successor book: contribution date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+
+  -- The successor inherits what identifies the money — owner, goal, bank,
+  -- currency — and takes the terms the user entered for the new book.
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type, amount_vnd,
+    investment_date, expiry_date, interest_rate, notes, bank_code, currency,
+    deposit_group_id, top_up_lock_days, plan_id, affects_progress
+  ) values (
+    v_new_id, v_source.user_id, v_source.goal_id, 'bank', 'investment', p_amount_vnd,
+    p_investment_date, p_expiry_date, p_interest_rate,
+    coalesce(nullif(btrim(coalesce(p_notes, '')), ''), v_source.notes),
+    v_source.bank_code, v_source.currency,
+    v_new_id, p_top_up_lock_days, p_plan_id, true
+  )
+  returning * into v_book;
+
+  update public.investment_transactions
+     set successor_deposit_tx_id = v_new_id, updated_at = now()
+   where transaction_id = p_source_book_id;
+
+  -- Recurring-driven: the month is contributed to B, marked fulfilled, and the
+  -- saving now points at B. A saving linked elsewhere is not this flow's to move.
+  if p_saving_id is not null then
+    if not exists (
+      select 1 from public.recurring_savings
+       where saving_id = p_saving_id
+         and user_id = v_source.user_id
+         and linked_deposit_tx_id = p_source_book_id
+    ) then
+      raise exception 'successor book: that recurring saving is not linked to this book'
+        using errcode = 'check_violation';
+    end if;
+    if p_ym is null then
+      raise exception 'successor book: a recurring contribution needs its month'
+        using errcode = 'check_violation';
+    end if;
+
+    insert into public.recurring_saving_fulfillments (
+      user_id, recurring_saving_id, ym, amount_vnd, source
+    ) values (
+      v_source.user_id, p_saving_id, p_ym, p_amount_vnd, 'recurring-topup'
+    )
+    on conflict (recurring_saving_id, ym) do update
+      set amount_vnd = excluded.amount_vnd,
+          source     = excluded.source,
+          updated_at = now();
+
+    update public.recurring_savings
+       set linked_deposit_tx_id = v_new_id, updated_at = now()
+     where saving_id = p_saving_id;
+  end if;
+
+  return v_book;
+end;
+$$;
+
+comment on function public.open_successor_book(uuid, bigint, numeric, date, date, integer, text, uuid, text, uuid) is
+  'Open the accumulating book that takes over from one that stopped accepting top-ups, moving the recurring link and the month with it (#638).';

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -279,6 +279,16 @@ declare
   v_new_id uuid := gen_random_uuid();
   v_today date := (now() at time zone 'Asia/Ho_Chi_Minh')::date;
 begin
+  -- SAVINGS FIRST, then the book. The other path through here — an ordinary
+  -- recurring edit — locks its own saving row and only then waits for the book,
+  -- via the link trigger. Taking them in the opposite order would invert the two
+  -- and turn a pair of concurrent edits into a deadlock that Postgres resolves
+  -- by killing one of them.
+  perform 1 from public.recurring_savings
+   where linked_deposit_tx_id = p_source_book_id
+   order by saving_id
+   for update;
+
   select * into v_source
     from public.investment_transactions
    where transaction_id = p_source_book_id
@@ -379,13 +389,8 @@ begin
   -- record the month at all. This runs whichever entry point opened the
   -- successor: the manual one names no saving, and would otherwise strand them.
   --
-  -- LOCK them while reading. The book lock says nothing about these rows, so
-  -- without it a relink landing between the read and the write would be
-  -- silently overwritten.
-  perform 1 from public.recurring_savings
-   where user_id = v_source.user_id and linked_deposit_tx_id = p_source_book_id
-   order by saving_id
-   for update;
+  -- They were locked at the top, before the book, so nothing can relink between
+  -- the read and the write below.
 
   -- Recurring-driven: the month is also contributed to B and marked fulfilled.
   -- A saving linked elsewhere is not this flow's to move.
@@ -478,6 +483,17 @@ begin
      where transaction_id = old.successor_deposit_tx_id
   ) then
     raise exception 'successor book: this book is promised to a successor, so cancel the handover before deleting it'
+      using errcode = 'check_violation';
+  end if;
+  -- Taking the successor along in the same statement is not a way around it
+  -- either: what the guard is really protecting is the book, so its tranches
+  -- must be gone too. An account cascade satisfies that; a two-row delete of
+  -- anchor + successor, leaving the tranches behind, does not.
+  if exists (
+    select 1 from public.investment_transactions
+     where deposit_group_id = old.transaction_id
+  ) then
+    raise exception 'successor book: this book still holds tranches, so it cannot be deleted out from under them'
       using errcode = 'check_violation';
   end if;
   return null;

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -299,7 +299,11 @@ begin
   -- 00:00 and 06:59 Vietnam time the session's current_date is still yesterday,
   -- so a maturity of "today in Vietnam" would read as future to Postgres and
   -- mature to the app.
-  if p_investment_date > v_today + 1 then
+  -- No grace day. The route's own check is isFutureInvestmentDate with no grace,
+  -- and a direct PostgREST caller reaches this SECURITY INVOKER function without
+  -- passing through it — the grace only existed to absorb the UTC/Vietnam skew
+  -- that v_today now removes.
+  if p_investment_date > v_today then
     raise exception 'successor book: contribution date cannot be in the future'
       using errcode = 'check_violation';
   end if;

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -684,11 +684,15 @@ $$;
 -- their own writes; anything else arriving with a real session behind it is
 -- refused here.
 --
--- Not by privileges alone: a column-level revoke is undone by any later
--- `grant update on all tables`, which is a normal thing for a project to do, so
--- it stands as a second line rather than the boundary itself. auth.uid() is
--- null for the service role, for migrations and for SQL maintenance, which keep
--- their reach — the same convention the rest of this file uses.
+-- Not by privileges: the revoke below does not survive here at all. The stack
+-- grants `authenticated` its table privileges after migrations run, so the
+-- column is readable and writable again by the time anyone connects — CI proved
+-- it, an assertion on the privilege failing there while passing locally. It is
+-- left in as a statement of intent for anyone reading the schema, and as the
+-- thing that holds if the platform's grant order ever changes; the trigger is
+-- what actually refuses. auth.uid() is null for the service role, for
+-- migrations and for SQL maintenance, which keep their reach — the same
+-- convention the rest of this file uses.
 create or replace function public.enforce_successor_written_by_rpc()
 returns trigger language plpgsql set search_path = '' as $$
 begin

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -143,6 +143,14 @@ begin
       v_successor.expiry_date, v_source.expiry_date
       using errcode = 'check_violation';
   end if;
+  -- Far enough after it to still be open on the day: a successor inside its own
+  -- lock window when the source matures cannot receive the merge, and the lock
+  -- can be tightened long after the handover was arranged.
+  if v_successor.expiry_date - v_source.expiry_date <= coalesce(v_successor.top_up_lock_days, 0) then
+    raise exception 'successor book: the successor would be inside its own % day lock window when % matures',
+      v_successor.top_up_lock_days, v_source.expiry_date
+      using errcode = 'check_violation';
+  end if;
 end;
 $$;
 
@@ -202,7 +210,7 @@ create constraint trigger investment_transactions_successor_pairing_ins
 
 drop trigger if exists investment_transactions_successor_pairing_upd on public.investment_transactions;
 create constraint trigger investment_transactions_successor_pairing_upd
-  after update of successor_deposit_tx_id, goal_id, currency, deposit_group_id, expiry_date, interest_rate, is_pledged, transaction_type
+  after update of successor_deposit_tx_id, goal_id, currency, deposit_group_id, expiry_date, interest_rate, is_pledged, transaction_type, top_up_lock_days
   on public.investment_transactions
   deferrable initially deferred
   for each row
@@ -358,10 +366,23 @@ begin
       using errcode = 'check_violation';
   end if;
   -- And it has to outlive the book it takes over from, since the merge happens
-  -- when that one matures.
-  if v_source.expiry_date is not null and p_expiry_date <= v_source.expiry_date then
-    raise exception 'successor book: the new maturity must come after the old book''s (%)', v_source.expiry_date
+  -- when that one matures. Outliving it is not enough on its own: the successor
+  -- has its OWN lock window, and a term short enough to sit inside it is a book
+  -- that refuses the very contributions this handover is arranging — including
+  -- the merge itself, on the day the old book matures.
+  if p_expiry_date - v_today <= coalesce(p_top_up_lock_days, 0) then
+    raise exception 'successor book: the new book would already be inside its own % day lock window', coalesce(p_top_up_lock_days, 0)
       using errcode = 'check_violation';
+  end if;
+  if v_source.expiry_date is not null then
+    if p_expiry_date <= v_source.expiry_date then
+      raise exception 'successor book: the new maturity must come after the old book''s (%)', v_source.expiry_date
+        using errcode = 'check_violation';
+    end if;
+    if p_expiry_date - v_source.expiry_date <= coalesce(p_top_up_lock_days, 0) then
+      raise exception 'successor book: the new book must still accept a top-up when the old one matures on %', v_source.expiry_date
+        using errcode = 'check_violation';
+    end if;
   end if;
 
   -- The successor inherits what identifies the money — owner, goal, bank,

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -154,17 +154,32 @@ end;
 $$;
 
 drop trigger if exists investment_transactions_successor_pairing on public.investment_transactions;
-create constraint trigger investment_transactions_successor_pairing
-  after insert or update of successor_deposit_tx_id, goal_id, currency, deposit_group_id, expiry_date, interest_rate
+drop trigger if exists investment_transactions_successor_pairing_ins on public.investment_transactions;
+-- Two triggers rather than one, because the UPDATE side has to look at the row's
+-- OLD shape as well and OLD is not available to an INSERT trigger's WHEN.
+--
+-- Both stay narrow: a deferred event is queued until commit, and pending events
+-- block ALTER TABLE on this table, so every unrelated edit must not carry one.
+create constraint trigger investment_transactions_successor_pairing_ins
+  after insert on public.investment_transactions
+  deferrable initially deferred
+  for each row
+  when (new.successor_deposit_tx_id is not null)
+  execute function public.enforce_successor_book_pairing();
+
+drop trigger if exists investment_transactions_successor_pairing_upd on public.investment_transactions;
+create constraint trigger investment_transactions_successor_pairing_upd
+  after update of successor_deposit_tx_id, goal_id, currency, deposit_group_id, expiry_date, interest_rate
   on public.investment_transactions
   deferrable initially deferred
   for each row
-  -- Only two kinds of row can affect a pairing: one that names a successor, and
-  -- a book anchor, which is the only kind that can BE one. Narrow, because a
-  -- deferred event is queued until commit and pending events block ALTER TABLE
-  -- on this table — every unrelated edit would otherwise carry one.
+  -- A row that names a successor, a book anchor (the only kind that can BE one),
+  -- and a row that STOPPED being an anchor: a fully withdrawn successor has its
+  -- group cleared, and matching only on the new shape would let it slip away
+  -- from a source still promising to merge into it.
   when (new.successor_deposit_tx_id is not null
-        or new.deposit_group_id = new.transaction_id)
+        or new.deposit_group_id = new.transaction_id
+        or old.deposit_group_id = old.transaction_id)
   execute function public.enforce_successor_book_pairing();
 
 -- ── A book that has handed over is closed to new money ──────────────────────
@@ -305,11 +320,16 @@ begin
   -- Recurring-driven: the month is contributed to B, marked fulfilled, and the
   -- saving now points at B. A saving linked elsewhere is not this flow's to move.
   if p_saving_id is not null then
+    -- LOCK the saving while checking it. The book lock says nothing about this
+    -- row, so without it another request could relink the saving between the
+    -- check and the write below, and this call would silently overwrite that
+    -- newer choice — moving a saving that no longer points here.
     if not exists (
       select 1 from public.recurring_savings
        where saving_id = p_saving_id
          and user_id = v_source.user_id
          and linked_deposit_tx_id = p_source_book_id
+       for update
     ) then
       raise exception 'successor book: that recurring saving is not linked to this book'
         using errcode = 'check_violation';
@@ -331,7 +351,12 @@ begin
 
     update public.recurring_savings
        set linked_deposit_tx_id = v_new_id, updated_at = now()
-     where saving_id = p_saving_id;
+     where saving_id = p_saving_id
+       and linked_deposit_tx_id = p_source_book_id;
+    if not found then
+      raise exception 'successor book: that recurring saving moved while this was being recorded'
+        using errcode = 'check_violation';
+    end if;
   end if;
 
   return v_book;

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -226,7 +226,8 @@ begin
   -- savings. The door has to be closed here too, or a book still taking money
   -- would start refusing it with its savings left pointing at it.
   if new.successor_deposit_tx_id is not null
-     and (tg_op = 'INSERT' or old.successor_deposit_tx_id is null)
+     and (tg_op = 'INSERT'
+       or old.successor_deposit_tx_id is distinct from new.successor_deposit_tx_id)
      and (new.expiry_date is null
           or (new.expiry_date - (now() at time zone 'Asia/Ho_Chi_Minh')::date > 0
               and (new.top_up_lock_days is null
@@ -240,8 +241,12 @@ begin
   -- one open_successor_book asks. A link written straight to the column must
   -- answer it too, or it lands the savings on a book that is already mature or
   -- inside its own lock window.
+  -- On every change of the link, not only when one first appears: repointing a
+  -- promise onto a different book is the same decision made again, and the new
+  -- destination has to be able to receive just as the first one did.
   if new.successor_deposit_tx_id is not null
-     and (tg_op = 'INSERT' or old.successor_deposit_tx_id is null) then
+     and (tg_op = 'INSERT'
+       or old.successor_deposit_tx_id is distinct from new.successor_deposit_tx_id) then
     select expiry_date, top_up_lock_days into v_dest_expiry, v_dest_lock
       from public.investment_transactions
      where transaction_id = new.successor_deposit_tx_id and user_id = new.user_id;

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -204,14 +204,20 @@ begin
   -- recurring saving transferred onto it, whose next contribution the book will
   -- refuse. Only the edit is judged, and only for a row someone succeeds into.
   if tg_op = 'UPDATE'
-     and old.expiry_date is distinct from new.expiry_date
+     and (old.expiry_date is distinct from new.expiry_date
+       or old.top_up_lock_days is distinct from new.top_up_lock_days)
      and new.expiry_date is not null
-     and new.expiry_date <= (now() at time zone 'Asia/Ho_Chi_Minh')::date
+     -- Inside its own window, not merely past: the pairing rules measure the
+     -- successor against the SOURCE's maturity, which says nothing about today
+     -- once that maturity is behind us. A book whose remaining term is shorter
+     -- than its own lock refuses the savings that were moved onto it.
+     and new.expiry_date - (now() at time zone 'Asia/Ho_Chi_Minh')::date
+         <= coalesce(new.top_up_lock_days, 0)
      and exists (
        select 1 from public.investment_transactions
         where successor_deposit_tx_id = new.transaction_id
      ) then
-    raise exception 'successor book: a successor cannot be given a maturity that has already passed'
+    raise exception 'successor book: a successor cannot be given terms that leave it unable to take a contribution today'
       using errcode = 'check_violation';
   end if;
 

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -42,8 +42,11 @@ alter table public.investment_transactions
 create or replace function public.enforce_successor_before_dissolve()
 returns trigger language plpgsql set search_path = '' as $$
 begin
+  -- Judged on the OLD link alone. Clearing deposit_group_id and the successor in
+  -- ONE update would otherwise walk straight past this: the promise would be
+  -- dropped by the same statement that dissolves the book, which is exactly the
+  -- silent loss the guard exists to prevent. Cancelling is its own decision.
   if old.successor_deposit_tx_id is not null
-     and new.successor_deposit_tx_id is not null
      and new.deposit_group_id is distinct from new.transaction_id then
     raise exception 'successor book: this book is promised to a successor, so cancel the handover before closing it'
       using errcode = 'check_violation';
@@ -444,17 +447,30 @@ create trigger recurring_savings_link_not_handed_over
 -- carrying the link goes, and with it the plan — while any remaining tranches
 -- are left grouped under an anchor that no longer exists. Same answer as
 -- closing it: cancel the handover first, on purpose.
-create or replace function public.enforce_successor_before_delete()
+-- Deferred, and phrased as "did the successor survive?", because deleting the
+-- account cascades over this table in no guaranteed row order: refusing every
+-- promised source outright would abort account deletion depending on which row
+-- the cascade reached first. What actually matters is the state left behind — a
+-- promise pointing at a book that is still there, with nothing left to keep it.
+create or replace function public.enforce_successor_after_delete()
 returns trigger language plpgsql set search_path = '' as $$
 begin
-  raise exception 'successor book: this book is promised to a successor, so cancel the handover before deleting it'
-    using errcode = 'check_violation';
+  if exists (
+    select 1 from public.investment_transactions
+     where transaction_id = old.successor_deposit_tx_id
+  ) then
+    raise exception 'successor book: this book is promised to a successor, so cancel the handover before deleting it'
+      using errcode = 'check_violation';
+  end if;
+  return null;
 end;
 $$;
 
 drop trigger if exists investment_transactions_successor_before_delete on public.investment_transactions;
-create trigger investment_transactions_successor_before_delete
-  before delete on public.investment_transactions
+drop trigger if exists investment_transactions_successor_after_delete on public.investment_transactions;
+create constraint trigger investment_transactions_successor_after_delete
+  after delete on public.investment_transactions
+  deferrable initially deferred
   for each row
   when (old.successor_deposit_tx_id is not null)
-  execute function public.enforce_successor_before_delete();
+  execute function public.enforce_successor_after_delete();

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -696,8 +696,13 @@ $$;
 create or replace function public.enforce_successor_written_by_rpc()
 returns trigger language plpgsql set search_path = '' as $$
 begin
-  if (tg_op = 'INSERT' and new.successor_deposit_tx_id is not null
-      or tg_op = 'UPDATE' and old.successor_deposit_tx_id is distinct from new.successor_deposit_tx_id)
+  -- Only ARRANGING one is restricted. Clearing the link is cancelling, which is
+  -- the user's to do — and the FK's `on delete set null` does exactly that write
+  -- when the successor book is deleted, so refusing it here would take the
+  -- deletion down with it.
+  if new.successor_deposit_tx_id is not null
+     and (tg_op = 'INSERT'
+       or old.successor_deposit_tx_id is distinct from new.successor_deposit_tx_id)
      and auth.uid() is not null
      and coalesce(current_setting('app.successor_write', true), '') <> '1' then
     raise exception 'successor book: a handover is arranged through open_successor_book, not by writing the link'
@@ -715,3 +720,14 @@ create trigger investment_transactions_successor_rpc_only
 
 revoke insert (successor_deposit_tx_id), update (successor_deposit_tx_id)
   on public.investment_transactions from anon, authenticated;
+
+
+-- A SECURITY DEFINER function is executable by PUBLIC unless told otherwise, and
+-- these two treat a null auth.uid() as a trusted caller — which `anon` also has.
+-- Left open, anyone holding a book's UUID could arrange a handover inside
+-- someone else's account. The trust in a null uid is for the service role and
+-- for SQL; neither of them needs PUBLIC to hold EXECUTE.
+revoke all on function public.open_successor_book(uuid, bigint, numeric, date, date, integer, text, uuid, text, uuid) from public, anon;
+revoke all on function public.cancel_successor_book(uuid) from public, anon;
+grant execute on function public.open_successor_book(uuid, bigint, numeric, date, date, integer, text, uuid, text, uuid) to authenticated, service_role;
+grant execute on function public.cancel_successor_book(uuid) to authenticated, service_role;

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -317,19 +317,28 @@ begin
      set successor_deposit_tx_id = v_new_id, updated_at = now()
    where transaction_id = p_source_book_id;
 
-  -- Recurring-driven: the month is contributed to B, marked fulfilled, and the
-  -- saving now points at B. A saving linked elsewhere is not this flow's to move.
+  -- EVERY saving pointing at the old book follows it. The source stops accepting
+  -- contributions the moment this commits, so a saving left behind would be
+  -- funding a book that refuses it — and the monthly plan would have no way to
+  -- record the month at all. This runs whichever entry point opened the
+  -- successor: the manual one names no saving, and would otherwise strand them.
+  --
+  -- LOCK them while reading. The book lock says nothing about these rows, so
+  -- without it a relink landing between the read and the write would be
+  -- silently overwritten.
+  perform 1 from public.recurring_savings
+   where user_id = v_source.user_id and linked_deposit_tx_id = p_source_book_id
+   order by saving_id
+   for update;
+
+  -- Recurring-driven: the month is also contributed to B and marked fulfilled.
+  -- A saving linked elsewhere is not this flow's to move.
   if p_saving_id is not null then
-    -- LOCK the saving while checking it. The book lock says nothing about this
-    -- row, so without it another request could relink the saving between the
-    -- check and the write below, and this call would silently overwrite that
-    -- newer choice — moving a saving that no longer points here.
     if not exists (
       select 1 from public.recurring_savings
        where saving_id = p_saving_id
          and user_id = v_source.user_id
          and linked_deposit_tx_id = p_source_book_id
-       for update
     ) then
       raise exception 'successor book: that recurring saving is not linked to this book'
         using errcode = 'check_violation';
@@ -349,15 +358,12 @@ begin
           source     = excluded.source,
           updated_at = now();
 
-    update public.recurring_savings
-       set linked_deposit_tx_id = v_new_id, updated_at = now()
-     where saving_id = p_saving_id
-       and linked_deposit_tx_id = p_source_book_id;
-    if not found then
-      raise exception 'successor book: that recurring saving moved while this was being recorded'
-        using errcode = 'check_violation';
-    end if;
   end if;
+
+  update public.recurring_savings
+     set linked_deposit_tx_id = v_new_id, updated_at = now()
+   where user_id = v_source.user_id
+     and linked_deposit_tx_id = p_source_book_id;
 
   return v_book;
 end;

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -255,6 +255,16 @@ begin
       raise exception 'successor book: that book cannot take a contribution today, so it cannot be the successor'
         using errcode = 'check_violation';
     end if;
+    -- And nothing may be left funding the book that just closed its door. The
+    -- RPC moves those savings before this deferred check runs; a link written
+    -- straight to the column moves nothing, and would strand them.
+    if exists (
+      select 1 from public.recurring_savings
+       where linked_deposit_tx_id = new.transaction_id and user_id = new.user_id
+    ) then
+      raise exception 'successor book: recurring savings still point at this book, so they would be left funding a book that refuses them'
+        using errcode = 'check_violation';
+    end if;
   end if;
 
   perform public.assert_successor_book_pairing(new.transaction_id);
@@ -352,7 +362,12 @@ create or replace function public.open_successor_book(
 )
 returns public.investment_transactions
 language plpgsql
-security invoker
+-- DEFINER, because `authenticated` no longer holds the privilege to write
+-- successor_deposit_tx_id at all (see the revoke below): this function is the
+-- only supported way to arrange a handover, so it is the one thing that may.
+-- Which means RLS no longer scopes what it reads — every row it touches is
+-- checked against the caller explicitly.
+security definer
 set search_path = ''
 as $$
 declare
@@ -360,6 +375,7 @@ declare
   v_book public.investment_transactions;
   v_new_id uuid := gen_random_uuid();
   v_today date := (now() at time zone 'Asia/Ho_Chi_Minh')::date;
+  v_plan_ym text;
 begin
   -- SAVINGS FIRST, then the book. The other path through here — an ordinary
   -- recurring edit — locks its own saving row and only then waits for the book,
@@ -377,6 +393,12 @@ begin
      and deposit_group_id = p_source_book_id
    for update;
   if not found then
+    raise exception 'successor book: accumulating book not found'
+      using errcode = 'no_data_found';
+  end if;
+  -- RLS is not doing this for us any more. auth.uid() is null for the service
+  -- role and for SQL callers, which keep their reach.
+  if auth.uid() is not null and v_source.user_id is distinct from auth.uid() then
     raise exception 'successor book: accumulating book not found'
       using errcode = 'no_data_found';
   end if;
@@ -474,18 +496,22 @@ begin
   )
   returning * into v_book;
 
-  update public.investment_transactions
-     set successor_deposit_tx_id = v_new_id, updated_at = now()
-   where transaction_id = p_source_book_id;
 
-  -- EVERY saving pointing at the old book follows it. The source stops accepting
-  -- contributions the moment this commits, so a saving left behind would be
-  -- funding a book that refuses it — and the monthly plan would have no way to
-  -- record the month at all. This runs whichever entry point opened the
-  -- successor: the manual one names no saving, and would otherwise strand them.
-  --
-  -- They were locked at the top, before the book, so nothing can relink between
-  -- the read and the write below.
+  -- The plan tags the tranche while the fulfillment is filed under p_ym, so a
+  -- plan from another month splits one contribution across two. The route says
+  -- this too, but the route is not the only way in here.
+  if p_plan_id is not null and p_ym is not null then
+    select to_char(make_date(year, month, 1), 'YYYY-MM') into v_plan_ym
+      from public.monthly_plans
+     where id = p_plan_id and user_id = v_source.user_id;
+    if not found then
+      raise exception 'successor book: plan not found' using errcode = 'no_data_found';
+    end if;
+    if v_plan_ym is distinct from p_ym then
+      raise exception 'successor book: the plan is for % but the contribution is for %', v_plan_ym, p_ym
+        using errcode = 'check_violation';
+    end if;
+  end if;
 
   -- Recurring-driven: the month is also contributed to B and marked fulfilled.
   -- A saving linked elsewhere is not this flow's to move.
@@ -513,13 +539,23 @@ begin
       set amount_vnd = excluded.amount_vnd,
           source     = excluded.source,
           updated_at = now();
-
   end if;
 
+  -- SAVINGS BEFORE THE LINK. The moment the link lands, the old book refuses
+  -- contributions — so anything still pointing at it would be stranded, and the
+  -- guard that says so is entitled to run right there. Moving them first means
+  -- the book is never handed over while something still funds it, whether that
+  -- check is deferred to commit or forced earlier.
   update public.recurring_savings
      set linked_deposit_tx_id = v_new_id, updated_at = now()
    where user_id = v_source.user_id
      and linked_deposit_tx_id = p_source_book_id;
+
+  perform set_config('app.successor_write', '1', true);
+  update public.investment_transactions
+     set successor_deposit_tx_id = v_new_id, updated_at = now()
+   where transaction_id = p_source_book_id;
+  perform set_config('app.successor_write', '', true);
 
   return v_book;
 end;
@@ -603,3 +639,75 @@ create constraint trigger investment_transactions_successor_after_delete
   for each row
   when (old.successor_deposit_tx_id is not null)
   execute function public.enforce_successor_after_delete();
+
+
+-- Cancelling is the other write to the column, so it goes the same way: a
+-- function that may, called by a route that no longer can.
+create or replace function public.cancel_successor_book(p_source_book_id uuid)
+returns public.investment_transactions
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare v_row public.investment_transactions;
+begin
+  select * into v_row from public.investment_transactions
+   where transaction_id = p_source_book_id
+   for update;
+  if not found then
+    raise exception 'successor book: deposit not found' using errcode = 'no_data_found';
+  end if;
+  if auth.uid() is not null and v_row.user_id is distinct from auth.uid() then
+    raise exception 'successor book: deposit not found' using errcode = 'no_data_found';
+  end if;
+
+  perform set_config('app.successor_write', '1', true);
+  update public.investment_transactions
+     set successor_deposit_tx_id = null, updated_at = now()
+   where transaction_id = p_source_book_id
+  returning * into v_row;
+  perform set_config('app.successor_write', '', true);
+  return v_row;
+end;
+$$;
+
+-- ── The boundary ────────────────────────────────────────────────────────────
+--
+-- Every hole found in this feature that needed its own guard had the same
+-- shape: a client writing successor_deposit_tx_id directly, skipping the flow
+-- that gives the handover its meaning — the reason for it, the月 fulfillment,
+-- the recurring links that have to move with it. Guarding each path one at a
+-- time is endless, because the paths are however many ways there are to write
+-- a column.
+--
+-- So the column stops being a client's to write. The two functions above mark
+-- their own writes; anything else arriving with a real session behind it is
+-- refused here.
+--
+-- Not by privileges alone: a column-level revoke is undone by any later
+-- `grant update on all tables`, which is a normal thing for a project to do, so
+-- it stands as a second line rather than the boundary itself. auth.uid() is
+-- null for the service role, for migrations and for SQL maintenance, which keep
+-- their reach — the same convention the rest of this file uses.
+create or replace function public.enforce_successor_written_by_rpc()
+returns trigger language plpgsql set search_path = '' as $$
+begin
+  if (tg_op = 'INSERT' and new.successor_deposit_tx_id is not null
+      or tg_op = 'UPDATE' and old.successor_deposit_tx_id is distinct from new.successor_deposit_tx_id)
+     and auth.uid() is not null
+     and coalesce(current_setting('app.successor_write', true), '') <> '1' then
+    raise exception 'successor book: a handover is arranged through open_successor_book, not by writing the link'
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists investment_transactions_successor_rpc_only on public.investment_transactions;
+create trigger investment_transactions_successor_rpc_only
+  before insert or update of successor_deposit_tx_id on public.investment_transactions
+  for each row
+  execute function public.enforce_successor_written_by_rpc();
+
+revoke insert (successor_deposit_tx_id), update (successor_deposit_tx_id)
+  on public.investment_transactions from anon, authenticated;

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -95,6 +95,12 @@ begin
     raise exception 'successor book: a successor must itself be an accumulating book'
       using errcode = 'check_violation';
   end if;
+  -- Either side pledged freezes the merge this link promises, and a pledge can
+  -- be applied long after the handover was arranged.
+  if v_source.is_pledged or v_successor.is_pledged then
+    raise exception 'successor book: a pledged deposit cannot be part of a handover'
+      using errcode = 'check_violation';
+  end if;
   if v_successor.goal_id is distinct from v_source.goal_id then
     raise exception 'successor book: both books must belong to the same goal'
       using errcode = 'check_violation';
@@ -169,7 +175,7 @@ create constraint trigger investment_transactions_successor_pairing_ins
 
 drop trigger if exists investment_transactions_successor_pairing_upd on public.investment_transactions;
 create constraint trigger investment_transactions_successor_pairing_upd
-  after update of successor_deposit_tx_id, goal_id, currency, deposit_group_id, expiry_date, interest_rate
+  after update of successor_deposit_tx_id, goal_id, currency, deposit_group_id, expiry_date, interest_rate, is_pledged
   on public.investment_transactions
   deferrable initially deferred
   for each row
@@ -259,6 +265,13 @@ begin
   end if;
   if v_source.successor_deposit_tx_id is not null then
     raise exception 'successor book: this book already has a successor'
+      using errcode = 'check_violation';
+  end if;
+  -- Pledged collateral is frozen: it cannot be settled or merged (the held
+  -- settlement refuses it outright), so promising to fold it into another book
+  -- would be a plan the merge itself would later reject.
+  if v_source.is_pledged then
+    raise exception 'successor book: a pledged deposit cannot be handed over while it is collateral'
       using errcode = 'check_violation';
   end if;
   if p_amount_vnd is null or p_amount_vnd <= 0 then
@@ -371,3 +384,30 @@ $$;
 
 comment on function public.open_successor_book(uuid, bigint, numeric, date, date, integer, text, uuid, text, uuid) is
   'Open the accumulating book that takes over from one that stopped accepting top-ups, moving the recurring link and the month with it (#638).';
+
+-- The API refuses a recurring link to a handed-over book, and so does the table:
+-- RLS lets `authenticated` write recurring_savings directly, and a link that can
+-- never be funded is worse than a refused one — the plan would keep asking for a
+-- month it has nowhere to put.
+create or replace function public.enforce_recurring_link_not_handed_over()
+returns trigger language plpgsql security definer set search_path = '' as $$
+begin
+  if exists (
+    select 1 from public.investment_transactions
+     where transaction_id = new.linked_deposit_tx_id
+       and user_id = new.user_id
+       and successor_deposit_tx_id is not null
+  ) then
+    raise exception 'successor book: that book has handed over to a successor, so link the successor instead'
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists recurring_savings_link_not_handed_over on public.recurring_savings;
+create trigger recurring_savings_link_not_handed_over
+  before insert or update of linked_deposit_tx_id on public.recurring_savings
+  for each row
+  when (new.linked_deposit_tx_id is not null)
+  execute function public.enforce_recurring_link_not_handed_over();

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -29,27 +29,36 @@ alter table public.investment_transactions
   );
 
 -- Which makes the dissolve flows the constraint's problem: withdraw_book_close_group
--- and collapse_accumulating_book both clear deposit_group_id across the group,
--- and they would now be refused. They should not be: once the book is dissolved
--- its money has left, and a plan to merge it later is moot. Drop the plan with
--- the book, the same way `on delete set null` drops it with a deleted successor.
-create or replace function public.clear_successor_when_book_dissolved()
+-- and collapse_accumulating_book both clear deposit_group_id across the group.
+--
+-- Clearing the link along with the book would be wrong, and quietly so. Collapse
+-- is what "handle maturity" runs today: it re-deposits the book's principal into
+-- a fresh term cycle. The money has NOT left — and that is precisely the moment
+-- the handover was made for, the merge into the successor that Phase 3 performs.
+-- Dropping the relationship there would lose the plan exactly when it comes due.
+--
+-- So a promised book is not dissolved by any route: the promise is cancelled
+-- first, deliberately, by whoever made it (DELETE on the successor endpoint).
+create or replace function public.enforce_successor_before_dissolve()
 returns trigger language plpgsql set search_path = '' as $$
 begin
-  if new.successor_deposit_tx_id is not null
+  if old.successor_deposit_tx_id is not null
+     and new.successor_deposit_tx_id is not null
      and new.deposit_group_id is distinct from new.transaction_id then
-    new.successor_deposit_tx_id := null;
+    raise exception 'successor book: this book is promised to a successor, so cancel the handover before closing it'
+      using errcode = 'check_violation';
   end if;
   return new;
 end;
 $$;
 
 drop trigger if exists investment_transactions_successor_cleared_on_dissolve on public.investment_transactions;
-create trigger investment_transactions_successor_cleared_on_dissolve
+drop trigger if exists investment_transactions_successor_before_dissolve on public.investment_transactions;
+create trigger investment_transactions_successor_before_dissolve
   before update of deposit_group_id on public.investment_transactions
   for each row
   when (old.successor_deposit_tx_id is not null)
-  execute function public.clear_successor_when_book_dissolved();
+  execute function public.enforce_successor_before_dissolve();
 
 create unique index if not exists investment_transactions_successor_unique
   on public.investment_transactions (successor_deposit_tx_id)
@@ -105,6 +114,13 @@ begin
     raise exception 'successor book: both books need a maturity while the handover stands'
       using errcode = 'check_violation';
   end if;
+  -- The successor holds real money and inherits the recurring link, and a
+  -- rateless deposit is not a valid target for one — the edit route can clear a
+  -- rate long after the book was opened.
+  if v_successor.interest_rate is null or v_successor.interest_rate <= 0 then
+    raise exception 'successor book: the successor needs a rate while the handover stands'
+      using errcode = 'check_violation';
+  end if;
   if v_successor.expiry_date <= v_source.expiry_date then
     raise exception 'successor book: the successor must mature after the book it takes over from (% is not after %)',
       v_successor.expiry_date, v_source.expiry_date
@@ -139,7 +155,7 @@ $$;
 
 drop trigger if exists investment_transactions_successor_pairing on public.investment_transactions;
 create constraint trigger investment_transactions_successor_pairing
-  after insert or update of successor_deposit_tx_id, goal_id, currency, deposit_group_id, expiry_date
+  after insert or update of successor_deposit_tx_id, goal_id, currency, deposit_group_id, expiry_date, interest_rate
   on public.investment_transactions
   deferrable initially deferred
   for each row

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -88,6 +88,20 @@ begin
   select * into v_source from public.investment_transactions where transaction_id = p_source_id;
   if not found or v_source.successor_deposit_tx_id is null then return; end if;
 
+  -- LOCK BOTH BOOKS, in id order, then re-read them. Two requests pairing the
+  -- same books in opposite directions touch different rows and write different
+  -- values, so nothing else would stop them: each would read the other's
+  -- pre-update version, see no cycle, and commit one. Ordering by id is what
+  -- keeps the two lockers from deadlocking on each other — and if they do
+  -- collide, one aborts, which beats committing a pair that promises itself.
+  perform 1 from public.investment_transactions
+   where transaction_id in (p_source_id, v_source.successor_deposit_tx_id)
+   order by transaction_id
+   for update;
+
+  select * into v_source from public.investment_transactions where transaction_id = p_source_id;
+  if not found or v_source.successor_deposit_tx_id is null then return; end if;
+
   select * into v_successor from public.investment_transactions
    where transaction_id = v_source.successor_deposit_tx_id and user_id = v_source.user_id;
   -- Ownership is the fk trigger's job; say nothing here about a row that is not
@@ -177,7 +191,7 @@ $$;
 -- ends in is the state the user asked for.
 create or replace function public.enforce_successor_book_pairing()
 returns trigger language plpgsql security definer set search_path = '' as $$
-declare v_id uuid;
+declare v_id uuid; v_dest_expiry date; v_dest_lock integer;
 begin
   -- A pair ages naturally, so "already mature" is not a standing invariant — but
   -- MOVING a successor's maturity into the past is an edit that strands every
@@ -208,6 +222,22 @@ begin
   then
     raise exception 'successor book: this book still accepts top-ups, so it has nothing to hand over yet'
       using errcode = 'check_violation';
+  end if;
+  -- ...and the destination has to be able to receive. The pairing rules compare
+  -- the two books to each other; being usable TODAY is a separate question, and
+  -- one open_successor_book asks. A link written straight to the column must
+  -- answer it too, or it lands the savings on a book that is already mature or
+  -- inside its own lock window.
+  if new.successor_deposit_tx_id is not null
+     and (tg_op = 'INSERT' or old.successor_deposit_tx_id is null) then
+    select expiry_date, top_up_lock_days into v_dest_expiry, v_dest_lock
+      from public.investment_transactions
+     where transaction_id = new.successor_deposit_tx_id and user_id = new.user_id;
+    if found and (v_dest_expiry is null
+      or v_dest_expiry - (now() at time zone 'Asia/Ho_Chi_Minh')::date <= coalesce(v_dest_lock, 0)) then
+      raise exception 'successor book: that book cannot take a contribution today, so it cannot be the successor'
+        using errcode = 'check_violation';
+    end if;
   end if;
 
   perform public.assert_successor_book_pairing(new.transaction_id);

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -21,8 +21,35 @@ alter table public.investment_transactions
 alter table public.investment_transactions
   add constraint investment_transactions_successor_shape check (
     successor_deposit_tx_id is null
-    or (deposit_group_id = transaction_id and successor_deposit_tx_id <> transaction_id)
+    -- NULL-safe on purpose: `deposit_group_id = transaction_id` is NULL for a
+    -- dissolved row, and a CHECK passes on NULL, so the plain comparison would
+    -- let a row keep its successor after it stopped being a book.
+    or (deposit_group_id is not distinct from transaction_id
+        and successor_deposit_tx_id is distinct from transaction_id)
   );
+
+-- Which makes the dissolve flows the constraint's problem: withdraw_book_close_group
+-- and collapse_accumulating_book both clear deposit_group_id across the group,
+-- and they would now be refused. They should not be: once the book is dissolved
+-- its money has left, and a plan to merge it later is moot. Drop the plan with
+-- the book, the same way `on delete set null` drops it with a deleted successor.
+create or replace function public.clear_successor_when_book_dissolved()
+returns trigger language plpgsql set search_path = '' as $$
+begin
+  if new.successor_deposit_tx_id is not null
+     and new.deposit_group_id is distinct from new.transaction_id then
+    new.successor_deposit_tx_id := null;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists investment_transactions_successor_cleared_on_dissolve on public.investment_transactions;
+create trigger investment_transactions_successor_cleared_on_dissolve
+  before update of deposit_group_id on public.investment_transactions
+  for each row
+  when (old.successor_deposit_tx_id is not null)
+  execute function public.clear_successor_when_book_dissolved();
 
 create unique index if not exists investment_transactions_successor_unique
   on public.investment_transactions (successor_deposit_tx_id)
@@ -71,10 +98,14 @@ begin
     raise exception 'successor book: two books cannot succeed each other'
       using errcode = 'check_violation';
   end if;
-  -- The merge happens when the SOURCE matures, so the successor has to still be
-  -- open then. A successor maturing first is a plan that cannot be carried out.
-  if v_source.expiry_date is not null and v_successor.expiry_date is not null
-     and v_successor.expiry_date <= v_source.expiry_date then
+  -- The merge happens when the SOURCE matures, so both books need a maturity at
+  -- all — the edit route lets one be cleared — and the successor's has to come
+  -- after. A successor maturing first is a plan that cannot be carried out.
+  if v_source.expiry_date is null or v_successor.expiry_date is null then
+    raise exception 'successor book: both books need a maturity while the handover stands'
+      using errcode = 'check_violation';
+  end if;
+  if v_successor.expiry_date <= v_source.expiry_date then
     raise exception 'successor book: the successor must mature after the book it takes over from (% is not after %)',
       v_successor.expiry_date, v_source.expiry_date
       using errcode = 'check_violation';
@@ -201,6 +232,11 @@ begin
   end if;
   if p_amount_vnd is null or p_amount_vnd <= 0 then
     raise exception 'successor book: amount must be positive' using errcode = 'check_violation';
+  end if;
+  -- A deposit with no rate earns nothing here and is not a valid target for a
+  -- recurring link either, and this book opens holding real money.
+  if p_interest_rate is null or p_interest_rate <= 0 then
+    raise exception 'successor book: the new book needs its own rate' using errcode = 'check_violation';
   end if;
   if p_expiry_date is null or p_investment_date is null or p_expiry_date <= p_investment_date then
     raise exception 'successor book: the new maturity must come after the contribution'

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -159,6 +159,22 @@ create or replace function public.enforce_successor_book_pairing()
 returns trigger language plpgsql security definer set search_path = '' as $$
 declare v_id uuid;
 begin
+  -- A pair ages naturally, so "already mature" is not a standing invariant — but
+  -- MOVING a successor's maturity into the past is an edit that strands every
+  -- recurring saving transferred onto it, whose next contribution the book will
+  -- refuse. Only the edit is judged, and only for a row someone succeeds into.
+  if tg_op = 'UPDATE'
+     and old.expiry_date is distinct from new.expiry_date
+     and new.expiry_date is not null
+     and new.expiry_date <= (now() at time zone 'Asia/Ho_Chi_Minh')::date
+     and exists (
+       select 1 from public.investment_transactions
+        where successor_deposit_tx_id = new.transaction_id
+     ) then
+    raise exception 'successor book: a successor cannot be given a maturity that has already passed'
+      using errcode = 'check_violation';
+  end if;
+
   perform public.assert_successor_book_pairing(new.transaction_id);
   for v_id in
     select transaction_id from public.investment_transactions
@@ -418,17 +434,19 @@ comment on function public.open_successor_book(uuid, bigint, numeric, date, date
 -- month it has nowhere to put.
 create or replace function public.enforce_recurring_link_not_handed_over()
 returns trigger language plpgsql security definer set search_path = '' as $$
+declare v_successor uuid;
 begin
-  -- LOCK the book while reading it: a link created concurrently with a handover
-  -- would otherwise read the source's pre-handover version and commit after it,
-  -- landing on a book that now refuses contributions.
-  if exists (
-    select 1 from public.investment_transactions
-     where transaction_id = new.linked_deposit_tx_id
-       and user_id = new.user_id
-       and successor_deposit_tx_id is not null
-     for share
-  ) then
+  -- LOCK the book, THEN read its successor. Locking inside a predicate that
+  -- already tests the successor locks nothing while a handover is uncommitted:
+  -- the visible version still has a null link, so the row does not match and the
+  -- write sails past to commit against a book that, moments later, refuses it.
+  -- The lock has to be taken on the row itself, whatever it currently says.
+  select successor_deposit_tx_id into v_successor
+    from public.investment_transactions
+   where transaction_id = new.linked_deposit_tx_id
+     and user_id = new.user_id
+   for share;
+  if found and v_successor is not null then
     raise exception 'successor book: that book has handed over to a successor, so link the successor instead'
       using errcode = 'check_violation';
   end if;

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -124,6 +124,18 @@ begin
     raise exception 'successor book: two books cannot succeed each other'
       using errcode = 'check_violation';
   end if;
+  -- Nor a chain. A book that has handed over refuses contributions, and the
+  -- merge INTO it is a contribution: if B is promised to C, then A's promised
+  -- merge into B can never be carried out. One promise at a time, in both
+  -- directions — settle the incoming one first (Phase 3), or cancel it.
+  if v_source.successor_deposit_tx_id is not null and exists (
+    select 1 from public.investment_transactions
+     where successor_deposit_tx_id = v_source.transaction_id
+       and user_id = v_source.user_id
+  ) then
+    raise exception 'successor book: this book is itself promised a merge, so settle that before handing over again'
+      using errcode = 'check_violation';
+  end if;
   -- The merge happens when the SOURCE matures, so both books need a maturity at
   -- all — the edit route lets one be cleared — and the successor's has to come
   -- after. A successor maturing first is a plan that cannot be carried out.
@@ -180,6 +192,21 @@ begin
         where successor_deposit_tx_id = new.transaction_id
      ) then
     raise exception 'successor book: a successor cannot be given a maturity that has already passed'
+      using errcode = 'check_violation';
+  end if;
+
+  -- A link written straight to the column skips open_successor_book entirely —
+  -- and with it the reason for the handover and the transfer of the recurring
+  -- savings. The door has to be closed here too, or a book still taking money
+  -- would start refusing it with its savings left pointing at it.
+  if new.successor_deposit_tx_id is not null
+     and (tg_op = 'INSERT' or old.successor_deposit_tx_id is null)
+     and (new.expiry_date is null
+          or (new.expiry_date - (now() at time zone 'Asia/Ho_Chi_Minh')::date > 0
+              and (new.top_up_lock_days is null
+                   or new.expiry_date - (now() at time zone 'Asia/Ho_Chi_Minh')::date > new.top_up_lock_days)))
+  then
+    raise exception 'successor book: this book still accepts top-ups, so it has nothing to hand over yet'
       using errcode = 'check_violation';
   end if;
 

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -95,6 +95,14 @@ begin
     raise exception 'successor book: a successor must itself be an accumulating book'
       using errcode = 'check_violation';
   end if;
+  -- Either row can be turned into a withdrawal through an ordinary edit, which
+  -- takes it out of holdings entirely — a pair of which one half is not a live
+  -- investment promises a merge between something and nothing.
+  if v_source.transaction_type is distinct from 'investment'
+     or v_successor.transaction_type is distinct from 'investment' then
+    raise exception 'successor book: both books must stay live deposits'
+      using errcode = 'check_violation';
+  end if;
   -- Either side pledged freezes the merge this link promises, and a pledge can
   -- be applied long after the handover was arranged.
   if v_source.is_pledged or v_successor.is_pledged then
@@ -175,7 +183,7 @@ create constraint trigger investment_transactions_successor_pairing_ins
 
 drop trigger if exists investment_transactions_successor_pairing_upd on public.investment_transactions;
 create constraint trigger investment_transactions_successor_pairing_upd
-  after update of successor_deposit_tx_id, goal_id, currency, deposit_group_id, expiry_date, interest_rate, is_pledged
+  after update of successor_deposit_tx_id, goal_id, currency, deposit_group_id, expiry_date, interest_rate, is_pledged, transaction_type
   on public.investment_transactions
   deferrable initially deferred
   for each row
@@ -250,6 +258,7 @@ declare
   v_source public.investment_transactions;
   v_book public.investment_transactions;
   v_new_id uuid := gen_random_uuid();
+  v_today date := (now() at time zone 'Asia/Ho_Chi_Minh')::date;
 begin
   select * into v_source
     from public.investment_transactions
@@ -286,7 +295,11 @@ begin
     raise exception 'successor book: the new maturity must come after the contribution'
       using errcode = 'check_violation';
   end if;
-  if p_investment_date > current_date + 1 then
+  -- Business dates are Asia/Ho_Chi_Minh here as everywhere else (#591): between
+  -- 00:00 and 06:59 Vietnam time the session's current_date is still yesterday,
+  -- so a maturity of "today in Vietnam" would read as future to Postgres and
+  -- mature to the app.
+  if p_investment_date > v_today + 1 then
     raise exception 'successor book: contribution date cannot be in the future'
       using errcode = 'check_violation';
   end if;
@@ -307,7 +320,7 @@ begin
   -- The new book has to be open for business: a contribution can be historical,
   -- but a book that has already matured cannot take the next one — and every
   -- recurring link is about to be moved onto it.
-  if p_expiry_date <= current_date then
+  if p_expiry_date <= v_today then
     raise exception 'successor book: the new book must mature in the future'
       using errcode = 'check_violation';
   end if;
@@ -399,11 +412,15 @@ comment on function public.open_successor_book(uuid, bigint, numeric, date, date
 create or replace function public.enforce_recurring_link_not_handed_over()
 returns trigger language plpgsql security definer set search_path = '' as $$
 begin
+  -- LOCK the book while reading it: a link created concurrently with a handover
+  -- would otherwise read the source's pre-handover version and commit after it,
+  -- landing on a book that now refuses contributions.
   if exists (
     select 1 from public.investment_transactions
      where transaction_id = new.linked_deposit_tx_id
        and user_id = new.user_id
        and successor_deposit_tx_id is not null
+     for share
   ) then
     raise exception 'successor book: that book has handed over to a successor, so link the successor instead'
       using errcode = 'check_violation';

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -304,8 +304,15 @@ begin
     raise exception 'successor book: this book still accepts a contribution dated %, so record it as a top-up', p_investment_date
       using errcode = 'check_violation';
   end if;
-  -- Whatever the successor's own terms, it has to outlive the book it takes
-  -- over from, since the merge happens when that one matures.
+  -- The new book has to be open for business: a contribution can be historical,
+  -- but a book that has already matured cannot take the next one — and every
+  -- recurring link is about to be moved onto it.
+  if p_expiry_date <= current_date then
+    raise exception 'successor book: the new book must mature in the future'
+      using errcode = 'check_violation';
+  end if;
+  -- And it has to outlive the book it takes over from, since the merge happens
+  -- when that one matures.
   if v_source.expiry_date is not null and p_expiry_date <= v_source.expiry_date then
     raise exception 'successor book: the new maturity must come after the old book''s (%)', v_source.expiry_date
       using errcode = 'check_violation';
@@ -411,3 +418,22 @@ create trigger recurring_savings_link_not_handed_over
   for each row
   when (new.linked_deposit_tx_id is not null)
   execute function public.enforce_recurring_link_not_handed_over();
+
+-- Deleting the source is the other way to drop the promise silently: the row
+-- carrying the link goes, and with it the plan — while any remaining tranches
+-- are left grouped under an anchor that no longer exists. Same answer as
+-- closing it: cancel the handover first, on purpose.
+create or replace function public.enforce_successor_before_delete()
+returns trigger language plpgsql set search_path = '' as $$
+begin
+  raise exception 'successor book: this book is promised to a successor, so cancel the handover before deleting it'
+    using errcode = 'check_violation';
+end;
+$$;
+
+drop trigger if exists investment_transactions_successor_before_delete on public.investment_transactions;
+create trigger investment_transactions_successor_before_delete
+  before delete on public.investment_transactions
+  for each row
+  when (old.successor_deposit_tx_id is not null)
+  execute function public.enforce_successor_before_delete();

--- a/supabase/migrations/20260811000001_successor_book.sql
+++ b/supabase/migrations/20260811000001_successor_book.sql
@@ -71,6 +71,14 @@ begin
     raise exception 'successor book: two books cannot succeed each other'
       using errcode = 'check_violation';
   end if;
+  -- The merge happens when the SOURCE matures, so the successor has to still be
+  -- open then. A successor maturing first is a plan that cannot be carried out.
+  if v_source.expiry_date is not null and v_successor.expiry_date is not null
+     and v_successor.expiry_date <= v_source.expiry_date then
+    raise exception 'successor book: the successor must mature after the book it takes over from (% is not after %)',
+      v_successor.expiry_date, v_source.expiry_date
+      using errcode = 'check_violation';
+  end if;
 end;
 $$;
 
@@ -100,7 +108,7 @@ $$;
 
 drop trigger if exists investment_transactions_successor_pairing on public.investment_transactions;
 create constraint trigger investment_transactions_successor_pairing
-  after insert or update of successor_deposit_tx_id, goal_id, currency, deposit_group_id
+  after insert or update of successor_deposit_tx_id, goal_id, currency, deposit_group_id, expiry_date
   on public.investment_transactions
   deferrable initially deferred
   for each row
@@ -200,6 +208,26 @@ begin
   end if;
   if p_investment_date > current_date + 1 then
     raise exception 'successor book: contribution date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+  -- A successor is the answer to a bank that WILL NOT take the money. If the old
+  -- book still accepts this contribution on this date, opening one would retire
+  -- a perfectly usable book and move its recurring link for nothing — and the
+  -- contribution date is editable in the sheet, so this is reachable from the UI.
+  -- The eligibility rule is spelled out rather than delegated: the shared
+  -- assertion is deliberately not executable by `authenticated`, and this is a
+  -- SECURITY INVOKER function.
+  if v_source.expiry_date is null
+     or (v_source.expiry_date - p_investment_date > 0
+         and (v_source.top_up_lock_days is null
+              or v_source.expiry_date - p_investment_date > v_source.top_up_lock_days)) then
+    raise exception 'successor book: this book still accepts a contribution dated %, so record it as a top-up', p_investment_date
+      using errcode = 'check_violation';
+  end if;
+  -- Whatever the successor's own terms, it has to outlive the book it takes
+  -- over from, since the merge happens when that one matures.
+  if v_source.expiry_date is not null and p_expiry_date <= v_source.expiry_date then
+    raise exception 'successor book: the new maturity must come after the old book''s (%)', v_source.expiry_date
       using errcode = 'check_violation';
   end if;
 

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -21,6 +21,7 @@ declare
   v_short_book uuid := gen_random_uuid();
   v_tail public.investment_transactions;
   v_extra_saving uuid := gen_random_uuid();
+  v_dated_book uuid := gen_random_uuid();
 begin
   insert into auth.users (id, email) values (v_user, 'successor-book@test.invalid');
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Successor') returning goal_id into v_goal;
@@ -309,6 +310,31 @@ begin
     update public.recurring_savings set linked_deposit_tx_id = v_short_book
      where saving_id = v_extra_saving;
     raise exception 'linking to a handed-over book must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- A book that matured a while ago, being caught up on late.
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate, deposit_group_id
+  ) values (
+    v_dated_book, v_user, v_goal, 'bank', 'investment',
+    current_date - 400, current_date - 60, 10000000, 4, v_dated_book
+  );
+
+  -- ── A successor that has already matured cannot take the next month ─────
+  -- A contribution may be historical; the book it opens may not be.
+  begin
+    perform public.open_successor_book(
+      v_dated_book, 1000000, 4, current_date - 200, current_date - 10, 30, null, null, null, null);
+    raise exception 'a successor that already matured must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── Deleting the source drops the promise as silently as closing it ──────
+  begin
+    delete from public.investment_transactions where transaction_id = v_short_book;
+    raise exception 'deleting a promised book must be refused';
   exception when sqlstate '23514' then null;
   end;
 

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -26,6 +26,7 @@ declare
   v_tail3 public.investment_transactions;
   v_lockable uuid := gen_random_uuid();
   v_rec_book uuid := gen_random_uuid();
+  v_closed uuid := gen_random_uuid();
 begin
   insert into auth.users (id, email) values (v_user, 'successor-book@test.invalid');
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Successor') returning goal_id into v_goal;
@@ -496,6 +497,26 @@ begin
      where transaction_id in (v_dated_book, v_tail2.transaction_id);
     set constraints all immediate;
     raise exception 'deleting a promised anchor beside its successor must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── Repointing a promise is the same decision, judged the same way ──────
+  -- v_dated_book matured long ago and already promises v_tail2. Moving that
+  -- promise onto a book that cannot take money today would leave the overdue
+  -- merge with nowhere to land.
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate,
+    deposit_group_id, top_up_lock_days
+  ) values (
+    v_closed, v_user, v_goal, 'bank', 'investment',
+    current_date - 300, current_date + 10, 5000000, 4, v_closed, 30
+  );
+  begin
+    update public.investment_transactions set successor_deposit_tx_id = v_closed
+     where transaction_id = v_dated_book;
+    set constraints all immediate;
+    raise exception 'repointing onto a book that cannot receive must be refused';
   exception when sqlstate '23514' then null;
   end;
 

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -23,6 +23,9 @@ declare
   v_extra_saving uuid := gen_random_uuid();
   v_dated_book uuid := gen_random_uuid();
   v_tail2 public.investment_transactions;
+  v_tail3 public.investment_transactions;
+  v_lockable uuid := gen_random_uuid();
+  v_rec_book uuid := gen_random_uuid();
 begin
   insert into auth.users (id, email) values (v_user, 'successor-book@test.invalid');
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Successor') returning goal_id into v_goal;
@@ -102,21 +105,25 @@ begin
   end;
 
   -- ── The recurring-driven flow moves the whole month in one transaction ───
+  -- Its own book, closing in on maturity, with the recurring pointing at it. B
+  -- cannot play this part: a successor must stay open past its source's
+  -- maturity, so it can never also be a book that is itself nearly mature.
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate,
+    deposit_group_id, top_up_lock_days
+  ) values (
+    v_rec_book, v_user, v_goal, 'bank', 'investment',
+    current_date - 200, current_date + 20, 10000000, 4, v_rec_book, 30
+  );
   insert into public.recurring_savings (
     saving_id, user_id, goal_id, name, amount_vnd, linked_deposit_tx_id
   ) values (
-    v_saving, v_user, v_goal, 'Monthly', 2000000, v_b.transaction_id
+    v_saving, v_user, v_goal, 'Monthly', 2000000, v_rec_book
   );
 
-  -- Now B is the one closing in on maturity, and the recurring points at it.
-  -- Still after A's own maturity: a successor that matured first could never
-  -- absorb the book it succeeds.
-  update public.investment_transactions set expiry_date = current_date + 25
-   where transaction_id = v_b.transaction_id;
-  set constraints all immediate;
-
   select * into v_c from public.open_successor_book(
-    v_b.transaction_id, 2000000, 4.5, current_date - 4, current_date + 361, 30, null,
+    v_rec_book, 2000000, 4.5, current_date - 4, current_date + 361, 30, null,
     v_saving, to_char(current_date, 'YYYY-MM'), null);
 
   select linked_deposit_tx_id into v_linked
@@ -250,18 +257,16 @@ begin
   -- link there would drop the plan exactly when it comes due.
   begin
     update public.investment_transactions set deposit_group_id = null
-     where deposit_group_id = v_b.transaction_id;
+     where deposit_group_id = v_rec_book;
     raise exception 'closing a promised book must be refused';
   exception when sqlstate '23514' then null;
   end;
 
   -- Cancelling the handover first is the way out, and then it closes normally.
-  -- Both ends of it: v_b promises to merge into v_c, and v_book promises to
-  -- merge into v_b, so v_b cannot leave until neither promise stands.
   update public.investment_transactions set successor_deposit_tx_id = null
-   where transaction_id in (v_b.transaction_id, v_book);
+   where transaction_id = v_rec_book;
   update public.investment_transactions set deposit_group_id = null
-   where deposit_group_id = v_b.transaction_id;
+   where deposit_group_id = v_rec_book;
   set constraints all immediate;
 
   -- ── A successor cannot be withdrawn out from under its source ────────────
@@ -355,6 +360,38 @@ begin
     perform public.open_successor_book(
       v_dated_book, 1000000, 4, current_date + 1, current_date + 400, 30, null, null, null, null);
     raise exception 'a contribution dated tomorrow must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- A locked book of its own, for the lock-window cases below.
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate,
+    deposit_group_id, top_up_lock_days
+  ) values (
+    v_lockable, v_user, v_goal, 'bank', 'investment',
+    current_date - 200, current_date + 20, 10000000, 4, v_lockable, 30
+  );
+
+  -- ── A successor must be open for business, now and at the handover ──────
+  -- 25 days out with a 30-day lock is a book already inside its own window: the
+  -- savings moved onto it could never contribute, and the merge would be refused
+  -- on the very day the old book matures.
+  begin
+    perform public.open_successor_book(
+      v_lockable, 1000000, 4, current_date - 2, current_date + 25, 30, null, null, null, null);
+    raise exception 'a successor born inside its own lock window must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  -- Far enough past the source's maturity, it is fine.
+  select * into v_tail3 from public.open_successor_book(
+    v_lockable, 1000000, 4, current_date - 2, current_date + 400, 30, null, null, null, null);
+  -- ...and tightening its lock afterwards may not close that gap either.
+  begin
+    update public.investment_transactions set top_up_lock_days = 3000
+     where transaction_id = v_tail3.transaction_id;
+    set constraints all immediate;
+    raise exception 'tightening a successor lock past the source maturity must be refused';
   exception when sqlstate '23514' then null;
   end;
 

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -508,14 +508,11 @@ begin
   -- Every hole in this feature had one shape: a client writing the link
   -- directly, skipping what gives a handover its meaning. The privilege is the
   -- boundary; the guards above are what the two functions answer to.
-  -- The privilege is revoked, and the trigger holds even if a later
-  -- `grant update on all tables` hands it back — so the test grants it back and
-  -- checks the boundary still refuses. The grant mirrors the deployed database;
-  -- the surrounding transaction rolls it away.
-  if has_column_privilege('authenticated', 'public.investment_transactions',
-                          'successor_deposit_tx_id', 'UPDATE') then
-    raise exception 'authenticated must not hold the privilege on successor_deposit_tx_id';
-  end if;
+  -- Deliberately NOT asserting the revoke: the stack re-grants `authenticated`
+  -- after migrations, so the privilege is back by the time anyone connects. The
+  -- boundary is the trigger, and this is the case that proves it — granted the
+  -- privilege outright, a direct write is still refused. The grant mirrors the
+  -- deployed database; the surrounding transaction rolls it away.
   grant select, update on public.investment_transactions to authenticated;
   perform set_config('request.jwt.claims', json_build_object('sub', v_user::text)::text, true);
   perform set_config('request.jwt.claim.sub', v_user::text, true);

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -16,6 +16,7 @@ declare
   v_successor uuid;
   v_linked uuid;
   v_fulfilled bigint;
+  v_moved_goal uuid;
 begin
   insert into auth.users (id, email) values (v_user, 'successor-book@test.invalid');
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Successor') returning goal_id into v_goal;
@@ -69,6 +70,9 @@ begin
     update public.investment_transactions
        set successor_deposit_tx_id = v_book
      where transaction_id = v_b.transaction_id;
+    -- The pairing check is deferred so a multi-statement book edit is judged on
+    -- its final state; force it here to see the refusal from inside the test.
+    set constraints all immediate;
     raise exception 'the successor cannot point back at its source';
   exception when sqlstate '23514' then null;
   end;
@@ -86,6 +90,7 @@ begin
   begin
     update public.investment_transactions set successor_deposit_tx_id = v_foreign_book
      where transaction_id = v_b.transaction_id;
+    set constraints all immediate;
     raise exception 'a foreign book must not be named as a successor';
   exception when others then null;
   end;
@@ -129,6 +134,30 @@ begin
       v_c.transaction_id, 1000000, 4, current_date - 3, current_date + 362, 30, null,
       v_saving, to_char(current_date + 31, 'YYYY-MM'), null);
     raise exception 'a recurring linked elsewhere must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── A book that has handed over takes no more money ──────────────────────
+  -- The lock window alone does not cover this: a date before the window still
+  -- clears it, and the UI is not the only writer.
+  begin
+    insert into public.investment_transactions (
+      user_id, goal_id, asset_type, transaction_type, investment_date,
+      expiry_date, amount_vnd, interest_rate, deposit_group_id
+    ) values (v_user, v_goal, 'bank', 'investment', current_date - 100,
+      current_date + 24, 1000000, 4, v_book);
+    raise exception 'a top-up into a handed-over book must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── The pairing holds when the SUCCESSOR is the row that moves ───────────
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Elsewhere') returning goal_id into v_moved_goal;
+  begin
+    perform public.update_deposit_book(
+      v_b.transaction_id, true, v_moved_goal, false, null, false, null,
+      false, null, false, null, false, null, false, null);
+    set constraints all immediate;
+    raise exception 'moving the successor to another goal must be refused';
   exception when sqlstate '23514' then null;
   end;
 

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -373,6 +373,17 @@ begin
     current_date - 200, current_date + 20, 10000000, 4, v_lockable, 30
   );
 
+  -- ── A handover written straight to the column still needs a reason ──────
+  -- v_open_book takes contributions happily; naming a successor on it would
+  -- close its door without moving anything, stranding its savings.
+  begin
+    update public.investment_transactions set successor_deposit_tx_id = v_c.transaction_id
+     where transaction_id = v_open_book;
+    set constraints all immediate;
+    raise exception 'a handover from a book that still accepts top-ups must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- ── A successor must be open for business, now and at the handover ──────
   -- 25 days out with a 30-day lock is a book already inside its own window: the
   -- savings moved onto it could never contribute, and the merge would be refused
@@ -392,6 +403,23 @@ begin
      where transaction_id = v_tail3.transaction_id;
     set constraints all immediate;
     raise exception 'tightening a successor lock past the source maturity must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── No chains: a book owed a merge cannot hand over in turn ─────────────
+  -- Reachable once the source has matured and its merge is still outstanding:
+  -- v_lockable matured 15 days ago, and v_tail3 is now closing in on its own
+  -- maturity. If v_tail3 could promise onward, the merge v_lockable is waiting
+  -- for would be refused by the very guard that a handover installs.
+  update public.investment_transactions set expiry_date = current_date - 15
+   where deposit_group_id = v_lockable;
+  update public.investment_transactions set expiry_date = current_date + 20
+   where deposit_group_id = v_tail3.transaction_id;
+  set constraints all immediate;
+  begin
+    perform public.open_successor_book(
+      v_tail3.transaction_id, 1000000, 4, current_date - 1, current_date + 500, 30, null, null, null, null);
+    raise exception 'a book already promised a merge must not hand over again';
   exception when sqlstate '23514' then null;
   end;
 

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -384,6 +384,17 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- A link written by hand must also land somewhere that can receive: v_b has
+  -- long since been given a maturity, but a book inside its own lock window is
+  -- no destination for the savings this would move.
+  begin
+    update public.investment_transactions set successor_deposit_tx_id = v_lockable
+     where transaction_id = v_dated_book;
+    set constraints all immediate;
+    raise exception 'a successor that cannot take money today must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- ── A successor must be open for business, now and at the handover ──────
   -- 25 days out with a 30-day lock is a book already inside its own window: the
   -- savings moved onto it could never contribute, and the merge would be refused

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -357,6 +357,26 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- ── Clearing both columns at once is still a dissolve ───────────────────
+  begin
+    update public.investment_transactions
+       set deposit_group_id = null, successor_deposit_tx_id = null
+     where transaction_id = v_short_book;
+    raise exception 'dissolving while dropping the link in one update must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── Deleting the user takes both books, and that is allowed ─────────────
+  -- The cascade reaches these rows in no guaranteed order, so the check asks
+  -- whether the successor SURVIVED rather than refusing every promised source.
+  -- v_short_book is still promised to v_tail at this point, so this cascade is
+  -- the real case: both halves go, and the promise goes with them.
+  delete from auth.users where id = v_user;
+  set constraints all immediate;
+  if exists (select 1 from public.investment_transactions where user_id = v_user) then
+    raise exception 'the account cascade must remove both books';
+  end if;
+
   raise notice 'successor book: OK';
 end;
 $$;

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -357,6 +357,18 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- ── A successor cannot be edited into a maturity already behind us ──────
+  -- The pair ages naturally, so this is about the EDIT: moving the successor's
+  -- maturity into the past strands every saving transferred onto it.
+  begin
+    perform public.update_deposit_book(
+      v_tail.transaction_id, false, null, true, (current_date - 1)::date, false, null,
+      false, null, false, null, false, null, false, null);
+    set constraints all immediate;
+    raise exception 'moving a successor maturity into the past must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- ── Clearing both columns at once is still a dissolve ───────────────────
   begin
     update public.investment_transactions

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -27,6 +27,10 @@ declare
   v_lockable uuid := gen_random_uuid();
   v_rec_book uuid := gen_random_uuid();
   v_closed uuid := gen_random_uuid();
+  v_stray_saving uuid := gen_random_uuid();
+  v_plan uuid := gen_random_uuid();
+  v_plan_saving uuid := gen_random_uuid();
+  v_lockable2 uuid := gen_random_uuid();
 begin
   insert into auth.users (id, email) values (v_user, 'successor-book@test.invalid');
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Successor') returning goal_id into v_goal;
@@ -497,6 +501,68 @@ begin
      where transaction_id in (v_dated_book, v_tail2.transaction_id);
     set constraints all immediate;
     raise exception 'deleting a promised anchor beside its successor must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── The column is not a client's to write ───────────────────────────────
+  -- Every hole in this feature had one shape: a client writing the link
+  -- directly, skipping what gives a handover its meaning. The privilege is the
+  -- boundary; the guards above are what the two functions answer to.
+  -- The privilege is revoked, and the trigger holds even if a later
+  -- `grant update on all tables` hands it back — so the test grants it back and
+  -- checks the boundary still refuses. The grant mirrors the deployed database;
+  -- the surrounding transaction rolls it away.
+  if has_column_privilege('authenticated', 'public.investment_transactions',
+                          'successor_deposit_tx_id', 'UPDATE') then
+    raise exception 'authenticated must not hold the privilege on successor_deposit_tx_id';
+  end if;
+  grant select, update on public.investment_transactions to authenticated;
+  perform set_config('request.jwt.claims', json_build_object('sub', v_user::text)::text, true);
+  perform set_config('request.jwt.claim.sub', v_user::text, true);
+  begin
+    set local role authenticated;
+    update public.investment_transactions set successor_deposit_tx_id = v_tail2.transaction_id
+     where transaction_id = v_short_book;
+    reset role;
+    raise exception 'writing the link directly must be refused';
+  exception when sqlstate '23514' then
+    reset role;
+  end;
+  perform set_config('request.jwt.claims', '', true);
+  perform set_config('request.jwt.claim.sub', '', true);
+
+  -- Cancelling goes through its own function for the same reason.
+  perform public.cancel_successor_book(v_dated_book);
+  select successor_deposit_tx_id into v_successor
+    from public.investment_transactions where transaction_id = v_dated_book;
+  if v_successor is not null then
+    raise exception 'cancel_successor_book must clear the link';
+  end if;
+
+  -- A locked book with a saving on it, for the plan-month case.
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate,
+    deposit_group_id, top_up_lock_days
+  ) values (
+    v_lockable2, v_user, v_goal, 'bank', 'investment',
+    current_date - 200, current_date + 15, 8000000, 4, v_lockable2, 30
+  );
+  insert into public.recurring_savings (
+    saving_id, user_id, goal_id, name, amount_vnd, linked_deposit_tx_id
+  ) values (
+    v_plan_saving, v_user, v_goal, 'Planned', 1000000, v_lockable2
+  );
+
+  -- ── The plan and the contribution must name the same month ──────────────
+  insert into public.monthly_plans (id, user_id, month, year, salary_vnd)
+  values (v_plan, v_user, extract(month from current_date - 40)::int,
+          extract(year from current_date - 40)::int, 30000000);
+  begin
+    perform public.open_successor_book(
+      v_lockable2, 1000000, 4, current_date - 1, current_date + 400, 30, null,
+      v_plan_saving, to_char(current_date, 'YYYY-MM'), v_plan);
+    raise exception 'a plan from another month must be refused';
   exception when sqlstate '23514' then null;
   end;
 

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -20,6 +20,7 @@ declare
   v_open_book uuid := gen_random_uuid();
   v_short_book uuid := gen_random_uuid();
   v_tail public.investment_transactions;
+  v_extra_saving uuid := gen_random_uuid();
 begin
   insert into auth.users (id, email) values (v_user, 'successor-book@test.invalid');
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Successor') returning goal_id into v_goal;
@@ -263,9 +264,24 @@ begin
   -- ── A successor cannot be withdrawn out from under its source ────────────
   -- A full close clears the successor's own group, which would leave the source
   -- promising to merge into a row that is no longer a book at all.
+  -- ── Every saving on the old book follows it, even a manual handover ──────
+  -- The source stops accepting contributions the moment the handover commits,
+  -- so a saving left pointing at it could never be recorded again.
+  insert into public.recurring_savings (
+    saving_id, user_id, goal_id, name, amount_vnd, linked_deposit_tx_id
+  ) values (
+    v_extra_saving, v_user, v_goal, 'Also here', 500000, v_short_book
+  );
+
   -- v_short_book is still locked and unpromised, so it can open one now.
   select * into v_tail from public.open_successor_book(
     v_short_book, 1000000, 4, current_date - 2, current_date + 400, 30, null, null, null, null);
+  select linked_deposit_tx_id into v_linked
+    from public.recurring_savings where saving_id = v_extra_saving;
+  if v_linked is distinct from v_tail.transaction_id then
+    raise exception 'a saving on the old book must follow it, found %', v_linked;
+  end if;
+
   begin
     update public.investment_transactions set deposit_group_id = null
      where transaction_id = v_tail.transaction_id;

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -19,6 +19,7 @@ declare
   v_moved_goal uuid;
   v_open_book uuid := gen_random_uuid();
   v_short_book uuid := gen_random_uuid();
+  v_tail public.investment_transactions;
 begin
   insert into auth.users (id, email) values (v_user, 'successor-book@test.invalid');
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Successor') returning goal_id into v_goal;
@@ -251,11 +252,27 @@ begin
   end;
 
   -- Cancelling the handover first is the way out, and then it closes normally.
+  -- Both ends of it: v_b promises to merge into v_c, and v_book promises to
+  -- merge into v_b, so v_b cannot leave until neither promise stands.
   update public.investment_transactions set successor_deposit_tx_id = null
-   where transaction_id = v_b.transaction_id;
+   where transaction_id in (v_b.transaction_id, v_book);
   update public.investment_transactions set deposit_group_id = null
    where deposit_group_id = v_b.transaction_id;
   set constraints all immediate;
+
+  -- ── A successor cannot be withdrawn out from under its source ────────────
+  -- A full close clears the successor's own group, which would leave the source
+  -- promising to merge into a row that is no longer a book at all.
+  -- v_short_book is still locked and unpromised, so it can open one now.
+  select * into v_tail from public.open_successor_book(
+    v_short_book, 1000000, 4, current_date - 2, current_date + 400, 30, null, null, null, null);
+  begin
+    update public.investment_transactions set deposit_group_id = null
+     where transaction_id = v_tail.transaction_id;
+    set constraints all immediate;
+    raise exception 'dissolving a book that is someone''s successor must be refused';
+  exception when sqlstate '23514' then null;
+  end;
 
   raise notice 'successor book: OK';
 end;

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -528,10 +528,31 @@ begin
   perform set_config('request.jwt.claims', '', true);
   perform set_config('request.jwt.claim.sub', '', true);
 
-  -- Cancelling goes through its own function for the same reason.
-  perform public.cancel_successor_book(v_dated_book);
+  -- Neither RPC is PUBLIC's to call: they trust a null auth.uid(), which `anon`
+  -- also has, so an open EXECUTE would let anyone arrange a handover inside
+  -- someone else's account.
+  if has_function_privilege('anon',
+       'public.open_successor_book(uuid, bigint, numeric, date, date, integer, text, uuid, text, uuid)', 'EXECUTE')
+     or has_function_privilege('anon', 'public.cancel_successor_book(uuid)', 'EXECUTE') then
+    raise exception 'anon must not be able to execute the successor functions';
+  end if;
+  if not has_function_privilege('authenticated', 'public.cancel_successor_book(uuid)', 'EXECUTE') then
+    raise exception 'authenticated must keep the cancel function';
+  end if;
+
+  -- Deleting the successor drops the promise through the FK, and the boundary
+  -- must not take the deletion down with it.
+  delete from public.investment_transactions where transaction_id = v_tail2.transaction_id;
   select successor_deposit_tx_id into v_successor
     from public.investment_transactions where transaction_id = v_dated_book;
+  if v_successor is not null then
+    raise exception 'deleting the successor must drop the promise, found %', v_successor;
+  end if;
+
+  -- Cancelling goes through its own function for the same reason.
+  perform public.cancel_successor_book(v_short_book);
+  select successor_deposit_tx_id into v_successor
+    from public.investment_transactions where transaction_id = v_short_book;
   if v_successor is not null then
     raise exception 'cancel_successor_book must clear the link';
   end if;

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -133,7 +133,8 @@ begin
   -- A recurring saving linked to another book cannot be swept along: v_c is a
   -- book of the caller's with no successor yet, and the saving now points at it,
   -- so this fails on the link and not on some earlier guard.
-  update public.recurring_savings set linked_deposit_tx_id = v_book
+  -- (not at v_book: that one has handed over, and a link there is refused now)
+  update public.recurring_savings set linked_deposit_tx_id = null
    where saving_id = v_saving;
   begin
     perform public.open_successor_book(
@@ -287,6 +288,27 @@ begin
      where transaction_id = v_tail.transaction_id;
     set constraints all immediate;
     raise exception 'dissolving a book that is someone''s successor must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── Pledged collateral is frozen, so it cannot be promised away ──────────
+  update public.investment_transactions set is_pledged = true
+   where transaction_id = v_open_book;
+  update public.investment_transactions set expiry_date = current_date + 10
+   where deposit_group_id = v_open_book;
+  set constraints all immediate;
+  begin
+    perform public.open_successor_book(
+      v_open_book, 1000000, 4, current_date - 2, current_date + 400, 30, null, null, null, null);
+    raise exception 'a pledged book must not hand over';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── A recurring saving cannot be pointed at a book that handed over ──────
+  begin
+    update public.recurring_savings set linked_deposit_tx_id = v_short_book
+     where saving_id = v_extra_saving;
+    raise exception 'linking to a handed-over book must be refused';
   exception when sqlstate '23514' then null;
   end;
 

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -17,6 +17,8 @@ declare
   v_linked uuid;
   v_fulfilled bigint;
   v_moved_goal uuid;
+  v_open_book uuid := gen_random_uuid();
+  v_short_book uuid := gen_random_uuid();
 begin
   insert into auth.users (id, email) values (v_user, 'successor-book@test.invalid');
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Successor') returning goal_id into v_goal;
@@ -103,7 +105,9 @@ begin
   );
 
   -- Now B is the one closing in on maturity, and the recurring points at it.
-  update public.investment_transactions set expiry_date = current_date + 20
+  -- Still after A's own maturity: a successor that matured first could never
+  -- absorb the book it succeeds.
+  update public.investment_transactions set expiry_date = current_date + 25
    where transaction_id = v_b.transaction_id;
   set constraints all immediate;
 
@@ -158,6 +162,54 @@ begin
       false, null, false, null, false, null, false, null);
     set constraints all immediate;
     raise exception 'moving the successor to another goal must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── A successor is only for a book that has actually closed its doors ────
+  -- v_open still takes contributions: nothing about it needs replacing.
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate,
+    deposit_group_id, top_up_lock_days
+  ) values (
+    v_open_book, v_user, v_goal, 'bank', 'investment',
+    current_date - 200, current_date + 100, 10000000, 4, v_open_book, 30
+  );
+  begin
+    perform public.open_successor_book(
+      v_open_book, 1000000, 4, current_date - 5, current_date + 400, 30, null, null, null, null);
+    raise exception 'a book that still accepts the contribution must not hand over';
+  exception when sqlstate '23514' then null;
+  end;
+
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate,
+    deposit_group_id, top_up_lock_days
+  ) values (
+    v_short_book, v_user, v_goal, 'bank', 'investment',
+    current_date - 200, current_date + 20, 10000000, 4, v_short_book, 30
+  );
+
+  -- ── The successor has to outlive the book it takes over from ─────────────
+  -- The merge happens at the SOURCE's maturity, so a successor maturing first
+  -- is a plan that can never be carried out — refused when it is opened...
+  begin
+    perform public.open_successor_book(
+      v_short_book, 1000000, 4, current_date - 5, current_date + 10, 30, null, null, null, null);
+    raise exception 'a successor maturing before its source must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  -- ...and refused later, when either book's maturity is edited into that shape.
+  begin
+    perform public.update_deposit_book(
+      v_b.transaction_id, false, null, true, (current_date + 500)::date, false, null,
+      false, null, false, null, false, null, false, null);
+    perform public.update_deposit_book(
+      v_book, false, null, true, (current_date + 600)::date, false, null,
+      false, null, false, null, false, null, false, null);
+    set constraints all immediate;
+    raise exception 'pushing the source past its successor must be refused';
   exception when sqlstate '23514' then null;
   end;
 

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -408,6 +408,17 @@ begin
   -- Far enough past the source's maturity, it is fine.
   select * into v_tail3 from public.open_successor_book(
     v_lockable, 1000000, 4, current_date - 2, current_date + 400, 30, null, null, null, null);
+  -- ...nor may its maturity be pulled into its own lock window: comparing the
+  -- two maturities says nothing about whether it can take money TODAY, which is
+  -- what the savings moved onto it need.
+  begin
+    update public.investment_transactions set expiry_date = current_date + 10
+     where transaction_id = v_tail3.transaction_id;
+    set constraints all immediate;
+    raise exception 'a successor left inside its own lock window must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- ...and tightening its lock afterwards may not close that gap either.
   begin
     update public.investment_transactions set top_up_lock_days = 3000
@@ -422,11 +433,16 @@ begin
   -- v_lockable matured 15 days ago, and v_tail3 is now closing in on its own
   -- maturity. If v_tail3 could promise onward, the merge v_lockable is waiting
   -- for would be refused by the very guard that a handover installs.
+  -- This state only arises by AGEING: the pair was valid when it was made, and
+  -- then the calendar moved. No edit can produce it — the rule below refuses
+  -- terms that leave a successor unable to take money today — so the test ages
+  -- the rows with the pairing trigger off, the way time would have.
+  alter table public.investment_transactions disable trigger investment_transactions_successor_pairing_upd;
   update public.investment_transactions set expiry_date = current_date - 15
    where deposit_group_id = v_lockable;
   update public.investment_transactions set expiry_date = current_date + 20
    where deposit_group_id = v_tail3.transaction_id;
-  set constraints all immediate;
+  alter table public.investment_transactions enable trigger investment_transactions_successor_pairing_upd;
   begin
     perform public.open_successor_book(
       v_tail3.transaction_id, 1000000, 4, current_date - 1, current_date + 500, 30, null, null, null, null);

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -213,6 +213,35 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- ── A book opens with real money, so it needs a rate ─────────────────────
+  begin
+    perform public.open_successor_book(
+      v_short_book, 1000000, null, current_date - 5, current_date + 400, 30, null, null, null, null);
+    raise exception 'a successor without a rate must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── Neither book may lose its maturity while the handover stands ─────────
+  begin
+    update public.investment_transactions set expiry_date = null
+     where transaction_id = v_c.transaction_id;
+    set constraints all immediate;
+    raise exception 'clearing the successor maturity must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── Dissolving the source drops the plan with it ─────────────────────────
+  -- The money has left; a merge planned for later is moot. The old maturity
+  -- flows clear deposit_group_id across the group and must not start failing.
+  update public.investment_transactions set deposit_group_id = null
+   where deposit_group_id = v_b.transaction_id;
+  set constraints all immediate;
+  select successor_deposit_tx_id into v_successor
+    from public.investment_transactions where transaction_id = v_b.transaction_id;
+  if v_successor is not null then
+    raise exception 'a dissolved book must not keep its successor, found %', v_successor;
+  end if;
+
   raise notice 'successor book: OK';
 end;
 $$;

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -221,6 +221,15 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- ── Nor its rate: the successor holds money and inherits a recurring link ─
+  begin
+    update public.investment_transactions set interest_rate = null
+     where transaction_id = v_c.transaction_id;
+    set constraints all immediate;
+    raise exception 'clearing the successor rate must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- ── Neither book may lose its maturity while the handover stands ─────────
   begin
     update public.investment_transactions set expiry_date = null
@@ -230,17 +239,23 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
-  -- ── Dissolving the source drops the plan with it ─────────────────────────
-  -- The money has left; a merge planned for later is moot. The old maturity
-  -- flows clear deposit_group_id across the group and must not start failing.
+  -- ── A promised book is not closed behind the promise's back ─────────────
+  -- Collapse re-deposits the book's principal into a new cycle: the money has
+  -- NOT left, and that is the very moment the handover was made for. Losing the
+  -- link there would drop the plan exactly when it comes due.
+  begin
+    update public.investment_transactions set deposit_group_id = null
+     where deposit_group_id = v_b.transaction_id;
+    raise exception 'closing a promised book must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Cancelling the handover first is the way out, and then it closes normally.
+  update public.investment_transactions set successor_deposit_tx_id = null
+   where transaction_id = v_b.transaction_id;
   update public.investment_transactions set deposit_group_id = null
    where deposit_group_id = v_b.transaction_id;
   set constraints all immediate;
-  select successor_deposit_tx_id into v_successor
-    from public.investment_transactions where transaction_id = v_b.transaction_id;
-  if v_successor is not null then
-    raise exception 'a dissolved book must not keep its successor, found %', v_successor;
-  end if;
 
   raise notice 'successor book: OK';
 end;

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -434,6 +434,16 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- Nor by repointing an existing promise onto a book that has handed over:
+  -- a repoint is not a "new link", so it must be judged here, not at creation.
+  begin
+    update public.investment_transactions set successor_deposit_tx_id = v_rec_book
+     where transaction_id = v_dated_book;
+    set constraints all immediate;
+    raise exception 'repointing onto a book that has handed over must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- ── A successor cannot be edited into a maturity already behind us ──────
   -- The pair ages naturally, so this is about the EDIT: moving the successor's
   -- maturity into the past strands every saving transferred onto it.

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -338,6 +338,17 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- ── A pair is two live deposits, and stays that way ─────────────────────
+  -- An ordinary edit can turn a row into a withdrawal, which takes it out of
+  -- holdings: a pair with one half like that promises a merge with nothing.
+  begin
+    update public.investment_transactions set transaction_type = 'withdrawal'
+     where transaction_id = v_tail.transaction_id;
+    set constraints all immediate;
+    raise exception 'a successor turned into a withdrawal must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
   raise notice 'successor book: OK';
 end;
 $$;

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -349,6 +349,14 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- ── Not even tomorrow: the money has not moved yet ──────────────────────
+  begin
+    perform public.open_successor_book(
+      v_dated_book, 1000000, 4, current_date + 1, current_date + 400, 30, null, null, null, null);
+    raise exception 'a contribution dated tomorrow must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
   raise notice 'successor book: OK';
 end;
 $$;

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -22,6 +22,7 @@ declare
   v_tail public.investment_transactions;
   v_extra_saving uuid := gen_random_uuid();
   v_dated_book uuid := gen_random_uuid();
+  v_tail2 public.investment_transactions;
 begin
   insert into auth.users (id, email) values (v_user, 'successor-book@test.invalid');
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Successor') returning goal_id into v_goal;
@@ -375,6 +376,24 @@ begin
        set deposit_group_id = null, successor_deposit_tx_id = null
      where transaction_id = v_short_book;
     raise exception 'dissolving while dropping the link in one update must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── Nor by deleting the successor in the same statement ─────────────────
+  -- The guard protects the BOOK, so a two-row delete of anchor + successor must
+  -- not leave the anchor's tranches behind grouped under a row that is gone.
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, investment_date,
+    expiry_date, amount_vnd, interest_rate, deposit_group_id
+  ) values (v_user, v_goal, 'bank', 'investment', current_date - 300,
+    current_date - 60, 1000000, 4, v_dated_book);
+  select * into v_tail2 from public.open_successor_book(
+    v_dated_book, 1000000, 4, current_date - 2, current_date + 400, 30, null, null, null, null);
+  begin
+    delete from public.investment_transactions
+     where transaction_id in (v_dated_book, v_tail2.transaction_id);
+    set constraints all immediate;
+    raise exception 'deleting a promised anchor beside its successor must be refused';
   exception when sqlstate '23514' then null;
   end;
 

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -1,0 +1,139 @@
+-- A locked book hands its contributions to a successor book (#638, Phase 2).
+-- Run via `npm run test:db` after migrations are applied.
+begin;
+
+do $$
+declare
+  v_user uuid := gen_random_uuid();
+  v_other uuid := gen_random_uuid();
+  v_goal uuid;
+  v_other_goal uuid;
+  v_book uuid := gen_random_uuid();
+  v_foreign_book uuid := gen_random_uuid();
+  v_saving uuid := gen_random_uuid();
+  v_b public.investment_transactions;
+  v_c public.investment_transactions;
+  v_successor uuid;
+  v_linked uuid;
+  v_fulfilled bigint;
+begin
+  insert into auth.users (id, email) values (v_user, 'successor-book@test.invalid');
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Successor') returning goal_id into v_goal;
+
+  -- Book A: a 30-day lock and a maturity 24 days out, so it takes no more.
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate,
+    deposit_group_id, top_up_lock_days, bank_code, notes
+  ) values (
+    v_book, v_user, v_goal, 'bank', 'investment',
+    current_date - 200, current_date + 24, 10000000, 4,
+    v_book, 30, null, 'PVcomBank tích luỹ'
+  );
+
+  -- ── The successor carries the book's terms, and the link records it ───────
+  select * into v_b from public.open_successor_book(
+    v_book, 2000000, 4.2, current_date - 6, current_date + 359, 30, null, null, null, null);
+
+  if v_b.deposit_group_id is distinct from v_b.transaction_id then
+    raise exception 'the successor must be an accumulating book anchor';
+  end if;
+  if v_b.goal_id is distinct from v_goal then raise exception 'the successor must keep the goal'; end if;
+  if v_b.amount_vnd <> 2000000 then raise exception 'the successor must hold the contribution'; end if;
+  if v_b.expiry_date <> current_date + 359 then raise exception 'the successor takes the entered maturity'; end if;
+  if v_b.interest_rate <> 4.2 then raise exception 'the successor takes the entered rate'; end if;
+  if v_b.top_up_lock_days is distinct from 30 then raise exception 'the policy carries over as the default'; end if;
+
+  select successor_deposit_tx_id into v_successor
+    from public.investment_transactions where transaction_id = v_book;
+  if v_successor is distinct from v_b.transaction_id then
+    raise exception 'the source book must record its successor';
+  end if;
+
+  -- ── One successor per book ────────────────────────────────────────────────
+  begin
+    perform public.open_successor_book(
+      v_book, 1000000, 4, current_date - 5, current_date + 360, 30, null, null, null, null);
+    raise exception 'a second successor must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── A book cannot succeed itself, nor a book it already succeeds ─────────
+  begin
+    update public.investment_transactions set successor_deposit_tx_id = v_book
+     where transaction_id = v_book;
+    raise exception 'a book cannot be its own successor';
+  exception when sqlstate '23514' then null;
+  end;
+  begin
+    update public.investment_transactions
+       set successor_deposit_tx_id = v_book
+     where transaction_id = v_b.transaction_id;
+    raise exception 'the successor cannot point back at its source';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── Only a book may be named, and only one of the caller's own ───────────
+  insert into auth.users (id, email) values (v_other, 'successor-book-other@test.invalid');
+  insert into public.savings_goals (user_id, goal_name) values (v_other, 'Foreign') returning goal_id into v_other_goal;
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate, deposit_group_id
+  ) values (
+    v_foreign_book, v_other, v_other_goal, 'bank', 'investment',
+    current_date - 200, current_date + 150, 10000000, 4, v_foreign_book
+  );
+  begin
+    update public.investment_transactions set successor_deposit_tx_id = v_foreign_book
+     where transaction_id = v_b.transaction_id;
+    raise exception 'a foreign book must not be named as a successor';
+  exception when others then null;
+  end;
+
+  -- ── The recurring-driven flow moves the whole month in one transaction ───
+  insert into public.recurring_savings (
+    saving_id, user_id, goal_id, name, amount_vnd, linked_deposit_tx_id
+  ) values (
+    v_saving, v_user, v_goal, 'Monthly', 2000000, v_b.transaction_id
+  );
+
+  -- Now B is the one closing in on maturity, and the recurring points at it.
+  update public.investment_transactions set expiry_date = current_date + 20
+   where transaction_id = v_b.transaction_id;
+  set constraints all immediate;
+
+  select * into v_c from public.open_successor_book(
+    v_b.transaction_id, 2000000, 4.5, current_date - 4, current_date + 361, 30, null,
+    v_saving, to_char(current_date, 'YYYY-MM'), null);
+
+  select linked_deposit_tx_id into v_linked
+    from public.recurring_savings where saving_id = v_saving;
+  if v_linked is distinct from v_c.transaction_id then
+    raise exception 'the recurring link must move to the successor, found %', v_linked;
+  end if;
+
+  select amount_vnd into v_fulfilled
+    from public.recurring_saving_fulfillments
+   where recurring_saving_id = v_saving and ym = to_char(current_date, 'YYYY-MM');
+  if v_fulfilled is distinct from 2000000 then
+    raise exception 'the month must be fulfilled by the successor, found %', v_fulfilled;
+  end if;
+
+  -- A recurring saving linked to another book cannot be swept along: v_c is a
+  -- book of the caller's with no successor yet, and the saving now points at it,
+  -- so this fails on the link and not on some earlier guard.
+  update public.recurring_savings set linked_deposit_tx_id = v_book
+   where saving_id = v_saving;
+  begin
+    perform public.open_successor_book(
+      v_c.transaction_id, 1000000, 4, current_date - 3, current_date + 362, 30, null,
+      v_saving, to_char(current_date + 31, 'YYYY-MM'), null);
+    raise exception 'a recurring linked elsewhere must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  raise notice 'successor book: OK';
+end;
+$$;
+
+rollback;


### PR DESCRIPTION
Part of #638 — Phase 2. Phase 3 (folding the old book into the new one at maturity) is still to come, so this does not close the issue.

## The problem it solves

Phase 1 taught the app when a bank refuses another tranche. That left the user holding a contribution with nowhere to put it — and, from the monthly plan, a dead end: the Saved pill answered a matured book with "handle its maturity first" and opened nothing.

The real PVcomBank workflow is to open a **new** accumulating book, send the month there, and fold the old book in when it matures.

## What this adds

**The relationship is stored, not guessed.** `successor_deposit_tx_id` on the old book's anchor — the link exists to steer money: the recurring saving's contributions now, the maturity action in Phase 3.

**One RPC owns it.** `open_successor_book` creates the book, records the month's contribution in it, files the fulfillment so the plan does not ask again, and moves every recurring saving off a book that can no longer receive them — together, because half of that is a plan that double-counts or a contribution filed in a book nothing points at. `cancel_successor_book` withdraws the promise.

**Two entry points, one sheet.** From the book's top-up control, once the entered date is inside the lock window the submit becomes **Open successor book**, carrying the amount and date already typed. From the monthly plan, the Saved pill opens the same sheet with the month prefilled. If the entered date turns out to be one the old book still accepts, the sheet says so and offers to record it as the top-up it is.

## What the review turned it into

Direct writes to the link were the source of most findings, so the column stopped being a client's to write: the two functions above mark their own writes and anything else with a session behind it is refused at the table. (The column-level revoke is there too, but CI showed the stack re-grants `authenticated` after migrations — the trigger is the boundary, and the test proves it by granting the privilege back.)

The invariants a handover has to keep, all enforced in the database: same owner, goal and currency; both books live, unpledged deposits; the successor matures after the source **and stays outside its own lock window** when the source matures; no self-reference and no chains, in either direction; the source cannot be closed, collapsed or deleted behind the promise; recurring savings cannot point at a book that has handed over; and business dates throughout (Asia/Ho_Chi_Minh, #591).

A promised book cannot be collapsed, because that merge is what its maturity is for. Until Phase 3 lands, the maturity sheet carries the way out: cancelling the handover from where the refusal appears.

## Validation

- `npm run typecheck`, `npm run lint`, `npm test -- --run` (2305 tests), `npm run build`
- `npx supabase db reset --local` + every `supabase/tests/*.sql`, including `successor_book.test.sql`
- route tests for the API's validation, the recurring link, plan↔month, and the 400/404/409 mapping

Dates in the new SQL test are relative to `current_date`, so it will not rot as the calendar moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)