### PR TITLE
feat(db): business dates in the database follow Vietnam, not the session (#627)

### DIFF
--- a/supabase/migrations/20260815000003_business_today.sql
+++ b/supabase/migrations/20260815000003_business_today.sql
@@ -1,0 +1,309 @@
+-- Business dates in the database follow Vietnam, not the session's zone (#627).
+--
+-- #591 settled this for the app: there is exactly ONE business timezone,
+-- Asia/Ho_Chi_Minh, every "today" comes from lib/dates wherever the code runs,
+-- and an eslint rule blocks deriving one from UTC or the runtime's local zone.
+-- The database was never brought under that rule. `show timezone` on a Supabase
+-- stack is UTC — no migration sets it — so a `current_date` in a migration is a
+-- UTC business date, the very idiom the lint rule refuses in TypeScript. Between
+-- 00:00 and 06:59 Vietnam time the UTC date is still YESTERDAY.
+--
+-- #638 already started writing `(now() at time zone 'Asia/Ho_Chi_Minh')::date`
+-- inline where it mattered (20260811000001, 20260812000001). This gives that
+-- expression a name — the SQL counterpart of todayIso() — and points the
+-- remaining live business dates at it.
+--
+-- ── what this changes ────────────────────────────────────────────────────────
+--
+--   1. insurance_savings.saved_date's DEFAULT. The route omits the column when
+--      the client sends none (app/api/v1/insurance-savings), so the default IS
+--      the business date for that request, and a contribution dated a day early
+--      lands in the previous cycle — which is what isInCurrentCycle reads. The
+--      current modal always sends a date, so this is the API contract rather
+--      than a bug a user can hit through the UI today.
+--   2. create_held_settlement's `coalesce(p_investment_date, current_date)`.
+--      Latent: the only caller passes a validated date, so the fallback is a
+--      trap for the next caller rather than a live bug.
+--   3. savings_goal_finish_blockers' "is this holding still in the future?".
+--      Live, and it fails CLOSED: in the 00:00–06:59 window a holding bought
+--      TODAY reads as future, and the goal cannot be finished at all until the
+--      session's date catches up.
+--
+-- ── what this deliberately does not change ───────────────────────────────────
+--
+-- Six functions guard against future-dating with `p_some_date > current_date + 1`:
+-- collapse_accumulating_book, finish_savings_goal, record_recurring_book_topup,
+-- renew_term_deposit, renew_term_deposit_with_merge, withdraw_accumulating_book.
+--
+-- The + 1 is a TOLERANCE, not a timezone conversion: it exists so a client whose
+-- clock is a day ahead is not refused outright, and every route already applies
+-- lib/dates' own future-date check with no grace before the call arrives. Under
+-- the skew that guard only gets STRICTER — with the session a day behind,
+-- `current_date + 1` is today, so it refuses a date it would otherwise allow. It
+-- never admits one it should have refused, which is the promise a value guard
+-- has to keep.
+--
+-- Correcting them would mean recreating six functions of 65–205 lines each to
+-- change one token, and a copy whose next edit does not reach it is how this
+-- schema has produced real bugs (#616's fund-bucket drift). So they are left,
+-- and the decision is written down where it can be revisited: if the slack is
+-- ever tightened, they move to business_today() in the same change.
+-- supabase/tests/business_timezone.test.sql holds the allow-list, so a SEVENTH
+-- one cannot appear quietly.
+--
+-- Issue #627 also named record_recurring_book_topup's
+-- `v_anchor.expiry_date < current_date` maturity check. It is already gone:
+-- 20260810000003/4 moved that comparison onto the ENTERED date
+-- (assert_accumulating_book_topup_allowed measures expiry_date - p_top_up_date),
+-- which is both timezone-free and the right question to ask.
+--
+-- now() / CURRENT_TIMESTAMP for created_at / updated_at is correct and untouched:
+-- those are instants, not business dates — the same distinction lib/dates makes.
+
+-- STABLE, not IMMUTABLE: the answer changes with the clock, so it must not be
+-- folded into an index or cached across statements. Stable is also what lets it
+-- serve as a column default and be read inside a plan.
+--
+-- search_path pinned like every other function here; the expression names both
+-- schema-qualified pieces it needs, so an empty path costs nothing.
+create or replace function public.business_today()
+returns date
+language sql
+stable
+set search_path = ''
+as $$ select (pg_catalog.now() at time zone 'Asia/Ho_Chi_Minh')::date $$;
+
+comment on function public.business_today() is
+  'Today in the one business timezone, Asia/Ho_Chi_Minh — the SQL counterpart of lib/dates todayIso() (#591/#627).';
+
+-- Readable by everyone who writes a row that carries a business date. The column
+-- default below is evaluated as the INSERTing role, so `authenticated` needs it
+-- for an insurance contribution to be written at all.
+grant execute on function public.business_today() to authenticated, anon, service_role;
+
+-- ── 1) an insurance contribution is dated in Vietnam ─────────────────────────
+alter table public.insurance_savings
+  alter column saved_date set default public.business_today();
+
+-- ── 2) a held settlement that names no date ──────────────────────────────────
+--
+-- Body identical to 20260731000001's except the coalesce fallback.
+
+create or replace function public.create_held_settlement(
+  p_source_id uuid,
+  p_amount_vnd bigint,
+  p_investment_date date default null,
+  p_merge_target_goal_id uuid default null,
+  p_merge_anchor_inv_id uuid default null
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  -- Same ×10 sanity bound the multi-source merge already applies to a client's
+  -- "received" (20260620000006). Settling a deposit releases its remaining
+  -- principal plus interest, never a multiple of it. Deriving an exact cap would
+  -- mean reimplementing lib/depositValuation's accrual in SQL and keeping the two
+  -- in step forever; a bound generous enough never to refuse a real
+  -- held-to-maturity value, but tight enough that the number cannot be invented,
+  -- is the trade the merge path already made. Same rule in both places.
+  v_src    public.investment_transactions;
+  v_eff    bigint;
+  v_target uuid;
+  v_row    public.investment_transactions;
+begin
+  if p_amount_vnd is null or p_amount_vnd <= 0 then
+    raise exception 'held settlement: the amount received must be positive'
+      using errcode = 'check_violation';
+  end if;
+  if p_source_id is null then
+    raise exception 'held settlement: name the deposit this settles'
+      using errcode = 'check_violation';
+  end if;
+
+  -- The lock is taken by THIS function rather than by the shared check: it is what
+  -- makes two settlements of one deposit impossible, and taking it under RLS is
+  -- also the ownership boundary — a source belonging to someone else is not
+  -- visible here at all.
+  select * into v_src
+    from public.investment_transactions
+   where transaction_id = p_source_id
+   for update;
+  if not found then
+    raise exception 'held settlement: the deposit being settled was not found'
+      using errcode = 'no_data_found';
+  end if;
+
+  -- Eligibility and the remaining principal come from the one definition every
+  -- writer answers to. The amount bound is NOT checked here — the row trigger owns
+  -- it, so there is one comparison rather than two that can drift.
+  select remaining into v_eff from public.held_settlement_source_state(p_source_id);
+
+  -- Net-worth safety. Closing the deposit removes it from net worth, and the
+  -- pool adds the cash back ONLY through merge_target_goal_id. Unresolvable
+  -- means the money leaves and is surfaced nowhere — so refuse rather than
+  -- mis-state total assets. Defaulting to the source's own goal is what the app
+  -- means by "stays where the deposit was".
+  v_target := coalesce(p_merge_target_goal_id, v_src.goal_id);
+  if v_target is null then
+    raise exception 'held settlement: needs a target goal, or the parked cash leaves net worth with nothing to add it back to'
+      using errcode = 'check_violation';
+  end if;
+  -- merge_target_goal_id is an app-managed mirror with no FK (20260620000004),
+  -- so ownership is checked here rather than by a constraint.
+  --
+  -- insufficient_privilege, not check_violation: this is the #474/#525 rule that
+  -- a caller may not point at another user's row, and the route turns it into the
+  -- 403 every other cross-user reference in the API answers with. A malformed
+  -- request and a forbidden one are different answers.
+  perform 1 from public.savings_goals
+   where goal_id = v_target and user_id = v_src.user_id;
+  if not found then
+    raise exception 'held settlement: the target goal does not belong to this deposit'
+      using errcode = 'insufficient_privilege';
+  end if;
+  -- The two goal columns must agree, because two different readers use two
+  -- different ones: the dashboard shows the parked cash under
+  -- merge_target_goal_id, while renew_term_deposit_with_merge will only let a
+  -- deposit consume a held row whose goal_id matches its own. Let them diverge
+  -- and the settlement is displayed in one goal and consumable only from
+  -- another — visible, and impossible to act on where it is visible.
+  --
+  -- So a settlement does not move cash between goals: an explicit target may
+  -- only name the goal the deposit is already in. The one case where the target
+  -- genuinely decides is a deposit with NO goal, where there is nothing to
+  -- disagree with — and the row then takes the target as its own goal_id so both
+  -- readers still agree.
+  if v_src.goal_id is not null and v_target is distinct from v_src.goal_id then
+    raise exception 'held settlement: the cash stays in the deposit''s own goal — it cannot be earmarked to a different one'
+      using errcode = 'check_violation';
+  end if;
+
+  if p_merge_anchor_inv_id is not null then
+    if p_merge_anchor_inv_id = p_source_id then
+      raise exception 'held settlement: a deposit cannot wait to be merged into itself'
+        using errcode = 'check_violation';
+    end if;
+    perform 1 from public.investment_transactions
+     where transaction_id = p_merge_anchor_inv_id and user_id = v_src.user_id;
+    if not found then
+      raise exception 'held settlement: the anchor deposit does not belong to this deposit'
+        using errcode = 'insufficient_privilege';
+    end if;
+  end if;
+
+  -- "Để dành gộp" closes the deposit outright, so principal_withdrawn is the
+  -- whole remaining principal — derived, never the client's number. The
+  -- withdrawal invariant re-checks it against the same balance on the way in.
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
+    investment_date, amount_vnd, principal_withdrawn, affects_progress,
+    held_for_merge, merge_target_goal_id, merge_anchor_inv_id
+  ) values (
+    -- goal_id = v_target, not v_src.goal_id: they are equal whenever the source
+    -- has a goal (checked above), and when it has none this is what keeps the
+    -- row's goal and its display goal the same.
+    v_src.user_id, v_target, 'bank', 'withdrawal', p_source_id,
+    coalesce(p_investment_date, public.business_today()), p_amount_vnd, v_eff, true,
+    true, v_target, p_merge_anchor_inv_id
+  )
+  returning * into v_row;
+
+  return v_row;
+end;
+$$;
+
+grant execute on function public.create_held_settlement(uuid, bigint, date, uuid, uuid) to authenticated;
+
+-- ── 3) a holding is "in the future" against the Vietnam date ─────────────────
+--
+-- Body identical to 20260813000002's except the future_holding predicate.
+
+create or replace function public.savings_goal_finish_blockers(p_goal_id uuid)
+returns table (code text, label text)
+language sql
+security invoker
+stable
+set search_path = ''
+as $$
+  -- EVERY recurring saving pointed at this goal, not only the ones still
+  -- running. An ended one keeps contributing: the dashboard synthesizes a
+  -- contribution for every realized plan month inside its window (there is no
+  -- investment_transactions row — that is what #640 is about), and it adds them
+  -- to the goal's value and to net worth forever. The finish RPC withdraws
+  -- transactions, so it cannot liquidate that balance; archiving the goal on top
+  -- of it would leave money permanently counted in a goal declared spent.
+  -- Blocking is the honest answer: unassign or delete the saving first.
+  select 'recurring_saving'::text, r.name
+    from public.recurring_savings r
+   where r.goal_id = p_goal_id
+  union all
+  -- ...and a saving that feeds a DEPOSIT held by this goal, whatever goal it is
+  -- itself filed under. Nothing makes those two agree — the ownership trigger
+  -- checks whose rows they are, not which goal — so a direct write, or a deposit
+  -- reassigned to this goal afterwards, leaves a saving pointing here while its
+  -- own goal_id says elsewhere.
+  --
+  -- Both shapes of link break, differently. A BOOK: the full close inside
+  -- withdraw_accumulating_book clears every recurring link targeting the book it
+  -- settles, regardless of goal, so the finish ends another goal's plan outright.
+  -- A single term DEPOSIT: the link survives the liquidation, and now points at
+  -- an empty deposit that has dropped out of the maturity flow — the saving can
+  -- never be folded into the deposit it was promised to, while still showing as
+  -- linked. Either way the finish has quietly changed what happens next month.
+  select 'recurring_saving'::text, r.name
+    from public.recurring_savings r
+    join public.investment_transactions t
+      on t.transaction_id = r.linked_deposit_tx_id
+   where r.linked_deposit_tx_id is not null
+     and t.goal_id = p_goal_id
+     and r.goal_id is distinct from p_goal_id
+  union all
+  -- The same predicate seed_and_sync_plan_dca uses (20260722000001). A fund can
+  -- keep dca_goal_id with is_dca off — disable_fund_dca clears both together, but
+  -- only since 20260722000002, and the table takes the pair in any combination.
+  -- Nothing is seeded from it, so nothing feeds the goal; blocking on it trapped
+  -- the goal forever and named a fund whose DCA the user had already turned off.
+  -- funds_dca_goal_not_completed is what stops it being switched back on later.
+  select 'dca_plan'::text, f.name
+    from public.funds f
+   where f.dca_goal_id = p_goal_id
+     and f.is_dca
+     and f.dca_monthly_amount_vnd is not null
+  union all
+  -- A contribution dated in the FUTURE. POST /api/v1/investment-transactions
+  -- allows one when it carries a plan_id — that is how next month's planned
+  -- deposit is recorded before it happens — and it is a live holding from the
+  -- moment it is written. Liquidating it would date the withdrawal before the
+  -- purchase it draws on, and would settle a contribution the user has not made
+  -- yet. Wait for it, or move it out of the goal.
+  select 'future_holding'::text, coalesce(t.notes, t.investment_date::text)
+    from public.investment_transactions t
+   where t.goal_id = p_goal_id
+     and t.transaction_type = 'investment'
+     and t.renewed_from_transaction_id is null
+     and t.investment_date > public.business_today()
+  union all
+  -- Cash parked for a merge is money in the goal that is not a holding — it has
+  -- no source row left to liquidate, so a finish would archive the goal on top of
+  -- it. Consumed settlements are history and skipped (mirrors DELETE on the goal).
+  select 'held_settlement'::text, coalesce(t.notes, '')
+    from public.investment_transactions t
+   where t.held_for_merge
+     and t.consumed_by_inv_id is null
+     and (t.goal_id = p_goal_id or t.merge_target_goal_id = p_goal_id)
+  union all
+  -- A book promised to a successor cannot be dissolved at all
+  -- (enforce_successor_before_dissolve). Saying so up front beats letting the
+  -- user fill in every figure and then hit the refusal on submit.
+  select 'successor_handover'::text, coalesce(t.notes, '')
+    from public.investment_transactions t
+   where t.goal_id = p_goal_id
+     and t.successor_deposit_tx_id is not null
+     and t.deposit_group_id = t.transaction_id;
+$$;
+
+comment on function public.savings_goal_finish_blockers(uuid) is
+  'Names everything that still feeds a goal and so blocks finishing it: recurring savings, DCA plans, held-for-merge cash, promised successor handovers (#650).';

--- a/supabase/tests/business_timezone.test.sql
+++ b/supabase/tests/business_timezone.test.sql
@@ -1,0 +1,210 @@
+-- Business dates in the database are Asia/Ho_Chi_Minh, not the session's zone (#627).
+--
+-- #591 settled this for TypeScript: the app has exactly ONE business timezone,
+-- every "today" comes from lib/dates, and an eslint rule blocks deriving one from
+-- UTC or the runtime's local zone. The database was never brought under that rule.
+-- `show timezone` on a Supabase stack is UTC, so every `current_date` in a
+-- migration was a UTC business date — and between 00:00 and 06:59 Vietnam time
+-- the UTC date is still YESTERDAY.
+--
+-- public.business_today() is the SQL counterpart of todayIso(). This file pins
+-- two things:
+--
+--   • behaviour — the places that derive a business date follow Vietnam, tested
+--     by moving the SESSION's zone somewhere extreme and watching them not move;
+--   • the invariant — a catalog scan, so a new `current_date` cannot appear in a
+--     business-date position without either failing here or being added to the
+--     allow-list deliberately.
+--
+-- now() / CURRENT_TIMESTAMP for created_at / updated_at is correct and untouched:
+-- those are instants, not business dates, exactly the distinction the TypeScript
+-- rule already makes.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  -- The two session zones the behavioural checks run under. Neither is anywhere
+  -- the app runs; that is the point — the answer must not depend on the session.
+  --
+  -- WHY TWO. 'Etc/GMT+12' is 19 hours behind Vietnam, so its date differs from
+  -- the Vietnam date at every hour EXCEPT 19:00–23:59 Vietnam time.
+  -- 'Pacific/Kiritimati' is 7 hours ahead, so its date differs from 17:00
+  -- onwards. Between them, at least one is always on a different calendar day
+  -- than Vietnam — so this file discriminates whatever hour CI happens to run
+  -- at, which a single zone cannot promise.
+  c_zones constant text[] := array['Etc/GMT+12', 'Pacific/Kiritimati'];
+
+  -- Functions allowed to keep `current_date`, and why. Each of these is the same
+  -- shape: `if p_some_date > current_date + 1 then <refuse as future-dated>`.
+  --
+  -- The + 1 is a TOLERANCE, not a timezone conversion — it was added so a client
+  -- a day ahead of the server is not refused outright, and the routes do their
+  -- own check through lib/dates with no grace before the call ever gets here.
+  -- Under the UTC/Vietnam skew that guard only ever gets STRICTER: between 00:00
+  -- and 06:59 Vietnam the session's date is yesterday, so `current_date + 1` is
+  -- today and the guard refuses a date it would otherwise have allowed. It never
+  -- admits a date it should have refused, which is what a value guard has to
+  -- promise.
+  --
+  -- So they are left alone rather than rewritten: correcting them means
+  -- recreating six functions of 65–205 lines each for one token, and a copy
+  -- whose next edit does not reach it is how this schema has produced real bugs
+  -- (#616's fund-bucket drift). If the slack is ever tightened, that decision
+  -- has to move them to business_today() at the same time — this list is where
+  -- to look.
+  --
+  -- Only CODE counts: the scan strips `--` comments first, so a function that
+  -- merely discusses the skew (open_successor_book explains why it computes the
+  -- Vietnam date itself) is not on this list and must not be added to it.
+  c_future_guards constant text[] := array[
+    'collapse_accumulating_book',
+    'finish_savings_goal',
+    'record_recurring_book_topup',
+    'renew_term_deposit',
+    'renew_term_deposit_with_merge',
+    'withdraw_accumulating_book'
+  ];
+
+  v_zone     text;
+  v_vn       date;
+  v_bad      text;
+  v_user     uuid;
+  v_member   uuid;
+  v_goal     uuid;
+  v_src      uuid;
+  v_saved    date;
+  v_row      public.investment_transactions;
+  v_kinds    text[];
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'tz@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+  insert into public.insurance_members (user_id, member_name, relationship, annual_payment_vnd)
+  values (v_user, 'Mẹ', 'parent', 12000000) returning member_id into v_member;
+
+  -- ── 1) the helper itself ────────────────────────────────────────────────────
+  foreach v_zone in array c_zones loop
+    perform set_config('TimeZone', v_zone, true);
+    v_vn := (now() at time zone 'Asia/Ho_Chi_Minh')::date;
+
+    if public.business_today() is distinct from v_vn then
+      raise exception 'business_today() must be the Vietnam date under %, got % want %',
+        v_zone, public.business_today(), v_vn;
+    end if;
+
+    -- ── 2) the insurance contribution's own date ─────────────────────────────
+    -- The route omits saved_date when the client sends none, so the column
+    -- default IS the business date for that request — and a contribution filed a
+    -- day early lands in the previous cycle, which is what isInCurrentCycle reads.
+    insert into public.insurance_savings (user_id, insurance_member_id, amount_saved_vnd)
+    values (v_user, v_member, 1000000)
+    returning saved_date into v_saved;
+    if v_saved is distinct from v_vn then
+      raise exception 'an insurance contribution must be dated in Vietnam under %, got % want %',
+        v_zone, v_saved, v_vn;
+    end if;
+
+    -- ── 3) a held settlement that names no date ──────────────────────────────
+    -- Latent rather than live — the only caller passes a validated date — so this
+    -- pins the fallback before the next caller finds it.
+    insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+    values (v_user, v_goal, 'bank', 'investment', v_vn - 30, 1000000) returning transaction_id into v_src;
+    v_row := public.create_held_settlement(v_src, 1000000, null);
+    if v_row.investment_date is distinct from v_vn then
+      raise exception 'a settlement with no date must be dated in Vietnam under %, got % want %',
+        v_zone, v_row.investment_date, v_vn;
+    end if;
+
+    -- ── 4) "is this holding still in the future?" ────────────────────────────
+    -- A holding dated TODAY in Vietnam is live, not future, so it must not block
+    -- finishing the goal. Under a session zone a day behind, current_date called
+    -- it future and the goal could not be finished at all.
+    insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+    values (v_user, v_goal, 'bank', 'investment', v_vn, 2000000) returning transaction_id into v_src;
+    select array_agg(code) into v_kinds from public.savings_goal_finish_blockers(v_goal);
+    if 'future_holding' = any(coalesce(v_kinds, '{}')) then
+      raise exception 'a holding dated today in Vietnam must not read as future under %', v_zone;
+    end if;
+    -- And one genuinely in the future still does.
+    update public.investment_transactions set investment_date = v_vn + 1 where transaction_id = v_src;
+    select array_agg(code) into v_kinds from public.savings_goal_finish_blockers(v_goal);
+    if not ('future_holding' = any(coalesce(v_kinds, '{}'))) then
+      raise exception 'a holding dated tomorrow must still read as future under %', v_zone;
+    end if;
+    delete from public.investment_transactions where transaction_id = v_src;
+  end loop;
+  perform set_config('TimeZone', 'UTC', true);
+
+  -- ── 5) the invariant, as a catalog scan ─────────────────────────────────────
+  --
+  -- Reading the catalog rather than the migration files: what is installed is
+  -- what runs, and a superseded copy in an old migration is not a live rule.
+  select string_agg(p.proname, ', ' order by p.proname) into v_bad
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+   where n.nspname = 'public'
+     and pg_catalog.regexp_replace(p.prosrc, '--[^\n]*', '', 'g') ~* '\mcurrent_date\M'
+     and not (p.proname = any(c_future_guards));
+  if v_bad is not null then
+    raise exception 'these functions derive a business date from the session zone — use public.business_today(): %', v_bad;
+  end if;
+
+  -- now()::date is the same mistake spelled differently: it takes the session's
+  -- zone just as current_date does. `now() at time zone 'Asia/Ho_Chi_Minh'` is
+  -- the correct form and does not match.
+  select string_agg(p.proname, ', ' order by p.proname) into v_bad
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+   where n.nspname = 'public'
+     and pg_catalog.regexp_replace(p.prosrc, '--[^\n]*', '', 'g') ~* 'now\(\)\s*::\s*date';
+  if v_bad is not null then
+    raise exception 'these functions cast now() to a date in the session zone — use public.business_today(): %', v_bad;
+  end if;
+
+  select string_agg(table_name || '.' || column_name, ', ') into v_bad
+    from information_schema.columns
+   where table_schema = 'public'
+     and column_default ~* '\mcurrent_date\M|now\(\)\s*::\s*date';
+  if v_bad is not null then
+    raise exception 'these column defaults date a row in the session zone — use public.business_today(): %', v_bad;
+  end if;
+
+  -- Views and CHECK constraints have no business-date derivation today. Asserted
+  -- rather than assumed, because either is a place one could appear without
+  -- touching a function.
+  select string_agg(viewname, ', ') into v_bad
+    from pg_views where schemaname = 'public' and definition ~* '\mcurrent_date\M';
+  if v_bad is not null then
+    raise exception 'these views derive a business date from the session zone: %', v_bad;
+  end if;
+
+  select string_agg(c.conname, ', ') into v_bad
+    from pg_constraint c
+    join pg_class t on t.oid = c.conrelid
+    join pg_namespace n on n.oid = t.relnamespace
+   where n.nspname = 'public' and pg_get_constraintdef(c.oid) ~* '\mcurrent_date\M';
+  if v_bad is not null then
+    raise exception 'these constraints derive a business date from the session zone: %', v_bad;
+  end if;
+
+  -- ── 6) timestamps are instants and stay untouched ───────────────────────────
+  -- The other half of the rule: created_at / updated_at record WHEN something
+  -- happened, which has no timezone question in it. If this file ever pushed
+  -- them at business_today() it would be replacing an instant with a date.
+  if not exists (
+    select 1 from information_schema.columns
+     where table_schema = 'public' and table_name = 'investment_transactions'
+       and column_name in ('created_at', 'updated_at')
+       and column_default ~* 'now\(\)'
+       and data_type = 'timestamp with time zone'
+  ) then
+    raise exception 'created_at / updated_at must stay now() timestamptz instants';
+  end if;
+
+  raise notice 'business_timezone.test.sql: OK';
+end $$;
+
+rollback;


