### PR TITLE
fix(funds): an assign waits for a concurrent sell instead of losing to it (#610)

### DIFF
--- a/app/api/v1/fund-investments/assign/__tests__/route.test.ts
+++ b/app/api/v1/fund-investments/assign/__tests__/route.test.ts
@@ -7,21 +7,25 @@ import { NextRequest } from 'next/server'
 // row also dragged rows that belonged to another goal, and a partial failure left
 // the fund split across goals with no row in the UI to repair it from.
 //
-// This route is the replacement primitive: one UPDATE statement — hence one
-// transaction, all-or-nothing — that moves the fund's rows from ONE goal bucket
-// to another. `from_goal_id: null` is the Unallocated bucket, which is what the
-// assign flow uses; `to_goal_id: null` unassigns, which is what goal detail uses.
+// This route is the replacement primitive: one statement — hence one transaction,
+// all-or-nothing — that moves the fund's rows from ONE goal bucket to another.
+// `from_goal_id: null` is the Unallocated bucket, which is what the assign flow
+// uses; `to_goal_id: null` unassigns, which is what goal detail uses.
 //
-// What the filter chain contains is the whole fix, so the mock records it.
-
-type Filter = { table: string; kind: string; args: unknown[] }
+// That statement is now assign_fund_bucket (#610), because the move has to hold
+// the row locks a concurrent sell of the bucket takes and a lock lives as long as
+// its transaction — so it cannot be split across two round trips from here. What
+// this route still owns, and what these tests cover: the shape of the request, the
+// bucket the RPC is asked to move, the 403 on a goal the caller does not own, and
+// the answer it gives when the database says the bucket was contended. The scoping
+// of the move itself is the function's, and is covered in
+// supabase/tests/fund_bucket_assign.test.sql.
 
 const h = vi.hoisted(() => ({
   user: { id: 'user-1' } as { id: string } | null,
   goal: { data: null as unknown, error: null as unknown },
-  updated: { data: [] as unknown[] | null, error: null as unknown },
-  update: null as unknown,
-  filters: [] as Filter[],
+  moved: { data: [] as unknown, error: null as { code?: string; message: string } | null },
+  rpc: [] as { fn: string; args: Record<string, unknown> }[],
   tables: [] as string[],
 }))
 
@@ -29,14 +33,8 @@ vi.mock('@/lib/supabase-server', () => {
   const chain = (table: string) => {
     const c: Record<string, unknown> = {
       select: () => c,
-      update: (payload: unknown) => { h.update = payload; return c },
-      eq: (...args: unknown[]) => { h.filters.push({ table, kind: 'eq', args }); return c },
-      is: (...args: unknown[]) => { h.filters.push({ table, kind: 'is', args }); return c },
-      or: (...args: unknown[]) => { h.filters.push({ table, kind: 'or', args }); return c },
+      eq: () => c,
       single: async () => h.goal,
-      // `.update(...).select()` is awaited directly — it resolves to the rows the
-      // statement actually touched, which is how the route counts the move.
-      then: (resolve: (v: unknown) => void) => resolve(h.updated),
     }
     h.tables.push(table)
     return c
@@ -45,6 +43,10 @@ vi.mock('@/lib/supabase-server', () => {
     createSupabaseServerClient: async () => ({
       auth: { getUser: async () => ({ data: { user: h.user } }) },
       from: (table: string) => chain(table),
+      rpc: async (fn: string, args: Record<string, unknown>) => {
+        h.rpc.push({ fn, args })
+        return h.moved
+      },
     }),
   }
 })
@@ -63,22 +65,17 @@ const call = (body: unknown) =>
     body: JSON.stringify(body),
   }))
 
-// Only the UPDATE's own filters — the goal ownership lookup filters by goal_id too.
-const filter = (kind: string, col: string) => {
-  const found = h.filters.find((f) =>
-    f.table === 'investment_transactions' && f.kind === kind && f.args[0] === col)
-  return found ? { kind: found.kind, args: found.args } : undefined
-}
+const move = () => h.rpc.find((r) => r.fn === 'assign_fund_bucket')
 
 describe('POST /api/v1/fund-investments/assign', () => {
   beforeEach(() => {
     h.user = { id: 'user-1' }
     h.goal = { data: { goal_id: GOAL_A }, error: null }
-    h.updated = { data: [{ transaction_id: TX_1 }, { transaction_id: TX_2 }], error: null }
-    h.update = null
-    h.filters = []
+    h.moved = { data: [TX_1, TX_2], error: null }
+    h.rpc = []
     h.tables = []
     vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
   })
 
   afterEach(() => vi.restoreAllMocks())
@@ -87,49 +84,35 @@ describe('POST /api/v1/fund-investments/assign', () => {
     const res = await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })
 
     expect(res.status).toBe(200)
-    await expect(res.json()).resolves.toMatchObject({ moved: 2 })
-    expect(h.update).toMatchObject({ goal_id: GOAL_A })
+    await expect(res.json()).resolves.toMatchObject({
+      moved: 2,
+      transaction_ids: [TX_1, TX_2],
+    })
   })
 
