### PR TITLE
feat(planning): say when a deleted deposit leaves a recurring saving feeding nothing (#655)

### DIFF
--- a/app/(app)/planning/components/DesktopPlanningView.tsx
+++ b/app/(app)/planning/components/DesktopPlanningView.tsx
@@ -120,6 +120,7 @@ export default function DesktopPlanningView({
   } = usePlanningDerivations({
     plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,
     recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, isVI,
+    ym: `${year}-${String(month).padStart(2, '0')}`,
   })
   const savedPct = (plan && savedPercent(totalGoalAmount, plan.salary_vnd)) ?? 0
 

--- a/app/(app)/planning/components/LinkLostBadge.tsx
+++ b/app/(app)/planning/components/LinkLostBadge.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useId, useState } from 'react'
 import { AlertTriangle } from 'lucide-react'
 import type { GoalItem } from '@/lib/planning'
 
@@ -12,26 +13,60 @@ import type { GoalItem } from '@/lib/planning'
 // moves the link onto the new book, so deleting that book is one click away
 // from an unlinked plan.
 //
+// The badge is a button, not a `title`. The detail — what happens to the money
+// now, and how to put it back — is the half worth reading, and a hover tooltip
+// hides exactly that half from a phone, which is where this app is mostly used.
+// Tapping it opens the sentence inline; hovering still shows it, for a mouse.
+//
 // One component for both layouts, because the two row files have drifted before
 // (#603) and a warning that shows on the desktop table but not on a phone is
 // worse than none — it is a warning the user has learned to expect.
 export function LinkLostBadge({ item, isVI }: { item: GoalItem; isVI: boolean }) {
+  const [open, setOpen] = useState(false)
+  const generatedId = useId()
   if (!item.linkLost) return null
+
+  const key = item.recurringId ?? generatedId
+  const detailId = `plan-link-lost-detail-${key}`
+  const detail = isVI
+    ? 'Sổ tiết kiệm khoản này nạp vào đã bị xoá. Tiền hàng tháng giờ được ghi thành khoản gửi riêng — mở "Sửa kế hoạch định kỳ" để chọn sổ khác.'
+    : 'The deposit this saving fed was deleted. Monthly contributions now record a standalone deposit — use "Edit recurring plan" to point it at another book.'
+
   return (
-    <span
-      data-testid={item.recurringId ? `plan-link-lost-${item.recurringId}` : 'plan-link-lost'}
-      title={isVI
-        ? 'Sổ tiết kiệm khoản này nạp vào đã bị xoá. Tiền hàng tháng giờ được ghi thành khoản gửi riêng — sửa kế hoạch định kỳ để chọn sổ khác.'
-        : 'The deposit this saving fed was deleted. The monthly contribution now records a standalone deposit — edit the recurring plan to point it at another book.'}
-      style={{
-        display: 'inline-flex', alignItems: 'center', gap: 3, flexShrink: 0,
-        padding: '1px 5px', borderRadius: 4,
-        background: 'var(--c-warn-tint)', color: 'var(--c-warn)',
-        fontSize: 9, fontWeight: 700, whiteSpace: 'nowrap',
-      }}
-    >
-      <AlertTriangle size={9} strokeWidth={2.6} />
-      {isVI ? 'Sổ đã bị xoá' : 'Deposit deleted'}
+    <span style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'flex-start', gap: 3, minWidth: 0 }}>
+      <button
+        type="button"
+        data-testid={item.recurringId ? `plan-link-lost-${item.recurringId}` : 'plan-link-lost'}
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={detailId}
+        title={detail}
+        style={{
+          display: 'inline-flex', alignItems: 'center', gap: 3, flexShrink: 0,
+          // Vertical padding pulled back out as margin: the pill keeps its size
+          // in the row while the thumb gets roughly twice the height to hit. It
+          // is short of the 44px the row's menu button gets — this is a
+          // disclosure next to that menu, not a primary action, and buying the
+          // full target would push every plan line taller for a badge most rows
+          // never show.
+          padding: '7px 6px', margin: '-5px 0', borderRadius: 4, border: 'none',
+          background: 'var(--c-warn-tint)', color: 'var(--c-warn)',
+          fontSize: 9, fontWeight: 700, whiteSpace: 'nowrap',
+          fontFamily: 'inherit', cursor: 'pointer',
+        }}
+      >
+        <AlertTriangle size={9} strokeWidth={2.6} />
+        {isVI ? 'Sổ đã bị xoá' : 'Deposit deleted'}
+      </button>
+      {open && (
+        <span
+          id={detailId}
+          data-testid={detailId}
+          style={{ fontSize: 10, lineHeight: 1.45, color: 'var(--c-warn)', whiteSpace: 'normal' }}
+        >
+          {detail}
+        </span>
+      )}
     </span>
   )
 }

--- a/app/(app)/planning/components/LinkLostBadge.tsx
+++ b/app/(app)/planning/components/LinkLostBadge.tsx
@@ -1,0 +1,37 @@
+'use client'
+
+import { AlertTriangle } from 'lucide-react'
+import type { GoalItem } from '@/lib/planning'
+
+// The deposit a recurring saving was feeding has been deleted (#655).
+//
+// Nothing is broken — an unlinked saving still records a plain deposit when the
+// month is marked saved — but the routing the user set up has quietly stopped,
+// and a green monthly line is the only thing they would otherwise see. The
+// handover flow (#638) makes this easy to walk into: opening a successor book
+// moves the link onto the new book, so deleting that book is one click away
+// from an unlinked plan.
+//
+// One component for both layouts, because the two row files have drifted before
+// (#603) and a warning that shows on the desktop table but not on a phone is
+// worse than none — it is a warning the user has learned to expect.
+export function LinkLostBadge({ item, isVI }: { item: GoalItem; isVI: boolean }) {
+  if (!item.linkLost) return null
+  return (
+    <span
+      data-testid={item.recurringId ? `plan-link-lost-${item.recurringId}` : 'plan-link-lost'}
+      title={isVI
+        ? 'Sổ tiết kiệm khoản này nạp vào đã bị xoá. Tiền hàng tháng giờ được ghi thành khoản gửi riêng — sửa kế hoạch định kỳ để chọn sổ khác.'
+        : 'The deposit this saving fed was deleted. The monthly contribution now records a standalone deposit — edit the recurring plan to point it at another book.'}
+      style={{
+        display: 'inline-flex', alignItems: 'center', gap: 3, flexShrink: 0,
+        padding: '1px 5px', borderRadius: 4,
+        background: 'var(--c-warn-tint)', color: 'var(--c-warn)',
+        fontSize: 9, fontWeight: 700, whiteSpace: 'nowrap',
+      }}
+    >
+      <AlertTriangle size={9} strokeWidth={2.6} />
+      {isVI ? 'Sổ đã bị xoá' : 'Deposit deleted'}
+    </span>
+  )
+}

--- a/app/(app)/planning/components/LinkLostBadge.tsx
+++ b/app/(app)/planning/components/LinkLostBadge.tsx
@@ -28,9 +28,17 @@ export function LinkLostBadge({ item, isVI }: { item: GoalItem; isVI: boolean })
 
   const key = item.recurringId ?? generatedId
   const detailId = `plan-link-lost-detail-${key}`
-  const detail = isVI
-    ? 'Sổ tiết kiệm khoản này nạp vào đã bị xoá. Tiền hàng tháng giờ được ghi thành khoản gửi riêng — mở "Sửa kế hoạch định kỳ" để chọn sổ khác.'
-    : 'The deposit this saving fed was deleted. Monthly contributions now record a standalone deposit — use "Edit recurring plan" to point it at another book.'
+  // Only a book was taking the monthly contribution. A link to a single term
+  // deposit just told the maturity-combine picker which saving belonged to it,
+  // and that contribution was already recorded as a standalone deposit — so
+  // saying it "now" is one tells that user about a change that never happened.
+  const detail = item.linkLostFromBook
+    ? (isVI
+      ? 'Sổ tích luỹ khoản này nạp vào đã bị xoá. Tiền hàng tháng giờ được ghi thành khoản gửi riêng — mở "Sửa kế hoạch định kỳ" để chọn sổ khác.'
+      : 'The accumulating book this saving fed was deleted. Monthly contributions now record a standalone deposit — use "Edit recurring plan" to point it at another book.')
+    : (isVI
+      ? 'Sổ tiết kiệm liên kết với khoản này đã bị xoá, nên khoản này giờ không còn gắn với sổ nào — mở "Sửa kế hoạch định kỳ" để chọn sổ khác.'
+      : 'The deposit this saving was linked to was deleted, so the saving is no longer linked to any deposit — use "Edit recurring plan" to point it at another.')
 
   return (
     <span style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'flex-start', gap: 3, minWidth: 0 }}>

--- a/app/(app)/planning/components/MobilePlanningView.tsx
+++ b/app/(app)/planning/components/MobilePlanningView.tsx
@@ -94,6 +94,7 @@ export default function MobilePlanningView({
   } = usePlanningDerivations({
     plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,
     recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, isVI,
+    ym: `${year}-${String(month).padStart(2, '0')}`,
   })
   const savedPct = plan ? savedPercent(totalGoals, plan.salary_vnd) : null
 

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -90,6 +90,29 @@ describe('DesktopPlanningView — goal header "+" log contribution', () => {
   })
 })
 