### PR DESCRIPTION
Closes #627.

## The gap

#591 settled this for TypeScript: one business timezone, `Asia/Ho_Chi_Minh`, every "today" through `lib/dates`, an eslint rule blocking the UTC idiom. The database was never brought under that rule — `show timezone` on a Supabase stack is UTC, so a `current_date` in a migration is a *UTC* business date, and between 00:00 and 06:59 Vietnam time that is still **yesterday**.

## What changed

`public.business_today()` names the expression #638 had already started writing inline (`(now() at time zone 'Asia/Ho_Chi_Minh')::date`, six copies across 20260811000001 / 20260812000001) — the SQL counterpart of `todayIso()`. `stable`, `search_path` pinned, `execute` granted to `authenticated` because a column default is evaluated as the inserting role.

The three live business dates now use it:

| | reachability | what the skew did |
|---|---|---|
| `insurance_savings.saved_date` DEFAULT | API contract (the route omits the column when the client sends none; the modal always sends one) | a contribution filed a day early lands in the previous cycle — what `isInCurrentCycle` reads |
| `create_held_settlement`'s date fallback | latent (its only caller passes a validated date) | a trap for the next caller |
| `savings_goal_finish_blockers`' future-holding test | live | fails **closed**: a holding bought *today* read as future, so the goal could not be finished at all in that window |