-  // The #589 bug: without this the UPDATE spans every goal's rows for the fund.
-  it('scopes the move to the source bucket — Unallocated means goal_id IS NULL', async () => {
+  // The #589 bug: without a source bucket the move spans every goal's rows for
+  // the fund. Unallocated is null, and the function matches it with IS NOT
+  // DISTINCT FROM — so null is a scope here, never "no filter".
+  it('scopes the move to the source bucket — Unallocated is a null source', async () => {
     await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })
 
-    expect(filter('is', 'goal_id')).toEqual({ kind: 'is', args: ['goal_id', null] })
-    // No eq on goal_id as well — that would contradict the IS NULL scope.
-    expect(filter('eq', 'goal_id')).toBeUndefined()
+    expect(move()!.args).toEqual({
+      p_fund_id: FUND,
+      p_from_goal_id: null,
+      p_to_goal_id: GOAL_A,
+    })
   })
 
   it('scopes an unassign to the goal it is leaving', async () => {
     await call({ fund_id: FUND, from_goal_id: GOAL_A, to_goal_id: null })
 
-    expect(filter('eq', 'goal_id')).toEqual({ kind: 'eq', args: ['goal_id', GOAL_A] })
-    expect(filter('is', 'goal_id')).toBeUndefined()
-    expect(h.update).toMatchObject({ goal_id: null })
+    expect(move()!.args).toMatchObject({ p_from_goal_id: GOAL_A, p_to_goal_id: null })
   })
 
   it('scopes a goal-to-goal move to the source goal', async () => {
     await call({ fund_id: FUND, from_goal_id: GOAL_A, to_goal_id: GOAL_B })
 
-    expect(filter('eq', 'goal_id')).toEqual({ kind: 'eq', args: ['goal_id', GOAL_A] })
-    expect(h.update).toMatchObject({ goal_id: GOAL_B })
-  })
-
-  it('restricts the move to the caller, the fund, and fund rows', async () => {
-    await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })
-
-    expect(filter('eq', 'user_id')).toEqual({ kind: 'eq', args: ['user_id', 'user-1'] })
-    expect(filter('eq', 'fund_id')).toEqual({ kind: 'eq', args: ['fund_id', FUND] })
-    expect(filter('eq', 'asset_type')).toEqual({ kind: 'eq', args: ['asset_type', 'fund'] })
-  })
-
-  // Pending DCA seeds (is_dca_seeded with no units) are not holdings: the fund
-  // list excludes them and the dashboard never values them, so the old client
-  // path never moved them. Same filter here keeps that behaviour.
-  it('leaves pending DCA seed rows where they are', async () => {
-    await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })
-
-    expect(filter('or', 'is_dca_seeded.eq.false,units.not.is.null')).toBeTruthy()
+    expect(move()!.args).toMatchObject({ p_from_goal_id: GOAL_A, p_to_goal_id: GOAL_B })
   })
 
   it('rejects a goal the caller does not own', async () => {
@@ -139,20 +122,20 @@ describe('POST /api/v1/fund-investments/assign', () => {
 
     expect(res.status).toBe(403)
     // Nothing was written.
-    expect(h.update).toBeNull()
+    expect(move()).toBeUndefined()
   })
 
   it('does not need a goal lookup when unassigning', async () => {
     await call({ fund_id: FUND, from_goal_id: GOAL_A, to_goal_id: null })
 
-    expect(h.tables).toEqual(['investment_transactions'])
+    expect(h.tables).toEqual([])
   })
 
   // The row is on screen, so rows were expected. Zero moved means something else
   // moved them first — the caller has to be told rather than shown a success it
   // can't see the result of.
   it('reports a conflict when nothing was left to move', async () => {
-    h.updated = { data: [], error: null }
+    h.moved = { data: [], error: null }
 
     const res = await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })
 
@@ -164,25 +147,41 @@ describe('POST /api/v1/fund-investments/assign', () => {
     const res = await call({ fund_id: FUND, from_goal_id: GOAL_A, to_goal_id: GOAL_A })
 
     expect(res.status).toBe(400)
-    expect(h.update).toBeNull()
+    expect(move()).toBeUndefined()
   })
 
   it('rejects a missing or malformed fund id', async () => {
     expect((await call({ to_goal_id: GOAL_A })).status).toBe(400)
     expect((await call({ fund_id: 'not-a-uuid', to_goal_id: GOAL_A })).status).toBe(400)
     expect((await call({ fund_id: FUND, from_goal_id: 'not-a-uuid', to_goal_id: null })).status).toBe(400)
-    expect(h.update).toBeNull()
+    expect(move()).toBeUndefined()
   })
 
   it('requires a session', async () => {
     h.user = null
 
     expect((await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })).status).toBe(401)
-    expect(h.update).toBeNull()
+    expect(move()).toBeUndefined()
   })
 
