### PR TITLE
test(e2e): cover the successor-book journey end to end (#638)

### DIFF
--- a/e2e/successor-book-journey.spec.ts
+++ b/e2e/successor-book-journey.spec.ts
@@ -1,0 +1,210 @@
+import { test, expect } from '@playwright/test'
+import * as api from './helpers/api'
+import { makeCleanupStack } from './helpers/cleanup'
+
+// The one E2E #638 asks for: the whole successor-book journey, end to end.
+//
+// Every rule inside this flow is already pinned lower down — the lock-window
+// boundaries in lib/__tests__/accumulatingTopUp.test.ts, the atomic handover in
+// supabase/tests/successor_book.test.sql, the merge's conservation and lineage in
+// merge_successor_book.test.sql, the refusals in the route tests. None of that is
+// repeated here.
+//
+// What only a browser can show is the seam between them: the plan's "Saved" pill
+// discovering the lock through a live deposit read, the handover moving the
+// recurring link while the month is filed, and the dashboard totalling the result
+// afterwards. The Phase 4 double-count bug lived in exactly that seam — a name-only
+// lookup fed into the holdings input, so a dissolved source counted twice — and it
+// was found by hand, not by a test.
+//
+// Deliberately NOT tagged @smoke: this is a five-round-trip journey and the smoke
+// lane has a three-minute budget for the whole suite.
+
+test.use({ viewport: { width: 1280, height: 800 } })
+
+const cleanup = makeCleanupStack()
+test.afterEach(() => cleanup.run())
+
+const iso = (d: number) => new Date(Date.now() + d * 86_400_000).toISOString().slice(0, 10)
+
+const today = new Date()
+const MONTH = today.getMonth() + 1
+const YEAR = today.getFullYear()
+
+const BOOK_PRINCIPAL = 50_000_000
+const MONTHLY = 2_000_000
+
+test('a locked book hands over to a successor, which absorbs it at maturity', async ({ page }) => {
+  test.slow()
+
+  const stamp = Date.now()
+  const goal = await api.createGoal({ goal_name: `E2E Successor Goal ${stamp}`, target_amount: 200_000_000 })
+  cleanup.add(() => api.deleteGoal(goal.goal_id))
+
+  // Book A: live, but inside a 30-day lock window — the bank stopped taking
+  // top-ups 20 days before maturity, which is the situation #638 exists for.
+  const bookA = await (await page.request.post('/api/v1/investment-transactions', {
+    data: {
+      asset_type: 'bank', accumulating: true, goal_id: goal.goal_id,
+      notes: `E2E Successor Source ${stamp}`,
+      amount_vnd: BOOK_PRINCIPAL, interest_rate: 3.0,
+      investment_date: iso(-150), expiry_date: iso(20), top_up_lock_days: 30,
+    },
+  })).json()
+  expect(bookA.deposit_group_id).toBe(bookA.transaction_id)
+  cleanup.add(() => api.deleteBookCascade(bookA.transaction_id))
+
+  // The monthly contribution the bank will refuse, aimed at A.
+  const saving = await api.createRecurringSaving({
+    name: `E2E Successor Saving ${stamp}`, goal_id: goal.goal_id, amount_vnd: MONTHLY,
+    linked_deposit_tx_id: bookA.transaction_id,
+  })
+  cleanup.add(() => api.deleteRecurringFulfillments(saving.saving_id))
+  cleanup.add(() => api.deleteRecurringSaving(saving.saving_id))
+
+  const plan = await api.createMonthlyPlan({ month: MONTH, year: YEAR, salary_vnd: 30_000_000 })
+  cleanup.add(() => api.deleteMonthlyPlan(plan.id))
+
+  // ── 1. The plan discovers the lock and offers the successor ────────────────
+  await page.goto('/planning')
+  await page.waitForLoadState('networkidle')
+  const desktop = page.getByTestId('desktop-planning')
+  const line = desktop.getByTestId(`plan-recurring-${saving.saving_id}`)
+  await expect(line).toBeVisible({ timeout: 10_000 })
+
+  // "Saved" reads the linked book before deciding what to open. A is inside its
+  // lock window, so the answer is a new book rather than a top-up sheet.
+  await line.getByRole('button', { name: /Record deposit|Ghi nhận đã gửi/i }).click()
+  const sheet = page.getByTestId('successor-modal')
+  await expect(sheet).toBeVisible({ timeout: 10_000 })
+
+  // Prefilled with the month the plan already knows about, and with A's own lock
+  // window — the new book is the same product.
+  await expect(sheet.getByTestId('successor-amount')).toHaveValue('2.000.000')
+  await expect(sheet.getByTestId('successor-lock')).toHaveValue('30')
+
+  // The bank's terms for a NEW deposit are the user's to supply.
+  await sheet.getByTestId('successor-expiry').fill(iso(180))
+  await sheet.getByTestId('successor-rate').fill('4,2')
+
+  const [openRes] = await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/successor') && r.request().method() === 'POST', { timeout: 20_000 }),
+    sheet.getByTestId('successor-submit').click(),
+  ])
+  expect(openRes.status()).toBe(201)
+  const bookB = await openRes.json()
+  cleanup.add(() => api.deleteBookCascade(bookB.transaction_id))
+
+  // ── 2. The month landed in B, and the plan says so ─────────────────────────
+  await expect(line).toHaveAttribute('data-recorded', 'true', { timeout: 15_000 })
+  expect(bookB.deposit_group_id).toBe(bookB.transaction_id)
+  expect(bookB.amount_vnd).toBe(MONTHLY)
+
+  // ── 3. The recurring link followed the money ───────────────────────────────
+  const linked = await api.getRecurringSaving(saving.saving_id)
+  expect(linked!.linked_deposit_tx_id).toBe(bookB.transaction_id)
+
+  // ── 4. A matures, and goal detail offers the merge it was promised ─────────
+  const matured = await page.request.put(`/api/v1/investment-transactions/${bookA.transaction_id}`, {
+    data: { expiry_date: iso(-2) },
+  })
+  expect(matured.ok()).toBeTruthy()
+
+  // Read the totals from the overview route directly rather than off the wire:
+  // a response body captured during a navigation is gone by the time the page
+  // settles. Same route the panel renders from, and uncached.
+  const before = await (await page.request.get('/api/v1/dashboard/overview')).json()
+  const goalBefore = before.goals.find((g: { goalId: string }) => g.goalId === goal.goal_id)
+  expect(goalBefore).toBeTruthy()
+
+  await page.goto('/settings')
+  await page.evaluate(() => {
+    Object.keys(localStorage).filter((k) => k.startsWith('dashboardOverviewCache')).forEach((k) => localStorage.removeItem(k))
+  })
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/v1/dashboard/overview') && r.status() === 200, { timeout: 20_000 }),
+    page.goto('/dashboard'),
+  ])
+
+  // The merge is offered from goal detail, which is the only surface that knows
+  // a book was promised: the dashboard's needs-attention card builds its rows
+  // without `successorDepositTxId`, so the same book opens the ordinary renewal
+  // there. Filed separately — this test takes the path that works.
+  await page.getByText(`E2E Successor Goal ${stamp}`).first().click()
+  const panel = page.getByTestId('desktop-goal-detail')
+  await expect(panel).toBeVisible({ timeout: 10_000 })
+
+  // Both books sit in this goal, so scope to the row that carries the source's
+  // name AND its own Options button — the innermost such div is the row itself.
+  const rowA = panel.locator('div')
+    .filter({ hasText: `E2E Successor Source ${stamp}` })
+    .filter({ has: page.getByRole('button', { name: 'Options', exact: true }) })
+    .last()
+  await rowA.getByRole('button', { name: 'Options', exact: true }).click()
+  await page.getByRole('button', { name: /Handle maturity|Xử lý đáo hạn/i }).first().click()
+
+  // The maturity sheet leads with the promise rather than the ordinary renewal.
+  const mergePanel = page.getByTestId('merge-successor-panel')
+  await expect(mergePanel).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByTestId('merge-not-due')).toHaveCount(0)
+
+  // Take the prefilled payout as-is: it is the same value the dashboard is
+  // currently carrying for A, which is what makes step 6 an exact statement
+  // rather than an approximate one.
+  const received = Number((await mergePanel.getByTestId('merge-received').inputValue()).replace(/\D/g, ''))
+  expect(received).toBeGreaterThan(BOOK_PRINCIPAL) // principal + interest, not bare principal
+
+  const [mergeRes] = await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/merge-successor') && r.request().method() === 'POST', { timeout: 20_000 }),
+    mergePanel.getByTestId('merge-successor-submit').click(),
+  ])
+  expect(mergeRes.status()).toBe(201) // a tranche was created in B
+
+  // ── 5. The ledger: A closed, B holding exactly what arrived ────────────────
+  const all = await (await page.request.get('/api/v1/investment-transactions?include_history=true&limit=1000')).json()
+  const rows = all.transactions as Array<{
+    transaction_id: string; deposit_group_id: string | null; transaction_type: string
+    amount_vnd: number; principal_withdrawn: number | null; consumed_by_inv_id: string | null
+    renewed_from_transaction_id: string | null
+  }>
+
+  const sourceTranches = rows.filter((r) => r.deposit_group_id === bookA.transaction_id && r.transaction_type === 'investment' && !r.renewed_from_transaction_id)
+  const leftInA = sourceTranches.reduce((s, t) => {
+    const drawn = rows
+      .filter((w) => w.transaction_type === 'withdrawal' && (w as { parent_transaction_id?: string }).parent_transaction_id === t.transaction_id)
+      .reduce((x, w) => x + (w.principal_withdrawn ?? 0), 0)
+    return s + (t.amount_vnd - drawn)
+  }, 0)
+  expect(leftInA).toBe(0)
+
+  const inB = rows.filter((r) => r.deposit_group_id === bookB.transaction_id && r.transaction_type === 'investment' && !r.renewed_from_transaction_id)
+  expect(inB).toHaveLength(2) // B's own opening tranche + the one the merge added
+  expect(inB.reduce((s, t) => s + t.amount_vnd, 0)).toBe(MONTHLY + received)
+
+  // ── 6. The dashboard: the money moved, it did not multiply or vanish ───────
+  const after = await (await page.request.get('/api/v1/dashboard/overview')).json()
+  const goalAfter = after.goals.find((g: { goalId: string }) => g.goalId === goal.goal_id)
+
+  // A double-count would add a whole book (+50M); a disappearance would drop one.
+  // The tolerance covers only the projection being recomputed either side of the
+  // merge — the source's own accrual was folded into `received`, but the two
+  // numbers come from different code paths (the merge preview and the overview
+  // valuation), so they are allowed to disagree by rounding, not by a holding.
+  const slack = BOOK_PRINCIPAL * 0.01
+  expect(Math.abs(goalAfter.currentValue - goalBefore.currentValue)).toBeLessThan(slack)
+  expect(Math.abs(after.netWorth.totalAssets - before.netWorth.totalAssets)).toBeLessThan(slack)
+
+  // And the source is gone from the goal's live holdings rather than lingering
+  // beside the book that now holds its cash.
+  await page.goto('/settings')
+  await page.evaluate(() => {
+    Object.keys(localStorage).filter((k) => k.startsWith('dashboardOverviewCache')).forEach((k) => localStorage.removeItem(k))
+  })
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes('/api/v1/dashboard/overview') && r.status() === 200, { timeout: 20_000 }),
+    page.goto('/dashboard'),
+  ])
+  await page.getByText(`E2E Successor Goal ${stamp}`).first().click()
+  await expect(panel).toBeVisible({ timeout: 10_000 })
+  await expect(panel.getByText(`E2E Successor Source ${stamp}`)).toHaveCount(0)
+})