## What is deliberately left, and why

Six functions guard future-dating with `p_some_date > current_date + 1`: `collapse_accumulating_book`, `finish_savings_goal`, `record_recurring_book_topup`, `renew_term_deposit`, `renew_term_deposit_with_merge`, `withdraw_accumulating_book`.

The `+ 1` is a **client-clock tolerance**, not a timezone conversion, and every route already applies `lib/dates`' own no-grace check first. Under the skew that guard only ever gets *stricter* — with the session a day behind, `current_date + 1` is today, so it refuses a date it would otherwise allow. It never admits one it should have refused, which is the promise a value guard has to keep.

Correcting them means recreating six functions of 65–205 lines each to change one token, and a copy whose next edit does not reach it is how this schema has produced real bugs (#616's fund-bucket drift). So the issue's option "leave the slack and document why" is what this takes — recorded in the migration header and in the test's allow-list, with the trigger for revisiting it (if the slack is ever tightened, they move at the same time).

Two notes from the survey:

- The issue counted 14 guard sites; the **live catalog** has 6. The rest are superseded copies in older migration files.
- Item 2 (`record_recurring_book_topup`'s `expiry_date < current_date`) is already gone: 20260810000003/4 moved that comparison onto the *entered* date (`assert_accumulating_book_topup_allowed` measures `expiry_date - p_top_up_date`), which is both timezone-free and the better question.

`now()` / `CURRENT_TIMESTAMP` for `created_at` / `updated_at` is untouched, and the test asserts it stays that way — those are instants, not business dates.

## Tests

`supabase/tests/business_timezone.test.sql`, new, pins both halves:

- **behaviour** — each check runs under two extreme session zones, `Etc/GMT+12` (19h behind Vietnam) and `Pacific/Kiritimati` (7h ahead), chosen so **at least one always disagrees with the Vietnam date whatever hour CI runs at**, which a single zone cannot promise. Verified discriminating: with the old `CURRENT_DATE` default restored, the insurance row came back `2026-08-14` against a Vietnam date of `2026-08-15`.
- **the invariant** — a catalog scan (not a grep of migration files: what is installed is what runs) over `pg_proc`, column defaults, views and constraints, with the allow-list above. `--` comments are stripped first, so a function that merely *discusses* the skew — `open_successor_book` explains why it computes the Vietnam date itself — is not on the list.

## Checks

- `npm run test:db` — 30/30 suites pass, including a fresh `supabase db reset` (the migration applies to an empty database)
- `npm test -- --run` 2498 ✓, `npm run typecheck`, `npm run lint`
- Full E2E 238 ✓ — the one failure is `recent-activity.spec.ts`, which is #660 (fails in the full lane depending on how much same-day data ran before it) and passes in isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)