### PR TITLE
feat(deposits): fold a matured book into the successor it was promised to (#638)

### DIFF
--- a/app/api/v1/investment-transactions/[id]/merge-successor/__tests__/route.test.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/__tests__/route.test.ts
@@ -102,6 +102,38 @@ describe('GET /api/v1/investment-transactions/[id]/merge-successor (#638)', () =
     // ...and every tranche is still accounted for, across the groups.
     expect(byId.flatMap((q) => q.in!.values).sort()).toEqual([...trancheIds].sort())
   })
+
+  // The write only ever names tranches that still hold something, so a long
+  // history of spent ones is not what the ceiling is for. Counting raw rows
+  // rejected a book that would have merged perfectly well, and no reload could
+  // ever change that answer.
+  it('measures the ceiling against the tranches that still hold something', async () => {
+    const ids = Array.from({ length: 2400 }, (_, i) =>
+      `${(i + 1).toString(16).padStart(8, '0')}-0000-4000-8000-000000000000`)
+    const spent = new Set(ids.slice(0, 2000))
+    h.rowsFor = (q) => {
+      if (q.in) {
+        // Each spent tranche has one withdrawal taking all of it.
+        return q.in.values.filter((id) => spent.has(id))
+          .map((id) => ({ parent_transaction_id: id, principal_withdrawn: 1_000_000 }))
+      }
+      const [from, to] = q.range!
+      return ids.slice(from, to + 1).map((id) => ({
+        transaction_id: id, amount_vnd: 1_000_000, interest_rate: 4,
+        investment_date: '2026-01-01', expiry_date: '2026-12-31',
+        successor_deposit_tx_id: id === ids[0] ? NEW_TRANCHE : null,
+      }))
+    }
+
+    const res = await GET(
+      new Request('https://app.test/x') as unknown as NextRequest,
+      { params: Promise.resolve({ id: ids[0] }) },
+    )
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.tranches).toHaveLength(400)
+  })
 })
 
 describe('POST /api/v1/investment-transactions/[id]/merge-successor (#638)', () => {

--- a/app/api/v1/investment-transactions/[id]/merge-successor/__tests__/route.test.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/__tests__/route.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// Keeping the promise (#638, Phase 3). The route is thin: the coupled writes all
+// live in merge_book_into_successor. What it owes is validation, naming the
+// tranches it saw so a book that changed underneath can be refused, and turning
+// the RPC's refusals into answers the user can act on.
+
+const BOOK = '11111111-1111-4111-8111-111111111111'
+const T1 = '22222222-2222-4222-8222-222222222222'
+const T2 = '33333333-3333-4333-8333-333333333333'
+const NEW_TRANCHE = '44444444-4444-4444-8444-444444444444'
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  rpcResult: { data: { transaction_id: '44444444-4444-4444-8444-444444444444' } as unknown, error: null as unknown },
+  rpcCalls: [] as { name: string; args: Record<string, unknown> }[],
+}))
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: h.user } }) },
+    rpc: (name: string, args: Record<string, unknown>) => {
+      h.rpcCalls.push({ name, args })
+      return { single: async () => h.rpcResult }
+    },
+  }),
+}))
+
+const { POST } = await import('../route')
+
+const BODY = {
+  received_vnd: 12_500_000,
+  interest_rate: 4.6,
+  merge_date: '2026-08-01',
+  tranche_ids: [T1, T2],
+}
+
+const call = (body: Record<string, unknown> = BODY) =>
+  POST(
+    new Request(`https://app.test/api/v1/investment-transactions/${BOOK}/merge-successor`, {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest,
+    { params: Promise.resolve({ id: BOOK }) },
+  )
+
+beforeEach(() => {
+  h.user = { id: 'user-1' }
+  h.rpcResult = { data: { transaction_id: NEW_TRANCHE }, error: null }
+  h.rpcCalls = []
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('POST /api/v1/investment-transactions/[id]/merge-successor (#638)', () => {
+  it('hands the whole merge to the atomic RPC, tranches included', async () => {
+    const res = await call()
+
+    expect(res.status).toBe(201)
+    await expect(res.json()).resolves.toMatchObject({ transaction_id: NEW_TRANCHE })
+    expect(h.rpcCalls[0]).toMatchObject({
+      name: 'merge_book_into_successor',
+      args: {
+        p_source_book_id: BOOK,
+        p_received_vnd: 12_500_000,
+        p_interest_rate: 4.6,
+        p_merge_date: '2026-08-01',
+        p_tranche_ids: [T1, T2],
+      },
+    })
+  })
+
+  it('rejects an anonymous caller', async () => {
+    h.user = null
+    expect((await call()).status).toBe(401)
+  })
+
+  it.each([
+    ['no tranches named', { ...BODY, tranche_ids: [] }],
+    ['a rate of nothing', { ...BODY, interest_rate: null }],
+    ['nothing received', { ...BODY, received_vnd: 0 }],
+    ['a merge dated in the future', { ...BODY, merge_date: '2099-01-01' }],
+  ])('refuses %s before reaching the database', async (_label, body) => {
+    const res = await call(body)
+
+    expect(res.status).toBe(400)
+    expect(h.rpcCalls).toHaveLength(0)
+  })
+
+  // A top-up landing while the confirmation is open means the cash being
+  // confirmed is not the cash the book holds.
+  it('asks the client to reload when the book changed underneath', async () => {
+    h.rpcResult = { data: null, error: { message: 'merge successor: book changed since load, reload and retry' } }
+
+    const res = await call()
+
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toMatchObject({ code: 'book_changed' })
+  })
+
+  it('passes on a rule the user can satisfy as a 400, not a fault', async () => {
+    h.rpcResult = { data: null, error: { message: 'merge successor: this book has not matured yet' } }
+
+    const res = await call()
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({
+      error: 'this book has not matured yet', code: 'merge_refused',
+    })
+  })
+
+  it('explains a successor that has closed its own door', async () => {
+    h.rpcResult = {
+      data: null,
+      error: { message: 'accumulating top-up: this deposit no longer accepts top-ups: 20 days remain before maturity (its lock window is 30 days)' },
+    }
+
+    const res = await call()
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ code: 'successor_closed' })
+  })
+
+  it('reports a missing book as a 404', async () => {
+    h.rpcResult = { data: null, error: { message: 'merge successor: accumulating book not found' } }
+
+    expect((await call()).status).toBe(404)
+  })
+})

--- a/app/api/v1/investment-transactions/[id]/merge-successor/__tests__/route.test.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/__tests__/route.test.ts
@@ -34,6 +34,7 @@ const BODY = {
   interest_rate: 4.6,
   merge_date: '2026-08-01',
   tranche_ids: [T1, T2],
+  tranche_principals: [8_000_000, 4_500_000],
 }
 
 const call = (body: Record<string, unknown> = BODY) =>
@@ -66,6 +67,7 @@ describe('POST /api/v1/investment-transactions/[id]/merge-successor (#638)', () 
         p_interest_rate: 4.6,
         p_merge_date: '2026-08-01',
         p_tranche_ids: [T1, T2],
+        p_tranche_principals: [8_000_000, 4_500_000],
       },
     })
   })