--- a/e2e/successor-book-journey.spec.ts
+++ b/e2e/successor-book-journey.spec.ts
@@ -52,7 +52,27 @@ test('a locked book hands over to a successor, which absorbs it at maturity', as
     },
   })).json()
   expect(bookA.deposit_group_id).toBe(bookA.transaction_id)
-  // Teardown for the merged pair is registered together, after the handover — see there.
+
+  // Registered HERE, not after the handover: everything between this line and the
+  // successor POST can fail — and the run that matters most, a genuine regression
+  // in the handover, is exactly the one that would leave the source book behind.
+  // A deleted goal does not take it with it (the goal FK is ON DELETE SET NULL),
+  // so it would drift into Unallocated and into every later spec's view of the
+  // dashboard, including this test's own CI retry.
+  //
+  // One cleanup for the pair, because a merged pair cannot be torn down a book at
+  // a time: B's credited tranche is referenced by A's closing withdrawal through
+  // `consumed_by_inv_id`, and `move_merge_lineage_to_book` refuses to delete it
+  // while that reference stands — deliberately, so an ordinary delete cannot walk
+  // off with the successor's payout. `deleteBookCascade` swallows that error, so
+  // the order is load-bearing: A's cascade removes the withdrawals, and with them
+  // the reference that was blocking B. `bookB` is read at teardown time, so this
+  // covers both the early failures and the completed journey.
+  let bookB: { transaction_id: string; deposit_group_id: string; amount_vnd: number } | null = null
+  cleanup.add(async () => {
+    await api.deleteBookCascade(bookA.transaction_id)
+    if (bookB) await api.deleteBookCascade(bookB.transaction_id)
+  })
 
   // The monthly contribution the bank will refuse, aimed at A.
   const saving = await api.createRecurringSaving({
@@ -92,31 +112,16 @@ test('a locked book hands over to a successor, which absorbs it at maturity', as
     sheet.getByTestId('successor-submit').click(),
   ])
   expect(openRes.status()).toBe(201)
-  const bookB = await openRes.json()
-
-  // A merged pair cannot be torn down one book at a time. B's credited tranche is
-  // referenced by A's closing withdrawal through `consumed_by_inv_id`, and
-  // `move_merge_lineage_to_book` refuses to delete it while that reference stands
-  // — deliberately, so an ordinary delete cannot take the successor's payout with
-  // it. `deleteBookCascade` swallows the resulting error, so the whole merged
-  // fixture would survive into the rest of the run.
-  //
-  // Registered last so the stack runs it FIRST, and it does both books in one
-  // order: A's cascade removes the withdrawals (children by parent) and with them
-  // the reference, which is what lets B's tranche go.
-  cleanup.add(async () => {
-    await api.deleteBookCascade(bookA.transaction_id)
-    await api.deleteBookCascade(bookB.transaction_id)
-  })
+  bookB = await openRes.json()
 
   // ── 2. The month landed in B, and the plan says so ─────────────────────────
   await expect(line).toHaveAttribute('data-recorded', 'true', { timeout: 15_000 })
-  expect(bookB.deposit_group_id).toBe(bookB.transaction_id)
-  expect(bookB.amount_vnd).toBe(MONTHLY)
+  expect(bookB!.deposit_group_id).toBe(bookB!.transaction_id)
+  expect(bookB!.amount_vnd).toBe(MONTHLY)
 
   // ── 3. The recurring link followed the money ───────────────────────────────
   const linked = await api.getRecurringSaving(saving.saving_id)
-  expect(linked!.linked_deposit_tx_id).toBe(bookB.transaction_id)
+  expect(linked!.linked_deposit_tx_id).toBe(bookB!.transaction_id)
 
   // ── 4. A matures, and goal detail offers the merge it was promised ─────────
   const matured = await page.request.put(`/api/v1/investment-transactions/${bookA.transaction_id}`, {
@@ -197,7 +202,7 @@ test('a locked book hands over to a successor, which absorbs it at maturity', as
   expect(anchorA!.amount_vnd - drawnFromA).toBe(0)
   expect(drawnFromA).toBe(BOOK_PRINCIPAL)
 
-  const inB = rows.filter((r) => r.deposit_group_id === bookB.transaction_id && r.transaction_type === 'investment' && !r.renewed_from_transaction_id)
+  const inB = rows.filter((r) => r.deposit_group_id === bookB!.transaction_id && r.transaction_type === 'investment' && !r.renewed_from_transaction_id)
   expect(inB).toHaveLength(2) // B's own opening tranche + the one the merge added
   expect(inB.reduce((s, t) => s + t.amount_vnd, 0)).toBe(MONTHLY + received)
 

--- a/e2e/successor-book-journey.spec.ts
+++ b/e2e/successor-book-journey.spec.ts
@@ -52,7 +52,7 @@ test('a locked book hands over to a successor, which absorbs it at maturity', as
     },
   })).json()
   expect(bookA.deposit_group_id).toBe(bookA.transaction_id)
-  cleanup.add(() => api.deleteBookCascade(bookA.transaction_id))
+  // Teardown for the merged pair is registered together, after the handover — see there.
 
   // The monthly contribution the bank will refuse, aimed at A.
   const saving = await api.createRecurringSaving({
@@ -93,7 +93,21 @@ test('a locked book hands over to a successor, which absorbs it at maturity', as
   ])
   expect(openRes.status()).toBe(201)
   const bookB = await openRes.json()
-  cleanup.add(() => api.deleteBookCascade(bookB.transaction_id))
+
+  // A merged pair cannot be torn down one book at a time. B's credited tranche is
+  // referenced by A's closing withdrawal through `consumed_by_inv_id`, and
+  // `move_merge_lineage_to_book` refuses to delete it while that reference stands
+  // — deliberately, so an ordinary delete cannot take the successor's payout with
+  // it. `deleteBookCascade` swallows the resulting error, so the whole merged
+  // fixture would survive into the rest of the run.
+  //
+  // Registered last so the stack runs it FIRST, and it does both books in one
+  // order: A's cascade removes the withdrawals (children by parent) and with them
+  // the reference, which is what lets B's tranche go.
+  cleanup.add(async () => {
+    await api.deleteBookCascade(bookA.transaction_id)
+    await api.deleteBookCascade(bookB.transaction_id)
+  })
 
   // ── 2. The month landed in B, and the plan says so ─────────────────────────
   await expect(line).toHaveAttribute('data-recorded', 'true', { timeout: 15_000 })
@@ -134,10 +148,14 @@ test('a locked book hands over to a successor, which absorbs it at maturity', as
   const panel = page.getByTestId('desktop-goal-detail')
   await expect(panel).toBeVisible({ timeout: 10_000 })
 
-  // Both books sit in this goal, so scope to the row that carries the source's
-  // name AND its own Options button — the innermost such div is the row itself.
+  // Both books are in this goal and they share a NAME: open_successor_book copies
+  // the source's notes when the caller supplies none, and the sheet supplies
+  // none. So the rows are told apart by their amounts, which this test chose to
+  // be an order of magnitude apart (50M source, 2M successor).
+  const options = panel.getByRole('button', { name: 'Options', exact: true })
+  await expect(options).toHaveCount(2)
   const rowA = panel.locator('div')
-    .filter({ hasText: `E2E Successor Source ${stamp}` })
+    .filter({ hasText: /5\d[.,]\dM/ })
     .filter({ has: page.getByRole('button', { name: 'Options', exact: true }) })
     .last()
   await rowA.getByRole('button', { name: 'Options', exact: true }).click()
@@ -168,14 +186,16 @@ test('a locked book hands over to a successor, which absorbs it at maturity', as
     renewed_from_transaction_id: string | null
   }>
 
-  const sourceTranches = rows.filter((r) => r.deposit_group_id === bookA.transaction_id && r.transaction_type === 'investment' && !r.renewed_from_transaction_id)
-  const leftInA = sourceTranches.reduce((s, t) => {
-    const drawn = rows
-      .filter((w) => w.transaction_type === 'withdrawal' && (w as { parent_transaction_id?: string }).parent_transaction_id === t.transaction_id)
-      .reduce((x, w) => x + (w.principal_withdrawn ?? 0), 0)
-    return s + (t.amount_vnd - drawn)
-  }, 0)
-  expect(leftInA).toBe(0)
+  // By id, not by group: the merge DISSOLVES the source book, so a filter on
+  // `deposit_group_id === bookA` matches nothing afterwards and would report a
+  // closed book whether or not the merge did anything at all.
+  const anchorA = rows.find((r) => r.transaction_id === bookA.transaction_id)
+  expect(anchorA).toBeTruthy()
+  const drawnFromA = rows
+    .filter((w) => w.transaction_type === 'withdrawal' && (w as { parent_transaction_id?: string }).parent_transaction_id === bookA.transaction_id)
+    .reduce((x, w) => x + (w.principal_withdrawn ?? 0), 0)
+  expect(anchorA!.amount_vnd - drawnFromA).toBe(0)
+  expect(drawnFromA).toBe(BOOK_PRINCIPAL)
 
   const inB = rows.filter((r) => r.deposit_group_id === bookB.transaction_id && r.transaction_type === 'investment' && !r.renewed_from_transaction_id)
   expect(inB).toHaveLength(2) // B's own opening tranche + the one the merge added
@@ -195,7 +215,10 @@ test('a locked book hands over to a successor, which absorbs it at maturity', as
   expect(Math.abs(after.netWorth.totalAssets - before.netWorth.totalAssets)).toBeLessThan(slack)
 
   // And the source is gone from the goal's live holdings rather than lingering
-  // beside the book that now holds its cash.
+  // beside the book that now holds its cash. Counted, not named: the successor
+  // inherited the source's notes, so "the label disappeared" would be false even
+  // on a perfect merge — and it would pass anyway on an empty panel that had not
+  // finished loading.
   await page.goto('/settings')
   await page.evaluate(() => {
     Object.keys(localStorage).filter((k) => k.startsWith('dashboardOverviewCache')).forEach((k) => localStorage.removeItem(k))
@@ -206,5 +229,10 @@ test('a locked book hands over to a successor, which absorbs it at maturity', as
   ])
   await page.getByText(`E2E Successor Goal ${stamp}`).first().click()
   await expect(panel).toBeVisible({ timeout: 10_000 })
-  await expect(panel.getByText(`E2E Successor Source ${stamp}`)).toHaveCount(0)
+  await expect(panel.getByRole('button', { name: 'Options', exact: true })).toHaveCount(1)
+
+  // The one left is the book that absorbed the other: its top-up history carries
+  // the provenance line Phase 4 added, which only a merged tranche renders.
+  await panel.getByRole('button', { name: 'Options', exact: true }).click()
+  await expect(page.getByTestId('tranche-merged-from')).toBeVisible({ timeout: 10_000 })
 })

--- a/e2e/zz-successor-book-journey.spec.ts
+++ b/e2e/zz-successor-book-journey.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test'
 import * as api from './helpers/api'
 import { makeCleanupStack } from './helpers/cleanup'
+import { addDaysIso, businessYearMonth, todayIso } from '../lib/dates'
 
 // The one E2E #638 asks for: the whole successor-book journey, end to end.
 //
@@ -30,11 +31,15 @@ test.use({ viewport: { width: 1280, height: 800 } })
 const cleanup = makeCleanupStack()
 test.afterEach(() => cleanup.run())
 
-const iso = (d: number) => new Date(Date.now() + d * 86_400_000).toISOString().slice(0, 10)
+// The app has one calendar — Asia/Ho_Chi_Minh — and the plan page opens the
+// business month, so the fixture has to be filed under the same one. Derived from
+// the runtime's local month, a run between 17:00 UTC and midnight on the last UTC
+// day of a month would seed the plan into the month the page has already left,
+// and the recurring line would simply never appear. Same reason the offsets count
+// days from the business date rather than from a UTC instant (#591).
+const iso = (d: number) => addDaysIso(todayIso(), d)
 
-const today = new Date()
-const MONTH = today.getMonth() + 1
-const YEAR = today.getFullYear()
+const { month: MONTH, year: YEAR } = businessYearMonth()
 
 const BOOK_PRINCIPAL = 50_000_000
 const MONTHLY = 2_000_000

--- a/e2e/zz-successor-book-journey.spec.ts
+++ b/e2e/zz-successor-book-journey.spec.ts
@@ -19,6 +19,11 @@ import { makeCleanupStack } from './helpers/cleanup'
 //
 // Deliberately NOT tagged @smoke: this is a five-round-trip journey and the smoke
 // lane has a three-minute budget for the whole suite.
+//
+// The `zz-` prefix is load-bearing, not cosmetic. A completed merge cannot be
+// taken apart again — the database refuses it from both sides, by design — so
+// this spec leaves a book behind that only the run-level teardown can remove.
+// Sorting last means it does that after every other spec has already run.
 
 test.use({ viewport: { width: 1280, height: 800 } })
 
@@ -58,16 +63,22 @@ test('a locked book hands over to a successor, which absorbs it at maturity', as
   // in the handover, is exactly the one that would leave the source book behind.
   // A deleted goal does not take it with it (the goal FK is ON DELETE SET NULL),
   // so it would drift into Unallocated and into every later spec's view of the
-  // dashboard, including this test's own CI retry.
+  // dashboard, including this test's own CI retry. Measured: with a forced failure
+  // here, this teardown leaves nothing but the fixture the global setup creates.
   //
-  // One cleanup for the pair, because a merged pair cannot be torn down a book at
-  // a time: B's credited tranche is referenced by A's closing withdrawal through
-  // `consumed_by_inv_id`, and `move_merge_lineage_to_book` refuses to delete it
-  // while that reference stands — deliberately, so an ordinary delete cannot walk
-  // off with the successor's payout. `deleteBookCascade` swallows that error, so
-  // the order is load-bearing: A's cascade removes the withdrawals, and with them
-  // the reference that was blocking B. `bookB` is read at teardown time, so this
-  // covers both the early failures and the completed journey.
+  // A COMPLETED merge is a different matter, and this cleanup cannot undo one.
+  // The database refuses to unpick a merge row by row, in both directions and on
+  // purpose: `guard_merged_source_withdrawal_deleted` refuses to delete the
+  // source's closing withdrawal while it carries `consumed_by_inv_id`, and
+  // `move_merge_lineage_to_book` refuses to delete the tranche that withdrawal
+  // points at. There is no order out of that, and no supported route either —
+  // the only mechanism the guards permit is deleting the account, which both of
+  // them early-return for, and which the global teardown does at the end of every
+  // run. `deleteBookCascade` swallows the refusals, so this stays best-effort.
+  //
+  // That is why the file is named to sort LAST: the fixture it cannot remove then
+  // exists only after every other spec has finished, instead of sitting in the
+  // shared user's dashboard for the rest of the run.
   let bookB: { transaction_id: string; deposit_group_id: string; amount_vnd: number } | null = null
   cleanup.add(async () => {
     await api.deleteBookCascade(bookA.transaction_id)


### PR DESCRIPTION
Closes the last unchecked item on #638's test plan: one E2E for the whole successor-book journey.

## What it covers, and what it deliberately does not

Everything *inside* this flow is already pinned at a lower layer — the lock-window boundaries in `lib/__tests__/accumulatingTopUp.test.ts`, the atomic handover in `successor_book.test.sql`, the merge's conservation and lineage in `merge_successor_book.test.sql`, the refusals in the route tests. None of that is repeated.

What only a browser can show is the **seam** between them:

1. the plan's "Saved" pill reads the linked book live and discovers it is inside its lock window, so it opens the successor sheet instead of a top-up;
2. the handover files the month, moves `linked_deposit_tx_id` onto B, and marks the plan line recorded;
3. the matured source offers the merge it was promised, from goal detail;
4. the ledger closes A to zero and B holds exactly what arrived;
5. the dashboard totals are unchanged.

That seam is where this feature's one escaped bug lived: the Phase 4 double-count was a name-only lookup fed into the holdings input, so a dissolved source counted twice. It was found by hand, not by a test.

## The conservation assertion

It takes the merge form's **prefilled** payout rather than typing a number. That prefill is the same value the dashboard is currently carrying for the source, so after the merge the totals should not move at all — "the money moved without multiplying or vanishing" becomes a statement about one number instead of an approximation. The tolerance is 1% of the book's principal, which covers the projection being recomputed by two different code paths (the merge preview and the overview valuation) but is nowhere near a whole holding: a double count would be +100%, a disappearance −100%.

Not tagged `@smoke`: five round trips against a lane budgeted at three minutes.

## Two things found while writing it

**Filed, not fixed here** — the merge is only reachable from goal detail. The dashboard's needs-attention card builds its rows without `successorDepositTxId`, so the same matured book opens the *ordinary renewal* there, which the database then refuses (a promised book cannot be collapsed). The test takes the path that works and says so in a comment.

**Not mine** — the full suite ends 238 passed / 1 failed on `recent-activity.spec.ts` ("seeded investment shows as a positive row"). That file runs at position 204, before this spec at 220, so nothing here can have caused it; it passes when run alone. The card shows a top-N slice and that assertion depends on how many same-day rows earlier specs have left behind — the test's own comment records an earlier round of the same fragility. Reported separately.

## Checks

`npm run typecheck`, `npm run lint`, the new spec alone, and two full `npm run test:e2e` runs (6.8 min each) — the second re-run confirmed both the pass and the unrelated failure's position in the order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