-  it('reports a failed update instead of a silent success', async () => {
-    h.updated = { data: null, error: { message: 'deadlock detected' } }
+  // Contention is not a failure: two writers reached the same bucket, Postgres
+  // aborted one, nothing was written and nothing is wrong with the request. A 500
+  // reads as a bug and tells the client nothing it can act on (#610).
+  it.each([
+    ['40P01', 'deadlock detected'],
+    ['55P03', 'could not obtain lock on row'],
+    ['40001', 'could not serialize access'],
+  ])('answers %s with a retryable conflict', async (code, message) => {
+    h.moved = { data: null, error: { code, message } }
+
+    const res = await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })
+
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toMatchObject({ code: 'bucket_busy' })
+  })
+
+  it('reports a genuine failure instead of a silent success', async () => {
+    h.moved = { data: null, error: { code: '23514', message: 'withdrawal invariant' } }
 
     const res = await call({ fund_id: FUND, from_goal_id: null, to_goal_id: GOAL_A })
 

--- a/app/api/v1/fund-investments/assign/route.ts
+++ b/app/api/v1/fund-investments/assign/route.ts
@@ -15,16 +15,35 @@ import { readJsonBody } from '@/lib/apiBody'
 //   2. Either path could half-succeed. The list shows one row per fund, so a
 //      fund split between two goals is a state the user cannot see or repair.
 //
-// One UPDATE statement fixes both: Postgres runs it in its own transaction, so
-// it is all-or-nothing, and the WHERE clause carries the source scope the client
-// could only approximate. Under concurrency the statement re-checks its qual
-// after taking each row lock, so rows a competing assign/unassign already moved
-// out of the source bucket are skipped rather than dragged along.
+// One statement fixes both: Postgres runs it in its own transaction, so it is
+// all-or-nothing, and its WHERE clause carries the source scope the client could
+// only approximate.
+//
+// That statement now lives in assign_fund_bucket (#610) rather than here. It has
+// to: the move must take the row locks a concurrent SELL of the same bucket takes,
+// and a lock is held for the length of a transaction — so the lock and the move
+// belong to one call, not to two round trips from this route. Without it the sell
+// and the assign did not wait for each other, and the assign lost: a sale that
+// committed after the UPDATE's snapshot stayed behind while its purchases moved
+// away, splitting the bucket across two goals (#587 refuses that split, which made
+// a legitimate assign fail instead of wait). See the migration for why those locks
+// and not an advisory one.
 //
 // The buckets are addressed by goal id, with null meaning Unallocated:
 //   assign   from_goal_id: null    → to_goal_id: goal
 //   unassign from_goal_id: goal    → to_goal_id: null
 //   move     from_goal_id: goalA   → to_goal_id: goalB
+
+// Contention, not failure: two writers reached the same bucket and Postgres broke
+// the tie by aborting one of them. Nothing is wrong with the request and nothing
+// was written, so the answer is "try again" — a 500 reads as a bug and gives the
+// client no reason to retry. supabase-js surfaces the SQLSTATE as error.code, so
+// this is a discriminated map rather than a match on the message text.
+//   40P01 deadlock_detected      — an edit of a row in the bucket crossed the move
+//   55P03 lock_not_available     — a NOWAIT/timeout writer got there first
+//   40001 serialization_failure  — check_fund_bucket_solvent's own retry signal
+const RETRYABLE_SQLSTATES = new Set(['40P01', '55P03', '40001'])
+
 export async function POST(request: NextRequest) {
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
@@ -67,30 +86,30 @@ export async function POST(request: NextRequest) {
     if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
   }
 
-  let query = supabase
-    .from('investment_transactions')
-    .update({ goal_id: toGoalId, updated_at: new Date().toISOString() })
-    .eq('user_id', user.id)
-    .eq('fund_id', cleanFundId)
-    .eq('asset_type', 'fund')
-    // Pending DCA seeds (seeded with no units yet) are plan placeholders, not
-    // holdings: GET /fund-investments hides them and the dashboard never values
-    // them, so the old client path never moved them either. Same filter keeps
-    // planning's rows out of an assign.
-    .or('is_dca_seeded.eq.false,units.not.is.null')
-
-  query = fromGoalId === null
-    ? query.is('goal_id', null)
-    : query.eq('goal_id', fromGoalId)
-
-  const { data, error } = await query.select('transaction_id')
+  // The source scope, the fund, the caller's own rows, and the exclusion of
+  // pending DCA seeds all live in the function now — see the migration. Passing
+  // null as the source is the Unallocated bucket, matched with IS NOT DISTINCT
+  // FROM there rather than with an IS NULL filter built here.
+  const { data, error } = await supabase.rpc('assign_fund_bucket', {
+    p_fund_id: cleanFundId,
+    p_from_goal_id: fromGoalId,
+    p_to_goal_id: toGoalId,
+  })
 
   if (error) {
+    if (RETRYABLE_SQLSTATES.has(error.code ?? '')) {
+      console.warn('fund assign: bucket contended', error.code)
+      return NextResponse.json({
+        error: 'This fund was being changed at the same time. Try again.',
+        code: 'bucket_busy',
+      }, { status: 409 })
+    }
     console.error('fund assign: update failed', error.message)
     return NextResponse.json({ error: 'Failed to assign fund' }, { status: 500 })
   }
 
-  const moved = data?.length ?? 0
+  const movedIds = (data ?? []) as string[]
+  const moved = movedIds.length
   if (moved === 0) {
     // The caller acted on a row it could see, so rows were expected. Zero means
     // something else moved them first (another tab, or a stale dashboard) — the
@@ -101,5 +120,5 @@ export async function POST(request: NextRequest) {
     }, { status: 409 })
   }
 
-  return NextResponse.json({ moved, transaction_ids: data!.map((r) => r.transaction_id) })
+  return NextResponse.json({ moved, transaction_ids: movedIds })
 }

--- a/supabase/migrations/20260813000001_serialize_fund_bucket_assign.sql
+++ b/supabase/migrations/20260813000001_serialize_fund_bucket_assign.sql
@@ -1,0 +1,117 @@
+-- An assign waits for a concurrent sell of the same bucket instead of losing to
+-- it (#610, follow-up to #589).
+--
+-- #589 made the assign ONE scoped UPDATE, which fixed the half of the problem
+-- where it moved rows it should not have. It did not make assign and sell wait
+-- for each other, and they contend for the same thing:
+--
+--   session 1: begin; insert a sell of 30 units      -- check_withdrawal_balance
+--              …                                        locks the bucket's purchases
+--   session 2: update … set goal_id = B where goal_id = A
+--
+-- Under READ COMMITTED the UPDATE's snapshot predates the sale, so the sale is
+-- invisible to it: the purchases move, the sale stays behind, and the bucket is
+-- split across two goals. lib/withdrawalProgress keys fund rows by
+-- (goal_id, fund_id), so the orphaned sale stops offsetting the purchase it was
+-- drawn on — goal B shows 100 units bought and nothing sold, goal A a sale against
+-- no holding, and the sold units come back onto the dashboard. Reproduced with
+-- both of #587's triggers disabled, so this is the shape of the move, not of the
+-- invariant.
+--
+-- #587's check_fund_bucket_solvent already refuses such a relocation, which turns
+-- silent corruption into a failed assign — the right trade, and not the fix. The
+-- move was never invalid: the user assigned a fund to a goal, someone (they
+-- themselves, in another tab) sold part of it, and the correct answer is to WAIT
+-- and then move both rows. A refusal makes a legitimate action fail for a reason
+-- the user cannot see or act on.
+--
+-- ─── Which lock, and in which order ──────────────────────────────────────────
+--
+-- A lock only one side takes serializes nothing, so the assign takes the lock the
+-- SELL already takes: `select … for update` over the bucket's purchase rows, with
+-- the sell's own predicate and the sell's own `order by transaction_id`. Same
+-- rows, same order, so the two cannot deadlock against each other — one of them
+-- waits at the first row and the other finishes.
+--
+-- An advisory lock on the bucket key was the alternative (check_fund_bucket_solvent
+-- takes one, for the edit-vs-edit race #608 describes). It was not chosen here
+-- because the sell path does not take it, so adopting it would have meant
+-- re-issuing check_withdrawal_balance — 300 lines of decision table — to add one
+-- statement, and would have introduced an ordering between two lock kinds that the
+-- edit path takes in the opposite sequence. Reusing the row locks needs neither.
+--
+-- What the wait buys is a fresh read: the FOR UPDATE and the UPDATE are separate
+-- statements, so under READ COMMITTED (what PostgREST and every RPC here run at)
+-- the UPDATE takes its snapshot after the winner committed, and the sale it
+-- inserted is inside the move. The loser of the opposite ordering — an assign that
+-- commits while a sell waits — is not a split either: the sell then measures a
+-- bucket whose purchases have left and is refused, which is what selling units
+-- that are no longer in that goal should do.
+--
+-- Deadlock does not disappear, it becomes an expected answer: an EDIT of a row in
+-- the bucket holds that row's lock before check_source_backs_claims asks for the
+-- bucket's advisory lock, so an edit and an assign can still cross. Postgres
+-- aborts one with 40P01, and the route answers 409 — try again — rather than 500.
+--
+-- The move itself is unchanged from the route's statement, including the two
+-- filters that carry the fix from #589: the source bucket is addressed by goal id
+-- (null being Unallocated), and pending DCA seeds are left where they are (they
+-- carry a planned amount with no units bought yet — GET /fund-investments hides
+-- them and the dashboard never values them, so the assign never moved them).
+create or replace function public.assign_fund_bucket(
+  p_fund_id uuid,
+  p_from_goal_id uuid,
+  p_to_goal_id uuid
+)
+returns setof uuid
+-- INVOKER, deliberately: RLS is the ownership check for the rows being moved, and
+-- it is the same one the route's UPDATE ran under. The destination goal is the
+-- caller's own by the FK-ownership trigger (#607) and by the route's explicit
+-- 403 lookup before it gets here.
+security invoker
+language plpgsql
+set search_path = ''
+as $$
+declare
+  v_user uuid := (select auth.uid());
+begin
+  if v_user is null then
+    raise exception 'assign fund bucket: no session' using errcode = 'insufficient_privilege';
+  end if;
+  if p_from_goal_id is not distinct from p_to_goal_id then
+    raise exception 'assign fund bucket: source and destination must differ' using errcode = 'invalid_parameter_value';
+  end if;
+
+  -- The sell's lock, taken the sell's way (20260803000005). Purchases only, in
+  -- transaction_id order: a sell of this bucket is queued behind whichever of the
+  -- two arrived first, and the statement below then reads what it committed.
+  perform 1
+    from public.investment_transactions t
+   where t.user_id = v_user
+     and t.fund_id = p_fund_id
+     and t.asset_type = 'fund'
+     and t.transaction_type = 'investment'
+     and t.goal_id is not distinct from p_from_goal_id
+     and t.renewed_from_transaction_id is null
+     and t.units is not null
+   order by t.transaction_id
+     for update;
+
+  return query
+    update public.investment_transactions t
+       set goal_id = p_to_goal_id,
+           updated_at = now()
+     where t.user_id = v_user
+       and t.fund_id = p_fund_id
+       and t.asset_type = 'fund'
+       and t.goal_id is not distinct from p_from_goal_id
+       and (t.is_dca_seeded = false or t.units is not null)
+    returning t.transaction_id;
+end;
+$$;
+
+comment on function public.assign_fund_bucket(uuid, uuid, uuid) is
+  'Moves every row of one fund from one goal bucket to another, under the row locks a concurrent sell of that bucket takes, so the two serialize instead of racing (#589, #610).';
+
+revoke all on function public.assign_fund_bucket(uuid, uuid, uuid) from public;
+grant execute on function public.assign_fund_bucket(uuid, uuid, uuid) to authenticated;

--- a/supabase/tests/fund_bucket_assign.test.sql
+++ b/supabase/tests/fund_bucket_assign.test.sql
@@ -1,0 +1,326 @@
+-- assign_fund_bucket: what it moves, and what it waits for (#589, #610).
+--
+-- Two halves, and the file is in two parts to match. The FIRST is what the move
+-- is scoped to — the source bucket, the fund, the caller — which one rolled-back
+-- session can prove. The SECOND is the race, which needs two sessions and so
+-- commits; it is described where it starts.
+--
+-- Run via `npm run test:db`.
+
+-- ─── Part 1: what one assign moves, and what it leaves alone ────────────────
+--
+-- The scope used to be a filter chain built in the route, and the #589 bug was a
+-- missing link in it: the assign listed the fund with no goal filter, so assigning
+-- the Unallocated row dragged rows that already belonged to another goal. The
+-- chain now lives in the function, so this is where it is pinned down.
+begin;
+
+do $$
+declare
+  v_user      uuid;
+  v_other     uuid;
+  v_unalloc   uuid;   -- rows with no goal
+  v_goal_a    uuid;
+  v_goal_b    uuid;
+  v_fund      uuid;
+  v_fund_2    uuid;
+  v_buy       uuid;
+  v_sell      uuid;
+  v_seed      uuid;
+  v_elsewhere uuid;
+  v_foreign   uuid;
+  v_moved     uuid[];
+  v_msg       text;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'assign-scope@test.invalid') returning id into v_user;
+  insert into auth.users (id, email) values (gen_random_uuid(), 'assign-scope-other@test.invalid') returning id into v_other;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal_a;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Car') returning goal_id into v_goal_b;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Scope Fund', 'SCF', 'equity', 20000) returning id into v_fund;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Other Fund', 'OTF', 'equity', 20000) returning id into v_fund_2;
+
+  -- The Unallocated bucket: a purchase, the sale drawn on it, and a pending DCA
+  -- seed (a planned amount with no units bought yet).
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, null, v_fund, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000)
+  returning transaction_id into v_buy;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date,
+     amount_vnd, principal_withdrawn, units_withdrawn)
+  values (v_user, null, v_fund, 'fund', 'withdrawal', '2026-02-01', 600000, 600000, 30)
+  returning transaction_id into v_sell;
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, is_dca_seeded)
+  values (v_user, null, v_fund, 'fund', 'investment', '2026-03-01', 1000000, true)
+  returning transaction_id into v_seed;
+
+  -- Same fund, already in a goal — the rows #589 dragged along.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, v_goal_b, v_fund, 'fund', 'investment', '2026-01-01', 400000, 20, 20000)
+  returning transaction_id into v_elsewhere;
+  -- Another user's Unallocated rows for a fund of their own.
+  insert into public.savings_goals (user_id, goal_name) values (v_other, 'Theirs');
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_other, null, null, 'bank', 'investment', '2026-01-01', 400000, null, null)
+  returning transaction_id into v_foreign;
+  -- A different fund of the caller's, also Unallocated.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_user, null, v_fund_2, 'fund', 'investment', '2026-01-01', 400000, 20, 20000);
+
+  -- The RPC is security invoker and takes its owner from auth.uid(), which reads
+  -- this claim. postgres owns the table, so RLS is not in the way and the
+  -- function's own user_id filter is what these assertions measure.
+  perform set_config('request.jwt.claims', json_build_object('sub', v_user::text)::text, true);
+
+  select array_agg(x order by x) into v_moved
+    from public.assign_fund_bucket(v_fund, null, v_goal_a) as x;
+
+  -- The purchase AND the sale drawn on it. Moving the purchases alone is the split
+  -- this whole pair of issues is about.
+  if not (v_buy = any(v_moved) and v_sell = any(v_moved)) then
+    raise exception 'the move must carry the bucket whole — purchases and the sales drawn on them (moved %)', v_moved;
+  end if;
+  if array_length(v_moved, 1) <> 2 then
+    raise exception 'exactly the two rows of the source bucket should have moved, moved %', v_moved;
+  end if;
+
+  if (select goal_id from public.investment_transactions where transaction_id = v_seed) is not null then
+    raise exception 'a pending DCA seed is a plan placeholder, not a holding, and must stay put';
+  end if;
+  if (select goal_id from public.investment_transactions where transaction_id = v_elsewhere) <> v_goal_b then
+    raise exception 'a row already sitting in another goal is not in the source bucket (#589)';
+  end if;
+  if (select goal_id from public.investment_transactions where transaction_id = v_foreign) is not null then
+    raise exception 'another user''s rows are not the caller''s to move';
+  end if;
+  if (select count(*) from public.investment_transactions
+       where user_id = v_user and fund_id = v_fund_2 and goal_id is not null) <> 0 then
+    raise exception 'another fund of the caller''s is not in the source bucket';
+  end if;
+
+  -- Unassign is the same statement in the other direction, and it takes the sale
+  -- back with the purchase.
+  perform public.assign_fund_bucket(v_fund, v_goal_a, null);
+  if (select count(*) from public.investment_transactions
+       where transaction_id in (v_buy, v_sell) and goal_id is null) <> 2 then
+    raise exception 'an unassign must return the whole bucket to Unallocated';
+  end if;
+
+  -- A move to the bucket it is already in would take the lock and write nothing;
+  -- it is a client bug, and it is refused rather than answered with "0 rows moved".
+  begin
+    perform public.assign_fund_bucket(v_fund, null, null);
+    raise exception 'a move whose source and destination are the same must be refused';
+  exception when invalid_parameter_value then
+    null;
+  end;
+
+  -- No claim, no caller: the function must not fall back to moving rows for
+  -- whoever happens to be connected.
+  perform set_config('request.jwt.claims', '', true);
+  begin
+    perform public.assign_fund_bucket(v_fund, null, v_goal_a);
+    raise exception 'a sessionless call must be refused';
+  exception when insufficient_privilege then
+    null;
+  end;
+end;
+$$;
+
+rollback;
+
+-- ─── Part 2: an assign and a sell of one bucket must SERIALIZE, not race ─────
+--
+-- #589 made the assign one scoped UPDATE, which fixed "moves rows it shouldn't".
+-- It did not make assign and sell wait for each other, and they contend for the
+-- same thing: a sell's BEFORE trigger locks the bucket's purchase rows
+-- (20260803000005's check_withdrawal_balance) and an assign moves those same
+-- rows. A sell that commits after the assign's statement took its snapshot is
+-- invisible to it, so the purchases move and the sale stays behind —
+-- lib/withdrawalProgress keys fund rows by (goal_id, fund_id), so the orphaned
+-- sale stops offsetting the purchase it belongs to and the sold units come back.
+--
+-- #587's check_fund_bucket_solvent turned that split into a REFUSED assign, which
+-- is the right trade but not the fix: a legitimate move fails with nothing wrong
+-- with the input. assign_fund_bucket takes the sell's own row locks, in the sell's
+-- own order, BEFORE it moves anything — so the loser waits, and the statement
+-- after the wait reads a fresh snapshot containing the winner's committed sale.
+--
+-- ─── Why this part does not roll back ────────────────────────────────────────
+--
+-- Part 1 and every other file here run inside `begin` … `rollback`, because one
+-- session can prove a single-session invariant. This needs TWO sessions that see
+-- each other's committed work, so its fixture has to be committed — dblink
+-- supplies the extra connections. The block therefore cleans up after itself,
+-- including on failure: the handler deletes the fixture user (everything else
+-- cascades) through a fresh dblink connection, because a delete issued from this
+-- session would roll back with the block that failed.
+--
+-- Both extra sessions connect as postgres, which owns the table — so RLS is not in
+-- the way, and the claim the assigner sets is what auth.uid() answers. RLS is not
+-- what is under test here; the locking is.
+
+create extension if not exists dblink;
+
+-- A leftover from a crashed earlier run would make the assertions read rows this
+-- run never wrote. Fixed ids, cleared first.
+delete from auth.users where id = '61061061-0610-4610-8610-610610610610';
+
+do $$
+declare
+  c_user     constant uuid := '61061061-0610-4610-8610-610610610610';
+  v_goal_a   uuid;
+  v_goal_b   uuid;
+  v_fund     uuid;
+  v_conn     text;
+  v_moved    int;
+  v_split    int;
+  v_a_rows   int;
+  v_b_units  numeric;
+  v_b_sold   numeric;
+begin
+  -- Both sessions come back to this same database, on the port the server itself
+  -- is listening on — so the test follows whatever stack psql reached.
+  --
+  -- Addressed by the server's OWN address rather than 127.0.0.1, and that is not
+  -- cosmetic: `postgres` is not a superuser on a Supabase stack, and dblink refuses
+  -- a non-superuser connection that did not actually USE a password. The loopback
+  -- line in pg_hba is trust, so the password in the string is never consumed there
+  -- and the connect fails; the address this session came in on matches the rule
+  -- that asks for one.
+  v_conn := format('host=%s port=%s dbname=%s user=postgres password=postgres',
+                   inet_server_addr(), current_setting('port'), current_database());
+
+  perform dblink_connect('assign610_seller', v_conn);
+  perform dblink_connect('assign610_assigner', v_conn);
+
+  -- ── the fixture, committed so both sessions can see it ────────────────────
+  -- Written through the seller connection rather than from here: this block's own
+  -- inserts stay uncommitted until it ends, and the other session would find an
+  -- empty bucket and prove nothing.
+  perform dblink_exec('assign610_seller', format($f$
+    insert into auth.users (id, email) values (%L, 'assign-serialized@test.invalid');
+  $f$, c_user));
+
+  select id into v_goal_a from dblink('assign610_seller', format($f$
+    insert into public.savings_goals (user_id, goal_name) values (%L, 'House') returning goal_id;
+  $f$, c_user)) as t(id uuid);
+
+  select id into v_goal_b from dblink('assign610_seller', format($f$
+    insert into public.savings_goals (user_id, goal_name) values (%L, 'Car') returning goal_id;
+  $f$, c_user)) as t(id uuid);
+
+  select id into v_fund from dblink('assign610_seller', format($f$
+    insert into public.funds (user_id, name, code, fund_type, nav)
+    values (%L, 'Race Fund', 'RCF', 'equity', 20000) returning id;
+  $f$, c_user)) as t(id uuid);
+
+  perform dblink_exec('assign610_seller', format($f$
+    insert into public.investment_transactions
+      (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+    values (%L, %L, %L, 'fund', 'investment', '2026-01-01', 2000000, 100, 20000);
+  $f$, c_user, v_goal_a, v_fund));
+
+  -- The RPC is security invoker and reads auth.uid(), so the caller's session
+  -- carries the claim PostgREST would have put there.
+  perform dblink_exec('assign610_assigner', format($f$
+    set "request.jwt.claims" = %L;
+  $f$, json_build_object('sub', c_user::text)::text));
+
+  -- ── the race ──────────────────────────────────────────────────────────────
+  -- Session 1 sells 30 of goal A's 100 units and holds its transaction open, so it
+  -- is still holding the row locks the sell took on that bucket's purchases.
+  perform dblink_exec('assign610_seller', 'begin');
+  perform dblink_exec('assign610_seller', format($f$
+    insert into public.investment_transactions
+      (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date,
+       amount_vnd, principal_withdrawn, units_withdrawn)
+    values (%L, %L, %L, 'fund', 'withdrawal', '2026-02-01', 600000, 600000, 30);
+  $f$, c_user, v_goal_a, v_fund));
+
+  -- Session 2 moves the whole bucket to goal B. Sent asynchronously because it MUST
+  -- block — that is the behaviour under test. Before the fix it did not block: it
+  -- ran past the uncommitted sale, and was then refused by the bucket-solvency
+  -- check (or, with that check absent, split the bucket in silence).
+  perform dblink_send_query('assign610_assigner', format($f$
+    select * from public.assign_fund_bucket(%L, %L, %L);
+  $f$, v_fund, v_goal_a, v_goal_b));
+
+  -- Long enough for the assign to reach the lock and queue behind the seller.
+  perform pg_sleep(1);
+
+  perform dblink_exec('assign610_seller', 'commit');
+
+  -- Raises here if the assign was refused, which is the pre-fix outcome.
+  select count(*) into v_moved
+    from dblink_get_result('assign610_assigner') as t(transaction_id uuid);
+
+  perform dblink_disconnect('assign610_seller');
+  perform dblink_disconnect('assign610_assigner');
+
+  -- ── what must be true afterwards ──────────────────────────────────────────
+  -- The invariant first, and without naming a winner: no (goal_id, fund_id) bucket
+  -- may be left holding sales its purchases cannot back.
+  select count(*) into v_split
+    from (
+      select w.goal_id, coalesce(sum(w.units_withdrawn), 0) as sold,
+             (select coalesce(sum(p.units), 0)
+                from public.investment_transactions p
+               where p.user_id = c_user and p.fund_id = v_fund and p.asset_type = 'fund'
+                 and p.transaction_type = 'investment'
+                 and p.goal_id is not distinct from w.goal_id) as held
+        from public.investment_transactions w
+       where w.user_id = c_user and w.fund_id = v_fund and w.asset_type = 'fund'
+         and w.transaction_type = 'withdrawal'
+       group by w.goal_id
+    ) b
+   where b.sold > b.held;
+
+  if v_split > 0 then
+    raise exception 'the bucket was split: % goal bucket(s) hold sales their purchases cannot back', v_split;
+  end if;
+
+  -- And the assign must have SUCCEEDED. The solvency mitigation also leaves the
+  -- invariant intact — by failing a move that was never invalid — so asserting the
+  -- invariant alone would pass without the lock. Both rows moved: the purchase, and
+  -- the sale that committed while the assign was waiting for it.
+  if v_moved <> 2 then
+    raise exception 'the assign should have waited for the sell and moved both rows, moved % row(s)', v_moved;
+  end if;
+
+  select count(*) into v_a_rows
+    from public.investment_transactions
+   where user_id = c_user and fund_id = v_fund and goal_id = v_goal_a;
+  if v_a_rows <> 0 then
+    raise exception 'goal A should have been emptied, % row(s) left behind', v_a_rows;
+  end if;
+
+  select coalesce(sum(units), 0), coalesce(sum(units_withdrawn), 0)
+    into v_b_units, v_b_sold
+    from public.investment_transactions
+   where user_id = c_user and fund_id = v_fund and goal_id = v_goal_b;
+  if v_b_units <> 100 or v_b_sold <> 30 then
+    raise exception 'goal B should hold the whole bucket (100 units bought, 30 sold), got % / %',
+      v_b_units, v_b_sold;
+  end if;
+
+  -- The committed fixture, removed on the way out.
+  perform dblink_exec(v_conn, format('delete from auth.users where id = %L', c_user));
+exception
+  when others then
+    -- The fixture outlives a failure unless it goes now, and a delete issued from
+    -- this session would roll back with the block — hence a fresh connection.
+    -- Live handles first: they would otherwise survive as long as this session.
+    perform dblink_disconnect(name)
+       from unnest(coalesce(dblink_get_connections(), '{}')) as name
+      where name like 'assign610\_%';
+    perform dblink_exec(v_conn, format('delete from auth.users where id = %L', c_user));
+    raise;
+end;
+$$;


### PR DESCRIPTION
Closes #610.

## The race

#589 made the fund assign one scoped `UPDATE`, which fixed the "moves rows it shouldn't" half. It did not make assign and sell **serialize**, and they contend for the same bucket:

```
session 1: BEGIN; insert a sell of 30 units   -- locks the bucket's purchase rows
session 2: UPDATE … SET goal_id = B WHERE goal_id = A
```

Under READ COMMITTED the `UPDATE`'s snapshot predates the sale, so the purchases move and the sale stays behind. `lib/withdrawalProgress` keys fund rows by `(goal_id, fund_id)`, so the orphaned sale stops offsetting the purchase it was drawn on and the sold units come back onto the dashboard.

#587's `check_fund_bucket_solvent` already refuses that relocation — silent corruption became a failed assign, the right trade but not the fix. The move was never invalid; it needed to wait.

## The fix

**`assign_fund_bucket`** (new RPC) takes the row locks the *sell* takes — the same predicate, the same `order by transaction_id` — **before** it moves anything, then moves purchases and sales together. The lock and the move have to be one call: a lock lives as long as its transaction, so it cannot be split across two round trips from the route.

Row locks rather than an advisory lock on the bucket key: the sell path does not take the advisory one, so adopting it would have meant re-issuing `check_withdrawal_balance` (300 lines of decision table) to add one statement, and would have introduced an ordering between two lock kinds that the edit path takes the other way round. Reusing the sell's locks needs neither, and same-rows-same-order means the two cannot deadlock against each other.

**409 instead of 500 on contention.** An edit of a row in the bucket holds that row's lock before it asks for the bucket's advisory lock, so an edit and an assign can still cross and Postgres aborts one. The route maps `40P01` / `55P03` / `40001` to 409 `bucket_busy` — nothing failed, try again — rather than collapsing every Postgres error into a 500 that reads as a bug.

## Tests

`supabase/tests/fund_bucket_assign.test.sql`, in two parts:

- **Part 1** (rolled back) — what one assign moves and what it leaves alone: the sale moves with its purchase, a pending DCA seed stays, another goal's rows / another fund / another user's rows are untouched (the #589 scoping, which used to be a filter chain in the route), plus the same-bucket and sessionless refusals.
- **Part 2** (commits, cleans up after itself, including on failure) — the issue's two-session repro over dblink: a seller holding its transaction open, an assign sent asynchronously so it must block, then the assertion on the **end state** rather than on which call won — no bucket left holding sales its purchases cannot back, *and* the assign succeeded with both rows.

Verified red first: with the function's `FOR UPDATE` removed, part 2 fails with `withdrawal invariant: this fund bucket would be left owing 30 units / 600000 of basis it does not hold` — today's behaviour, exactly as the issue describes it.

Checks run: `typecheck`, full Vitest suite + coverage, `eslint`, `npm run test:db` (all 25 files), and the four affected E2E specs (`fund-unassign`, `assign-goal-desktop`, `withdrawal-balance`, `fk-ownership` — 45 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)