@@ -77,6 +79,7 @@ describe('POST /api/v1/investment-transactions/[id]/merge-successor (#638)', () 
 
   it.each([
     ['no tranches named', { ...BODY, tranche_ids: [] }],
+    ['balances that do not match the tranches', { ...BODY, tranche_principals: [8_000_000] }],
     ['a rate of nothing', { ...BODY, interest_rate: null }],
     ['nothing received', { ...BODY, received_vnd: 0 }],
     ['a merge dated in the future', { ...BODY, merge_date: '2099-01-01' }],

--- a/app/api/v1/investment-transactions/[id]/merge-successor/__tests__/route.test.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/__tests__/route.test.ts
@@ -10,6 +10,7 @@ const BOOK = '11111111-1111-4111-8111-111111111111'
 const T1 = '22222222-2222-4222-8222-222222222222'
 const T2 = '33333333-3333-4333-8333-333333333333'
 const NEW_TRANCHE = '44444444-4444-4444-8444-444444444444'
+const SUCCESSOR = '55555555-5555-4555-8555-555555555555'
 
 const h = vi.hoisted(() => ({
   user: { id: 'user-1' } as { id: string } | null,
@@ -35,6 +36,7 @@ const BODY = {
   merge_date: '2026-08-01',
   tranche_ids: [T1, T2],
   tranche_principals: [8_000_000, 4_500_000],
+  expected_successor_id: SUCCESSOR,
 }
 
 const call = (body: Record<string, unknown> = BODY) =>
@@ -68,6 +70,10 @@ describe('POST /api/v1/investment-transactions/[id]/merge-successor (#638)', () 
         p_merge_date: '2026-08-01',
         p_tranche_ids: [T1, T2],
         p_tranche_principals: [8_000_000, 4_500_000],
+        // The destination the user was looking at. The promise is cancellable,
+        // so without this a replacement opened mid-confirmation would take the
+        // cash while passing every other check.
+        p_expected_successor_id: SUCCESSOR,
       },
     })
   })
@@ -83,6 +89,7 @@ describe('POST /api/v1/investment-transactions/[id]/merge-successor (#638)', () 
     ['a rate of nothing', { ...BODY, interest_rate: null }],
     ['nothing received', { ...BODY, received_vnd: 0 }],
     ['a merge dated in the future', { ...BODY, merge_date: '2099-01-01' }],
+    ['no destination named', { ...BODY, expected_successor_id: undefined }],
   ])('refuses %s before reaching the database', async (_label, body) => {
     const res = await call(body)
 

--- a/app/api/v1/investment-transactions/[id]/merge-successor/__tests__/route.test.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/__tests__/route.test.ts
@@ -16,6 +16,9 @@ const h = vi.hoisted(() => ({
   user: { id: 'user-1' } as { id: string } | null,
   rpcResult: { data: { transaction_id: '44444444-4444-4444-8444-444444444444' } as unknown, error: null as unknown },
   rpcCalls: [] as { name: string; args: Record<string, unknown> }[],
+  // What the preview asked the database for. Every filter and range, in order.
+  selects: [] as { table: string; in?: { column: string; values: string[] }; range?: [number, number] }[],
+  rowsFor: (_q: { in?: { column: string; values: string[] }; range?: [number, number] }) => [] as unknown[],
 }))
 
 vi.mock('@/lib/supabase-server', () => ({
@@ -25,10 +28,22 @@ vi.mock('@/lib/supabase-server', () => ({
       h.rpcCalls.push({ name, args })
       return { single: async () => h.rpcResult }
     },
+    from: (table: string) => {
+      const q: { table: string; in?: { column: string; values: string[] }; range?: [number, number] } = { table }
+      const builder: Record<string, unknown> = {}
+      for (const m of ['select', 'eq', 'is', 'order']) builder[m] = () => builder
+      builder.in = (column: string, values: string[]) => { q.in = { column, values }; return builder }
+      builder.range = (from: number, to: number) => {
+        q.range = [from, to]
+        h.selects.push(q)
+        return Promise.resolve({ data: h.rowsFor(q), error: null })
+      }
+      return builder
+    },
   }),
 }))
 
-const { POST } = await import('../route')
+const { POST, GET } = await import('../route')
 
 const BODY = {
   received_vnd: 12_500_000,
@@ -52,7 +67,41 @@ beforeEach(() => {
   h.user = { id: 'user-1' }
   h.rpcResult = { data: { transaction_id: NEW_TRANCHE }, error: null }
   h.rpcCalls = []
+  h.selects = []
+  h.rowsFor = () => []
   vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+// A big book is the whole reason the preview reads from the server rather than
+// from the goal page's capped list, so the read has to survive one.
+describe('GET /api/v1/investment-transactions/[id]/merge-successor (#638)', () => {
+  it('asks for withdrawals in bounded groups, whatever the book’s size', async () => {
+    const trancheIds = Array.from({ length: 640 }, (_, i) =>
+      `${(i + 1).toString(16).padStart(8, '0')}-0000-4000-8000-000000000000`)
+    h.rowsFor = (q) => {
+      if (q.in) return []
+      const [from, to] = q.range!
+      return trancheIds.slice(from, to + 1).map((id) => ({
+        transaction_id: id, amount_vnd: 1_000_000, interest_rate: 4,
+        investment_date: '2026-01-01', expiry_date: '2026-12-31',
+        successor_deposit_tx_id: id === trancheIds[0] ? NEW_TRANCHE : null,
+      }))
+    }
+
+    const res = await GET(
+      new Request('https://app.test/x') as unknown as NextRequest,
+      { params: Promise.resolve({ id: trancheIds[0] }) },
+    )
+
+    expect(res.status).toBe(200)
+    const byId = h.selects.filter((q) => q.in)
+    expect(byId.length).toBeGreaterThan(1)
+    // One filter per group, never one filter carrying the whole book — that URL
+    // is tens of kilobytes and the gateway rejects it before PostgREST sees it.
+    for (const q of byId) expect(q.in!.values.length).toBeLessThanOrEqual(100)
+    // ...and every tranche is still accounted for, across the groups.
+    expect(byId.flatMap((q) => q.in!.values).sort()).toEqual([...trancheIds].sort())
+  })
 })
 
 describe('POST /api/v1/investment-transactions/[id]/merge-successor (#638)', () => {

--- a/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
@@ -13,6 +13,11 @@ const MERGE_TRANCHE_LIMIT = 2000
 // request quietly returns fewer. Pages of this size, read until one comes back
 // short, are how the whole book is actually seen.
 const PAGE = 500
+// `in.(...)` puts every id in the query string. At the tranche ceiling that is
+// one ~74 KB URL, past what the gateway in front of PostgREST will accept — and
+// paging the RANGE does not shorten the filter, so the preview failed outright
+// on exactly the large books paging exists for. Asked in bounded groups instead.
+const ID_CHUNK = 100
 
 async function readAllPages<T>(
   run: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>,
@@ -92,29 +97,36 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   const withdrawnBy = new Map<string, number>()
   if (tranchesRows.length > 0) {
     const ids = tranchesRows.map((r) => r.transaction_id)
-    // A book can carry more withdrawals than tranches, so this is paged too.
-    const wPages = await readAllPages<{ parent_transaction_id: string | null; principal_withdrawn: number | null }>(
-      (from, to) => supabase
-        .from('investment_transactions')
-        .select('parent_transaction_id, principal_withdrawn')
-        .eq('user_id', user.id)
-        .eq('transaction_type', 'withdrawal')
-        .in('parent_transaction_id', ids)
-        .order('transaction_id')
-        .range(from, to), MERGE_TRANCHE_LIMIT * 4)
-    if (wPages.error) {
-      console.error('merge preview failed', wPages.error)
-      return NextResponse.json({ error: 'Failed to read the book' }, { status: 500 })
-    }
-    if (wPages.truncated) {
-      return NextResponse.json(
-        { error: 'This book has more history than the merge can take at once.', code: 'book_too_large' },
-        { status: 422 },
-      )
-    }
-    for (const w of wPages.rows) {
-      if (!w.parent_transaction_id) continue
-      withdrawnBy.set(w.parent_transaction_id, (withdrawnBy.get(w.parent_transaction_id) ?? 0) + (w.principal_withdrawn ?? 0))
+    const WITHDRAWAL_LIMIT = MERGE_TRANCHE_LIMIT * 4
+    let seen = 0
+    // A book can carry more withdrawals than tranches, so each group is paged
+    // too — and the ceiling counts across groups, not within one.
+    for (let i = 0; i < ids.length; i += ID_CHUNK) {
+      const group = ids.slice(i, i + ID_CHUNK)
+      const wPages = await readAllPages<{ parent_transaction_id: string | null; principal_withdrawn: number | null }>(
+        (from, to) => supabase
+          .from('investment_transactions')
+          .select('parent_transaction_id, principal_withdrawn')
+          .eq('user_id', user.id)
+          .eq('transaction_type', 'withdrawal')
+          .in('parent_transaction_id', group)
+          .order('transaction_id')
+          .range(from, to), WITHDRAWAL_LIMIT - seen)
+      if (wPages.error) {
+        console.error('merge preview failed', wPages.error)
+        return NextResponse.json({ error: 'Failed to read the book' }, { status: 500 })
+      }
+      if (wPages.truncated) {
+        return NextResponse.json(
+          { error: 'This book has more history than the merge can take at once.', code: 'book_too_large' },
+          { status: 422 },
+        )
+      }
+      seen += wPages.rows.length
+      for (const w of wPages.rows) {
+        if (!w.parent_transaction_id) continue
+        withdrawnBy.set(w.parent_transaction_id, (withdrawnBy.get(w.parent_transaction_id) ?? 0) + (w.principal_withdrawn ?? 0))
+      }
     }
   }
 

--- a/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
@@ -4,6 +4,11 @@ import { ValidationError, validateAmount, validateDate, validateRate, validateUU
 import { isFutureInvestmentDate } from '@/lib/dates'
 import { readJsonBody } from '@/lib/apiBody'
 
+// One ceiling for the preview and the write. Reaching it is reported rather than
+// silently truncated — a short preview can never satisfy the RPC, and the merge
+// would fail with book_changed forever.
+const MERGE_TRANCHE_LIMIT = 2000
+
 // Keep the promise: fold a matured accumulating book into the successor it was
 // handed to (#638, Phase 3). `id` is the source book's anchor.
 //
@@ -42,7 +47,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     .eq('deposit_group_id', bookId)
     .eq('transaction_type', 'investment')
     .is('renewed_from_transaction_id', null)
-    .limit(2000)
+    .limit(MERGE_TRANCHE_LIMIT + 1)
 
   if (error) {
     console.error('merge preview failed', error.message)
@@ -50,6 +55,12 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   }
 
   const tranchesRows = trancheRows ?? []
+  if (tranchesRows.length > MERGE_TRANCHE_LIMIT) {
+    return NextResponse.json(
+      { error: 'This book has more tranches than the merge can take at once.', code: 'book_too_large' },
+      { status: 422 },
+    )
+  }
   const withdrawnBy = new Map<string, number>()
   if (tranchesRows.length > 0) {
     const { data: withdrawals, error: wErr } = await supabase
@@ -116,7 +127,9 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     if (!Array.isArray(tranche_ids) || tranche_ids.length === 0) {
       throw new ValidationError('tranche_ids is required')
     }
-    if (tranche_ids.length > 500) throw new ValidationError('tranche_ids is too long')
+    // Whatever the preview can return, this has to accept: the RPC requires
+    // every live tranche, so a book between the two limits could never merge.
+    if (tranche_ids.length > MERGE_TRANCHE_LIMIT) throw new ValidationError('tranche_ids is too long')
     cleanTrancheIds = tranche_ids.map((v, i) => validateUUID(v, `tranche_ids[${i}]`))
     // The balances the client saw, not just which rows it saw: a partial
     // withdrawal landing after the confirmation loaded leaves every id in place

--- a/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
@@ -31,11 +31,17 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     throw e
   }
 
-  const { data: rows, error } = await supabase
+  // The book first, then only the withdrawals that belong to it. Asking for
+  // every parented row the user owns and filtering afterwards is bounded by the
+  // whole account rather than by this book — and anything the cap drops comes
+  // back as a permanent `book_changed` that reloading cannot fix.
+  const { data: trancheRows, error } = await supabase
     .from('investment_transactions')
-    .select('transaction_id, transaction_type, parent_transaction_id, amount_vnd, principal_withdrawn, interest_rate, investment_date, expiry_date, deposit_group_id, renewed_from_transaction_id')
+    .select('transaction_id, transaction_type, amount_vnd, interest_rate, investment_date, renewed_from_transaction_id')
     .eq('user_id', user.id)
-    .or(`deposit_group_id.eq.${bookId},parent_transaction_id.not.is.null`)
+    .eq('deposit_group_id', bookId)
+    .eq('transaction_type', 'investment')
+    .is('renewed_from_transaction_id', null)
     .limit(2000)
 
   if (error) {
@@ -43,13 +49,23 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     return NextResponse.json({ error: 'Failed to read the book' }, { status: 500 })
   }
 
-  const all = rows ?? []
-  const tranchesRows = all.filter((r) => r.deposit_group_id === bookId
-    && r.transaction_type === 'investment' && !r.renewed_from_transaction_id)
+  const tranchesRows = trancheRows ?? []
   const withdrawnBy = new Map<string, number>()
-  for (const r of all) {
-    if (r.transaction_type !== 'withdrawal' || !r.parent_transaction_id) continue
-    withdrawnBy.set(r.parent_transaction_id, (withdrawnBy.get(r.parent_transaction_id) ?? 0) + (r.principal_withdrawn ?? 0))
+  if (tranchesRows.length > 0) {
+    const { data: withdrawals, error: wErr } = await supabase
+      .from('investment_transactions')
+      .select('parent_transaction_id, principal_withdrawn')
+      .eq('user_id', user.id)
+      .eq('transaction_type', 'withdrawal')
+      .in('parent_transaction_id', tranchesRows.map((r) => r.transaction_id))
+    if (wErr) {
+      console.error('merge preview failed', wErr.message)
+      return NextResponse.json({ error: 'Failed to read the book' }, { status: 500 })
+    }
+    for (const w of withdrawals ?? []) {
+      if (!w.parent_transaction_id) continue
+      withdrawnBy.set(w.parent_transaction_id, (withdrawnBy.get(w.parent_transaction_id) ?? 0) + (w.principal_withdrawn ?? 0))
+    }
   }
 
   // Only what still holds something: a spent tranche is not the caller's to

--- a/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
@@ -80,7 +80,11 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
     .eq('transaction_type', 'investment')
     .is('renewed_from_transaction_id', null)
     .order('transaction_id')
-    .range(from, to), MERGE_TRANCHE_LIMIT)
+    // The ceiling belongs on the LIVE tranches, applied further down: what the
+    // write needs is every tranche that still holds something, and a long
+    // history of spent ones is not that. Capping the raw read at the same
+    // number rejected a book that would have merged perfectly well.
+    .range(from, to), MERGE_TRANCHE_LIMIT * 4)
 
   if (tranchePages.error) {
     console.error('merge preview failed', tranchePages.error)
@@ -144,6 +148,13 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
 
   if (tranches.length === 0) {
     return NextResponse.json({ error: 'Accumulating book not found.' }, { status: 404 })
+  }
+  // Now the ceiling, on what the write actually has to name.
+  if (tranches.length > MERGE_TRANCHE_LIMIT) {
+    return NextResponse.json(
+      { error: 'This book has more tranches than the merge can take at once.', code: 'book_too_large' },
+      { status: 422 },
+    )
   }
   // What the bank pays out: the principal still held plus the interest it
   // accrued, valued with the one formula the collapse route uses. The sheet's

--- a/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServerClient } from '@/lib/supabase-server'
+import { ValidationError, validateAmount, validateDate, validateRate, validateUUID } from '@/lib/validation'
+import { isFutureInvestmentDate } from '@/lib/dates'
+import { readJsonBody } from '@/lib/apiBody'
+
+// Keep the promise: fold a matured accumulating book into the successor it was
+// handed to (#638, Phase 3). `id` is the source book's anchor.
+//
+// Everything that has to happen together happens in merge_book_into_successor —
+// closing every tranche, allocating the cash the bank actually paid across them,
+// recording it as one tranche in the new book, moving what still funded the old
+// one, and retiring the promise. The route validates, names the tranches it saw
+// so the RPC can refuse a book that changed underneath, and turns refusals into
+// answers.
+export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  const parsed = await readJsonBody(request)
+  if (!parsed.ok) return parsed.response
+  const body = parsed.body
+  const { received_vnd, interest_rate, merge_date, tranche_ids } = body
+
+  let bookId: string
+  let cleanReceived: number
+  let cleanRate: number
+  let cleanDate: string
+  let cleanTrancheIds: string[]
+  try {
+    bookId = validateUUID(id, 'id')
+    cleanReceived = validateAmount(received_vnd, 'received_vnd')
+    if (cleanReceived <= 0) throw new ValidationError('received_vnd must be positive')
+    if (interest_rate == null || interest_rate === '') throw new ValidationError('interest_rate is required')
+    cleanRate = validateRate(interest_rate, 'interest_rate')
+    if (!(cleanRate > 0)) throw new ValidationError('interest_rate must be positive')
+    cleanDate = validateDate(merge_date, 'merge_date')
+    if (!Array.isArray(tranche_ids) || tranche_ids.length === 0) {
+      throw new ValidationError('tranche_ids is required')
+    }
+    if (tranche_ids.length > 500) throw new ValidationError('tranche_ids is too long')
+    cleanTrancheIds = tranche_ids.map((v, i) => validateUUID(v, `tranche_ids[${i}]`))
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  if (isFutureInvestmentDate(cleanDate)) {
+    return NextResponse.json({ error: 'The merge date cannot be in the future.' }, { status: 400 })
+  }
+
+  const { data: merged, error } = await supabase
+    .rpc('merge_book_into_successor', {
+      p_source_book_id: bookId,
+      p_received_vnd: Math.round(cleanReceived),
+      p_interest_rate: cleanRate,
+      p_merge_date: cleanDate,
+      p_tranche_ids: cleanTrancheIds,
+    })
+    .single<{ transaction_id: string }>()
+
+  if (error || !merged) {
+    const msg = error?.message ?? ''
+    // The book took a top-up while the confirmation was open, so the cash the
+    // user is confirming is not the cash the book holds. Reload and look again.
+    if (msg.includes('book changed since load')) {
+      return NextResponse.json(
+        { error: 'This book changed — please reload and try again.', code: 'book_changed' },
+        { status: 409 },
+      )
+    }
+    if (msg.includes('not found') || msg.includes('successor book is gone')) {
+      return NextResponse.json({ error: 'Accumulating book not found.' }, { status: 404 })
+    }
+    // Everything else this family raises is a rule the user can satisfy — the
+    // book is not due yet, the successor has closed its own door, the amount is
+    // not one this book could have paid out.
+    if (msg.startsWith('merge successor: ')) {
+      return NextResponse.json(
+        { error: msg.slice('merge successor: '.length), code: 'merge_refused' },
+        { status: 400 },
+      )
+    }
+    if (msg.startsWith('accumulating top-up: ')) {
+      return NextResponse.json(
+        { error: msg.slice('accumulating top-up: '.length), code: 'successor_closed' },
+        { status: 400 },
+      )
+    }
+    console.error('merge_book_into_successor failed', msg)
+    return NextResponse.json({ error: 'Failed to merge the book' }, { status: 500 })
+  }
+
+  return NextResponse.json(merged, { status: 201 })
+}

--- a/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
@@ -66,10 +66,10 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   // back as a permanent `book_changed` that reloading cannot fix.
   const tranchePages = await readAllPages<{
     transaction_id: string; amount_vnd: number | null; interest_rate: number | null
-    investment_date: string; expiry_date: string | null
+    investment_date: string; expiry_date: string | null; successor_deposit_tx_id: string | null
   }>((from, to) => supabase
     .from('investment_transactions')
-    .select('transaction_id, amount_vnd, interest_rate, investment_date, expiry_date')
+    .select('transaction_id, amount_vnd, interest_rate, investment_date, expiry_date, successor_deposit_tx_id')
     .eq('user_id', user.id)
     .eq('deposit_group_id', bookId)
     .eq('transaction_type', 'investment')
@@ -148,6 +148,10 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   })))
   return NextResponse.json({
     tranches,
+    // Which book this one is promised to right now. The confirmation submits it
+    // back, so a handover cancelled and re-made in the meantime is caught rather
+    // than silently paid out to the replacement.
+    successor_id: tranchesRows.find((r) => r.transaction_id === bookId)?.successor_deposit_tx_id ?? null,
     effective_principal: plan.totalPrincipal,
     projected_value: plan.totalPrincipal + plan.totalInterest,
   })
@@ -162,7 +166,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const parsed = await readJsonBody(request)
   if (!parsed.ok) return parsed.response
   const body = parsed.body
-  const { received_vnd, interest_rate, merge_date, tranche_ids, tranche_principals } = body
+  const { received_vnd, interest_rate, merge_date, tranche_ids, tranche_principals, expected_successor_id } = body
 
   let bookId: string
   let cleanReceived: number
@@ -170,8 +174,14 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   let cleanDate: string
   let cleanTrancheIds: string[]
   let cleanTranchePrincipals: number[]
+  let cleanExpectedSuccessor: string
   try {
     bookId = validateUUID(id, 'id')
+    // The destination the sheet showed. A handover can be cancelled and re-made
+    // while the confirmation is open, and the replacement satisfies every rule
+    // the pairing enforces — so the only thing that can catch it is the caller
+    // saying which book they were looking at.
+    cleanExpectedSuccessor = validateUUID(expected_successor_id, 'expected_successor_id')
     cleanReceived = validateAmount(received_vnd, 'received_vnd')
     if (cleanReceived <= 0) throw new ValidationError('received_vnd must be positive')
     if (interest_rate == null || interest_rate === '') throw new ValidationError('interest_rate is required')
@@ -209,6 +219,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       p_merge_date: cleanDate,
       p_tranche_ids: cleanTrancheIds,
       p_tranche_principals: cleanTranchePrincipals,
+      p_expected_successor_id: cleanExpectedSuccessor,
     })
     .single<{ transaction_id: string }>()
 

--- a/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
@@ -13,6 +13,65 @@ import { readJsonBody } from '@/lib/apiBody'
 // one, and retiring the promise. The route validates, names the tranches it saw
 // so the RPC can refuse a book that changed underneath, and turns refusals into
 // answers.
+// What the book actually holds, straight from the source. The goal page caps at
+// 200 rows and backfills only missing anchors, so a large goal hands the sheet a
+// partial book — and a partial book can never satisfy the RPC's tranche check,
+// however many times it is reloaded. So the confirmation asks here instead.
+export async function GET(_request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params
+  const supabase = await createSupabaseServerClient()
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+
+  let bookId: string
+  try {
+    bookId = validateUUID(id, 'id')
+  } catch (e) {
+    if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
+    throw e
+  }
+
+  const { data: rows, error } = await supabase
+    .from('investment_transactions')
+    .select('transaction_id, transaction_type, parent_transaction_id, amount_vnd, principal_withdrawn, interest_rate, investment_date, expiry_date, deposit_group_id, renewed_from_transaction_id')
+    .eq('user_id', user.id)
+    .or(`deposit_group_id.eq.${bookId},parent_transaction_id.not.is.null`)
+    .limit(2000)
+
+  if (error) {
+    console.error('merge preview failed', error.message)
+    return NextResponse.json({ error: 'Failed to read the book' }, { status: 500 })
+  }
+
+  const all = rows ?? []
+  const tranchesRows = all.filter((r) => r.deposit_group_id === bookId
+    && r.transaction_type === 'investment' && !r.renewed_from_transaction_id)
+  const withdrawnBy = new Map<string, number>()
+  for (const r of all) {
+    if (r.transaction_type !== 'withdrawal' || !r.parent_transaction_id) continue
+    withdrawnBy.set(r.parent_transaction_id, (withdrawnBy.get(r.parent_transaction_id) ?? 0) + (r.principal_withdrawn ?? 0))
+  }
+
+  // Only what still holds something: a spent tranche is not the caller's to
+  // account for, and the RPC skips it for the same reason.
+  const tranches = tranchesRows
+    .map((r) => ({
+      transaction_id: r.transaction_id,
+      investment_date: r.investment_date,
+      interest_rate: r.interest_rate,
+      effective_principal: (r.amount_vnd ?? 0) - (withdrawnBy.get(r.transaction_id) ?? 0),
+    }))
+    .filter((t) => t.effective_principal > 0)
+
+  if (tranches.length === 0) {
+    return NextResponse.json({ error: 'Accumulating book not found.' }, { status: 404 })
+  }
+  return NextResponse.json({
+    tranches,
+    effective_principal: tranches.reduce((sum, t) => sum + t.effective_principal, 0),
+  })
+}
+
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
   const supabase = await createSupabaseServerClient()

--- a/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
@@ -8,6 +8,26 @@ import { readJsonBody } from '@/lib/apiBody'
 // silently truncated — a short preview can never satisfy the RPC, and the merge
 // would fail with book_changed forever.
 const MERGE_TRANCHE_LIMIT = 2000
+// PostgREST caps a response at config.toml's max_rows, so asking for more in one
+// request quietly returns fewer. Pages of this size, read until one comes back
+// short, are how the whole book is actually seen.
+const PAGE = 500
+
+async function readAllPages<T>(
+  run: (from: number, to: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>,
+  ceiling: number,
+): Promise<{ rows: T[]; error?: string; truncated?: boolean }> {
+  const rows: T[] = []
+  for (let from = 0; from <= ceiling; from += PAGE) {
+    const { data, error } = await run(from, from + PAGE - 1)
+    if (error) return { rows, error: error.message }
+    const page = data ?? []
+    rows.push(...page)
+    if (page.length < PAGE) return { rows }
+    if (rows.length > ceiling) return { rows, truncated: true }
+  }
+  return { rows, truncated: true }
+}
 
 // Keep the promise: fold a matured accumulating book into the successor it was
 // handed to (#638, Phase 3). `id` is the source book's anchor.
@@ -40,22 +60,25 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   // every parented row the user owns and filtering afterwards is bounded by the
   // whole account rather than by this book — and anything the cap drops comes
   // back as a permanent `book_changed` that reloading cannot fix.
-  const { data: trancheRows, error } = await supabase
+  const tranchePages = await readAllPages<{
+    transaction_id: string; amount_vnd: number | null; interest_rate: number | null; investment_date: string
+  }>((from, to) => supabase
     .from('investment_transactions')
-    .select('transaction_id, transaction_type, amount_vnd, interest_rate, investment_date, renewed_from_transaction_id')
+    .select('transaction_id, amount_vnd, interest_rate, investment_date')
     .eq('user_id', user.id)
     .eq('deposit_group_id', bookId)
     .eq('transaction_type', 'investment')
     .is('renewed_from_transaction_id', null)
-    .limit(MERGE_TRANCHE_LIMIT + 1)
+    .order('transaction_id')
+    .range(from, to), MERGE_TRANCHE_LIMIT)
 
-  if (error) {
-    console.error('merge preview failed', error.message)
+  if (tranchePages.error) {
+    console.error('merge preview failed', tranchePages.error)
     return NextResponse.json({ error: 'Failed to read the book' }, { status: 500 })
   }
 
-  const tranchesRows = trancheRows ?? []
-  if (tranchesRows.length > MERGE_TRANCHE_LIMIT) {
+  const tranchesRows = tranchePages.rows
+  if (tranchePages.truncated) {
     return NextResponse.json(
       { error: 'This book has more tranches than the merge can take at once.', code: 'book_too_large' },
       { status: 422 },
@@ -63,17 +86,28 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   }
   const withdrawnBy = new Map<string, number>()
   if (tranchesRows.length > 0) {
-    const { data: withdrawals, error: wErr } = await supabase
-      .from('investment_transactions')
-      .select('parent_transaction_id, principal_withdrawn')
-      .eq('user_id', user.id)
-      .eq('transaction_type', 'withdrawal')
-      .in('parent_transaction_id', tranchesRows.map((r) => r.transaction_id))
-    if (wErr) {
-      console.error('merge preview failed', wErr.message)
+    const ids = tranchesRows.map((r) => r.transaction_id)
+    // A book can carry more withdrawals than tranches, so this is paged too.
+    const wPages = await readAllPages<{ parent_transaction_id: string | null; principal_withdrawn: number | null }>(
+      (from, to) => supabase
+        .from('investment_transactions')
+        .select('parent_transaction_id, principal_withdrawn')
+        .eq('user_id', user.id)
+        .eq('transaction_type', 'withdrawal')
+        .in('parent_transaction_id', ids)
+        .order('transaction_id')
+        .range(from, to), MERGE_TRANCHE_LIMIT * 4)
+    if (wPages.error) {
+      console.error('merge preview failed', wPages.error)
       return NextResponse.json({ error: 'Failed to read the book' }, { status: 500 })
     }
-    for (const w of withdrawals ?? []) {
+    if (wPages.truncated) {
+      return NextResponse.json(
+        { error: 'This book has more history than the merge can take at once.', code: 'book_too_large' },
+        { status: 422 },
+      )
+    }
+    for (const w of wPages.rows) {
       if (!w.parent_transaction_id) continue
       withdrawnBy.set(w.parent_transaction_id, (withdrawnBy.get(w.parent_transaction_id) ?? 0) + (w.principal_withdrawn ?? 0))
     }

--- a/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
@@ -23,8 +23,11 @@ async function readAllPages<T>(
     if (error) return { rows, error: error.message }
     const page = data ?? []
     rows.push(...page)
-    if (page.length < PAGE) return { rows }
+    // Ceiling first: a short page that arrives ALREADY over the limit was
+    // returning as a complete read, so the preview handed back more than the
+    // write would accept and the book could never be merged.
     if (rows.length > ceiling) return { rows, truncated: true }
+    if (page.length < PAGE) return { rows }
   }
   return { rows, truncated: true }
 }

--- a/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
@@ -3,6 +3,7 @@ import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateRate, validateUUID } from '@/lib/validation'
 import { isFutureInvestmentDate } from '@/lib/dates'
 import { readJsonBody } from '@/lib/apiBody'
+import { buildCollapsePlan } from '@/lib/accumulating'
 
 // One ceiling for the preview and the write. Reaching it is reported rather than
 // silently truncated — a short preview can never satisfy the RPC, and the merge
@@ -64,10 +65,11 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   // whole account rather than by this book — and anything the cap drops comes
   // back as a permanent `book_changed` that reloading cannot fix.
   const tranchePages = await readAllPages<{
-    transaction_id: string; amount_vnd: number | null; interest_rate: number | null; investment_date: string
+    transaction_id: string; amount_vnd: number | null; interest_rate: number | null
+    investment_date: string; expiry_date: string | null
   }>((from, to) => supabase
     .from('investment_transactions')
-    .select('transaction_id, amount_vnd, interest_rate, investment_date')
+    .select('transaction_id, amount_vnd, interest_rate, investment_date, expiry_date')
     .eq('user_id', user.id)
     .eq('deposit_group_id', bookId)
     .eq('transaction_type', 'investment')
@@ -123,6 +125,7 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
       transaction_id: r.transaction_id,
       investment_date: r.investment_date,
       interest_rate: r.interest_rate,
+      expiry_date: r.expiry_date,
       effective_principal: (r.amount_vnd ?? 0) - (withdrawnBy.get(r.transaction_id) ?? 0),
     }))
     .filter((t) => t.effective_principal > 0)
@@ -130,9 +133,23 @@ export async function GET(_request: NextRequest, { params }: { params: Promise<{
   if (tranches.length === 0) {
     return NextResponse.json({ error: 'Accumulating book not found.' }, { status: 404 })
   }
+  // What the bank pays out: the principal still held plus the interest it
+  // accrued, valued with the one formula the collapse route uses. The sheet's
+  // default came from the goal page's own valuation, which is computed from a
+  // capped list — on a large goal it understated the payout, and the RPC only
+  // bounds a payout from ABOVE, so submitting the default quietly credited the
+  // successor with too little.
+  const plan = buildCollapsePlan(tranches.map((t) => ({
+    id: t.transaction_id,
+    principal: t.effective_principal,
+    rate: t.interest_rate,
+    investmentDate: t.investment_date,
+    expiryDate: t.expiry_date,
+  })))
   return NextResponse.json({
     tranches,
-    effective_principal: tranches.reduce((sum, t) => sum + t.effective_principal, 0),
+    effective_principal: plan.totalPrincipal,
+    projected_value: plan.totalPrincipal + plan.totalInterest,
   })
 }
 

--- a/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
+++ b/app/api/v1/investment-transactions/[id]/merge-successor/route.ts
@@ -22,13 +22,14 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
   const parsed = await readJsonBody(request)
   if (!parsed.ok) return parsed.response
   const body = parsed.body
-  const { received_vnd, interest_rate, merge_date, tranche_ids } = body
+  const { received_vnd, interest_rate, merge_date, tranche_ids, tranche_principals } = body
 
   let bookId: string
   let cleanReceived: number
   let cleanRate: number
   let cleanDate: string
   let cleanTrancheIds: string[]
+  let cleanTranchePrincipals: number[]
   try {
     bookId = validateUUID(id, 'id')
     cleanReceived = validateAmount(received_vnd, 'received_vnd')
@@ -42,6 +43,13 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     }
     if (tranche_ids.length > 500) throw new ValidationError('tranche_ids is too long')
     cleanTrancheIds = tranche_ids.map((v, i) => validateUUID(v, `tranche_ids[${i}]`))
+    // The balances the client saw, not just which rows it saw: a partial
+    // withdrawal landing after the confirmation loaded leaves every id in place
+    // while the payout being confirmed is no longer one this book can make.
+    if (!Array.isArray(tranche_principals) || tranche_principals.length !== cleanTrancheIds.length) {
+      throw new ValidationError('tranche_principals must match tranche_ids')
+    }
+    cleanTranchePrincipals = tranche_principals.map((v, i) => Math.round(validateAmount(v, `tranche_principals[${i}]`)))
   } catch (e) {
     if (e instanceof ValidationError) return NextResponse.json({ error: e.message }, { status: 400 })
     throw e
@@ -58,6 +66,7 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
       p_interest_rate: cleanRate,
       p_merge_date: cleanDate,
       p_tranche_ids: cleanTrancheIds,
+      p_tranche_principals: cleanTranchePrincipals,
     })
     .single<{ transaction_id: string }>()
 

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -392,6 +392,11 @@ export function MaturityResolveBody({
   // principal plus the interest it accrued — which the user confirms or corrects
   // against the slip.
   const successorRecv = mergeRecvStr === '' ? Math.round(inv.value) : Number(mergeRecvStr)
+  // The sheet also opens in the week BEFORE maturity, as a reminder. The cash is
+  // not paid out until the day itself, and the merge refuses a source that has
+  // not matured — so offering the button then is offering a certain error.
+  const bookMatured = !!inv.expiryDate && inv.expiryDate <= todayIso()
+  const mergeReady = successorRecv > 0 && Number(mergeRate) > 0 && bookMatured
 
   async function handleMergeIntoSuccessor() {
     if (!(successorRecv > 0) || !(Number(mergeRate) > 0)) {
@@ -572,9 +577,16 @@ export function MaturityResolveBody({
                 onChange={(e) => setMergeDate(e.target.value)} style={dateInput} />
             </div>
           </div>
-          <button type="button" data-testid="merge-successor-submit" disabled={saving || !(successorRecv > 0) || !(Number(mergeRate) > 0)}
+          {!bookMatured && (
+            <p data-testid="merge-not-due" style={{ margin: 0, fontSize: 12, lineHeight: 1.45, color: 'var(--c-muted)' }}>
+              {isVi
+                ? 'Sổ chưa đến ngày đáo hạn — ngân hàng chưa trả tiền, nên chưa gộp được.'
+                : 'This book has not matured yet — the bank has not paid out, so there is nothing to move.'}
+            </p>
+          )}
+          <button type="button" data-testid="merge-successor-submit" disabled={saving || !mergeReady}
             onClick={handleMergeIntoSuccessor}
-            style={{ padding: '11px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit', opacity: saving || !(successorRecv > 0) || !(Number(mergeRate) > 0) ? 0.6 : 1 }}>
+            style={{ padding: '11px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit', opacity: saving || !mergeReady ? 0.6 : 1 }}>
             {isVi ? 'Gộp vào sổ kế nhiệm' : 'Merge into the successor'}
           </button>
         </div>

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -132,6 +132,8 @@ export function MaturityResolveBody({
   // goal hands this sheet a partial book — and a partial book can never satisfy
   // the merge's tranche check, however often it is reloaded.
   const [mergeTranches, setMergeTranches] = useState<{ transaction_id: string; effective_principal: number }[] | null>(null)
+  const [mergeLoadFailed, setMergeLoadFailed] = useState(false)
+  const [mergeReload, setMergeReload] = useState(0)
   const [done, setDone] = useState<null | { newPrincipal: number; newMaturity: string; sources: string[] }>(null)
   // Settle-with-hold success: the deposit was parked in the pool (no re-deposit).
   const [heldDone, setHeldDone] = useState<null | { anchorName: string }>(null)
@@ -405,12 +407,15 @@ export function MaturityResolveBody({
   useEffect(() => {
     if (!hasSuccessor) return
     let live = true
+    setMergeLoadFailed(false)
     fetch(`/api/v1/investment-transactions/${inv.id}/merge-successor`, { cache: 'no-store' })
-      .then((r) => r.ok ? r.json() : null)
-      .then((res) => { if (live && res?.tranches) setMergeTranches(res.tranches) })
-      .catch(() => {})
+      .then((r) => { if (!r.ok) throw new Error('preview failed'); return r.json() })
+      .then((res) => { if (live) setMergeTranches(res?.tranches ?? []) })
+      // Failing quietly here leaves the button disabled with nothing said, and a
+      // matured book looks impossible to resolve until the sheet is reopened.
+      .catch(() => { if (live) setMergeLoadFailed(true) })
     return () => { live = false }
-  }, [hasSuccessor, inv.id])
+  }, [hasSuccessor, inv.id, mergeReload])
 
   async function handleMergeIntoSuccessor() {
     if (!(successorRecv > 0) || !(Number(mergeRate) > 0)) {
@@ -591,6 +596,15 @@ export function MaturityResolveBody({
                 onChange={(e) => setMergeDate(e.target.value)} style={dateInput} />
             </div>
           </div>
+          {mergeLoadFailed && (
+            <div data-testid="merge-preview-failed" style={{ margin: 0, fontSize: 12, lineHeight: 1.45, color: 'var(--c-neg)' }}>
+              {isVi ? 'Không đọc được sổ này.' : "Could not read this book."}
+              <button type="button" data-testid="merge-preview-retry" onClick={() => setMergeReload((n) => n + 1)}
+                style={{ marginLeft: 6, padding: 0, border: 'none', background: 'none', color: 'var(--c-navy)', fontSize: 12, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', textDecoration: 'underline' }}>
+                {isVi ? 'Thử lại' : 'Try again'}
+              </button>
+            </div>
+          )}
           {!bookMatured && (
             <p data-testid="merge-not-due" style={{ margin: 0, fontSize: 12, lineHeight: 1.45, color: 'var(--c-muted)' }}>
               {isVi

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -441,6 +441,10 @@ export function MaturityResolveBody({
       if (!res.ok) {
         const body = await res.json().catch(() => ({}))
         setError(body.error ?? (isVi ? 'Không gộp được' : 'Could not merge'))
+        // The book moved under the confirmation. Showing the error alone leaves
+        // the stale figures in place, so every further press resubmits them and
+        // gets the same 409 — read the book again instead.
+        if (body.code === 'book_changed') setMergeReload((n) => n + 1)
         setSaving(false)
         return
       }

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -132,6 +132,11 @@ export function MaturityResolveBody({
   // goal hands this sheet a partial book — and a partial book can never satisfy
   // the merge's tranche check, however often it is reloaded.
   const [mergeTranches, setMergeTranches] = useState<{ transaction_id: string; effective_principal: number }[] | null>(null)
+  // The payout the server values from the WHOLE book. inv.value is computed from
+  // the goal page's capped list, so on a large goal it understates it — and the
+  // merge only bounds a payout from above, so the understated default would have
+  // gone through.
+  const [mergeValue, setMergeValue] = useState<number | null>(null)
   const [mergeLoadFailed, setMergeLoadFailed] = useState(false)
   const [mergeReload, setMergeReload] = useState(0)
   const [done, setDone] = useState<null | { newPrincipal: number; newMaturity: string; sources: string[] }>(null)
@@ -397,7 +402,7 @@ export function MaturityResolveBody({
   // The cash the bank actually paid out, defaulting to what the book is worth —
   // principal plus the interest it accrued — which the user confirms or corrects
   // against the slip.
-  const successorRecv = mergeRecvStr === '' ? Math.round(inv.value) : Number(mergeRecvStr)
+  const successorRecv = mergeRecvStr === '' ? Math.round(mergeValue ?? inv.value) : Number(mergeRecvStr)
   // The sheet also opens in the week BEFORE maturity, as a reminder. The cash is
   // not paid out until the day itself, and the merge refuses a source that has
   // not matured — so offering the button then is offering a certain error.
@@ -410,7 +415,11 @@ export function MaturityResolveBody({
     setMergeLoadFailed(false)
     fetch(`/api/v1/investment-transactions/${inv.id}/merge-successor`, { cache: 'no-store' })
       .then((r) => { if (!r.ok) throw new Error('preview failed'); return r.json() })
-      .then((res) => { if (live) setMergeTranches(res?.tranches ?? []) })
+      .then((res) => {
+        if (!live) return
+        setMergeTranches(res?.tranches ?? [])
+        setMergeValue(typeof res?.projected_value === 'number' ? res.projected_value : null)
+      })
       // Failing quietly here leaves the button disabled with nothing said, and a
       // matured book looks impossible to resolve until the sheet is reopened.
       .catch(() => { if (live) setMergeLoadFailed(true) })
@@ -585,7 +594,7 @@ export function MaturityResolveBody({
           <div>
             <label style={fieldLabel}>{isVi ? 'Tiền thực nhận (₫)' : 'Cash received (₫)'}</label>
             <input data-testid="merge-received" type="text" inputMode="numeric"
-              value={formatIntVN(mergeRecvStr === '' ? String(Math.round(inv.value)) : mergeRecvStr)}
+              value={formatIntVN(mergeRecvStr === '' ? String(Math.round(mergeValue ?? inv.value)) : mergeRecvStr)}
               onChange={(e) => setMergeRecvStr(parseIntVN(e.target.value))} style={moneyInput} />
           </div>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -124,7 +124,10 @@ export function MaturityResolveBody({
   // Phase 3: a book that was handed over has one thing left to do at maturity —
   // go where it was promised. That is offered here instead of a renewal, since
   // renewing it is the one thing the handover said would not happen.
-  const hasSuccessor = !!inv.successorDepositTxId
+  // Cancelling the promise here hands the book back to the ordinary maturity
+  // decisions, without waiting for the page prop to be refetched.
+  const [handoverCancelled, setHandoverCancelled] = useState(false)
+  const hasSuccessor = !!inv.successorDepositTxId && !handoverCancelled
   const [mergeRecvStr, setMergeRecvStr] = useState('')
   const [mergeRate, setMergeRate] = useState(inv.interestRate != null ? String(inv.interestRate) : '')
   const [mergeDate, setMergeDate] = useState(() => todayIso())
@@ -137,6 +140,10 @@ export function MaturityResolveBody({
   // merge only bounds a payout from above, so the understated default would have
   // gone through.
   const [mergeValue, setMergeValue] = useState<number | null>(null)
+  // Which book the server says this one is promised to, as of the last read. The
+  // confirmation submits it back so a handover cancelled and re-made underneath
+  // is refused instead of quietly paying out to a book nobody confirmed.
+  const [mergeSuccessorId, setMergeSuccessorId] = useState<string | null>(null)
   const [mergeLoadFailed, setMergeLoadFailed] = useState(false)
   const [mergeReload, setMergeReload] = useState(0)
   const [done, setDone] = useState<null | { newPrincipal: number; newMaturity: string; sources: string[] }>(null)
@@ -419,6 +426,7 @@ export function MaturityResolveBody({
         if (!live) return
         setMergeTranches(res?.tranches ?? [])
         setMergeValue(typeof res?.projected_value === 'number' ? res.projected_value : null)
+        setMergeSuccessorId(typeof res?.successor_id === 'string' ? res.successor_id : null)
       })
       // Failing quietly here leaves the button disabled with nothing said, and a
       // matured book looks impossible to resolve until the sheet is reopened.
@@ -445,6 +453,10 @@ export function MaturityResolveBody({
           // the cash the book holds.
           tranche_ids: (mergeTranches ?? []).map((t) => t.transaction_id),
           tranche_principals: (mergeTranches ?? []).map((t) => Math.round(t.effective_principal)),
+          // And which book we were told it goes to. Preferring the server's own
+          // read over the page prop matters after a book_changed reload, when
+          // the prop is the stale one and the preview is not.
+          expected_successor_id: mergeSuccessorId ?? inv.successorDepositTxId,
         }),
       })
       if (!res.ok) {
@@ -636,7 +648,7 @@ export function MaturityResolveBody({
       {/* Discoverability nudge: a later-maturing sibling in this goal makes this
           deposit a hold-for-merge candidate. Surfaced up top so the option isn't
           buried; the actual commit lives in the withdraw fork below. */}
-      {canHold && holdAnchor && (
+      {canHold && holdAnchor && !hasSuccessor && (
         <div data-testid="maturity-hold-nudge" style={{ display: 'flex', gap: 10, alignItems: 'flex-start', padding: '11px 13px', background: 'var(--c-card-2)', borderRadius: 10 }}>
           <PiggyBank size={15} color="var(--c-navy)" strokeWidth={2.2} style={{ flexShrink: 0, marginTop: 1 }} />
           <p style={{ margin: 0, fontSize: 12.5, color: 'var(--c-ink)', lineHeight: 1.5 }}>
@@ -645,7 +657,12 @@ export function MaturityResolveBody({
         </div>
       )}
 
-      {/* Decision picker */}
+      {/* Decision picker. A promised book has exactly one thing it may do at
+          maturity — go where it was promised — and renewing, combining or
+          settling it are all refused by the database while the promise stands.
+          Offering them would be offering certain errors, so the merge panel
+          above replaces this whole flow until the handover is cancelled. */}
+      {!hasSuccessor && (
       <div>
         <div style={fieldLabel}>{t.prompt}</div>
         <div style={{ display: 'grid', gap: 8 }}>
@@ -676,9 +693,10 @@ export function MaturityResolveBody({
           })}
         </div>
       </div>
+      )}
 
       {/* Combine — settle & re-deposit, folding in this month's recurring saving */}
-      {mode === 'combine' && (
+      {!hasSuccessor && mode === 'combine' && (
         <div data-testid="maturity-combine" style={{ display: 'grid', gap: 12 }}>
           <RecurringRedepositSection
             combineLink={combineLink} pickedCand={pickedCand} setPickedSavingId={setPickedSavingId}
@@ -736,7 +754,7 @@ export function MaturityResolveBody({
       )}
 
       {/* Inputs per mode */}
-      {mode !== 'withdraw' && mode !== 'combine' && (
+      {!hasSuccessor && mode !== 'withdraw' && mode !== 'combine' && (
         <div style={{ display: 'grid', gap: 12 }}>
           <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
             {mode === 'change'
@@ -815,7 +833,7 @@ export function MaturityResolveBody({
         </div>
       )}
 
-      {mode === 'withdraw' && (
+      {!hasSuccessor && mode === 'withdraw' && (
         <WithdrawSection
           t={{
             holdForkPrompt: t.holdForkPrompt, holdCardTitle: t.holdCardTitle, holdCardSub: t.holdCardSub,
@@ -830,18 +848,20 @@ export function MaturityResolveBody({
       )}
 
       {error && <p style={{ margin: 0, fontSize: 13, color: 'var(--c-neg)' }}>{error}</p>}
-      {handoverBlocked && (
+      {(handoverBlocked || hasSuccessor) && (
         <button type="button" data-testid="cancel-handover-btn" disabled={saving}
           onClick={async () => {
             setSaving(true)
             try {
               const res = await fetch(`/api/v1/investment-transactions/${inv.id}/successor`, { method: 'DELETE' })
-              if (res.ok) { setHandoverBlocked(false); setError('') }
+              if (res.ok) { setHandoverBlocked(false); setHandoverCancelled(true); setError('') }
               else setError(isVi ? 'Không huỷ được bàn giao' : 'Could not cancel the handover')
             } catch { setError(isVi ? 'Lỗi kết nối' : 'Connection error') } finally { setSaving(false) }
           }}
           style={{ alignSelf: 'flex-start', padding: 0, border: 'none', background: 'none', color: 'var(--c-navy)', fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', textDecoration: 'underline' }}>
-          {isVi ? 'Huỷ bàn giao rồi thử lại' : 'Cancel the handover and try again'}
+          {handoverBlocked
+            ? (isVi ? 'Huỷ bàn giao rồi thử lại' : 'Cancel the handover and try again')
+            : (isVi ? 'Huỷ bàn giao để xử lý theo cách khác' : 'Cancel the handover to resolve this another way')}
         </button>
       )}
 
@@ -849,7 +869,7 @@ export function MaturityResolveBody({
           deposit moving to another bank is the ordinary case, and it used to be
           reachable only after picking a sibling to merge (#640). A book collapses
           through a route that takes no bank, so it keeps its own. */}
-      {mode !== 'withdraw' && !isBook && banks.length > 0 && (
+      {!hasSuccessor && mode !== 'withdraw' && !isBook && banks.length > 0 && (
         <DestinationBankField
           banks={banks} value={destBank} onChange={setDestBank}
           label={t.destBankLabel} noneLabel={t.destBankNone}
@@ -858,7 +878,7 @@ export function MaturityResolveBody({
       )}
 
       {/* Actions */}
-      {tooEarlyToRenew && mode !== 'withdraw' && (
+      {!hasSuccessor && tooEarlyToRenew && mode !== 'withdraw' && (
         <p data-testid="maturity-too-early-hint" style={{ margin: 0, fontSize: 12.5, lineHeight: 1.45, color: 'var(--c-muted)' }}>
           {isVi
             ? `Sổ chưa tới hạn (còn ${daysLeft} ngày) — ghi nhận tái tục khi đáo hạn. Bạn vẫn có thể rút trước hạn.`
@@ -867,7 +887,10 @@ export function MaturityResolveBody({
       )}
       <div style={{ display: 'flex', gap: 8 }}>
         <button type="button" onClick={onClose} className="cn-btn ghost" style={{ flex: 1, justifyContent: 'center', border: '1px solid var(--c-line)' }}>{t.cancel}</button>
-        {(() => {
+        {/* A promised book confirms from the merge panel; this button drives the
+            flow that was hidden above, so leaving it would be a button whose
+            every outcome is a refusal. */}
+        {!hasSuccessor && (() => {
           // Holding posts instead of withdrawing — navy CTA + piggy icon, never the
           // red withdraw button (the money is staying in the goal).
           const holding = mode === 'withdraw' && canHold && holdChoice === 'hold'

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -121,6 +121,13 @@ export function MaturityResolveBody({
   // that successor is what its maturity is for. Until that merge exists, the way
   // out has to be reachable from here, or the refusal is a dead end.
   const [handoverBlocked, setHandoverBlocked] = useState(false)
+  // Phase 3: a book that was handed over has one thing left to do at maturity —
+  // go where it was promised. That is offered here instead of a renewal, since
+  // renewing it is the one thing the handover said would not happen.
+  const hasSuccessor = !!inv.successorDepositTxId
+  const [mergeRecvStr, setMergeRecvStr] = useState('')
+  const [mergeRate, setMergeRate] = useState(inv.interestRate != null ? String(inv.interestRate) : '')
+  const [mergeDate, setMergeDate] = useState(() => todayIso())
   const [done, setDone] = useState<null | { newPrincipal: number; newMaturity: string; sources: string[] }>(null)
   // Settle-with-hold success: the deposit was parked in the pool (no re-deposit).
   const [heldDone, setHeldDone] = useState<null | { anchorName: string }>(null)
@@ -381,6 +388,41 @@ export function MaturityResolveBody({
     }
   }
 
+  // The cash the bank actually paid out, defaulting to what the book is worth —
+  // principal plus the interest it accrued — which the user confirms or corrects
+  // against the slip.
+  const successorRecv = mergeRecvStr === '' ? Math.round(inv.value) : Number(mergeRecvStr)
+
+  async function handleMergeIntoSuccessor() {
+    if (!(successorRecv > 0) || !(Number(mergeRate) > 0)) {
+      setError(isVi ? 'Cần nhập số tiền và lãi suất' : 'Amount and rate are required')
+      return
+    }
+    setSaving(true); setError('')
+    try {
+      const res = await fetch(`/api/v1/investment-transactions/${inv.id}/merge-successor`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          received_vnd: Math.round(successorRecv),
+          interest_rate: Number(mergeRate),
+          merge_date: mergeDate,
+          // Naming what we saw: a top-up landing while this was open means the
+          // cash being confirmed is not the cash the book holds.
+          tranche_ids: (inv.tranches ?? []).map((t) => t.id),
+        }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setError(body.error ?? (isVi ? 'Không gộp được' : 'Could not merge'))
+        setSaving(false)
+        return
+      }
+      onRenewed()
+      onClose()
+    } catch { setError(isVi ? 'Lỗi kết nối' : 'Connection error') } finally { setSaving(false) }
+  }
+
   async function handleConfirm() {
     if (mode === 'withdraw') {
       // The hold fork only exists when there's an eligible anchor; default is hold.
@@ -497,6 +539,44 @@ export function MaturityResolveBody({
         <AlertTriangle size={15} color="var(--c-warn)" strokeWidth={2.2} style={{ flexShrink: 0, marginTop: 1 }} />
         <p style={{ margin: 0, fontSize: 12.5, color: 'var(--c-warn)', lineHeight: 1.5 }}>{t.why}</p>
       </div>
+
+      {/* The promise, come due. A handed-over book is not renewed — it goes where
+          it was promised, carrying the cash the bank actually paid out (#638). */}
+      {hasSuccessor && (
+        <div data-testid="merge-successor-panel" style={{ display: 'grid', gap: 10, padding: '13px 14px', border: '1px solid var(--c-line)', borderRadius: 12, background: 'var(--c-card)' }}>
+          <div>
+            <div style={{ fontSize: 14, fontWeight: 700 }}>{isVi ? 'Gộp vào sổ kế nhiệm' : 'Merge into the successor book'}</div>
+            <p style={{ margin: '4px 0 0', fontSize: 12, lineHeight: 1.5, color: 'var(--c-muted)' }}>
+              {isVi
+                ? 'Sổ này đã được hẹn gộp vào sổ kế nhiệm khi đáo hạn. Xác nhận số tiền ngân hàng thực trả để ghi vào sổ mới.'
+                : 'This book was promised to its successor at maturity. Confirm what the bank actually paid out, and it lands there.'}
+            </p>
+          </div>
+          <div>
+            <label style={fieldLabel}>{isVi ? 'Tiền thực nhận (₫)' : 'Cash received (₫)'}</label>
+            <input data-testid="merge-received" type="text" inputMode="numeric"
+              value={formatIntVN(mergeRecvStr === '' ? String(Math.round(inv.value)) : mergeRecvStr)}
+              onChange={(e) => setMergeRecvStr(parseIntVN(e.target.value))} style={moneyInput} />
+          </div>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 10 }}>
+            <div>
+              <label style={fieldLabel}>{isVi ? 'Lãi suất phần gộp' : 'Rate for this tranche'}</label>
+              <input data-testid="merge-rate" type="text" inputMode="decimal" value={mergeRate}
+                onChange={(e) => setMergeRate(e.target.value.replace(/[^0-9.,]/g, '').replace(',', '.'))} style={moneyInput} />
+            </div>
+            <div>
+              <label style={fieldLabel}>{isVi ? 'Ngày gộp' : 'Merge date'}</label>
+              <input data-testid="merge-date" type="date" value={mergeDate}
+                onChange={(e) => setMergeDate(e.target.value)} style={dateInput} />
+            </div>
+          </div>
+          <button type="button" data-testid="merge-successor-submit" disabled={saving || !(successorRecv > 0) || !(Number(mergeRate) > 0)}
+            onClick={handleMergeIntoSuccessor}
+            style={{ padding: '11px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit', opacity: saving || !(successorRecv > 0) || !(Number(mergeRate) > 0) ? 0.6 : 1 }}>
+            {isVi ? 'Gộp vào sổ kế nhiệm' : 'Merge into the successor'}
+          </button>
+        </div>
+      )}
 
       {/* Discoverability nudge: a later-maturing sibling in this goal makes this
           deposit a hold-for-merge candidate. Surfaced up top so the option isn't

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -128,6 +128,10 @@ export function MaturityResolveBody({
   const [mergeRecvStr, setMergeRecvStr] = useState('')
   const [mergeRate, setMergeRate] = useState(inv.interestRate != null ? String(inv.interestRate) : '')
   const [mergeDate, setMergeDate] = useState(() => todayIso())
+  // The book as the server sees it. The goal page caps at 200 rows, so a large
+  // goal hands this sheet a partial book — and a partial book can never satisfy
+  // the merge's tranche check, however often it is reloaded.
+  const [mergeTranches, setMergeTranches] = useState<{ transaction_id: string; effective_principal: number }[] | null>(null)
   const [done, setDone] = useState<null | { newPrincipal: number; newMaturity: string; sources: string[] }>(null)
   // Settle-with-hold success: the deposit was parked in the pool (no re-deposit).
   const [heldDone, setHeldDone] = useState<null | { anchorName: string }>(null)
@@ -396,7 +400,17 @@ export function MaturityResolveBody({
   // not paid out until the day itself, and the merge refuses a source that has
   // not matured — so offering the button then is offering a certain error.
   const bookMatured = !!inv.expiryDate && inv.expiryDate <= todayIso()
-  const mergeReady = successorRecv > 0 && Number(mergeRate) > 0 && bookMatured
+  const mergeReady = successorRecv > 0 && Number(mergeRate) > 0 && bookMatured && !!mergeTranches?.length
+
+  useEffect(() => {
+    if (!hasSuccessor) return
+    let live = true
+    fetch(`/api/v1/investment-transactions/${inv.id}/merge-successor`, { cache: 'no-store' })
+      .then((r) => r.ok ? r.json() : null)
+      .then((res) => { if (live && res?.tranches) setMergeTranches(res.tranches) })
+      .catch(() => {})
+    return () => { live = false }
+  }, [hasSuccessor, inv.id])
 
   async function handleMergeIntoSuccessor() {
     if (!(successorRecv > 0) || !(Number(mergeRate) > 0)) {
@@ -415,8 +429,8 @@ export function MaturityResolveBody({
           // Naming what we saw, and what each held: a top-up or a withdrawal
           // landing while this was open means the cash being confirmed is not
           // the cash the book holds.
-          tranche_ids: (inv.tranches ?? []).map((t) => t.id),
-          tranche_principals: (inv.tranches ?? []).map((t) => Math.round(t.amount)),
+          tranche_ids: (mergeTranches ?? []).map((t) => t.transaction_id),
+          tranche_principals: (mergeTranches ?? []).map((t) => Math.round(t.effective_principal)),
         }),
       })
       if (!res.ok) {

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -407,9 +407,11 @@ export function MaturityResolveBody({
           received_vnd: Math.round(successorRecv),
           interest_rate: Number(mergeRate),
           merge_date: mergeDate,
-          // Naming what we saw: a top-up landing while this was open means the
-          // cash being confirmed is not the cash the book holds.
+          // Naming what we saw, and what each held: a top-up or a withdrawal
+          // landing while this was open means the cash being confirmed is not
+          // the cash the book holds.
           tranche_ids: (inv.tranches ?? []).map((t) => t.id),
+          tranche_principals: (inv.tranches ?? []).map((t) => Math.round(t.amount)),
         }),
       })
       if (!res.ok) {

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -853,21 +853,17 @@ describe('MaturityResolveBody', () => {
   })
 
   // A book promised to a successor cannot be collapsed: the merge into that
-  // successor is what its maturity is for (#638). Until that merge exists, the
-  // refusal has to carry its own way out, or it is a dead end.
-  it('offers to cancel the handover when the collapse is refused for one', async () => {
-    const user = userEvent.setup()
-    const calls: { url: string; method?: string }[] = []
+  // successor is what its maturity is for (#638). Renewing, combining and
+  // settling all end at the same refusal, so the sheet does not offer them —
+  // it offers the merge, and the one way out of the promise.
+  it('shows a promised book only the actions it can actually take', async () => {
     global.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
-      const u = String(url)
-      calls.push({ url: u, method: init?.method })
-      if (init?.method === 'POST') {
-        return {
-          ok: false,
-          json: async () => ({ error: 'this book is promised to a successor, so cancel the handover before closing it', code: 'successor_planned' }),
-        } as Response
+      if (String(url).includes('/merge-successor') && init?.method !== 'POST') {
+        return { ok: true, json: async () => ({
+          tranches: [{ transaction_id: 'tr-1', effective_principal: 35_000_000 }],
+          successor_id: 'book-2', projected_value: 37_000_000,
+        }) } as Response
       }
-      if (init?.method === 'DELETE') return { ok: true, json: async () => ({}) } as Response
       return { ok: true, json: async () => ({ banks: [] }) } as Response
     }) as unknown as typeof fetch
 
@@ -876,12 +872,40 @@ describe('MaturityResolveBody', () => {
       <MaturityResolveBody inv={book} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
     )
 
-    await user.click(screen.getByRole('button', { name: /Xác nhận tái tục|Confirm renewal/i }))
-    await waitFor(() => expect(screen.getByTestId('cancel-handover-btn')).toBeInTheDocument())
+    expect(screen.getByTestId('merge-successor-panel')).toBeInTheDocument()
+    // Every one of these is rejected by the database while the promise stands.
+    expect(screen.queryByRole('button', { name: /Confirm renewal/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Don.t renew/i })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('maturity-term-input')).not.toBeInTheDocument()
+    // ...and the way out is offered without having to trip over a refusal first.
+    expect(screen.getByTestId('cancel-handover-btn')).toBeInTheDocument()
+  })
+
+  it('cancels the handover from the promised book’s own sheet', async () => {
+    const calls: { url: string; method?: string }[] = []
+    global.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      const u = String(url)
+      calls.push({ url: u, method: init?.method })
+      if (init?.method === 'DELETE') return { ok: true, json: async () => ({}) } as Response
+      if (u.includes('/merge-successor')) {
+        return { ok: true, json: async () => ({
+          tranches: [{ transaction_id: 'tr-1', effective_principal: 35_000_000 }], successor_id: 'book-2',
+        }) } as Response
+      }
+      return { ok: true, json: async () => ({ banks: [] }) } as Response
+    }) as unknown as typeof fetch
+
+    const book: InvRow = { ...maturedDeposit, depositGroupId: 'tx-bank-1', successorDepositTxId: 'book-2' }
+    render(
+      <MaturityResolveBody inv={book} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
 
     fireEvent.click(screen.getByTestId('cancel-handover-btn'))
     await waitFor(() => expect(screen.queryByTestId('cancel-handover-btn')).not.toBeInTheDocument())
     expect(calls.some(c => c.method === 'DELETE' && c.url.endsWith('/tx-bank-1/successor'))).toBe(true)
+    // The promise is gone, so the ordinary maturity decisions come back with it.
+    expect(screen.queryByTestId('merge-successor-panel')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /Confirm renewal/i })).toBeInTheDocument()
   })
 
   // Phase 3: a handed-over book is not renewed at maturity — it goes where it
@@ -900,6 +924,8 @@ describe('MaturityResolveBody', () => {
           // Valued over the whole book, which the goal page's own number
           // understates whenever the book is bigger than its page.
           projected_value: 38_500_000,
+          // And where the server says this book is promised, as of now.
+          successor_id: 'book-2',
         }) } as Response
       }
       return { ok: true, json: async () => ({ banks: [] }) } as Response
@@ -939,6 +965,10 @@ describe('MaturityResolveBody', () => {
       tranche_ids: ['tr-1', 'tr-2'],
       // ...and what each held, so a withdrawal landing mid-confirmation is caught too.
       tranche_principals: [20_000_000, 15_000_000],
+      // ...and which book we were told it goes to, so a handover cancelled and
+      // re-made mid-confirmation cannot redirect the cash to a book the user
+      // never saw. Every other check would pass for the replacement.
+      expected_successor_id: 'book-2',
     })
   })
 

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -887,10 +887,16 @@ describe('MaturityResolveBody', () => {
   // Phase 3: a handed-over book is not renewed at maturity — it goes where it
   // was promised, carrying the cash the bank actually paid out (#638).
   it('offers the merge into the successor, prefilled with what the book is worth', async () => {
-    const calls: { url: string; body?: unknown }[] = []
+    const calls: { url: string; method?: string; body?: unknown }[] = []
     global.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
-      calls.push({ url: String(url), body: init?.body ? JSON.parse(String(init.body)) : undefined })
+      calls.push({ url: String(url), method: init?.method, body: init?.body ? JSON.parse(String(init.body)) : undefined })
       if (init?.method === 'POST') return { ok: true, json: async () => ({ transaction_id: 'new-1' }) } as Response
+      if (String(url).includes('/merge-successor')) {
+        return { ok: true, json: async () => ({ tranches: [
+          { transaction_id: 'tr-1', effective_principal: 20_000_000 },
+          { transaction_id: 'tr-2', effective_principal: 15_000_000 },
+        ] }) } as Response
+      }
       return { ok: true, json: async () => ({ banks: [] }) } as Response
     }) as unknown as typeof fetch
 
@@ -909,6 +915,8 @@ describe('MaturityResolveBody', () => {
     )
 
     expect(screen.getByTestId('merge-successor-panel')).toBeInTheDocument()
+    // The tranche set comes from the server, not from the goal page's capped list.
+    await waitFor(() => expect(screen.getByTestId('merge-successor-submit')).toBeEnabled())
     // Prefilled with the book's value — principal plus the interest it accrued —
     // for the user to confirm against the bank's slip.
     expect((screen.getByTestId('merge-received') as HTMLInputElement).value).toBe(formatIntVN(String(book.value)))
@@ -916,7 +924,8 @@ describe('MaturityResolveBody', () => {
     fireEvent.click(screen.getByTestId('merge-successor-submit'))
     await waitFor(() => expect(onRenewed).toHaveBeenCalled())
 
-    const post = calls.find(c => String(c.url).includes('/merge-successor'))!
+    // The GET preview shares the path, so match the write.
+    const post = calls.find(c => c.method === 'POST' && String(c.url).includes('/merge-successor'))!
     expect(post).toBeTruthy()
     // Every live tranche is named, so a top-up landing mid-confirmation is caught.
     expect(post.body).toMatchObject({
@@ -933,6 +942,9 @@ describe('MaturityResolveBody', () => {
       if (init?.method === 'POST') {
         return { ok: false, json: async () => ({ error: 'this book has not matured yet', code: 'merge_refused' }) } as Response
       }
+      if (String(_url).includes('/merge-successor')) {
+        return { ok: true, json: async () => ({ tranches: [{ transaction_id: 'tr-1', effective_principal: 35_000_000 }] }) } as Response
+      }
       return { ok: true, json: async () => ({ banks: [] }) } as Response
     }) as unknown as typeof fetch
 
@@ -944,6 +956,7 @@ describe('MaturityResolveBody', () => {
       <MaturityResolveBody inv={book} isVi={false} onClose={() => {}} onRenewed={onRenewed} onWithdraw={() => {}} />,
     )
 
+    await waitFor(() => expect(screen.getByTestId('merge-successor-submit')).toBeEnabled())
     fireEvent.click(screen.getByTestId('merge-successor-submit'))
     await waitFor(() => expect(screen.getByText(/has not matured yet/i)).toBeInTheDocument())
     expect(onRenewed).not.toHaveBeenCalled()
@@ -968,7 +981,13 @@ describe('MaturityResolveBody', () => {
     expect(screen.getByTestId('merge-successor-submit')).toBeDisabled()
   })
 
-  it('offers it on the maturity day itself, which the merge accepts', () => {
+  it('offers it on the maturity day itself, which the merge accepts', async () => {
+    global.fetch = vi.fn(async (url: string | URL | Request) => {
+      if (String(url).includes('/merge-successor')) {
+        return { ok: true, json: async () => ({ tranches: [{ transaction_id: 'tr-1', effective_principal: 35_000_000 }] }) } as Response
+      }
+      return { ok: true, json: async () => ({ banks: [] }) } as Response
+    }) as unknown as typeof fetch
     const dueToday: InvRow = {
       ...maturedDeposit,
       expiryDate: todayIso(),
@@ -981,6 +1000,7 @@ describe('MaturityResolveBody', () => {
     )
 
     expect(screen.queryByTestId('merge-not-due')).not.toBeInTheDocument()
-    expect(screen.getByTestId('merge-successor-submit')).toBeEnabled()
+    // Enabled only once the server has said what the book holds.
+    await waitFor(() => expect(screen.getByTestId('merge-successor-submit')).toBeEnabled())
   })
 })

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -1032,4 +1032,36 @@ describe('MaturityResolveBody', () => {
     await waitFor(() => expect(screen.getByTestId('merge-successor-submit')).toBeEnabled())
     expect(screen.queryByTestId('merge-preview-failed')).not.toBeInTheDocument()
   })
+
+  // A stale-book answer with the old figures left in place means every further
+  // press resubmits them and gets the same 409 (#638).
+  it('reads the book again when the merge says it changed', async () => {
+    let previews = 0
+    global.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return { ok: false, status: 409, json: async () => ({ error: 'This book changed — please reload and try again.', code: 'book_changed' }) } as Response
+      }
+      if (String(url).includes('/merge-successor')) {
+        previews += 1
+        return { ok: true, json: async () => ({ tranches: [{ transaction_id: 'tr-1', effective_principal: 35_000_000 }] }) } as Response
+      }
+      return { ok: true, json: async () => ({ banks: [] }) } as Response
+    }) as unknown as typeof fetch
+
+    const book: InvRow = {
+      ...maturedDeposit, depositGroupId: 'tx-bank-1', successorDepositTxId: 'book-2',
+      tranches: [{ id: 'tr-1', date: daysFromNow(-300), amount: 35_000_000, rate: 4, value: 37_030_000 }],
+    }
+    render(
+      <MaturityResolveBody inv={book} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('merge-successor-submit')).toBeEnabled())
+    expect(previews).toBe(1)
+
+    fireEvent.click(screen.getByTestId('merge-successor-submit'))
+    await waitFor(() => expect(screen.getByText(/please reload and try again/i)).toBeInTheDocument())
+    // The figures are re-read rather than left stale.
+    await waitFor(() => expect(previews).toBe(2))
+  })
 })

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -948,4 +948,39 @@ describe('MaturityResolveBody', () => {
     await waitFor(() => expect(screen.getByText(/has not matured yet/i)).toBeInTheDocument())
     expect(onRenewed).not.toHaveBeenCalled()
   })
+
+  // The sheet opens in the week before maturity too, as a reminder — and the
+  // merge refuses a source that has not matured, so the button would be a
+  // guaranteed error (#638).
+  it('waits for maturity before offering the merge', () => {
+    const notDue: InvRow = {
+      ...maturedDeposit,
+      expiryDate: daysFromNow(3),
+      depositGroupId: 'tx-bank-1',
+      successorDepositTxId: 'book-2',
+      tranches: [{ id: 'tr-1', date: daysFromNow(-300), amount: 35_000_000, rate: 4, value: 37_030_000 }],
+    }
+    render(
+      <MaturityResolveBody inv={notDue} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+
+    expect(screen.getByTestId('merge-not-due')).toBeInTheDocument()
+    expect(screen.getByTestId('merge-successor-submit')).toBeDisabled()
+  })
+
+  it('offers it on the maturity day itself, which the merge accepts', () => {
+    const dueToday: InvRow = {
+      ...maturedDeposit,
+      expiryDate: todayIso(),
+      depositGroupId: 'tx-bank-1',
+      successorDepositTxId: 'book-2',
+      tranches: [{ id: 'tr-1', date: daysFromNow(-300), amount: 35_000_000, rate: 4, value: 37_030_000 }],
+    }
+    render(
+      <MaturityResolveBody inv={dueToday} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+
+    expect(screen.queryByTestId('merge-not-due')).not.toBeInTheDocument()
+    expect(screen.getByTestId('merge-successor-submit')).toBeEnabled()
+  })
 })

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -1003,4 +1003,33 @@ describe('MaturityResolveBody', () => {
     // Enabled only once the server has said what the book holds.
     await waitFor(() => expect(screen.getByTestId('merge-successor-submit')).toBeEnabled())
   })
+
+  // A preview that fails silently leaves the merge button disabled with nothing
+  // said, and a matured book looks impossible to resolve (#638).
+  it('says so when the book cannot be read, and offers to try again', async () => {
+    let attempt = 0
+    global.fetch = vi.fn(async (url: string | URL | Request) => {
+      if (String(url).includes('/merge-successor')) {
+        attempt += 1
+        if (attempt === 1) return { ok: false, json: async () => ({}) } as Response
+        return { ok: true, json: async () => ({ tranches: [{ transaction_id: 'tr-1', effective_principal: 35_000_000 }] }) } as Response
+      }
+      return { ok: true, json: async () => ({ banks: [] }) } as Response
+    }) as unknown as typeof fetch
+
+    const book: InvRow = {
+      ...maturedDeposit, depositGroupId: 'tx-bank-1', successorDepositTxId: 'book-2',
+      tranches: [{ id: 'tr-1', date: daysFromNow(-300), amount: 35_000_000, rate: 4, value: 37_030_000 }],
+    }
+    render(
+      <MaturityResolveBody inv={book} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+
+    await waitFor(() => expect(screen.getByTestId('merge-preview-failed')).toBeInTheDocument())
+    expect(screen.getByTestId('merge-successor-submit')).toBeDisabled()
+
+    fireEvent.click(screen.getByTestId('merge-preview-retry'))
+    await waitFor(() => expect(screen.getByTestId('merge-successor-submit')).toBeEnabled())
+    expect(screen.queryByTestId('merge-preview-failed')).not.toBeInTheDocument()
+  })
 })

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -883,4 +883,64 @@ describe('MaturityResolveBody', () => {
     await waitFor(() => expect(screen.queryByTestId('cancel-handover-btn')).not.toBeInTheDocument())
     expect(calls.some(c => c.method === 'DELETE' && c.url.endsWith('/tx-bank-1/successor'))).toBe(true)
   })
+
+  // Phase 3: a handed-over book is not renewed at maturity — it goes where it
+  // was promised, carrying the cash the bank actually paid out (#638).
+  it('offers the merge into the successor, prefilled with what the book is worth', async () => {
+    const calls: { url: string; body?: unknown }[] = []
+    global.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), body: init?.body ? JSON.parse(String(init.body)) : undefined })
+      if (init?.method === 'POST') return { ok: true, json: async () => ({ transaction_id: 'new-1' }) } as Response
+      return { ok: true, json: async () => ({ banks: [] }) } as Response
+    }) as unknown as typeof fetch
+
+    const book: InvRow = {
+      ...maturedDeposit,
+      depositGroupId: 'tx-bank-1',
+      successorDepositTxId: 'book-2',
+      tranches: [
+        { id: 'tr-1', date: daysFromNow(-300), amount: 20_000_000, rate: 4, value: 21_000_000 },
+        { id: 'tr-2', date: daysFromNow(-200), amount: 15_000_000, rate: 4.2, value: 16_030_000 },
+      ],
+    }
+    const onRenewed = vi.fn()
+    render(
+      <MaturityResolveBody inv={book} isVi={false} onClose={() => {}} onRenewed={onRenewed} onWithdraw={() => {}} />,
+    )
+
+    expect(screen.getByTestId('merge-successor-panel')).toBeInTheDocument()
+    // Prefilled with the book's value — principal plus the interest it accrued —
+    // for the user to confirm against the bank's slip.
+    expect((screen.getByTestId('merge-received') as HTMLInputElement).value).toBe(formatIntVN(String(book.value)))
+
+    fireEvent.click(screen.getByTestId('merge-successor-submit'))
+    await waitFor(() => expect(onRenewed).toHaveBeenCalled())
+
+    const post = calls.find(c => String(c.url).includes('/merge-successor'))!
+    expect(post).toBeTruthy()
+    // Every live tranche is named, so a top-up landing mid-confirmation is caught.
+    expect(post.body).toMatchObject({ received_vnd: book.value, tranche_ids: ['tr-1', 'tr-2'] })
+  })
+
+  it('surfaces a refusal from the merge rather than pretending it worked', async () => {
+    const onRenewed = vi.fn()
+    global.fetch = vi.fn(async (_url: string | URL | Request, init?: RequestInit) => {
+      if (init?.method === 'POST') {
+        return { ok: false, json: async () => ({ error: 'this book has not matured yet', code: 'merge_refused' }) } as Response
+      }
+      return { ok: true, json: async () => ({ banks: [] }) } as Response
+    }) as unknown as typeof fetch
+
+    const book: InvRow = {
+      ...maturedDeposit, depositGroupId: 'tx-bank-1', successorDepositTxId: 'book-2',
+      tranches: [{ id: 'tr-1', date: daysFromNow(-300), amount: 35_000_000, rate: 4, value: 37_030_000 }],
+    }
+    render(
+      <MaturityResolveBody inv={book} isVi={false} onClose={() => {}} onRenewed={onRenewed} onWithdraw={() => {}} />,
+    )
+
+    fireEvent.click(screen.getByTestId('merge-successor-submit'))
+    await waitFor(() => expect(screen.getByText(/has not matured yet/i)).toBeInTheDocument())
+    expect(onRenewed).not.toHaveBeenCalled()
+  })
 })

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -892,10 +892,15 @@ describe('MaturityResolveBody', () => {
       calls.push({ url: String(url), method: init?.method, body: init?.body ? JSON.parse(String(init.body)) : undefined })
       if (init?.method === 'POST') return { ok: true, json: async () => ({ transaction_id: 'new-1' }) } as Response
       if (String(url).includes('/merge-successor')) {
-        return { ok: true, json: async () => ({ tranches: [
-          { transaction_id: 'tr-1', effective_principal: 20_000_000 },
-          { transaction_id: 'tr-2', effective_principal: 15_000_000 },
-        ] }) } as Response
+        return { ok: true, json: async () => ({
+          tranches: [
+            { transaction_id: 'tr-1', effective_principal: 20_000_000 },
+            { transaction_id: 'tr-2', effective_principal: 15_000_000 },
+          ],
+          // Valued over the whole book, which the goal page's own number
+          // understates whenever the book is bigger than its page.
+          projected_value: 38_500_000,
+        }) } as Response
       }
       return { ok: true, json: async () => ({ banks: [] }) } as Response
     }) as unknown as typeof fetch
@@ -917,9 +922,10 @@ describe('MaturityResolveBody', () => {
     expect(screen.getByTestId('merge-successor-panel')).toBeInTheDocument()
     // The tranche set comes from the server, not from the goal page's capped list.
     await waitFor(() => expect(screen.getByTestId('merge-successor-submit')).toBeEnabled())
-    // Prefilled with the book's value — principal plus the interest it accrued —
-    // for the user to confirm against the bank's slip.
-    expect((screen.getByTestId('merge-received') as HTMLInputElement).value).toBe(formatIntVN(String(book.value)))
+    // Prefilled from the server's valuation of the whole book, not the goal
+    // page's — which is capped and would understate the payout.
+    await waitFor(() => expect((screen.getByTestId('merge-received') as HTMLInputElement).value)
+      .toBe(formatIntVN('38500000')))
 
     fireEvent.click(screen.getByTestId('merge-successor-submit'))
     await waitFor(() => expect(onRenewed).toHaveBeenCalled())
@@ -929,7 +935,7 @@ describe('MaturityResolveBody', () => {
     expect(post).toBeTruthy()
     // Every live tranche is named, so a top-up landing mid-confirmation is caught.
     expect(post.body).toMatchObject({
-      received_vnd: book.value,
+      received_vnd: 38_500_000,
       tranche_ids: ['tr-1', 'tr-2'],
       // ...and what each held, so a withdrawal landing mid-confirmation is caught too.
       tranche_principals: [20_000_000, 15_000_000],

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -919,7 +919,12 @@ describe('MaturityResolveBody', () => {
     const post = calls.find(c => String(c.url).includes('/merge-successor'))!
     expect(post).toBeTruthy()
     // Every live tranche is named, so a top-up landing mid-confirmation is caught.
-    expect(post.body).toMatchObject({ received_vnd: book.value, tranche_ids: ['tr-1', 'tr-2'] })
+    expect(post.body).toMatchObject({
+      received_vnd: book.value,
+      tranche_ids: ['tr-1', 'tr-2'],
+      // ...and what each held, so a withdrawal landing mid-confirmation is caught too.
+      tranche_principals: [20_000_000, 15_000_000],
+    })
   })
 
   it('surfaces a refusal from the merge rather than pretending it worked', async () => {

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -503,13 +503,21 @@ begin
   if old.consumed_by_inv_id is not null
      and new.consumed_by_inv_id is distinct from old.consumed_by_inv_id
      -- Unless it is following the tranche it named up to that tranche's own
-     -- book: renewing the successor deletes the credited tranche, and the cash
-     -- carries on inside the anchor. Anything else pointed elsewhere is still a
-     -- rewrite of where the cash went.
+     -- book, DURING the collapse that is deleting it — the same evidence the
+     -- delete trigger asks for, a snapshot this transaction has just written
+     -- for that book. Allowing the move on its own made it step one of taking
+     -- the payout: with nothing left pointing at the credited tranche, deleting
+     -- it stopped being refused.
      and not exists (
        select 1 from public.investment_transactions t
         where t.transaction_id = old.consumed_by_inv_id
           and t.deposit_group_id = new.consumed_by_inv_id
+          and exists (
+            select 1 from public.investment_transactions s
+             where s.renewed_from_transaction_id = t.deposit_group_id
+               and s.user_id = t.user_id
+               and s.xmin = pg_current_xact_id()::xid
+          )
      ) then
     raise exception 'merge successor: this withdrawal records where the cash went, so that cannot be unset'
       using errcode = 'check_violation';

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -427,6 +427,10 @@ begin
      -- held_for_merge is how the holding-side guard tells a successor merge from
      -- a held settlement. Left editable, flipping it turns that guard off.
      and new.held_for_merge is not distinct from old.held_for_merge
+     -- And renewal lineage hides the row outright: the active-transactions view
+     -- and the default query both read a row carrying it as history, so the
+     -- withdrawal stops counting and the folded principal comes back.
+     and new.renewed_from_transaction_id is not distinct from old.renewed_from_transaction_id
      -- affects_progress decides whether the goal bar sees this withdrawal at
      -- all: turned off, valuation still closes the source while progress counts
      -- its principal again, beside the successor that now holds the cash.
@@ -465,7 +469,7 @@ drop trigger if exists investment_transactions_merged_withdrawal_immutable on pu
 create trigger investment_transactions_merged_withdrawal_immutable
   before update of principal_withdrawn, amount_vnd, parent_transaction_id,
     consumed_by_inv_id, transaction_type, affects_progress, goal_id,
-    asset_type, fund_id, units_withdrawn, held_for_merge
+    asset_type, fund_id, units_withdrawn, held_for_merge, renewed_from_transaction_id
   on public.investment_transactions
   for each row
   when (old.transaction_type = 'withdrawal' and old.parent_transaction_id is not null)

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -257,6 +257,23 @@ begin
     raise exception 'merge successor: this book has a withdrawal filed under another goal; move it back before merging'
       using errcode = 'check_violation';
   end if;
+  -- And one re-keyed to a fund. buildWithdrawalMaps sends any withdrawal naming
+  -- an asset_type of 'fund' with a fund_id to that fund's bucket instead of to
+  -- the holding it came out of, while the balance below subtracts it by parent
+  -- regardless: the merge would close the apparent remainder and the rerouted
+  -- portion would go on reading as live beside the successor's payout. (The
+  -- post-fold guard freezes these columns; this is about what is already there.)
+  if exists (
+    select 1 from public.investment_transactions w
+     join public.investment_transactions t on t.transaction_id = w.parent_transaction_id
+     where t.deposit_group_id = p_source_book_id
+       and t.transaction_type = 'investment'
+       and w.transaction_type = 'withdrawal'
+       and (w.asset_type is distinct from 'bank' or w.fund_id is not null)
+  ) then
+    raise exception 'merge successor: this book has a withdrawal filed against a fund; key it back to the deposit before merging'
+      using errcode = 'check_violation';
+  end if;
   -- And one carrying renewal lineage, which readers treat as history and skip.
   -- The balance below still subtracts it, so the merge would close only what is
   -- left and the hidden portion would read as live beside the successor's

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -367,7 +367,11 @@ begin
 
   if new.principal_withdrawn is not distinct from old.principal_withdrawn
      and new.amount_vnd is not distinct from old.amount_vnd
-     and new.parent_transaction_id is not distinct from old.parent_transaction_id then
+     and new.parent_transaction_id is not distinct from old.parent_transaction_id
+     -- affects_progress decides whether the goal bar sees this withdrawal at
+     -- all: turned off, valuation still closes the source while progress counts
+     -- its principal again, beside the successor that now holds the cash.
+     and new.affects_progress is not distinct from old.affects_progress then
     return new;
   end if;
 
@@ -389,8 +393,91 @@ revoke all on function public.guard_merged_source_withdrawal_edited() from publi
 
 drop trigger if exists investment_transactions_merged_withdrawal_immutable on public.investment_transactions;
 create trigger investment_transactions_merged_withdrawal_immutable
-  before update of principal_withdrawn, amount_vnd, parent_transaction_id, consumed_by_inv_id, transaction_type
+  before update of principal_withdrawn, amount_vnd, parent_transaction_id, consumed_by_inv_id, transaction_type, affects_progress
   on public.investment_transactions
   for each row
   when (old.transaction_type = 'withdrawal' and old.parent_transaction_id is not null)
   execute function public.guard_merged_source_withdrawal_edited();
+
+
+-- The other side of the same coin. Once the merge dissolves the book, each
+-- source tranche is an ordinary deposit again as far as the edit route is
+-- concerned — and raising its amount_vnd sails past the solvency check, because
+-- the withdrawals recorded against it are still smaller than the new amount. The
+-- difference then shows up as a live holding while its payout sits in the
+-- successor.
+--
+-- So a holding whose balance was folded away is fixed in every column that says
+-- what it is worth or how it counts. Its history is a record of money that has
+-- already moved.
+create or replace function public.guard_folded_holding_edited()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if new.amount_vnd is not distinct from old.amount_vnd
+     and new.units is not distinct from old.units
+     and new.unit_price is not distinct from old.unit_price
+     and new.transaction_type is not distinct from old.transaction_type
+     and new.affects_progress is not distinct from old.affects_progress then
+    return new;
+  end if;
+
+  if exists (
+    select 1 from public.investment_transactions w
+     where w.parent_transaction_id = old.transaction_id
+       and w.transaction_type = 'withdrawal'
+       and w.consumed_by_inv_id is not null
+  ) then
+    raise exception 'merge successor: this deposit was folded into another one, so what it holds cannot be rewritten'
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+revoke all on function public.guard_folded_holding_edited() from public, anon, authenticated;
+
+drop trigger if exists investment_transactions_folded_holding_immutable on public.investment_transactions;
+create trigger investment_transactions_folded_holding_immutable
+  before update of amount_vnd, units, unit_price, transaction_type, affects_progress
+  on public.investment_transactions
+  for each row
+  when (old.transaction_type = 'investment')
+  execute function public.guard_folded_holding_edited();
+
+-- (3) A recurring link arriving while the merge runs waits on the anchor lock,
+-- then re-reads a source whose successor has just been cleared — and accepts,
+-- because the promise is gone. The next statement dissolves the book, and the
+-- link is left pointing at something no top-up can reach. What the waiter has to
+-- see is not the promise but its outcome: this deposit's balance went elsewhere.
+create or replace function public.enforce_recurring_link_not_handed_over()
+returns trigger language plpgsql security definer set search_path = '' as $$
+declare v_successor uuid; v_folded boolean;
+begin
+  select successor_deposit_tx_id,
+         exists (
+           select 1 from public.investment_transactions w
+            where w.parent_transaction_id = t.transaction_id
+              and w.transaction_type = 'withdrawal'
+              and w.consumed_by_inv_id is not null
+         )
+    into v_successor, v_folded
+    from public.investment_transactions t
+   where t.transaction_id = new.linked_deposit_tx_id
+     and t.user_id = new.user_id
+   for share;
+
+  if found and v_successor is not null then
+    raise exception 'successor book: that book has handed over to a successor, so link the successor instead'
+      using errcode = 'check_violation';
+  end if;
+  if found and v_folded then
+    raise exception 'successor book: that deposit has been folded into another one, so link that one instead'
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -536,7 +536,17 @@ begin
   -- DIFFERENT holding still is.
   if new.parent_transaction_id is null and old.parent_transaction_id is not null
      and new.principal_withdrawn is not distinct from old.principal_withdrawn
-     and new.amount_vnd is not distinct from old.amount_vnd then
+     and new.amount_vnd is not distinct from old.amount_vnd
+     -- ...and only when the holding really is gone. A client can null this
+     -- column on a holding that still stands, which is a detachment, not a
+     -- cleanup: the withdrawal would stop subtracting from a source that is
+     -- still there. The withdrawal-balance invariant (20260730000002) refuses
+     -- that on its own today, so this is not a hole — but a guard that leans on
+     -- its neighbour's conditions is one narrowing away from being one.
+     and not exists (
+       select 1 from public.investment_transactions p
+        where p.transaction_id = old.parent_transaction_id
+     ) then
     return new;
   end if;
 

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -604,6 +604,14 @@ begin
     return new;
   end if;
 
+  -- Only a tranche INSIDE a book, which is the one shape this merge writes. An
+  -- ordinary re-deposit consumes siblings the same way — the renewal stamps
+  -- them and then rewrites its own amount — and that path is settled, with its
+  -- own rules and tests. Guarding it too broke it (the smoke lane caught it).
+  if old.deposit_group_id is null or old.deposit_group_id = old.transaction_id then
+    return new;
+  end if;
+
   if exists (
     select 1 from public.investment_transactions w
      where w.consumed_by_inv_id = old.transaction_id

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -336,6 +336,16 @@ security definer
 set search_path = ''
 as $$
 begin
+  -- The account going takes everything with it. Being immediate, this guard sees
+  -- each row of that cascade individually and would refuse the first folded one,
+  -- making any account that ever completed a merge undeletable. The owner's auth
+  -- row is already gone by the time the cascade reaches here, which is what
+  -- tells the two apart: unpicking history one row at a time is what this
+  -- refuses, not removing the account that history belongs to.
+  if not exists (select 1 from auth.users u where u.id = old.user_id) then
+    return old;
+  end if;
+
   if old.consumed_by_inv_id is not null or exists (
     select 1 from public.investment_transactions w
      where w.parent_transaction_id = old.parent_transaction_id

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -317,3 +317,65 @@ create trigger investment_transactions_merged_withdrawal_kept
   for each row
   when (old.transaction_type = 'withdrawal' and old.parent_transaction_id is not null)
   execute function public.guard_merged_source_withdrawal_deleted();
+
+
+-- Deleting the row is not the only way to give the principal back: an edit that
+-- lowers principal_withdrawn does exactly the same, and the balance check does
+-- not catch it because it excludes the row being edited. Clearing the stamp is
+-- the other half — the lineage is what says the cash moved.
+--
+-- Stamping an unstamped row is left alone: that is how a merge records where the
+-- cash went in the first place.
+create or replace function public.guard_merged_source_withdrawal_edited()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare v_folded boolean;
+begin
+  if old.consumed_by_inv_id is not null
+     and new.consumed_by_inv_id is distinct from old.consumed_by_inv_id then
+    raise exception 'merge successor: this withdrawal records where the cash went, so that cannot be unset'
+      using errcode = 'check_violation';
+  end if;
+
+  -- The FK's own cleanup: deleting a holding sets its withdrawals' parent to
+  -- null rather than removing them. Nothing is restored by that — the holding
+  -- itself is gone — so it is not this guard's business. Re-parenting to a
+  -- DIFFERENT holding still is.
+  if new.parent_transaction_id is null and old.parent_transaction_id is not null
+     and new.principal_withdrawn is not distinct from old.principal_withdrawn
+     and new.amount_vnd is not distinct from old.amount_vnd then
+    return new;
+  end if;
+
+  if new.principal_withdrawn is not distinct from old.principal_withdrawn
+     and new.amount_vnd is not distinct from old.amount_vnd
+     and new.parent_transaction_id is not distinct from old.parent_transaction_id then
+    return new;
+  end if;
+
+  v_folded := old.consumed_by_inv_id is not null or exists (
+    select 1 from public.investment_transactions w
+     where w.parent_transaction_id = old.parent_transaction_id
+       and w.transaction_type = 'withdrawal'
+       and w.consumed_by_inv_id is not null
+  );
+  if v_folded then
+    raise exception 'merge successor: this holding was folded into another deposit, so its withdrawals cannot be rewritten'
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+revoke all on function public.guard_merged_source_withdrawal_edited() from public, anon, authenticated;
+
+drop trigger if exists investment_transactions_merged_withdrawal_immutable on public.investment_transactions;
+create trigger investment_transactions_merged_withdrawal_immutable
+  before update of principal_withdrawn, amount_vnd, parent_transaction_id, consumed_by_inv_id
+  on public.investment_transactions
+  for each row
+  when (old.transaction_type = 'withdrawal' and old.parent_transaction_id is not null)
+  execute function public.guard_merged_source_withdrawal_edited();

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -250,6 +250,16 @@ begin
    where transaction_id = p_source_book_id;
   perform set_config('app.successor_write', '', true);
 
+  -- And it stops being a book at all. Settled but still self-grouped, it stays a
+  -- valid target for a top-up: a backdated one waiting on the anchor lock would
+  -- be accepted the moment this commits — after the tranche set was checked and
+  -- every tranche closed — resurrecting a book whose payout already sits in the
+  -- successor. The full-withdrawal close path clears the group for the same
+  -- reason (20260618000009); one statement, so the whole book leaves together.
+  update public.investment_transactions
+     set deposit_group_id = null, updated_at = now()
+   where deposit_group_id = p_source_book_id;
+
   return v_new;
 end;
 $$;
@@ -262,3 +272,48 @@ comment on function public.merge_book_into_successor(uuid, bigint, numeric, date
 -- `anon` has one too.
 revoke all on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[], bigint[]) from public, anon;
 grant execute on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[], bigint[]) to authenticated, service_role;
+
+
+-- Deleting a withdrawal gives its principal back to the holding it came from.
+-- That is ordinary — unless the holding has since been folded into another
+-- deposit, in which case the principal being restored was paid away and now
+-- lives somewhere else. Both halves matter: the withdrawal that DID the folding
+-- (deleting it re-opens the whole holding), and any earlier one beside it
+-- (deleting that restores the part the merge measured around).
+--
+-- Immediate, not deferred: a deferred trigger queues an event for every delete
+-- it watches, and pending events block ALTER TABLE on this table for the rest of
+-- the transaction — which is how the withdrawal-balance suite noticed.
+--
+-- Being immediate, it also refuses the cascade that would delete a folded
+-- holding along with its withdrawals. That is the rule, not a side effect: once
+-- a holding's balance has been paid into another deposit, its rows are what say
+-- so, and removing them would leave the destination holding cash from nowhere.
+create or replace function public.guard_merged_source_withdrawal_deleted()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if old.consumed_by_inv_id is not null or exists (
+    select 1 from public.investment_transactions w
+     where w.parent_transaction_id = old.parent_transaction_id
+       and w.transaction_type = 'withdrawal'
+       and w.consumed_by_inv_id is not null
+  ) then
+    raise exception 'merge successor: this holding was folded into another deposit, so its withdrawals cannot be removed'
+      using errcode = 'check_violation';
+  end if;
+  return old;
+end;
+$$;
+
+revoke all on function public.guard_merged_source_withdrawal_deleted() from public, anon, authenticated;
+
+drop trigger if exists investment_transactions_merged_withdrawal_kept on public.investment_transactions;
+create trigger investment_transactions_merged_withdrawal_kept
+  before delete on public.investment_transactions
+  for each row
+  when (old.transaction_type = 'withdrawal' and old.parent_transaction_id is not null)
+  execute function public.guard_merged_source_withdrawal_deleted();

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -1,0 +1,228 @@
+-- The promise kept: folding a matured book into the successor it was handed to
+-- (#638, Phase 3).
+--
+-- Phase 2 recorded the relationship and steered the contributions. What it could
+-- not do was end it: the old book reaches maturity holding real money, and the
+-- only thing the app knew how to do with a matured book — collapse it into a
+-- fresh cycle — is precisely what the handover said not to do. So a book with a
+-- successor had nowhere to go. This is where it goes.
+--
+-- One function, for the same reason the handover is one: closing the old book,
+-- allocating the cash it actually paid out, recording that cash in the new book
+-- and retiring the promise are only correct together. Half of it committed is a
+-- book closed with its money nowhere, or money in two places at once.
+
+create or replace function public.merge_book_into_successor(
+  p_source_book_id uuid,
+  p_received_vnd bigint,
+  p_interest_rate numeric,
+  p_merge_date date,
+  p_tranche_ids uuid[]
+)
+returns public.investment_transactions
+language plpgsql
+-- DEFINER for the same reason as open_successor_book: it has to clear the
+-- successor link, which no client may write. RLS therefore scopes nothing here,
+-- and every row it touches is checked against the caller explicitly.
+security definer
+set search_path = ''
+as $$
+declare
+  v_source public.investment_transactions;
+  v_dest public.investment_transactions;
+  v_tranche public.investment_transactions;
+  v_new public.investment_transactions;
+  v_new_id uuid := gen_random_uuid();
+  v_today date := (now() at time zone 'Asia/Ho_Chi_Minh')::date;
+  v_effective bigint;
+  v_total bigint := 0;
+  v_allocated bigint := 0;
+  v_share bigint;
+  v_last uuid;
+begin
+  -- Both books, locked in id order — the same order every other pairing write
+  -- takes, so two of them cannot deadlock against each other.
+  perform 1 from public.investment_transactions
+   where transaction_id in (
+     p_source_book_id,
+     (select successor_deposit_tx_id from public.investment_transactions
+       where transaction_id = p_source_book_id)
+   )
+   order by transaction_id
+   for update;
+
+  select * into v_source from public.investment_transactions
+   where transaction_id = p_source_book_id and deposit_group_id = p_source_book_id;
+  if not found then
+    raise exception 'merge successor: accumulating book not found' using errcode = 'no_data_found';
+  end if;
+  if auth.uid() is not null and v_source.user_id is distinct from auth.uid() then
+    raise exception 'merge successor: accumulating book not found' using errcode = 'no_data_found';
+  end if;
+  if v_source.successor_deposit_tx_id is null then
+    raise exception 'merge successor: this book has no successor to merge into'
+      using errcode = 'check_violation';
+  end if;
+
+  select * into v_dest from public.investment_transactions
+   where transaction_id = v_source.successor_deposit_tx_id;
+  if not found then
+    raise exception 'merge successor: the successor book is gone' using errcode = 'no_data_found';
+  end if;
+
+  -- What the pairing invariant has been holding all along is checked once more
+  -- here, at the only moment it has to be true for real.
+  if v_dest.user_id is distinct from v_source.user_id
+     or v_dest.goal_id is distinct from v_source.goal_id
+     or coalesce(v_dest.currency, 'VND') is distinct from coalesce(v_source.currency, 'VND')
+     or v_dest.deposit_group_id is distinct from v_dest.transaction_id
+     or v_dest.transaction_type is distinct from 'investment' then
+    raise exception 'merge successor: the successor is no longer a book this one can merge into'
+      using errcode = 'check_violation';
+  end if;
+  if v_source.is_pledged or v_dest.is_pledged then
+    raise exception 'merge successor: a pledged deposit cannot be merged while it is collateral'
+      using errcode = 'check_violation';
+  end if;
+
+  -- The merge is what maturity is for, so it does not happen before maturity —
+  -- the money has not been paid out yet.
+  if v_source.expiry_date is null or v_source.expiry_date > v_today then
+    raise exception 'merge successor: this book has not matured yet'
+      using errcode = 'check_violation';
+  end if;
+  if p_merge_date is null or p_merge_date > v_today then
+    raise exception 'merge successor: the merge date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+  if p_merge_date < v_source.expiry_date then
+    raise exception 'merge successor: the cash is paid out at maturity (%), not before', v_source.expiry_date
+      using errcode = 'check_violation';
+  end if;
+  if p_received_vnd is null or p_received_vnd <= 0 then
+    raise exception 'merge successor: the received amount must be positive'
+      using errcode = 'check_violation';
+  end if;
+  if p_interest_rate is null or p_interest_rate <= 0 then
+    raise exception 'merge successor: the new tranche needs its own rate'
+      using errcode = 'check_violation';
+  end if;
+
+  -- What the book still holds, after any partial withdrawals it has taken.
+  select coalesce(sum(t.amount_vnd - coalesce((
+           select sum(w.principal_withdrawn) from public.investment_transactions w
+            where w.parent_transaction_id = t.transaction_id
+              and w.transaction_type = 'withdrawal'), 0)), 0)
+    into v_total
+    from public.investment_transactions t
+   where t.deposit_group_id = p_source_book_id
+     and t.transaction_type = 'investment'
+     and t.renewed_from_transaction_id is null;
+  if v_total <= 0 then
+    raise exception 'merge successor: this book is already fully withdrawn'
+      using errcode = 'check_violation';
+  end if;
+  -- The received cash is the client's number — a settled deposit pays out its
+  -- principal plus interest, never a multiple of it. The same bound the renewal
+  -- merge applies (20260620000006): loose enough for any real payout, tight
+  -- enough that a wrong number cannot inflate the destination out of nothing.
+  if p_received_vnd > v_total * 10 then
+    raise exception 'merge successor: the received amount is unreasonably large for this book'
+      using errcode = 'check_violation';
+  end if;
+
+  -- The cash lands in the successor FIRST, because every withdrawal below is
+  -- stamped with where it went. The insert passes the same top-up guard any
+  -- contribution to that book would — if it has since closed its own door, the
+  -- merge stops here rather than closing this book into nothing.
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type, amount_vnd,
+    investment_date, expiry_date, interest_rate, notes, bank_code, currency,
+    deposit_group_id, top_up_lock_days, affects_progress
+  ) values (
+    v_new_id, v_dest.user_id, v_dest.goal_id, 'bank', 'investment', p_received_vnd,
+    p_merge_date, v_dest.expiry_date, p_interest_rate, v_dest.notes,
+    v_dest.bank_code, v_dest.currency, v_dest.transaction_id, v_dest.top_up_lock_days, true
+  )
+  returning * into v_new;
+
+  -- Close every live tranche, allocating the received cash across them in
+  -- proportion to what each still held. The last one takes whatever rounding
+  -- left behind, so the parts add up to the whole exactly.
+  select t.transaction_id into v_last
+    from public.investment_transactions t
+   where t.deposit_group_id = p_source_book_id
+     and t.transaction_type = 'investment'
+     and t.renewed_from_transaction_id is null
+   order by t.investment_date desc, t.transaction_id desc
+   limit 1;
+
+  for v_tranche in
+    select * from public.investment_transactions
+     where deposit_group_id = p_source_book_id
+       and transaction_type = 'investment'
+       and renewed_from_transaction_id is null
+     order by investment_date, transaction_id
+     for update
+  loop
+    -- A live tranche the caller never saw means the book changed under them (a
+    -- top-up landed while the confirmation was open). Abort rather than close a
+    -- tranche whose cash nobody counted. Plain P0001, not serialization_failure:
+    -- this is deterministic, and a pooler must not spin retrying it.
+    if array_position(p_tranche_ids, v_tranche.transaction_id) is null then
+      raise exception 'merge successor: book changed since load, reload and retry';
+    end if;
+
+    v_effective := v_tranche.amount_vnd - coalesce((
+      select sum(w.principal_withdrawn) from public.investment_transactions w
+       where w.parent_transaction_id = v_tranche.transaction_id
+         and w.transaction_type = 'withdrawal'), 0);
+    if v_effective <= 0 then continue; end if;
+
+    if v_tranche.transaction_id = v_last then
+      v_share := p_received_vnd - v_allocated;
+    else
+      v_share := (p_received_vnd * v_effective) / v_total;
+      v_allocated := v_allocated + v_share;
+    end if;
+
+    insert into public.investment_transactions (
+      user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
+      investment_date, amount_vnd, principal_withdrawn, affects_progress,
+      consumed_by_inv_id
+    ) values (
+      v_tranche.user_id, v_tranche.goal_id, 'bank', 'withdrawal', v_tranche.transaction_id,
+      p_merge_date, v_share, v_effective, true, v_new_id
+    );
+  end loop;
+
+  -- Anything still funding the old book now funds the new one — the old one has
+  -- nothing left to receive.
+  update public.recurring_savings
+     set linked_deposit_tx_id = v_dest.transaction_id, updated_at = now()
+   where user_id = v_source.user_id
+     and linked_deposit_tx_id in (
+       select transaction_id from public.investment_transactions
+        where deposit_group_id = p_source_book_id
+     );
+
+  -- The promise has been kept, so it stops standing. Nothing else may write this
+  -- column (20260811000001), which is why this function marks its own write.
+  perform set_config('app.successor_write', '1', true);
+  update public.investment_transactions
+     set successor_deposit_tx_id = null, updated_at = now()
+   where transaction_id = p_source_book_id;
+  perform set_config('app.successor_write', '', true);
+
+  return v_new;
+end;
+$$;
+
+comment on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[]) is
+  'Fold a matured accumulating book into the successor it was handed to, closing it and retiring the promise (#638).';
+
+-- Executable by the people who own books, not by everyone: like the handover
+-- functions, this one trusts a null auth.uid() as the service role or SQL, and
+-- `anon` has one too.
+revoke all on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[]) from public, anon;
+grant execute on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[]) to authenticated, service_role;

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -78,6 +78,7 @@ declare
   v_last uuid;
   v_idx int;
   v_seen int := 0;
+  v_last_expiry date;
 begin
   if p_tranche_principals is null
      or array_length(p_tranche_principals, 1) is distinct from array_length(p_tranche_ids, 1) then
@@ -278,6 +279,24 @@ begin
             and w.transaction_type = 'withdrawal'), 0) > 0
   ) then
     raise exception 'merge successor: this book still holds a tranche that has not matured; it cannot be folded yet'
+      using errcode = 'check_violation';
+  end if;
+  -- ...and the date the cash arrived is bounded by the LAST of them, not by the
+  -- anchor. In the same split book, an anchor that matured in July says nothing
+  -- about a tranche that matured in August: dating the fold to July would record
+  -- that tranche's withdrawal, and start the successor's interest, before its
+  -- money existed.
+  select max(t.expiry_date) into v_last_expiry
+    from public.investment_transactions t
+   where t.deposit_group_id = p_source_book_id
+     and t.transaction_type = 'investment'
+     and t.renewed_from_transaction_id is null
+     and t.amount_vnd - coalesce((
+       select sum(w.principal_withdrawn) from public.investment_transactions w
+        where w.parent_transaction_id = t.transaction_id
+          and w.transaction_type = 'withdrawal'), 0) > 0;
+  if v_last_expiry is not null and p_merge_date < v_last_expiry then
+    raise exception 'merge successor: the cash is paid out at maturity (%), not before', v_last_expiry
       using errcode = 'check_violation';
   end if;
   -- And one re-keyed to a fund. buildWithdrawalMaps sends any withdrawal naming

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -141,6 +141,41 @@ begin
     raise exception 'merge successor: this book is already fully withdrawn'
       using errcode = 'check_violation';
   end if;
+  -- ── Shapes this merge cannot represent honestly ─────────────────────────
+  -- Both of these are fixable BEFORE the fold and not after, since the rows
+  -- become immutable once the cash has moved. So they are refused here, with
+  -- the reason, rather than folded into a picture that cannot be corrected.
+  --
+  -- A withdrawal kept out of progress leaves its principal counted toward the
+  -- goal on purpose. Folding around it puts the successor's payout beside a
+  -- portion the bar is still counting, and nothing afterwards can reconcile the
+  -- two.
+  if exists (
+    select 1 from public.investment_transactions w
+     join public.investment_transactions t on t.transaction_id = w.parent_transaction_id
+     where t.deposit_group_id = p_source_book_id
+       and t.transaction_type = 'investment'
+       and w.transaction_type = 'withdrawal'
+       and coalesce(w.affects_progress, true) = false
+  ) then
+    raise exception 'merge successor: this book has a withdrawal kept out of goal progress; put it back before merging'
+      using errcode = 'check_violation';
+  end if;
+  -- And one sitting in a different goal from the tranche it came out of: goal
+  -- detail reads by goal, so that goal would show the tranche and the closing
+  -- withdrawal but not this one, and its principal would read as live.
+  if exists (
+    select 1 from public.investment_transactions w
+     join public.investment_transactions t on t.transaction_id = w.parent_transaction_id
+     where t.deposit_group_id = p_source_book_id
+       and t.transaction_type = 'investment'
+       and w.transaction_type = 'withdrawal'
+       and w.goal_id is distinct from t.goal_id
+  ) then
+    raise exception 'merge successor: this book has a withdrawal filed under another goal; move it back before merging'
+      using errcode = 'check_violation';
+  end if;
+
   -- The received cash is the client's number — a settled deposit pays out its
   -- principal plus interest, never a multiple of it. The same bound the renewal
   -- merge applies (20260620000006): loose enough for any real payout, tight

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -17,7 +17,8 @@ create or replace function public.merge_book_into_successor(
   p_received_vnd bigint,
   p_interest_rate numeric,
   p_merge_date date,
-  p_tranche_ids uuid[]
+  p_tranche_ids uuid[],
+  p_tranche_principals bigint[]
 )
 returns public.investment_transactions
 language plpgsql
@@ -39,7 +40,13 @@ declare
   v_allocated bigint := 0;
   v_share bigint;
   v_last uuid;
+  v_idx int;
 begin
+  if p_tranche_principals is null
+     or array_length(p_tranche_principals, 1) is distinct from array_length(p_tranche_ids, 1) then
+    raise exception 'merge successor: every named tranche needs the balance it was seen holding'
+      using errcode = 'check_violation';
+  end if;
   -- Both books, locked in id order — the same order every other pairing write
   -- takes, so two of them cannot deadlock against each other.
   perform 1 from public.investment_transactions
@@ -193,19 +200,25 @@ begin
     -- however many times they reloaded.
     if v_effective <= 0 then continue; end if;
 
-    -- One that DOES still hold something, and that the caller never saw, means
-    -- the book changed under them — a top-up landing while the confirmation was
-    -- open. Abort rather than close a tranche whose cash nobody counted. Plain
-    -- P0001, not serialization_failure: this is deterministic, and a pooler must
-    -- not spin retrying it.
-    if array_position(p_tranche_ids, v_tranche.transaction_id) is null then
+    -- One that DOES still hold something has to be one the caller saw, holding
+    -- what they saw it hold. Ids alone are not enough: a partial withdrawal
+    -- landing after the confirmation screen loaded leaves every id in place
+    -- while the payout being confirmed is no longer the payout this book can
+    -- make — the destination would be credited with cash the withdrawal already
+    -- took. Comparing balances is what catches that. Plain P0001, not
+    -- serialization_failure: this is deterministic, and a pooler must not spin
+    -- retrying it.
+    v_idx := array_position(p_tranche_ids, v_tranche.transaction_id);
+    if v_idx is null or p_tranche_principals[v_idx] is distinct from v_effective then
       raise exception 'merge successor: book changed since load, reload and retry';
     end if;
 
     if v_tranche.transaction_id = v_last then
       v_share := p_received_vnd - v_allocated;
     else
-      v_share := (p_received_vnd * v_effective) / v_total;
+      -- In numeric: a multi-billion payout times a multi-billion balance passes
+      -- the bigint ceiling long before the division brings it back down.
+      v_share := floor((p_received_vnd::numeric * v_effective) / v_total)::bigint;
       v_allocated := v_allocated + v_share;
     end if;
 
@@ -241,11 +254,11 @@ begin
 end;
 $$;
 
-comment on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[]) is
+comment on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[], bigint[]) is
   'Fold a matured accumulating book into the successor it was handed to, closing it and retiring the promise (#638).';
 
 -- Executable by the people who own books, not by everyone: like the handover
 -- functions, this one trusts a null auth.uid() as the service role or SQL, and
 -- `anon` has one too.
-revoke all on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[]) from public, anon;
-grant execute on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[]) to authenticated, service_role;
+revoke all on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[], bigint[]) from public, anon;
+grant execute on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[], bigint[]) to authenticated, service_role;

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -109,6 +109,12 @@ begin
     raise exception 'merge successor: a pledged deposit cannot be merged while it is collateral'
       using errcode = 'check_violation';
   end if;
+  -- Can the successor still take money TODAY? The tranche below is dated when
+  -- the bank paid the source out, and the top-up guard judges by that date — so
+  -- an overdue book resolved weeks late would fold into a successor that has
+  -- itself matured in the meantime, landing the cash in a closed book and
+  -- redirecting the recurring savings to one that will refuse them.
+  perform public.assert_accumulating_book_topup_allowed(v_dest.transaction_id, v_dest.user_id, v_today);
 
   -- The merge is what maturity is for, so it does not happen before maturity —
   -- the money has not been paid out yet.
@@ -278,6 +284,14 @@ begin
       -- the bigint ceiling long before the division brings it back down.
       v_share := floor((p_received_vnd::numeric * v_effective) / v_total)::bigint;
       v_allocated := v_allocated + v_share;
+    end if;
+    -- A payout far below what the book holds floors somebody's share to
+    -- nothing, and a withdrawal of zero is not a row this table takes: the
+    -- merge died on a raw constraint and the route answered with a fault, for
+    -- an amount its own validation had accepted.
+    if v_share <= 0 then
+      raise exception 'merge successor: the received amount is too small to spread across every tranche of this book'
+        using errcode = 'check_violation';
     end if;
 
     insert into public.investment_transactions (

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -77,6 +77,7 @@ declare
   v_share bigint;
   v_last uuid;
   v_idx int;
+  v_seen int := 0;
 begin
   if p_tranche_principals is null
      or array_length(p_tranche_principals, 1) is distinct from array_length(p_tranche_ids, 1) then
@@ -348,6 +349,7 @@ begin
     if p_tranche_principals[v_idx] is distinct from v_effective then
       raise exception 'merge successor: book changed since load, reload and retry';
     end if;
+    v_seen := v_seen + 1;
     if v_effective <= 0 then continue; end if;
 
     if v_tranche.transaction_id = v_last then
@@ -376,6 +378,15 @@ begin
       p_merge_date, v_share, v_effective, true, v_new_id
     );
   end loop;
+
+  -- The loop can only judge tranches it walks, so one the caller named that is
+  -- no longer there was simply never met — the book closed what survived while
+  -- the successor was credited with the payout of a book that included it. The
+  -- ×10 bound is far too loose to notice. Every named tranche has to have been
+  -- accounted for, not just every surviving one.
+  if v_seen is distinct from coalesce(array_length(p_tranche_ids, 1), 0) then
+    raise exception 'merge successor: book changed since load, reload and retry';
+  end if;
 
   -- Anything still funding the old book now funds the new one — the old one has
   -- nothing left to receive.
@@ -743,17 +754,36 @@ begin
     return old;
   end if;
 
-  -- Not part of a book any more (a plain delete of the credited row, or a book
-  -- already dissolved): nothing to move it onto, so the foreign key and the
-  -- withdrawal guard refuse the delete — which is what should happen, since the
-  -- cash would be left with nowhere to say it went.
-  if old.deposit_group_id is null or old.deposit_group_id = old.transaction_id then
+  -- Only a collapse in progress, recognised by the snapshot it has just written
+  -- for this book inside this very transaction. Moving the lineage for any other
+  -- delete would clear the foreign key that stands in the way and let an
+  -- ordinary DELETE take the successor's whole payout with it, while the source
+  -- it emptied stays closed for good.
+  if old.deposit_group_id is not null
+     and old.deposit_group_id <> old.transaction_id
+     and exists (
+       select 1 from public.investment_transactions s
+        where s.renewed_from_transaction_id = old.deposit_group_id
+          and s.user_id = old.user_id
+          and s.xmin = pg_current_xact_id()::xid
+     ) then
+    update public.investment_transactions
+       set consumed_by_inv_id = old.deposit_group_id, updated_at = now()
+     where consumed_by_inv_id = old.transaction_id;
     return old;
   end if;
 
-  update public.investment_transactions
-     set consumed_by_inv_id = old.deposit_group_id, updated_at = now()
-   where consumed_by_inv_id = old.transaction_id;
+  -- Anything else: refuse while this row still stands for cash another book
+  -- paid out. Said here rather than left to the foreign key, which would answer
+  -- with a constraint name instead of a reason.
+  if exists (
+    select 1 from public.investment_transactions w
+     where w.consumed_by_inv_id = old.transaction_id
+       and w.transaction_type = 'withdrawal'
+  ) then
+    raise exception 'merge successor: this deposit holds another book''s payout, so it cannot be deleted on its own'
+      using errcode = 'check_violation';
+  end if;
   return old;
 end;
 $$;

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -194,24 +194,29 @@ begin
       select sum(w.principal_withdrawn) from public.investment_transactions w
        where w.parent_transaction_id = v_tranche.transaction_id
          and w.transaction_type = 'withdrawal'), 0);
-    -- A tranche with nothing left is not the caller's to account for: the book
-    -- as they see it does not contain it (buildInvRows drops a tranche once its
-    -- principal is gone), so demanding its id would make such a book unmergeable
-    -- however many times they reloaded.
-    if v_effective <= 0 then continue; end if;
-
-    -- One that DOES still hold something has to be one the caller saw, holding
-    -- what they saw it hold. Ids alone are not enough: a partial withdrawal
-    -- landing after the confirmation screen loaded leaves every id in place
-    -- while the payout being confirmed is no longer the payout this book can
-    -- make — the destination would be credited with cash the withdrawal already
-    -- took. Comparing balances is what catches that. Plain P0001, not
+    -- Membership FIRST, balance second. Skipping spent tranches before the
+    -- comparison hid the case where one the caller SUBMITTED has since been
+    -- withdrawn to nothing: the rest still matched, the loose payout bound
+    -- accepted the old figure, and the successor was credited with cash the
+    -- intervening withdrawal had already taken.
+    --
+    -- So: a tranche the caller named must still hold exactly what they saw, and
+    -- one they did not name must hold nothing — the preview omits spent
+    -- tranches, which is why demanding their ids would make such a book
+    -- unmergeable however often it was reloaded. Plain P0001, not
     -- serialization_failure: this is deterministic, and a pooler must not spin
     -- retrying it.
     v_idx := array_position(p_tranche_ids, v_tranche.transaction_id);
-    if v_idx is null or p_tranche_principals[v_idx] is distinct from v_effective then
+    if v_idx is null then
+      if v_effective > 0 then
+        raise exception 'merge successor: book changed since load, reload and retry';
+      end if;
+      continue;
+    end if;
+    if p_tranche_principals[v_idx] is distinct from v_effective then
       raise exception 'merge successor: book changed since load, reload and retry';
     end if;
+    if v_effective <= 0 then continue; end if;
 
     if v_tranche.transaction_id = v_last then
       v_share := p_received_vnd - v_allocated;

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -83,6 +83,21 @@ begin
     raise exception 'merge successor: every named tranche needs the balance it was seen holding'
       using errcode = 'check_violation';
   end if;
+  -- SAVINGS FIRST, then the books — the order open_successor_book takes, and
+  -- the order an ordinary recurring edit ends up in on its own (it holds its
+  -- saving row, then waits for the book through the link trigger). Locking the
+  -- book first here would invert the two and turn the pair into a deadlock that
+  -- Postgres resolves by killing one of them. These are the savings this merge
+  -- will move; one linked to a tranche that appears after this read is not
+  -- locked, but such a book fails the tranche check below anyway.
+  perform 1 from public.recurring_savings
+   where linked_deposit_tx_id in (
+     select transaction_id from public.investment_transactions
+      where deposit_group_id = p_source_book_id
+   )
+   order by saving_id
+   for update;
+
   -- Both books, locked in id order — the same order every other pairing write
   -- takes, so two of them cannot deadlock against each other.
   perform 1 from public.investment_transactions
@@ -174,6 +189,23 @@ begin
      and transaction_type = 'investment'
      and renewed_from_transaction_id is null
    order by transaction_id
+   for update;
+
+  -- And the withdrawals themselves, for the same reason one step further out.
+  -- Deleting an earlier partial withdrawal is refused once this merge's own
+  -- withdrawal exists — but a delete running concurrently cannot see that row
+  -- while it is uncommitted, so both would commit: the deleted principal comes
+  -- back to a source that is now dissolved, while the successor keeps the whole
+  -- payout. Holding these rows makes the delete wait for the answer instead of
+  -- deciding without it.
+  perform 1 from public.investment_transactions w
+   where w.transaction_type = 'withdrawal'
+     and w.parent_transaction_id in (
+       select t.transaction_id from public.investment_transactions t
+        where t.deposit_group_id = p_source_book_id
+          and t.transaction_type = 'investment'
+     )
+   order by w.transaction_id
    for update;
 
   -- What the book still holds, after any partial withdrawals it has taken.
@@ -703,6 +735,14 @@ security definer
 set search_path = ''
 as $$
 begin
+  -- The account going away takes all of this with it, and the cascade may
+  -- already have removed the goal these rows point at — so rewriting them now
+  -- fails the ownership check and makes an account that ever completed a merge
+  -- undeletable. There is nothing to preserve lineage for either.
+  if not exists (select 1 from auth.users u where u.id = old.user_id) then
+    return old;
+  end if;
+
   -- Not part of a book any more (a plain delete of the credited row, or a book
   -- already dissolved): nothing to move it onto, so the foreign key and the
   -- withdrawal guard refuse the delete — which is what should happen, since the

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -108,6 +108,18 @@ begin
       using errcode = 'check_violation';
   end if;
 
+  -- LOCK EVERY TRANCHE BEFORE MEASURING. The balance below decides how much
+  -- cash the destination is credited with; read without the lock, a withdrawal
+  -- committing between the read and the loop would leave the destination holding
+  -- money that withdrawal also took. The withdrawal path takes these same row
+  -- locks before it measures (20260730000002), so it waits for us or we for it.
+  perform 1 from public.investment_transactions
+   where deposit_group_id = p_source_book_id
+     and transaction_type = 'investment'
+     and renewed_from_transaction_id is null
+   order by transaction_id
+   for update;
+
   -- What the book still holds, after any partial withdrawals it has taken.
   select coalesce(sum(t.amount_vnd - coalesce((
            select sum(w.principal_withdrawn) from public.investment_transactions w
@@ -149,11 +161,17 @@ begin
   -- Close every live tranche, allocating the received cash across them in
   -- proportion to what each still held. The last one takes whatever rounding
   -- left behind, so the parts add up to the whole exactly.
+  -- Among the tranches that still hold something: a spent one is skipped by the
+  -- loop, so making it the remainder-taker would drop the rounding on the floor.
   select t.transaction_id into v_last
     from public.investment_transactions t
    where t.deposit_group_id = p_source_book_id
      and t.transaction_type = 'investment'
      and t.renewed_from_transaction_id is null
+     and t.amount_vnd - coalesce((
+       select sum(w.principal_withdrawn) from public.investment_transactions w
+        where w.parent_transaction_id = t.transaction_id
+          and w.transaction_type = 'withdrawal'), 0) > 0
    order by t.investment_date desc, t.transaction_id desc
    limit 1;
 
@@ -165,19 +183,24 @@ begin
      order by investment_date, transaction_id
      for update
   loop
-    -- A live tranche the caller never saw means the book changed under them (a
-    -- top-up landed while the confirmation was open). Abort rather than close a
-    -- tranche whose cash nobody counted. Plain P0001, not serialization_failure:
-    -- this is deterministic, and a pooler must not spin retrying it.
-    if array_position(p_tranche_ids, v_tranche.transaction_id) is null then
-      raise exception 'merge successor: book changed since load, reload and retry';
-    end if;
-
     v_effective := v_tranche.amount_vnd - coalesce((
       select sum(w.principal_withdrawn) from public.investment_transactions w
        where w.parent_transaction_id = v_tranche.transaction_id
          and w.transaction_type = 'withdrawal'), 0);
+    -- A tranche with nothing left is not the caller's to account for: the book
+    -- as they see it does not contain it (buildInvRows drops a tranche once its
+    -- principal is gone), so demanding its id would make such a book unmergeable
+    -- however many times they reloaded.
     if v_effective <= 0 then continue; end if;
+
+    -- One that DOES still hold something, and that the caller never saw, means
+    -- the book changed under them — a top-up landing while the confirmation was
+    -- open. Abort rather than close a tranche whose cash nobody counted. Plain
+    -- P0001, not serialization_failure: this is deterministic, and a pooler must
+    -- not spin retrying it.
+    if array_position(p_tranche_ids, v_tranche.transaction_id) is null then
+      raise exception 'merge successor: book changed since load, reload and retry';
+    end if;
 
     if v_tranche.transaction_id = v_last then
       v_share := p_received_vnd - v_allocated;

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -180,25 +180,16 @@ begin
       using errcode = 'check_violation';
   end if;
 
-  -- LOCK EVERY TRANCHE BEFORE MEASURING. The balance below decides how much
-  -- cash the destination is credited with; read without the lock, a withdrawal
-  -- committing between the read and the loop would leave the destination holding
-  -- money that withdrawal also took. The withdrawal path takes these same row
-  -- locks before it measures (20260730000002), so it waits for us or we for it.
-  perform 1 from public.investment_transactions
-   where deposit_group_id = p_source_book_id
-     and transaction_type = 'investment'
-     and renewed_from_transaction_id is null
-   order by transaction_id
-   for update;
-
-  -- And the withdrawals themselves, for the same reason one step further out.
-  -- Deleting an earlier partial withdrawal is refused once this merge's own
-  -- withdrawal exists — but a delete running concurrently cannot see that row
-  -- while it is uncommitted, so both would commit: the deleted principal comes
-  -- back to a source that is now dissolved, while the successor keeps the whole
-  -- payout. Holding these rows makes the delete wait for the answer instead of
-  -- deciding without it.
+  -- WITHDRAWALS FIRST, then the tranches they came out of. Editing a withdrawal
+  -- locks that row and only then reaches its parent, through the balance trigger
+  -- (20260803000005) — so taking the parents first inverts the pair and turns a
+  -- concurrent edit into a deadlock Postgres resolves by killing one side.
+  --
+  -- Holding them also settles a race of its own: deleting an earlier partial
+  -- withdrawal is refused once this merge's own withdrawal exists, but a delete
+  -- running concurrently cannot see that row while it is uncommitted, so both
+  -- would commit — the deleted principal back in a source that is by then
+  -- dissolved, while the successor keeps the whole payout.
   perform 1 from public.investment_transactions w
    where w.transaction_type = 'withdrawal'
      and w.parent_transaction_id in (
@@ -207,6 +198,17 @@ begin
           and t.transaction_type = 'investment'
      )
    order by w.transaction_id
+   for update;
+
+  -- LOCK EVERY TRANCHE BEFORE MEASURING. The balance below decides how much
+  -- cash the destination is credited with; read without the lock, a withdrawal
+  -- committing between the read and the loop would leave the destination holding
+  -- money that withdrawal also took.
+  perform 1 from public.investment_transactions
+   where deposit_group_id = p_source_book_id
+     and transaction_type = 'investment'
+     and renewed_from_transaction_id is null
+   order by transaction_id
    for update;
 
   -- What the book still holds, after any partial withdrawals it has taken.
@@ -255,6 +257,27 @@ begin
        and w.goal_id is distinct from t.goal_id
   ) then
     raise exception 'merge successor: this book has a withdrawal filed under another goal; move it back before merging'
+      using errcode = 'check_violation';
+  end if;
+  -- A tranche that has not matured, in a book whose anchor has. The old
+  -- two-statement edit flow could leave a book's expiries split
+  -- (20260618000004) and never normalised what was already there, so the
+  -- anchor's date does not answer for the rest. Closing a tranche the bank has
+  -- not paid out yet would credit the successor with cash that does not exist.
+  if exists (
+    select 1 from public.investment_transactions t
+     where t.deposit_group_id = p_source_book_id
+       and t.transaction_type = 'investment'
+       and t.renewed_from_transaction_id is null
+       and (t.expiry_date is null or t.expiry_date > v_today)
+       -- Only what still holds something: a spent tranche pays out nothing,
+       -- whatever date it carries.
+       and t.amount_vnd - coalesce((
+         select sum(w.principal_withdrawn) from public.investment_transactions w
+          where w.parent_transaction_id = t.transaction_id
+            and w.transaction_type = 'withdrawal'), 0) > 0
+  ) then
+    raise exception 'merge successor: this book still holds a tranche that has not matured; it cannot be folded yet'
       using errcode = 'check_violation';
   end if;
   -- And one re-keyed to a fund. buildWithdrawalMaps sends any withdrawal naming

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -421,7 +421,30 @@ begin
      and new.units is not distinct from old.units
      and new.unit_price is not distinct from old.unit_price
      and new.transaction_type is not distinct from old.transaction_type
-     and new.affects_progress is not distinct from old.affects_progress then
+     and new.affects_progress is not distinct from old.affects_progress
+     -- Moving it to another goal splits it from its own withdrawals, which stay
+     -- behind: the new goal then sees a holding with nothing recorded against it
+     -- and shows the paid-away principal as live.
+     --
+     -- Only for a book folded by THIS merge. The held-settlement path allows the
+     -- same move on purpose (20260731000001, 11c): once its cash is consumed the
+     -- pool skips the row, and pinning the goal made any goal that had completed
+     -- a merge undeletable. The hazard is arguably shared, but that is a settled
+     -- decision with its own tests, and not this migration's to overturn.
+     and new.goal_id is not distinct from old.goal_id then
+    return new;
+  end if;
+
+  -- A goal being deleted nulls this column through the FK, and that is not a
+  -- move: nothing is left to move it away from. An unassign, where the goal is
+  -- still there, is — it would leave the withdrawals behind in it.
+  if new.goal_id is null and old.goal_id is not null
+     and new.amount_vnd is not distinct from old.amount_vnd
+     and new.units is not distinct from old.units
+     and new.unit_price is not distinct from old.unit_price
+     and new.transaction_type is not distinct from old.transaction_type
+     and new.affects_progress is not distinct from old.affects_progress
+     and not exists (select 1 from public.savings_goals g where g.goal_id = old.goal_id) then
     return new;
   end if;
 
@@ -430,6 +453,8 @@ begin
      where w.parent_transaction_id = old.transaction_id
        and w.transaction_type = 'withdrawal'
        and w.consumed_by_inv_id is not null
+       -- A held settlement's own consumption is the other path's business.
+       and coalesce(w.held_for_merge, false) = false
   ) then
     raise exception 'merge successor: this deposit was folded into another one, so what it holds cannot be rewritten'
       using errcode = 'check_violation';
@@ -442,7 +467,7 @@ revoke all on function public.guard_folded_holding_edited() from public, anon, a
 
 drop trigger if exists investment_transactions_folded_holding_immutable on public.investment_transactions;
 create trigger investment_transactions_folded_holding_immutable
-  before update of amount_vnd, units, unit_price, transaction_type, affects_progress
+  before update of amount_vnd, units, unit_price, transaction_type, affects_progress, goal_id
   on public.investment_transactions
   for each row
   when (old.transaction_type = 'investment')

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -100,15 +100,25 @@ begin
    order by saving_id
    for update;
 
-  -- Both books, locked in id order — the same order every other pairing write
-  -- takes, so two of them cannot deadlock against each other.
+  -- The whole source book in ONE ordered acquisition, anchor included. Taking
+  -- the anchor first and its tranches later put an anchor→tranche edge in the
+  -- way of update_deposit_book, which locks the tranche it was handed and then
+  -- rewrites the group — the opposite direction, and a deadlock between them.
+  -- (That function still locks its group in whatever order the update finds, so
+  -- this removes our half of the cycle rather than the whole of it.)
   perform 1 from public.investment_transactions
-   where transaction_id in (
-     p_source_book_id,
-     (select successor_deposit_tx_id from public.investment_transactions
-       where transaction_id = p_source_book_id)
-   )
+   where deposit_group_id = p_source_book_id
    order by transaction_id
+   for update;
+
+  -- Then the successor's own anchor. A book cannot be both a source and a
+  -- successor — the pairing forbids chains — so no two merges can hold these
+  -- two in opposite orders.
+  perform 1 from public.investment_transactions
+   where transaction_id = (
+     select successor_deposit_tx_id from public.investment_transactions
+      where transaction_id = p_source_book_id
+   )
    for update;
 
   select * into v_source from public.investment_transactions
@@ -201,17 +211,6 @@ begin
    order by w.transaction_id
    for update;
 
-  -- LOCK EVERY TRANCHE BEFORE MEASURING. The balance below decides how much
-  -- cash the destination is credited with; read without the lock, a withdrawal
-  -- committing between the read and the loop would leave the destination holding
-  -- money that withdrawal also took.
-  perform 1 from public.investment_transactions
-   where deposit_group_id = p_source_book_id
-     and transaction_type = 'investment'
-     and renewed_from_transaction_id is null
-   order by transaction_id
-   for update;
-
   -- What the book still holds, after any partial withdrawals it has taken.
   select coalesce(sum(t.amount_vnd - coalesce((
            select sum(w.principal_withdrawn) from public.investment_transactions w
@@ -279,6 +278,25 @@ begin
             and w.transaction_type = 'withdrawal'), 0) > 0
   ) then
     raise exception 'merge successor: this book still holds a tranche that has not matured; it cannot be folded yet'
+      using errcode = 'check_violation';
+  end if;
+  -- ...and a tranche filed under a different goal from the book it belongs to,
+  -- which the same old edit flow could also leave behind. Every closing
+  -- withdrawal is written in its own tranche's goal while the whole payout is
+  -- credited in the anchor's, so folding such a book quietly moves that
+  -- tranche's value from one goal to the other.
+  if exists (
+    select 1 from public.investment_transactions t
+     where t.deposit_group_id = p_source_book_id
+       and t.transaction_type = 'investment'
+       and t.renewed_from_transaction_id is null
+       and t.goal_id is distinct from v_source.goal_id
+       and t.amount_vnd - coalesce((
+         select sum(w.principal_withdrawn) from public.investment_transactions w
+          where w.parent_transaction_id = t.transaction_id
+            and w.transaction_type = 'withdrawal'), 0) > 0
+  ) then
+    raise exception 'merge successor: this book holds a tranche filed under another goal; put it back before merging'
       using errcode = 'check_violation';
   end if;
   -- ...and the date the cash arrived is bounded by the LAST of them, not by the

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -581,6 +581,52 @@ create trigger investment_transactions_folded_holding_immutable
   when (old.transaction_type = 'investment')
   execute function public.guard_folded_holding_edited();
 
+-- (2b) ...and the other side of the same fact. The withdrawals that paid for the
+-- credited tranche are frozen and allocate exactly what the bank paid out, but
+-- nothing protected the row they point at: the ordinary book edit path could
+-- raise or lower it afterwards, inventing or destroying money while the source
+-- stayed closed for good. The pair only balances if both sides are held.
+create or replace function public.guard_merge_credited_tranche_edited()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if new.amount_vnd is not distinct from old.amount_vnd
+     and new.units is not distinct from old.units
+     and new.unit_price is not distinct from old.unit_price
+     and new.transaction_type is not distinct from old.transaction_type
+     and new.affects_progress is not distinct from old.affects_progress
+     -- A row with a renewal parent is history, which valuation skips. Setting
+     -- one here empties the successor of this cash without touching a figure.
+     and new.renewed_from_transaction_id is not distinct from old.renewed_from_transaction_id then
+    return new;
+  end if;
+
+  if exists (
+    select 1 from public.investment_transactions w
+     where w.consumed_by_inv_id = old.transaction_id
+       and w.transaction_type = 'withdrawal'
+       -- A held settlement's own consumption is the other path's business.
+       and coalesce(w.held_for_merge, false) = false
+  ) then
+    raise exception 'merge successor: another deposit was folded into this one, so what it holds cannot be rewritten'
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+revoke all on function public.guard_merge_credited_tranche_edited() from public, anon, authenticated;
+
+drop trigger if exists investment_transactions_credited_tranche_immutable on public.investment_transactions;
+create trigger investment_transactions_credited_tranche_immutable
+  before update of amount_vnd, units, unit_price, transaction_type, affects_progress, renewed_from_transaction_id
+  on public.investment_transactions
+  for each row
+  execute function public.guard_merge_credited_tranche_edited();
+
 -- (3) A recurring link arriving while the merge runs waits on the anchor lock,
 -- then re-reads a source whose successor has just been cleared — and accepts,
 -- because the promise is gone. The next statement dissolves the book, and the

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -340,6 +340,21 @@ begin
       using errcode = 'check_violation';
   end if;
 
+  -- Reclassifying the row is the quietest way to undo it: as an investment it
+  -- stops subtracting its principal from the source, while the successor keeps
+  -- the credit — and it slips out of both guards, whose WHEN clauses ask for a
+  -- withdrawal, so everything around it becomes editable afterwards too.
+  if new.transaction_type is distinct from old.transaction_type
+     and (old.consumed_by_inv_id is not null or exists (
+       select 1 from public.investment_transactions w
+        where w.parent_transaction_id = old.parent_transaction_id
+          and w.transaction_type = 'withdrawal'
+          and w.consumed_by_inv_id is not null
+     )) then
+    raise exception 'merge successor: this holding was folded into another deposit, so its withdrawals cannot be reclassified'
+      using errcode = 'check_violation';
+  end if;
+
   -- The FK's own cleanup: deleting a holding sets its withdrawals' parent to
   -- null rather than removing them. Nothing is restored by that — the holding
   -- itself is gone — so it is not this guard's business. Re-parenting to a
@@ -374,7 +389,7 @@ revoke all on function public.guard_merged_source_withdrawal_edited() from publi
 
 drop trigger if exists investment_transactions_merged_withdrawal_immutable on public.investment_transactions;
 create trigger investment_transactions_merged_withdrawal_immutable
-  before update of principal_withdrawn, amount_vnd, parent_transaction_id, consumed_by_inv_id
+  before update of principal_withdrawn, amount_vnd, parent_transaction_id, consumed_by_inv_id, transaction_type
   on public.investment_transactions
   for each row
   when (old.transaction_type = 'withdrawal' and old.parent_transaction_id is not null)

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -373,15 +373,30 @@ begin
   if new.principal_withdrawn is not distinct from old.principal_withdrawn
      and new.amount_vnd is not distinct from old.amount_vnd
      and new.parent_transaction_id is not distinct from old.parent_transaction_id
+     -- What the row claims and from whom: re-keyed to a fund, it is measured
+     -- against that fund's bucket instead of its parent, and the source
+     -- principal comes back while the successor keeps the payout.
+     and new.asset_type is not distinct from old.asset_type
+     and new.fund_id is not distinct from old.fund_id
+     and new.units_withdrawn is not distinct from old.units_withdrawn
+     -- held_for_merge is how the holding-side guard tells a successor merge from
+     -- a held settlement. Left editable, flipping it turns that guard off.
+     and new.held_for_merge is not distinct from old.held_for_merge
      -- affects_progress decides whether the goal bar sees this withdrawal at
      -- all: turned off, valuation still closes the source while progress counts
      -- its principal again, beside the successor that now holds the cash.
      and new.affects_progress is not distinct from old.affects_progress
      -- And moving it to another goal has the same effect by another route: goal
      -- detail loads by raw goal_id, so the source is then shown without the
-     -- withdrawal that closed it. Held settlements keep their own rules.
+     -- withdrawal that closed it. Held settlements keep their own rules — and a
+     -- goal being DELETED nulls this through the FK, which is not a move and
+     -- must not make a goal that once completed a merge undeletable. (The
+     -- holding-side guard has carried this carve-out since it was written; this
+     -- side went without it.)
      and (new.goal_id is not distinct from old.goal_id
-          or coalesce(old.held_for_merge, false)) then
+          or coalesce(old.held_for_merge, false)
+          or (new.goal_id is null
+              and not exists (select 1 from public.savings_goals g where g.goal_id = old.goal_id))) then
     return new;
   end if;
 
@@ -403,7 +418,9 @@ revoke all on function public.guard_merged_source_withdrawal_edited() from publi
 
 drop trigger if exists investment_transactions_merged_withdrawal_immutable on public.investment_transactions;
 create trigger investment_transactions_merged_withdrawal_immutable
-  before update of principal_withdrawn, amount_vnd, parent_transaction_id, consumed_by_inv_id, transaction_type, affects_progress, goal_id
+  before update of principal_withdrawn, amount_vnd, parent_transaction_id,
+    consumed_by_inv_id, transaction_type, affects_progress, goal_id,
+    asset_type, fund_id, units_withdrawn, held_for_merge
   on public.investment_transactions
   for each row
   when (old.transaction_type = 'withdrawal' and old.parent_transaction_id is not null)

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -12,6 +12,31 @@
 -- and retiring the promise are only correct together. Half of it committed is a
 -- book closed with its money nowhere, or money in two places at once.
 
+-- Where a credited tranche came from, said outright rather than inferred.
+--
+-- The guard below has to know "this row holds another book's payout" for as long
+-- as that is true, and every shape it could be read off is temporary: the row is
+-- a tranche of the successor until the successor itself closes, and its
+-- withdrawals look like any other consumption. So the merge records the fact.
+--
+-- Deliberately not a foreign key. This is history, not a live reference — an FK
+-- would null it when the source anchor is deleted, which is exactly the moment
+-- the freeze would be handed away. Deleting the account still removes the row
+-- itself. (It is also what Phase 4 needs to show "merged from A" on this side.)
+alter table public.investment_transactions
+  add column if not exists merged_from_book_id uuid;
+
+comment on column public.investment_transactions.merged_from_book_id is
+  'The accumulating book whose payout this tranche was credited with (#638, Phase 3). Historical fact, not a live reference.';
+
+-- Same-user only, like every other reference this table carries (#474, #525):
+-- a foreign uuid here would name someone else''s book in this one''s history.
+drop trigger if exists investment_transactions_merged_from_book_owner on public.investment_transactions;
+create trigger investment_transactions_merged_from_book_owner
+  before insert or update of merged_from_book_id, user_id on public.investment_transactions
+  for each row execute function public.enforce_user_scoped_fk_ownership(
+    'merged_from_book_id', 'investment_transactions', 'transaction_id');
+
 -- An earlier draft of this same migration took six arguments. Replacing it would
 -- leave both, and PostgREST cannot choose between two overloads — so the shape
 -- that no longer exists goes first. (This function has never reached production,
@@ -199,6 +224,21 @@ begin
     raise exception 'merge successor: this book has a withdrawal filed under another goal; move it back before merging'
       using errcode = 'check_violation';
   end if;
+  -- And one carrying renewal lineage, which readers treat as history and skip.
+  -- The balance below still subtracts it, so the merge would close only what is
+  -- left and the hidden portion would read as live beside the successor's
+  -- payout — and by then the folded-history guard refuses to correct it.
+  if exists (
+    select 1 from public.investment_transactions w
+     join public.investment_transactions t on t.transaction_id = w.parent_transaction_id
+     where t.deposit_group_id = p_source_book_id
+       and t.transaction_type = 'investment'
+       and w.transaction_type = 'withdrawal'
+       and w.renewed_from_transaction_id is not null
+  ) then
+    raise exception 'merge successor: this book has a withdrawal filed as renewal history; clear its lineage before merging'
+      using errcode = 'check_violation';
+  end if;
 
   -- The received cash is the client's number — a settled deposit pays out its
   -- principal plus interest, never a multiple of it. The same bound the renewal
@@ -216,11 +256,12 @@ begin
   insert into public.investment_transactions (
     transaction_id, user_id, goal_id, asset_type, transaction_type, amount_vnd,
     investment_date, expiry_date, interest_rate, notes, bank_code, currency,
-    deposit_group_id, top_up_lock_days, affects_progress
+    deposit_group_id, top_up_lock_days, affects_progress, merged_from_book_id
   ) values (
     v_new_id, v_dest.user_id, v_dest.goal_id, 'bank', 'investment', p_received_vnd,
     p_merge_date, v_dest.expiry_date, p_interest_rate, v_dest.notes,
-    v_dest.bank_code, v_dest.currency, v_dest.transaction_id, v_dest.top_up_lock_days, true
+    v_dest.bank_code, v_dest.currency, v_dest.transaction_id, v_dest.top_up_lock_days, true,
+    p_source_book_id
   )
   returning * into v_new;
 
@@ -600,29 +641,22 @@ begin
      and new.affects_progress is not distinct from old.affects_progress
      -- A row with a renewal parent is history, which valuation skips. Setting
      -- one here empties the successor of this cash without touching a figure.
-     and new.renewed_from_transaction_id is not distinct from old.renewed_from_transaction_id then
+     and new.renewed_from_transaction_id is not distinct from old.renewed_from_transaction_id
+     -- Erasing the marker below would hand the freeze away in one statement.
+     and new.merged_from_book_id is not distinct from old.merged_from_book_id then
     return new;
   end if;
 
-  -- Only a tranche INSIDE a book, which is the one shape this merge writes. An
-  -- ordinary re-deposit consumes siblings the same way — the renewal stamps
-  -- them and then rewrites its own amount — and that path is settled, with its
-  -- own rules and tests. Guarding it too broke it (the smoke lane caught it).
-  if old.deposit_group_id is null or old.deposit_group_id = old.transaction_id then
+  -- The row says so itself. Keying off shape instead — a tranche inside a book —
+  -- covered the ordinary re-deposit as well (the smoke lane caught that), and
+  -- then stopped covering this row the moment the successor book was closed and
+  -- every tranche's group was cleared.
+  if old.merged_from_book_id is null then
     return new;
   end if;
 
-  if exists (
-    select 1 from public.investment_transactions w
-     where w.consumed_by_inv_id = old.transaction_id
-       and w.transaction_type = 'withdrawal'
-       -- A held settlement's own consumption is the other path's business.
-       and coalesce(w.held_for_merge, false) = false
-  ) then
-    raise exception 'merge successor: another deposit was folded into this one, so what it holds cannot be rewritten'
-      using errcode = 'check_violation';
-  end if;
-  return new;
+  raise exception 'merge successor: another book was folded into this deposit, so what it holds cannot be rewritten'
+    using errcode = 'check_violation';
 end;
 $$;
 
@@ -630,9 +664,11 @@ revoke all on function public.guard_merge_credited_tranche_edited() from public,
 
 drop trigger if exists investment_transactions_credited_tranche_immutable on public.investment_transactions;
 create trigger investment_transactions_credited_tranche_immutable
-  before update of amount_vnd, units, unit_price, transaction_type, affects_progress, renewed_from_transaction_id
+  before update of amount_vnd, units, unit_price, transaction_type, affects_progress,
+                   renewed_from_transaction_id, merged_from_book_id
   on public.investment_transactions
   for each row
+  when (old.merged_from_book_id is not null)
   execute function public.guard_merge_credited_tranche_edited();
 
 -- (3) A recurring link arriving while the merge runs waits on the anchor lock,

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -371,7 +371,12 @@ begin
      -- affects_progress decides whether the goal bar sees this withdrawal at
      -- all: turned off, valuation still closes the source while progress counts
      -- its principal again, beside the successor that now holds the cash.
-     and new.affects_progress is not distinct from old.affects_progress then
+     and new.affects_progress is not distinct from old.affects_progress
+     -- And moving it to another goal has the same effect by another route: goal
+     -- detail loads by raw goal_id, so the source is then shown without the
+     -- withdrawal that closed it. Held settlements keep their own rules.
+     and (new.goal_id is not distinct from old.goal_id
+          or coalesce(old.held_for_merge, false)) then
     return new;
   end if;
 
@@ -393,7 +398,7 @@ revoke all on function public.guard_merged_source_withdrawal_edited() from publi
 
 drop trigger if exists investment_transactions_merged_withdrawal_immutable on public.investment_transactions;
 create trigger investment_transactions_merged_withdrawal_immutable
-  before update of principal_withdrawn, amount_vnd, parent_transaction_id, consumed_by_inv_id, transaction_type, affects_progress
+  before update of principal_withdrawn, amount_vnd, parent_transaction_id, consumed_by_inv_id, transaction_type, affects_progress, goal_id
   on public.investment_transactions
   for each row
   when (old.transaction_type = 'withdrawal' and old.parent_transaction_id is not null)

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -488,6 +488,9 @@ create trigger investment_transactions_folded_holding_immutable
 -- because the promise is gone. The next statement dissolves the book, and the
 -- link is left pointing at something no top-up can reach. What the waiter has to
 -- see is not the promise but its outcome: this deposit's balance went elsewhere.
+-- (Redefined here, so it keeps the revoke the other guard functions carry: a
+-- SECURITY DEFINER function has no business being executable by everyone, even
+-- one that can only run as a trigger.)
 create or replace function public.enforce_recurring_link_not_handed_over()
 returns trigger language plpgsql security definer set search_path = '' as $$
 declare v_successor uuid; v_folded boolean;
@@ -516,3 +519,5 @@ begin
   return new;
 end;
 $$;
+
+revoke all on function public.enforce_recurring_link_not_handed_over() from public, anon, authenticated;

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -12,13 +12,24 @@
 -- and retiring the promise are only correct together. Half of it committed is a
 -- book closed with its money nowhere, or money in two places at once.
 
+-- An earlier draft of this same migration took six arguments. Replacing it would
+-- leave both, and PostgREST cannot choose between two overloads — so the shape
+-- that no longer exists goes first. (This function has never reached production,
+-- so there is nothing here to drop there.)
+drop function if exists public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[], bigint[]);
+
 create or replace function public.merge_book_into_successor(
   p_source_book_id uuid,
   p_received_vnd bigint,
   p_interest_rate numeric,
   p_merge_date date,
   p_tranche_ids uuid[],
-  p_tranche_principals bigint[]
+  p_tranche_principals bigint[],
+  -- The destination the caller was looking at when they confirmed. The promise
+  -- is cancellable, so between the preview and the press this book can be handed
+  -- to a different one — different bank, different terms — and every other check
+  -- here would still pass while the cash went somewhere the user never saw.
+  p_expected_successor_id uuid
 )
 returns public.investment_transactions
 language plpgsql
@@ -69,6 +80,13 @@ begin
   if v_source.successor_deposit_tx_id is null then
     raise exception 'merge successor: this book has no successor to merge into'
       using errcode = 'check_violation';
+  end if;
+  -- Same wording as a moved balance, and for the same reason: what the caller
+  -- confirmed is no longer what the book says. Reloading shows them the book it
+  -- is actually promised to now, and they decide again.
+  if p_expected_successor_id is distinct from v_source.successor_deposit_tx_id then
+    raise exception 'merge successor: book changed since load, reload and retry'
+      using errcode = 'raise_exception';
   end if;
 
   select * into v_dest from public.investment_transactions
@@ -304,14 +322,14 @@ begin
 end;
 $$;
 
-comment on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[], bigint[]) is
+comment on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[], bigint[], uuid) is
   'Fold a matured accumulating book into the successor it was handed to, closing it and retiring the promise (#638).';
 
 -- Executable by the people who own books, not by everyone: like the handover
 -- functions, this one trusts a null auth.uid() as the service role or SQL, and
 -- `anon` has one too.
-revoke all on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[], bigint[]) from public, anon;
-grant execute on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[], bigint[]) to authenticated, service_role;
+revoke all on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[], bigint[], uuid) from public, anon;
+grant execute on function public.merge_book_into_successor(uuid, bigint, numeric, date, uuid[], bigint[], uuid) to authenticated, service_role;
 
 
 -- Deleting a withdrawal gives its principal back to the holding it came from.

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -100,25 +100,23 @@ begin
    order by saving_id
    for update;
 
-  -- The whole source book in ONE ordered acquisition, anchor included. Taking
-  -- the anchor first and its tranches later put an anchor→tranche edge in the
-  -- way of update_deposit_book, which locks the tranche it was handed and then
-  -- rewrites the group — the opposite direction, and a deadlock between them.
-  -- (That function still locks its group in whatever order the update finds, so
-  -- this removes our half of the cycle rather than the whole of it.)
+  -- Every row this merge will touch, in ONE acquisition ordered by id: the whole
+  -- source book, anchor included, and the successor's anchor beside it.
+  --
+  -- Two separate steps cannot get this right, and both orders were tried. Anchor
+  -- first then tranches inverts update_deposit_book, which locks the tranche it
+  -- was handed and then rewrites the group. Source group first then the
+  -- successor inverts assert_successor_book_pairing, which takes the two anchors
+  -- in id order — so an edit on the successor holds that anchor and waits for
+  -- this one. Ordering the union by id satisfies the pairing exactly and leaves
+  -- only update_deposit_book's own unordered group update outside it.
   perform 1 from public.investment_transactions
    where deposit_group_id = p_source_book_id
+      or transaction_id = (
+        select successor_deposit_tx_id from public.investment_transactions
+         where transaction_id = p_source_book_id
+      )
    order by transaction_id
-   for update;
-
-  -- Then the successor's own anchor. A book cannot be both a source and a
-  -- successor — the pairing forbids chains — so no two merges can hold these
-  -- two in opposite orders.
-  perform 1 from public.investment_transactions
-   where transaction_id = (
-     select successor_deposit_tx_id from public.investment_transactions
-      where transaction_id = p_source_book_id
-   )
    for update;
 
   select * into v_source from public.investment_transactions

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -832,6 +832,45 @@ create trigger investment_transactions_merge_lineage_follows
   when (old.merged_from_book_id is not null)
   execute function public.move_merge_lineage_to_book();
 
+-- ...and the freeze travels after it, at commit rather than during the collapse.
+--
+-- The anchor inherits the lineage but, without this, none of the protection: the
+-- ordinary edit route could then rewrite what it holds — even below the payout it
+-- now carries — while the source stayed closed for good. Marking it inside the
+-- collapse instead would have frozen the anchor before that same collapse gets to
+-- write the new cycle onto it, and the exemption that would take to undo is one
+-- any edit sharing the transaction could stand behind. Deferred to commit, the
+-- collapse finishes untouched and the row is frozen from the moment it is
+-- visible to anyone else.
+create or replace function public.carry_merge_freeze_to_book()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if not exists (select 1 from auth.users u where u.id = old.user_id) then
+    return null;
+  end if;
+  update public.investment_transactions
+     set merged_from_book_id = coalesce(merged_from_book_id, old.merged_from_book_id)
+   where transaction_id = old.deposit_group_id
+     and merged_from_book_id is null;
+  return null;
+end;
+$$;
+
+revoke all on function public.carry_merge_freeze_to_book() from public, anon, authenticated;
+
+drop trigger if exists investment_transactions_merge_freeze_follows on public.investment_transactions;
+create constraint trigger investment_transactions_merge_freeze_follows
+  after delete on public.investment_transactions
+  deferrable initially deferred
+  for each row
+  when (old.merged_from_book_id is not null and old.deposit_group_id is not null
+        and old.deposit_group_id <> old.transaction_id)
+  execute function public.carry_merge_freeze_to_book();
+
 -- (3) A recurring link arriving while the merge runs waits on the anchor lock,
 -- then re-reads a source whose successor has just been cleared — and accepts,
 -- because the promise is gone. The next statement dissolves the book, and the

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -832,44 +832,22 @@ create trigger investment_transactions_merge_lineage_follows
   when (old.merged_from_book_id is not null)
   execute function public.move_merge_lineage_to_book();
 
--- ...and the freeze travels after it, at commit rather than during the collapse.
+-- ...but the freeze does NOT travel with it, and that is deliberate.
 --
--- The anchor inherits the lineage but, without this, none of the protection: the
--- ordinary edit route could then rewrite what it holds — even below the payout it
--- now carries — while the source stayed closed for good. Marking it inside the
--- collapse instead would have frozen the anchor before that same collapse gets to
--- write the new cycle onto it, and the exemption that would take to undo is one
--- any edit sharing the transaction could stand behind. Deferred to commit, the
--- collapse finishes untouched and the row is frozen from the moment it is
--- visible to anyone else.
-create or replace function public.carry_merge_freeze_to_book()
-returns trigger
-language plpgsql
-security definer
-set search_path = ''
-as $$
-begin
-  if not exists (select 1 from auth.users u where u.id = old.user_id) then
-    return null;
-  end if;
-  update public.investment_transactions
-     set merged_from_book_id = coalesce(merged_from_book_id, old.merged_from_book_id)
-   where transaction_id = old.deposit_group_id
-     and merged_from_book_id is null;
-  return null;
-end;
-$$;
-
-revoke all on function public.carry_merge_freeze_to_book() from public, anon, authenticated;
-
-drop trigger if exists investment_transactions_merge_freeze_follows on public.investment_transactions;
-create constraint trigger investment_transactions_merge_freeze_follows
-  after delete on public.investment_transactions
-  deferrable initially deferred
-  for each row
-  when (old.merged_from_book_id is not null and old.deposit_group_id is not null
-        and old.deposit_group_id <> old.transaction_id)
-  execute function public.carry_merge_freeze_to_book();
+-- Carrying it onto the anchor reads as the obvious next step: the anchor now
+-- holds the payout, and an ordinary edit could write it away. It was tried. It
+-- makes that deposit permanently unrenewable — both renewal RPCs rewrite
+-- amount_vnd on that very row, so its next maturity fails outright, and a live
+-- deposit that can never be renewed again is certain breakage. What it would buy
+-- is protection against the ordinary editability that every deposit here already
+-- has.
+--
+-- So the line is drawn where the shape ends. While the credited tranche exists it
+-- is another book's payout sitting inside this one, and nothing may touch it.
+-- Once the successor is collapsed, that cash is principal of a live deposit under
+-- the same rules as any other — the withdrawal invariants, the balance checks.
+-- The source withdrawals still record where it went: consumed_by_inv_id is
+-- provenance, not a balance the anchor has to answer for.
 
 -- (3) A recurring link arriving while the merge runs waits on the anchor lock,
 -- then re-reads a source whose successor has just been cleared — and accepts,

--- a/supabase/migrations/20260812000001_merge_book_into_successor.sql
+++ b/supabase/migrations/20260812000001_merge_book_into_successor.sql
@@ -458,7 +458,16 @@ as $$
 declare v_folded boolean;
 begin
   if old.consumed_by_inv_id is not null
-     and new.consumed_by_inv_id is distinct from old.consumed_by_inv_id then
+     and new.consumed_by_inv_id is distinct from old.consumed_by_inv_id
+     -- Unless it is following the tranche it named up to that tranche's own
+     -- book: renewing the successor deletes the credited tranche, and the cash
+     -- carries on inside the anchor. Anything else pointed elsewhere is still a
+     -- rewrite of where the cash went.
+     and not exists (
+       select 1 from public.investment_transactions t
+        where t.transaction_id = old.consumed_by_inv_id
+          and t.deposit_group_id = new.consumed_by_inv_id
+     ) then
     raise exception 'merge successor: this withdrawal records where the cash went, so that cannot be unset'
       using errcode = 'check_violation';
   end if;
@@ -670,6 +679,53 @@ create trigger investment_transactions_credited_tranche_immutable
   for each row
   when (old.merged_from_book_id is not null)
   execute function public.guard_merge_credited_tranche_edited();
+
+-- (2c) ...and the successor must still be renewable afterwards.
+--
+-- Collapsing a book snapshots each tranche, re-parents that tranche's own
+-- withdrawals onto the snapshot, and deletes the tranche. The credited tranche
+-- is always a non-anchor tranche, but the SOURCE's withdrawals point at it
+-- through consumed_by_inv_id — a reference the collapse knows nothing about — so
+-- the delete hit the foreign key and a successor that had ever received a merge
+-- could never be renewed again.
+--
+-- The lineage moves up to the book rather than blocking the delete. The
+-- collapse's per-tranche snapshot is filed under the BOOK, not the tranche, so
+-- it cannot be matched to this row — but the anchor survives the collapse with
+-- its own id and now holds the renewed principal, this cash included. So "where
+-- did it go" becomes the book itself, which is the truthful answer and the one
+-- that stays true. Done here rather than inside collapse_accumulating_book so
+-- that function stays one definition in one migration.
+create or replace function public.move_merge_lineage_to_book()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  -- Not part of a book any more (a plain delete of the credited row, or a book
+  -- already dissolved): nothing to move it onto, so the foreign key and the
+  -- withdrawal guard refuse the delete — which is what should happen, since the
+  -- cash would be left with nowhere to say it went.
+  if old.deposit_group_id is null or old.deposit_group_id = old.transaction_id then
+    return old;
+  end if;
+
+  update public.investment_transactions
+     set consumed_by_inv_id = old.deposit_group_id, updated_at = now()
+   where consumed_by_inv_id = old.transaction_id;
+  return old;
+end;
+$$;
+
+revoke all on function public.move_merge_lineage_to_book() from public, anon, authenticated;
+
+drop trigger if exists investment_transactions_merge_lineage_follows on public.investment_transactions;
+create trigger investment_transactions_merge_lineage_follows
+  before delete on public.investment_transactions
+  for each row
+  when (old.merged_from_book_id is not null)
+  execute function public.move_merge_lineage_to_book();
 
 -- (3) A recurring link arriving while the merge runs waits on the anchor lock,
 -- then re-reads a source whose successor has just been cleared — and accepts,

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -332,6 +332,17 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- Nor may the lineage be walked up to the book by hand. A collapse moves it
+  -- there legitimately, but on its own that move is step one of taking the
+  -- payout: with nothing left pointing at the credited tranche, deleting it
+  -- stops being refused.
+  begin
+    update public.investment_transactions set consumed_by_inv_id = v_b.transaction_id
+     where consumed_by_inv_id = v_new.transaction_id;
+    raise exception 'the lineage must not be moved to the book outside a collapse';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- Nor may a folded withdrawal be detached from the holding it came out of
   -- while that holding still stands: it would stop subtracting, so the source
   -- principal reappears beside the payout the successor now holds. (Either the

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -19,6 +19,7 @@ declare
   v_received bigint := 12500000;
   v_count int;
   v_stamped int;
+  v_principals bigint[];
 begin
   insert into auth.users (id, email) values (v_user, 'merge-successor@test.invalid');
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Merge') returning goal_id into v_goal;
@@ -70,13 +71,14 @@ begin
     v_saving, to_char(current_date - 5, 'YYYY-MM'), null);
 
   v_ids := array[v_a, v_a2];
+  v_principals := array[8000000::bigint, 4000000::bigint];
 
   -- ── A book that is not yet due is not merged early ───────────────────────
   update public.investment_transactions set expiry_date = current_date + 5
    where deposit_group_id = v_a;
   set constraints all immediate;
   begin
-    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids);
+    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids, v_principals);
     raise exception 'merging a book before its maturity must be refused';
   exception when sqlstate '23514' then null;
   end;
@@ -86,26 +88,36 @@ begin
 
   -- ── A tranche the caller never saw aborts the whole thing ────────────────
   begin
-    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, array[v_a]);
+    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, array[v_a], array[8000000::bigint]);
     raise exception 'a book that changed since load must be refused';
   exception when others then null;
   end;
 
   -- ── Nothing arrives from nowhere ─────────────────────────────────────────
   begin
-    perform public.merge_book_into_successor(v_a, 0, 4.5, current_date, v_ids);
+    perform public.merge_book_into_successor(v_a, 0, 4.5, current_date, v_ids, v_principals);
     raise exception 'a merge of nothing must be refused';
   exception when sqlstate '23514' then null;
   end;
   begin
-    perform public.merge_book_into_successor(v_a, 999000000000, 4.5, current_date, v_ids);
+    perform public.merge_book_into_successor(v_a, 999000000000, 4.5, current_date, v_ids, v_principals);
     raise exception 'a received amount unmoored from the book must be refused';
   exception when sqlstate '23514' then null;
   end;
 
+  -- ── A balance that moved since the screen loaded is a changed book ───────
+  -- The ids are all still there; only what they hold has changed, which is
+  -- exactly the case ids alone cannot see.
+  begin
+    perform public.merge_book_into_successor(
+      v_a, v_received, 4.5, current_date, v_ids, array[7000000::bigint, 4000000::bigint]);
+    raise exception 'a tranche whose balance moved must be refused';
+  exception when others then null;
+  end;
+
   -- ── The merge itself ─────────────────────────────────────────────────────
   select * into v_new from public.merge_book_into_successor(
-    v_a, v_received, 4.6, current_date, v_ids);
+    v_a, v_received, 4.6, current_date, v_ids, v_principals);
 
   -- Exactly one tranche lands in B, holding the cash that was actually received.
   if v_new.deposit_group_id is distinct from v_b.transaction_id then
@@ -166,7 +178,7 @@ begin
 
   -- ── Once kept, it cannot be kept again ───────────────────────────────────
   begin
-    perform public.merge_book_into_successor(v_a, v_received, 4.6, current_date, v_ids);
+    perform public.merge_book_into_successor(v_a, v_received, 4.6, current_date, v_ids, v_principals);
     raise exception 'a book with no successor must not be merged';
   exception when others then null;
   end;

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -690,16 +690,12 @@ begin
     raise exception 'the collapse must still delete the credited tranche';
   end if;
 
-  -- ...and the freeze travels after it, at commit — so the collapse could write
-  -- the new cycle onto the anchor first. Flushing the deferred trigger here is
-  -- what commit does. The anchor now carries the payout, so rewriting what it
-  -- holds would take that cash while the source stays closed.
+  -- ...and the deposit it became goes on living. Freezing it because it once
+  -- absorbed a merged payout was tried and makes it unrenewable for good: the
+  -- renewal rewrites amount_vnd on this very row. Past the collapse the cash is
+  -- ordinary principal, under the ordinary rules.
   set constraints all immediate;
-  begin
-    update public.investment_transactions set amount_vnd = 1 where transaction_id = v_b;
-    raise exception 'the renewed anchor must not be rewritten once it carries a folded payout';
-  exception when sqlstate '23514' then null;
-  end;
+  perform public.renew_term_deposit(v_b, 11000000, 5.2, current_date + 400, current_date, 400000);
 
   raise notice 'merge successor book (successor still collapses): OK';
 end;

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -199,6 +199,16 @@ begin
     raise exception 'a withdrawal filed under another goal must block the merge';
   exception when sqlstate '23514' then null;
   end;
+  -- Renewal lineage hides a withdrawal from every reader while the balance here
+  -- still subtracts it: the merge would close what is left and the hidden part
+  -- would read as live beside the payout, with the guards refusing to fix it.
+  begin
+    update public.investment_transactions set renewed_from_transaction_id = v_a
+     where parent_transaction_id = v_a2 and transaction_type = 'withdrawal';
+    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids, v_principals, v_b.transaction_id);
+    raise exception 'a withdrawal filed as renewal history must block the merge';
+  exception when sqlstate '23514' then null;
+  end;
 
   -- ── The merge itself ─────────────────────────────────────────────────────
   select * into v_new from public.merge_book_into_successor(
@@ -299,6 +309,26 @@ begin
     update public.investment_transactions set renewed_from_transaction_id = v_b.transaction_id
      where transaction_id = v_new.transaction_id;
     raise exception 'the credited tranche must not be turned into renewal history';
+  exception when sqlstate '23514' then null;
+  end;
+  -- Nor by erasing what says it was credited in the first place.
+  begin
+    update public.investment_transactions set merged_from_book_id = null
+     where transaction_id = v_new.transaction_id;
+    raise exception 'the credited tranche must not be able to forget where it came from';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- And the freeze must outlive the book it landed in. B's own closure clears
+  -- every tranche's deposit_group_id, and while the guard keyed off that shape
+  -- the closure handed back an editable row — with the source shut for good.
+  update public.investment_transactions set deposit_group_id = null
+   where deposit_group_id = v_b.transaction_id;
+  set constraints all immediate;
+  begin
+    update public.investment_transactions set amount_vnd = amount_vnd + 5000000
+     where transaction_id = v_new.transaction_id;
+    raise exception 'closing the successor book must not unfreeze the credited tranche';
   exception when sqlstate '23514' then null;
   end;
 

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -8,6 +8,7 @@ declare
   v_goal uuid;
   v_a uuid := gen_random_uuid();
   v_a2 uuid := gen_random_uuid();
+  v_a3 uuid := gen_random_uuid();
   v_b public.investment_transactions;
   v_saving uuid := gen_random_uuid();
   v_new public.investment_transactions;
@@ -43,6 +44,25 @@ begin
   insert into public.recurring_savings (
     saving_id, user_id, goal_id, name, amount_vnd, linked_deposit_tx_id
   ) values (v_saving, v_user, v_goal, 'Monthly', 1000000, v_a);
+
+  -- ── A spent tranche is not the caller's to name ──────────────────────────
+  -- The book as the user sees it drops a tranche once its principal is gone, so
+  -- demanding its id would make such a book unmergeable however often they
+  -- reloaded. v_a3 is fully withdrawn and deliberately left out of v_ids.
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate, deposit_group_id
+  ) values (
+    v_a3, v_user, v_goal, 'bank', 'investment',
+    current_date - 150, current_date - 3, 1000000, 4, v_a
+  );
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
+    investment_date, amount_vnd, principal_withdrawn, affects_progress
+  ) values (
+    v_user, v_goal, 'bank', 'withdrawal', v_a3,
+    current_date - 20, 1000000, 1000000, true
+  );
 
   -- The handover A -> B, arranged while A was closing in on maturity.
   select * into v_b from public.open_successor_book(

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -20,6 +20,7 @@ declare
   v_count int;
   v_stamped int;
   v_principals bigint[];
+  v_other_goal uuid;
 begin
   insert into auth.users (id, email) values (v_user, 'merge-successor@test.invalid');
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Merge') returning goal_id into v_goal;
@@ -262,6 +263,16 @@ begin
     update public.investment_transactions set amount_vnd = amount_vnd + 5000000
      where transaction_id = v_a2;
     raise exception 'a folded holding must not be able to grow';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Nor moved to another goal, which would leave its withdrawals behind and let
+  -- the new goal show the paid-away principal as live.
+  begin
+    insert into public.savings_goals (user_id, goal_name) values (v_user, 'Elsewhere') returning goal_id into v_other_goal;
+    update public.investment_transactions set goal_id = v_other_goal
+     where transaction_id = v_a2;
+    raise exception 'a folded holding must not be moved between goals';
   exception when sqlstate '23514' then null;
   end;
 

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -276,6 +276,32 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- Nor can the credited side be rewritten. The withdrawals that paid for this
+  -- tranche are frozen and allocate exactly what was received, so raising or
+  -- lowering it here invents or destroys money while the source stays closed
+  -- for good.
+  begin
+    update public.investment_transactions set amount_vnd = amount_vnd + 5000000
+     where transaction_id = v_new.transaction_id;
+    raise exception 'the credited tranche must not be rewritten';
+  exception when sqlstate '23514' then null;
+  end;
+  begin
+    update public.investment_transactions set affects_progress = false
+     where transaction_id = v_new.transaction_id;
+    raise exception 'the credited tranche must not be taken out of progress';
+  exception when sqlstate '23514' then null;
+  end;
+  -- The same trick that hides a folded withdrawal hides this: a row with a
+  -- renewal parent is history, which valuation skips — the source would stay
+  -- closed while the cash it paid out showed up nowhere.
+  begin
+    update public.investment_transactions set renewed_from_transaction_id = v_b.transaction_id
+     where transaction_id = v_new.transaction_id;
+    raise exception 'the credited tranche must not be turned into renewal history';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- Nor an earlier partial withdrawal beside it: deleting that would restore the
   -- part the merge measured around, to a book whose payout is already elsewhere.
   begin

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -224,6 +224,18 @@ begin
     raise exception 'a tranche that has not matured must block the merge';
   exception when sqlstate '23514' then null;
   end;
+  -- Split the other way: both matured, but this tranche later than the anchor.
+  -- Dating the fold to the anchor's maturity would record its withdrawal, and
+  -- start the successor's interest, before its cash existed.
+  begin
+    update public.investment_transactions set expiry_date = current_date - 1
+     where transaction_id = v_a2;
+    set constraints all immediate;
+    perform public.merge_book_into_successor(
+      v_a, v_received, 4.5, current_date - 3, v_ids, v_principals, v_b.transaction_id);
+    raise exception 'a merge dated before the last tranche matured must be refused';
+  exception when sqlstate '23514' then null;
+  end;
   update public.investment_transactions set expiry_date = current_date - 3
    where transaction_id = v_a2;
   set constraints all immediate;

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -236,6 +236,16 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- Nor reclassified: as an investment the row stops subtracting its principal
+  -- from the source while the successor keeps the credit — and it would slip out
+  -- of these guards entirely, since they ask for a withdrawal.
+  begin
+    update public.investment_transactions set transaction_type = 'investment'
+     where consumed_by_inv_id = v_new.transaction_id;
+    raise exception 'a consumed withdrawal must not be reclassified';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- ── The settled book stops being a book ──────────────────────────────────
   -- Still self-grouped, it would remain a valid target for a backdated top-up
   -- that resurrects it after its payout has gone.

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -665,6 +665,11 @@ declare
   v_new uuid := current_setting('cairn.collapse_new')::uuid;
   v_target uuid;
 begin
+  -- Back to the default mode first: an earlier block in this transaction made
+  -- constraints immediate, and that sticks for the whole transaction — which
+  -- would fire the deferred freeze below mid-collapse and refuse the collapse's
+  -- own write. Nothing outside these tests ever issues SET CONSTRAINTS.
+  set constraints all deferred;
   perform public.collapse_accumulating_book(
     v_b, 10600000, 5.0, current_date + 365, current_date,
     array[v_b, v_new], array[100000::bigint, 200000::bigint]);
@@ -684,6 +689,17 @@ begin
   if exists (select 1 from public.investment_transactions where transaction_id = v_new) then
     raise exception 'the collapse must still delete the credited tranche';
   end if;
+
+  -- ...and the freeze travels after it, at commit — so the collapse could write
+  -- the new cycle onto the anchor first. Flushing the deferred trigger here is
+  -- what commit does. The anchor now carries the payout, so rewriting what it
+  -- holds would take that cash while the source stays closed.
+  set constraints all immediate;
+  begin
+    update public.investment_transactions set amount_vnd = 1 where transaction_id = v_b;
+    raise exception 'the renewed anchor must not be rewritten once it carries a folded payout';
+  exception when sqlstate '23514' then null;
+  end;
 
   raise notice 'merge successor book (successor still collapses): OK';
 end;

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -213,6 +213,21 @@ begin
     raise exception 'a withdrawal filed under another goal must block the merge';
   exception when sqlstate '23514' then null;
   end;
+  -- A book whose expiries were left split by the old two-statement edit: the
+  -- anchor has matured, a tranche has not. Folding it would credit the
+  -- successor with cash the bank has not paid out.
+  begin
+    update public.investment_transactions set expiry_date = current_date + 30
+     where transaction_id = v_a2;
+    set constraints all immediate;
+    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids, v_principals, v_b.transaction_id);
+    raise exception 'a tranche that has not matured must block the merge';
+  exception when sqlstate '23514' then null;
+  end;
+  update public.investment_transactions set expiry_date = current_date - 3
+   where transaction_id = v_a2;
+  set constraints all immediate;
+
   -- A withdrawal re-keyed to a fund is measured against that fund's bucket, not
   -- against the tranche it came out of — while the sum here subtracts it by
   -- parent all the same. The merge would close the apparent remainder and the

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -21,6 +21,7 @@ declare
   v_stamped int;
   v_principals bigint[];
   v_other_goal uuid;
+  v_side_goal uuid;
 begin
   insert into auth.users (id, email) values (v_user, 'merge-successor@test.invalid');
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Merge') returning goal_id into v_goal;
@@ -147,6 +148,24 @@ begin
     raise exception 'a submitted tranche emptied since the preview must be refused';
   exception when sqlstate 'P0001' then
     if sqlerrm not like '%book changed since load%' then raise; end if;
+  end;
+
+  -- ── Shapes the merge refuses rather than folds ───────────────────────────
+  -- Both are correctable now and not afterwards, once the rows are immutable.
+  begin
+    update public.investment_transactions set affects_progress = false
+     where parent_transaction_id = v_a2 and transaction_type = 'withdrawal';
+    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids, v_principals);
+    raise exception 'a withdrawal kept out of progress must block the merge';
+  exception when sqlstate '23514' then null;
+  end;
+  begin
+    insert into public.savings_goals (user_id, goal_name) values (v_user, 'Sideways') returning goal_id into v_side_goal;
+    update public.investment_transactions set goal_id = v_side_goal
+     where parent_transaction_id = v_a2 and transaction_type = 'withdrawal';
+    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids, v_principals);
+    raise exception 'a withdrawal filed under another goal must block the merge';
+  exception when sqlstate '23514' then null;
   end;
 
   -- ── The merge itself ─────────────────────────────────────────────────────

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -129,6 +129,26 @@ begin
     if sqlerrm not like '%book changed since load%' then raise; end if;
   end;
 
+  -- ── A submitted tranche that has since been emptied ──────────────────────
+  -- Skipping spent tranches before comparing would have hidden this: the others
+  -- still match, and the payout bound is loose enough to accept the old figure.
+  -- The withdrawal below lands after the caller read the book; the block's own
+  -- rollback undoes it once the case has been proved.
+  begin
+    insert into public.investment_transactions (
+      user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
+      investment_date, amount_vnd, principal_withdrawn, affects_progress
+    ) values (
+      v_user, v_goal, 'bank', 'withdrawal', v_a2,
+      current_date - 1, 3000000, 3000000, true
+    );
+    perform public.merge_book_into_successor(
+      v_a, v_received, 4.5, current_date, v_ids, v_principals);
+    raise exception 'a submitted tranche emptied since the preview must be refused';
+  exception when sqlstate 'P0001' then
+    if sqlerrm not like '%book changed since load%' then raise; end if;
+  end;
+
   -- ── The merge itself ─────────────────────────────────────────────────────
   select * into v_new from public.merge_book_into_successor(
     v_a, v_received, 4.6, current_date, v_ids, v_principals);

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -365,6 +365,15 @@ begin
     raise exception 'the settled book must be dissolved, % rows still grouped', v_count;
   end if;
 
+  -- ── Deleting the account takes the whole merge with it ───────────────────
+  -- The guards above keep folded history from being unpicked one row at a time;
+  -- they must not make an account that ever completed a merge undeletable.
+  delete from auth.users where id = v_user;
+  select count(*) into v_count from public.investment_transactions where user_id = v_user;
+  if v_count <> 0 then
+    raise exception 'deleting the account must remove its rows, % left', v_count;
+  end if;
+
   raise notice 'merge successor book: OK';
 end;
 $$;

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -1,0 +1,166 @@
+-- The promise kept: a matured book folded into the successor it was handed to
+-- (#638, Phase 3). Run via `npm run test:db` after migrations are applied.
+begin;
+
+do $$
+declare
+  v_user uuid := gen_random_uuid();
+  v_goal uuid;
+  v_a uuid := gen_random_uuid();
+  v_a2 uuid := gen_random_uuid();
+  v_b public.investment_transactions;
+  v_saving uuid := gen_random_uuid();
+  v_new public.investment_transactions;
+  v_ids uuid[];
+  v_successor uuid;
+  v_linked uuid;
+  v_closed bigint;
+  v_received bigint := 12500000;
+  v_count int;
+  v_stamped int;
+begin
+  insert into auth.users (id, email) values (v_user, 'merge-successor@test.invalid');
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Merge') returning goal_id into v_goal;
+
+  -- Book A: two tranches, matured 3 days ago, locked well before that.
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate,
+    deposit_group_id, top_up_lock_days, notes
+  ) values (
+    v_a, v_user, v_goal, 'bank', 'investment',
+    current_date - 300, current_date - 3, 8000000, 4, v_a, 30, 'PVcomBank A'
+  );
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate, deposit_group_id
+  ) values (
+    v_a2, v_user, v_goal, 'bank', 'investment',
+    current_date - 200, current_date - 3, 4000000, 4.2, v_a
+  );
+
+  -- A recurring saving still points at A; it must end on B.
+  insert into public.recurring_savings (
+    saving_id, user_id, goal_id, name, amount_vnd, linked_deposit_tx_id
+  ) values (v_saving, v_user, v_goal, 'Monthly', 1000000, v_a);
+
+  -- The handover A -> B, arranged while A was closing in on maturity.
+  select * into v_b from public.open_successor_book(
+    v_a, 2000000, 4.5, current_date - 5, current_date + 300, 30, null,
+    v_saving, to_char(current_date - 5, 'YYYY-MM'), null);
+
+  v_ids := array[v_a, v_a2];
+
+  -- ── A book that is not yet due is not merged early ───────────────────────
+  update public.investment_transactions set expiry_date = current_date + 5
+   where deposit_group_id = v_a;
+  set constraints all immediate;
+  begin
+    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids);
+    raise exception 'merging a book before its maturity must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  update public.investment_transactions set expiry_date = current_date - 3
+   where deposit_group_id = v_a;
+  set constraints all immediate;
+
+  -- ── A tranche the caller never saw aborts the whole thing ────────────────
+  begin
+    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, array[v_a]);
+    raise exception 'a book that changed since load must be refused';
+  exception when others then null;
+  end;
+
+  -- ── Nothing arrives from nowhere ─────────────────────────────────────────
+  begin
+    perform public.merge_book_into_successor(v_a, 0, 4.5, current_date, v_ids);
+    raise exception 'a merge of nothing must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  begin
+    perform public.merge_book_into_successor(v_a, 999000000000, 4.5, current_date, v_ids);
+    raise exception 'a received amount unmoored from the book must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── The merge itself ─────────────────────────────────────────────────────
+  select * into v_new from public.merge_book_into_successor(
+    v_a, v_received, 4.6, current_date, v_ids);
+
+  -- Exactly one tranche lands in B, holding the cash that was actually received.
+  if v_new.deposit_group_id is distinct from v_b.transaction_id then
+    raise exception 'the merged tranche must join the successor book';
+  end if;
+  if v_new.amount_vnd <> v_received then
+    raise exception 'the merged tranche must hold the received cash, found %', v_new.amount_vnd;
+  end if;
+  if v_new.interest_rate <> 4.6 then
+    raise exception 'the merged tranche takes the entered rate';
+  end if;
+  if v_new.expiry_date is distinct from v_b.expiry_date then
+    raise exception 'the merged tranche matures with its new book';
+  end if;
+  select count(*) into v_count from public.investment_transactions
+   where deposit_group_id = v_b.transaction_id and transaction_type = 'investment';
+  if v_count <> 2 then  -- B's own anchor + this one
+    raise exception 'the merge must add exactly one tranche, found %', v_count;
+  end if;
+
+  -- Every tranche of A is closed to the last đồng.
+  select sum(t.amount_vnd - coalesce((
+           select sum(w.principal_withdrawn) from public.investment_transactions w
+            where w.parent_transaction_id = t.transaction_id and w.transaction_type = 'withdrawal'), 0))
+    into v_closed
+    from public.investment_transactions t
+   where t.deposit_group_id = v_a and t.transaction_type = 'investment';
+  if v_closed <> 0 then
+    raise exception 'the source book must be fully closed, % left', v_closed;
+  end if;
+
+  -- The cash is allocated across the source history without drift, and every
+  -- withdrawal says where it went.
+  select count(*), coalesce(sum(amount_vnd), 0) into v_stamped, v_closed
+    from public.investment_transactions
+   where transaction_type = 'withdrawal'
+     and consumed_by_inv_id = v_new.transaction_id;
+  if v_stamped <> 2 then
+    raise exception 'each closed tranche must be stamped, found %', v_stamped;
+  end if;
+  if v_closed <> v_received then
+    raise exception 'the allocated cash must equal what was received, found %', v_closed;
+  end if;
+
+  -- The promise has been kept, so it stops standing.
+  select successor_deposit_tx_id into v_successor
+    from public.investment_transactions where transaction_id = v_a;
+  if v_successor is not null then
+    raise exception 'a kept promise must not still stand';
+  end if;
+
+  -- And nothing is left funding the closed book.
+  select linked_deposit_tx_id into v_linked
+    from public.recurring_savings where saving_id = v_saving;
+  if v_linked is distinct from v_b.transaction_id then
+    raise exception 'the recurring link must end on the successor, found %', v_linked;
+  end if;
+
+  -- ── Once kept, it cannot be kept again ───────────────────────────────────
+  begin
+    perform public.merge_book_into_successor(v_a, v_received, 4.6, current_date, v_ids);
+    raise exception 'a book with no successor must not be merged';
+  exception when others then null;
+  end;
+
+  -- ── The cash cannot be unpicked from B while it sits there ───────────────
+  begin
+    delete from public.investment_transactions
+     where consumed_by_inv_id = v_new.transaction_id;
+    raise exception 'a consumed withdrawal must not be deletable';
+  exception when others then null;
+  end;
+
+  raise notice 'merge successor book: OK';
+end;
+$$;
+
+rollback;

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -518,6 +518,77 @@ begin
 end;
 $$;
 
+-- ── The successor can still be renewed the ordinary way ─────────────────────
+--
+-- Collapsing a book deletes every non-anchor tranche after snapshotting it. The
+-- credited tranche is always one of those, and the source's withdrawals point at
+-- it — so without moving that lineage onto the snapshot, the delete hits the
+-- foreign key and a successor that ever received a merge can never be renewed
+-- again.
+do $$
+declare
+  v_user uuid := gen_random_uuid();
+  v_goal uuid;
+  v_a uuid := gen_random_uuid();
+  v_b public.investment_transactions;
+  v_new public.investment_transactions;
+begin
+  insert into auth.users (id, email) values (v_user, 'merge-collapse@test.invalid');
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Collapse') returning goal_id into v_goal;
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate, deposit_group_id, top_up_lock_days
+  ) values (
+    v_a, v_user, v_goal, 'bank', 'investment',
+    current_date - 300, current_date - 3, 8000000, 4, v_a, 30
+  );
+  -- No lock window on B, so its maturity can be brought forward below without
+  -- the merged tranche falling inside it.
+  select * into v_b from public.open_successor_book(
+    v_a, 2000000, 4.5, current_date - 5, current_date + 300, null, null, null, null, null);
+  select * into v_new from public.merge_book_into_successor(
+    v_a, 8300000, 4.5, current_date - 3, array[v_a], array[8000000::bigint], v_b.transaction_id);
+  set constraints all immediate;
+  perform set_config('cairn.collapse_b', v_b.transaction_id::text, false);
+  perform set_config('cairn.collapse_new', v_new.transaction_id::text, false);
+  perform set_config('cairn.collapse_user', v_user::text, false);
+end;
+$$;
+
+-- B reaches its own maturity.
+update public.investment_transactions set expiry_date = current_date
+ where deposit_group_id = current_setting('cairn.collapse_b')::uuid;
+
+do $$
+declare
+  v_b uuid := current_setting('cairn.collapse_b')::uuid;
+  v_new uuid := current_setting('cairn.collapse_new')::uuid;
+  v_target uuid;
+begin
+  perform public.collapse_accumulating_book(
+    v_b, 10600000, 5.0, current_date + 365, current_date,
+    array[v_b, v_new], array[100000::bigint, 200000::bigint]);
+
+  -- The lineage moved rather than vanished: the source's withdrawals now name
+  -- the book that carried their cash into its new cycle.
+  select consumed_by_inv_id into v_target from public.investment_transactions
+   where transaction_type = 'withdrawal' and consumed_by_inv_id is not null
+     and user_id = current_setting('cairn.collapse_user')::uuid
+   limit 1;
+  if v_target is null then
+    raise exception 'the folded withdrawal must still say where its cash went';
+  end if;
+  if v_target <> v_b then
+    raise exception 'the lineage must follow the tranche up to its book, found %', v_target;
+  end if;
+  if exists (select 1 from public.investment_transactions where transaction_id = v_new) then
+    raise exception 'the collapse must still delete the credited tranche';
+  end if;
+
+  raise notice 'merge successor book (successor still collapses): OK';
+end;
+$$;
+
 -- ── A successor that matured while the source sat unresolved ────────────────
 --
 -- The merge is dated when the bank paid the source out, and the successor's own

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -127,6 +127,19 @@ begin
     if sqlerrm not like '%book changed since load%' then raise; end if;
   end;
 
+  -- ── A named tranche that is no longer there ──────────────────────────────
+  -- The loop can only notice tranches it walks, so one deleted between the
+  -- preview and the lock was simply never met: the merge closed what survived
+  -- while crediting the successor with the whole book's payout.
+  begin
+    perform public.merge_book_into_successor(
+      v_a, v_received, 4.5, current_date,
+      v_ids || gen_random_uuid(), v_principals || 1000000::bigint, v_b.transaction_id);
+    raise exception 'a named tranche that no longer exists must be refused';
+  exception when sqlstate 'P0001' then
+    if sqlerrm not like '%book changed since load%' then raise; end if;
+  end;
+
   -- ── A payout too small to spread ─────────────────────────────────────────
   -- Each tranche's share is its proportion of the payout, floored. A payout far
   -- below what the book holds floors a share to nothing, and a withdrawal of
@@ -316,6 +329,15 @@ begin
     update public.investment_transactions set merged_from_book_id = null
      where transaction_id = v_new.transaction_id;
     raise exception 'the credited tranche must not be able to forget where it came from';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Nor deleted outright. The lineage move that lets a collapse through also
+  -- clears the foreign key that used to block this, so on its own the delete
+  -- would take the successor's whole payout away while the source stays closed.
+  begin
+    delete from public.investment_transactions where transaction_id = v_new.transaction_id;
+    raise exception 'the credited tranche must not be deletable on its own';
   exception when sqlstate '23514' then null;
   end;
 

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -22,6 +22,7 @@ declare
   v_principals bigint[];
   v_other_goal uuid;
   v_side_goal uuid;
+  v_fund uuid;
 begin
   insert into auth.users (id, email) values (v_user, 'merge-successor@test.invalid');
   insert into public.savings_goals (user_id, goal_name) values (v_user, 'Merge') returning goal_id into v_goal;
@@ -212,6 +213,21 @@ begin
     raise exception 'a withdrawal filed under another goal must block the merge';
   exception when sqlstate '23514' then null;
   end;
+  -- A withdrawal re-keyed to a fund is measured against that fund's bucket, not
+  -- against the tranche it came out of — while the sum here subtracts it by
+  -- parent all the same. The merge would close the apparent remainder and the
+  -- rerouted portion would still read as live beside the successor's payout.
+  begin
+    insert into public.funds (user_id, name, code, fund_type, nav)
+    values (v_user, 'Sideways fund', 'SIDEWAYS', 'stock', 10000) returning id into v_fund;
+    update public.investment_transactions
+       set asset_type = 'fund', fund_id = v_fund
+     where parent_transaction_id = v_a2 and transaction_type = 'withdrawal';
+    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids, v_principals, v_b.transaction_id);
+    raise exception 'a withdrawal re-keyed to a fund must block the merge';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- Renewal lineage hides a withdrawal from every reader while the balance here
   -- still subtracts it: the merge would close what is left and the hidden part
   -- would read as live beside the payout, with the guards refusing to fix it.

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -22,6 +22,7 @@ declare
   v_principals bigint[];
   v_other_goal uuid;
   v_side_goal uuid;
+  v_split_goal uuid;
   v_fund uuid;
 begin
   insert into auth.users (id, email) values (v_user, 'merge-successor@test.invalid');
@@ -224,6 +225,20 @@ begin
     raise exception 'a tranche that has not matured must block the merge';
   exception when sqlstate '23514' then null;
   end;
+  -- The same old edit flow could split a book across goals. Every closing
+  -- withdrawal lands in its own tranche's goal while the payout is credited in
+  -- the anchor's, so folding this would move that tranche's value sideways.
+  begin
+    insert into public.savings_goals (user_id, goal_name) values (v_user, 'Split') returning goal_id into v_split_goal;
+    update public.investment_transactions set goal_id = v_split_goal where transaction_id = v_a2;
+    set constraints all immediate;
+    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids, v_principals, v_b.transaction_id);
+    raise exception 'a tranche filed under another goal must block the merge';
+  exception when sqlstate '23514' then null;
+  end;
+  update public.investment_transactions set goal_id = v_goal where transaction_id = v_a2;
+  set constraints all immediate;
+
   -- Split the other way: both matured, but this tranche later than the anchor.
   -- Dating the fold to the anchor's maturity would record its withdrawal, and
   -- start the successor's interest, before its cash existed.

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -127,6 +127,18 @@ begin
     if sqlerrm not like '%book changed since load%' then raise; end if;
   end;
 
+  -- ── A payout too small to spread ─────────────────────────────────────────
+  -- Each tranche's share is its proportion of the payout, floored. A payout far
+  -- below what the book holds floors a share to nothing, and a withdrawal of
+  -- zero is not a row this table will take — the merge died on a constraint and
+  -- the route answered with a fault, for an amount it had accepted as valid.
+  begin
+    perform public.merge_book_into_successor(v_a, 1, 4.5, current_date, v_ids, v_principals, v_b.transaction_id);
+    raise exception 'a payout too small to reach every tranche must be refused';
+  exception when sqlstate '23514' then
+    if sqlerrm not like '%merge successor:%' then raise; end if;
+  end;
+
   -- ── Nothing arrives from nowhere ─────────────────────────────────────────
   begin
     perform public.merge_book_into_successor(v_a, 0, 4.5, current_date, v_ids, v_principals, v_b.transaction_id);
@@ -404,6 +416,64 @@ begin
   end if;
 
   raise notice 'merge successor book: OK';
+end;
+$$;
+
+-- ── A successor that matured while the source sat unresolved ────────────────
+--
+-- The merge is dated when the bank paid the source out, and the successor's own
+-- door is judged against that date. An overdue book resolved weeks later can
+-- therefore be folded into a successor that has itself matured since: the money
+-- lands in a book that is already closed, and the recurring savings the merge
+-- redirects there have their next contribution refused.
+--
+-- No write can build this state — the pairing trigger refuses a successor that
+-- cannot take a contribution today — so only the calendar moving produces it,
+-- and only disabling that trigger reproduces it here.
+do $$
+declare
+  v_user uuid := gen_random_uuid();
+  v_goal uuid;
+  v_a uuid := gen_random_uuid();
+  v_b public.investment_transactions;
+begin
+  insert into auth.users (id, email) values (v_user, 'merge-late@test.invalid');
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Late') returning goal_id into v_goal;
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate, deposit_group_id, top_up_lock_days
+  ) values (
+    v_a, v_user, v_goal, 'bank', 'investment',
+    current_date - 300, current_date - 3, 8000000, 4, v_a, 30
+  );
+  -- No lock window on the successor: with one, the same check happens to refuse
+  -- this for an unrelated reason, and the hole stays hidden.
+  select * into v_b from public.open_successor_book(
+    v_a, 2000000, 4.5, current_date - 5, current_date + 300, null, null, null, null, null);
+  perform set_config('cairn.test_a', v_a::text, false);
+  perform set_config('cairn.test_b', v_b.transaction_id::text, false);
+  perform set_config('cairn.test_user', v_user::text, false);
+  set constraints all immediate;
+end;
+$$;
+
+-- The calendar moves past the successor's own maturity.
+alter table public.investment_transactions disable trigger investment_transactions_successor_pairing_upd;
+update public.investment_transactions set expiry_date = current_date - 1
+ where deposit_group_id = current_setting('cairn.test_b')::uuid;
+alter table public.investment_transactions enable trigger investment_transactions_successor_pairing_upd;
+
+do $$
+declare v_a uuid := current_setting('cairn.test_a')::uuid;
+begin
+  begin
+    perform public.merge_book_into_successor(
+      v_a, 8300000, 4.5, current_date - 3, array[v_a], array[8000000::bigint],
+      current_setting('cairn.test_b')::uuid);
+    raise exception 'a merge into a successor that has itself matured must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+  raise notice 'merge successor book (late resolution): OK';
 end;
 $$;
 

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -445,6 +445,49 @@ begin
 end;
 $$;
 
+-- ── The ordinary re-deposit still folds a sibling in ────────────────────────
+--
+-- Renewing a deposit stamps the sibling's withdrawal as consumed by it and then
+-- rewrites its own amount. That is the same shape as a merge's credited tranche
+-- seen from the outside, and freezing both broke it — the smoke lane caught what
+-- this suite did not, so the case belongs here.
+do $$
+declare
+  v_user uuid := gen_random_uuid();
+  v_goal uuid;
+  v_d uuid := gen_random_uuid();
+  v_s uuid := gen_random_uuid();
+begin
+  insert into auth.users (id, email) values (v_user, 'merge-sibling@test.invalid');
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Sibling') returning goal_id into v_goal;
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate
+  ) values (v_d, v_user, v_goal, 'bank', 'investment', current_date - 380, current_date - 15, 20000000, 6);
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate
+  ) values (v_s, v_user, v_goal, 'bank', 'investment', current_date - 120, current_date + 60, 8000000, 6);
+
+  -- S is settled early and folded into D, exactly as the renewal does it.
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
+    investment_date, amount_vnd, principal_withdrawn, affects_progress, consumed_by_inv_id
+  ) values (
+    v_user, v_goal, 'bank', 'withdrawal', v_s,
+    current_date, 8100000, 8000000, true, v_d
+  );
+
+  -- D rolls forward carrying that cash. Nothing here is a book merge, so
+  -- nothing here is frozen.
+  update public.investment_transactions
+     set amount_vnd = 28100000, expiry_date = current_date + 365
+   where transaction_id = v_d;
+
+  raise notice 'merge successor book (sibling re-deposit untouched): OK';
+end;
+$$;
+
 -- ── A successor that matured while the source sat unresolved ────────────────
 --
 -- The merge is dated when the bank paid the source out, and the successor's own

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -246,6 +246,34 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- Nor may the goal bar be told to ignore the withdrawal: valuation would still
+  -- close the source while progress counted its principal again.
+  begin
+    update public.investment_transactions set affects_progress = false
+     where consumed_by_inv_id = v_new.transaction_id;
+    raise exception 'affects_progress on a folded withdrawal must not be changed';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- And the holding itself: once the book is dissolved it looks like an ordinary
+  -- deposit to the edit route, and raising its amount passes the solvency check
+  -- because the withdrawals against it are smaller than the new amount.
+  begin
+    update public.investment_transactions set amount_vnd = amount_vnd + 5000000
+     where transaction_id = v_a2;
+    raise exception 'a folded holding must not be able to grow';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- A recurring saving cannot be attached to it afterwards either: nothing can
+  -- be paid into a deposit whose balance has gone.
+  begin
+    update public.recurring_savings set linked_deposit_tx_id = v_a2
+     where saving_id = v_saving;
+    raise exception 'linking to a folded deposit must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- ── The settled book stops being a book ──────────────────────────────────
   -- Still self-grouped, it would remain a valid target for a backdated top-up
   -- that resurrects it after its payout has gone.

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -214,6 +214,28 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- Nor rewritten: lowering what a withdrawal took gives the principal back just
+  -- as deleting it would, and the balance check does not see it because it
+  -- excludes the row being edited.
+  begin
+    update public.investment_transactions set principal_withdrawn = 1
+     where consumed_by_inv_id = v_new.transaction_id;
+    raise exception 'a consumed withdrawal must not be rewritten';
+  exception when sqlstate '23514' then null;
+  end;
+  begin
+    update public.investment_transactions set consumed_by_inv_id = null
+     where consumed_by_inv_id = v_new.transaction_id;
+    raise exception 'the lineage stamp must not be cleared';
+  exception when sqlstate '23514' then null;
+  end;
+  begin
+    update public.investment_transactions set principal_withdrawn = 1
+     where parent_transaction_id = v_a2 and consumed_by_inv_id is null;
+    raise exception 'an earlier withdrawal on a folded holding must not be rewritten';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- ── The settled book stops being a book ──────────────────────────────────
   -- Still self-grouped, it would remain a valid target for a backdated top-up
   -- that resurrects it after its payout has gone.

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -352,6 +352,15 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- Nor dressed up as renewal history, which hides the row from the views that
+  -- count it and brings the folded principal back that way.
+  begin
+    update public.investment_transactions set renewed_from_transaction_id = v_b.transaction_id
+     where consumed_by_inv_id = v_new.transaction_id;
+    raise exception 'a folded withdrawal must not be turned into renewal history';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- But deleting the goal must still work: the FK nulls goal_id on all of this,
   -- and a goal that once completed a merge cannot be made undeletable by it.
   delete from public.savings_goals where goal_id = v_other_goal;

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -41,6 +41,17 @@ begin
     current_date - 200, current_date - 3, 4000000, 4.2, v_a
   );
 
+  -- An earlier partial withdrawal on a tranche the merge will fold: the merge
+  -- measures around it, and restoring it afterwards would hand back principal
+  -- whose payout is by then in the successor.
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
+    investment_date, amount_vnd, principal_withdrawn, affects_progress
+  ) values (
+    v_user, v_goal, 'bank', 'withdrawal', v_a2,
+    current_date - 40, 1000000, 1000000, true
+  );
+
   -- A recurring saving still points at A; it must end on B.
   insert into public.recurring_savings (
     saving_id, user_id, goal_id, name, amount_vnd, linked_deposit_tx_id
@@ -71,7 +82,7 @@ begin
     v_saving, to_char(current_date - 5, 'YYYY-MM'), null);
 
   v_ids := array[v_a, v_a2];
-  v_principals := array[8000000::bigint, 4000000::bigint];
+  v_principals := array[8000000::bigint, 3000000::bigint];
 
   -- ── A book that is not yet due is not merged early ───────────────────────
   update public.investment_transactions set expiry_date = current_date + 5
@@ -90,7 +101,8 @@ begin
   begin
     perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, array[v_a], array[8000000::bigint]);
     raise exception 'a book that changed since load must be refused';
-  exception when others then null;
+  exception when sqlstate 'P0001' then
+    if sqlerrm not like '%book changed since load%' then raise; end if;
   end;
 
   -- ── Nothing arrives from nowhere ─────────────────────────────────────────
@@ -112,7 +124,8 @@ begin
     perform public.merge_book_into_successor(
       v_a, v_received, 4.5, current_date, v_ids, array[7000000::bigint, 4000000::bigint]);
     raise exception 'a tranche whose balance moved must be refused';
-  exception when others then null;
+  exception when sqlstate 'P0001' then
+    if sqlerrm not like '%book changed since load%' then raise; end if;
   end;
 
   -- ── The merge itself ─────────────────────────────────────────────────────
@@ -180,7 +193,7 @@ begin
   begin
     perform public.merge_book_into_successor(v_a, v_received, 4.6, current_date, v_ids, v_principals);
     raise exception 'a book with no successor must not be merged';
-  exception when others then null;
+  exception when sqlstate '23514' or no_data_found then null;
   end;
 
   -- ── The cash cannot be unpicked from B while it sits there ───────────────
@@ -188,8 +201,27 @@ begin
     delete from public.investment_transactions
      where consumed_by_inv_id = v_new.transaction_id;
     raise exception 'a consumed withdrawal must not be deletable';
-  exception when others then null;
+  exception when sqlstate '23514' then null;
   end;
+
+  -- Nor an earlier partial withdrawal beside it: deleting that would restore the
+  -- part the merge measured around, to a book whose payout is already elsewhere.
+  begin
+    delete from public.investment_transactions
+     where parent_transaction_id = v_a2 and transaction_type = 'withdrawal'
+       and consumed_by_inv_id is null;
+    raise exception 'a withdrawal on a folded holding must not be deletable';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- ── The settled book stops being a book ──────────────────────────────────
+  -- Still self-grouped, it would remain a valid target for a backdated top-up
+  -- that resurrects it after its payout has gone.
+  select count(*) into v_count from public.investment_transactions
+   where deposit_group_id = v_a;
+  if v_count <> 0 then
+    raise exception 'the settled book must be dissolved, % rows still grouped', v_count;
+  end if;
 
   raise notice 'merge successor book: OK';
 end;

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -518,6 +518,45 @@ begin
 end;
 $$;
 
+-- ── Deleting the account still works after a merge ──────────────────────────
+--
+-- The lineage move above runs as a BEFORE DELETE trigger, so it also fires
+-- during the cascade from auth.users — where the goal these rows point at may
+-- already be gone, and rewriting them fails the ownership check. That made an
+-- account that had ever completed a merge undeletable.
+do $$
+declare
+  v_user uuid := gen_random_uuid();
+  v_goal uuid;
+  v_a uuid := gen_random_uuid();
+  v_b public.investment_transactions;
+  v_count int;
+begin
+  insert into auth.users (id, email) values (v_user, 'merge-erase@test.invalid');
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Erase') returning goal_id into v_goal;
+  insert into public.investment_transactions (
+    transaction_id, user_id, goal_id, asset_type, transaction_type,
+    investment_date, expiry_date, amount_vnd, interest_rate, deposit_group_id, top_up_lock_days
+  ) values (
+    v_a, v_user, v_goal, 'bank', 'investment',
+    current_date - 300, current_date - 3, 8000000, 4, v_a, 30
+  );
+  select * into v_b from public.open_successor_book(
+    v_a, 2000000, 4.5, current_date - 5, current_date + 300, 30, null, null, null, null);
+  perform public.merge_book_into_successor(
+    v_a, 8300000, 4.5, current_date, array[v_a], array[8000000::bigint], v_b.transaction_id);
+  set constraints all immediate;
+
+  delete from auth.users where id = v_user;
+  select count(*) into v_count from public.investment_transactions where user_id = v_user;
+  if v_count <> 0 then
+    raise exception 'deleting the account must remove its rows, % left', v_count;
+  end if;
+
+  raise notice 'merge successor book (account still deletable): OK';
+end;
+$$;
+
 -- ── The successor can still be renewed the ordinary way ─────────────────────
 --
 -- Collapsing a book deletes every non-anchor tranche after snapshotting it. The

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -315,6 +315,28 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- Nor re-keyed to a fund, which would measure it against that fund's bucket
+  -- instead of its parent and hand the source principal back.
+  begin
+    update public.investment_transactions set asset_type = 'fund'
+     where consumed_by_inv_id = v_new.transaction_id;
+    raise exception 'a folded withdrawal must not be re-keyed to a fund';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- Nor marked as a held settlement, which is how the holding-side guard tells
+  -- the two apart — flipping it turns that guard off.
+  begin
+    update public.investment_transactions set held_for_merge = true
+     where consumed_by_inv_id = v_new.transaction_id;
+    raise exception 'a folded withdrawal must not be relabelled as held';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- But deleting the goal must still work: the FK nulls goal_id on all of this,
+  -- and a goal that once completed a merge cannot be made undeletable by it.
+  delete from public.savings_goals where goal_id = v_other_goal;
+
   -- ── The settled book stops being a book ──────────────────────────────────
   -- Still self-grouped, it would remain a valid target for a backdated top-up
   -- that resurrects it after its payout has gone.

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -332,6 +332,18 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- Nor may a folded withdrawal be detached from the holding it came out of
+  -- while that holding still stands: it would stop subtracting, so the source
+  -- principal reappears beside the payout the successor now holds. (Either the
+  -- withdrawal-balance invariant or this migration's own guard refuses it; what
+  -- matters here is that it is refused.)
+  begin
+    update public.investment_transactions set parent_transaction_id = null
+     where consumed_by_inv_id = v_new.transaction_id;
+    raise exception 'a folded withdrawal must not be detached from a live holding';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- Nor deleted outright. The lineage move that lets a collapse through also
   -- clears the foreign key that used to block this, so on its own the delete
   -- would take the successor's whole payout away while the source stays closed.

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -91,7 +91,7 @@ begin
    where deposit_group_id = v_a;
   set constraints all immediate;
   begin
-    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids, v_principals);
+    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids, v_principals, v_b.transaction_id);
     raise exception 'merging a book before its maturity must be refused';
   exception when sqlstate '23514' then null;
   end;
@@ -101,20 +101,40 @@ begin
 
   -- ── A tranche the caller never saw aborts the whole thing ────────────────
   begin
-    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, array[v_a], array[8000000::bigint]);
+    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, array[v_a], array[8000000::bigint], v_b.transaction_id);
     raise exception 'a book that changed since load must be refused';
+  exception when sqlstate 'P0001' then
+    if sqlerrm not like '%book changed since load%' then raise; end if;
+  end;
+
+  -- ── A destination the caller never saw ───────────────────────────────────
+  -- The promise can be cancelled and re-made while the confirmation sits open,
+  -- and the replacement passes every same-goal/same-currency check the pairing
+  -- makes. Nothing else here would notice, so the cash would leave for a bank
+  -- the user never confirmed. What they saw is named, and has to still be true.
+  begin
+    perform public.merge_book_into_successor(
+      v_a, v_received, 4.5, current_date, v_ids, v_principals, gen_random_uuid());
+    raise exception 'a merge naming a successor that is no longer linked must be refused';
+  exception when sqlstate 'P0001' then
+    if sqlerrm not like '%book changed since load%' then raise; end if;
+  end;
+  begin
+    perform public.merge_book_into_successor(
+      v_a, v_received, 4.5, current_date, v_ids, v_principals, null);
+    raise exception 'a merge naming no successor at all must be refused';
   exception when sqlstate 'P0001' then
     if sqlerrm not like '%book changed since load%' then raise; end if;
   end;
 
   -- ── Nothing arrives from nowhere ─────────────────────────────────────────
   begin
-    perform public.merge_book_into_successor(v_a, 0, 4.5, current_date, v_ids, v_principals);
+    perform public.merge_book_into_successor(v_a, 0, 4.5, current_date, v_ids, v_principals, v_b.transaction_id);
     raise exception 'a merge of nothing must be refused';
   exception when sqlstate '23514' then null;
   end;
   begin
-    perform public.merge_book_into_successor(v_a, 999000000000, 4.5, current_date, v_ids, v_principals);
+    perform public.merge_book_into_successor(v_a, 999000000000, 4.5, current_date, v_ids, v_principals, v_b.transaction_id);
     raise exception 'a received amount unmoored from the book must be refused';
   exception when sqlstate '23514' then null;
   end;
@@ -124,7 +144,7 @@ begin
   -- exactly the case ids alone cannot see.
   begin
     perform public.merge_book_into_successor(
-      v_a, v_received, 4.5, current_date, v_ids, array[7000000::bigint, 4000000::bigint]);
+      v_a, v_received, 4.5, current_date, v_ids, array[7000000::bigint, 4000000::bigint], v_b.transaction_id);
     raise exception 'a tranche whose balance moved must be refused';
   exception when sqlstate 'P0001' then
     if sqlerrm not like '%book changed since load%' then raise; end if;
@@ -144,7 +164,7 @@ begin
       current_date - 1, 3000000, 3000000, true
     );
     perform public.merge_book_into_successor(
-      v_a, v_received, 4.5, current_date, v_ids, v_principals);
+      v_a, v_received, 4.5, current_date, v_ids, v_principals, v_b.transaction_id);
     raise exception 'a submitted tranche emptied since the preview must be refused';
   exception when sqlstate 'P0001' then
     if sqlerrm not like '%book changed since load%' then raise; end if;
@@ -155,7 +175,7 @@ begin
   begin
     update public.investment_transactions set affects_progress = false
      where parent_transaction_id = v_a2 and transaction_type = 'withdrawal';
-    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids, v_principals);
+    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids, v_principals, v_b.transaction_id);
     raise exception 'a withdrawal kept out of progress must block the merge';
   exception when sqlstate '23514' then null;
   end;
@@ -163,14 +183,14 @@ begin
     insert into public.savings_goals (user_id, goal_name) values (v_user, 'Sideways') returning goal_id into v_side_goal;
     update public.investment_transactions set goal_id = v_side_goal
      where parent_transaction_id = v_a2 and transaction_type = 'withdrawal';
-    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids, v_principals);
+    perform public.merge_book_into_successor(v_a, v_received, 4.5, current_date, v_ids, v_principals, v_b.transaction_id);
     raise exception 'a withdrawal filed under another goal must block the merge';
   exception when sqlstate '23514' then null;
   end;
 
   -- ── The merge itself ─────────────────────────────────────────────────────
   select * into v_new from public.merge_book_into_successor(
-    v_a, v_received, 4.6, current_date, v_ids, v_principals);
+    v_a, v_received, 4.6, current_date, v_ids, v_principals, v_b.transaction_id);
 
   -- Exactly one tranche lands in B, holding the cash that was actually received.
   if v_new.deposit_group_id is distinct from v_b.transaction_id then
@@ -231,7 +251,7 @@ begin
 
   -- ── Once kept, it cannot be kept again ───────────────────────────────────
   begin
-    perform public.merge_book_into_successor(v_a, v_received, 4.6, current_date, v_ids, v_principals);
+    perform public.merge_book_into_successor(v_a, v_received, 4.6, current_date, v_ids, v_principals, v_b.transaction_id);
     raise exception 'a book with no successor must not be merged';
   exception when sqlstate '23514' or no_data_found then null;
   end;

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -276,6 +276,16 @@ begin
   exception when sqlstate '23514' then null;
   end;
 
+  -- The withdrawals cannot be moved out of the goal either: goal detail loads by
+  -- raw goal_id, so the source would be shown without the withdrawal that closed
+  -- it, and its paid-away principal would read as live.
+  begin
+    update public.investment_transactions set goal_id = v_other_goal
+     where consumed_by_inv_id = v_new.transaction_id;
+    raise exception 'a folded withdrawal must not be moved between goals';
+  exception when sqlstate '23514' then null;
+  end;
+
   -- A recurring saving cannot be attached to it afterwards either: nothing can
   -- be paid into a deposit whose balance has gone.
   begin

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -106,7 +106,9 @@ begin
      where transaction_id = v_b.transaction_id;
     set constraints all immediate;
     raise exception 'a foreign book must not be named as a successor';
-  exception when others then null;
+  -- Catching `others` here would catch the line above too, and the case would
+  -- pass whether or not anything refused it.
+  exception when sqlstate '23514' or sqlstate '23503' then null;
   end;
 
   -- ── The recurring-driven flow moves the whole month in one transaction ───


### PR DESCRIPTION
Part of #638 — Phase 3. Phase 4 (history, provenance and polish) remains, so this does not close the issue.

## What was missing

Phase 2 recorded the handover and steered the contributions to the new book. What it could not do was end it: the old book reaches maturity holding real money, and the only thing the app knew how to do with a matured book — collapse it into a fresh cycle — is exactly what the handover said would not happen. A promised book therefore had nowhere to go, and the only way forward was to cancel the promise and lose the plan.

## What this adds

`merge_book_into_successor` — one function, because these are only correct together:

1. lock both books in id order, the same order every other pairing write takes;
2. check the caller owns the source, that it has a successor, and that the pair is still one that can merge (same goal and currency, both live and unpledged, the successor still an accumulating book);
3. refuse before maturity — the cash has not been paid out yet — and refuse a merge date before it;
4. record the received cash as **one** tranche in the successor, which passes the same top-up guard any contribution to that book would, so a successor that has closed its own door stops the merge rather than losing the source into nothing;
5. close every live tranche of the source, allocating the cash in proportion to what each still held, the last taking the rounding so the parts add up to the whole exactly;
6. stamp every withdrawal `consumed_by_inv_id` — what stops the ledger from re-opening the old book while its cash sits in the new one;
7. move anything still funding the old book onto the new one;
8. retire the promise, which no client may write.

The caller names the tranches it saw. A top-up landing while the confirmation is open aborts the merge with a 409 rather than closing a tranche nobody counted — the same shape as the collapse route's stale-book guard.

At maturity, the sheet now offers **Merge into the successor** instead of a renewal, prefilled with what the book is worth for the user to confirm against the bank's slip.

## Validation

- `npm run typecheck`, `npm run lint`, `npm test -- --run` (2317 tests), `npm run build`
- `npx supabase db reset --local` + every `supabase/tests/*.sql`, including the new `merge_successor_book.test.sql`: the source fully closed, exactly one tranche added, the allocated cash equal to what was received, every withdrawal stamped, the promise retired, the recurring link ending on the successor, and refusals for early merges, stale tranche sets, absurd amounts and a second merge
- route tests for validation and the 400/404/409 mapping; component tests for the panel and for a refusal surfacing rather than reading as success

🤖 Generated with [Claude Code](https://claude.com/claude-code)