### PR TITLE
feat(deposits): say where a merged book's money went (#638 Phase 4)

### DIFF
--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -51,7 +51,7 @@ export async function GET(request: NextRequest) {
 
   let query = supabase
     .from('investment_transactions')
-    .select('transaction_id, goal_id, asset_type, transaction_type, parent_transaction_id, renewed_from_transaction_id, deposit_group_id, interest_earned_vnd, investment_date, amount_vnd, unit_price, units, interest_rate, expiry_date, notes, fund_id, bank_code, currency, is_pledged, top_up_lock_days, successor_deposit_tx_id, principal_withdrawn, units_withdrawn, affects_progress, held_for_merge, consumed_by_inv_id, merge_anchor_inv_id, savings_goals(goal_name), funds(id, name, nav)', { count: 'exact' })
+    .select('transaction_id, goal_id, asset_type, transaction_type, parent_transaction_id, renewed_from_transaction_id, deposit_group_id, interest_earned_vnd, investment_date, amount_vnd, unit_price, units, interest_rate, expiry_date, notes, fund_id, bank_code, currency, is_pledged, top_up_lock_days, successor_deposit_tx_id, merged_from_book_id, principal_withdrawn, units_withdrawn, affects_progress, held_for_merge, consumed_by_inv_id, merge_anchor_inv_id, savings_goals(goal_name), funds(id, name, nav)', { count: 'exact' })
     .eq('user_id', user.id)
     .order('investment_date', { ascending: false })
     .range(offset, offset + limit - 1)

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -72,7 +72,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
   // Transactions + gold price load (shared with GoalDetailSheet, #467). The
   // panel is always mounted, so it always loads; each load clears the optimistic
   // unassign filter.
-  const { transactions, txLoading, txError, goldPricePerChi } = useGoalDetailData({
+  const { transactions, bookNames, txLoading, txError, goldPricePerChi } = useGoalDetailData({
     goalId: goal.goalId,
     enabled: true,
     refreshKey,
@@ -117,7 +117,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
   const creditedWithdrawn = progressCredit(goal.currentValue, goal.progressValue)
 
   // Build investment rows (shared with the mobile sheet's valuation logic).
-  const invRows: InvRow[] = buildInvRows(transactions, goal.funds, goldPricePerChi, isVi)
+  const invRows: InvRow[] = buildInvRows(transactions, goal.funds, goldPricePerChi, isVi, bookNames)
 
   // Composition segments — held-for-merge cash is folded back in (see helper) so the
   // bar reconciles with the headline instead of summing short.

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -62,7 +62,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   const [unassignedIds, setUnassignedIds] = useState<string[]>([])
   // Transactions + gold price load (shared with DesktopGoalDetail, #467). The
   // sheet only loads while open; each load clears the optimistic unassign filter.
-  const { transactions, txLoading, txError, goldPricePerChi } = useGoalDetailData({
+  const { transactions, bookNames, txLoading, txError, goldPricePerChi } = useGoalDetailData({
     goalId: goal?.goalId,
     enabled: open && !!goal,
     refreshKey,
@@ -173,7 +173,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
 
   // Build typed investment rows for the Investments tab, then drop any
   // optimistically-unassigned ones.
-  const invRows: InvRow[] = buildInvRows(transactions, goal.funds, goldPricePerChi, isVI)
+  const invRows: InvRow[] = buildInvRows(transactions, goal.funds, goldPricePerChi, isVI, bookNames)
     .filter((row) => !unassignedIds.includes(row.id))
 
   // Calculator (shared projection math — #467). `monthly` is parsed here (the

--- a/app/assets/components/__tests__/BankInfoStrip.test.tsx
+++ b/app/assets/components/__tests__/BankInfoStrip.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { BankInfoStrip } from '../goalDetailShared'
+import type { InvRow } from '@/features/dashboard/contracts'
+
+// A book's top-up history is where its money visibly came from. After a merge
+// (#638 Phase 4) one of those tranches did not come from the user at all — it is
+// another book's payout, and that book is dissolved by then, so this line is the
+// only trace left of where the jump came from.
+const book: InvRow = {
+  id: 'B', name: 'PVcomBank B', type: 'bank', value: 10_300_000, gainPct: null,
+  units: null, principal: 10_300_000, interestRate: 5, expiryDate: '2027-01-01',
+  investmentDate: '2026-06-01', fund: null, depositGroupId: 'B',
+  tranches: [
+    { id: 'credited', date: '2026-08-11', amount: 8_300_000, rate: 5, value: 8_300_000, mergedFrom: 'PVcomBank A' },
+    { id: 'own', date: '2026-06-01', amount: 2_000_000, rate: 5, value: 2_000_000 },
+  ],
+}
+
+describe('BankInfoStrip — merged-in provenance (#638)', () => {
+  it('says which book a credited tranche was folded in from', () => {
+    render(<BankInfoStrip inv={book} isVi={false} />)
+
+    expect(screen.getByTestId('tranche-merged-from')).toHaveTextContent('Merged from PVcomBank A')
+  })
+
+  it('says nothing on the tranches the user paid in themselves', () => {
+    render(<BankInfoStrip inv={{ ...book, tranches: [book.tranches![1]] }} isVi={false} />)
+
+    expect(screen.queryByTestId('tranche-merged-from')).not.toBeInTheDocument()
+  })
+
+  it('falls back to the plain date when the source name is unknown', () => {
+    render(<BankInfoStrip inv={{ ...book, tranches: [{ ...book.tranches![0], mergedFrom: null }] }} isVi={false} />)
+
+    expect(screen.queryByTestId('tranche-merged-from')).not.toBeInTheDocument()
+    expect(screen.getByTestId('tranche-row')).toBeInTheDocument()
+  })
+})

--- a/app/assets/components/__tests__/TopUpControl.test.tsx
+++ b/app/assets/components/__tests__/TopUpControl.test.tsx
@@ -91,4 +91,19 @@ describe('TopUpControl', () => {
     expect(screen.getByTestId('successor-planned')).toBeInTheDocument()
     expect(screen.queryByTestId('top-up-btn')).not.toBeInTheDocument()
   })
+
+  // #638 Phase 4. "Its successor book" is not something the user can act on:
+  // with several deposits in a goal there is no telling which one was promised,
+  // and cancelling is the only alternative offered.
+  it('names the successor it is promised to, when the name is known', () => {
+    render(<TopUpControl inv={{ ...lockedBook, successorDepositTxId: 'book-2', successorName: 'PVcomBank B' }} isVi={false} onDone={() => {}} />)
+
+    expect(screen.getByTestId('successor-planned')).toHaveTextContent('PVcomBank B')
+  })
+
+  it('...and stays sensible when it is not', () => {
+    render(<TopUpControl inv={{ ...lockedBook, successorDepositTxId: 'book-2' }} isVi={false} onDone={() => {}} />)
+
+    expect(screen.getByTestId('successor-planned')).toHaveTextContent(/successor book/i)
+  })
 })

--- a/app/assets/components/__tests__/goalDetailShared.test.tsx
+++ b/app/assets/components/__tests__/goalDetailShared.test.tsx
@@ -129,6 +129,24 @@ describe('buildInvRows', () => {
     expect(book.tranches!.find((t) => t.id === 'B')!.mergedFrom).toBeFalsy()
   })
 
+  // On a goal past the 200-row page the source is fetched for its name alone and
+  // deliberately kept out of the holdings input — it is a closed row whose own
+  // closing withdrawal may be off the page, and counting it here would show the
+  // money twice. The name still has to arrive.
+  it('names a source that was fetched for its name alone', () => {
+    const rows = buildInvRows(
+      [
+        baseTx({ transaction_id: 'B', asset_type: 'bank', amount_vnd: 2_000_000, interest_rate: 5, deposit_group_id: 'B', notes: 'PVcomBank B', investment_date: daysFromNow(-60) }),
+        baseTx({ transaction_id: 'credited', asset_type: 'bank', amount_vnd: 8_300_000, interest_rate: 5, deposit_group_id: 'B', investment_date: daysFromNow(-1), merged_from_book_id: 'A' }),
+      ],
+      [], null, false, { A: 'PVcomBank A' },
+    )
+    const book = rows.find((r) => r.depositGroupId === 'B')!
+    expect(book.tranches!.find((t) => t.id === 'credited')!.mergedFrom).toBe('PVcomBank A')
+    // ...and the source is not a holding of its own.
+    expect(rows.some((r) => r.id === 'A')).toBe(false)
+  })
+
   it('names the successor a promised book is waiting to be folded into', () => {
     const rows = buildInvRows(
       [

--- a/app/assets/components/__tests__/goalDetailShared.test.tsx
+++ b/app/assets/components/__tests__/goalDetailShared.test.tsx
@@ -106,6 +106,40 @@ describe('buildInvRows', () => {
     expect(rows[0].bankCode).toBe('MB')
   })
 
+  // #638 Phase 4. After a book is folded into its successor, the successor holds
+  // a tranche that came from somewhere else entirely, and the source is gone from
+  // the holdings list — dissolved. Without saying where that money came from, the
+  // new book just grows by an unexplained amount on a date nothing else marks.
+  it('names the book a credited tranche was folded in from', () => {
+    const rows = buildInvRows(
+      [
+        baseTx({ transaction_id: 'B', asset_type: 'bank', amount_vnd: 2_000_000, interest_rate: 5, deposit_group_id: 'B', notes: 'PVcomBank B', investment_date: daysFromNow(-60) }),
+        baseTx({ transaction_id: 'credited', asset_type: 'bank', amount_vnd: 8_300_000, interest_rate: 5, deposit_group_id: 'B', investment_date: daysFromNow(-1), merged_from_book_id: 'A' }),
+        // A's anchor still exists — closed and dissolved, so it is no longer a
+        // holding, but it is what carries the name the user knew it by.
+        baseTx({ transaction_id: 'A', asset_type: 'bank', amount_vnd: 8_000_000, interest_rate: 4, notes: 'PVcomBank A', investment_date: daysFromNow(-300), principal_withdrawn: null }),
+        baseTx({ transaction_id: 'w', transaction_type: 'withdrawal', asset_type: 'bank', parent_transaction_id: 'A', amount_vnd: 8_300_000, principal_withdrawn: 8_000_000, investment_date: daysFromNow(-1) }),
+      ],
+      [], null, false,
+    )
+    const book = rows.find((r) => r.depositGroupId === 'B')!
+    const credited = book.tranches!.find((t) => t.id === 'credited')!
+    expect(credited.mergedFrom).toBe('PVcomBank A')
+    // The ordinary tranche says nothing.
+    expect(book.tranches!.find((t) => t.id === 'B')!.mergedFrom).toBeFalsy()
+  })
+
+  it('names the successor a promised book is waiting to be folded into', () => {
+    const rows = buildInvRows(
+      [
+        baseTx({ transaction_id: 'A', asset_type: 'bank', amount_vnd: 8_000_000, interest_rate: 4, deposit_group_id: 'A', notes: 'PVcomBank A', investment_date: daysFromNow(-300), successor_deposit_tx_id: 'B' }),
+        baseTx({ transaction_id: 'B', asset_type: 'bank', amount_vnd: 2_000_000, interest_rate: 5, deposit_group_id: 'B', notes: 'PVcomBank B', investment_date: daysFromNow(-60) }),
+      ],
+      [], null, false,
+    )
+    expect(rows.find((r) => r.depositGroupId === 'A')!.successorName).toBe('PVcomBank B')
+  })
+
   it('caps a matured deposit at its term interest (frozen, simple interest)', () => {
     // Term 2025-01-01 → 2025-07-01 (181 days). Interest is capped at maturity, so
     // the value is deterministic regardless of when the test runs (today is past

--- a/app/assets/components/__tests__/transactionUtils.test.ts
+++ b/app/assets/components/__tests__/transactionUtils.test.ts
@@ -35,6 +35,22 @@ describe('txKind / txDir — held-for-merge labeling', () => {
     expect(txKind({ transaction_type: 'withdrawal', held_for_merge: false })).toBe('withdrawal')
   })
 
+  // #638 Phase 4. Folding a book into its successor closes every tranche with a
+  // withdrawal whose cash goes straight into the new book — it never left. Those
+  // rows carry consumed_by_inv_id but not held_for_merge, so they read as red
+  // spending: a merged book looked like the account had been emptied. What makes
+  // a row neutral is where the cash went, not which path parked it.
+  it('a withdrawal folded into another deposit is neutral, held or not', () => {
+    const tx = { transaction_type: 'withdrawal', held_for_merge: false, consumed_by_inv_id: 'new-tranche' }
+    expect(txKind(tx)).toBe('consumed')
+    expect(txDir(tx)).toMatchObject({ kind: 'consumed', tone: 'muted', sign: '' })
+  })
+
+  it('...and the same when held_for_merge was never set at all', () => {
+    const tx = { transaction_type: 'withdrawal', consumed_by_inv_id: 'new-tranche' }
+    expect(txDir(tx)).toMatchObject({ kind: 'consumed', tone: 'muted', sign: '' })
+  })
+
   it('a missing transaction_type defaults to investment (no held flags)', () => {
     expect(txKind({})).toBe('investment')
   })

--- a/app/assets/components/__tests__/useGoalDetailData.test.tsx
+++ b/app/assets/components/__tests__/useGoalDetailData.test.tsx
@@ -57,6 +57,44 @@ describe('useGoalDetailData (#467)', () => {
     expect(urls.filter(u => u.includes('ids=')).length).toBe(1)
   })
 
+  // #638 Phase 4. The books a page has to NAME are not only the ones it groups
+  // by: a merged source is dissolved, so it carries no deposit_group_id anyone
+  // still points at — only merged_from_book_id on the tranche it paid for. Left
+  // out of the backfill, a large goal drops the source off the page and the
+  // "Merged from …" line silently disappears. Same for a successor that fell out.
+  it('fetches the books a page only needs in order to name them', async () => {
+    const asked: string[] = []
+    mockFetch((url) => {
+      if (url.includes('ids=')) {
+        asked.push(url)
+        return { ok: true, body: { transactions: [
+          { transaction_id: 'A', investment_date: '2025-01-01', notes: 'PVcomBank A' },
+          { transaction_id: 'B', deposit_group_id: 'B', investment_date: '2026-02-01', notes: 'PVcomBank B' },
+        ] } }
+      }
+      if (url.includes('/investment-transactions?')) {
+        return { ok: true, body: { transactions: [
+          // The credited tranche names a source that is off the page...
+          { transaction_id: 'credited', deposit_group_id: 'C', investment_date: '2026-08-01', merged_from_book_id: 'A' },
+          { transaction_id: 'C', deposit_group_id: 'C', investment_date: '2026-07-01' },
+          // ...and a promised book names a successor that is off it too.
+          { transaction_id: 'D', deposit_group_id: 'D', investment_date: '2026-06-01', successor_deposit_tx_id: 'B' },
+        ] } }
+      }
+      if (url.includes('/recurring-contributions')) return { ok: true, body: { contributions: [] } }
+      return { ok: true, body: {} }
+    })
+
+    const { result } = renderHook(() => useGoalDetailData({ goalId: 'g1', enabled: true, refreshKey: 0, txReload: 0 }))
+    await waitFor(() => expect(result.current.txLoading).toBe(false))
+
+    expect(asked).toHaveLength(1)
+    expect(asked[0]).toContain('A')
+    expect(asked[0]).toContain('B')
+    expect(result.current.transactions.find(t => t.transaction_id === 'A')?.notes).toBe('PVcomBank A')
+    expect(result.current.transactions.find(t => t.transaction_id === 'B')?.notes).toBe('PVcomBank B')
+  })
+
   it('asks for every missing anchor, in batches', async () => {
     const urls: string[] = []
     const anchorIds = Array.from({ length: 150 }, (_, i) => `anchor-${i}`)

--- a/app/assets/components/__tests__/useGoalDetailData.test.tsx
+++ b/app/assets/components/__tests__/useGoalDetailData.test.tsx
@@ -53,8 +53,13 @@ describe('useGoalDetailData (#467)', () => {
 
     const anchor = result.current.transactions.find(t => t.transaction_id === 'anchor-1')
     expect(anchor?.successor_deposit_tx_id).toBe('book-2')
-    // One request for the whole set, not one per anchor.
-    expect(urls.filter(u => u.includes('ids=')).length).toBe(1)
+    // One request for the whole set of anchors, not one per anchor.
+    const byIds = urls.filter(u => u.includes('ids='))
+    expect(byIds.filter(u => u.includes('anchor-1'))).toHaveLength(1)
+    // The anchor names a successor that is off the page too, so exactly one
+    // more round follows to learn its name — never one request per reference.
+    expect(byIds).toHaveLength(2)
+    expect(byIds[1]).toContain('book-2')
   })
 
   // #638 Phase 4. The books a page has to NAME are not only the ones it groups
@@ -99,6 +104,46 @@ describe('useGoalDetailData (#467)', () => {
     expect(result.current.bookNames.B).toBe('PVcomBank B')
     expect(result.current.transactions.map(t => t.transaction_id)).not.toContain('A')
     expect(result.current.transactions.map(t => t.transaction_id)).not.toContain('B')
+  })
+
+  // A promised book's successor is named on its ANCHOR. When the anchor itself
+  // fell off the page, the successor's id only appears once that anchor has been
+  // fetched — so a single pass over the first page never asks for it, and the
+  // promise reads as the anonymous "successor book" again (#638 Phase 4).
+  it('follows a successor named by an anchor that was itself backfilled', async () => {
+    const asked: string[][] = []
+    mockFetch((url) => {
+      if (url.includes('ids=')) {
+        const ids = decodeURIComponent(url.split('ids=')[1].split('&')[0]).split(',')
+        asked.push(ids)
+        if (ids.includes('A')) {
+          // A fell off the page, and it is the row that names the successor.
+          return { ok: true, body: { transactions: [
+            { transaction_id: 'A', deposit_group_id: 'A', investment_date: '2025-01-01', notes: 'PVcomBank A', successor_deposit_tx_id: 'B' },
+          ] } }
+        }
+        return { ok: true, body: { transactions: [
+          { transaction_id: 'B', deposit_group_id: 'B', investment_date: '2025-06-01', notes: 'PVcomBank B' },
+        ] } }
+      }
+      if (url.includes('/investment-transactions?')) {
+        return { ok: true, body: { transactions: [
+          { transaction_id: 'tr', deposit_group_id: 'A', investment_date: '2026-08-01' },
+        ] } }
+      }
+      if (url.includes('/recurring-contributions')) return { ok: true, body: { contributions: [] } }
+      return { ok: true, body: {} }
+    })
+
+    const { result } = renderHook(() => useGoalDetailData({ goalId: 'g1', enabled: true, refreshKey: 0, txReload: 0 }))
+    await waitFor(() => expect(result.current.txLoading).toBe(false))
+
+    expect(asked.flat()).toContain('B')
+    expect(result.current.bookNames.B).toBe('PVcomBank B')
+    // ...and B is still only a name here, not a holding this page counts.
+    expect(result.current.transactions.map(t => t.transaction_id)).not.toContain('B')
+    // A is a real anchor of a book on this page, so it stays a holding.
+    expect(result.current.transactions.map(t => t.transaction_id)).toContain('A')
   })
 
   it('asks for every missing anchor, in batches', async () => {

--- a/app/assets/components/__tests__/useGoalDetailData.test.tsx
+++ b/app/assets/components/__tests__/useGoalDetailData.test.tsx
@@ -91,8 +91,14 @@ describe('useGoalDetailData (#467)', () => {
     expect(asked).toHaveLength(1)
     expect(asked[0]).toContain('A')
     expect(asked[0]).toContain('B')
-    expect(result.current.transactions.find(t => t.transaction_id === 'A')?.notes).toBe('PVcomBank A')
-    expect(result.current.transactions.find(t => t.transaction_id === 'B')?.notes).toBe('PVcomBank B')
+    // Names, yes — holdings, no. A merged source is a closed row whose OWN
+    // closing withdrawal may sit outside the page; fed into the holdings input
+    // it reads as a live deposit at full value and the goal counts that money
+    // twice, once here and once in the book it was folded into.
+    expect(result.current.bookNames.A).toBe('PVcomBank A')
+    expect(result.current.bookNames.B).toBe('PVcomBank B')
+    expect(result.current.transactions.map(t => t.transaction_id)).not.toContain('A')
+    expect(result.current.transactions.map(t => t.transaction_id)).not.toContain('B')
   })
 
   it('asks for every missing anchor, in batches', async () => {

--- a/app/assets/components/goalDetailRows.ts
+++ b/app/assets/components/goalDetailRows.ts
@@ -70,6 +70,16 @@ export function buildInvRows(
     }
   }
 
+  // What each deposit is called, by id — including rows that are no longer
+  // holdings. A merge dissolves the source book and closes it, so the only place
+  // its name survives is its own (now closed) anchor row; the same lookup names
+  // a successor that has not been folded into yet (#638 Phase 4).
+  const nameById = new Map<string, string>()
+  for (const tx of transactions) {
+    const n = tx.notes?.trim()
+    if (n) nameById.set(tx.transaction_id, n)
+  }
+
   // Exclude withdrawals and renewal history snapshots — only live investment
   // rows are active holdings. Recurring savings are excluded here too and rolled
   // up separately below: they are contributions the plan says have happened, not
@@ -147,7 +157,11 @@ export function buildInvRows(
       const interest = tx.interest_rate
         ? calcProjectedInterest(effPrincipal, tx.interest_rate, tx.investment_date, tx.expiry_date)
         : 0
-      tranches.push({ id: tx.transaction_id, date: tx.investment_date, amount: effPrincipal, rate: tx.interest_rate ?? null, value: Math.round(effPrincipal + interest) })
+      tranches.push({
+        id: tx.transaction_id, date: tx.investment_date, amount: effPrincipal,
+        rate: tx.interest_rate ?? null, value: Math.round(effPrincipal + interest),
+        mergedFrom: tx.merged_from_book_id ? (nameById.get(tx.merged_from_book_id) ?? null) : null,
+      })
     }
     if (tranches.length === 0) return null // whole book withdrawn
     tranches.sort((a, b) => (a.date < b.date ? 1 : a.date > b.date ? -1 : 0)) // newest first
@@ -172,6 +186,7 @@ export function buildInvRows(
       isPledged: anchor.is_pledged ?? false,
       topUpLockDays: anchor.top_up_lock_days ?? null,
       successorDepositTxId: anchor.successor_deposit_tx_id ?? null,
+      successorName: anchor.successor_deposit_tx_id ? (nameById.get(anchor.successor_deposit_tx_id) ?? null) : null,
       tranches,
     }
   }).filter((row): row is InvRow => row !== null)

--- a/app/assets/components/goalDetailRows.ts
+++ b/app/assets/components/goalDetailRows.ts
@@ -53,6 +53,11 @@ export function buildInvRows(
   funds: FundBreakdownItem[],
   goldPricePerChi: number | null,
   isVi: boolean,
+  // Names of deposits this page must be able to name but must NOT hold — a
+  // merged source, a successor that fell off the page (#638). They are kept out
+  // of `transactions` on purpose: a closed row whose own closing withdrawal is
+  // off the page would read here as a live deposit at full value.
+  bookNames: Record<string, string> = {},
 ): InvRow[] {
   // Aggregate withdrawals onto their parent holding. Bank/gold withdrawals are
   // stored as separate `withdrawal` rows linked via parent_transaction_id, so
@@ -74,7 +79,7 @@ export function buildInvRows(
   // holdings. A merge dissolves the source book and closes it, so the only place
   // its name survives is its own (now closed) anchor row; the same lookup names
   // a successor that has not been folded into yet (#638 Phase 4).
-  const nameById = new Map<string, string>()
+  const nameById = new Map<string, string>(Object.entries(bookNames))
   for (const tx of transactions) {
     const n = tx.notes?.trim()
     if (n) nameById.set(tx.transaction_id, n)

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -230,6 +230,9 @@ export interface GoalDetailTx {
   top_up_lock_days?: number | null
   // The book this one is planned to be folded into at maturity (#638).
   successor_deposit_tx_id?: string | null
+  // ...and, on the tranche a completed merge credited, the book its cash came
+  // from. Historical fact: the source is dissolved by then.
+  merged_from_book_id?: string | null
   // Set on the rows the recurring-contributions endpoint synthesizes for a
   // goal's recurring savings. They have no investment_transactions row behind
   // them — `transaction_id` is a `recurring:<savingId>:<date>` label, not an id
@@ -294,7 +297,16 @@ export function BankInfoStrip({ inv, isVi }: { inv: InvRow; isVi: boolean }) {
           <div style={{ display: 'grid', gap: 6 }}>
             {acc.map((tr) => (
               <div key={tr.id} data-testid="tranche-row" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', fontSize: 12, padding: '6px 10px', background: 'var(--c-card-2)', borderRadius: 8 }}>
-                <span style={{ color: 'var(--c-muted)' }}>{fmtTxDate(tr.date, isVi ? 'vi' : 'en')}</span>
+                <span style={{ color: 'var(--c-muted)', display: 'flex', flexDirection: 'column', gap: 1, minWidth: 0 }}>
+                  {fmtTxDate(tr.date, isVi ? 'vi' : 'en')}
+                  {/* Where an unexplained jump came from: the source book is
+                      dissolved by now, so this line is the only trace of it. */}
+                  {tr.mergedFrom && (
+                    <span data-testid="tranche-merged-from" style={{ fontSize: 10, color: 'var(--c-navy)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                      {isVi ? `Gộp từ ${tr.mergedFrom}` : `Merged from ${tr.mergedFrom}`}
+                    </span>
+                  )}
+                </span>
                 <span style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
                   <span style={{ fontVariantNumeric: 'tabular-nums', fontWeight: 600 }}>{fmtCompact(tr.amount)}</span>
                   {tr.rate != null && <span style={{ fontSize: 10, color: 'var(--c-muted)' }}>{tr.rate}%/{isVi ? 'năm' : 'yr'}</span>}
@@ -330,7 +342,9 @@ export function TopUpControl({ inv, isVi, onDone }: { inv: InvRow; isVi: boolean
     // withdrawable on purpose, or the deposit could never be closed at all.
     return (
       <div data-testid="successor-planned" style={{ margin: '0 0 4px', padding: '9px 10px', borderRadius: 10, background: 'var(--c-canvas,#faf9f7)', border: '1px solid var(--c-line)', color: 'var(--c-muted)', fontSize: 12, lineHeight: 1.45 }}>
-        {isVi ? 'Sẽ gộp vào sổ kế nhiệm khi đáo hạn.' : 'Will merge into its successor book at maturity.'}
+        {inv.successorName
+          ? (isVi ? `Sẽ gộp vào “${inv.successorName}” khi đáo hạn.` : `Will merge into “${inv.successorName}” at maturity.`)
+          : (isVi ? 'Sẽ gộp vào sổ kế nhiệm khi đáo hạn.' : 'Will merge into its successor book at maturity.')}
         <button type="button" data-testid="cancel-successor-btn" disabled={saving}
           onClick={async () => {
             setSaving(true)

--- a/app/assets/components/transactionUtils.ts
+++ b/app/assets/components/transactionUtils.ts
@@ -61,7 +61,13 @@ export interface TxKindFields {
 
 export function txKind(tx: TxKindFields): TxKind {
   if (tx.transaction_type !== 'withdrawal') return 'investment'
-  if (tx.held_for_merge === true) return tx.consumed_by_inv_id != null ? 'consumed' : 'held'
+  // Where the cash went decides the tone, not which path parked it. A book
+  // folded into its successor (#638) closes every tranche with a withdrawal that
+  // carries consumed_by_inv_id and no held_for_merge — the money went straight
+  // into the new book, but the row read as red spending, so a merged book looked
+  // like the account had been emptied.
+  if (tx.consumed_by_inv_id != null) return 'consumed'
+  if (tx.held_for_merge === true) return 'held'
   return 'withdrawal'
 }
 

--- a/app/assets/components/useGoalDetailData.ts
+++ b/app/assets/components/useGoalDetailData.ts
@@ -101,8 +101,15 @@ export function useGoalDetailData(opts: {
         // read off a tranche, which knows none of that, and would look like it
         // still takes top-ups (#638). Ask for the few anchors that fell out.
         const present = new Set(rows.map((r) => r.transaction_id))
+        // Every book this page has to read or NAME. Not only the ones it groups
+        // by: a merged source is dissolved, so nothing points at it through
+        // deposit_group_id any more — only merged_from_book_id, on the tranche
+        // it paid for. Leaving those out dropped the "Merged from …" line on any
+        // goal big enough to push the source off the page, and did it silently
+        // (#638 Phase 4). A promised successor can fall off the same edge.
         const missingAnchors = [...new Set(
-          rows.map((r) => r.deposit_group_id).filter((id): id is string => !!id && !present.has(id)),
+          rows.flatMap((r) => [r.deposit_group_id, r.merged_from_book_id, r.successor_deposit_tx_id])
+            .filter((id): id is string => !!id && !present.has(id)),
         )]
         // Batched, because a goal holding many older books would otherwise open
         // one connection per anchor before the page could render — and chunked

--- a/app/assets/components/useGoalDetailData.ts
+++ b/app/assets/components/useGoalDetailData.ts
@@ -27,6 +27,8 @@ export interface InvestmentTx {
   consumed_by_inv_id?: string | null
   top_up_lock_days?: number | null
   successor_deposit_tx_id?: string | null
+  // On the tranche a completed merge credited: the book its cash came from.
+  merged_from_book_id?: string | null
   // Set on every row of an accumulating book; equals transaction_id on the
   // anchor, which is the row that carries the book's terms.
   deposit_group_id?: string | null

--- a/app/assets/components/useGoalDetailData.ts
+++ b/app/assets/components/useGoalDetailData.ts
@@ -36,6 +36,9 @@ export interface InvestmentTx {
 
 export interface UseGoalDetailData {
   transactions: InvestmentTx[]
+  // Deposits this page must be able to NAME but must not treat as holdings —
+  // a merged source, a successor that fell off the page. Keyed by id (#638).
+  bookNames: Record<string, string>
   txLoading: boolean
   txError: boolean
   goldPricePerChi: number | null
@@ -57,6 +60,7 @@ export function useGoalDetailData(opts: {
 }): UseGoalDetailData {
   const { goalId, enabled, refreshKey, txReload } = opts
   const [transactions, setTransactions] = useState<InvestmentTx[]>([])
+  const [bookNames, setBookNames] = useState<Record<string, string>>({})
   const [goldPricePerChi, setGoldPricePerChi] = useState<number | null>(null)
   const [txLoading, setTxLoading] = useState(false)
   const [txError, setTxError] = useState(false)
@@ -101,22 +105,33 @@ export function useGoalDetailData(opts: {
         // read off a tranche, which knows none of that, and would look like it
         // still takes top-ups (#638). Ask for the few anchors that fell out.
         const present = new Set(rows.map((r) => r.transaction_id))
-        // Every book this page has to read or NAME. Not only the ones it groups
-        // by: a merged source is dissolved, so nothing points at it through
-        // deposit_group_id any more — only merged_from_book_id, on the tranche
-        // it paid for. Leaving those out dropped the "Merged from …" line on any
-        // goal big enough to push the source off the page, and did it silently
-        // (#638 Phase 4). A promised successor can fall off the same edge.
         const missingAnchors = [...new Set(
-          rows.flatMap((r) => [r.deposit_group_id, r.merged_from_book_id, r.successor_deposit_tx_id])
-            .filter((id): id is string => !!id && !present.has(id)),
+          rows.map((r) => r.deposit_group_id).filter((id): id is string => !!id && !present.has(id)),
+        )]
+        // Books this page only has to NAME, which is a different thing from a
+        // book it has to read. A merged source is dissolved, so nothing points
+        // at it through deposit_group_id any more — only merged_from_book_id, on
+        // the tranche it paid for — and on a goal past the page it fell out and
+        // the "Merged from …" line silently vanished (#638 Phase 4).
+        //
+        // Fetched apart from the anchors above and kept OUT of `transactions`.
+        // That source is a closed row whose own closing withdrawal may sit
+        // outside the page too; handed to the holdings build it reads as a live
+        // deposit at full value, and the goal counts that money twice — here and
+        // in the book it was folded into.
+        const nameOnly = [...new Set(
+          rows.flatMap((r) => [r.merged_from_book_id, r.successor_deposit_tx_id])
+            .filter((id): id is string => !!id && !present.has(id) && !missingAnchors.includes(id)),
         )]
         // Batched, because a goal holding many older books would otherwise open
         // one connection per anchor before the page could render — and chunked
         // rather than capped, so no book is quietly left reading a tranche.
         const CHUNK = 100
         const chunks: string[][] = []
-        for (let i = 0; i < missingAnchors.length; i += CHUNK) chunks.push(missingAnchors.slice(i, i + CHUNK))
+        // One set of requests for both, so a page needing an anchor and a name
+        // does not open two rounds of connections; the results part ways after.
+        const wanted = [...missingAnchors, ...nameOnly]
+        for (let i = 0; i < wanted.length; i += CHUNK) chunks.push(wanted.slice(i, i + CHUNK))
         // A failed anchor batch fails the load. These are not supplementary like
         // the recurring contributions: without an anchor a book renders off a
         // tranche, which does not know the book has handed over — so it would
@@ -127,7 +142,19 @@ export function useGoalDetailData(opts: {
             .then((res) => (res?.transactions ?? []) as InvestmentTx[]),
         ))).flat()
 
-        const merged: InvestmentTx[] = [...rows, ...anchors, ...(recRes.contributions ?? [])]
+        const nameOnlySet = new Set(nameOnly)
+        const names: Record<string, string> = {}
+        for (const a of anchors) {
+          const n = a.notes?.trim()
+          if (n) names[a.transaction_id] = n
+        }
+        setBookNames(names)
+
+        const merged: InvestmentTx[] = [
+          ...rows,
+          ...anchors.filter((a) => !nameOnlySet.has(a.transaction_id)),
+          ...(recRes.contributions ?? []),
+        ]
         merged.sort((a, b) => (a.investment_date < b.investment_date ? 1 : a.investment_date > b.investment_date ? -1 : 0))
         setTransactions(merged)
       })
@@ -141,5 +168,5 @@ export function useGoalDetailData(opts: {
       .catch(() => setGoldPricePerChi(null))
   }, [enabled, goalId, refreshKey, txReload])
 
-  return { transactions, txLoading, txError, goldPricePerChi }
+  return { transactions, bookNames, txLoading, txError, goldPricePerChi }
 }

--- a/app/assets/components/useGoalDetailData.ts
+++ b/app/assets/components/useGoalDetailData.ts
@@ -127,24 +127,40 @@ export function useGoalDetailData(opts: {
         // one connection per anchor before the page could render — and chunked
         // rather than capped, so no book is quietly left reading a tranche.
         const CHUNK = 100
-        const chunks: string[][] = []
-        // One set of requests for both, so a page needing an anchor and a name
-        // does not open two rounds of connections; the results part ways after.
-        const wanted = [...missingAnchors, ...nameOnly]
-        for (let i = 0; i < wanted.length; i += CHUNK) chunks.push(wanted.slice(i, i + CHUNK))
-        // A failed anchor batch fails the load. These are not supplementary like
-        // the recurring contributions: without an anchor a book renders off a
+        // A failed batch fails the load. These are not supplementary like the
+        // recurring contributions: without an anchor a book renders off a
         // tranche, which does not know the book has handed over — so it would
         // offer actions the database then refuses. A retry beats a wrong page.
-        const anchors: InvestmentTx[] = (await Promise.all(chunks.map((chunk) =>
-          fetch(`/api/v1/investment-transactions?ids=${chunk.join(',')}&include_history=true&limit=${CHUNK}`, { cache: 'no-store' })
-            .then((r) => { if (!r.ok) throw new Error('anchor load failed'); return r.json() })
-            .then((res) => (res?.transactions ?? []) as InvestmentTx[]),
-        ))).flat()
+        const fetchByIds = async (ids: string[]): Promise<InvestmentTx[]> => {
+          const chunks: string[][] = []
+          for (let i = 0; i < ids.length; i += CHUNK) chunks.push(ids.slice(i, i + CHUNK))
+          return (await Promise.all(chunks.map((chunk) =>
+            fetch(`/api/v1/investment-transactions?ids=${chunk.join(',')}&include_history=true&limit=${CHUNK}`, { cache: 'no-store' })
+              .then((r) => { if (!r.ok) throw new Error('anchor load failed'); return r.json() })
+              .then((res) => (res?.transactions ?? []) as InvestmentTx[]),
+          ))).flat()
+        }
 
-        const nameOnlySet = new Set(nameOnly)
+        // One round for both, so a page needing an anchor and a name does not
+        // open two sets of connections; the results part ways after.
+        const anchors = await fetchByIds([...missingAnchors, ...nameOnly])
+
+        // A promise is recorded on the ANCHOR, so a book whose anchor fell off
+        // the page only reveals its successor once that anchor is back. One
+        // more round for those, and only when there are any: computing this
+        // from the first page alone left the promise reading as the anonymous
+        // "successor book" on exactly the goals big enough to need the backfill.
+        const known = new Set([...present, ...anchors.map((a) => a.transaction_id)])
+        const secondPass = [...new Set(
+          anchors.flatMap((a) => [a.merged_from_book_id, a.successor_deposit_tx_id])
+            .filter((id): id is string => !!id && !known.has(id)),
+        )]
+        const namedOnly = secondPass.length > 0 ? await fetchByIds(secondPass) : []
+
+        // Every one of these was fetched to be named, not to be held.
+        const nameOnlySet = new Set([...nameOnly, ...secondPass])
         const names: Record<string, string> = {}
-        for (const a of anchors) {
+        for (const a of [...anchors, ...namedOnly]) {
           const n = a.notes?.trim()
           if (n) names[a.transaction_id] = n
         }

--- a/features/dashboard/contracts.ts
+++ b/features/dashboard/contracts.ts
@@ -137,6 +137,9 @@ export interface InvRow {
   // The book this one is planned to be folded into at maturity, once it stopped
   // accepting top-ups and its contributions moved on (#638).
   successorDepositTxId?: string | null
+  // ...and what that book is called, so the promise can be stated in the user's
+  // own words rather than as an anonymous "a successor book".
+  successorName?: string | null
   // The book's tranches (top-ups), newest first, for the detail view. Each is one
   // underlying row; present only on an accumulating book row.
   tranches?: InvTranche[] | null
@@ -155,6 +158,11 @@ export interface InvTranche {
   amount: number
   rate: number | null
   value: number
+  // The name of the book this tranche's cash was folded in from, when it was
+  // credited by a merge (#638). The source is dissolved by then and gone from
+  // the holdings list, so without this the new book simply grows by an
+  // unexplained amount on a date nothing else marks.
+  mergedFrom?: string | null
 }
 
 // What a sell/withdraw sheet is handed: the holding being closed, plus the


### PR DESCRIPTION
Phase 4 of #638 — history and provenance, i.e. what the merge leaves behind for a person to read.

## Internal transfers stop reading as spending

Folding a book into its successor closes every tranche with a withdrawal whose cash goes **straight into the new book**. Those rows carry `consumed_by_inv_id` but not `held_for_merge`, and `txKind` only treated the held-settlement path as neutral — so a merged book looked like the account had been emptied, in red, across History, Recent activity and the ledger.

What makes a row neutral is **where the cash went**, not which path parked it. `txKind` now keys on `consumed_by_inv_id`. This also covers the ordinary sibling merge (settle S early, fold into D), which was red for the same wrong reason.

## The successor says where its money came from

After the merge the source book is dissolved and gone from the holdings list, so the successor simply grew by an unexplained amount on a date nothing else marks. Its top-up history now labels that tranche `Gộp từ <sổ A>` / `Merged from <A>`, resolved from the source's own closed anchor — the only place that name survives.

Uses `merged_from_book_id`, the column added in #649 for the guard, which is what it was written down for.

## A promised book names its successor

`Sẽ gộp vào sổ kế nhiệm` → `Sẽ gộp vào "PVcomBank B"`. With several deposits in one goal, "its successor book" is not something the user can act on, and cancelling was the only alternative offered. Falls back to the old wording when the name is unknown.

## What was already done, and what was deliberately not

- **Stale previews** return `409 book_changed` — landed in Phase 3.
- **A deleted successor** already clears the plan (the FK's `on delete set null`) and the locked book goes back to offering *Open successor book*, which is the "ask the user to choose another target" the issue asks for. Verified rather than assumed.
- **Auto-relinking a recurring saving** when its successor is deleted was tried and reverted: it needs policy this issue does not settle, and the first mechanism collided with the FK's own write. Raised separately — see the issue linked below.

## Verification

- Unit: 2335 pass, including new tests for the tone rule, the provenance resolution, and both render cases.
- DB suite: 25/25 on a database built from scratch.
- Smoke lane: 20/20 in 30s.
- Typecheck + lint clean.

Test layers follow the repo rule: the tone rule is a pure unit test, provenance resolution is a `buildInvRows` unit test, and the two labels are component tests. No new E2E — nothing here crosses a layer the existing specs do not already cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)