### PR TITLE
fix(maturity): dòng gộp sổ chỉ đếm sổ đang hiện trên card (#651)

### DIFF
--- a/e2e/maturity-combine-cluster.spec.ts
+++ b/e2e/maturity-combine-cluster.spec.ts
@@ -68,11 +68,16 @@ test.describe('Maturity card — merge-cluster auto-detection', () => {
 
       // Complete the merge and assert the sibling left the goal's holdings (folded
       // in, not duplicated).
-      await Promise.all([
-        page.waitForRequest((r) => r.url().endsWith(`/${D.transaction_id}/renew`) && r.method() === 'POST'),
+      const [res] = await Promise.all([
+        page.waitForResponse((r) => r.url().endsWith(`/${D.transaction_id}/renew`) && r.request().method() === 'POST'),
         page.getByRole('button', { name: /Save new deposit|Lưu sổ mới/i }).click(),
       ])
-      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+      expect(res.ok()).toBeTruthy()
+      // NOT the `maturity-renewed` flash: it shows for SUCCESS_FLASH_MS and then the
+      // sheet closes itself, so racing it made this test fail ~1 run in 3 (on main
+      // too). The durable outcomes — the sheet closing, and the sibling leaving the
+      // goal's holdings — are what the merge actually promises.
+      await expect(page.getByRole('button', { name: /Save new deposit|Lưu sổ mới/i })).toBeHidden({ timeout: 20_000 })
 
       await gotoFreshDashboard(page)
       const after = await goalHoldingIds(page, goal.goal_id)
@@ -84,22 +89,19 @@ test.describe('Maturity card — merge-cluster auto-detection', () => {
     }
   })
 
-  test('surfaces the banner even when the close sibling is not itself due yet', async ({ page }) => {
+  test('shows no banner when the close sibling is not itself due yet (#651)', async ({ page }) => {
     test.slow()
     const goal = await api.createGoal({ goal_name: 'E2E NotDue Goal', target_amount: 200_000_000 })
-    // Two windows are in play and they are both 7 days, which is what the original
-    // fixture missed:
+    // Two windows are in play and they are both 7 days:
     //   • actionable  — MATURITY_REMINDER_DAYS from TODAY (lib/maturity.ts)
     //   • merge window — 7 days between the sibling's and the ANCHOR's maturity
-    // The original dates (D at -1, B at +4) made B 4 days out, i.e. inside the reminder
-    // window, so B was actionable too and the Handle count was always 2 — this test could
-    // never have passed. A matured anchor makes the case impossible: any sibling within 7
-    // days of it is also within 7 days of today. So the anchor is actionable-but-not-yet-
-    // matured instead, which pushes the sibling past the reminder window while keeping it
-    // inside the merge window.
+    // A matured anchor can't separate them (any sibling within 7 days of it is also
+    // within 7 days of today), so the anchor is actionable-but-not-yet-matured, which
+    // pushes the sibling past the reminder window while keeping it inside the merge one.
     //
-    // D at +6: actionable ('maturing'), the only Handle row → the anchor.
-    // B at +12: 12 > 7 so NOT actionable on its own, yet 6 days from D → cluster sibling.
+    // D at +6: actionable ('maturing'), the only Handle row.
+    // B at +12: 12 > 7 so NOT actionable — the card never lists it, so it must not be
+    // counted in a banner either (#651); it stays mergeable from inside the sheet.
     const D = await api.createTransaction({
       asset_type: 'bank', amount_vnd: 20_000_000, investment_date: iso(-380),
       interest_rate: 6, expiry_date: iso(6), goal_id: goal.goal_id, notes: 'E2E NotDue D',
@@ -114,13 +116,12 @@ test.describe('Maturity card — merge-cluster auto-detection', () => {
       await expect(card).toBeVisible({ timeout: 10_000 })
       // Only D is actionable → the card lists a single Handle row…
       await expect(page.getByTestId('maturity-action-count')).toHaveText('1')
-      // …yet the banner advertises the 2-deposit cluster anchored on D.
-      const banner = page.getByTestId(`merge-cluster-banner-${D.transaction_id}`)
-      await expect(banner).toBeVisible()
-      await expect(banner).toContainText('2')
+      // …and with nothing else on the card, no banner may claim a 2-deposit cluster.
+      await expect(page.getByTestId(`merge-cluster-banner-${D.transaction_id}`)).toHaveCount(0)
 
-      // Opening it preselects B even though B isn't due on its own.
-      await banner.getByRole('button').click()
+      // B is still foldable in from inside the sheet — the banner is what's gone,
+      // not the merge itself: handle D and B is preselected as a source.
+      await card.getByRole('button', { name: /Handle|Xử lý/i }).click()
       await page.getByRole('button', { name: /Settle & re-deposit|Tất toán & gửi lại/i }).click()
       await expect(page.getByTestId(`merge-received-${B.transaction_id}`)).toBeVisible()
     } finally {

--- a/features/dashboard/__tests__/dashboardModel.test.ts
+++ b/features/dashboard/__tests__/dashboardModel.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { addDaysIso, todayIso } from '@/lib/dates'
 import type { DashboardData, GoalData, NonFundUnallocatedItem, FundBreakdownItem } from '../contracts'
 import {
   isDashboardEmpty,
@@ -185,6 +186,20 @@ describe('mergeClusterSummaries', () => {
     const clusters = mergeClusterSummaries(tagNonFunds(d))
     expect(clusters.length).toBeGreaterThan(0)
     expect(clusters[0].size).toBeGreaterThanOrEqual(2)
+  })
+
+  it('reports nothing when only ONE deposit is on the card (#651)', () => {
+    // The card lists the due deposit alone; the other one matures well outside
+    // the reminder window, so a "2 sổ đáo hạn sát nhau" banner would be a promise
+    // the user cannot see the other half of.
+    const soon = addDaysIso(todayIso(), 3) // inside the reminder window → on the card
+    const later = addDaysIso(todayIso(), 9) // outside it, but 6 days from `soon`
+    const d = dash({ goals: [goal({ goalId: 'g1', nonFunds: [
+      nonFund({ transactionId: 'due', expiryDate: soon }),
+      nonFund({ transactionId: 'not-yet', expiryDate: later }),
+    ] })] })
+    expect(maturingDeposits(tagNonFunds(d), false)).toHaveLength(1)
+    expect(mergeClusterSummaries(tagNonFunds(d))).toEqual([])
   })
 
   it('reports nothing when no deposit is actionable yet', () => {

--- a/features/dashboard/dashboardModel.ts
+++ b/features/dashboard/dashboardModel.ts
@@ -107,11 +107,11 @@ export function maturingDeposits(
 
 /**
  * Goals whose deposits fall close together, so the card can offer a one-tap
- * "gộp lại". Fed from ALL the goal's bank deposits with an `actionable` flag:
- * the anchor must be due now — that's what the card opens on — but a
- * close-maturing sibling counts even if it isn't due yet, exactly matching what
- * the sheet preselects. Reuses the eligibility rules so the banner can't
- * over-promise.
+ * "gộp lại". Fed from ALL the goal's bank deposits with an `actionable` flag,
+ * which the detector uses to keep the banner to deposits the card lists: a
+ * not-yet-due sibling can still be merged from inside the sheet, but it must not
+ * inflate a count the user can only see half of (#651). Reuses the eligibility
+ * rules so the banner can't over-promise.
  */
 export function mergeClusterSummaries(
   tagged: TaggedTranche<NonFundUnallocatedItem>[],

--- a/lib/__tests__/mergeCluster.test.ts
+++ b/lib/__tests__/mergeCluster.test.ts
@@ -89,15 +89,13 @@ describe('detectMergeClusters', () => {
     expect([...clusters[0].siblingIds].sort()).toEqual(['a', 'b'])
   })
 
-  it('anchors on an actionable deposit and folds a not-yet-actionable close sibling', () => {
-    // A is due now; B matures a few days later (not actionable) but within the
-    // window — it can settle early and fold in, so the banner still fires.
+  it('forms no cluster when the only close sibling is not on the card yet (#651)', () => {
+    // A is due now; B matures a few days later and is NOT actionable, so the
+    // card never lists it. Counting it made the banner promise "2 sổ" over a
+    // single visible row — and kept promising it after the other one was handled.
     const a = mk({ id: 'a', expiryDate: '2026-07-01', actionable: true })
     const b = mk({ id: 'b', expiryDate: '2026-07-05', actionable: false }) // gap 4, not due
-    const clusters = detectMergeClusters([a, b], 7)
-    expect(clusters).toHaveLength(1)
-    expect(clusters[0]).toMatchObject({ anchorId: 'a', size: 2 })
-    expect(clusters[0].siblingIds).toEqual(['b'])
+    expect(detectMergeClusters([a, b], 7)).toHaveLength(0)
   })
 
   it('forms no cluster when nothing in the goal is actionable yet', () => {
@@ -106,15 +104,16 @@ describe('detectMergeClusters', () => {
     expect(detectMergeClusters([a, b], 7)).toHaveLength(0)
   })
 
-  it('anchors on the latest ACTIONABLE deposit, not a later not-yet-due one', () => {
+  it('anchors on the latest ACTIONABLE deposit and counts only actionable ones', () => {
     const a = mk({ id: 'a', expiryDate: '2026-07-01', actionable: true })
     const b = mk({ id: 'b', expiryDate: '2026-07-03', actionable: true }) // latest actionable
     const c = mk({ id: 'c', expiryDate: '2026-07-05', actionable: false }) // later, not due
     const clusters = detectMergeClusters([a, b, c], 7)
     expect(clusters).toHaveLength(1)
     expect(clusters[0].anchorId).toBe('b')
-    expect(clusters[0].size).toBe(3)
-    expect([...clusters[0].siblingIds].sort()).toEqual(['a', 'c'])
+    // c is close to b but isn't on the card, so it is not part of the promise.
+    expect(clusters[0].size).toBe(2)
+    expect(clusters[0].siblingIds).toEqual(['a'])
   })
 
   it('treats an unspecified actionable flag as actionable (lib default)', () => {

--- a/lib/mergeCluster.ts
+++ b/lib/mergeCluster.ts
@@ -6,16 +6,19 @@
 // exactly what the resolve sheet will preselect — no over-promising.
 //
 // A cluster is goal-scoped: it needs ≥2 liquidatable bank deposits in the same
-// goal, with at least one sibling that is eligible (in-window, same currency, not
-// pledged) against the ANCHOR — the latest-maturing ACTIONABLE deposit. Opening
-// the sheet on that anchor lets the rest settle early and roll into it.
+// goal that are ACTIONABLE (matured / within the reminder window), with at least
+// one sibling that is eligible (in-window, same currency, not pledged) against
+// the ANCHOR — the latest-maturing one. Opening the sheet on that anchor lets
+// the rest settle early and roll into it.
 //
-// The anchor must be actionable (matured / within the reminder window) for two
-// reasons: the maturity card only surfaces actionable deposits, and the resolve
-// flow opens on one. A SIBLING need not be actionable, though — a deposit that
-// matures a few days later can still settle early and fold in. So the banner
-// surfaces exactly when the sheet would preselect: as soon as there is something
-// to act on now plus a close-maturing partner, even if the partner isn't due yet.
+// Every member must be actionable because the banner sits on the "Cần xử lý"
+// card and speaks about its rows: its count must equal what the user can see and
+// act on. Counting a not-yet-due close sibling (the pre-#651 rule) made the
+// banner promise "2 sổ đáo hạn sát nhau" above a single row, and left it standing
+// after the user handled the deposit they could see — indistinguishable from a
+// stale banner. A not-yet-due deposit can still be folded in from inside the
+// resolve sheet, which classifies sources itself (lib/mergeEligibility); it just
+// no longer raises a banner of its own.
 
 import { classifyMergeSource, type MergeEligInput } from './mergeEligibility'
 
@@ -60,6 +63,12 @@ export function detectMergeClusters(
   const byGoal = new Map<string, MergeClusterInput[]>()
   for (const d of deposits) {
     if (d.goalId == null || !liquidatable(d)) continue
+    // Only deposits the card actually lists can be part of the promise (#651).
+    // A not-yet-due deposit can still be folded in from inside the sheet, but
+    // counting it here made the banner claim "2 sổ đáo hạn sát nhau" over a
+    // single visible row — and keep claiming it after the user had handled the
+    // one they could see, which reads as a stale banner.
+    if (!(d.actionable ?? true)) continue
     const arr = byGoal.get(d.goalId) ?? []
     arr.push(d)
     byGoal.set(d.goalId, arr)
@@ -68,12 +77,9 @@ export function detectMergeClusters(
   const clusters: MergeCluster[] = []
   for (const [goalId, group] of byGoal) {
     if (group.length < 2) continue
-    // Anchor = latest-maturity ACTIONABLE deposit (tie-break by id). A goal with
-    // nothing actionable has nothing to act on now → no banner, even if two
-    // future deposits would otherwise pair up.
-    const actionables = group.filter((d) => d.actionable ?? true)
-    if (actionables.length === 0) continue
-    const anchor = [...actionables].sort(
+    // Anchor = latest-maturity deposit of the group (tie-break by id) — every
+    // member is actionable by now, so this is also the one the card lists last.
+    const anchor = [...group].sort(
       (a, b) => (b.expiryDate ?? '').localeCompare(a.expiryDate ?? '') || a.id.localeCompare(b.id),
     )[0]
     // Count siblings the sheet would actually preselect — same eligibility


### PR DESCRIPTION
Closes #651.

## Vấn đề

Card "Cần xử lý" hiện đúng 1 sổ (Eximbank, đáo hạn sau 3 ngày) nhưng banner vẫn nói **"2 sổ đáo hạn sát nhau"**, kể cả sau khi sổ kia đã được xử lý.

Không phải state cũ trên client: banner và danh sách đều tính từ cùng một payload. Nguyên nhân nằm ở luật phát hiện cụm (`lib/mergeCluster.ts`): **anchor** phải actionable (đã/sắp đáo hạn trong 7 ngày), nhưng **sibling thì không cần**. Một sổ đáo hạn sau 8–10 ngày không bao giờ xuất hiện trên card, mà vẫn cách anchor ≤7 ngày → vẫn được cộng vào con số trên banner. Người dùng thấy 1 dòng, banner hứa 2, và xử lý xong dòng nhìn thấy được thì banner vẫn đứng đó — không phân biệt được với banner cũ chưa refresh.

(Một sổ đã tái tục / tất toán thì không thể còn nằm trong cụm: tái tục dời expiry ra xa và snapshot bị lọc, tất toán đóng hẳn row khỏi payload. Nên phần còn lại của "2" luôn là một sổ thật nhưng vô hình trên card.)

## Cách sửa

`detectMergeClusters` chỉ nhận sổ **actionable** vào cụm → con số trên banner luôn bằng số dòng người dùng nhìn thấy. Sổ chưa tới hạn **vẫn gộp được từ trong sheet** (luật `lib/mergeEligibility` không đổi), chỉ là nó không tự dựng banner nữa.

## Test

- `lib/__tests__/mergeCluster.test.ts` — case "sibling chưa tới hạn" đảo lại thành không có cụm; case anchor đếm 2 thay vì 3.
- `features/dashboard/__tests__/dashboardModel.test.ts` — case dựng đúng ảnh trong issue: 1 dòng trên card → không banner.
- `e2e/maturity-combine-cluster.spec.ts` — assert không có banner, nhưng mở sheet vẫn preselect được sổ chưa tới hạn.
- Tiện thể khử flake trong chính spec đó: assertion cũ đua với flash `maturity-renewed` (hiện SUCCESS_FLASH_MS rồi sheet tự đóng) nên rớt ~1/3 lần **trên cả main**; giờ assert response 200 + sheet đóng + sibling rời goal. Chạy lại 3 lần: 9/9 xanh.

Đã chạy: `typecheck`, `vitest` (2366 passed), `lint`, `test:coverage` (đạt ngưỡng), 4 spec maturity-combine* + cluster spec ×3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)