### PR TITLE
fix(deposits): only a bank deposit can be an accumulating book (#618)

### DIFF
--- a/app/api/v1/fund-investments/[id]/goal/route.ts
+++ b/app/api/v1/fund-investments/[id]/goal/route.ts
@@ -71,8 +71,10 @@ export async function PATCH(
     if (!goal) return NextResponse.json({ error: "You don't have permission to access this goal." }, { status: 403 })
   }
 
-  // Books are created as bank deposits, but POST /investment-transactions will
-  // group any asset type when asked, so a fund row CAN carry a deposit_group_id.
+  // Books are created as bank deposits. POST /investment-transactions used to
+  // group any asset type when asked, so a fund row CAN carry a deposit_group_id
+  // — it no longer creates one (#618: the route refuses it and the table carries
+  // the rule), which leaves only rows written before that.
   // goal is book-level, so such a row has to move with its whole group — through
   // the same single-transaction RPC the canonical PUT uses. Doing the row update
   // and the cascade as two statements risks a partial failure that splits the

--- a/app/api/v1/investment-transactions/__tests__/route.post.accumulating.test.ts
+++ b/app/api/v1/investment-transactions/__tests__/route.post.accumulating.test.ts
@@ -21,24 +21,29 @@ const h = vi.hoisted(() => ({
   user: { id: 'user-1' } as { id: string } | null,
   inserts: [] as Record<string, unknown>[],
   fund: { data: { id: 'fund-1' } as unknown, error: null as unknown },
-  parent: { data: { transaction_id: 'parent-1', deposit_group_id: null, asset_type: 'bank' } as unknown, error: null as unknown },
+  rows: {} as Record<string, unknown>,
   insertResult: { data: null as unknown, error: null as unknown },
 }))
 
 vi.mock('@/lib/supabase-server', () => {
   const chain = (table: string) => {
     let op = 'select'
+    let rowId: string | null = null
     const c: Record<string, unknown> = {
       select: () => c,
       insert: (payload: Record<string, unknown>) => { op = 'insert'; h.inserts.push(payload); return c },
       update: () => { op = 'update'; return c },
-      eq: () => c,
+      // The id being looked up decides which row comes back: a withdrawal's
+      // parent and a top-up's anchor are both reads of this table, and the two
+      // are different rows.
+      eq: (col: string, val: string) => { if (col === 'transaction_id') rowId = val; return c },
       is: () => c,
       not: () => c,
       single: async () => {
         if (op === 'insert') return h.insertResult
         if (table === 'funds') return h.fund
-        return table === 'investment_transactions' ? h.parent : { data: null, error: null }
+        if (table !== 'investment_transactions') return { data: null, error: null }
+        return { data: (rowId && h.rows[rowId]) || null, error: null }
       },
       maybeSingle: async () => (table === 'funds' ? h.fund : { data: null, error: null }),
       then: (resolve: (v: unknown) => void) => resolve({ data: null, error: null }),
@@ -58,6 +63,7 @@ const { POST } = await import('../route')
 
 const FUND_ID = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
 const PARENT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+const BOOK_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb'
 
 const call = (body: Record<string, unknown>) =>
   POST(new NextRequest('https://app.test/api/v1/investment-transactions', {
@@ -80,7 +86,14 @@ describe('POST /api/v1/investment-transactions — accumulating is a bank shape'
     h.user = { id: 'user-1' }
     h.inserts = []
     h.fund = { data: { id: FUND_ID }, error: null }
-    h.parent = { data: { transaction_id: PARENT_ID, deposit_group_id: null, asset_type: 'bank' }, error: null }
+    // A plain deposit to withdraw from, and a live book to top up.
+    h.rows = {
+      [PARENT_ID]: { transaction_id: PARENT_ID, deposit_group_id: null, asset_type: 'bank' },
+      [BOOK_ID]: {
+        transaction_id: BOOK_ID, asset_type: 'bank', deposit_group_id: BOOK_ID,
+        goal_id: null, expiry_date: '2027-07-01', bank_code: null, top_up_lock_days: null,
+      },
+    }
     h.insertResult = { data: { transaction_id: 'new-tx' }, error: null }
     vi.spyOn(console, 'error').mockImplementation(() => {})
   })
@@ -136,6 +149,42 @@ describe('POST /api/v1/investment-transactions — accumulating is a bank shape'
       parent_transaction_id: PARENT_ID,
       principal_withdrawn: 1_000_000,
       accumulating: true,
+    })
+
+    expect(res.status).toBe(400)
+    expect(h.inserts).toEqual([])
+  })
+
+  // The other way into a book is joining one. It sets deposit_group_id too, so a
+  // withdrawal naming a book as its top-up target lands in the same shape by a
+  // different door — and the table refusing it would answer a nameable request
+  // with a 500.
+  it('refuses a withdrawal that tops up a book', async () => {
+    const res = await call({
+      asset_type: 'bank',
+      transaction_type: 'withdrawal',
+      investment_date: '2026-07-01',
+      amount_vnd: 1_000_000,
+      parent_transaction_id: PARENT_ID,
+      principal_withdrawn: 1_000_000,
+      tops_up_deposit_id: BOOK_ID,
+    })
+
+    expect(res.status).toBe(400)
+    expect(h.inserts).toEqual([])
+  })
+
+  // A tranche is a bank deposit. The top-up branch reads the type off the anchor,
+  // so this used to be accepted and silently rewritten to bank — with the fund_id
+  // dropped, since the row is no longer a fund.
+  it('refuses a fund purchase filed into a book', async () => {
+    const res = await call({
+      asset_type: 'fund',
+      transaction_type: 'investment',
+      investment_date: '2026-07-01',
+      amount_vnd: 1_000_000,
+      fund_id: FUND_ID,
+      tops_up_deposit_id: BOOK_ID,
     })
 
     expect(res.status).toBe(400)

--- a/app/api/v1/investment-transactions/__tests__/route.post.accumulating.test.ts
+++ b/app/api/v1/investment-transactions/__tests__/route.post.accumulating.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NextRequest } from 'next/server'
+
+// An accumulating book ("Loại 2") is a BANK concept: the anchor self-groups
+// (deposit_group_id = its own transaction_id) and every tranche is the same bank
+// deposit, which is why the book-level fields — goal, maturity, notes, bank —
+// cascade across the group.
+//
+// The top-up branch has always said so ("Can only top up an accumulating bank
+// deposit"). The branch that CREATES a book never checked, so
+// `{ asset_type: 'fund', accumulating: true }` wrote a fund row carrying a
+// deposit_group_id — a shape nothing downstream expects (#618). lib/mergeEligibility
+// reads a group as "a book, not a single deposit"; update_deposit_book cascades
+// book-level fields across the group without asking what the rows are.
+//
+// This is request validation, so it is tested here rather than in an E2E. The
+// table carries the same rule as a constraint (20260815000002), for the writers
+// that never come through this route.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  inserts: [] as Record<string, unknown>[],
+  fund: { data: { id: 'fund-1' } as unknown, error: null as unknown },
+  parent: { data: { transaction_id: 'parent-1', deposit_group_id: null, asset_type: 'bank' } as unknown, error: null as unknown },
+  insertResult: { data: null as unknown, error: null as unknown },
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chain = (table: string) => {
+    let op = 'select'
+    const c: Record<string, unknown> = {
+      select: () => c,
+      insert: (payload: Record<string, unknown>) => { op = 'insert'; h.inserts.push(payload); return c },
+      update: () => { op = 'update'; return c },
+      eq: () => c,
+      is: () => c,
+      not: () => c,
+      single: async () => {
+        if (op === 'insert') return h.insertResult
+        if (table === 'funds') return h.fund
+        return table === 'investment_transactions' ? h.parent : { data: null, error: null }
+      },
+      maybeSingle: async () => (table === 'funds' ? h.fund : { data: null, error: null }),
+      then: (resolve: (v: unknown) => void) => resolve({ data: null, error: null }),
+    }
+    return c
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (table: string) => chain(table),
+      rpc: () => ({ single: async () => ({ data: null, error: null }) }),
+    }),
+  }
+})
+
+const { POST } = await import('../route')
+
+const FUND_ID = 'ffffffff-ffff-4fff-8fff-ffffffffffff'
+const PARENT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa'
+
+const call = (body: Record<string, unknown>) =>
+  POST(new NextRequest('https://app.test/api/v1/investment-transactions', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  }))
+
+const BANK_BOOK = {
+  asset_type: 'bank',
+  transaction_type: 'investment',
+  investment_date: '2026-07-01',
+  amount_vnd: 10_000_000,
+  interest_rate: 5.5,
+  expiry_date: '2027-07-01',
+  accumulating: true,
+}
+
+describe('POST /api/v1/investment-transactions — accumulating is a bank shape', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.inserts = []
+    h.fund = { data: { id: FUND_ID }, error: null }
+    h.parent = { data: { transaction_id: PARENT_ID, deposit_group_id: null, asset_type: 'bank' }, error: null }
+    h.insertResult = { data: { transaction_id: 'new-tx' }, error: null }
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('creates a bank book whose anchor groups itself', async () => {
+    const res = await call(BANK_BOOK)
+
+    expect(res.status).toBe(201)
+    const row = h.inserts[0]
+    // The anchor IS the book: deposit_group_id is not null ⇔ accumulating, and
+    // the anchor is the row whose group equals its own id.
+    expect(row.deposit_group_id).toBeTruthy()
+    expect(row.deposit_group_id).toBe(row.transaction_id)
+    expect(row.asset_type).toBe('bank')
+  })
+
+  it('refuses a fund book, and writes nothing', async () => {
+    const res = await call({
+      ...BANK_BOOK,
+      asset_type: 'fund',
+      fund_id: FUND_ID,
+      interest_rate: undefined,
+      expiry_date: undefined,
+    })
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringMatching(/bank/i) })
+    expect(h.inserts).toEqual([])
+  })
+
+  it('refuses a gold book, and writes nothing', async () => {
+    const res = await call({ ...BANK_BOOK, asset_type: 'gold', interest_rate: undefined, expiry_date: undefined })
+
+    expect(res.status).toBe(400)
+    expect(h.inserts).toEqual([])
+  })
+
+  // A book is made of deposits, so its anchor is an investment. A withdrawal
+  // that self-groups would be read as a live book by every path that keys on
+  // deposit_group_id alone, holding a balance nothing put there. Parent-backed
+  // on purpose: a parentless withdrawal is refused earlier for another reason,
+  // and would pass this test without the rule under test existing.
+  it('refuses a withdrawal that asks to be a book', async () => {
+    const res = await call({
+      asset_type: 'bank',
+      transaction_type: 'withdrawal',
+      investment_date: '2026-07-01',
+      amount_vnd: 1_000_000,
+      parent_transaction_id: PARENT_ID,
+      principal_withdrawn: 1_000_000,
+      accumulating: true,
+    })
+
+    expect(res.status).toBe(400)
+    expect(h.inserts).toEqual([])
+  })
+
+  // Without the flag nothing changes: an ordinary fund purchase is not a book.
+  it('leaves an ordinary fund purchase alone', async () => {
+    const res = await call({
+      asset_type: 'fund',
+      transaction_type: 'investment',
+      investment_date: '2026-07-01',
+      amount_vnd: 5_000_000,
+      fund_id: FUND_ID,
+    })
+
+    expect(res.status).toBe(201)
+    expect(h.inserts[0].deposit_group_id).toBeNull()
+  })
+})

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -333,6 +333,26 @@ export async function POST(request: NextRequest) {
   // makes the anchor row self-group. The book's goal + maturity are book-level,
   // so a top-up inherits them (copied down) and the tranche just carries its own
   // amount/rate/date.
+  //
+  // Both ways in — starting a book (`accumulating`) and joining one
+  // (`tops_up_deposit_id`) — set deposit_group_id, so what a book is made of is
+  // checked once, in front of them, rather than in whichever branch happens to
+  // be reading. A grouped row that is not a bank investment is refused by the
+  // table now (20260815000002); reaching that constraint would answer a request
+  // the route can name with a catch-all 500.
+  //
+  // A withdrawal has no business in a book from either direction: self-grouped
+  // it reads as a live book to every path that keys on deposit_group_id alone,
+  // holding a balance nothing put there.
+  if (isWithdrawal && (cleanTopsUpId || accumulating)) {
+    return NextResponse.json({ error: 'A withdrawal cannot be part of an accumulating book.' }, { status: 400 })
+  }
+  // And joining one is the same rule as starting one. The branch below takes the
+  // type from the ANCHOR, so a caller filing a fund purchase into a book had it
+  // silently rewritten to bank — with its fund_id dropped on the way in.
+  if (cleanTopsUpId && cleanAssetType !== 'bank') {
+    return NextResponse.json({ error: 'Only a bank deposit can be part of an accumulating book.' }, { status: 400 })
+  }
   let explicitTxId: string | undefined
   let depositGroupId: string | null = null
   let effectiveGoalId = cleanGoalId
@@ -367,13 +387,12 @@ export async function POST(request: NextRequest) {
     // then read as a book: lib/mergeEligibility calls it "not a single deposit",
     // update_deposit_book cascades goal/maturity/notes/bank across the group
     // without asking what the rows are, and create_held_settlement has to refuse
-    // a grouped source explicitly because of it. A withdrawal is refused for the
-    // same reason from the other side: self-grouped, it reads as a live book
-    // holding a balance nothing put there.
+    // a grouped source explicitly because of it. (The withdrawal half of the
+    // rule is checked above, where both branches meet it.)
     //
     // Same rule on the table (20260815000002), because an API guard only binds
     // callers who come through the API.
-    if (isWithdrawal || cleanAssetType !== 'bank') {
+    if (cleanAssetType !== 'bank') {
       return NextResponse.json({ error: 'Only a bank deposit can be an accumulating book.' }, { status: 400 })
     }
     // New accumulating book: the anchor self-groups so deposit_group_id IS NOT

--- a/app/api/v1/investment-transactions/route.ts
+++ b/app/api/v1/investment-transactions/route.ts
@@ -360,6 +360,22 @@ export async function POST(request: NextRequest) {
     effectiveBankCode = anchor.bank_code ?? null // tranche inherits the book's bank
     cleanTopUpLockDays = anchor.top_up_lock_days ?? null
   } else if (accumulating) {
+    // A book is bank deposits, and its anchor is one of them. The top-up branch
+    // above has always said so; this branch never did, so
+    // `{ asset_type: 'fund', accumulating: true }` wrote a fund row carrying a
+    // deposit_group_id (#618) — a shape the paths that key on the group ALONE
+    // then read as a book: lib/mergeEligibility calls it "not a single deposit",
+    // update_deposit_book cascades goal/maturity/notes/bank across the group
+    // without asking what the rows are, and create_held_settlement has to refuse
+    // a grouped source explicitly because of it. A withdrawal is refused for the
+    // same reason from the other side: self-grouped, it reads as a live book
+    // holding a balance nothing put there.
+    //
+    // Same rule on the table (20260815000002), because an API guard only binds
+    // callers who come through the API.
+    if (isWithdrawal || cleanAssetType !== 'bank') {
+      return NextResponse.json({ error: 'Only a bank deposit can be an accumulating book.' }, { status: 400 })
+    }
     // New accumulating book: the anchor self-groups so deposit_group_id IS NOT
     // NULL ⇔ accumulating, and the anchor is the row whose group = its own id.
     explicitTxId = randomUUID()

--- a/supabase/migrations/20260815000002_a_book_is_bank_deposits.sql
+++ b/supabase/migrations/20260815000002_a_book_is_bank_deposits.sql
@@ -1,0 +1,66 @@
+-- A book is made of bank deposits, from the first row (#618).
+--
+-- An accumulating book ("Loại 2") is a BANK concept: the anchor self-groups
+-- (deposit_group_id = its own transaction_id) and every tranche is the same bank
+-- deposit, which is why the book-level fields — goal, maturity, notes, bank —
+-- cascade across the group.
+--
+-- POST /api/v1/investment-transactions never said so on the branch that CREATES
+-- a book: the top-up branch checks the anchor ("Can only top up an accumulating
+-- bank deposit"), while `accumulating: true` was honoured for any asset type.
+-- That route now refuses it, and this is the same rule on the table, for the
+-- writers that never come through the route — RLS lets `authenticated` INSERT
+-- its own investment_transactions rows straight through PostgREST, and the
+-- browser holds that session.
+--
+-- What is already covered, and what is not. investment_transactions_subtype_shape
+-- (20260802000001) requires deposit_group_id to be null on a fund/gold/stock
+-- INVESTMENT, so the case #618 was filed about is refused by the database today.
+-- Two shapes it cannot see, because it only measures investments:
+--
+--   • a WITHDRAWAL carrying a group. Nothing writes one — withdraw_book_close_group
+--     parents its rows to the tranches and leaves the group off — and self-grouped
+--     it would read as a live book to every path that keys on deposit_group_id
+--     alone: lib/mergeEligibility ("not a single deposit"), update_deposit_book's
+--     cascade, the recurring-link target list, create_held_settlement's refusal.
+--     A book holding a balance nothing put there.
+--   • a row with NO asset_type at all carrying a group — the CASE falls through
+--     to `true`, and asset_type is nullable.
+--
+-- So the rule is stated once, positively: a grouped row is a bank investment.
+-- Overlapping with the subtype constraint on the fund/gold/stock case is the
+-- point — that one is about which columns an asset type may carry, this one is
+-- about what a book is made of, and neither has to remember the other.
+--
+-- NOT VALID, the stance #611 and #588 took for the same reason: this validates
+-- every INSERT and UPDATE from here on, but does not scan rows written before
+-- it, so a migration cannot refuse to apply against real history and block the
+-- deploy. #618 asks for the audit rather than a migration of old rows, and the
+-- audit is this — read-only, run against production when convenient:
+--
+--   select transaction_id, asset_type, transaction_type, deposit_group_id
+--     from public.investment_transactions
+--    where deposit_group_id is not null
+--      and (asset_type is distinct from 'bank' or transaction_type <> 'investment');
+--
+-- Expected to be empty: `accumulating` is only ever sent by the bank branch of
+-- the add-transaction form, so a row like this would have to come from a
+-- hand-made API call. If it does come back with rows, decide what they are
+-- before validating the constraint; once it is empty, run
+--   alter table public.investment_transactions
+--     validate constraint investment_transactions_book_is_bank;
+--
+-- Covered by supabase/tests/deposit_book_tranche_guard.test.sql (`npm run test:db`).
+
+alter table public.investment_transactions
+  drop constraint if exists investment_transactions_book_is_bank;
+
+alter table public.investment_transactions
+  add constraint investment_transactions_book_is_bank
+  check (
+    deposit_group_id is null
+    or (asset_type = 'bank' and transaction_type = 'investment')
+  ) not valid;
+
+comment on constraint investment_transactions_book_is_bank on public.investment_transactions is
+  'An accumulating book is made of bank deposits: only a bank investment may carry a deposit_group_id (#618).';

--- a/supabase/tests/deposit_book_tranche_guard.test.sql
+++ b/supabase/tests/deposit_book_tranche_guard.test.sql
@@ -29,6 +29,7 @@ declare
   v_tranche uuid;
   v_other   uuid;
   v_plain   uuid;
+  v_book    uuid;  -- a live book for the #618 inserts
   v_left    int;
 begin
   insert into auth.users (id, email) values (gen_random_uuid(), 'book-guard@test.invalid') returning id into v_user;
@@ -150,6 +151,61 @@ begin
   update public.investment_transactions
   set asset_type = 'gold', units = 1, unit_price = 3500000, interest_rate = null
   where transaction_id = v_plain;
+
+  -- ── A book is made of bank deposits, from the first row (#618) ───────────
+  --
+  -- The rules above are about a row that is ALREADY in a book: it cannot change
+  -- type, cannot move, cannot leave alone. None of them fires on the INSERT that
+  -- puts a non-deposit into a book in the first place — and POST accepted
+  -- `{ asset_type: 'fund', accumulating: true }` for exactly as long, so a fund
+  -- row could carry a deposit_group_id. Every path that keys on the group ALONE
+  -- reads such a row as a book: lib/mergeEligibility, update_deposit_book's
+  -- cascade, and create_held_settlement, which refuses a grouped source
+  -- explicitly because of it.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, interest_rate, expiry_date)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 30000000, 5.5, '2027-01-01')
+  returning transaction_id into v_book;
+  update public.investment_transactions set deposit_group_id = v_book where transaction_id = v_book;
+
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+       fund_id, units, unit_price, deposit_group_id)
+    values (v_user, v_goal, 'fund', 'investment', '2026-03-01', 10000000,
+            v_fund, 500, 20000, v_book);
+    raise exception 'a fund holding must not be born in a book';
+  exception when sqlstate '23514' then null;
+  end;
+
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+       units, unit_price, deposit_group_id)
+    values (v_user, v_goal, 'gold', 'investment', '2026-03-01', 10000000, 2, 5000000, v_book);
+    raise exception 'a gold holding must not be born in a book';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- The anchor of a book is a deposit, so a withdrawal has no business carrying
+  -- the group: self-grouped it would read as a live book holding a balance
+  -- nothing put there.
+  begin
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
+       investment_date, amount_vnd, principal_withdrawn, deposit_group_id)
+    values (v_user, v_goal, 'bank', 'withdrawal', v_book,
+            '2026-03-01', 1000000, 1000000, v_book);
+    raise exception 'a withdrawal must not carry a book';
+  exception when sqlstate '23514' then null;
+  end;
+
+  -- And the shape every writer actually produces still goes in.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, interest_rate, deposit_group_id)
+  values (v_user, v_goal, 'bank', 'investment', '2026-03-01', 20000000, 5.5, v_book)
+  returning transaction_id into v_tranche;
+  delete from public.investment_transactions where transaction_id = v_tranche;
 
   raise notice 'deposit book tranche guard: OK';
 end $$;


### PR DESCRIPTION
Closes #618.

## The gap

An accumulating book ("Loại 2") is a **bank** concept: the anchor self-groups (`deposit_group_id` = its own `transaction_id`) and every tranche is the same bank deposit, which is why the book-level fields — goal, maturity, notes, bank — cascade across the group.

The top-up branch of `POST /api/v1/investment-transactions` has always said so. The branch that **creates** a book never checked:

```ts
} else if (accumulating) {
  // no asset_type check at all
  explicitTxId = randomUUID()
  depositGroupId = explicitTxId
}
```

So `{ asset_type: 'fund', accumulating: true }` asked for a fund row carrying a `deposit_group_id` — the shape every path that keys on the group **alone** reads as a book: `lib/mergeEligibility` ("not a single deposit"), `update_deposit_book`'s cascade, the recurring-link target list, and `create_held_settlement`, whose `deposit_group_id is not null` refusal exists because of it.

## The fix

**Route** — `accumulating` is refused for anything but a bank *investment*, with the message the top-up branch already gives in its own words, and nothing is written:

```
Only a bank deposit can be an accumulating book.  → 400
```

A withdrawal is refused from the other side: self-grouped, it would read as a live book holding a balance nothing put there.

**Table** — the same rule, for the writers that never come through the route (RLS lets `authenticated` INSERT its own rows straight through PostgREST):

```sql
check (deposit_group_id is null or (asset_type = 'bank' and transaction_type = 'investment')) not valid
```

Worth noting what the database already did. `investment_transactions_subtype_shape` (20260802000001, landed *after* #618 was filed) forbids a group on a fund/gold/stock **investment**, so the exact case in the issue is refused today — as a raw constraint error, not a readable 400. What it cannot see, because it only measures investments, is a **withdrawal** carrying a group, or a row with **no `asset_type`** at all. Those are what this closes. The overlap on fund/gold/stock is deliberate: that constraint is about which columns an asset type may carry, this one about what a book is made of, and neither has to remember the other.

`NOT VALID`, the stance #611/#588 took: no scan of history, so the migration cannot refuse to apply against real rows and block the deploy. #618 asks for an audit rather than a data migration, and the audit query is in the migration header — with the `validate constraint` line to run once it comes back empty.

## Tests

- `app/api/v1/investment-transactions/__tests__/route.post.accumulating.test.ts` (new, 5 cases) — bank book → 201 and the anchor self-groups; fund → 400 with nothing written; gold → 400; a parent-backed withdrawal asking to be a book → 400 (parent-backed on purpose: a parentless withdrawal is already refused for a different reason and would pass without the rule existing); an ordinary fund purchase unaffected.
- `supabase/tests/deposit_book_tranche_guard.test.sql` — inserting a fund/gold row into a live book, and a withdrawal carrying the group, are refused; the shape every writer actually produces still goes in.
- Request validation, so no new E2E — per CLAUDE.md's layer rule.

## Checks

- `npm test -- --run` 2496 ✓, `npm run test:coverage` (thresholds hold), `npm run typecheck`, `npm run lint`
- `npm run test:db` — all suites pass
- E2E: the six book specs (accumulating-deposit, accumulating-collapse, book-withdrawal, recurring-book-topup, unallocated-book, successor-book journey) 17 ✓; smoke lane 20 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)