### PR TITLE
feat(db): replay the withdrawal ledger in write order (#613)

### DIFF
--- a/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
+++ b/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
@@ -396,27 +396,43 @@ events as (
 --
 -- That order is what the replay REPORTS against. It is not what it proves from —
 -- see the ordering search below, which assumes no order at all.
+-- A debit the invariant would have refused OUTRIGHT contributes NOTHING here: not
+-- a verdict, and not a delta either. The row could not have been written, so no
+-- legal history of this holding contains it, and the balances its neighbours have
+-- to answer for are the ones the holding would show without it.
+--
+-- Leaving the delta in was wrong in both directions. It invented balances that
+-- convicted innocent rows — a 40,000,000 / 4 unit gold holding with a no-principal
+-- 1-unit claim replayed the perfectly ordinary 1-unit / 10,000,000 sale after it
+-- against 40,000,000 / 3. And because these deltas are SIGNED, it also hid real
+-- ones: a 100 đồng holding with a -100 withdrawal and then a 150 withdrawal
+-- replayed the 150 against 200 and said nothing, while the screen's aggregate came
+-- to 50 and said nothing either. That overdraw was reported by no view at all,
+-- which is the exact silence this family exists to break.
+--
+-- The key is still marked, because the row is still there and an operator reading
+-- a finding on this holding needs to know a broken row sits beside it — see the
+-- sentence appended in the detail below.
 state as (
   select e.*,
-         coalesce(sum(e.d_basis) over w_prev, 0) as rem_basis,
-         coalesce(sum(e.d_units) over w_prev, 0) as rem_units,
+         coalesce(sum(case when e.is_debit and not e.shape_ok then 0 else e.d_basis end)
+                  over w_prev, 0) as rem_basis,
+         coalesce(sum(case when e.is_debit and not e.shape_ok then 0 else e.d_units end)
+                  over w_prev, 0) as rem_units,
          bool_or(e.touched)      over w_key      as key_touched,
          count(*) filter (where e.is_debit) over w_key as claims_on_key,
          -- Where this claim sits in the holding's history, which is the number an
          -- operator needs to find it in the ledger. Counted over the claims alone,
-         -- so an interleaved fund purchase does not shift it.
+         -- so an interleaved fund purchase does not shift it — and over ALL of
+         -- them, including the refused ones, because the operator is counting rows
+         -- in a ledger, not events in this view's model of it.
          count(*) filter (where e.is_debit) over w_upto as claim_ordinal,
          -- The events that have to be permuted to decide the key: everything but
-         -- the source, which opens the balance rather than happening in it.
-         count(*) filter (where e.ord_at > '-infinity') over w_key as movable,
-         -- A debit the invariant would have refused OUTRIGHT is not judged (the
-         -- screen owns it), but its deltas are still in the running balance and in
-         -- the search's states — so every other row on the key is measured against
-         -- a balance that could never have existed. A 40,000,000 / 4 unit gold
-         -- holding with a no-principal 1-unit claim in it replays the perfectly
-         -- ordinary 1-unit / 10,000,000 sale after it against 40,000,000 / 3, and
-         -- calls the innocent sale wrong. The key is therefore quarantined: its
-         -- findings stay, and they stop claiming to be proof.
+         -- the source, which opens the balance rather than happening in it, and
+         -- everything the invariant would have refused, which is not part of any
+         -- history there is to order.
+         count(*) filter (where e.ord_at > '-infinity'
+                            and not (e.is_debit and not e.shape_ok)) over w_key as movable,
          bool_or(e.is_debit and not e.shape_ok) over w_key as key_contaminated
     from events e
   window
@@ -507,6 +523,10 @@ movable as (
                              order by s.ord_at, s.ord_kind, s.ord_id) - 1)::int as idx
     from state s
    where s.ord_at > '-infinity'
+     -- Out of the search for the same reason it is out of the running balance:
+     -- a row the invariant would have refused is not part of any history there is
+     -- to order, so it neither takes a position nor carries a delta into one.
+     and not (s.is_debit and not s.shape_ok)
      and exists (select 1 from fails f
                   where f.user_id = s.user_id and f.balance_key = s.balance_key)
 ),
@@ -620,14 +640,14 @@ select distinct on (f.user_id, f.balance_key)
        -- Provable only where the replay's premise holds: nothing on this key was
        -- touched after it was written, so these rows ARE what was measured; the key
        -- was small enough to search; and THIS ROW had no legal position in it.
-       -- Contamination is deliberately NOT a severity clause here, though it looks
-       -- like one. A shape-invalid row is unjudged and therefore freely placeable,
-       -- so every subset WITHOUT it is reachable — and those are exactly the states
-       -- of the ledger as it would stand once that row is gone. A judged row that
-       -- survives none of them fails in the clean ledger too, so it is genuinely
-       -- proven, and downgrading it because something else on the holding is broken
-       -- would throw away a true proof. What contamination earns is the sentence in
-       -- the detail, not a change of verdict.
+       -- Contamination is deliberately NOT a clause here, though it looks like one.
+       -- A row the invariant would have refused is out of the balances and out of
+       -- the search entirely, so what remains on the key IS the legal ledger and a
+       -- finding against it is as sound as any other. Downgrading it because
+       -- something else on the holding is broken would throw away a true proof —
+       -- and it was a real one: the 150 đồng overdraw hiding behind a -100 đồng row
+       -- is only reported because this stays 'violation'. What contamination earns
+       -- is the sentence in the detail, not a change of verdict.
        case when f.key_touched
               or f.movable > 14
               or exists (select 1 from row_rescued x
@@ -675,12 +695,11 @@ select distinct on (f.user_id, f.balance_key)
                                and x.row_id = f.row_id)
                  then '. No ordering of this holding''s claims is legal, so at least one of them is wrong — but this row is not provably the one, since it would have been accepted had it been written earlier'
                else '' end
-       -- Why a contaminated key's findings are only ever 'review', said where the
-       -- operator meets them: the balance below such a row is not one the invariant
-       -- would have allowed, so nothing measured against it can be trusted, and the
-       -- row to fix is the one the screen already names.
+       -- Said where the operator meets it, because the balances above will not
+       -- reconcile against the rows they can see otherwise: one of those rows is
+       -- deliberately not in them.
        || case when f.key_contaminated
-                 then '. This holding also carries a row check_withdrawal_balance would have refused outright — withdrawal_ledger_audit names it — so the balances here are not ones the invariant ever allowed, and this finding may belong to that row rather than to this one'
+                 then '. This holding also carries a row check_withdrawal_balance would have refused outright — withdrawal_ledger_audit names it — and it is left out of the balances above, since no legal history of this holding contains it'
                else '' end as detail
   from fails f
  order by f.user_id, f.balance_key, f.ord_at, f.ord_kind, f.ord_id;

--- a/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
+++ b/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
@@ -75,6 +75,13 @@
 -- the order they arrived in. A key with a legal reading is 'review' however
 -- damning the created_at order looks, and the finding is reported either way.
 --
+-- One ordering fact IS honoured, because the ledger genuinely records it: a claim
+-- parented to a purchase cannot have been written before that purchase existed —
+-- the foreign key would have refused it. That is a fact about the schema, not a
+-- guess about clocks, and without it the search invents histories in which a
+-- bucket's claim precedes its own source. It is the difference between 'review'
+-- and 'violation' on a real shape; see the fixture in the test suite.
+--
 -- The price is real and worth stating plainly: a fund bucket whose purchases could
 -- be reordered ahead of its sells is rarely provable, because "all the purchases
 -- first" is usually a legal reading. Those report 'review'. What stays provable is
@@ -171,7 +178,8 @@ events as (
          coalesce(p.units, 0)::numeric         as d_units,
          null::numeric                         as took_principal,
          null::numeric                         as took_units,
-         (p.updated_at > p.created_at)         as touched
+         (p.updated_at > p.created_at)         as touched,
+         null::uuid                            as depends_on
     from public.investment_transactions p
    where p.transaction_type = 'investment'
      and exists (select 1 from wd w
@@ -183,7 +191,7 @@ events as (
          w.created_at, 1, w.transaction_id, true, true, w.transaction_id,
          -coalesce(w.principal_withdrawn, 0), -coalesce(w.units_withdrawn, 0),
          coalesce(w.principal_withdrawn, 0), coalesce(w.units_withdrawn, 0),
-         (w.updated_at > w.created_at)
+         (w.updated_at > w.created_at), null::uuid
     from wd w
     join public.investment_transactions pa on pa.transaction_id = w.parent_transaction_id
    where not w.fund_keyed
@@ -215,7 +223,13 @@ events as (
          -case when coalesce(w.units_withdrawn, 0) > 0 then w.units_withdrawn
                else least(p.units, p.units * coalesce(w.principal_withdrawn, 0) / p.amount_vnd) end,
          null, null,
-         (w.updated_at > w.created_at)
+         (w.updated_at > w.created_at),
+         -- The one order the ledger DOES record. A claim parented to a purchase
+         -- cannot have been written before that purchase existed: the foreign key
+         -- would have refused it, and the invariant finds the claim by joining to
+         -- it. Unlike created_at, that is a fact about the schema rather than a
+         -- guess about clocks, so the search must honour it.
+         p.transaction_id
     from wd w
     join public.investment_transactions p on p.transaction_id = w.parent_transaction_id
    where not w.fund_keyed
@@ -235,7 +249,7 @@ events as (
          null, t.fund_id, t.goal_id, true,
          t.created_at, 0, t.transaction_id, false, false, t.transaction_id,
          coalesce(t.amount_vnd, 0), coalesce(t.units, 0), null, null,
-         (t.updated_at > t.created_at)
+         (t.updated_at > t.created_at), null::uuid
     from public.investment_transactions t
    where t.transaction_type = 'investment'
      and t.asset_type = 'fund'
@@ -250,7 +264,7 @@ events as (
          w.created_at, 1, w.transaction_id, true, true, w.transaction_id,
          -coalesce(w.principal_withdrawn, 0), -coalesce(w.units_withdrawn, 0),
          coalesce(w.principal_withdrawn, 0), coalesce(w.units_withdrawn, 0),
-         (w.updated_at > w.created_at)
+         (w.updated_at > w.created_at), null::uuid
     from wd w
    where w.fund_keyed
 ),
@@ -360,14 +374,27 @@ fails as (
 -- and only keys that already produced a finding are searched at all — a clean
 -- ledger does no work here.
 movable as (
-  select s.user_id, s.balance_key, s.is_debit, s.judge_here, s.quantity_valued,
-         s.d_basis, s.d_units, s.took_principal, s.took_units,
+  select s.user_id, s.balance_key, s.row_id, s.is_debit, s.judge_here, s.quantity_valued,
+         s.d_basis, s.d_units, s.took_principal, s.took_units, s.depends_on,
          (row_number() over (partition by s.user_id, s.balance_key
                              order by s.ord_at, s.ord_kind, s.ord_id) - 1)::int as idx
     from state s
    where s.ord_at > '-infinity'
      and exists (select 1 from fails f
                   where f.user_id = s.user_id and f.balance_key = s.balance_key)
+),
+-- The claim-to-purchase dependency, resolved to the bit that purchase occupies.
+-- Null when the purchase is not an event on this key at all — a renewal snapshot,
+-- say, which the invariant still counts the claim against but which is no part of
+-- the bucket — and the claim is then unconstrained, which is the cautious way to
+-- be wrong.
+movable_dep as (
+  select m.*, buy.idx as dep_idx
+    from movable m
+    left join movable buy
+      on buy.user_id = m.user_id
+     and buy.balance_key = m.balance_key
+     and buy.row_id = m.depends_on
 ),
 opening as (
   select s.user_id, s.balance_key,
@@ -390,9 +417,13 @@ reach as (
   select r.user_id, r.balance_key, r.mask | (1::bigint << m.idx),
          r.rem_basis + m.d_basis, r.rem_units + m.d_units
     from reach r
-    join movable m
+    join movable_dep m
       on m.user_id = r.user_id and m.balance_key = r.balance_key
      and (r.mask >> m.idx) & 1 = 0
+     -- The purchase a claim names has to have happened already. This is the ONE
+     -- ordering fact the ledger actually records: the foreign key would have
+     -- refused the claim otherwise.
+     and (m.dep_idx is null or (r.mask >> m.dep_idx) & 1 = 1)
    where not m.is_debit
       -- A purchase claims nothing, and a claim the invariant does not measure here
       -- (a bucket's parent-backed claim) is only counted, never judged — so both

--- a/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
+++ b/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
@@ -107,6 +107,15 @@
 -- adding a fact. The two views are complements: run the screen for shapes and
 -- aggregates, run this for sequences.
 --
+-- That division has to be enforced and not merely intended, because one shape
+-- reaches the transition rules and comes out mis-described. A parent-backed claim
+-- recording no principal is `withdrawal_missing_principal` over there; judged as an
+-- allocation here it reads "it should have taken 10,000,000 đồng, it took 0" — a
+-- misallocation, where the defect is that no principal was recorded at all. Such a
+-- row is therefore not judged (see the parent-backed branch below). It still
+-- consumes the balance, and it stays freely placeable in the ordering search: a row
+-- that could never have been written proves nothing about its neighbours.
+--
 -- Only the FIRST failing row per balance key is reported. Once a row could not
 -- have been written, the state every later row is measured against is fiction, so
 -- the rows after it are not evidence of anything — the detail says how many there
@@ -188,7 +197,21 @@ events as (
   union all
   select w.user_id, 'p:' || w.parent_transaction_id::text, w.parent_transaction_id, null, w.goal_id,
          (pa.asset_type = 'gold'),
-         w.created_at, 1, w.transaction_id, true, true, w.transaction_id,
+         w.created_at, 1, w.transaction_id, true,
+         -- Judged here UNLESS its shape is already condemned. The invariant demands
+         -- a positive principal from any parent-backed claim and refuses one
+         -- without ever reaching the allocation rule, and withdrawal_ledger_audit
+         -- names that row `withdrawal_missing_principal`. Judging it anyway makes
+         -- the replay report the same row a second time under a WORSE name: a
+         -- gold sale recording no principal comes out as "it should have taken
+         -- 10,000,000 đồng, it took 0", which describes a misallocation where the
+         -- defect is that no principal was recorded at all. The two views are
+         -- advertised as complements, and a complement does not restate its
+         -- partner's finding in vaguer words. It still consumes the balance, and
+         -- it stays freely placeable in the ordering search — a row that could
+         -- never have been written cannot be used to prove anything about its
+         -- neighbours.
+         coalesce(w.principal_withdrawn, 0) > 0, w.transaction_id,
          -coalesce(w.principal_withdrawn, 0), -coalesce(w.units_withdrawn, 0),
          coalesce(w.principal_withdrawn, 0), coalesce(w.units_withdrawn, 0),
          (w.updated_at > w.created_at), null::uuid

--- a/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
+++ b/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
@@ -56,6 +56,14 @@
 -- by construction, rather than being flagged as corruption or having their shapes
 -- hand-listed here — a list that would go stale the first time an RPC changed.
 --
+-- The second thing a 'violation' has to answer for is that the order it replayed
+-- is the only one the ledger allows. now() is transaction-stable, so every row a
+-- single RPC writes shares one created_at exactly, and transaction_id is a random
+-- uuid — sorting by it invents an order rather than recovering one. An instant
+-- holding more than one event, at least one of them a claim, therefore drops
+-- everything from that point on to 'review' as well. See the `tied` CTE for the
+-- legal pair that fails when its two rows are replayed the other way round.
+--
 -- Two residual gaps, stated rather than papered over. updated_at is maintained by
 -- the writers, not by a trigger, so a hand-written SQL UPDATE that leaves it alone
 -- is invisible to this test and its key would still read as pristine. And the test
@@ -138,7 +146,8 @@ events as (
          '-infinity'::timestamptz              as ord_at,
          0                                     as ord_kind,
          p.transaction_id                      as ord_id,
-         false                                 as is_sale,
+         false                                 as is_debit,
+         false                                 as judge_here,
          null::uuid                            as row_id,
          coalesce(p.amount_vnd, 0)::numeric    as d_basis,
          coalesce(p.units, 0)::numeric         as d_units,
@@ -153,7 +162,7 @@ events as (
   union all
   select w.user_id, 'p:' || w.parent_transaction_id::text, w.parent_transaction_id, null, w.goal_id,
          (pa.asset_type = 'gold'),
-         w.created_at, 1, w.transaction_id, true, w.transaction_id,
+         w.created_at, 1, w.transaction_id, true, true, w.transaction_id,
          -coalesce(w.principal_withdrawn, 0), -coalesce(w.units_withdrawn, 0),
          coalesce(w.principal_withdrawn, 0), coalesce(w.units_withdrawn, 0),
          (w.updated_at > w.created_at)
@@ -166,6 +175,39 @@ events as (
      and pa.transaction_type = 'investment'
 
   union all
+  -- The bucket's OTHER kind of claim (#606). A withdrawal parented to a fund
+  -- PURCHASE is not fund-keyed, so it is measured on the parent axis above — but
+  -- 20260803000005 also charges it against that purchase's (goal, fund) bucket
+  -- when the next sale is measured, because lib/withdrawalProgress values it
+  -- there. Leaving it out of the bucket made the replay miss exactly the overdraw
+  -- that migration exists to refuse: a legacy 10-unit claim on a 50-unit purchase
+  -- followed by a 45-unit sell replays as 45 of 50 and reports clean.
+  --
+  -- It is a DEBIT here and not a judged one: the invariant never measures such a
+  -- row against the bucket, only counts it. Its verdict is the parent axis's.
+  --
+  -- Every predicate below is that function's, including the derived units for a
+  -- claim that records none, and `p.units > 0` — a purchase with no units is no
+  -- bucket, so its claim stays on the parent axis alone.
+  select w.user_id,
+         'f:' || p.fund_id::text || ':' || coalesce(p.goal_id::text, ''),
+         null, p.fund_id, p.goal_id, true,
+         w.created_at, 1, w.transaction_id, true, false, w.transaction_id,
+         -coalesce(w.principal_withdrawn, 0),
+         -case when coalesce(w.units_withdrawn, 0) > 0 then w.units_withdrawn
+               else least(p.units, p.units * coalesce(w.principal_withdrawn, 0) / p.amount_vnd) end,
+         null, null,
+         (w.updated_at > w.created_at)
+    from wd w
+    join public.investment_transactions p on p.transaction_id = w.parent_transaction_id
+   where not w.fund_keyed
+     and p.transaction_type = 'investment'
+     and p.asset_type = 'fund'
+     and p.fund_id is not null
+     and coalesce(p.units, 0) > 0
+     and coalesce(p.amount_vnd, 0) > 0
+
+  union all
   -- A fund bucket's purchases DO interleave: the invariant sums whatever is in the
   -- bucket at the moment of the sell, so a purchase made later is not part of that
   -- sum. The exclusions mirror the invariant's own — a pending DCA seed (units
@@ -173,7 +215,7 @@ events as (
   select t.user_id,
          'f:' || t.fund_id::text || ':' || coalesce(t.goal_id::text, ''),
          null, t.fund_id, t.goal_id, true,
-         t.created_at, 0, t.transaction_id, false, t.transaction_id,
+         t.created_at, 0, t.transaction_id, false, false, t.transaction_id,
          coalesce(t.amount_vnd, 0), coalesce(t.units, 0), null, null,
          (t.updated_at > t.created_at)
     from public.investment_transactions t
@@ -187,7 +229,7 @@ events as (
   select w.user_id,
          'f:' || w.fund_id::text || ':' || coalesce(w.goal_id::text, ''),
          null, w.fund_id, w.goal_id, true,
-         w.created_at, 1, w.transaction_id, true, w.transaction_id,
+         w.created_at, 1, w.transaction_id, true, true, w.transaction_id,
          -coalesce(w.principal_withdrawn, 0), -coalesce(w.units_withdrawn, 0),
          coalesce(w.principal_withdrawn, 0), coalesce(w.units_withdrawn, 0),
          (w.updated_at > w.created_at)
@@ -201,24 +243,45 @@ events as (
 -- sorted before debits at the same instant, which is the only reading under which
 -- such a transaction could have passed the invariant in the first place: a
 -- purchase and the sell of it written together must have gone in that order.
-state as (
+--
+-- Ties are the limit of that reading, and they are load-bearing. Two withdrawals
+-- written by separate statements of ONE transaction share a created_at exactly,
+-- and transaction_id is a random uuid — it recovers no order, it only invents a
+-- stable one. A pristine, legal ledger can fail under the invented order: against
+-- 1000 đồng / 100 units, (34 units, 339 đồng) then (32 units, 319 đồng) is legal
+-- both ways round as written, but replayed in the other order the 34-unit row owes
+-- 341 and is two đồng out. So an instant holding more than one event, at least one
+-- of them a debit, makes every finding from that point on a 'review' — the replay
+-- still says what it found and against what, it just does not claim the ordering
+-- was the one that happened.
+tied as (
   select e.*,
-         coalesce(sum(e.d_basis) over w_prev, 0) as rem_basis,
-         coalesce(sum(e.d_units) over w_prev, 0) as rem_units,
-         bool_or(e.touched)      over w_key      as key_touched,
-         count(*) filter (where e.is_sale) over w_key as sales_on_key,
-         -- Where this sale sits in the holding's history, which is the number an
-         -- operator needs to find it in the ledger. Counted over the sales alone,
-         -- so an interleaved fund purchase does not shift it.
-         count(*) filter (where e.is_sale) over w_upto as sale_ordinal
+         (count(*) over w_at > 1 and count(*) filter (where e.is_debit) over w_at > 0)
+           as ambiguous_instant
     from events e
+  window w_at as (partition by e.user_id, e.balance_key, e.ord_at)
+),
+state as (
+  select t.*,
+         coalesce(sum(t.d_basis) over w_prev, 0) as rem_basis,
+         coalesce(sum(t.d_units) over w_prev, 0) as rem_units,
+         bool_or(t.touched)      over w_key      as key_touched,
+         count(*) filter (where t.is_debit) over w_key as claims_on_key,
+         -- Where this claim sits in the holding's history, which is the number an
+         -- operator needs to find it in the ledger. Counted over the claims alone,
+         -- so an interleaved fund purchase does not shift it.
+         count(*) filter (where t.is_debit) over w_upto as claim_ordinal,
+         -- Only ties up to and including this row can have moved the balance it was
+         -- measured against; a tie later in the holding says nothing about it.
+         bool_or(t.ambiguous_instant) over w_upto as order_ambiguous
+    from tied t
   window
-    w_key  as (partition by e.user_id, e.balance_key),
-    w_prev as (partition by e.user_id, e.balance_key
-               order by e.ord_at, e.ord_kind, e.ord_id
+    w_key  as (partition by t.user_id, t.balance_key),
+    w_prev as (partition by t.user_id, t.balance_key
+               order by t.ord_at, t.ord_kind, t.ord_id
                rows between unbounded preceding and 1 preceding),
-    w_upto as (partition by e.user_id, e.balance_key
-               order by e.ord_at, e.ord_kind, e.ord_id
+    w_upto as (partition by t.user_id, t.balance_key
+               order by t.ord_at, t.ord_kind, t.ord_id
                rows between unbounded preceding and current row)
 ),
 
@@ -254,7 +317,7 @@ judged as (
              then 'withdrawal_exceeded_the_balance'
          end as failure
     from state s
-   where s.is_sale
+   where s.judge_here
 ),
 
 fails as (
@@ -266,8 +329,10 @@ fails as (
 select distinct on (f.user_id, f.balance_key)
        f.failure::text  as check_name,
        -- Provable only where the replay's premise holds: nothing on this key was
-       -- touched after it was written, so these rows ARE the history.
-       case when f.key_touched then 'review' else 'violation' end::text as severity,
+       -- touched after it was written, and no instant up to this row holds two
+       -- events whose order the ledger does not record. Then these rows ARE the
+       -- history, and no ordering of them produces what was found.
+       case when f.key_touched or f.order_ambiguous then 'review' else 'violation' end::text as severity,
        f.user_id,
        f.row_id         as transaction_id,
        f.holding        as parent_transaction_id,
@@ -276,13 +341,13 @@ select distinct on (f.user_id, f.balance_key)
        case f.failure
          when 'sale_exceeded_the_units_left' then
            format('a sale of %s units when the holding had %s units left (%s đồng of basis), %s of %s sale(s) into its history',
-                  f.took_units, f.rem_units, f.rem_basis, f.sale_ordinal, f.sales_on_key)
+                  f.took_units, f.rem_units, f.rem_basis, f.claim_ordinal, f.claims_on_key)
          when 'sale_took_the_wrong_basis' then
            format('a sale of %s units out of the %s units then left, against a %s đồng basis: it should have taken %s đồng, it took %s',
                   f.took_units, f.rem_units, f.rem_basis, f.owed, f.took_principal)
          else
            format('a withdrawal of %s đồng when the holding had %s đồng left, %s of %s withdrawal(s) into its history',
-                  f.took_principal, f.rem_basis, f.sale_ordinal, f.sales_on_key)
+                  f.took_principal, f.rem_basis, f.claim_ordinal, f.claims_on_key)
        end
        || case when f.fails_on_key > 1
                  then format(' — and %s later row(s) on this holding fail the replay too, measured against a balance this one already made fiction',

--- a/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
+++ b/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
@@ -1,0 +1,301 @@
+-- Replay the withdrawal ledger in write order, and name the first row that could
+-- not have been written at its turn (#613).
+--
+-- 20260730000003 screens the ledger as it STANDS, and its header states the limit
+-- that no extra predicate can remove:
+--
+--   The invariant is STATEFUL. It measures each write against the balance
+--   remaining at that moment, so whether a row was legal depends on the order the
+--   rows were written in. Different histories — some legal, some not — reach the
+--   very same final state, and the state does not record which one happened.
+--
+-- The sharpest case, and the one this file exists for: 1000 đồng over 100 units,
+-- two sales of 50 units taking 497 and 503. Neither can be written first (50 of
+-- 100 units must take 500) and neither can follow the other, yet the totals are
+-- exactly proportional and each per-sale deviation is inside what a LEGAL two-sale
+-- ledger shows on other holdings. No predicate over the final state separates it,
+-- so the screen is silent — correctly, and a test pins that silence.
+--
+-- The order the screen lacks is recorded: created_at. So this replays it. Each
+-- balance key's rows are put back in write order and the invariant's own
+-- transition rules are re-run over them, carrying remaining principal and
+-- remaining units forward. Sharp answers, no tolerance-guessing — the epsilons
+-- below are the invariant's own two constants and nothing else.
+--
+-- ─── Why this could not ship before #608 ─────────────────────────────────────
+--
+-- A replay reconstructs history from rows as they are NOW. If a source's
+-- amount_vnd or units was edited after a sale drew on it, every later step is
+-- measured against a balance that never existed and the audit produces confident,
+-- wrong answers — worse than the screen's honest silence. #608 (20260804000001)
+-- refuses the edits that would make a ledger insolvent, which is what makes a
+-- replay worth running at all.
+--
+-- It does not make every replay sound, and this file does not pretend it does.
+-- #608 bounds the TOTAL a source owes, not each prefix of it: a gold holding of
+-- 1000 đồng / 100 units with one 50-unit sale taking 500 can still be re-priced
+-- down to 600, and the replay then measures a perfectly legal sale against a basis
+-- it never saw. Same for a fund purchase relocated into or out of a bucket, and
+-- for a withdrawal whose own amounts were later corrected — the row's numbers are
+-- no longer what was measured at its turn.
+--
+-- So the premise is TESTED rather than assumed, per key: a row is `touched` when
+-- its updated_at is later than its created_at, which every write path in the app
+-- maintains (an insert leaves them equal — both default to now() — and the PUT
+-- route, the assign route and every RPC set updated_at explicitly). A key whose
+-- rows are all pristine can be replayed exactly, and a finding there is a
+-- 'violation': no ordering of these rows produces it. A key with any touched row
+-- reports 'review' instead, the same vocabulary the screen uses and for the same
+-- reason — the number is worth looking at, the proof is not available.
+--
+-- That is also how the RPC rewrites the issue asks about are handled, and it needs
+-- no catalogue of them. renew_term_deposit_with_merge re-parents partial
+-- withdrawals onto the history snapshot it just wrote; collapse and the book
+-- top-up rewrite amounts mid-transaction. Every one of those bumps updated_at on
+-- the rows it touches, so the keys they produce carry their findings as 'review'
+-- by construction, rather than being flagged as corruption or having their shapes
+-- hand-listed here — a list that would go stale the first time an RPC changed.
+--
+-- Two residual gaps, stated rather than papered over. updated_at is maintained by
+-- the writers, not by a trigger, so a hand-written SQL UPDATE that leaves it alone
+-- is invisible to this test and its key would still read as pristine. And the test
+-- can only see rows that are STILL on the key: a purchase relocated OUT of a fund
+-- bucket carries its touched flag away with it, so a bucket left short by a
+-- relocation reads as pristine and its sells are reported as violations. That is
+-- the same verdict withdrawal_ledger_audit's fund_bucket_has_no_purchases already
+-- gives that state (#610), so the two agree — but the proof here is the weaker one.
+--
+-- ─── What the replay does NOT judge ──────────────────────────────────────────
+--
+-- Only the balance transitions — how much was left, and what a sale was allowed to
+-- take from it. The SHAPE checks (negative amounts, a fund sell with no units, a
+-- parent that is not an investment, a row drawing on no holding at all) are
+-- decidable from state alone and belong to withdrawal_ledger_audit, which already
+-- reports them as violations. Reporting them twice would double the noise without
+-- adding a fact. The two views are complements: run the screen for shapes and
+-- aggregates, run this for sequences.
+--
+-- Only the FIRST failing row per balance key is reported. Once a row could not
+-- have been written, the state every later row is measured against is fiction, so
+-- the rows after it are not evidence of anything — the detail says how many there
+-- are and stops.
+--
+-- Read-only. It names rows and holdings, changes nothing, and is safe to run on
+-- production in the SQL editor:
+--
+--   select check_name, severity, count(*)
+--     from public.withdrawal_ledger_replay
+--    group by 1, 2 order by 2, 1;
+--
+-- Its columns match public.withdrawal_ledger_audit's, so the two can be read side
+-- by side or unioned.
+--
+-- Why a view and not a script in a folder, and why a test that plants ledgers the
+-- invariant refuses to write: the same reason 20260730000003 gives. An audit that
+-- returns nothing is indistinguishable from an audit that looks for nothing, and
+-- the only way to keep it honest is to make it a database object a test can query.
+-- supabase/tests/withdrawal_ledger_replay.test.sql asserts of every catch that
+-- withdrawal_ledger_audit is SILENT on the same fixture, so the day this decays
+-- into a restatement of that view, the suite says so.
+
+create or replace view public.withdrawal_ledger_replay
+with (security_invoker = true) as
+with wd as (
+  select w.transaction_id, w.user_id, w.goal_id, w.fund_id, w.parent_transaction_id,
+         w.principal_withdrawn, w.units_withdrawn, w.created_at, w.updated_at,
+         -- The same branch precedence as check_withdrawal_balance and
+         -- lib/withdrawalProgress: asset_type='fund' + fund_id wins, and such a row
+         -- draws on its (goal, fund) bucket whatever parent it also names.
+         coalesce(w.asset_type = 'fund' and w.fund_id is not null, false) as fund_keyed
+    from public.investment_transactions w
+   where w.transaction_type = 'withdrawal'
+),
+
+-- ── the ledger as a sequence of events, per balance key ──────────────────────
+-- Two kinds of key, exactly the two the invariant resolves to:
+--   'p:<id>'          one source row — bank, gold, stock
+--   'f:<fund>:<goal>' a fund bucket, which a sell draws on with no parent at all
+--
+-- A credit adds to the balance, a debit takes from it, and the running sum of
+-- everything BEFORE a debit is the state that debit was measured against.
+events as (
+  -- The opening balance of a parent-backed holding. Sorted at -infinity rather
+  -- than at its own created_at, because a source is not an event in its holding's
+  -- history — check_withdrawal_balance reads its amount_vnd and units wholesale,
+  -- with no interleaving, and every claim parented to it is measured against that.
+  -- Ordering it by created_at would also invert the one case that matters: renewal
+  -- re-parents a deposit's partial withdrawals onto a history snapshot written
+  -- AFTER them (#585), so the source would sort last and every legal claim on it
+  -- would replay against an empty holding.
+  select p.user_id,
+         'p:' || p.transaction_id::text        as balance_key,
+         p.transaction_id                      as holding,
+         null::uuid                            as fund_id,
+         p.goal_id                             as goal_id,
+         -- Gold is the one non-fund holding valued by QUANTITY, so its sales follow
+         -- the proportional allocation rather than the outright principal cap.
+         (p.asset_type = 'gold')               as quantity_valued,
+         '-infinity'::timestamptz              as ord_at,
+         0                                     as ord_kind,
+         p.transaction_id                      as ord_id,
+         false                                 as is_sale,
+         null::uuid                            as row_id,
+         coalesce(p.amount_vnd, 0)::numeric    as d_basis,
+         coalesce(p.units, 0)::numeric         as d_units,
+         null::numeric                         as took_principal,
+         null::numeric                         as took_units,
+         (p.updated_at > p.created_at)         as touched
+    from public.investment_transactions p
+   where p.transaction_type = 'investment'
+     and exists (select 1 from wd w
+                  where w.parent_transaction_id = p.transaction_id and not w.fund_keyed)
+
+  union all
+  select w.user_id, 'p:' || w.parent_transaction_id::text, w.parent_transaction_id, null, w.goal_id,
+         (pa.asset_type = 'gold'),
+         w.created_at, 1, w.transaction_id, true, w.transaction_id,
+         -coalesce(w.principal_withdrawn, 0), -coalesce(w.units_withdrawn, 0),
+         coalesce(w.principal_withdrawn, 0), coalesce(w.units_withdrawn, 0),
+         (w.updated_at > w.created_at)
+    from wd w
+    join public.investment_transactions pa on pa.transaction_id = w.parent_transaction_id
+   where not w.fund_keyed
+     -- A parent that is not an investment invents a balance out of money that
+     -- already left; withdrawal_ledger_audit calls that by name, and replaying it
+     -- would only restate the same row less clearly.
+     and pa.transaction_type = 'investment'
+
+  union all
+  -- A fund bucket's purchases DO interleave: the invariant sums whatever is in the
+  -- bucket at the moment of the sell, so a purchase made later is not part of that
+  -- sum. The exclusions mirror the invariant's own — a pending DCA seed (units
+  -- null) holds nothing sellable, and a renewal snapshot is a history copy.
+  select t.user_id,
+         'f:' || t.fund_id::text || ':' || coalesce(t.goal_id::text, ''),
+         null, t.fund_id, t.goal_id, true,
+         t.created_at, 0, t.transaction_id, false, t.transaction_id,
+         coalesce(t.amount_vnd, 0), coalesce(t.units, 0), null, null,
+         (t.updated_at > t.created_at)
+    from public.investment_transactions t
+   where t.transaction_type = 'investment'
+     and t.asset_type = 'fund'
+     and t.fund_id is not null
+     and t.units is not null
+     and t.renewed_from_transaction_id is null
+
+  union all
+  select w.user_id,
+         'f:' || w.fund_id::text || ':' || coalesce(w.goal_id::text, ''),
+         null, w.fund_id, w.goal_id, true,
+         w.created_at, 1, w.transaction_id, true, w.transaction_id,
+         -coalesce(w.principal_withdrawn, 0), -coalesce(w.units_withdrawn, 0),
+         coalesce(w.principal_withdrawn, 0), coalesce(w.units_withdrawn, 0),
+         (w.updated_at > w.created_at)
+    from wd w
+   where w.fund_keyed
+),
+
+-- ── the state each row was written against ──────────────────────────────────
+-- now() is fixed for a whole transaction, so every row a single RPC writes shares
+-- one created_at and there is no order between them to read. Credits are therefore
+-- sorted before debits at the same instant, which is the only reading under which
+-- such a transaction could have passed the invariant in the first place: a
+-- purchase and the sell of it written together must have gone in that order.
+state as (
+  select e.*,
+         coalesce(sum(e.d_basis) over w_prev, 0) as rem_basis,
+         coalesce(sum(e.d_units) over w_prev, 0) as rem_units,
+         bool_or(e.touched)      over w_key      as key_touched,
+         count(*) filter (where e.is_sale) over w_key as sales_on_key,
+         -- Where this sale sits in the holding's history, which is the number an
+         -- operator needs to find it in the ledger. Counted over the sales alone,
+         -- so an interleaved fund purchase does not shift it.
+         count(*) filter (where e.is_sale) over w_upto as sale_ordinal
+    from events e
+  window
+    w_key  as (partition by e.user_id, e.balance_key),
+    w_prev as (partition by e.user_id, e.balance_key
+               order by e.ord_at, e.ord_kind, e.ord_id
+               rows between unbounded preceding and 1 preceding),
+    w_upto as (partition by e.user_id, e.balance_key
+               order by e.ord_at, e.ord_kind, e.ord_id
+               rows between unbounded preceding and current row)
+),
+
+-- ── the invariant's own transition rules, re-run ────────────────────────────
+-- Same three questions check_withdrawal_balance asks, same two constants, asked of
+-- the balance as it stood rather than of the balance as it ended.
+judged as (
+  select s.*,
+         case when s.rem_units > 0 and s.took_units < s.rem_units - 0.0001
+                then round(s.took_units * s.rem_basis / s.rem_units)
+              else s.rem_basis end as owed,
+         case
+           -- Quantity, for whichever kinds carry units. The epsilon rounds a real
+           -- balance and does not create one, so an emptied holding is measured
+           -- exactly — `case when v_left_units > 0` is the invariant's own wording.
+           when s.took_units > 0
+            and s.took_units > s.rem_units + case when s.rem_units > 0 then 0.0001 else 0 end
+             then 'sale_exceeded_the_units_left'
+           -- A quantity-valued holding binds its principal TO the units: a sale of
+           -- all that is left takes the remaining basis, a partial sale its
+           -- units-proportional share, and the two sides may differ by at most the
+           -- đồng that rounding a slice produces.
+           when s.quantity_valued and s.took_units > 0 and s.rem_units > 0
+            and abs(s.took_principal
+                    - case when s.took_units < s.rem_units - 0.0001
+                             then round(s.took_units * s.rem_basis / s.rem_units)
+                           else s.rem_basis end) > 1
+             then 'sale_took_the_wrong_basis'
+           -- Bank and stock: the principal is the user's own figure, capped
+           -- outright by what the holding still held.
+           when not s.quantity_valued and s.took_principal > 0
+            and s.took_principal > s.rem_basis
+             then 'withdrawal_exceeded_the_balance'
+         end as failure
+    from state s
+   where s.is_sale
+),
+
+fails as (
+  select j.*, count(*) over (partition by j.user_id, j.balance_key) as fails_on_key
+    from judged j
+   where j.failure is not null
+)
+
+select distinct on (f.user_id, f.balance_key)
+       f.failure::text  as check_name,
+       -- Provable only where the replay's premise holds: nothing on this key was
+       -- touched after it was written, so these rows ARE the history.
+       case when f.key_touched then 'review' else 'violation' end::text as severity,
+       f.user_id,
+       f.row_id         as transaction_id,
+       f.holding        as parent_transaction_id,
+       f.fund_id,
+       f.goal_id,
+       case f.failure
+         when 'sale_exceeded_the_units_left' then
+           format('a sale of %s units when the holding had %s units left (%s đồng of basis), %s of %s sale(s) into its history',
+                  f.took_units, f.rem_units, f.rem_basis, f.sale_ordinal, f.sales_on_key)
+         when 'sale_took_the_wrong_basis' then
+           format('a sale of %s units out of the %s units then left, against a %s đồng basis: it should have taken %s đồng, it took %s',
+                  f.took_units, f.rem_units, f.rem_basis, f.owed, f.took_principal)
+         else
+           format('a withdrawal of %s đồng when the holding had %s đồng left, %s of %s withdrawal(s) into its history',
+                  f.took_principal, f.rem_basis, f.sale_ordinal, f.sales_on_key)
+       end
+       || case when f.fails_on_key > 1
+                 then format(' — and %s later row(s) on this holding fail the replay too, measured against a balance this one already made fiction',
+                             f.fails_on_key - 1)
+               else '' end as detail
+  from fails f
+ order by f.user_id, f.balance_key, f.ord_at, f.ord_kind, f.ord_id;
+
+comment on view public.withdrawal_ledger_replay is
+  'Replays each balance key''s rows in created_at order against check_withdrawal_balance''s own transition rules and names the first row that could not have been written at its turn. severity=violation where every row on the key is pristine (updated_at = created_at), so the replay IS the history; severity=review where something was touched afterwards. Shape checks belong to withdrawal_ledger_audit (#613).';
+
+-- An operator tool, and there is no screen that reads it. security_invoker means
+-- RLS would confine a caller to their own rows anyway, but granting it adds a
+-- PostgREST surface for no gain — the same reasoning that revoked
+-- withdrawal_ledger_audit in 20260730000003.
+revoke all on public.withdrawal_ledger_replay from anon, authenticated;

--- a/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
+++ b/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
@@ -306,7 +306,17 @@ events as (
          -case when coalesce(w.units_withdrawn, 0) > 0 then w.units_withdrawn
                else least(p.units, p.units * coalesce(w.principal_withdrawn, 0) / p.amount_vnd) end,
          null, null,
-         (w.updated_at > w.created_at),
+         -- The PARENT's edits count as this event's too, because this event's units
+         -- are derived from the parent's current units and amount_vnd (see the
+         -- expression above) — so editing the purchase silently restates how much
+         -- of the bucket this claim took. Usually the purchase is a credit on this
+         -- same key and its own touched flag would carry, but not always: a
+         -- cross-owner purchase is partitioned under ITS owner, and a renewal
+         -- snapshot is no part of the bucket at all, while 20260803000005 counts
+         -- claims on both. Probed — a claim deriving 20 units, a legal 40-unit sale
+         -- against that, then the parent re-priced so the claim derives 10: every
+         -- row pristine, and the sale reported as a proven violation.
+         (w.updated_at > w.created_at or p.updated_at > p.created_at),
          -- The one order the ledger DOES record. A claim parented to a purchase
          -- cannot have been written before that purchase existed: the foreign key
          -- would have refused it, and the invariant finds the claim by joining to

--- a/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
+++ b/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
@@ -88,6 +88,19 @@
 -- the class #613 opens with — a holding no sequence explains, like the 497/503
 -- pair — and any holding whose claims exceed it outright.
 --
+-- One shape is left unreported ON PURPOSE, and it is worth saying so rather than
+-- letting silence read as a clean bill: a claim naming a holding that belongs to
+-- SOMEONE ELSE. check_withdrawal_balance looks for the parent under the claimant's
+-- own user_id, finds nothing, and returns without measuring anything — ownership is
+-- a different trigger's refusal (#474 / #525), and staying quiet here keeps that
+-- message the one the user sees. This view matches that silence, because judging it
+-- meant partitioning the holding under its owner and the claim under the claimant,
+-- which replays the claim against an opening balance of zero and reports a pristine
+-- overdraw of a holding nobody touched. withdrawal_ledger_audit is silent on it
+-- too, so no view in this family reports such a row. A candidate for the screen,
+-- where ownership would be an honest shape check; it is not a balance question and
+-- inventing a balance answer to it is what this note exists to prevent.
+--
 -- Two residual gaps, stated rather than papered over. updated_at is maintained by
 -- the writers, not by a trigger, so a hand-written SQL UPDATE that leaves it alone
 -- is invisible to this test and its key would still read as pristine. And the test
@@ -192,7 +205,8 @@ events as (
     from public.investment_transactions p
    where p.transaction_type = 'investment'
      and exists (select 1 from wd w
-                  where w.parent_transaction_id = p.transaction_id and not w.fund_keyed)
+                  where w.parent_transaction_id = p.transaction_id and not w.fund_keyed
+                    and w.user_id = p.user_id)
 
   union all
   select w.user_id, 'p:' || w.parent_transaction_id::text, w.parent_transaction_id, null, w.goal_id,
@@ -222,6 +236,14 @@ events as (
      -- already left; withdrawal_ledger_audit calls that by name, and replaying it
      -- would only restate the same row less clearly.
      and pa.transaction_type = 'investment'
+     -- And it has to be the writer's OWN holding, which is the same predicate
+     -- check_withdrawal_balance uses before it reads a balance at all — it finds
+     -- nothing and returns quietly, leaving ownership to the trigger whose refusal
+     -- it is (#474 / #525). Without this the two sides land in different partitions
+     -- (the holding under its owner, the claim under the claimant) and the claim
+     -- replays against an opening balance of zero, which reads as a pristine
+     -- overdraw of a holding that is in fact untouched.
+     and pa.user_id = w.user_id
 
   union all
   -- The bucket's OTHER kind of claim (#606). A withdrawal parented to a fund
@@ -261,6 +283,10 @@ events as (
      and p.fund_id is not null
      and coalesce(p.units, 0) > 0
      and coalesce(p.amount_vnd, 0) > 0
+     -- Same-owner, as on the parent axis. A fund belongs to one user, so the
+     -- invariant's own query reaches this implicitly through the bucket; stating it
+     -- keeps the two branches reading alike rather than relying on that.
+     and p.user_id = w.user_id
 
   union all
   -- A fund bucket's purchases DO interleave: the invariant sums whatever is in the

--- a/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
+++ b/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
@@ -207,6 +207,9 @@ events as (
          p.transaction_id                      as ord_id,
          false                                 as is_debit,
          false                                 as judge_here,
+         -- A credit claims nothing, so there is no shape for the invariant to
+         -- refuse. Only a DEBIT can be shape-invalid, and only those quarantine.
+         true                                  as shape_ok,
          null::uuid                            as row_id,
          coalesce(p.amount_vnd, 0)::numeric    as d_basis,
          coalesce(p.units, 0)::numeric         as d_units,
@@ -245,8 +248,19 @@ events as (
          -- and banks a credit later rows can spend — so judging the rows around it
          -- would measure them against a balance the invariant would never have
          -- allowed to exist.
+         -- judge_here and shape_ok are the SAME question on this axis, asked twice
+         -- because they answer different ones downstream: whether to grade this row,
+         -- and whether its numbers may be trusted as the balance for its neighbours.
+         -- The gold clause is the invariant's ("a gold sale must record
+         -- units_withdrawn"); it never produced a finding here, but such a row still
+         -- eats basis, so it has to quarantine.
          coalesce(w.principal_withdrawn, 0) > 0
-           and coalesce(w.units_withdrawn, 0) >= 0, w.transaction_id,
+           and coalesce(w.units_withdrawn, 0) >= 0
+           and (pa.asset_type is distinct from 'gold' or coalesce(w.units_withdrawn, 0) > 0),
+         coalesce(w.principal_withdrawn, 0) > 0
+           and coalesce(w.units_withdrawn, 0) >= 0
+           and (pa.asset_type is distinct from 'gold' or coalesce(w.units_withdrawn, 0) > 0),
+         w.transaction_id,
          -coalesce(w.principal_withdrawn, 0), -coalesce(w.units_withdrawn, 0),
          coalesce(w.principal_withdrawn, 0), coalesce(w.units_withdrawn, 0),
          (w.updated_at > w.created_at), null::uuid
@@ -284,7 +298,10 @@ events as (
   select w.user_id,
          'f:' || p.fund_id::text || ':' || coalesce(p.goal_id::text, ''),
          null, p.fund_id, p.goal_id, true,
-         w.created_at, 1, w.transaction_id, true, false, w.transaction_id,
+         -- Not judged here, and NOT quarantining either: 20260803000005's bucket
+         -- query sums this row's numbers exactly as they stand, whatever shape they
+         -- are in. They are not contamination — on this axis they are the balance.
+         w.created_at, 1, w.transaction_id, true, false, true, w.transaction_id,
          -coalesce(w.principal_withdrawn, 0),
          -case when coalesce(w.units_withdrawn, 0) > 0 then w.units_withdrawn
                else least(p.units, p.units * coalesce(w.principal_withdrawn, 0) / p.amount_vnd) end,
@@ -329,7 +346,7 @@ events as (
   select t.user_id,
          'f:' || t.fund_id::text || ':' || coalesce(t.goal_id::text, ''),
          null, t.fund_id, t.goal_id, true,
-         t.created_at, 0, t.transaction_id, false, false, t.transaction_id,
+         t.created_at, 0, t.transaction_id, false, false, true, t.transaction_id,
          coalesce(t.amount_vnd, 0), coalesce(t.units, 0), null, null,
          (t.updated_at > t.created_at), null::uuid
     from public.investment_transactions t
@@ -351,11 +368,21 @@ events as (
          -- the impossible sign it is. No positive-principal rule here, though:
          -- unlike the parent axis a fund sell may legitimately take nothing, since
          -- a slice worth less than half a đồng rounds to zero.
-         coalesce(w.principal_withdrawn, 0) >= 0
-           and coalesce(w.units_withdrawn, 0) >= 0, w.transaction_id,
+         -- Same pair as the parent axis. The units clause is the invariant's ("a
+         -- fund sale must record units_withdrawn") and, like gold's, it never
+         -- produced a finding — but such a row still eats basis, so it quarantines.
+         coalesce(w.principal_withdrawn, 0) >= 0 and coalesce(w.units_withdrawn, 0) > 0,
+         coalesce(w.principal_withdrawn, 0) >= 0 and coalesce(w.units_withdrawn, 0) > 0,
+         w.transaction_id,
          -coalesce(w.principal_withdrawn, 0), -coalesce(w.units_withdrawn, 0),
          coalesce(w.principal_withdrawn, 0), coalesce(w.units_withdrawn, 0),
-         (w.updated_at > w.created_at), null::uuid
+         (w.updated_at > w.created_at),
+         -- A fund sell ignores its parent for the BALANCE — the bucket is what it
+         -- draws on — but the foreign key still proves that parent existed when the
+         -- sell was written. Where the parent is a purchase in this same bucket that
+         -- is a real ordering fact, and without it the search invents the one
+         -- history that excuses the sell: its own parent purchase placed after it.
+         w.parent_transaction_id
     from wd w
    where w.fund_keyed
 ),
@@ -381,7 +408,16 @@ state as (
          count(*) filter (where e.is_debit) over w_upto as claim_ordinal,
          -- The events that have to be permuted to decide the key: everything but
          -- the source, which opens the balance rather than happening in it.
-         count(*) filter (where e.ord_at > '-infinity') over w_key as movable
+         count(*) filter (where e.ord_at > '-infinity') over w_key as movable,
+         -- A debit the invariant would have refused OUTRIGHT is not judged (the
+         -- screen owns it), but its deltas are still in the running balance and in
+         -- the search's states — so every other row on the key is measured against
+         -- a balance that could never have existed. A 40,000,000 / 4 unit gold
+         -- holding with a no-principal 1-unit claim in it replays the perfectly
+         -- ordinary 1-unit / 10,000,000 sale after it against 40,000,000 / 3, and
+         -- calls the innocent sale wrong. The key is therefore quarantined: its
+         -- findings stay, and they stop claiming to be proof.
+         bool_or(e.is_debit and not e.shape_ok) over w_key as key_contaminated
     from events e
   window
     w_key  as (partition by e.user_id, e.balance_key),
@@ -584,6 +620,14 @@ select distinct on (f.user_id, f.balance_key)
        -- Provable only where the replay's premise holds: nothing on this key was
        -- touched after it was written, so these rows ARE what was measured; the key
        -- was small enough to search; and THIS ROW had no legal position in it.
+       -- Contamination is deliberately NOT a severity clause here, though it looks
+       -- like one. A shape-invalid row is unjudged and therefore freely placeable,
+       -- so every subset WITHOUT it is reachable — and those are exactly the states
+       -- of the ledger as it would stand once that row is gone. A judged row that
+       -- survives none of them fails in the clean ledger too, so it is genuinely
+       -- proven, and downgrading it because something else on the holding is broken
+       -- would throw away a true proof. What contamination earns is the sentence in
+       -- the detail, not a change of verdict.
        case when f.key_touched
               or f.movable > 14
               or exists (select 1 from row_rescued x
@@ -630,6 +674,13 @@ select distinct on (f.user_id, f.balance_key)
                              where x.user_id = f.user_id and x.balance_key = f.balance_key
                                and x.row_id = f.row_id)
                  then '. No ordering of this holding''s claims is legal, so at least one of them is wrong — but this row is not provably the one, since it would have been accepted had it been written earlier'
+               else '' end
+       -- Why a contaminated key's findings are only ever 'review', said where the
+       -- operator meets them: the balance below such a row is not one the invariant
+       -- would have allowed, so nothing measured against it can be trusted, and the
+       -- row to fix is the one the screen already names.
+       || case when f.key_contaminated
+                 then '. This holding also carries a row check_withdrawal_balance would have refused outright — withdrawal_ledger_audit names it — so the balances here are not ones the invariant ever allowed, and this finding may belong to that row rather than to this one'
                else '' end as detail
   from fails f
  order by f.user_id, f.balance_key, f.ord_at, f.ord_kind, f.ord_id;

--- a/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
+++ b/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
@@ -237,7 +237,16 @@ events as (
          -- it stays freely placeable in the ordering search — a row that could
          -- never have been written cannot be used to prove anything about its
          -- neighbours.
-         coalesce(w.principal_withdrawn, 0) > 0, w.transaction_id,
+         -- A NEGATIVE amount is condemned by the screen too (`negative_amounts`),
+         -- and it is the same mistake to restate it here: principal 150 of a 100
+         -- holding with units -1 came out as a plain overdraw, which says nothing
+         -- about the sign that makes the row impossible. It is also the one shape
+         -- that runs the ledger BACKWARDS — a negative delta ADDS to the holding
+         -- and banks a credit later rows can spend — so judging the rows around it
+         -- would measure them against a balance the invariant would never have
+         -- allowed to exist.
+         coalesce(w.principal_withdrawn, 0) > 0
+           and coalesce(w.units_withdrawn, 0) >= 0, w.transaction_id,
          -coalesce(w.principal_withdrawn, 0), -coalesce(w.units_withdrawn, 0),
          coalesce(w.principal_withdrawn, 0), coalesce(w.units_withdrawn, 0),
          (w.updated_at > w.created_at), null::uuid
@@ -334,7 +343,16 @@ events as (
   select w.user_id,
          'f:' || w.fund_id::text || ':' || coalesce(w.goal_id::text, ''),
          null, w.fund_id, w.goal_id, true,
-         w.created_at, 1, w.transaction_id, true, true, w.transaction_id,
+         w.created_at, 1, w.transaction_id, true,
+         -- Same negative-amount carve-out as the parent axis, for the same reason:
+         -- the screen names it and this view would only restate it worse — a sell
+         -- of 50 units recording MINUS 500 đồng came out as "it should have taken
+         -- 500 đồng, it took -500", which reads as a misallocation rather than as
+         -- the impossible sign it is. No positive-principal rule here, though:
+         -- unlike the parent axis a fund sell may legitimately take nothing, since
+         -- a slice worth less than half a đồng rounds to zero.
+         coalesce(w.principal_withdrawn, 0) >= 0
+           and coalesce(w.units_withdrawn, 0) >= 0, w.transaction_id,
          -coalesce(w.principal_withdrawn, 0), -coalesce(w.units_withdrawn, 0),
          coalesce(w.principal_withdrawn, 0), coalesce(w.units_withdrawn, 0),
          (w.updated_at > w.created_at), null::uuid

--- a/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
+++ b/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
@@ -72,8 +72,20 @@
 -- no ordering of any history could have produced this row — answered by searching
 -- for a legal one. See the `reach` CTE: it is a subset search rather than a
 -- permutation one, because the balance after a set of events does not depend on
--- the order they arrived in. A key with a legal reading is 'review' however
--- damning the created_at order looks, and the finding is reported either way.
+-- the order they arrived in.
+--
+-- And the question is asked of the ROW, not of the holding, because those are not
+-- the same claim. Two 50-unit sales of a 1000 đồng / 100 unit holding each taking
+-- 499: either is legal written first (the đồng of rounding covers 499 against 500)
+-- and whichever comes second owes the whole 501 left, so the holding has no legal
+-- reading at all — yet neither sale is individually impossible, and grading them by
+-- the holding's verdict would call whichever sorts second a proven violation when
+-- it may be the innocent one. So `row_rescued` asks whether THIS row would have
+-- been accepted in any state the holding could legally have been in without it.
+-- Legal somewhere means 'review', and the finding is reported either way. The
+-- holding-level proof is not thrown away — where it says more than the row-level
+-- one, it goes into the detail sentence, which is where a claim about a set of rows
+-- can be made without pointing at one of them.
 --
 -- One ordering fact IS honoured, because the ledger genuinely records it: a claim
 -- parented to a purchase cannot have been written before that purchase existed —
@@ -495,17 +507,58 @@ explainable as (
     from reach r
     join opening o on o.user_id = r.user_id and o.balance_key = r.balance_key
    where r.mask = (1::bigint << o.n) - 1
+),
+
+-- ── and is THIS row the one that is wrong? ──────────────────────────────────
+-- "No ordering of this holding is legal" is a statement about the HOLDING. The
+-- finding names a ROW, and those are not the same claim. A pristine 1000 đồng /
+-- 100 unit holding with two 50-unit sales each taking 499: either is legal written
+-- first (the đồng of rounding covers 499 against 500) and whichever comes second
+-- owes the whole 501 that is left, so no complete ordering exists — yet neither
+-- sale is individually impossible, and calling one of them proven sends an
+-- operator to correct a row that may be the innocent one.
+--
+-- So the row is asked about itself: is there ANY state this holding could legally
+-- have been in, without this row, where this row would have been accepted? The
+-- reachable states are already computed above, so this is a scan over them. Legal
+-- somewhere means not proven, whatever the holding as a whole says.
+--
+-- This is strictly stronger than the holding-level test and replaces it: a holding
+-- with a legal ordering puts every one of its rows in a legal position, so nothing
+-- provable at row level can survive there. What the holding-level result still
+-- earns is a SENTENCE — the detail says the holding has no legal reading even when
+-- no single row can be blamed for it, which is the true and useful thing to tell
+-- an operator looking at a set of rows that cannot all be right.
+row_rescued as (
+  select distinct f.user_id, f.balance_key, f.row_id
+    from fails f
+    join movable_dep m
+      on m.user_id = f.user_id and m.balance_key = f.balance_key and m.row_id = f.row_id
+    join reach r
+      on r.user_id = f.user_id and r.balance_key = f.balance_key
+     and (r.mask >> m.idx) & 1 = 0
+     and (m.dep_idx is null or (r.mask >> m.dep_idx) & 1 = 1)
+   where not (f.took_units > 0
+              and f.took_units > r.rem_units + case when r.rem_units > 0 then 0.0001 else 0 end)
+     and not (f.quantity_valued and f.took_units > 0 and r.rem_units > 0
+              and abs(f.took_principal
+                      - case when f.took_units < r.rem_units - 0.0001
+                               then round(f.took_units * r.rem_basis / r.rem_units)
+                             else r.rem_basis end) > 1)
+     and not (not f.quantity_valued and f.took_principal > 0
+              and f.took_principal > r.rem_basis)
 )
 
 select distinct on (f.user_id, f.balance_key)
        f.failure::text  as check_name,
        -- Provable only where the replay's premise holds: nothing on this key was
-       -- touched after it was written, so these rows ARE what was measured; the
-       -- key was small enough to search; and no ordering of it is legal.
+       -- touched after it was written, so these rows ARE what was measured; the key
+       -- was small enough to search; and THIS ROW had no legal position in it.
        case when f.key_touched
               or f.movable > 14
-              or exists (select 1 from explainable x
-                          where x.user_id = f.user_id and x.balance_key = f.balance_key)
+              or exists (select 1 from row_rescued x
+                          where x.user_id = f.user_id and x.balance_key = f.balance_key
+                            and x.row_id = f.row_id)
               then 'review' else 'violation' end::text as severity,
        f.user_id,
        f.row_id         as transaction_id,
@@ -534,12 +587,25 @@ select distinct on (f.user_id, f.balance_key)
        || case when f.fails_on_key > 1
                  then format(' — and %s later row(s) on this holding fail the replay too, measured against a balance this one already made fiction',
                              f.fails_on_key - 1)
+               else '' end
+       -- The holding-level result, where it says more than the row-level one. Two
+       -- 50-unit sales of 1000 đồng / 100 units each taking 499 have no legal
+       -- reading between them, and neither one is individually impossible — the
+       -- proof is real but it belongs to the pair, so it goes in the sentence
+       -- rather than into a severity that would point at one of them.
+       || case when not f.key_touched and f.movable <= 14
+                and not exists (select 1 from explainable x
+                                 where x.user_id = f.user_id and x.balance_key = f.balance_key)
+                and exists (select 1 from row_rescued x
+                             where x.user_id = f.user_id and x.balance_key = f.balance_key
+                               and x.row_id = f.row_id)
+                 then '. No ordering of this holding''s claims is legal, so at least one of them is wrong — but this row is not provably the one, since it would have been accepted had it been written earlier'
                else '' end as detail
   from fails f
  order by f.user_id, f.balance_key, f.ord_at, f.ord_kind, f.ord_id;
 
 comment on view public.withdrawal_ledger_replay is
-  'Replays each balance key''s rows in created_at order against check_withdrawal_balance''s own transition rules and names the first row that could not have been written at its turn. severity=violation where every row on the key is pristine (updated_at = created_at), so the replay IS the history; severity=review where something was touched afterwards. Shape checks belong to withdrawal_ledger_audit (#613).';
+  'Replays each balance key''s rows against check_withdrawal_balance''s own transition rules and names the first row that could not have been written at its turn. created_at gives the order it REPORTS against; severity is decided by an exhaustive search over orderings, since created_at is transaction-start and records no write order. severity=violation means this row had no legal position in any history of its holding, and nothing on the key was edited after it was written; severity=review means it is worth looking at but not proven — read the detail, which carries the holding-level verdict where that says more. Shape checks belong to withdrawal_ledger_audit; the two are complements (#613).';
 
 -- An operator tool, and there is no screen that reads it. security_invoker means
 -- RLS would confine a caller to their own rows anyway, but granting it adds a

--- a/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
+++ b/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
@@ -295,10 +295,22 @@ events as (
      and p.fund_id is not null
      and coalesce(p.units, 0) > 0
      and coalesce(p.amount_vnd, 0) > 0
-     -- Same-owner, as on the parent axis. A fund belongs to one user, so the
-     -- invariant's own query reaches this implicitly through the bucket; stating it
-     -- keeps the two branches reading alike rather than relying on that.
-     and p.user_id = w.user_id
+     -- NO same-owner test on the purchase, deliberately, and NOT for symmetry with
+     -- the parent axis above. 20260803000005's query constrains the claim's owner
+     -- (`w.user_id = wd.user_id`) and never the purchase's — it reaches the purchase
+     -- through `p.fund_id = wd.fund_id`. The ownership trigger (#474 / 20260722000004)
+     -- stops new rows from carrying another user's fund, but legacy rows are the
+     -- whole reason this view exists, and on one of those the two halves diverge:
+     -- the BASIS sum does require `t.user_id = wd.user_id`, so a cross-owner
+     -- purchase is left out of what the bucket holds while a claim parented to it is
+     -- still charged against the bucket. Probed — a 100-unit bucket carrying a
+     -- 10-unit claim on such a purchase refuses a 95-unit sale at "the remaining
+     -- balance of 90 units". Adding the owner test here dropped that claim and the
+     -- sale replayed clean.
+     --
+     -- Whether that asymmetry is right is a question for the invariant, not for its
+     -- audit. This view's contract is to report what the database actually enforces,
+     -- and a predicate it does not have belongs nowhere in it.
 
   union all
   -- A fund bucket's purchases DO interleave: the invariant sums whatever is in the

--- a/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
+++ b/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
@@ -340,12 +340,20 @@ select distinct on (f.user_id, f.balance_key)
        f.goal_id,
        case f.failure
          when 'sale_exceeded_the_units_left' then
-           format('a sale of %s units when the holding had %s units left (%s đồng of basis), %s of %s sale(s) into its history',
+           -- "claim(s)", not "sale(s)": on a fund bucket this count includes the
+           -- withdrawals parented to its purchases (#606), which are claims on the
+           -- bucket without being sales of it. Counting them is the point — a
+           -- legacy claim is often the reason the sale that follows does not fit,
+           -- and an operator who cannot see it in the tally goes looking for a
+           -- second sale that is not there.
+           format('a sale of %s units when the holding had %s units left (%s đồng of basis), %s of %s claim(s) into its history',
                   f.took_units, f.rem_units, f.rem_basis, f.claim_ordinal, f.claims_on_key)
          when 'sale_took_the_wrong_basis' then
            format('a sale of %s units out of the %s units then left, against a %s đồng basis: it should have taken %s đồng, it took %s',
                   f.took_units, f.rem_units, f.rem_basis, f.owed, f.took_principal)
          else
+           -- This branch is the parent axis alone, where every claim IS a
+           -- withdrawal of the holding and the word can be the exact one.
            format('a withdrawal of %s đồng when the holding had %s đồng left, %s of %s withdrawal(s) into its history',
                   f.took_principal, f.rem_basis, f.claim_ordinal, f.claims_on_key)
        end

--- a/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
+++ b/supabase/migrations/20260814000002_withdrawal_ledger_replay.sql
@@ -56,13 +56,30 @@
 -- by construction, rather than being flagged as corruption or having their shapes
 -- hand-listed here — a list that would go stale the first time an RPC changed.
 --
--- The second thing a 'violation' has to answer for is that the order it replayed
--- is the only one the ledger allows. now() is transaction-stable, so every row a
--- single RPC writes shares one created_at exactly, and transaction_id is a random
--- uuid — sorting by it invents an order rather than recovering one. An instant
--- holding more than one event, at least one of them a claim, therefore drops
--- everything from that point on to 'review' as well. See the `tied` CTE for the
--- legal pair that fails when its two rows are replayed the other way round.
+-- The second thing a 'violation' has to answer for is the ORDER, and created_at
+-- cannot answer it. It defaults to now(), which is the transaction's START, while
+-- the invariant serializes claims on the source's row lock — so the write order is
+-- the lock order, and a long-running transaction writes after a later-starting
+-- one. Reproduced with two sessions: A begins at 11:06:57 and writes (32 units,
+-- 319 đồng); B begins at 11:06:59, writes (34, 339) and commits first. Both are
+-- accepted, both rows are pristine, and created_at puts them in the wrong order —
+-- replayed that way the 34-unit row owes 341 and is two đồng out. Rows a single
+-- RPC writes are worse still: they share one created_at exactly and transaction_id
+-- is a random uuid, which invents an order rather than recovering one.
+--
+-- So the ordering is not assumed AT ALL. created_at decides what the finding is
+-- reported against; what it is PROVED against is the question #613 actually asks —
+-- no ordering of any history could have produced this row — answered by searching
+-- for a legal one. See the `reach` CTE: it is a subset search rather than a
+-- permutation one, because the balance after a set of events does not depend on
+-- the order they arrived in. A key with a legal reading is 'review' however
+-- damning the created_at order looks, and the finding is reported either way.
+--
+-- The price is real and worth stating plainly: a fund bucket whose purchases could
+-- be reordered ahead of its sells is rarely provable, because "all the purchases
+-- first" is usually a legal reading. Those report 'review'. What stays provable is
+-- the class #613 opens with — a holding no sequence explains, like the 497/503
+-- pair — and any holding whose claims exceed it outright.
 --
 -- Two residual gaps, stated rather than papered over. updated_at is maintained by
 -- the writers, not by a trigger, so a hand-written SQL UPDATE that leaves it alone
@@ -108,7 +125,8 @@
 
 create or replace view public.withdrawal_ledger_replay
 with (security_invoker = true) as
-with wd as (
+-- RECURSIVE for the `reach` CTE alone, which walks the subsets of a key's events.
+with recursive wd as (
   select w.transaction_id, w.user_id, w.goal_id, w.fund_id, w.parent_transaction_id,
          w.principal_withdrawn, w.units_withdrawn, w.created_at, w.updated_at,
          -- The same branch precedence as check_withdrawal_balance and
@@ -244,44 +262,29 @@ events as (
 -- such a transaction could have passed the invariant in the first place: a
 -- purchase and the sell of it written together must have gone in that order.
 --
--- Ties are the limit of that reading, and they are load-bearing. Two withdrawals
--- written by separate statements of ONE transaction share a created_at exactly,
--- and transaction_id is a random uuid — it recovers no order, it only invents a
--- stable one. A pristine, legal ledger can fail under the invented order: against
--- 1000 đồng / 100 units, (34 units, 339 đồng) then (32 units, 319 đồng) is legal
--- both ways round as written, but replayed in the other order the 34-unit row owes
--- 341 and is two đồng out. So an instant holding more than one event, at least one
--- of them a debit, makes every finding from that point on a 'review' — the replay
--- still says what it found and against what, it just does not claim the ordering
--- was the one that happened.
-tied as (
-  select e.*,
-         (count(*) over w_at > 1 and count(*) filter (where e.is_debit) over w_at > 0)
-           as ambiguous_instant
-    from events e
-  window w_at as (partition by e.user_id, e.balance_key, e.ord_at)
-),
+-- That order is what the replay REPORTS against. It is not what it proves from —
+-- see the ordering search below, which assumes no order at all.
 state as (
-  select t.*,
-         coalesce(sum(t.d_basis) over w_prev, 0) as rem_basis,
-         coalesce(sum(t.d_units) over w_prev, 0) as rem_units,
-         bool_or(t.touched)      over w_key      as key_touched,
-         count(*) filter (where t.is_debit) over w_key as claims_on_key,
+  select e.*,
+         coalesce(sum(e.d_basis) over w_prev, 0) as rem_basis,
+         coalesce(sum(e.d_units) over w_prev, 0) as rem_units,
+         bool_or(e.touched)      over w_key      as key_touched,
+         count(*) filter (where e.is_debit) over w_key as claims_on_key,
          -- Where this claim sits in the holding's history, which is the number an
          -- operator needs to find it in the ledger. Counted over the claims alone,
          -- so an interleaved fund purchase does not shift it.
-         count(*) filter (where t.is_debit) over w_upto as claim_ordinal,
-         -- Only ties up to and including this row can have moved the balance it was
-         -- measured against; a tie later in the holding says nothing about it.
-         bool_or(t.ambiguous_instant) over w_upto as order_ambiguous
-    from tied t
+         count(*) filter (where e.is_debit) over w_upto as claim_ordinal,
+         -- The events that have to be permuted to decide the key: everything but
+         -- the source, which opens the balance rather than happening in it.
+         count(*) filter (where e.ord_at > '-infinity') over w_key as movable
+    from events e
   window
-    w_key  as (partition by t.user_id, t.balance_key),
-    w_prev as (partition by t.user_id, t.balance_key
-               order by t.ord_at, t.ord_kind, t.ord_id
+    w_key  as (partition by e.user_id, e.balance_key),
+    w_prev as (partition by e.user_id, e.balance_key
+               order by e.ord_at, e.ord_kind, e.ord_id
                rows between unbounded preceding and 1 preceding),
-    w_upto as (partition by t.user_id, t.balance_key
-               order by t.ord_at, t.ord_kind, t.ord_id
+    w_upto as (partition by e.user_id, e.balance_key
+               order by e.ord_at, e.ord_kind, e.ord_id
                rows between unbounded preceding and current row)
 ),
 
@@ -324,15 +327,106 @@ fails as (
   select j.*, count(*) over (partition by j.user_id, j.balance_key) as fails_on_key
     from judged j
    where j.failure is not null
+),
+
+-- ── is there ANY order this key could have been written in? ─────────────────
+-- What the replay reports comes from created_at. What it PROVES may not, because
+-- created_at is `now()`, which is the transaction's START — and the invariant
+-- serializes claims on a lock, so the write order is the lock order. A long
+-- transaction can write after a later-starting one:
+--
+--   A begins 11:06:57 .............................. writes (32 units, 319 đồng)
+--   B begins 11:06:59, writes (34, 339), commits
+--
+-- Both accepted — B against the full 1000 đồng / 100 units, A against the 661/66
+-- B left it. Both rows pristine, both timestamps distinct, and in the WRONG order:
+-- replayed by created_at the 34-unit row owes 341 and is two đồng out. Reproduced
+-- with two sessions against the local stack. No comparison of created_at values
+-- rescues that, whatever gap is allowed for, so the ordering is not assumed at all.
+--
+-- Instead the question #613 actually asks — "no ordering of any history could have
+-- produced this row" — is answered directly, and it is cheaper than it looks. The
+-- remaining balance after a SET of events does not depend on the order they came
+-- in: it is the opening balance plus their deltas, and addition commutes. So this
+-- is a search over subsets, not permutations. A subset is reachable when some
+-- event in it is legal against the balance the rest of it leaves.
+--
+-- A key where SOME ordering is legal cannot be called proven, however damning the
+-- created_at order looks; it drops to 'review' with the finding intact. Only a key
+-- where the full set is unreachable by any route has no legal reading at all.
+--
+-- The cap is a resource bound, not a tolerance: a key with more than 14 movable
+-- events is not searched and reports 'review'. Ordinary holdings are far below it,
+-- and only keys that already produced a finding are searched at all — a clean
+-- ledger does no work here.
+movable as (
+  select s.user_id, s.balance_key, s.is_debit, s.judge_here, s.quantity_valued,
+         s.d_basis, s.d_units, s.took_principal, s.took_units,
+         (row_number() over (partition by s.user_id, s.balance_key
+                             order by s.ord_at, s.ord_kind, s.ord_id) - 1)::int as idx
+    from state s
+   where s.ord_at > '-infinity'
+     and exists (select 1 from fails f
+                  where f.user_id = s.user_id and f.balance_key = s.balance_key)
+),
+opening as (
+  select s.user_id, s.balance_key,
+         -- The source opens a parent-backed holding; a fund bucket opens at zero
+         -- and is filled by the purchase events themselves.
+         coalesce(sum(s.d_basis) filter (where s.ord_at = '-infinity'), 0) as open_basis,
+         coalesce(sum(s.d_units) filter (where s.ord_at = '-infinity'), 0) as open_units,
+         max(s.movable)::int as n
+    from state s
+   where exists (select 1 from fails f
+                  where f.user_id = s.user_id and f.balance_key = s.balance_key)
+   group by s.user_id, s.balance_key
+),
+reach as (
+  select o.user_id, o.balance_key, 0::bigint as mask,
+         o.open_basis as rem_basis, o.open_units as rem_units
+    from opening o
+   where o.n <= 14
+  union
+  select r.user_id, r.balance_key, r.mask | (1::bigint << m.idx),
+         r.rem_basis + m.d_basis, r.rem_units + m.d_units
+    from reach r
+    join movable m
+      on m.user_id = r.user_id and m.balance_key = r.balance_key
+     and (r.mask >> m.idx) & 1 = 0
+   where not m.is_debit
+      -- A purchase claims nothing, and a claim the invariant does not measure here
+      -- (a bucket's parent-backed claim) is only counted, never judged — so both
+      -- may be placed anywhere.
+      or not m.judge_here
+      -- Otherwise it has to survive the same three questions, against the balance
+      -- the rest of this subset leaves.
+      or (not (m.took_units > 0
+               and m.took_units > r.rem_units + case when r.rem_units > 0 then 0.0001 else 0 end)
+          and not (m.quantity_valued and m.took_units > 0 and r.rem_units > 0
+                   and abs(m.took_principal
+                           - case when m.took_units < r.rem_units - 0.0001
+                                    then round(m.took_units * r.rem_basis / r.rem_units)
+                                  else r.rem_basis end) > 1)
+          and not (not m.quantity_valued and m.took_principal > 0
+                   and m.took_principal > r.rem_basis))
+),
+explainable as (
+  select distinct r.user_id, r.balance_key
+    from reach r
+    join opening o on o.user_id = r.user_id and o.balance_key = r.balance_key
+   where r.mask = (1::bigint << o.n) - 1
 )
 
 select distinct on (f.user_id, f.balance_key)
        f.failure::text  as check_name,
        -- Provable only where the replay's premise holds: nothing on this key was
-       -- touched after it was written, and no instant up to this row holds two
-       -- events whose order the ledger does not record. Then these rows ARE the
-       -- history, and no ordering of them produces what was found.
-       case when f.key_touched or f.order_ambiguous then 'review' else 'violation' end::text as severity,
+       -- touched after it was written, so these rows ARE what was measured; the
+       -- key was small enough to search; and no ordering of it is legal.
+       case when f.key_touched
+              or f.movable > 14
+              or exists (select 1 from explainable x
+                          where x.user_id = f.user_id and x.balance_key = f.balance_key)
+              then 'review' else 'violation' end::text as severity,
        f.user_id,
        f.row_id         as transaction_id,
        f.holding        as parent_transaction_id,

--- a/supabase/tests/withdrawal_ledger_replay.test.sql
+++ b/supabase/tests/withdrawal_ledger_replay.test.sql
@@ -61,6 +61,7 @@ declare
   v_shape      uuid; v_shape_w  uuid;
   v_other      uuid; v_other_g  uuid; v_foreign uuid; v_foreign_w uuid;
   v_pair       uuid; v_pair_a   uuid; v_pair_b  uuid;
+  v_xfund      uuid; v_x_mine   uuid; v_x_theirs uuid; v_x_claim uuid; v_x_sell uuid;
   i            int;
   v_found      text;
   v_count      int;
@@ -340,6 +341,45 @@ begin
           '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
   returning transaction_id into v_foreign_w;
 
+  -- ── a cross-owner purchase inside a bucket ─────────────────────────────────
+  -- The mirror of the parent-axis case above, and it goes the OTHER way, which is
+  -- why both are here. 20260803000005's bucket query constrains the CLAIM's owner
+  -- (`w.user_id = wd.user_id`) and never the purchase's — it reaches the purchase
+  -- through `p.fund_id = wd.fund_id`. Its basis sum does require the owner to
+  -- match. So on a legacy row carrying another user's fund, the two halves
+  -- diverge: the cross-owner purchase is left out of what the bucket HOLDS, while
+  -- a claim parented to it is still charged against the bucket.
+  --
+  -- 100 units of my own, a 10-unit claim on their purchase, and a 95-unit sale:
+  -- the invariant refuses it at "the remaining balance of 90 units". An owner test
+  -- on the purchase here — which the parent axis genuinely needs — drops that claim
+  -- and the sale replays clean. This view reports what the database enforces;
+  -- whether that asymmetry is right is a question for the invariant.
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Cross Fund', 'RXFD', 'equity', 20000) returning id into v_xfund;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'investment', '2026-01-01', 100000000, 100, 1000000, v_xfund,
+          '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_x_mine;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_other, v_goal, 'fund', 'investment', '2026-01-05', 50000000, 50, 1000000, v_xfund,
+          '2026-01-05T00:00:00Z', '2026-01-05T00:00:00Z')
+  returning transaction_id into v_x_theirs;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 10000000, v_x_theirs, 10000000, 10,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_x_claim;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id,
+     principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'withdrawal', '2026-03-01', 95000000, v_xfund, 95000000, 95,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z')
+  returning transaction_id into v_x_sell;
+
   -- ── a shape the screening view already owns ────────────────────────────────
   -- A gold sale with units and no principal. The invariant refuses it before the
   -- allocation rule is ever reached ("must record a positive principal_withdrawn")
@@ -616,6 +656,20 @@ begin
     raise exception 'the holding-level proof is real and has to reach the operator in the sentence, got %', v_found;
   end if;
 
+  -- the cross-owner purchase in a bucket: the claim on it still counts, and the
+  -- balance the replay reports is the one the invariant names in its own refusal
+  select r.check_name into v_found
+    from public.withdrawal_ledger_replay r where r.transaction_id = v_x_sell;
+  if v_found is distinct from 'sale_exceeded_the_units_left' then
+    raise exception 'a claim parented to a cross-owner purchase is still charged to the bucket by the invariant, so the replay must count it too, got %',
+      coalesce(v_found, '(silence)');
+  end if;
+  select r.detail into v_found
+    from public.withdrawal_ledger_replay r where r.transaction_id = v_x_sell;
+  if v_found not like '%90 units left%' then
+    raise exception 'the invariant refuses this at "the remaining balance of 90 units" — the replay has to agree, got %', v_found;
+  end if;
+
   -- the claim on another user's holding: silent, and silent for BOTH users — the
   -- holding's owner must not see an overdraw of a holding nobody touched either
   if exists (select 1 from public.withdrawal_ledger_replay r
@@ -660,10 +714,10 @@ begin
   -- tie-break, and it is the only fixture here that may do either.
   select count(*) into v_count from public.withdrawal_ledger_replay r
    where r.user_id = v_user and r.parent_transaction_id is distinct from v_tie;
-  if v_count <> 9 then
+  if v_count <> 10 then
     select string_agg(format('%s/%s: %s', r.check_name, r.severity, r.detail), E'\n')
       into v_found from public.withdrawal_ledger_replay r where r.user_id = v_user;
-    raise exception 'expected exactly the 9 planted sequences, got %:%s%s', v_count, E'\n', v_found;
+    raise exception 'expected exactly the 10 planted sequences, got %:%s%s', v_count, E'\n', v_found;
   end if;
 
   raise notice 'withdrawal_ledger_replay: ok';

--- a/supabase/tests/withdrawal_ledger_replay.test.sql
+++ b/supabase/tests/withdrawal_ledger_replay.test.sql
@@ -1,0 +1,445 @@
+-- The replay audit has to decide what the screening audit cannot (#613).
+--
+-- public.withdrawal_ledger_audit (#609 / #611) reads the ledger as it STANDS. The
+-- invariant it audits is stateful, so whole families of illegal ledgers reach a
+-- final state that a legal one could also have reached, and that view is silent on
+-- every one of them — deliberately, and its own header says so.
+--
+-- public.withdrawal_ledger_replay orders each balance key's rows by created_at and
+-- re-runs the invariant's transition rules over them. This file's job is to prove
+-- the two halves of that claim:
+--
+--   • it CATCHES the sequences the screening audit provably cannot. Each such
+--     fixture asserts BOTH — the replay names it, and withdrawal_ledger_audit does
+--     not — so the test fails if the replay ever silently becomes a restatement of
+--     the view it exists to go beyond.
+--   • it stays SILENT on ledgers the invariant itself vouched for. Those are
+--     planted with the triggers ON, so the invariant accepted every write, and the
+--     replay has no licence to complain about any of them.
+--
+-- Every fixture sets created_at and updated_at by hand, and has to: now() is fixed
+-- for the whole transaction, so rows inserted here would otherwise all share one
+-- timestamp and there would be no order to replay. Setting created_at without
+-- updated_at would also make every row look EDITED (updated_at defaults to now(),
+-- which is later than a backdated created_at) and drop every finding to 'review'.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_user       uuid;
+  v_goal       uuid;
+  v_fund       uuid;
+  v_fund_ok    uuid;
+  v_fund_late  uuid;
+  -- the clean half
+  v_ok_bank    uuid;
+  v_ok_gold    uuid;
+  v_ok_buy     uuid;
+  v_tiny_gold  uuid;
+  -- planted sequences
+  v_cancel     uuid; v_cancel_a uuid; v_cancel_b uuid;
+  v_early      uuid;
+  v_edited     uuid; v_edited_a uuid;
+  v_bank_over  uuid; v_bank_w2  uuid;
+  v_found      text;
+  v_count      int;
+  v_audit      int;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-replay@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Replay Fund', 'RPLF', 'equity', 20000) returning id into v_fund;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Clean Fund', 'RCLN', 'equity', 20000) returning id into v_fund_ok;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Late Fund', 'RLAT', 'equity', 20000) returning id into v_fund_late;
+
+  -- ═══ the clean half, written with the invariant WATCHING ═══════════════════
+  -- Each write below passed check_withdrawal_balance against the balance the
+  -- earlier writes left, which is the very sequence the replay reconstructs. A
+  -- finding on any of them is a false positive by construction.
+
+  -- bank: principal-only, drawn down to nothing in two withdrawals
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_ok_bank;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 40000000, v_ok_bank, 40000000,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z');
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-03-01', 60000000, v_ok_bank, 60000000,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z');
+
+  -- gold: quantity-valued, a partial slice and then the closer
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 40000000, 4, 10000000,
+          '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_ok_gold;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 11000000, v_ok_gold, 10000000, 1,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z');
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 31000000, v_ok_gold, 30000000, 3,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z');
+
+  -- a gold holding so small every slice's proportional share rounds to nothing —
+  -- three đồng legally leave a one đồng holding, every write accepted (the
+  -- invariant separately demands a positive principal). The replay must reach the
+  -- same verdict the invariant did, one sale at a time.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 1, 5, 1, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_tiny_gold;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 1, v_tiny_gold, 1, 1, '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z'),
+         (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 1, v_tiny_gold, 1, 1, '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z'),
+         (v_user, v_goal, 'gold', 'withdrawal', '2026-04-01', 1, v_tiny_gold, 1, 1, '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z');
+
+  -- a fund bucket with a purchase arriving BETWEEN two sells: the second sell's
+  -- share is computed from the basis as it stood then, which is exactly the drift
+  -- the screening audit can only call 'review'. The replay knows the order, so it
+  -- must be silent.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'investment', '2026-01-01', 100000000, 100, 1000000, v_fund_ok,
+          '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_ok_buy;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id,
+     principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'withdrawal', '2026-02-01', 55000000, v_fund_ok, 50000000, 50,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z');
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'investment', '2026-03-01', 60000000, 50, 1200000, v_fund_ok,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z');
+  -- 50 of the 100 units now in the bucket, against a 110,000,000 basis → 55,000,000
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id,
+     principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'withdrawal', '2026-04-01', 60000000, v_fund_ok, 55000000, 50,
+          '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z');
+
+  select count(*) into v_count from public.withdrawal_ledger_replay r where r.user_id = v_user;
+  if v_count <> 0 then
+    select string_agg(format('%s/%s: %s', r.check_name, r.severity, r.detail), E'\n')
+      into v_found from public.withdrawal_ledger_replay r where r.user_id = v_user;
+    raise exception 'the replay complained about a ledger the invariant itself accepted:%s%s', E'\n', v_found;
+  end if;
+
+  -- ═══ the sequences only a replay can decide ════════════════════════════════
+  -- Planted with the triggers off: every one of these is a shape the invariant
+  -- refuses to write, which is the whole reason they can only be found afterwards.
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted immediate;
+  alter table public.investment_transactions disable trigger user;
+
+  -- ── the headline case from #613 ────────────────────────────────────────────
+  -- 1000 đồng over 100 units, two sales of 50 units taking 497 and 503. The totals
+  -- are exactly proportional and each per-sale deviation is inside what a legal
+  -- two-sale ledger shows elsewhere, so no predicate over the final state can
+  -- separate it — the screening audit is silent, and a test there pins that
+  -- silence. Neither sale can be written first (50 of 100 units must take 500) and
+  -- neither can follow the other, so no ordering makes it legal.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 1000, 100, 10, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_cancel;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 497, v_cancel, 497, 50,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_cancel_a;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 503, v_cancel, 503, 50,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z')
+  returning transaction_id into v_cancel_b;
+
+  -- ── a fund sell that outran the purchases it now looks backed by ───────────
+  -- 50 units bought, 100 sold, 50 more bought afterwards. The bucket's totals
+  -- balance perfectly, so the screening audit sees nothing; at the moment the sell
+  -- was written only half its units existed.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'investment', '2026-01-01', 50000000, 50, 1000000, v_fund_late,
+          '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id,
+     principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'withdrawal', '2026-02-01', 110000000, v_fund_late, 100000000, 100,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_early;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'investment', '2026-03-01', 50000000, 50, 1000000, v_fund_late,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z');
+
+  -- ── the same impossible pair, on a holding that was EDITED afterwards ──────
+  -- A replay reconstructs history from rows as they are NOW, so a row touched
+  -- after it was written is measured against a balance that may never have
+  -- existed. That is the premise, and where it does not hold the finding drops to
+  -- 'review' rather than claiming proof it cannot have.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 1000, 100, 10, '2026-01-01T00:00:00Z', '2026-06-01T00:00:00Z')
+  returning transaction_id into v_edited;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 497, v_edited, 497, 50,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_edited_a;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 503, v_edited, 503, 50,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z');
+
+  -- ── a bank holding drawn past zero by its second withdrawal ────────────────
+  -- The screening audit reports this holding too; what the replay adds is WHICH
+  -- row broke it and the balance it was measured against.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_bank_over;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 80000000, v_bank_over, 80000000,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z');
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-03-01', 80000000, v_bank_over, 80000000,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z')
+  returning transaction_id into v_bank_w2;
+
+  alter table public.investment_transactions enable trigger user;
+  set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
+
+  -- ═══ what the replay must say ══════════════════════════════════════════════
+
+  -- the headline case: named, as a violation, on the FIRST of the two sales, and
+  -- invisible to the screening audit
+  select r.check_name || '/' || r.severity into v_found
+    from public.withdrawal_ledger_replay r
+   where r.transaction_id = v_cancel_a;
+  if v_found is distinct from 'sale_took_the_wrong_basis/violation' then
+    raise exception 'the 497/503 pair should be a proven violation on its first sale, got %', coalesce(v_found, '(silence)');
+  end if;
+  if exists (select 1 from public.withdrawal_ledger_replay r where r.transaction_id = v_cancel_b) then
+    raise exception 'only the FIRST row that could not have been written should be reported, not every later one';
+  end if;
+  select count(*) into v_audit from public.withdrawal_ledger_audit a
+   where a.parent_transaction_id = v_cancel or a.transaction_id in (v_cancel_a, v_cancel_b);
+  if v_audit <> 0 then
+    raise exception 'the screening audit was supposed to be silent here — this fixture no longer proves the replay adds anything';
+  end if;
+
+  -- the detail has to carry the state the row was measured against, which is what
+  -- makes a finding repairable rather than merely alarming
+  select r.detail into v_found from public.withdrawal_ledger_replay r where r.transaction_id = v_cancel_a;
+  if v_found not like '%1000%' or v_found not like '%100 units%' or v_found not like '%500%' then
+    raise exception 'the detail should report the balance at that turn and the basis owed, got %', v_found;
+  end if;
+
+  -- the fund sell that outran its purchases
+  select r.check_name || '/' || r.severity into v_found
+    from public.withdrawal_ledger_replay r where r.transaction_id = v_early;
+  if v_found is distinct from 'sale_exceeded_the_units_left/violation' then
+    raise exception 'a sell of 100 units against a 50-unit bucket should be a proven violation, got %', coalesce(v_found, '(silence)');
+  end if;
+  select count(*) into v_audit from public.withdrawal_ledger_audit a where a.fund_id = v_fund_late;
+  if v_audit <> 0 then
+    raise exception 'the screening audit was supposed to be silent on the late-purchase bucket';
+  end if;
+
+  -- the edited holding: same impossible pair, but the premise no longer holds
+  select r.severity into v_found
+    from public.withdrawal_ledger_replay r where r.transaction_id = v_edited_a;
+  if v_found is distinct from 'review' then
+    raise exception 'a finding on a holding edited after its sales must not claim proof, got %', coalesce(v_found, '(silence)');
+  end if;
+
+  -- the bank overdraw: the replay names the row, where the screening audit names
+  -- only the holding
+  select r.check_name || '/' || r.severity into v_found
+    from public.withdrawal_ledger_replay r where r.transaction_id = v_bank_w2;
+  if v_found is distinct from 'withdrawal_exceeded_the_balance/violation' then
+    raise exception 'the second bank withdrawal should be named as the row that broke the holding, got %', coalesce(v_found, '(silence)');
+  end if;
+  -- and placed in the holding's history, not merely in the list of failures: this
+  -- is the SECOND of two withdrawals, and an operator opening the ledger needs
+  -- that number to be the one they can count to.
+  select r.detail into v_found from public.withdrawal_ledger_replay r where r.transaction_id = v_bank_w2;
+  if v_found not like '%20000000 đồng left, 2 of 2 withdrawal(s)%' then
+    raise exception 'the detail should place the row at its turn in the holding''s history, got %', v_found;
+  end if;
+
+  -- and nothing beyond the four holdings planted above
+  select count(*) into v_count from public.withdrawal_ledger_replay r where r.user_id = v_user;
+  if v_count <> 4 then
+    select string_agg(format('%s/%s: %s', r.check_name, r.severity, r.detail), E'\n')
+      into v_found from public.withdrawal_ledger_replay r where r.user_id = v_user;
+    raise exception 'expected exactly the 4 planted sequences, got %:%s%s', v_count, E'\n', v_found;
+  end if;
+
+  raise notice 'withdrawal_ledger_replay: ok';
+end $$;
+
+-- ═══ the false-positive half, at scale ══════════════════════════════════════
+-- The fixtures above prove the replay CATCHES. This proves it does not cry wolf,
+-- which is the property that decides whether anyone ever reads its output.
+--
+-- Legal ledgers are not asserted to be legal here — they are BUILT with the
+-- invariant watching, one write at a time, in the order the replay will read them.
+-- Every insert below therefore has check_withdrawal_balance's own signature on it,
+-- and a single finding is a false positive by construction. The generator pushes
+-- each sale to the edge of what the rule allows (the đồng of rounding slack, the
+-- full-sale shortcut, slices small enough that their share rounds to nothing),
+-- because the middle of the range was never where the disagreements were.
+--
+-- Seeded, so a failure here is reproducible rather than a coin flip in CI.
+do $$
+declare
+  v_user    uuid;
+  v_goal    uuid;
+  v_fund    uuid;
+  v_src     uuid;
+  v_basis   bigint;
+  v_units   numeric;
+  v_left    bigint;
+  v_left_u  numeric;
+  v_take_u  numeric;
+  v_take_p  bigint;
+  v_when    timestamptz;
+  v_sales   int;
+  v_found   text;
+  i         int;
+  j         int;
+begin
+  perform setseed(0.613);
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-replay-fuzz@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Fuzz') returning goal_id into v_goal;
+
+  -- ── gold: one source, sales drawn down in sequence ────────────────────────
+  for i in 1..120 loop
+    -- Four magnitudes of basis and units, so the tiny holdings where every share
+    -- rounds to zero get the same exercise as the ordinary ones.
+    v_basis := (1 + floor(random() * 1000))::bigint * (10 ^ (floor(random() * 4)))::bigint;
+    v_units := round((0.5 + random() * 100)::numeric, 4);
+    v_when  := timestamptz '2026-01-01T00:00:00Z' + (i * interval '1 day');
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, created_at, updated_at)
+    values (v_user, v_goal, 'gold', 'investment', '2026-01-01', v_basis, v_units, 1, v_when, v_when)
+    returning transaction_id into v_src;
+
+    v_left := v_basis; v_left_u := v_units;
+    v_sales := 1 + floor(random() * 5);
+    for j in 1..v_sales loop
+      exit when v_left_u <= 0;
+      -- Sometimes close the holding outright, which is the branch that takes the
+      -- whole remaining basis rather than a share of it.
+      if random() < 0.3 or j = v_sales then
+        v_take_u := v_left_u;
+        v_take_p := v_left;
+      else
+        v_take_u := round((v_left_u * (0.05 + random() * 0.8))::numeric, 4);
+        exit when v_take_u <= 0;
+        v_take_p := round(v_take_u * v_left / v_left_u);
+        -- Spend the đồng of slack the rule allows, in whichever direction.
+        v_take_p := v_take_p + (floor(random() * 3) - 1)::bigint;
+      end if;
+      -- A parent-backed withdrawal must also record a positive principal, which is
+      -- what lets three đồng legally leave a one đồng holding.
+      if v_take_p < 1 then v_take_p := 1; end if;
+      v_when := v_when + interval '1 hour';
+      insert into public.investment_transactions
+        (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+         parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+      values (v_user, v_goal, 'gold', 'withdrawal', '2026-06-01', v_take_p, v_src, v_take_p, v_take_u, v_when, v_when);
+      v_left := v_left - v_take_p; v_left_u := v_left_u - v_take_u;
+    end loop;
+  end loop;
+
+  -- ── fund buckets: purchases INTERLEAVED with sells ────────────────────────
+  -- The case the parent axis cannot produce, and the one the screening audit can
+  -- only call 'review': a purchase landing between two sells moves the ratio the
+  -- second sell is measured against.
+  for i in 1..80 loop
+    insert into public.funds (user_id, name, code, fund_type, nav)
+    values (v_user, 'Fuzz ' || i, 'FZ' || lpad(i::text, 3, '0'), 'equity', 20000)
+    returning id into v_fund;
+    v_when := timestamptz '2026-01-01T00:00:00Z' + (i * interval '1 day');
+    v_left := 0; v_left_u := 0;
+    for j in 1..(2 + floor(random() * 5)) loop
+      if j = 1 or random() < 0.4 then
+        v_basis := (1 + floor(random() * 1000))::bigint * (10 ^ (floor(random() * 4)))::bigint;
+        v_units := round((0.5 + random() * 100)::numeric, 4);
+        v_when := v_when + interval '1 hour';
+        insert into public.investment_transactions
+          (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+        values (v_user, v_goal, 'fund', 'investment', '2026-01-01', v_basis, v_units, 1, v_fund, v_when, v_when);
+        v_left := v_left + v_basis; v_left_u := v_left_u + v_units;
+      else
+        exit when v_left_u <= 0;
+        if random() < 0.3 then
+          v_take_u := v_left_u; v_take_p := v_left;
+        else
+          v_take_u := round((v_left_u * (0.05 + random() * 0.8))::numeric, 4);
+          exit when v_take_u <= 0;
+          v_take_p := round(v_take_u * v_left / v_left_u) + (floor(random() * 3) - 1)::bigint;
+          -- A fund sell may legitimately take nothing: unlike the parent axis it
+          -- has no positive-principal rule, only the proportional one.
+          if v_take_p < 0 then v_take_p := 0; end if;
+        end if;
+        v_when := v_when + interval '1 hour';
+        insert into public.investment_transactions
+          (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id,
+           principal_withdrawn, units_withdrawn, created_at, updated_at)
+        -- amount_vnd is the row's own cash figure and must be positive; the
+        -- principal the replay measures is principal_withdrawn beside it.
+        values (v_user, v_goal, 'fund', 'withdrawal', '2026-06-01', greatest(v_take_p, 1), v_fund, v_take_p, v_take_u, v_when, v_when);
+        v_left := v_left - v_take_p; v_left_u := v_left_u - v_take_u;
+      end if;
+    end loop;
+  end loop;
+
+  select string_agg(format('%s/%s: %s', r.check_name, r.severity, r.detail), E'\n')
+    into v_found from public.withdrawal_ledger_replay r where r.user_id = v_user;
+  if v_found is not null then
+    raise exception 'the replay flagged ledgers the invariant itself wrote:%s%s', E'\n', v_found;
+  end if;
+
+  raise notice 'withdrawal_ledger_replay fuzz: ok';
+end $$;
+
+-- An operator tool, like the screen it extends: no screen reads it, and granting
+-- it would add a PostgREST surface for nothing.
+do $$
+begin
+  if has_table_privilege('authenticated', 'public.withdrawal_ledger_replay', 'select')
+     or has_table_privilege('anon', 'public.withdrawal_ledger_replay', 'select') then
+    raise exception 'withdrawal_ledger_replay should not be reachable from the API roles';
+  end if;
+end $$;
+
+rollback;

--- a/supabase/tests/withdrawal_ledger_replay.test.sql
+++ b/supabase/tests/withdrawal_ledger_replay.test.sql
@@ -16,6 +16,14 @@
 --   • it stays SILENT on ledgers the invariant itself vouched for. Those are
 --     planted with the triggers ON, so the invariant accepted every write, and the
 --     replay has no licence to complain about any of them.
+--   • and it only says 'violation' when it has the proof. created_at is the order
+--     it REPORTS against; what it proves against is the ordering search, which
+--     assumes no order at all. So the fixtures come in matched pairs that differ
+--     only in whether a legal reading exists — same shape, different verdict — and
+--     several of them are here to state what the search COSTS rather than what it
+--     catches. Getting that boundary wrong in the forgiving direction makes a
+--     tool nobody needs; getting it wrong the other way sends an operator to
+--     repair a ledger nobody wrote wrong.
 --
 -- Every fixture sets created_at and updated_at by hand, and has to: now() is fixed
 -- for the whole transaction, so rows inserted here would otherwise all share one
@@ -48,6 +56,8 @@ declare
   v_legacy_buy uuid; v_legacy   uuid; v_legacy_sell uuid;
   v_tie        uuid; v_tie_a    uuid; v_tie_b       uuid;
   v_inst       uuid; v_inst_a   uuid; v_inst_b      uuid;
+  v_big        uuid;
+  i            int;
   v_found      text;
   v_count      int;
   v_audit      int;
@@ -246,11 +256,11 @@ begin
           '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z');
 
   -- ── the impossible pair, written at ONE instant ────────────────────────────
-  -- The 497/503 ledger again, this time sharing a created_at. Both orders fail,
-  -- so a finding always appears — which is what makes this the deterministic half
-  -- of the tie rule: the pair above proves no false violation is produced, and
-  -- this proves the downgrade is what does it, rather than the replay happening to
-  -- pick the forgiving order that run.
+  -- The 497/503 ledger again, this time sharing a created_at — the shape a single
+  -- RPC writes, where transaction_id is the only tie-break and it recovers no
+  -- order at all. Beside the legal pair above it pins what the ordering search
+  -- actually keys on: not how the rows are timestamped, but whether any reading of
+  -- them is legal. This one has none in either order and stays proven.
   insert into public.investment_transactions
     (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, created_at, updated_at)
   values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 1000, 100, 10, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
@@ -267,6 +277,25 @@ begin
   values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 503, v_inst, 503, 50,
           '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
   returning transaction_id into v_inst_b;
+
+  -- ── past the search's reach ────────────────────────────────────────────────
+  -- The ordering search is capped at 14 movable events per key, and the cap is a
+  -- resource bound rather than a tolerance — beyond it the answer is unknown, not
+  -- forgiven. Fifteen claims of the same shape as a provable pair therefore report
+  -- 'review': the replay still names the row and the balance, it just cannot say
+  -- no ordering explains it. Ordinary holdings sit far below this.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 1000, 100, 10, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_big;
+  for i in 1..15 loop
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+       parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+    values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 33, v_big, 33, 5,
+            timestamptz '2026-02-01T00:00:00Z' + (i * interval '1 day'),
+            timestamptz '2026-02-01T00:00:00Z' + (i * interval '1 day'));
+  end loop;
 
   -- ── a bank holding drawn past zero by its second withdrawal ────────────────
   -- The screening audit reports this holding too; what the replay adds is WHICH
@@ -348,11 +377,18 @@ begin
     raise exception 'the detail should report the balance at that turn and the basis owed, got %', v_found;
   end if;
 
-  -- the fund sell that outran its purchases
+  -- the fund sell that outran its purchases: found, and deliberately NOT proven.
+  -- Ordering both purchases ahead of the sell is a legal reading of these rows —
+  -- the sell would then take all 100 units and the whole basis — and created_at
+  -- cannot rule it out, because created_at is transaction-start and a purchase
+  -- written in a long transaction can land after a later-starting sell. So the
+  -- search finds a legal order and the finding says 'review'. This is the class
+  -- the ordering search costs us, and the test states the cost rather than hiding
+  -- it: the screening audit is silent here, and the replay still speaks.
   select r.check_name || '/' || r.severity into v_found
     from public.withdrawal_ledger_replay r where r.transaction_id = v_early;
-  if v_found is distinct from 'sale_exceeded_the_units_left/violation' then
-    raise exception 'a sell of 100 units against a 50-unit bucket should be a proven violation, got %', coalesce(v_found, '(silence)');
+  if v_found is distinct from 'sale_exceeded_the_units_left/review' then
+    raise exception 'a sell of 100 units against a 50-unit bucket should be reported, unproven, got %', coalesce(v_found, '(silence)');
   end if;
   select count(*) into v_audit from public.withdrawal_ledger_audit a where a.fund_id = v_fund_late;
   if v_audit <> 0 then
@@ -385,8 +421,13 @@ begin
   -- words the live invariant refuses it with ("the remaining balance of 40 units")
   select r.check_name || '/' || r.severity into v_found
     from public.withdrawal_ledger_replay r where r.transaction_id = v_legacy_sell;
-  if v_found is distinct from 'sale_exceeded_the_units_left/violation' then
-    raise exception 'a 45-unit sell behind a 10-unit legacy claim on a 50-unit purchase should be a proven violation, got %',
+  -- Reported, and 'review' for the same reason as the bucket above: the 5-unit
+  -- purchase that squares the totals could be read as arriving before the sell.
+  -- What this fixture is here to prove is that the bucket's OTHER kind of claim is
+  -- counted at all — without it the sell replays against 50 units and there is no
+  -- finding to grade.
+  if v_found is distinct from 'sale_exceeded_the_units_left/review' then
+    raise exception 'a 45-unit sell behind a 10-unit legacy claim on a 50-unit purchase should be reported, got %',
       coalesce(v_found, '(silence)');
   end if;
   select r.detail into v_found from public.withdrawal_ledger_replay r where r.transaction_id = v_legacy_sell;
@@ -420,12 +461,23 @@ begin
     raise exception 'a legal ledger whose write order the database never recorded was called a proven violation';
   end if;
 
-  -- the impossible pair at one instant: a finding on every run, and never proof
+  -- the impossible pair at one instant: still PROVEN. Sharing a created_at costs a
+  -- finding nothing by itself — what would cost it is a legal reading, and this
+  -- pair has none in either order. The pair above and this one are the two halves
+  -- of that distinction, and they differ only in their numbers.
   select r.check_name || '/' || r.severity into v_found
     from public.withdrawal_ledger_replay r
    where r.transaction_id in (v_inst_a, v_inst_b);
-  if v_found is distinct from 'sale_took_the_wrong_basis/review' then
-    raise exception 'a finding whose ordering the ledger does not record must be reported without claiming proof, got %',
+  if v_found is distinct from 'sale_took_the_wrong_basis/violation' then
+    raise exception 'a pair with no legal reading stays proven however its rows are timestamped, got %',
+      coalesce(v_found, '(silence)');
+  end if;
+
+  -- past the search's reach: reported, and honest that it is not proof
+  select r.severity into v_found
+    from public.withdrawal_ledger_replay r where r.parent_transaction_id = v_big;
+  if v_found is distinct from 'review' then
+    raise exception 'a holding with more claims than the search can order must not claim proof, got %',
       coalesce(v_found, '(silence)');
   end if;
 
@@ -434,10 +486,10 @@ begin
   -- tie-break, and it is the only fixture here that may do either.
   select count(*) into v_count from public.withdrawal_ledger_replay r
    where r.user_id = v_user and r.parent_transaction_id is distinct from v_tie;
-  if v_count <> 6 then
+  if v_count <> 7 then
     select string_agg(format('%s/%s: %s', r.check_name, r.severity, r.detail), E'\n')
       into v_found from public.withdrawal_ledger_replay r where r.user_id = v_user;
-    raise exception 'expected exactly the 6 planted sequences, got %:%s%s', v_count, E'\n', v_found;
+    raise exception 'expected exactly the 7 planted sequences, got %:%s%s', v_count, E'\n', v_found;
   end if;
 
   raise notice 'withdrawal_ledger_replay: ok';

--- a/supabase/tests/withdrawal_ledger_replay.test.sql
+++ b/supabase/tests/withdrawal_ledger_replay.test.sql
@@ -60,6 +60,8 @@ declare
   v_fund_dep   uuid; v_dep_buy  uuid; v_dep_sell    uuid;
   v_shape      uuid; v_shape_w  uuid;
   v_neg        uuid; v_neg_w    uuid; v_negf uuid; v_negf_buy uuid; v_negf_sell uuid;
+  v_pfund      uuid; v_pf_p2    uuid; v_pf_sell uuid;
+  v_dirt       uuid; v_dirt_bad uuid; v_dirt_ok uuid;
   v_other      uuid; v_other_g  uuid; v_foreign uuid; v_foreign_w uuid;
   v_pair       uuid; v_pair_a   uuid; v_pair_b  uuid;
   v_xfund      uuid; v_x_mine   uuid; v_x_theirs uuid; v_x_claim uuid; v_x_sell uuid;
@@ -438,6 +440,59 @@ begin
           '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
   returning transaction_id into v_negf_sell;
 
+  -- ── a fund sell parented into its own bucket ───────────────────────────────
+  -- A fund sell ignores its parent for the BALANCE — the bucket is what it draws
+  -- on — but the foreign key still proves that parent existed when the sell was
+  -- written. Purchases of 1000/100 and 1000/10, and a 50-unit sell taking 500
+  -- parented to the SECOND: every FK-valid order refuses it, and the only reading
+  -- that excuses it puts the sell before its own parent. The dependency added for
+  -- legacy parent-backed claims did not reach this branch, so the search found
+  -- that invented history and downgraded a provable failure to 'review'.
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Parented Fund', 'RPAR', 'equity', 20000) returning id into v_pfund;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'investment', '2026-01-01', 1000, 100, 10, v_pfund,
+          '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'investment', '2026-02-01', 1000, 10, 100, v_pfund,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_pf_p2;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'withdrawal', '2026-03-01', 500, v_pfund, v_pf_p2, 500, 50,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z')
+  returning transaction_id into v_pf_sell;
+
+  -- ── a key contaminated by a shape-invalid row ──────────────────────────────
+  -- Not judging a shape-invalid row is only half of it: its deltas are still in
+  -- the running balance and in the search's states, so every OTHER row on the key
+  -- is measured against a balance that could never have existed. A 40,000,000 /
+  -- 4 unit gold holding with a no-principal 1-unit claim replays the perfectly
+  -- ordinary 1-unit / 10,000,000 sale after it against 40,000,000 / 3 units and
+  -- calls the innocent sale wrong. It stays reported — the numbers are real and
+  -- an operator wants to see them — but it may never be proof, and the sentence
+  -- has to point at the row that actually needs fixing.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 40000000, 4, 10000000,
+          '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_dirt;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 1, v_dirt, null, 1,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_dirt_bad;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 10000000, v_dirt, 10000000, 1,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z')
+  returning transaction_id into v_dirt_ok;
+
   -- ── the one order the ledger DOES record ───────────────────────────────────
   -- A claim parented to a purchase cannot have been written before that purchase
   -- existed — the foreign key would have refused it. That is a fact about the
@@ -745,6 +800,33 @@ begin
     raise exception 'the screening view was supposed to own this shape — if it no longer does, the replay must stop deferring to it';
   end if;
 
+  -- a fund sell parented into its own bucket: proven, because the only reading
+  -- that excuses it puts the sell before the parent its foreign key names
+  select r.check_name || '/' || r.severity into v_found
+    from public.withdrawal_ledger_replay r where r.transaction_id = v_pf_sell;
+  if v_found is distinct from 'sale_took_the_wrong_basis/violation' then
+    raise exception 'a fund sell cannot predate the parent its FK names, so this stays proven, got %',
+      coalesce(v_found, '(silence)');
+  end if;
+
+  -- a key contaminated by a shape-invalid row: the innocent sale beside it is
+  -- still reported, never proven, and the sentence names where to look
+  select r.check_name || '/' || r.severity into v_found
+    from public.withdrawal_ledger_replay r where r.transaction_id = v_dirt_ok;
+  if v_found is distinct from 'sale_took_the_wrong_basis/review' then
+    raise exception 'a row measured against a balance the invariant never allowed must not be proof, got %',
+      coalesce(v_found, '(silence)');
+  end if;
+  select r.detail into v_found
+    from public.withdrawal_ledger_replay r where r.transaction_id = v_dirt_ok;
+  if v_found not like '%would have refused outright%' then
+    raise exception 'the contaminated key has to say so where the operator meets it, got %', v_found;
+  end if;
+  if not exists (select 1 from public.withdrawal_ledger_audit a
+                  where a.transaction_id = v_dirt_bad and a.severity = 'violation') then
+    raise exception 'the sentence points at the screening view for the real row — it has to be there';
+  end if;
+
   -- the claim-to-purchase dependency: the sale is proven, because the only reading
   -- that excuses it puts a claim before the purchase it names
   select r.check_name || '/' || r.severity into v_found
@@ -767,10 +849,10 @@ begin
   -- tie-break, and it is the only fixture here that may do either.
   select count(*) into v_count from public.withdrawal_ledger_replay r
    where r.user_id = v_user and r.parent_transaction_id is distinct from v_tie;
-  if v_count <> 10 then
+  if v_count <> 12 then
     select string_agg(format('%s/%s: %s', r.check_name, r.severity, r.detail), E'\n')
       into v_found from public.withdrawal_ledger_replay r where r.user_id = v_user;
-    raise exception 'expected exactly the 10 planted sequences, got %:%s%s', v_count, E'\n', v_found;
+    raise exception 'expected exactly the 12 planted sequences, got %:%s%s', v_count, E'\n', v_found;
   end if;
 
   raise notice 'withdrawal_ledger_replay: ok';

--- a/supabase/tests/withdrawal_ledger_replay.test.sql
+++ b/supabase/tests/withdrawal_ledger_replay.test.sql
@@ -62,6 +62,7 @@ declare
   v_neg        uuid; v_neg_w    uuid; v_negf uuid; v_negf_buy uuid; v_negf_sell uuid;
   v_pfund      uuid; v_pf_p2    uuid; v_pf_sell uuid;
   v_dirt       uuid; v_dirt_bad uuid; v_dirt_ok uuid;
+  v_mask       uuid; v_mask_neg uuid; v_mask_over uuid;
   v_other      uuid; v_other_g  uuid; v_foreign uuid; v_foreign_w uuid;
   v_pair       uuid; v_pair_a   uuid; v_pair_b  uuid;
   v_xfund      uuid; v_x_mine   uuid; v_x_theirs uuid; v_x_claim uuid; v_x_sell uuid;
@@ -493,6 +494,31 @@ begin
           '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z')
   returning transaction_id into v_dirt_ok;
 
+  -- ── a refused row that HIDES one, which is the other direction ─────────────
+  -- The deltas of a refused row are signed, so leaving them in does not merely
+  -- convict the innocent — it acquits the guilty. 100 đồng, a -100 withdrawal,
+  -- then a 150 withdrawal: the 150 replayed against 200 and produced nothing,
+  -- while the screen's aggregate came to 50 and produced nothing either. An
+  -- overdraw reported by no view at all is the exact silence this family exists
+  -- to break, so this fixture is the one that decides the design: the refused row
+  -- leaves the balance entirely, rather than merely losing its verdict.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_mask;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 1, v_mask, -100,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_mask_neg;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-03-01', 150, v_mask, 150,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z')
+  returning transaction_id into v_mask_over;
+
   -- ── the one order the ledger DOES record ───────────────────────────────────
   -- A claim parented to a purchase cannot have been written before that purchase
   -- existed — the foreign key would have refused it. That is a fact about the
@@ -809,22 +835,34 @@ begin
       coalesce(v_found, '(silence)');
   end if;
 
-  -- a key contaminated by a shape-invalid row: the innocent sale beside it is
-  -- still reported, never proven, and the sentence names where to look
-  select r.check_name || '/' || r.severity into v_found
-    from public.withdrawal_ledger_replay r where r.transaction_id = v_dirt_ok;
-  if v_found is distinct from 'sale_took_the_wrong_basis/review' then
-    raise exception 'a row measured against a balance the invariant never allowed must not be proof, got %',
-      coalesce(v_found, '(silence)');
-  end if;
-  select r.detail into v_found
-    from public.withdrawal_ledger_replay r where r.transaction_id = v_dirt_ok;
-  if v_found not like '%would have refused outright%' then
-    raise exception 'the contaminated key has to say so where the operator meets it, got %', v_found;
+  -- a key carrying a shape-invalid row: the innocent sale beside it is SILENT.
+  -- The refused row is out of the balances, so the sale is measured against the
+  -- 40,000,000 / 4 units the holding legally shows and owes exactly what it took.
+  if exists (select 1 from public.withdrawal_ledger_replay r where r.transaction_id = v_dirt_ok) then
+    select r.check_name || ': ' || r.detail into v_found
+      from public.withdrawal_ledger_replay r where r.transaction_id = v_dirt_ok;
+    raise exception 'a refused row is in no legal history, so the sale beside it owes the clean balance and is not a finding: %', v_found;
   end if;
   if not exists (select 1 from public.withdrawal_ledger_audit a
                   where a.transaction_id = v_dirt_bad and a.severity = 'violation') then
-    raise exception 'the sentence points at the screening view for the real row — it has to be there';
+    raise exception 'the screening view owns the refused row — without it this holding goes unreported by both';
+  end if;
+
+  -- and the mirror of it, which is why the deltas had to go rather than just the
+  -- verdict: a NEGATIVE refused row credits the balance and hides a real overdraw.
+  -- 100 đồng, a -100 withdrawal, then a 150 withdrawal. Left in, the 150 replayed
+  -- against 200 and said nothing, while the screen's aggregate came to 50 and said
+  -- nothing either — an overdraw reported by no view at all.
+  select r.check_name || '/' || r.severity into v_found
+    from public.withdrawal_ledger_replay r where r.transaction_id = v_mask_over;
+  if v_found is distinct from 'withdrawal_exceeded_the_balance/violation' then
+    raise exception 'a real overdraw must not be masked by a row the invariant would have refused, got %',
+      coalesce(v_found, '(silence)');
+  end if;
+  select r.detail into v_found
+    from public.withdrawal_ledger_replay r where r.transaction_id = v_mask_over;
+  if v_found not like '%100 đồng left%' or v_found not like '%left out of the balances%' then
+    raise exception 'the balance is the one the holding legally shows, and the omission has to be stated, got %', v_found;
   end if;
 
   -- the claim-to-purchase dependency: the sale is proven, because the only reading

--- a/supabase/tests/withdrawal_ledger_replay.test.sql
+++ b/supabase/tests/withdrawal_ledger_replay.test.sql
@@ -58,6 +58,7 @@ declare
   v_inst       uuid; v_inst_a   uuid; v_inst_b      uuid;
   v_big        uuid;
   v_fund_dep   uuid; v_dep_buy  uuid; v_dep_sell    uuid;
+  v_shape      uuid; v_shape_w  uuid;
   i            int;
   v_found      text;
   v_count      int;
@@ -280,6 +281,27 @@ begin
   values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 503, v_inst, 503, 50,
           '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
   returning transaction_id into v_inst_b;
+
+  -- ── a shape the screening view already owns ────────────────────────────────
+  -- A gold sale with units and no principal. The invariant refuses it before the
+  -- allocation rule is ever reached ("must record a positive principal_withdrawn")
+  -- and withdrawal_ledger_audit names it withdrawal_missing_principal. The replay
+  -- must stay out of it: judged as an allocation, the row reads "it should have
+  -- taken 10,000,000 đồng, it took 0", which describes a misallocation where the
+  -- defect is that no principal was recorded at all — the same row, a second time,
+  -- under a worse name. The two views are advertised as complements, and this is
+  -- the test of that word.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 40000000, 4, 10000000,
+          '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_shape;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 1, v_shape, null, 1,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_shape_w;
 
   -- ── the one order the ledger DOES record ───────────────────────────────────
   -- A claim parented to a purchase cannot have been written before that purchase
@@ -510,6 +532,17 @@ begin
   if v_found is distinct from 'sale_took_the_wrong_basis/violation' then
     raise exception 'a pair with no legal reading stays proven however its rows are timestamped, got %',
       coalesce(v_found, '(silence)');
+  end if;
+
+  -- the shape the screening view owns: named there, and silent here
+  if exists (select 1 from public.withdrawal_ledger_replay r where r.transaction_id = v_shape_w) then
+    select r.check_name || '/' || r.detail into v_found
+      from public.withdrawal_ledger_replay r where r.transaction_id = v_shape_w;
+    raise exception 'a row the screening view already condemns by shape must not be restated as a balance finding: %', v_found;
+  end if;
+  if not exists (select 1 from public.withdrawal_ledger_audit a
+                  where a.transaction_id = v_shape_w and a.check_name = 'withdrawal_missing_principal') then
+    raise exception 'the screening view was supposed to own this shape — if it no longer does, the replay must stop deferring to it';
   end if;
 
   -- the claim-to-purchase dependency: the sale is proven, because the only reading

--- a/supabase/tests/withdrawal_ledger_replay.test.sql
+++ b/supabase/tests/withdrawal_ledger_replay.test.sql
@@ -59,6 +59,7 @@ declare
   v_big        uuid;
   v_fund_dep   uuid; v_dep_buy  uuid; v_dep_sell    uuid;
   v_shape      uuid; v_shape_w  uuid;
+  v_other      uuid; v_other_g  uuid; v_foreign uuid; v_foreign_w uuid;
   i            int;
   v_found      text;
   v_count      int;
@@ -281,6 +282,32 @@ begin
   values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 503, v_inst, 503, 50,
           '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
   returning transaction_id into v_inst_b;
+
+  -- ── a claim on someone ELSE'S holding ──────────────────────────────────────
+  -- check_withdrawal_balance looks for the parent under the claimant's own
+  -- user_id, finds nothing, and returns without measuring anything: ownership is a
+  -- different trigger's refusal (#474 / #525), and staying quiet keeps that message
+  -- the one the user sees. The replay has to match that silence, and the reason is
+  -- specific — judging it means partitioning the holding under its owner and the
+  -- claim under the claimant, so the claim replays against an opening balance of
+  -- zero and reads as a pristine overdraw of a holding nobody touched. The
+  -- screening view is silent here too, which the header records rather than
+  -- letting the silence pass for a clean bill.
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-replay-other@test.invalid')
+  returning id into v_other;
+  insert into public.savings_goals (user_id, goal_name) values (v_other, 'Theirs')
+  returning goal_id into v_other_g;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, created_at, updated_at)
+  values (v_other, v_other_g, 'bank', 'investment', '2026-01-01', 100000000,
+          '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_foreign;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 30000000, v_foreign, 30000000,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_foreign_w;
 
   -- ── a shape the screening view already owns ────────────────────────────────
   -- A gold sale with units and no principal. The invariant refuses it before the
@@ -532,6 +559,17 @@ begin
   if v_found is distinct from 'sale_took_the_wrong_basis/violation' then
     raise exception 'a pair with no legal reading stays proven however its rows are timestamped, got %',
       coalesce(v_found, '(silence)');
+  end if;
+
+  -- the claim on another user's holding: silent, and silent for BOTH users — the
+  -- holding's owner must not see an overdraw of a holding nobody touched either
+  if exists (select 1 from public.withdrawal_ledger_replay r
+              where r.transaction_id = v_foreign_w or r.parent_transaction_id = v_foreign
+                 or r.user_id = v_other) then
+    select r.check_name || '/' || r.severity || ': ' || r.detail into v_found
+      from public.withdrawal_ledger_replay r
+     where r.transaction_id = v_foreign_w or r.parent_transaction_id = v_foreign or r.user_id = v_other;
+    raise exception 'a claim naming another user''s holding is not a balance question — the invariant returns quietly and so must this: %', v_found;
   end if;
 
   -- the shape the screening view owns: named there, and silent here

--- a/supabase/tests/withdrawal_ledger_replay.test.sql
+++ b/supabase/tests/withdrawal_ledger_replay.test.sql
@@ -63,6 +63,7 @@ declare
   v_pfund      uuid; v_pf_p2    uuid; v_pf_sell uuid;
   v_dirt       uuid; v_dirt_bad uuid; v_dirt_ok uuid;
   v_mask       uuid; v_mask_neg uuid; v_mask_over uuid;
+  v_drv        uuid; v_drv_par  uuid; v_drv_claim uuid; v_drv_sell uuid;
   v_other      uuid; v_other_g  uuid; v_foreign uuid; v_foreign_w uuid;
   v_pair       uuid; v_pair_a   uuid; v_pair_b  uuid;
   v_xfund      uuid; v_x_mine   uuid; v_x_theirs uuid; v_x_claim uuid; v_x_sell uuid;
@@ -494,6 +495,45 @@ begin
           '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z')
   returning transaction_id into v_dirt_ok;
 
+  -- ── an edit the key cannot see ─────────────────────────────────────────────
+  -- A bucket claim that records no units has them DERIVED from its parent's
+  -- current units and amount_vnd, so editing that purchase silently restates how
+  -- much of the bucket the claim took — and the claim's own updated_at says
+  -- nothing about it. Usually the purchase is a credit on this same key and its
+  -- touched flag carries; not here. A cross-owner purchase is partitioned under
+  -- ITS owner (a renewal snapshot is no part of the bucket at all), while
+  -- 20260803000005 counts claims on both.
+  --
+  -- 1000/100 of my own, a claim of 400 on their 50-unit purchase, and a 40-unit
+  -- sale taking 300 — which is exactly right against the 600/80 the bucket showed
+  -- when the claim derived 20 units. Their purchase is since re-priced to 2000, so
+  -- the claim now derives 10, the bucket reads 600/90, and the sale owes 267. Every
+  -- row on this key is pristine, so without the parent's edit the replay calls a
+  -- legally-written sale a proven violation.
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Derived Fund', 'RDRV', 'equity', 20000) returning id into v_drv;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'investment', '2026-01-01', 1000, 100, 10, v_drv,
+          '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_other, v_goal, 'fund', 'investment', '2026-01-02', 2000, 50, 40, v_drv,
+          '2026-01-02T00:00:00Z', '2026-06-01T00:00:00Z')
+  returning transaction_id into v_drv_par;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 400, v_drv_par, 400,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_drv_claim;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id,
+     principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'withdrawal', '2026-03-01', 300, v_drv, 300, 40,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z')
+  returning transaction_id into v_drv_sell;
+
   -- ── a refused row that HIDES one, which is the other direction ─────────────
   -- The deltas of a refused row are signed, so leaving them in does not merely
   -- convict the innocent — it acquits the guilty. 100 đồng, a -100 withdrawal,
@@ -848,6 +888,16 @@ begin
     raise exception 'the screening view owns the refused row — without it this holding goes unreported by both';
   end if;
 
+  -- the derived claim whose parent moved under it: reported, never proven, because
+  -- the numbers this key was measured against are not the ones it was written
+  -- against — and no row ON the key records that
+  select r.severity into v_found
+    from public.withdrawal_ledger_replay r where r.transaction_id = v_drv_sell;
+  if v_found is distinct from 'review' then
+    raise exception 'a derived claim''s parent was edited under this sale, so the balance is not the one it met — that is not proof, got %',
+      coalesce(v_found, '(silence)');
+  end if;
+
   -- and the mirror of it, which is why the deltas had to go rather than just the
   -- verdict: a NEGATIVE refused row credits the balance and hides a real overdraw.
   -- 100 đồng, a -100 withdrawal, then a 150 withdrawal. Left in, the 150 replayed
@@ -887,10 +937,10 @@ begin
   -- tie-break, and it is the only fixture here that may do either.
   select count(*) into v_count from public.withdrawal_ledger_replay r
    where r.user_id = v_user and r.parent_transaction_id is distinct from v_tie;
-  if v_count <> 12 then
+  if v_count <> 13 then
     select string_agg(format('%s/%s: %s', r.check_name, r.severity, r.detail), E'\n')
       into v_found from public.withdrawal_ledger_replay r where r.user_id = v_user;
-    raise exception 'expected exactly the 12 planted sequences, got %:%s%s', v_count, E'\n', v_found;
+    raise exception 'expected exactly the 13 planted sequences, got %:%s%s', v_count, E'\n', v_found;
   end if;
 
   raise notice 'withdrawal_ledger_replay: ok';

--- a/supabase/tests/withdrawal_ledger_replay.test.sql
+++ b/supabase/tests/withdrawal_ledger_replay.test.sql
@@ -47,6 +47,7 @@ declare
   v_bank_over  uuid; v_bank_w2  uuid;
   v_legacy_buy uuid; v_legacy   uuid; v_legacy_sell uuid;
   v_tie        uuid; v_tie_a    uuid; v_tie_b       uuid;
+  v_inst       uuid; v_inst_a   uuid; v_inst_b      uuid;
   v_found      text;
   v_count      int;
   v_audit      int;
@@ -244,6 +245,29 @@ begin
   values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 503, v_edited, 503, 50,
           '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z');
 
+  -- ── the impossible pair, written at ONE instant ────────────────────────────
+  -- The 497/503 ledger again, this time sharing a created_at. Both orders fail,
+  -- so a finding always appears — which is what makes this the deterministic half
+  -- of the tie rule: the pair above proves no false violation is produced, and
+  -- this proves the downgrade is what does it, rather than the replay happening to
+  -- pick the forgiving order that run.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 1000, 100, 10, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_inst;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 497, v_inst, 497, 50,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_inst_a;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 503, v_inst, 503, 50,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_inst_b;
+
   -- ── a bank holding drawn past zero by its second withdrawal ────────────────
   -- The screening audit reports this holding too; what the replay adds is WHICH
   -- row broke it and the balance it was measured against.
@@ -369,6 +393,13 @@ begin
   if v_found not like '%40 units left%' then
     raise exception 'the bucket had 40 units left once the legacy claim is counted, got %', v_found;
   end if;
+  -- and the tally counts the legacy claim, saying CLAIMS rather than sales. It is
+  -- the second of two claims on this bucket though it is the only sale of it, and
+  -- that other claim is the reason it does not fit — an operator who cannot see it
+  -- in the count goes looking for a second sale that is not there.
+  if v_found not like '%2 of 2 claim(s)%' then
+    raise exception 'the tally should place the sale among the bucket''s claims, got %', v_found;
+  end if;
   -- and the screening audit does not report the overdraw: its bucket sums count
   -- the fund-keyed sells alone, so 45 of 50 units looks like it fits
   select count(*) into v_audit from public.withdrawal_ledger_audit a
@@ -377,19 +408,32 @@ begin
     raise exception 'the screening audit was supposed to miss the legacy-claim overdraw';
   end if;
 
-  -- the tied pair: reported, but never as proof — the ledger records no order
-  -- between two rows written in one transaction, and one of the two orders is
-  -- legal. A tie-break on a random uuid is not evidence.
+  -- the legal tied pair: never proof. Which of its two orders the tie-break picks
+  -- is itself random — transaction_id is a uuid — so whether this key produces a
+  -- finding at all varies from run to run, and asserting the finding would be
+  -- asserting the coin flip. What must hold on every run is the bound: this ledger
+  -- is legal, and no run may call it proven corrupt.
   select r.severity into v_found
     from public.withdrawal_ledger_replay r
    where r.transaction_id in (v_tie_a, v_tie_b);
-  if v_found is distinct from 'review' then
-    raise exception 'a finding whose ordering the ledger does not record must not claim proof, got %',
+  if v_found = 'violation' then
+    raise exception 'a legal ledger whose write order the database never recorded was called a proven violation';
+  end if;
+
+  -- the impossible pair at one instant: a finding on every run, and never proof
+  select r.check_name || '/' || r.severity into v_found
+    from public.withdrawal_ledger_replay r
+   where r.transaction_id in (v_inst_a, v_inst_b);
+  if v_found is distinct from 'sale_took_the_wrong_basis/review' then
+    raise exception 'a finding whose ordering the ledger does not record must be reported without claiming proof, got %',
       coalesce(v_found, '(silence)');
   end if;
 
-  -- and nothing beyond the six holdings planted above
-  select count(*) into v_count from public.withdrawal_ledger_replay r where r.user_id = v_user;
+  -- and nothing beyond the holdings planted above. The legal tied pair is excluded
+  -- for the reason above — it contributes a row or no row depending on the
+  -- tie-break, and it is the only fixture here that may do either.
+  select count(*) into v_count from public.withdrawal_ledger_replay r
+   where r.user_id = v_user and r.parent_transaction_id is distinct from v_tie;
   if v_count <> 6 then
     select string_agg(format('%s/%s: %s', r.check_name, r.severity, r.detail), E'\n')
       into v_found from public.withdrawal_ledger_replay r where r.user_id = v_user;

--- a/supabase/tests/withdrawal_ledger_replay.test.sql
+++ b/supabase/tests/withdrawal_ledger_replay.test.sql
@@ -57,6 +57,7 @@ declare
   v_tie        uuid; v_tie_a    uuid; v_tie_b       uuid;
   v_inst       uuid; v_inst_a   uuid; v_inst_b      uuid;
   v_big        uuid;
+  v_fund_dep   uuid; v_dep_buy  uuid; v_dep_sell    uuid;
   i            int;
   v_found      text;
   v_count      int;
@@ -70,6 +71,8 @@ begin
   values (v_user, 'Clean Fund', 'RCLN', 'equity', 20000) returning id into v_fund_ok;
   insert into public.funds (user_id, name, code, fund_type, nav)
   values (v_user, 'Late Fund', 'RLAT', 'equity', 20000) returning id into v_fund_late;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Dep Fund', 'RDEP', 'equity', 20000) returning id into v_fund_dep;
 
   -- ═══ the clean half, written with the invariant WATCHING ═══════════════════
   -- Each write below passed check_withdrawal_balance against the balance the
@@ -278,6 +281,42 @@ begin
           '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
   returning transaction_id into v_inst_b;
 
+  -- ── the one order the ledger DOES record ───────────────────────────────────
+  -- A claim parented to a purchase cannot have been written before that purchase
+  -- existed — the foreign key would have refused it. That is a fact about the
+  -- schema rather than a guess about clocks, and it is the only ordering fact this
+  -- view is entitled to use.
+  --
+  -- This ledger turns on it. Purchases of 1000/100 and 1000/10, a 500/5 claim on
+  -- the SECOND, and a sale of 50 units taking 263. Every reading that puts the
+  -- claimed purchase before its claim refuses the sale — the balances it could
+  -- have met are 1000/100 (owes 500), 2000/110 (owes 909), 1500/105 (owes 714),
+  -- 500/5 and 1000/10 (both short of 50 units). Exactly one subset makes 263
+  -- correct: 1000/100 with the claim already taken and its own purchase still to
+  -- come, which is the one history that could not have happened. Without the
+  -- dependency the search finds that reading and downgrades a provably impossible
+  -- ledger to 'review'.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'investment', '2026-01-01', 1000, 100, 10, v_fund_dep,
+          '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z');
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'investment', '2026-02-01', 1000, 10, 100, v_fund_dep,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_dep_buy;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-03-01', 500, v_dep_buy, 500, 5,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z');
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id,
+     principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'withdrawal', '2026-04-01', 263, v_fund_dep, 263, 50,
+          '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z')
+  returning transaction_id into v_dep_sell;
+
   -- ── past the search's reach ────────────────────────────────────────────────
   -- The ordering search is capped at 14 movable events per key, and the cap is a
   -- resource bound rather than a tolerance — beyond it the answer is unknown, not
@@ -473,6 +512,15 @@ begin
       coalesce(v_found, '(silence)');
   end if;
 
+  -- the claim-to-purchase dependency: the sale is proven, because the only reading
+  -- that excuses it puts a claim before the purchase it names
+  select r.check_name || '/' || r.severity into v_found
+    from public.withdrawal_ledger_replay r where r.transaction_id = v_dep_sell;
+  if v_found is distinct from 'sale_took_the_wrong_basis/violation' then
+    raise exception 'a ledger whose only legal reading predates a claim''s own purchase should stay proven, got %',
+      coalesce(v_found, '(silence)');
+  end if;
+
   -- past the search's reach: reported, and honest that it is not proof
   select r.severity into v_found
     from public.withdrawal_ledger_replay r where r.parent_transaction_id = v_big;
@@ -486,10 +534,10 @@ begin
   -- tie-break, and it is the only fixture here that may do either.
   select count(*) into v_count from public.withdrawal_ledger_replay r
    where r.user_id = v_user and r.parent_transaction_id is distinct from v_tie;
-  if v_count <> 7 then
+  if v_count <> 8 then
     select string_agg(format('%s/%s: %s', r.check_name, r.severity, r.detail), E'\n')
       into v_found from public.withdrawal_ledger_replay r where r.user_id = v_user;
-    raise exception 'expected exactly the 7 planted sequences, got %:%s%s', v_count, E'\n', v_found;
+    raise exception 'expected exactly the 8 planted sequences, got %:%s%s', v_count, E'\n', v_found;
   end if;
 
   raise notice 'withdrawal_ledger_replay: ok';

--- a/supabase/tests/withdrawal_ledger_replay.test.sql
+++ b/supabase/tests/withdrawal_ledger_replay.test.sql
@@ -59,6 +59,7 @@ declare
   v_big        uuid;
   v_fund_dep   uuid; v_dep_buy  uuid; v_dep_sell    uuid;
   v_shape      uuid; v_shape_w  uuid;
+  v_neg        uuid; v_neg_w    uuid; v_negf uuid; v_negf_buy uuid; v_negf_sell uuid;
   v_other      uuid; v_other_g  uuid; v_foreign uuid; v_foreign_w uuid;
   v_pair       uuid; v_pair_a   uuid; v_pair_b  uuid;
   v_xfund      uuid; v_x_mine   uuid; v_x_theirs uuid; v_x_claim uuid; v_x_sell uuid;
@@ -401,6 +402,42 @@ begin
           '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
   returning transaction_id into v_shape_w;
 
+  -- ── negative amounts, on both axes ─────────────────────────────────────────
+  -- The screen calls these `negative_amounts` and the invariant refuses them
+  -- before it measures anything, because a negative delta runs the ledger
+  -- BACKWARDS: it ADDS to the holding and banks a credit the next row can spend.
+  -- Judged as transitions they came out described as ordinary balance faults —
+  -- "a withdrawal of 150 đồng when the holding had 100 đồng left", saying nothing
+  -- about the sign that makes the row impossible, and on the fund side "it should
+  -- have taken 500 đồng, it took -500", which reads as a misallocation. Both are
+  -- the shape the screen owns, and the rows around them cannot be judged either:
+  -- the balance a credit like this leaves is one the invariant would never have
+  -- allowed to exist.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_neg;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 150, v_neg, 150, -1,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_neg_w;
+
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_user, 'Neg Fund', 'RNEG', 'equity', 20000) returning id into v_negf;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'investment', '2026-01-01', 1000, 100, 10, v_negf,
+          '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_negf_buy;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id,
+     principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'withdrawal', '2026-02-01', 1, v_negf, -500, 50,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_negf_sell;
+
   -- ── the one order the ledger DOES record ───────────────────────────────────
   -- A claim parented to a purchase cannot have been written before that purchase
   -- existed — the foreign key would have refused it. That is a fact about the
@@ -679,6 +716,22 @@ begin
       from public.withdrawal_ledger_replay r
      where r.transaction_id = v_foreign_w or r.parent_transaction_id = v_foreign or r.user_id = v_other;
     raise exception 'a claim naming another user''s holding is not a balance question — the invariant returns quietly and so must this: %', v_found;
+  end if;
+
+  -- negative amounts on both axes: silent here, named there
+  if exists (select 1 from public.withdrawal_ledger_replay r
+              where r.transaction_id in (v_neg_w, v_negf_sell)
+                 or r.parent_transaction_id = v_neg or r.fund_id = v_negf) then
+    select string_agg(r.check_name || ': ' || r.detail, E'\n') into v_found
+      from public.withdrawal_ledger_replay r
+     where r.transaction_id in (v_neg_w, v_negf_sell)
+        or r.parent_transaction_id = v_neg or r.fund_id = v_negf;
+    raise exception 'a negative amount is the screen''s finding, and describing it as a balance fault says nothing about the sign: %', v_found;
+  end if;
+  select count(distinct a.transaction_id) into v_audit from public.withdrawal_ledger_audit a
+   where a.transaction_id in (v_neg_w, v_negf_sell) and a.check_name = 'negative_amounts';
+  if v_audit <> 2 then
+    raise exception 'the screen was supposed to own both negative rows, it named %', v_audit;
   end if;
 
   -- the shape the screening view owns: named there, and silent here

--- a/supabase/tests/withdrawal_ledger_replay.test.sql
+++ b/supabase/tests/withdrawal_ledger_replay.test.sql
@@ -45,6 +45,8 @@ declare
   v_early      uuid;
   v_edited     uuid; v_edited_a uuid;
   v_bank_over  uuid; v_bank_w2  uuid;
+  v_legacy_buy uuid; v_legacy   uuid; v_legacy_sell uuid;
+  v_tie        uuid; v_tie_a    uuid; v_tie_b       uuid;
   v_found      text;
   v_count      int;
   v_audit      int;
@@ -143,6 +145,35 @@ begin
     raise exception 'the replay complained about a ledger the invariant itself accepted:%s%s', E'\n', v_found;
   end if;
 
+  -- ── two claims the ledger records no order between ────────────────────────
+  -- Still with the triggers ON, because this pair IS legal — 34 units taking 339
+  -- of 1000/100 (owing 340), then 32 of the 66 left taking 319 (owing 320), and
+  -- the invariant accepted both in that order. What it does not record is that
+  -- order: now() is transaction-stable, so two withdrawals written by separate
+  -- statements of ONE transaction share a created_at exactly, and transaction_id
+  -- is a random uuid — it invents an order, it does not recover one. Replayed the
+  -- other way round the 34-unit row owes 341 and is two đồng out, so the replay
+  -- would call a legal ledger proven corrupt if it trusted its own tie-break.
+  --
+  -- It sits outside the clean half deliberately: the replay is NOT silent here,
+  -- and it should not be. It reports what it found and says 'review'.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 1000, 100, 10, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_tie;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 339, v_tie, 339, 34,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_tie_a;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 319, v_tie, 319, 32,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_tie_b;
+
   -- ═══ the sequences only a replay can decide ════════════════════════════════
   -- Planted with the triggers off: every one of these is a shape the invariant
   -- refuses to write, which is the whole reason they can only be found afterwards.
@@ -232,6 +263,38 @@ begin
           '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z')
   returning transaction_id into v_bank_w2;
 
+  -- ── a fund bucket's OTHER kind of claim ────────────────────────────────────
+  -- A withdrawal parented to a fund PURCHASE is not fund-keyed, so it is measured
+  -- on the parent axis — but 20260803000005 also charges it against that
+  -- purchase's bucket when the next sale is measured (#606). A 10-unit legacy
+  -- claim on a 50-unit purchase leaves 40, and the 45-unit sell that follows is
+  -- refused by the live invariant in those words. Counting only the fund-keyed
+  -- sells replays it as 45 of 50 and reports clean.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'investment', '2026-01-01', 50000000, 50, 1000000, v_fund,
+          '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_legacy_buy;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 10000000, v_legacy_buy, 10000000, 10,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_legacy;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, fund_id,
+     principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'withdrawal', '2026-03-01', 45000000, v_fund, 45000000, 45,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z')
+  returning transaction_id into v_legacy_sell;
+  -- and a purchase afterwards that squares the bucket's totals, so the screening
+  -- audit — which sums both kinds of claim against both purchases — sees 55 units
+  -- bought and 55 sold and is silent. Only the order says the sell came first.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, fund_id, created_at, updated_at)
+  values (v_user, v_goal, 'fund', 'investment', '2026-04-01', 5000000, 5, 1000000, v_fund,
+          '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z');
+
   alter table public.investment_transactions enable trigger user;
   set constraints investment_transactions_source_backs_claims, investment_transactions_source_deleted deferred;
 
@@ -294,12 +357,43 @@ begin
     raise exception 'the detail should place the row at its turn in the holding''s history, got %', v_found;
   end if;
 
-  -- and nothing beyond the four holdings planted above
+  -- the bucket's legacy claim: the sell that followed it is named, in the same
+  -- words the live invariant refuses it with ("the remaining balance of 40 units")
+  select r.check_name || '/' || r.severity into v_found
+    from public.withdrawal_ledger_replay r where r.transaction_id = v_legacy_sell;
+  if v_found is distinct from 'sale_exceeded_the_units_left/violation' then
+    raise exception 'a 45-unit sell behind a 10-unit legacy claim on a 50-unit purchase should be a proven violation, got %',
+      coalesce(v_found, '(silence)');
+  end if;
+  select r.detail into v_found from public.withdrawal_ledger_replay r where r.transaction_id = v_legacy_sell;
+  if v_found not like '%40 units left%' then
+    raise exception 'the bucket had 40 units left once the legacy claim is counted, got %', v_found;
+  end if;
+  -- and the screening audit does not report the overdraw: its bucket sums count
+  -- the fund-keyed sells alone, so 45 of 50 units looks like it fits
+  select count(*) into v_audit from public.withdrawal_ledger_audit a
+   where a.fund_id = v_fund and a.severity = 'violation';
+  if v_audit <> 0 then
+    raise exception 'the screening audit was supposed to miss the legacy-claim overdraw';
+  end if;
+
+  -- the tied pair: reported, but never as proof — the ledger records no order
+  -- between two rows written in one transaction, and one of the two orders is
+  -- legal. A tie-break on a random uuid is not evidence.
+  select r.severity into v_found
+    from public.withdrawal_ledger_replay r
+   where r.transaction_id in (v_tie_a, v_tie_b);
+  if v_found is distinct from 'review' then
+    raise exception 'a finding whose ordering the ledger does not record must not claim proof, got %',
+      coalesce(v_found, '(silence)');
+  end if;
+
+  -- and nothing beyond the six holdings planted above
   select count(*) into v_count from public.withdrawal_ledger_replay r where r.user_id = v_user;
-  if v_count <> 4 then
+  if v_count <> 6 then
     select string_agg(format('%s/%s: %s', r.check_name, r.severity, r.detail), E'\n')
       into v_found from public.withdrawal_ledger_replay r where r.user_id = v_user;
-    raise exception 'expected exactly the 4 planted sequences, got %:%s%s', v_count, E'\n', v_found;
+    raise exception 'expected exactly the 6 planted sequences, got %:%s%s', v_count, E'\n', v_found;
   end if;
 
   raise notice 'withdrawal_ledger_replay: ok';

--- a/supabase/tests/withdrawal_ledger_replay.test.sql
+++ b/supabase/tests/withdrawal_ledger_replay.test.sql
@@ -60,6 +60,7 @@ declare
   v_fund_dep   uuid; v_dep_buy  uuid; v_dep_sell    uuid;
   v_shape      uuid; v_shape_w  uuid;
   v_other      uuid; v_other_g  uuid; v_foreign uuid; v_foreign_w uuid;
+  v_pair       uuid; v_pair_a   uuid; v_pair_b  uuid;
   i            int;
   v_found      text;
   v_count      int;
@@ -283,6 +284,36 @@ begin
           '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
   returning transaction_id into v_inst_b;
 
+  -- ── no legal ordering, and yet no guilty row ───────────────────────────────
+  -- 1000 đồng / 100 units, two 50-unit sales each taking 499. Either is legal
+  -- written FIRST — the đồng of rounding covers 499 against 500 — and whichever
+  -- comes second owes the whole 501 that is left. So the holding has no legal
+  -- reading, and neither sale is individually impossible.
+  --
+  -- "No ordering of this holding is legal" is a statement about the HOLDING; the
+  -- finding names a ROW. Grading the row by the holding's verdict points an
+  -- operator at whichever sale happens to sort second and calls it proven, when it
+  -- may be the innocent one. The pair beside it — 497/503, where each sale is
+  -- impossible in every position it could occupy — is the same shape and stays a
+  -- violation, which is what makes this a test of the row-level proof rather than
+  -- of the search.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-01', 1000, 100, 10, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')
+  returning transaction_id into v_pair;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-02-01', 499, v_pair, 499, 50,
+          '2026-02-01T00:00:00Z', '2026-02-01T00:00:00Z')
+  returning transaction_id into v_pair_a;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, units_withdrawn, created_at, updated_at)
+  values (v_user, v_goal, 'gold', 'withdrawal', '2026-03-01', 499, v_pair, 499, 50,
+          '2026-03-01T00:00:00Z', '2026-03-01T00:00:00Z')
+  returning transaction_id into v_pair_b;
+
   -- ── a claim on someone ELSE'S holding ──────────────────────────────────────
   -- check_withdrawal_balance looks for the parent under the claimant's own
   -- user_id, finds nothing, and returns without measuring anything: ownership is a
@@ -490,12 +521,22 @@ begin
     raise exception 'a finding on a holding edited after its sales must not claim proof, got %', coalesce(v_found, '(silence)');
   end if;
 
-  -- the bank overdraw: the replay names the row, where the screening audit names
-  -- only the holding
+  -- the bank overdraw: 100,000,000 with two 80,000,000 withdrawals. The HOLDING is
+  -- provably overdrawn and the screening audit says so, at the level where that
+  -- claim belongs. Neither ROW is the culprit — 80,000,000 fits a 100,000,000
+  -- holding, so either could have been written first and the second is whichever
+  -- it happened to be. So the replay names the row, points at the balance it met,
+  -- and grades it 'review'. The two views say different true things about the same
+  -- holding, which is the whole reason for running both.
   select r.check_name || '/' || r.severity into v_found
     from public.withdrawal_ledger_replay r where r.transaction_id = v_bank_w2;
-  if v_found is distinct from 'withdrawal_exceeded_the_balance/violation' then
-    raise exception 'the second bank withdrawal should be named as the row that broke the holding, got %', coalesce(v_found, '(silence)');
+  if v_found is distinct from 'withdrawal_exceeded_the_balance/review' then
+    raise exception 'neither of two 80m withdrawals of a 100m holding is provably the wrong one, got %', coalesce(v_found, '(silence)');
+  end if;
+  if not exists (select 1 from public.withdrawal_ledger_audit a
+                  where a.parent_transaction_id = v_bank_over
+                    and a.check_name = 'holding_overdrawn' and a.severity = 'violation') then
+    raise exception 'the screening audit owns the holding-level proof here — without it this overdraw would go unproven by both views';
   end if;
   -- and placed in the holding's history, not merely in the list of failures: this
   -- is the SECOND of two withdrawals, and an operator opening the ledger needs
@@ -561,6 +602,20 @@ begin
       coalesce(v_found, '(silence)');
   end if;
 
+  -- the pair with no legal ordering and no guilty row: reported, not proven, and
+  -- the holding-level proof said in words where it cannot be said in a severity
+  select r.severity into v_found
+    from public.withdrawal_ledger_replay r where r.parent_transaction_id = v_pair;
+  if v_found is distinct from 'review' then
+    raise exception 'a row that would have been accepted written earlier must not be called the proven culprit, got %',
+      coalesce(v_found, '(silence)');
+  end if;
+  select r.detail into v_found
+    from public.withdrawal_ledger_replay r where r.parent_transaction_id = v_pair;
+  if v_found not like '%No ordering of this holding%' or v_found not like '%not provably the one%' then
+    raise exception 'the holding-level proof is real and has to reach the operator in the sentence, got %', v_found;
+  end if;
+
   -- the claim on another user's holding: silent, and silent for BOTH users — the
   -- holding's owner must not see an overdraw of a holding nobody touched either
   if exists (select 1 from public.withdrawal_ledger_replay r
@@ -605,10 +660,10 @@ begin
   -- tie-break, and it is the only fixture here that may do either.
   select count(*) into v_count from public.withdrawal_ledger_replay r
    where r.user_id = v_user and r.parent_transaction_id is distinct from v_tie;
-  if v_count <> 8 then
+  if v_count <> 9 then
     select string_agg(format('%s/%s: %s', r.check_name, r.severity, r.detail), E'\n')
       into v_found from public.withdrawal_ledger_replay r where r.user_id = v_user;
-    raise exception 'expected exactly the 8 planted sequences, got %:%s%s', v_count, E'\n', v_found;
+    raise exception 'expected exactly the 9 planted sequences, got %:%s%s', v_count, E'\n', v_found;
   end if;
 
   raise notice 'withdrawal_ledger_replay: ok';


### PR DESCRIPTION
Closes #613.

## What this is

`withdrawal_ledger_audit` (#609 / #611) reads the ledger **as it stands**. The invariant it audits is stateful — each write is measured against the balance remaining at that moment — so different histories, some legal and some not, reach the same final state, and the state does not record which one happened. Its own header says so, and a test pins the silence.

`public.withdrawal_ledger_replay` puts each balance key's rows back in `created_at` order and re-runs `check_withdrawal_balance`'s own transition rules over them, carrying remaining principal and remaining units forward. It names the **first** row that could not have been written at its turn, and the state it was measured against.

The issue's headline case, which the screen provably cannot decide:

```
1000 đồng / 100 units, sales of 50 taking 497 and 503
  screening audit → (silent)
  replay          → sale_took_the_wrong_basis / violation
                    "a sale of 50 units out of the 100 units then left, against a
                     1000 đồng basis: it should have taken 500 đồng, it took 497"
```

The invariant's two constants (one đồng, 0.0001 units) are the only tolerances — no flat-rate yardstick, no per-sale slack to calibrate.

## Design notes

- **A view, not a loop.** The state the invariant carries is exactly `(remaining basis, remaining units)`, which is additive, so the replay is running sums over the events with window functions.
- **A source opens its holding's balance at `-infinity`,** not at its own `created_at`: `check_withdrawal_balance` reads a parent wholesale with no interleaving, and ordering it by `created_at` would invert renewal, which re-parents a deposit's partial withdrawals onto a snapshot written *after* them (#585). Fund purchases *do* interleave — that is the whole reason a bucket's later purchase can make an illegal sell look proportional.
- **`violation` vs `review`.** #608 bounds the *total* a source owes, not each prefix, so a legal ledger can still be re-priced or relocated under a sale that already drew on it. The premise is therefore *tested* per key rather than assumed: a row is `touched` when `updated_at > created_at`. All-pristine key → `violation`; any touched row → `review`.
- **The RPC rewrites #613 asks about need no catalogue.** Renewal, collapse and the book top-up all bump `updated_at` on what they rewrite, so their keys carry findings as `review` by construction — rather than being flagged as corruption, or having their shapes hand-listed in a list that would go stale the first time an RPC changed.
- **Shape checks stay with the screening view.** This judges balance transitions only; reporting them twice would double the noise without adding a fact.
- Both residual gaps (`updated_at` is writer-maintained, not trigger-maintained; a purchase relocated *out* of a bucket carries its touched flag away) are stated in the header.

## Tests

`supabase/tests/withdrawal_ledger_replay.test.sql`:

- Plants the sequences the screen provably cannot decide, and asserts of **each** that `withdrawal_ledger_audit` is silent on the same fixture — so the day this decays into a restatement of that view, the suite says so.
- A seeded generator builds ~200 ledgers with the invariant **watching**, one write at a time, pushed to the edge of what the rule allows (the đồng of rounding slack, the full-sale shortcut, slices whose share rounds to nothing, purchases interleaved between sells, across four magnitudes of basis and units). Every write carries `check_withdrawal_balance`'s own signature, so a single finding is a false positive by construction.
- Verified red: against a stub view returning nothing, the suite names the missing catch; against a tolerance tightened by one đồng, it names the false positive.

Every fixture sets `created_at` and `updated_at` by hand, and has to — `now()` is fixed for a transaction, so rows inserted in one test would otherwise share a timestamp and have no order to replay.

## Checks

- `supabase db reset` — the migration applies to an empty database.
- Full `supabase/tests` suite green, except `gold_refresh_cron_atomic.test.sql`, which fails on `permission denied for table gold_price_settings` on `main` too (verified with this view dropped) — pre-existing and unrelated.
- No TypeScript or app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)