+// Deleting the deposit a saving funds unlinks it silently (#655) — the monthly
+// line goes on looking healthy while the money stops reaching the book. The
+// stamp is the only thing separating this from the many savings that were never
+// linked, so the warning has to key on it, not on the absent link.
+describe('DesktopPlanningView — a saving whose deposit was deleted', () => {
+  it('warns on the plan line when the linked deposit is gone', () => {
+    const orphaned: RecurringSaving[] = [{ ...recurringSavings[0], linked_deposit_tx_id: null, unlinked_at: '2026-08-12T03:00:00Z' }]
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={orphaned} />)
+    expect(screen.getByTestId('plan-link-lost-rs1')).toBeInTheDocument()
+  })
+
+  it('says nothing about a saving that was never linked', () => {
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
+    expect(screen.queryByTestId('plan-link-lost-rs1')).not.toBeInTheDocument()
+  })
+
+  it('says nothing once the saving points at a deposit again', () => {
+    const relinked: RecurringSaving[] = [{ ...recurringSavings[0], linked_deposit_tx_id: 'tx-9', unlinked_at: '2026-08-12T03:00:00Z' }]
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={relinked} />)
+    expect(screen.queryByTestId('plan-link-lost-rs1')).not.toBeInTheDocument()
+  })
+})
+
 describe('DesktopPlanningView — recurring deep-link edit', () => {
   it('"Edit recurring plan" opens the manager straight on that item’s edit form', async () => {
     const fetchMock = vi.fn((url: string) => {

--- a/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/DesktopPlanningView.test.tsx
@@ -95,10 +95,20 @@ describe('DesktopPlanningView — goal header "+" log contribution', () => {
 // stamp is the only thing separating this from the many savings that were never
 // linked, so the warning has to key on it, not on the absent link.
 describe('DesktopPlanningView — a saving whose deposit was deleted', () => {
+  // basePlan is May 2026, so the loss has to fall in that month to be this
+  // month's news.
   it('warns on the plan line when the linked deposit is gone', () => {
-    const orphaned: RecurringSaving[] = [{ ...recurringSavings[0], linked_deposit_tx_id: null, unlinked_at: '2026-08-12T03:00:00Z' }]
+    const orphaned: RecurringSaving[] = [{ ...recurringSavings[0], linked_deposit_tx_id: null, unlinked_at: '2026-05-12T03:00:00Z' }]
     render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={orphaned} />)
     expect(screen.getByTestId('plan-link-lost-rs1')).toBeInTheDocument()
+  })
+
+  // The month on screen reaches the resolver — a link lost in August was intact
+  // all through May, and May's plan must not say otherwise.
+  it('says nothing in a month that ended before the deletion', () => {
+    const orphaned: RecurringSaving[] = [{ ...recurringSavings[0], linked_deposit_tx_id: null, unlinked_at: '2026-08-12T03:00:00Z' }]
+    render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={orphaned} />)
+    expect(screen.queryByTestId('plan-link-lost-rs1')).not.toBeInTheDocument()
   })
 
   it('says nothing about a saving that was never linked', () => {
@@ -107,7 +117,7 @@ describe('DesktopPlanningView — a saving whose deposit was deleted', () => {
   })
 
   it('says nothing once the saving points at a deposit again', () => {
-    const relinked: RecurringSaving[] = [{ ...recurringSavings[0], linked_deposit_tx_id: 'tx-9', unlinked_at: '2026-08-12T03:00:00Z' }]
+    const relinked: RecurringSaving[] = [{ ...recurringSavings[0], linked_deposit_tx_id: 'tx-9', unlinked_at: '2026-05-12T03:00:00Z' }]
     render(<DesktopPlanningView {...defaultProps} plan={basePlan} recurringSavings={relinked} />)
     expect(screen.queryByTestId('plan-link-lost-rs1')).not.toBeInTheDocument()
   })

--- a/app/(app)/planning/components/__tests__/LinkLostBadge.test.tsx
+++ b/app/(app)/planning/components/__tests__/LinkLostBadge.test.tsx
@@ -10,7 +10,7 @@ import type { GoalItem } from '@/lib/planning'
 // problem and withheld the answer.
 const lost: GoalItem = {
   name: 'VCB Savings', type: 'bank', amount: 2_000_000,
-  isRecurring: true, recurringId: 'rs1', linkLost: true,
+  isRecurring: true, recurringId: 'rs1', linkLost: true, linkLostFromBook: true,
 }
 
 describe('LinkLostBadge', () => {
@@ -40,6 +40,20 @@ describe('LinkLostBadge', () => {
 
     expect(badge).toHaveAttribute('aria-expanded', 'false')
     expect(screen.queryByTestId('plan-link-lost-detail-rs1')).toBeNull()
+  })
+
+  // A link to a plain term deposit never routed the monthly contribution
+  // anywhere — it only told the maturity picker which saving belonged to that
+  // deposit. Telling that user their contributions "now" record a standalone
+  // deposit describes a change that did not happen.
+  it('does not claim the routing changed when the link was a term deposit', async () => {
+    render(<LinkLostBadge item={{ ...lost, linkLostFromBook: false }} isVI={false} />)
+    await userEvent.click(screen.getByTestId('plan-link-lost-rs1'))
+
+    const detail = screen.getByTestId('plan-link-lost-detail-rs1')
+    expect(detail.textContent).not.toMatch(/standalone deposit/i)
+    expect(detail.textContent).toMatch(/no longer linked/i)
+    expect(detail.textContent).toMatch(/Edit recurring plan/i)  // still actionable
   })
 
   it('carries the Vietnamese copy too', async () => {

--- a/app/(app)/planning/components/__tests__/LinkLostBadge.test.tsx
+++ b/app/(app)/planning/components/__tests__/LinkLostBadge.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { LinkLostBadge } from '../LinkLostBadge'
+import type { GoalItem } from '@/lib/planning'
+
+// The badge says a link was lost; the part worth reading is what happens now and
+// how to undo it (#655). That lived only in a native `title`, which a phone
+// cannot open — so on the layout this app is mostly used in, the warning named a
+// problem and withheld the answer.
+const lost: GoalItem = {
+  name: 'VCB Savings', type: 'bank', amount: 2_000_000,
+  isRecurring: true, recurringId: 'rs1', linkLost: true,
+}
+
+describe('LinkLostBadge', () => {
+  it('says nothing for a saving that has not lost a link', () => {
+    render(<LinkLostBadge item={{ ...lost, linkLost: false }} isVI={false} />)
+    expect(screen.queryByTestId('plan-link-lost-rs1')).toBeNull()
+  })
+
+  it('opens the consequence and the way out on tap', async () => {
+    render(<LinkLostBadge item={lost} isVI={false} />)
+    expect(screen.queryByTestId('plan-link-lost-detail-rs1')).toBeNull()
+
+    await userEvent.click(screen.getByTestId('plan-link-lost-rs1'))
+
+    const detail = screen.getByTestId('plan-link-lost-detail-rs1')
+    expect(detail.textContent).toMatch(/standalone deposit/i)   // what happens now
+    expect(detail.textContent).toMatch(/Edit recurring plan/i)  // how to fix it
+  })
+
+  it('closes again on a second tap', async () => {
+    render(<LinkLostBadge item={lost} isVI={false} />)
+    const badge = screen.getByTestId('plan-link-lost-rs1')
+
+    await userEvent.click(badge)
+    expect(badge).toHaveAttribute('aria-expanded', 'true')
+    await userEvent.click(badge)
+
+    expect(badge).toHaveAttribute('aria-expanded', 'false')
+    expect(screen.queryByTestId('plan-link-lost-detail-rs1')).toBeNull()
+  })
+
+  it('carries the Vietnamese copy too', async () => {
+    render(<LinkLostBadge item={lost} isVI />)
+    await userEvent.click(screen.getByTestId('plan-link-lost-rs1'))
+    expect(screen.getByTestId('plan-link-lost-detail-rs1').textContent).toMatch(/Sửa kế hoạch định kỳ/)
+  })
+})

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -469,7 +469,7 @@ describe('MobilePlanningView — recurring savings in By goal', () => {
   // The mobile row is its own component, so the #655 warning has to be wired
   // there too — the desktop test proves nothing about this markup.
   it('warns when the deposit this saving funded was deleted', async () => {
-    const orphaned = [{ ...recurringSavings[0], linked_deposit_tx_id: null, unlinked_at: '2026-08-12T03:00:00Z' }]
+    const orphaned = [{ ...recurringSavings[0], linked_deposit_tx_id: null, unlinked_at: '2026-05-12T03:00:00Z' }]
     render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={orphaned} />)
     await userEvent.click(screen.getByText('Retirement'))
     expect(screen.getByTestId('plan-link-lost-rs1')).toBeInTheDocument()

--- a/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
+++ b/app/(app)/planning/components/__tests__/MobilePlanningView.test.tsx
@@ -466,6 +466,22 @@ describe('MobilePlanningView — recurring savings in By goal', () => {
     }
   })
 
+  // The mobile row is its own component, so the #655 warning has to be wired
+  // there too — the desktop test proves nothing about this markup.
+  it('warns when the deposit this saving funded was deleted', async () => {
+    const orphaned = [{ ...recurringSavings[0], linked_deposit_tx_id: null, unlinked_at: '2026-08-12T03:00:00Z' }]
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={orphaned} />)
+    await userEvent.click(screen.getByText('Retirement'))
+    expect(screen.getByTestId('plan-link-lost-rs1')).toBeInTheDocument()
+  })
+
+  it('says nothing about a saving that was never linked', async () => {
+    render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
+    await userEvent.click(screen.getByText('Retirement'))
+    expect(screen.getByText('VCB Savings')).toBeInTheDocument()
+    expect(screen.queryByTestId('plan-link-lost-rs1')).not.toBeInTheDocument()
+  })
+
   it('renders a Log contribution "+" on the goal header', () => {
     render(<MobilePlanningView {...defaultProps} plan={basePlan} recurringSavings={recurringSavings} />)
     expect(screen.getByRole('button', { name: /Log contribution/i })).toBeInTheDocument()

--- a/app/(app)/planning/components/desktopPlanningRows.tsx
+++ b/app/(app)/planning/components/desktopPlanningRows.tsx
@@ -11,6 +11,7 @@ import { type GoalItem } from '@/lib/planning'
 import { useCloseOnScroll } from '@/components/ui/useDialogA11y'
 import { goalItemSublabel } from '@/features/planning/planModel'
 import { EditIcon } from './planningIcons'
+import { LinkLostBadge } from './LinkLostBadge'
 
 function MenuBtn({ icon, label, onClick, danger, noBorder }: {
   icon: React.ReactNode; label: string; onClick: () => void; danger?: boolean; noBorder?: boolean
@@ -121,6 +122,7 @@ export function DGoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit
         <div style={{ fontSize: 10, color: item.overridden ? 'var(--c-navy)' : recorded ? 'var(--c-pos)' : 'var(--c-muted)', marginTop: 1 }}>
           {sublabel}
           {item.isDCA && <span style={{ marginLeft: 6, padding: '1px 5px', borderRadius: 4, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', fontSize: 9, fontWeight: 700 }}>DCA</span>}
+          {item.linkLost && <span style={{ marginLeft: 6 }}><LinkLostBadge item={item} isVI={isVI} /></span>}
         </div>
       </td>
       <td style={{ padding: '9px 12px', textAlign: 'right', verticalAlign: 'middle' }}>

--- a/app/(app)/planning/components/planningRows.tsx
+++ b/app/(app)/planning/components/planningRows.tsx
@@ -11,6 +11,7 @@ import { type GoalRow, type GoalItem } from '@/lib/planning'
 import { useCloseOnScroll } from '@/components/ui/useDialogA11y'
 import { goalItemSublabel, goalProgress } from '@/features/planning/planModel'
 import { EditIcon } from './planningIcons'
+import { LinkLostBadge } from './LinkLostBadge'
 
 export function GoalAllocationRow({ entry, isVI, onRecSkip, onRecRestore, onRecOverride, onRecEdit, onRecordBuy, onRecordDeposit, onLogContribution, onDcaSkip, onDcaRestore }: {
   entry: GoalRow; isVI: boolean
@@ -139,6 +140,7 @@ function GoalItemRow({ item, isVI, onSkip, onRestore, onOverride, onEdit, onReco
           {item.isDCA && (
             <span style={{ fontSize: 10, padding: '1px 5px', borderRadius: 4, background: 'var(--c-navy-tint)', color: 'var(--c-navy)', fontWeight: 600 }}>DCA</span>
           )}
+          <LinkLostBadge item={item} isVI={isVI} />
         </div>
       </div>
       <span style={{ fontSize: 12, fontWeight: 500, fontVariantNumeric: 'tabular-nums', color: 'var(--c-muted)', textDecoration: skipped ? 'line-through' : 'none' }}>

--- a/app/(app)/planning/usePlanningDerivations.ts
+++ b/app/(app)/planning/usePlanningDerivations.ts
@@ -41,6 +41,10 @@ export interface PlanningDerivationsInput {
   funds: Fund[]
   goals: Goal[]
   isVI: boolean
+  // The month on screen, "YYYY-MM". The plan pages backwards, and a link lost in
+  // August was still intact in July — the warning must not reach months that
+  // predate it (#655).
+  ym?: string
 }
 
 // The single source of truth for the planning page's derived model: the by-goal
@@ -50,14 +54,14 @@ export interface PlanningDerivationsInput {
 export function usePlanningDerivations(input: PlanningDerivationsInput) {
   const {
     plan, investments, savings, fixedExpenses, insuranceMembers, otherExpenses,
-    recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, isVI,
+    recurringSavings, recurringSavingOverrides, recurringFulfillments, dcaSkips, funds, goals, isVI, ym,
   } = input
 
   const goalsById = useMemo(() => new Map(goals.map(g => [g.goal_id, g.goal_name])), [goals])
 
   const resolvedRecurring = useMemo(
-    () => resolveRecurringSavings(recurringSavings, recurringSavingOverrides),
-    [recurringSavings, recurringSavingOverrides],
+    () => resolveRecurringSavings(recurringSavings, recurringSavingOverrides, ym),
+    [recurringSavings, recurringSavingOverrides, ym],
   )
 
   // Skipped DCA funds are no longer seeded as rows, so synthesize struck-through

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -93,7 +93,7 @@ export async function GET(request: NextRequest) {
         .select('id, description, amount_vnd, created_at').eq('plan_id', plan.id).order('created_at', { ascending: true }),
       supabase
         .from('recurring_savings')
-        .select('saving_id, name, goal_id, amount_vnd, effective_from, effective_to, linked_deposit_tx_id, unlinked_at, savings_goals(goal_name)')
+        .select('saving_id, name, goal_id, amount_vnd, effective_from, effective_to, linked_deposit_tx_id, unlinked_at, unlinked_from_book, savings_goals(goal_name)')
         .eq('user_id', user.id)
         .or(`effective_from.is.null,effective_from.lte.${planDateForActive}`)
         .or(`effective_to.is.null,effective_to.gte.${planDateForActive}`),

--- a/app/api/v1/monthly-plans/route.ts
+++ b/app/api/v1/monthly-plans/route.ts
@@ -93,7 +93,7 @@ export async function GET(request: NextRequest) {
         .select('id, description, amount_vnd, created_at').eq('plan_id', plan.id).order('created_at', { ascending: true }),
       supabase
         .from('recurring_savings')
-        .select('saving_id, name, goal_id, amount_vnd, effective_from, effective_to, linked_deposit_tx_id, savings_goals(goal_name)')
+        .select('saving_id, name, goal_id, amount_vnd, effective_from, effective_to, linked_deposit_tx_id, unlinked_at, savings_goals(goal_name)')
         .eq('user_id', user.id)
         .or(`effective_from.is.null,effective_from.lte.${planDateForActive}`)
         .or(`effective_to.is.null,effective_to.gte.${planDateForActive}`),

--- a/app/api/v1/recurring-savings/route.ts
+++ b/app/api/v1/recurring-savings/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
 
   let query = supabase
     .from('recurring_savings')
-    .select('saving_id, name, goal_id, amount_vnd, effective_from, effective_to, linked_deposit_tx_id, unlinked_at, savings_goals(goal_name)')
+    .select('saving_id, name, goal_id, amount_vnd, effective_from, effective_to, linked_deposit_tx_id, unlinked_at, unlinked_from_book, savings_goals(goal_name)')
     .eq('user_id', user.id)
     .order('created_at', { ascending: false })
 

--- a/app/api/v1/recurring-savings/route.ts
+++ b/app/api/v1/recurring-savings/route.ts
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
 
   let query = supabase
     .from('recurring_savings')
-    .select('saving_id, name, goal_id, amount_vnd, effective_from, effective_to, linked_deposit_tx_id, savings_goals(goal_name)')
+    .select('saving_id, name, goal_id, amount_vnd, effective_from, effective_to, linked_deposit_tx_id, unlinked_at, savings_goals(goal_name)')
     .eq('user_id', user.id)
     .order('created_at', { ascending: false })
 

--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -26,6 +26,11 @@ const ASSET_BADGE: Record<AssetType, string> = {
   gold: '#b45309',
 }
 
+// How long the delete confirmation waits for the "which savings does this fund?"
+// lookup (#655) before giving up on it. Short: the answer is one sentence, and
+// the user has already said what they want to do.
+const LOOKUP_TIMEOUT_MS = 5_000
+
 const labelStyle: React.CSSProperties = {
   display: 'block', fontSize: 10, fontWeight: 600,
   letterSpacing: '0.06em', textTransform: 'uppercase',
@@ -161,14 +166,38 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
   // when the dialog opens rather than with the ledger: it is one small request
   // on a rare, deliberate action, not a cost every ledger open pays.
   const [unlinkedByDelete, setUnlinkedByDelete] = useState<string[]>([])
+  // The dialog opens the instant the button is pressed, so on a slow lookup the
+  // Delete button would be live with nothing beside it — and a warning that
+  // arrives after the confirmation is not a warning at all. Delete waits for the
+  // lookup to settle; a failed or empty one settles just the same and the delete
+  // goes ahead.
+  const [lookupPending, setLookupPending] = useState(false)
+  // Which lookup the dialog is currently showing. Cancel one dialog, open
+  // another, and the first answer can land late — without this it would name the
+  // first deposit's savings inside the second one's dialog.
+  const lookupSeq = useRef(0)
+
+  const closeConfirm = useCallback(() => {
+    lookupSeq.current += 1
+    setConfirmTx(null)
+    setUnlinkedByDelete([])
+    setLookupPending(false)
+  }, [])
 
   const askDelete = useCallback(async (tx: LedgerTransaction) => {
+    const seq = ++lookupSeq.current
     setConfirmTx(tx)
     setUnlinkedByDelete([])
+    setLookupPending(true)
     try {
-      const res = await fetch('/api/v1/recurring-savings')
+      // Bounded, because the button waits on this: a request that never answers
+      // would otherwise leave the delete permanently unclickable, which is a
+      // worse failure than the missing sentence.
+      const res = await fetch('/api/v1/recurring-savings', { signal: AbortSignal.timeout(LOOKUP_TIMEOUT_MS) })
+      if (seq !== lookupSeq.current) return
       if (!res.ok) return
       const { savings } = await res.json()
+      if (seq !== lookupSeq.current) return
       setUnlinkedByDelete(
         (savings ?? [])
           .filter((s: { linked_deposit_tx_id?: string | null }) => s.linked_deposit_tx_id === tx.transaction_id)
@@ -177,6 +206,8 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
     } catch {
       // Advisory only. A failed lookup must not stand between the user and a
       // delete they asked for — it costs a sentence, not the action.
+    } finally {
+      if (seq === lookupSeq.current) setLookupPending(false)
     }
   }, [])
 
@@ -357,14 +388,14 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
     setDeletingId(tx.transaction_id)
     const result = await deleteTransaction(tx.transaction_id)
     if (result.ok) {
-      setConfirmTx(null)
+      closeConfirm()
       await fetchTransactions()
       notifyChanged()
     } else {
       // Close the dialog and let the toast carry the explanation. Leaving it
       // open would sit there unchanged with no indication of what happened —
       // which is what it did before, for every refusal (#550).
-      setConfirmTx(null)
+      closeConfirm()
       toast.error(td(result.code))
       // not_found isn't a refusal: the row really is gone (a stale tab, or
       // another surface removed it). Keeping it on screen would leave the user
@@ -767,7 +798,7 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
       />
 
       {/* Delete confirm — token-styled Shell so it stacks above the ledger. */}
-      <Shell open={!!confirmTx} onClose={() => setConfirmTx(null)} title={t('deleteTitle')} desktop={desktop} width={380}>
+      <Shell open={!!confirmTx} onClose={closeConfirm} title={t('deleteTitle')} desktop={desktop} width={380}>
         {confirmTx && (
           <div style={{ display: 'grid', gap: 16 }}>
             <div style={{ fontSize: 13, color: 'var(--c-muted)', lineHeight: 1.5 }}>
@@ -782,14 +813,14 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
               </div>
             )}
             <div style={{ display: 'flex', gap: 8 }}>
-              <button onClick={() => setConfirmTx(null)} className="cn-btn" style={{ flex: 1, justifyContent: 'center' }}>{tc('cancel')}</button>
+              <button onClick={closeConfirm} className="cn-btn" style={{ flex: 1, justifyContent: 'center' }}>{tc('cancel')}</button>
               <button
                 data-testid="tx-ledger-delete-confirm"
                 onClick={() => handleDelete(confirmTx)}
-                disabled={deletingId === confirmTx.transaction_id}
-                style={{ flex: 2, padding: '10px 14px', background: 'var(--c-neg)', color: '#fff', border: 'none', borderRadius: 10, fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, opacity: deletingId === confirmTx.transaction_id ? 0.7 : 1 }}
+                disabled={deletingId === confirmTx.transaction_id || lookupPending}
+                style={{ flex: 2, padding: '10px 14px', background: 'var(--c-neg)', color: '#fff', border: 'none', borderRadius: 10, fontSize: 13, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 6, opacity: deletingId === confirmTx.transaction_id || lookupPending ? 0.7 : 1 }}
               >
-                <Trash size={14} />{deletingId === confirmTx.transaction_id ? tc('loading') : tc('delete')}
+                <Trash size={14} />{deletingId === confirmTx.transaction_id || lookupPending ? tc('loading') : tc('delete')}
               </button>
             </div>
           </div>

--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -10,7 +10,7 @@ import { formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 import { fmtCompact, fmtNav, fmtUnits } from '@/lib/formatters'
 import { parseExcelPaste, type ParsedRow } from '@/lib/parseExcelPaste'
 import AddTransactionSheet from './AddTransactionSheet'
-import { ASSET_TYPES, type AssetType, type LedgerTransaction, isWithdrawal, txKind, txPrimaryName, fmtTxDate } from './transactionUtils'
+import { ASSET_TYPES, type AssetType, type LedgerTransaction, isWithdrawal, mayCarryRecurringLink, txKind, txPrimaryName, fmtTxDate } from './transactionUtils'
 import { toast } from 'sonner'
 import { deleteTransaction } from './deleteTransaction'
 import { useDialogMount } from '@/components/ui/useDialogMount'
@@ -188,6 +188,13 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
     const seq = ++lookupSeq.current
     setConfirmTx(tx)
     setUnlinkedByDelete([])
+    // Nothing can be linked to a fund, gold, stock or withdrawal row, so there
+    // is no question to ask — and since Delete waits on the answer, asking would
+    // charge every unrelated deletion for a warning that can never apply.
+    if (!mayCarryRecurringLink(tx)) {
+      setLookupPending(false)
+      return
+    }
     setLookupPending(true)
     try {
       // Bounded, because the button waits on this: a request that never answers

--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -155,6 +155,30 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
   const [saving, setSaving] = useState(false)
   const [deletingId, setDeletingId] = useState<string | null>(null)
   const [confirmTx, setConfirmTx] = useState<LedgerTransaction | null>(null)
+  // Recurring savings this deposit is funding (#655). Deleting it unlinks them
+  // — legal, silent, and the reason the plan quietly stops routing money — so
+  // the confirm dialog names them while the user can still back out. Looked up
+  // when the dialog opens rather than with the ledger: it is one small request
+  // on a rare, deliberate action, not a cost every ledger open pays.
+  const [unlinkedByDelete, setUnlinkedByDelete] = useState<string[]>([])
+
+  const askDelete = useCallback(async (tx: LedgerTransaction) => {
+    setConfirmTx(tx)
+    setUnlinkedByDelete([])
+    try {
+      const res = await fetch('/api/v1/recurring-savings')
+      if (!res.ok) return
+      const { savings } = await res.json()
+      setUnlinkedByDelete(
+        (savings ?? [])
+          .filter((s: { linked_deposit_tx_id?: string | null }) => s.linked_deposit_tx_id === tx.transaction_id)
+          .map((s: { name: string }) => s.name),
+      )
+    } catch {
+      // Advisory only. A failed lookup must not stand between the user and a
+      // delete they asked for — it costs a sentence, not the action.
+    }
+  }, [])
 
   const [showImport, setShowImport] = useState(false)
   const [importFundId, setImportFundId] = useState('')
@@ -406,7 +430,7 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
       {!isWithdrawal(tx) && (
         <button onClick={() => (tx.asset_type === 'stock' ? openEdit(tx) : setEditExisting(tx))} className="cn-btn ghost" style={{ ...iconHit }} aria-label={tc('edit')}><Edit2 size={14} color="var(--c-muted)" /></button>
       )}
-      <button data-testid="tx-ledger-delete" onClick={() => setConfirmTx(tx)} className="cn-btn ghost" style={{ ...iconHit }} aria-label={tc('delete')}><Trash size={14} color="var(--c-neg)" /></button>
+      <button data-testid="tx-ledger-delete" onClick={() => askDelete(tx)} className="cn-btn ghost" style={{ ...iconHit }} aria-label={tc('delete')}><Trash size={14} color="var(--c-neg)" /></button>
     </span>
   )
 
@@ -749,6 +773,14 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
             <div style={{ fontSize: 13, color: 'var(--c-muted)', lineHeight: 1.5 }}>
               {dirMeta(confirmTx).label} · {txPrimaryName(confirmTx, assetLabelOf(confirmTx.asset_type))} — <span className="tabular">{fmtCompact(confirmTx.amount_vnd)}</span>
             </div>
+            {unlinkedByDelete.length > 0 && (
+              <div
+                data-testid="tx-delete-unlinks-savings"
+                style={{ fontSize: 12, lineHeight: 1.5, padding: '8px 10px', borderRadius: 8, background: 'var(--c-warn-tint)', color: 'var(--c-warn)' }}
+              >
+                {t('deleteUnlinksSavings', { names: unlinkedByDelete.join(', ') })}
+              </div>
+            )}
             <div style={{ display: 'flex', gap: 8 }}>
               <button onClick={() => setConfirmTx(null)} className="cn-btn" style={{ flex: 1, justifyContent: 'center' }}>{tc('cancel')}</button>
               <button

--- a/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
+++ b/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
@@ -113,7 +113,10 @@ describe('TransactionLedgerSheet — a refused delete says why', () => {
 
     const del = await screen.findByTestId('tx-ledger-delete')
     del.click()
+    // Delete is held until the unlink lookup settles (#655), so a click fired
+    // the instant the dialog appears lands on a disabled button.
     const confirm = await screen.findByTestId('tx-ledger-delete-confirm')
+    await vi.waitFor(() => expect(confirm).toBeEnabled())
     confirm.click()
 
     await vi.waitFor(() => expect(toastError).toHaveBeenCalledWith(code))
@@ -125,7 +128,10 @@ describe('TransactionLedgerSheet — a refused delete says why', () => {
 
     const del = await screen.findByTestId('tx-ledger-delete')
     del.click()
+    // Delete is held until the unlink lookup settles (#655), so a click fired
+    // the instant the dialog appears lands on a disabled button.
     const confirm = await screen.findByTestId('tx-ledger-delete-confirm')
+    await vi.waitFor(() => expect(confirm).toBeEnabled())
     confirm.click()
 
     await vi.waitFor(() => expect(global.fetch).toHaveBeenCalled())
@@ -165,7 +171,10 @@ describe('TransactionLedgerSheet — a not_found delete reconciles the list', ()
 
     const del = await screen.findByTestId('tx-ledger-delete')
     del.click()
+    // Delete is held until the unlink lookup settles (#655), so a click fired
+    // the instant the dialog appears lands on a disabled button.
     const confirm = await screen.findByTestId('tx-ledger-delete-confirm')
+    await vi.waitFor(() => expect(confirm).toBeEnabled())
     confirm.click()
 
     await vi.waitFor(() => expect(onChanged).toHaveBeenCalled())

--- a/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
+++ b/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
@@ -2,8 +2,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import TransactionLedgerSheet from '../TransactionLedgerSheet'
 
+// Keys pass through, but interpolated values come with them — a message whose
+// whole job is to name something (the savings a delete would unlink, #655) is
+// untestable if the mock throws the params away.
 vi.mock('next-intl', () => ({
-  useTranslations: () => (k: string) => k,
+  useTranslations: () => (k: string, params?: Record<string, unknown>) =>
+    params ? `${k}:${JSON.stringify(params)}` : k,
 }))
 // Nested sheets fetch/render on their own; stub them so this test only exercises
 // the ledger rows.
@@ -167,6 +171,67 @@ describe('TransactionLedgerSheet — a not_found delete reconciles the list', ()
     await vi.waitFor(() => expect(onChanged).toHaveBeenCalled())
     expect(listCalls).toBeGreaterThan(1)
     await vi.waitFor(() => expect(screen.queryByTestId('tx-ledger-delete')).toBeNull())
+  })
+})
+
+// Deleting a deposit a recurring saving feeds unlinks that saving on the way out
+// (ON DELETE SET NULL) and says nothing (#655). The plan then stops routing
+// money into a book while its monthly line still reads healthy. The delete stays
+// allowed — it is the user's deposit — but the confirm dialog is the last moment
+// they can decide knowing that, so it names the savings at stake.
+describe('TransactionLedgerSheet — deleting a deposit a recurring saving feeds', () => {
+  const tx = {
+    transaction_id: 'd1', asset_type: 'bank', investment_date: '2026-06-01',
+    amount_vnd: 10_000_000, transaction_type: 'investment',
+    savings_goals: { goal_name: 'House' },
+  }
+
+  const mockWithSavings = (savings: unknown[]) => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('recurring-savings')) return Promise.resolve({ ok: true, json: async () => ({ savings }) })
+      if (url.includes('savings-goals')) return Promise.resolve({ ok: true, json: async () => ({ goals: [] }) })
+      if (url.includes('/api/funds')) return Promise.resolve({ ok: true, json: async () => ({ funds: [] }) })
+      if (url.includes('investment-transactions')) return Promise.resolve({ ok: true, json: async () => ({ transactions: [tx], total: 1 }) })
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+  }
+
+  it('names the saving that would lose its link', async () => {
+    mockWithSavings([{ saving_id: 'rs1', name: 'VCB Savings', linked_deposit_tx_id: 'd1' }])
+    render(<TransactionLedgerSheet open desktop locale="en" onClose={() => {}} />)
+
+    const del = await screen.findByTestId('tx-ledger-delete')
+    del.click()
+    const warning = await screen.findByTestId('tx-delete-unlinks-savings')
+    expect(warning.textContent).toContain('VCB Savings')
+  })
+
+  it('stays quiet when the savings point at other deposits', async () => {
+    mockWithSavings([{ saving_id: 'rs1', name: 'VCB Savings', linked_deposit_tx_id: 'other-tx' }])
+    render(<TransactionLedgerSheet open desktop locale="en" onClose={() => {}} />)
+
+    const del = await screen.findByTestId('tx-ledger-delete')
+    del.click()
+    await screen.findByTestId('tx-ledger-delete-confirm')
+    expect(screen.queryByTestId('tx-delete-unlinks-savings')).toBeNull()
+  })
+
+  // The warning is advisory: if the lookup fails there is still a delete to
+  // perform, and blocking it would turn a missing sentence into a dead button.
+  it('still offers the delete when the lookup fails', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('recurring-savings')) return Promise.reject(new Error('offline'))
+      if (url.includes('savings-goals')) return Promise.resolve({ ok: true, json: async () => ({ goals: [] }) })
+      if (url.includes('/api/funds')) return Promise.resolve({ ok: true, json: async () => ({ funds: [] }) })
+      if (url.includes('investment-transactions')) return Promise.resolve({ ok: true, json: async () => ({ transactions: [tx], total: 1 }) })
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+    render(<TransactionLedgerSheet open desktop locale="en" onClose={() => {}} />)
+
+    const del = await screen.findByTestId('tx-ledger-delete')
+    del.click()
+    expect(await screen.findByTestId('tx-ledger-delete-confirm')).toBeInTheDocument()
+    expect(screen.queryByTestId('tx-delete-unlinks-savings')).toBeNull()
   })
 })
 

--- a/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
+++ b/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
@@ -233,5 +233,70 @@ describe('TransactionLedgerSheet — deleting a deposit a recurring saving feeds
     expect(await screen.findByTestId('tx-ledger-delete-confirm')).toBeInTheDocument()
     expect(screen.queryByTestId('tx-delete-unlinks-savings')).toBeNull()
   })
+
+  // A warning that arrives after the user has confirmed is not a warning. The
+  // dialog opens the instant the button is pressed, so on a slow lookup the
+  // Delete button would be live with nothing shown next to it — the exact
+  // outcome this change exists to prevent.
+  it('does not accept a confirmation until the lookup has settled', async () => {
+    let release: (v: unknown) => void = () => {}
+    const pending = new Promise((resolve) => { release = resolve })
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('recurring-savings')) return pending
+      if (url.includes('savings-goals')) return Promise.resolve({ ok: true, json: async () => ({ goals: [] }) })
+      if (url.includes('/api/funds')) return Promise.resolve({ ok: true, json: async () => ({ funds: [] }) })
+      if (url.includes('investment-transactions')) return Promise.resolve({ ok: true, json: async () => ({ transactions: [tx], total: 1 }) })
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+    render(<TransactionLedgerSheet open desktop locale="en" onClose={() => {}} />)
+
+    const del = await screen.findByTestId('tx-ledger-delete')
+    del.click()
+    const confirm = await screen.findByTestId('tx-ledger-delete-confirm')
+    expect(confirm).toBeDisabled()
+
+    release({ ok: true, json: async () => ({ savings: [{ saving_id: 'rs1', name: 'VCB Savings', linked_deposit_tx_id: 'd1' }] }) })
+    await screen.findByTestId('tx-delete-unlinks-savings')
+    await vi.waitFor(() => expect(screen.getByTestId('tx-ledger-delete-confirm')).toBeEnabled())
+  })
+
+  // Cancel one dialog, open another, and the first lookup lands late: without a
+  // check that it still describes the transaction on screen, the second deposit
+  // gets told it funds savings that belong to the first.
+  it('drops a lookup that no longer describes the open dialog', async () => {
+    const second = { ...tx, transaction_id: 'd2' }
+    let release: (v: unknown) => void = () => {}
+    const pending = new Promise((resolve) => { release = resolve })
+    let lookups = 0
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('recurring-savings')) {
+        lookups += 1
+        return lookups === 1 ? pending : Promise.resolve({ ok: true, json: async () => ({ savings: [] }) })
+      }
+      if (url.includes('savings-goals')) return Promise.resolve({ ok: true, json: async () => ({ goals: [] }) })
+      if (url.includes('/api/funds')) return Promise.resolve({ ok: true, json: async () => ({ funds: [] }) })
+      if (url.includes('investment-transactions')) return Promise.resolve({ ok: true, json: async () => ({ transactions: [tx, second], total: 2 }) })
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+    render(<TransactionLedgerSheet open desktop locale="en" onClose={() => {}} />)
+
+    const rows = await screen.findAllByTestId('tx-ledger-delete')
+    rows[0].click()                                   // d1 — lookup hangs
+    await screen.findByTestId('tx-ledger-delete-confirm')
+    screen.getByText('cancel').click()
+    await vi.waitFor(() => expect(screen.queryByTestId('tx-ledger-delete-confirm')).toBeNull())
+
+    rows[1].click()                                   // d2 — lookup answers empty
+    await vi.waitFor(() => expect(screen.getByTestId('tx-ledger-delete-confirm')).toBeEnabled())
+
+    // d1's answer arrives now, naming a saving that has nothing to do with d2.
+    // Awaiting the very promise the component is suspended on hands its
+    // continuation to the microtask queue before the assertion runs — the test
+    // above proves a late answer does reach the dialog, so a silent one here is
+    // the guard working rather than nothing having happened yet.
+    release({ ok: true, json: async () => ({ savings: [{ saving_id: 'rs1', name: 'VCB Savings', linked_deposit_tx_id: 'd1' }] }) })
+    for (let i = 0; i < 5; i++) await new Promise((r) => setTimeout(r, 0))
+    expect(screen.queryByTestId('tx-delete-unlinks-savings')).toBeNull()
+  })
 })
 

--- a/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
+++ b/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
@@ -243,6 +243,48 @@ describe('TransactionLedgerSheet — deleting a deposit a recurring saving feeds
     expect(screen.queryByTestId('tx-delete-unlinks-savings')).toBeNull()
   })
 
+  // Only a bank deposit can carry a recurring link at all — the link validator
+  // accepts nothing else. Asking about a fund, gold or a withdrawal buys a
+  // guaranteed-empty answer and, now that Delete waits for it, a delay on every
+  // unrelated deletion.
+  it('does not ask about a holding that could never carry a link', async () => {
+    const fund = { ...tx, transaction_id: 'f1', asset_type: 'fund' }
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('savings-goals')) return Promise.resolve({ ok: true, json: async () => ({ goals: [] }) })
+      if (url.includes('/api/funds')) return Promise.resolve({ ok: true, json: async () => ({ funds: [] }) })
+      if (url.includes('investment-transactions')) return Promise.resolve({ ok: true, json: async () => ({ transactions: [fund], total: 1 }) })
+      if (url.includes('recurring-savings')) return new Promise(() => {})  // never answers
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+    render(<TransactionLedgerSheet open desktop locale="en" onClose={() => {}} />)
+
+    const del = await screen.findByTestId('tx-ledger-delete')
+    del.click()
+
+    // Enabled straight away: a hung lookup cannot be what it is waiting on,
+    // because it was never started.
+    expect(await screen.findByTestId('tx-ledger-delete-confirm')).toBeEnabled()
+    const asked = (global.fetch as ReturnType<typeof vi.fn>).mock.calls
+      .some((c) => String(c[0]).includes('recurring-savings'))
+    expect(asked).toBe(false)
+  })
+
+  it('skips a bank withdrawal too, which no link can point at', async () => {
+    const withdrawal = { ...tx, transaction_id: 'w1', transaction_type: 'withdrawal' }
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('savings-goals')) return Promise.resolve({ ok: true, json: async () => ({ goals: [] }) })
+      if (url.includes('/api/funds')) return Promise.resolve({ ok: true, json: async () => ({ funds: [] }) })
+      if (url.includes('investment-transactions')) return Promise.resolve({ ok: true, json: async () => ({ transactions: [withdrawal], total: 1 }) })
+      if (url.includes('recurring-savings')) return new Promise(() => {})
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+    render(<TransactionLedgerSheet open desktop locale="en" onClose={() => {}} />)
+
+    const del = await screen.findByTestId('tx-ledger-delete')
+    del.click()
+    expect(await screen.findByTestId('tx-ledger-delete-confirm')).toBeEnabled()
+  })
+
   // A warning that arrives after the user has confirmed is not a warning. The
   // dialog opens the instant the button is pressed, so on a slow lookup the
   // Delete button would be live with nothing shown next to it — the exact

--- a/app/assets/components/transactionUtils.ts
+++ b/app/assets/components/transactionUtils.ts
@@ -43,6 +43,20 @@ export function isWithdrawal(tx: LedgerTransaction): boolean {
   return tx.transaction_type === 'withdrawal'
 }
 
+// Could a recurring saving be pointing at this row (#655)? Only a bank
+// investment can: `validateLinkedDeposit` refuses every other asset type and
+// refuses withdrawals outright. Deleting a fund, gold, stock or withdrawal
+// therefore cannot unlink anything, and asking about it buys a
+// guaranteed-empty answer that the delete now waits on.
+//
+// Deliberately looser than that validator, which also requires a rate and a
+// maturity: an edit can clear either after the link was made, and a link that
+// outlived the check is exactly the case the warning exists for. This screens
+// out only what no edit could turn back into a linkable deposit.
+export function mayCarryRecurringLink(tx: LedgerTransaction): boolean {
+  return tx.asset_type === 'bank' && !isWithdrawal(tx)
+}
+
 // The display semantics of a row, beyond plain investment/withdrawal. A held-for-
 // merge settlement is a withdrawal whose cash was PARKED for a future merge, not
 // spent — so it must read NEUTRALLY (no red "−" loss) everywhere it appears

--- a/features/planning/contracts.ts
+++ b/features/planning/contracts.ts
@@ -72,6 +72,8 @@ export interface RecurringSaving {
   effective_from: string | null
   effective_to: string | null
   linked_deposit_tx_id?: string | null
+  // When the linked deposit was deleted out from under this saving (#655).
+  unlinked_at?: string | null
   savings_goals: { goal_name: string } | null
 }
 

--- a/features/planning/contracts.ts
+++ b/features/planning/contracts.ts
@@ -74,6 +74,9 @@ export interface RecurringSaving {
   linked_deposit_tx_id?: string | null
   // When the linked deposit was deleted out from under this saving (#655).
   unlinked_at?: string | null
+  // Whether that deposit was an accumulating book anchor rather than a single
+  // term deposit — it decides which consequence the warning may claim.
+  unlinked_from_book?: boolean | null
   savings_goals: { goal_name: string } | null
 }
 

--- a/lib/__tests__/planning.test.ts
+++ b/lib/__tests__/planning.test.ts
@@ -48,6 +48,26 @@ describe('resolveRecurringSavings', () => {
     const [r] = resolveRecurringSavings([saving()], [ov])
     expect(r.overridden).toBe(false)
   })
+
+  // The deposit a saving fed was deleted (#655). Most unlinked savings were
+  // never linked at all, so only the stamp tells the two apart — without it the
+  // plan can either nag everyone or warn nobody.
+  it('flags a saving whose linked deposit was deleted', () => {
+    const [r] = resolveRecurringSavings([saving({ unlinked_at: '2026-08-12T03:00:00Z', linked_deposit_tx_id: null })], [])
+    expect(r.linkLost).toBe(true)
+  })
+
+  it('does not flag a saving that was never linked', () => {
+    const [r] = resolveRecurringSavings([saving()], [])
+    expect(r.linkLost).toBe(false)
+  })
+
+  // A stamp left over from an earlier loss says nothing about a saving that now
+  // points at a deposit again — the warning has been answered.
+  it('does not flag a saving that is linked again', () => {
+    const [r] = resolveRecurringSavings([saving({ unlinked_at: '2026-08-12T03:00:00Z', linked_deposit_tx_id: 'tx-9' })], [])
+    expect(r.linkLost).toBe(false)
+  })
 })
 
 describe('recurringSavingsTotal', () => {
@@ -89,6 +109,18 @@ describe('buildByGoal — planned vs contributed', () => {
     expect(row.contributed).toBe(5_000_000)    // recorded DCA buy
     expect(row.items.map(i => i.type)).toEqual(['fund', 'bank'])
     expect(row.items[0].recorded).toBe(true)
+  })
+
+  // The plan page is where the user looks month after month, so the lost link
+  // has to reach the line item — a warning only the resolver knows about warns
+  // nobody (#655).
+  it('carries a lost deposit link onto the goal line item', () => {
+    const recurring = resolveRecurringSavings(
+      [saving({ goal_id: 'g-1', unlinked_at: '2026-08-12T03:00:00Z', linked_deposit_tx_id: null })],
+      [],
+    )
+    const [row] = buildByGoal([], [], recurring, goalsById)
+    expect(row.items[0].linkLost).toBe(true)
   })
 
   it('a pending DCA row is planned but not yet contributed', () => {

--- a/lib/__tests__/planning.test.ts
+++ b/lib/__tests__/planning.test.ts
@@ -68,6 +68,43 @@ describe('resolveRecurringSavings', () => {
     const [r] = resolveRecurringSavings([saving({ unlinked_at: '2026-08-12T03:00:00Z', linked_deposit_tx_id: 'tx-9' })], [])
     expect(r.linkLost).toBe(false)
   })
+
+  // The plan page can be paged back through past months. A deposit deleted in
+  // August was still linked all through July, so July's plan must not be told
+  // otherwise — the badge would be describing a state that month never had.
+  it('does not flag months that ended before the deposit was deleted', () => {
+    const [r] = resolveRecurringSavings([saving({ unlinked_at: '2026-08-12T03:00:00Z' })], [], '2026-07')
+    expect(r.linkLost).toBe(false)
+  })
+
+  it('flags the month the deletion happened in', () => {
+    const [r] = resolveRecurringSavings([saving({ unlinked_at: '2026-08-12T03:00:00Z' })], [], '2026-08')
+    expect(r.linkLost).toBe(true)
+  })
+
+  it('flags every month after it', () => {
+    const [r] = resolveRecurringSavings([saving({ unlinked_at: '2026-08-12T03:00:00Z' })], [], '2026-09')
+    expect(r.linkLost).toBe(true)
+  })
+
+  // 01:00 UTC on the 1st is already the 1st in Vietnam, but 18:00 UTC on the
+  // 31st of July is the 1st of August there — the month the stamp belongs to is
+  // the business month, not the UTC one.
+  it('files the stamp under the business month, not the UTC one', () => {
+    const [r] = resolveRecurringSavings([saving({ unlinked_at: '2026-07-31T18:00:00Z' })], [], '2026-08')
+    expect(r.linkLost).toBe(true)
+    const [july] = resolveRecurringSavings([saving({ unlinked_at: '2026-07-31T18:00:00Z' })], [], '2026-07')
+    expect(july.linkLost).toBe(false)
+  })
+
+  // Which kind of link was lost decides which sentence is true (#655): a book
+  // anchor really was taking the monthly contribution; a term deposit never did.
+  it('carries whether the lost link was a book', () => {
+    const [book] = resolveRecurringSavings([saving({ unlinked_at: '2026-08-12T03:00:00Z', unlinked_from_book: true })], [])
+    expect(book.linkLostFromBook).toBe(true)
+    const [term] = resolveRecurringSavings([saving({ unlinked_at: '2026-08-12T03:00:00Z', unlinked_from_book: false })], [])
+    expect(term.linkLostFromBook).toBe(false)
+  })
 })
 
 describe('recurringSavingsTotal', () => {

--- a/lib/planning.ts
+++ b/lib/planning.ts
@@ -7,6 +7,8 @@
 // to those active in the selected month; this module resolves overrides, groups
 // by goal, and keeps the Unallocated group (null goal) last.
 
+import { businessYearMonth } from './dates'
+
 const UNALLOCATED = '__unallocated__'
 
 // A recurring recorded this month via a fulfillment row, and whether that path
@@ -33,6 +35,10 @@ export interface RecurringSaving {
   // Stamped when the linked deposit was deleted out from under this saving
   // (#655). Not the same as "unlinked": most savings never had a link.
   unlinked_at?: string | null
+  // Whether that deposit was an accumulating book's anchor. A book really was
+  // taking the monthly contribution; a plain term deposit never was, so the two
+  // losses cannot be described by the same sentence.
+  unlinked_from_book?: boolean | null
   savings_goals?: { goal_name: string } | null
 }
 
@@ -55,13 +61,31 @@ export interface ResolvedSaving {
   // the monthly contribution no longer reaches the book the user aimed it at.
   // Both halves matter: a stamp on a saving that is linked again is answered.
   linkLost: boolean
+  // …and it was a book taking the contribution, not a term deposit the link
+  // merely identified. Decides which consequence the warning may claim.
+  linkLostFromBook: boolean
+}
+
+// Was the link already gone by the month being viewed? The plan pages back
+// through past months, and a deposit deleted in August was still linked all
+// through July — showing July the badge describes a state that month never had.
+// The stamp is an instant, so the month it belongs to is the BUSINESS month:
+// 18:00 UTC on 31 July is already August in Ho Chi Minh City.
+function lostByMonth(unlinkedAt: string | null | undefined, ym?: string): boolean {
+  if (unlinkedAt == null) return false
+  if (!ym) return true
+  const { year, month } = businessYearMonth(new Date(unlinkedAt))
+  return `${year}-${String(month).padStart(2, '0')}` <= ym
 }
 
 // Apply per-month overrides to the active recurring savings. An override of 0
 // means "skip this month"; any other positive value replaces the base amount.
+// `ym` ("YYYY-MM") is the month being viewed — omit it and a lost link is
+// reported regardless of when it was lost.
 export function resolveRecurringSavings(
   savings: RecurringSaving[],
   overrides: RecurringSavingOverride[],
+  ym?: string,
 ): ResolvedSaving[] {
   const ovMap = new Map(overrides.map(o => [o.recurring_saving_id, o.monthly_amount_override_vnd]))
   return savings.map(s => {
@@ -78,7 +102,8 @@ export function resolveRecurringSavings(
       skipped,
       overridden: hasOv && ov! > 0 && ov !== s.amount_vnd,
       linkedDepositTxId: s.linked_deposit_tx_id ?? null,
-      linkLost: s.unlinked_at != null && s.linked_deposit_tx_id == null,
+      linkLost: s.linked_deposit_tx_id == null && lostByMonth(s.unlinked_at, ym),
+      linkLostFromBook: s.unlinked_from_book === true,
     }
   })
 }
@@ -126,6 +151,8 @@ export interface GoalItem {
   linkedDepositTxId?: string | null
   // That book was deleted and this saving now feeds nothing in particular (#655).
   linkLost?: boolean
+  // …and it was a book, so the contribution really has stopped going somewhere.
+  linkLostFromBook?: boolean
 }
 
 export interface GoalRow {
@@ -251,6 +278,7 @@ export function buildByGoal(
       recorded,
       linkedDepositTxId: r.linkedDepositTxId,
       linkLost: r.linkLost,
+      linkLostFromBook: r.linkLostFromBook,
     })
   }
 

--- a/lib/planning.ts
+++ b/lib/planning.ts
@@ -30,6 +30,9 @@ export interface RecurringSaving {
   goal_id: string | null
   amount_vnd: number
   linked_deposit_tx_id?: string | null
+  // Stamped when the linked deposit was deleted out from under this saving
+  // (#655). Not the same as "unlinked": most savings never had a link.
+  unlinked_at?: string | null
   savings_goals?: { goal_name: string } | null
 }
 
@@ -48,6 +51,10 @@ export interface ResolvedSaving {
   skipped: boolean
   overridden: boolean
   linkedDepositTxId: string | null // an explicitly linked deposit/book, if any
+  // The deposit this saving fed was deleted and nothing replaced it (#655), so
+  // the monthly contribution no longer reaches the book the user aimed it at.
+  // Both halves matter: a stamp on a saving that is linked again is answered.
+  linkLost: boolean
 }
 
 // Apply per-month overrides to the active recurring savings. An override of 0
@@ -71,6 +78,7 @@ export function resolveRecurringSavings(
       skipped,
       overridden: hasOv && ov! > 0 && ov !== s.amount_vnd,
       linkedDepositTxId: s.linked_deposit_tx_id ?? null,
+      linkLost: s.unlinked_at != null && s.linked_deposit_tx_id == null,
     }
   })
 }
@@ -116,6 +124,8 @@ export interface GoalItem {
   // An accumulating book this recurring is linked to (its anchor id), if any —
   // the "Saved" pill tops up that book instead of logging a standalone deposit.
   linkedDepositTxId?: string | null
+  // That book was deleted and this saving now feeds nothing in particular (#655).
+  linkLost?: boolean
 }
 
 export interface GoalRow {
@@ -240,6 +250,7 @@ export function buildByGoal(
       overridden: r.overridden,
       recorded,
       linkedDepositTxId: r.linkedDepositTxId,
+      linkLost: r.linkLost,
     })
   }
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -393,7 +393,7 @@
     "unitsDefault": "Units",
     "deleteTitle": "Delete transaction?",
     "deleteMessage": "Are you sure you want to delete this investment transaction?",
-    "deleteUnlinksSavings": "Recurring savings pointed at this deposit will be unlinked: {names}. Their monthly contributions will record a standalone deposit instead.",
+    "deleteUnlinksSavings": "Recurring savings linked to this deposit will be unlinked: {names}. The plan will say so on their monthly lines.",
     "amountRequired": "Amount must be greater than 0.",
     "dateRequired": "Investment date is required."
   },

--- a/messages/en.json
+++ b/messages/en.json
@@ -393,6 +393,7 @@
     "unitsDefault": "Units",
     "deleteTitle": "Delete transaction?",
     "deleteMessage": "Are you sure you want to delete this investment transaction?",
+    "deleteUnlinksSavings": "Recurring savings pointed at this deposit will be unlinked: {names}. Their monthly contributions will record a standalone deposit instead.",
     "amountRequired": "Amount must be greater than 0.",
     "dateRequired": "Investment date is required."
   },

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -393,6 +393,7 @@
     "unitsDefault": "Đơn vị",
     "deleteTitle": "Xoá giao dịch?",
     "deleteMessage": "Bạn có chắc muốn xóa giao dịch đầu tư này?",
+    "deleteUnlinksSavings": "Các khoản tiết kiệm định kỳ đang nạp vào sổ này sẽ bị bỏ liên kết: {names}. Tiền hàng tháng sẽ được ghi thành khoản gửi riêng.",
     "amountRequired": "Số tiền phải lớn hơn 0.",
     "dateRequired": "Ngày đầu tư là bắt buộc."
   },

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -393,7 +393,7 @@
     "unitsDefault": "Đơn vị",
     "deleteTitle": "Xoá giao dịch?",
     "deleteMessage": "Bạn có chắc muốn xóa giao dịch đầu tư này?",
-    "deleteUnlinksSavings": "Các khoản tiết kiệm định kỳ đang nạp vào sổ này sẽ bị bỏ liên kết: {names}. Tiền hàng tháng sẽ được ghi thành khoản gửi riêng.",
+    "deleteUnlinksSavings": "Các khoản tiết kiệm định kỳ đang liên kết với sổ này sẽ bị bỏ liên kết: {names}. Kế hoạch sẽ ghi chú điều đó trên dòng hàng tháng của chúng.",
     "amountRequired": "Số tiền phải lớn hơn 0.",
     "dateRequired": "Ngày đầu tư là bắt buộc."
   },

--- a/supabase/migrations/20260812000002_mark_saving_link_lost.sql
+++ b/supabase/migrations/20260812000002_mark_saving_link_lost.sql
@@ -1,0 +1,92 @@
+-- Record when a recurring saving loses its deposit link to a deletion (#655).
+--
+-- `linked_deposit_tx_id` is ON DELETE SET NULL, so deleting the deposit a
+-- recurring saving funds unlinks the saving and says nothing anywhere. Nothing
+-- is corrupt — an unlinked saving is a legal, common shape — which is exactly
+-- why the plan can't warn about it: most unlinked savings were never linked at
+-- all. Without a record of the loss there is no honest way to tell the two
+-- apart, so the monthly line goes on looking healthy while the money it
+-- describes no longer reaches the book the user pointed it at.
+--
+-- The handover flow (#638) is where this bites hardest: opening a successor
+-- moves the saving's link onto the new book, so deleting that book is the one
+-- click that quietly stops the routing the user set up.
+--
+-- Two rules, and the second is as important as the first:
+--   • a DELETE of the linked deposit stamps `unlinked_at`;
+--   • the user clearing the link themselves does NOT — that is a decision, and
+--     nagging about a choice teaches the user to ignore the warning.
+-- Re-linking clears the stamp, which is the user answering the warning.
+--
+-- BEFORE DELETE, not AFTER: the foreign key's own SET NULL runs as an after-row
+-- action, so by AFTER DELETE the link this needs to match on is already gone.
+-- It writes `recurring_savings` while the delete targets
+-- `investment_transactions`, so it never collides with the FK's write on the row
+-- being deleted.
+--
+-- SECURITY DEFINER with an explicit user_id filter, matching
+-- `clear_recurring_link_on_hold` (20260727000003): the mark is authoritative
+-- regardless of the caller's RLS visibility, and can only ever touch the
+-- deleted row's own owner.
+
+alter table public.recurring_savings
+  add column if not exists unlinked_at timestamptz;
+
+comment on column public.recurring_savings.unlinked_at is
+  'When this saving''s linked deposit was deleted out from under it (#655). Null once the saving is linked again, or if it was never linked. Advisory only — no money depends on it.';
+
+create or replace function public.mark_saving_link_lost()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  -- Deleting the account cascades to both tables, and the saving being marked is
+  -- itself on its way out. Writing to it then re-checks its owner FK against a
+  -- `auth.users` row the cascade has already removed, which aborts the account
+  -- deletion over an advisory flag. Nobody is left to read the warning, so skip
+  -- it: the owner still existing is what makes the mark worth writing.
+  update public.recurring_savings
+     set unlinked_at = now(),
+         updated_at = now()
+   where linked_deposit_tx_id = old.transaction_id
+     and user_id = old.user_id
+     and exists (select 1 from auth.users u where u.id = old.user_id);
+  return old;
+end;
+$$;
+
+drop trigger if exists investment_transactions_mark_saving_link_lost on public.investment_transactions;
+create trigger investment_transactions_mark_saving_link_lost
+  before delete on public.investment_transactions
+  for each row
+  execute function public.mark_saving_link_lost();
+
+comment on function public.mark_saving_link_lost() is
+  'Stamps unlinked_at on any recurring saving whose linked deposit is being deleted, so the plan can say the routing stopped (#655).';
+
+-- The mark is a question the user answers by pointing the saving at another
+-- deposit. A BEFORE UPDATE on the row itself, so re-linking costs no extra write
+-- — and a link the user clears by hand leaves the stamp alone, since that path
+-- never sets a link.
+create or replace function public.clear_saving_unlinked_mark()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.unlinked_at := null;
+  return new;
+end;
+$$;
+
+drop trigger if exists recurring_savings_clear_unlinked_mark on public.recurring_savings;
+create trigger recurring_savings_clear_unlinked_mark
+  before update on public.recurring_savings
+  for each row
+  when (new.linked_deposit_tx_id is not null
+        and new.linked_deposit_tx_id is distinct from old.linked_deposit_tx_id)
+  execute function public.clear_saving_unlinked_mark();
+
+comment on function public.clear_saving_unlinked_mark() is
+  'Clears unlinked_at when a recurring saving is pointed at a deposit again (#655).';

--- a/supabase/migrations/20260812000002_mark_saving_link_lost.sql
+++ b/supabase/migrations/20260812000002_mark_saving_link_lost.sql
@@ -32,8 +32,21 @@
 alter table public.recurring_savings
   add column if not exists unlinked_at timestamptz;
 
+-- A link may target either an accumulating book's anchor — where the monthly
+-- contribution really was going into that book — or a single term deposit, where
+-- the link only tells the maturity-combine picker which saving belongs to it and
+-- the contribution was already recorded as a standalone deposit. Losing the two
+-- has different consequences, and the plan must not tell a term-deposit user
+-- that their routing changed when it never did. The kind is knowable only here,
+-- while the row being deleted still exists.
+alter table public.recurring_savings
+  add column if not exists unlinked_from_book boolean;
+
 comment on column public.recurring_savings.unlinked_at is
   'When this saving''s linked deposit was deleted out from under it (#655). Null once the saving is linked again, or if it was never linked. Advisory only — no money depends on it.';
+
+comment on column public.recurring_savings.unlinked_from_book is
+  'Whether the deposit deleted in #655 was an accumulating book anchor (the contribution was being paid into it) rather than a single term deposit. Advisory: it only decides which sentence the plan shows.';
 
 create or replace function public.mark_saving_link_lost()
 returns trigger
@@ -49,6 +62,10 @@ begin
   -- it: the owner still existing is what makes the mark worth writing.
   update public.recurring_savings
      set unlinked_at = now(),
+         -- An anchor is a book: deposit_group_id pointing at its own row. A
+         -- plain term deposit has no group at all, and the link validator
+         -- accepts nothing in between.
+         unlinked_from_book = (old.deposit_group_id is not distinct from old.transaction_id),
          updated_at = now()
    where linked_deposit_tx_id = old.transaction_id
      and user_id = old.user_id
@@ -76,6 +93,7 @@ language plpgsql
 as $$
 begin
   new.unlinked_at := null;
+  new.unlinked_from_book := null;
   return new;
 end;
 $$;

--- a/supabase/migrations/20260812000002_mark_saving_link_lost.sql
+++ b/supabase/migrations/20260812000002_mark_saving_link_lost.sql
@@ -48,6 +48,17 @@ comment on column public.recurring_savings.unlinked_at is
 comment on column public.recurring_savings.unlinked_from_book is
   'Whether the deposit deleted in #655 was an accumulating book anchor (the contribution was being paid into it) rather than a single term deposit. Advisory: it only decides which sentence the plan shows.';
 
+-- Both this trigger and the foreign key's own ON DELETE SET NULL look up
+-- recurring savings by linked_deposit_tx_id on EVERY delete from
+-- investment_transactions — including fund rows and bulk DCA cleanup that could
+-- never carry a link. Postgres does not index a referencing column for you, so
+-- until now each deleted row scanned the whole table and a bulk delete paid for
+-- that once per row. Partial, because the column is null for most savings and
+-- only the linked ones are ever searched for.
+create index if not exists recurring_savings_linked_deposit_idx
+  on public.recurring_savings (linked_deposit_tx_id)
+  where linked_deposit_tx_id is not null;
+
 create or replace function public.mark_saving_link_lost()
 returns trigger
 language plpgsql

--- a/supabase/tests/saving_link_lost_marked.test.sql
+++ b/supabase/tests/saving_link_lost_marked.test.sql
@@ -1,0 +1,117 @@
+-- Deleting a deposit must leave a mark on the recurring saving it was funding (#655).
+--
+-- `linked_deposit_tx_id` is ON DELETE SET NULL, so deleting the deposit unlinks
+-- the saving and says nothing. The plan then stops routing money into a book
+-- while still showing a green monthly line — the silence is the bug, not the
+-- unlink. `unlinked_at` records that the link was taken away rather than given
+-- up, which is the only thing that distinguishes this from the many savings that
+-- were never linked to anything.
+--
+-- Scope is exactly a deposit deletion. A user who clears the link themselves has
+-- said what they want, and must not be nagged about it.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_user     uuid;
+  v_other    uuid;
+  v_goal     uuid;
+  v_goal2    uuid;
+  v_dep      uuid;
+  v_dep2     uuid;
+  v_odep     uuid;
+  v_saving   uuid;
+  v_other_s  uuid;
+  v_osav     uuid;
+  v_link     uuid;
+  v_at       timestamptz;
+  v_at_count int;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'unlink-mark@test.invalid') returning id into v_user;
+  insert into auth.users (id, email) values (gen_random_uuid(), 'unlink-other@test.invalid') returning id into v_other;
+
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.savings_goals (user_id, goal_name) values (v_other, 'Their goal') returning goal_id into v_goal2;
+
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_dep;
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-02-01', 50000000) returning transaction_id into v_dep2;
+
+  insert into public.recurring_savings (user_id, name, goal_id, amount_vnd, linked_deposit_tx_id)
+  values (v_user, 'Monthly transfer', v_goal, 5000000, v_dep) returning saving_id into v_saving;
+  -- A sibling linked elsewhere, to prove the mark lands on the right saving only.
+  insert into public.recurring_savings (user_id, name, goal_id, amount_vnd, linked_deposit_tx_id)
+  values (v_user, 'Other transfer', v_goal, 3000000, v_dep2) returning saving_id into v_other_s;
+
+  -- Another user with the same shape: the mark must never reach across owners.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_other, v_goal2, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_odep;
+  insert into public.recurring_savings (user_id, name, goal_id, amount_vnd, linked_deposit_tx_id)
+  values (v_other, 'Theirs', v_goal2, 5000000, v_odep) returning saving_id into v_osav;
+
+  -- A saving nobody has touched carries no mark.
+  select unlinked_at into v_at from public.recurring_savings where saving_id = v_saving;
+  if v_at is not null then
+    raise exception 'a live link must carry no mark, got %', v_at;
+  end if;
+
+  -- 1) Deleting the linked deposit unlinks the saving AND records that it happened.
+  delete from public.investment_transactions where transaction_id = v_dep;
+
+  select linked_deposit_tx_id, unlinked_at into v_link, v_at
+    from public.recurring_savings where saving_id = v_saving;
+  if v_link is not null then
+    raise exception 'deleting the deposit must clear the link, still %', v_link;
+  end if;
+  if v_at is null then
+    raise exception 'deleting the deposit must stamp unlinked_at';
+  end if;
+
+  -- 2) The sibling and the other user are untouched.
+  select linked_deposit_tx_id, unlinked_at into v_link, v_at
+    from public.recurring_savings where saving_id = v_other_s;
+  if v_link is distinct from v_dep2 or v_at is not null then
+    raise exception 'an unrelated saving must be untouched, link % mark %', v_link, v_at;
+  end if;
+
+  select linked_deposit_tx_id, unlinked_at into v_link, v_at
+    from public.recurring_savings where saving_id = v_osav;
+  if v_link is distinct from v_odep or v_at is not null then
+    raise exception 'another user''s saving must be untouched, link % mark %', v_link, v_at;
+  end if;
+
+  -- 3) Re-linking answers the warning, so the mark goes.
+  update public.recurring_savings set linked_deposit_tx_id = v_dep2 where saving_id = v_saving;
+  select unlinked_at into v_at from public.recurring_savings where saving_id = v_saving;
+  if v_at is not null then
+    raise exception 're-linking must clear the mark, got %', v_at;
+  end if;
+
+  -- 4) A link the user gives up themselves is a decision, not a loss: no mark.
+  update public.recurring_savings set linked_deposit_tx_id = null where saving_id = v_saving;
+  select unlinked_at into v_at from public.recurring_savings where saving_id = v_saving;
+  if v_at is not null then
+    raise exception 'clearing the link by hand must not mark it, got %', v_at;
+  end if;
+
+  -- 5) Deleting the account must still work. Both tables cascade, so the saving
+  --    the mark would land on is on its way out too — writing to it re-checks an
+  --    owner that the same cascade has already removed, and an advisory flag must
+  --    never be the thing that blocks an account deletion.
+  update public.recurring_savings set linked_deposit_tx_id = v_dep2 where saving_id = v_saving;
+  delete from auth.users where id = v_user;
+
+  select count(*) into v_at_count from public.recurring_savings where user_id = v_user;
+  if v_at_count <> 0 then
+    raise exception 'deleting the account must take its savings with it, % left', v_at_count;
+  end if;
+
+  raise notice 'saving_link_lost_marked.test.sql: OK';
+end $$;
+
+rollback;

--- a/supabase/tests/saving_link_lost_marked.test.sql
+++ b/supabase/tests/saving_link_lost_marked.test.sql
@@ -15,6 +15,24 @@
 
 begin;
 
+-- The trigger runs on EVERY delete from investment_transactions, matching
+-- recurring savings by linked_deposit_tx_id — and so does the foreign key's own
+-- ON DELETE SET NULL, which Postgres does not index for you. Without an index
+-- both scan the whole table, once per deleted row, so a bulk delete degrades
+-- quadratically. Asserted here so a later migration cannot quietly drop it.
+do $$
+declare
+  v_idx int;
+begin
+  select count(*) into v_idx
+  from pg_indexes
+  where schemaname = 'public' and tablename = 'recurring_savings'
+    and indexdef like '%linked_deposit_tx_id%';
+  if v_idx = 0 then
+    raise exception 'recurring_savings needs an index on linked_deposit_tx_id';
+  end if;
+end $$;
+
 do $$
 declare
   v_user     uuid;

--- a/supabase/tests/saving_link_lost_marked.test.sql
+++ b/supabase/tests/saving_link_lost_marked.test.sql
@@ -28,7 +28,9 @@ declare
   v_other_s  uuid;
   v_osav     uuid;
   v_link     uuid;
+  v_book     uuid;
   v_at       timestamptz;
+  v_from_book boolean;
   v_at_count int;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'unlink-mark@test.invalid') returning id into v_user;
@@ -72,6 +74,16 @@ begin
     raise exception 'deleting the deposit must stamp unlinked_at';
   end if;
 
+  -- 1b) A plain term deposit is not a book. A link to one never routed the
+  --     monthly contribution anywhere — it only told the maturity-combine picker
+  --     which saving belonged to that deposit — so the plan must not claim the
+  --     routing changed. The kind is only knowable here, while the deleted row
+  --     still exists.
+  select unlinked_from_book into v_from_book from public.recurring_savings where saving_id = v_saving;
+  if v_from_book is not false then
+    raise exception 'a term-deposit link must not be marked as a book, got %', v_from_book;
+  end if;
+
   -- 2) The sibling and the other user are untouched.
   select linked_deposit_tx_id, unlinked_at into v_link, v_at
     from public.recurring_savings where saving_id = v_other_s;
@@ -97,6 +109,23 @@ begin
   select unlinked_at into v_at from public.recurring_savings where saving_id = v_saving;
   if v_at is not null then
     raise exception 'clearing the link by hand must not mark it, got %', v_at;
+  end if;
+
+  -- 4b) A book anchor IS the case the warning was written for: the monthly
+  --     contribution really was going into that book and now records a plain
+  --     deposit instead. Same shape as the link validator accepts — the anchor,
+  --     whose deposit_group_id is its own id.
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, interest_rate, expiry_date)
+  values (v_user, v_goal, 'bank', 'investment', '2026-03-01', 40000000, 5.5, '2027-03-01') returning transaction_id into v_book;
+  update public.investment_transactions set deposit_group_id = v_book where transaction_id = v_book;
+
+  update public.recurring_savings set linked_deposit_tx_id = v_book where saving_id = v_saving;
+  delete from public.investment_transactions where transaction_id = v_book;
+
+  select unlinked_at, unlinked_from_book into v_at, v_from_book
+    from public.recurring_savings where saving_id = v_saving;
+  if v_at is null or v_from_book is not true then
+    raise exception 'deleting a book anchor must mark the loss as a book, mark % book %', v_at, v_from_book;
   end if;
 
   -- 5) Deleting the account must still work. Both tables cascade, so the saving


### PR DESCRIPTION
Closes #655.

## The decision

The issue offered three answers and asked for one rather than a guess. This takes
**option 3 — leave it unlinked, but say so** — and the reason is worth recording:

**Option 1 (hand the link back to A) is wrong on the merits, not just awkward.** A
is the book the *bank had stopped topping up* — that is why a successor was opened
at all. Handing the recurring saving back to A points next month's contribution at
a deposit that cannot accept it. It is also the version that collided with the
foreign key's own write in the Phase 4 branch, but the product argument settles it
first.

**Option 2 (refuse the delete)** only moves the problem: after cancelling the
handover, deleting B still nulls the link, in silence.

So the link stays cleared. What changes is that the loss stops being silent.

## What the user sees

**Before the delete** — the ledger's confirm dialog names the recurring savings
that would lose their link, so the choice is made knowing. The lookup is advisory:
if it fails, the delete still goes ahead. A missing sentence must not become a dead
button.

**After it** — the plan's goal line carries a warning badge, on both the desktop
table and the mobile card stack, with a tooltip saying what happens now (the
monthly contribution records a standalone deposit) and how to fix it (edit the
recurring plan, point it at another book).

## Why this needed a column

Most unlinked savings were never linked to anything — an unlinked saving is a
normal, working shape. Keying the badge on the absent link would therefore nag
every user about every ordinary saving, and a warning everyone learns to ignore is
worse than none. `recurring_savings.unlinked_at` records that the link was *taken
away* rather than *given up*, which is the only thing separating the two:

- a DELETE of the linked deposit stamps it;
- the user clearing the link by hand does not — that is a decision;
- re-linking clears it — that is the user answering the warning.

## Two details worth a reviewer's eye

**BEFORE DELETE, not AFTER.** The foreign key's `ON DELETE SET NULL` runs as an
after-row action, so by AFTER DELETE the link the trigger matches on is already
gone. It writes `recurring_savings` while the delete targets
`investment_transactions`, so it never collides with the FK's write on the row
being deleted — the DB test proves the pair coexists.

**Account deletion.** The first version broke it: deleting a user cascades to both
tables, so the saving being marked was itself on its way out, and writing to it
re-checked its owner FK against an `auth.users` row the same cascade had already
removed. An advisory flag must never be the thing that aborts an account deletion,
so the trigger skips a saving whose owner is going away. The DB suite caught this
(`merge_successor_book.test.sql`), and the case is now pinned in the new test.

## Checks

`typecheck`, 2350 unit tests, `lint`, `build`, coverage, the full `test:db` suite
(31 files), the smoke lane, and `e2e/planning.spec.ts` all pass locally.

One note on the smoke lane: `maturity-combine-merge.spec.ts` failed on the first
run (a 20s wait for `maturity-renewed`) and passed on a re-run of the same lane and
in isolation. The same spec failed the same way in the #654 session, before any of
this existed, and passed on CI. I have not reproduced it deliberately, so I am
reporting it rather than classifying it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
