### PR TITLE
fix(maturity): a pledged deposit takes no merge, from either side (#635)

### DIFF
--- a/app/api/v1/investment-transactions/[id]/renew/__tests__/route.pledged.test.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/__tests__/route.pledged.test.ts
@@ -79,6 +79,22 @@ describe('POST /renew — merging into pledged collateral', () => {
     expect(body.error).not.toMatch(/^pledged deposit: /)
   })
 
+  // The rule has two sentences and only the trigger knows which applies, so the
+  // route forwards the one it was given rather than authoring its own.
+  it('forwards the source-side sentence too, not a fixed one', async () => {
+    h.rpcError = {
+      code: '23514',
+      message: 'pledged deposit: this deposit is pledged as collateral, so it cannot be liquidated into a merge — release the pledge first',
+    }
+
+    const res = await call()
+
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toMatchObject({
+      error: 'this deposit is pledged as collateral, so it cannot be liquidated into a merge — release the pledge first',
+    })
+  })
+
   // Anything without the prefix is not a rule we wrote — it stays a fault, and
   // echoing it would leak database internals as if it were advice.
   it('still reports an unrelated failure as a 500', async () => {

--- a/app/api/v1/investment-transactions/[id]/renew/__tests__/route.pledged.test.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/__tests__/route.pledged.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// A merge into a deposit pledged as collateral is refused by the database
+// (#635): the cash would land inside a balance the user cannot withdraw until
+// the pledge is released. The sheet no longer offers such an anchor, so anyone
+// reaching this has gone around the UI — but the answer still has to be the
+// user's rule, named, rather than the catch-all 500 every other RPC refusal on
+// this route gets.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  old: {
+    asset_type: 'bank', amount_vnd: 10_000_000, interest_rate: 6,
+    expiry_date: '2026-07-01', deposit_group_id: null,
+  } as Record<string, unknown> | null,
+  rpcError: null as { message: string; code?: string } | null,
+}))
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: h.user } }) },
+    from: () => {
+      const c: Record<string, unknown> = {
+        select: () => c,
+        eq: () => c,
+        single: async () => ({ data: h.old, error: null }),
+      }
+      return c
+    },
+    rpc: () => ({
+      single: async () =>
+        h.rpcError ? { data: null, error: h.rpcError } : { data: { transaction_id: TX_ID }, error: null },
+    }),
+  }),
+}))
+
+const { POST } = await import('../route')
+
+const TX_ID = '88888888-8888-4888-8888-888888888888'
+const HELD_ID = '77777777-7777-4777-8777-777777777777'
+
+const call = () =>
+  POST(
+    new Request(`https://app.test/api/v1/investment-transactions/${TX_ID}/renew`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        amount_vnd: 10_600_000,
+        interest_rate: 6.5,
+        expiry_date: '2027-01-01',
+        investment_date: '2026-07-01',
+        interest_earned_vnd: 600_000,
+        held_sources: [HELD_ID],
+      }),
+    }) as unknown as NextRequest,
+    { params: Promise.resolve({ id: TX_ID }) },
+  )
+
+beforeEach(() => {
+  h.rpcError = null
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+describe('POST /renew — merging into pledged collateral', () => {
+  it('reports the collateral rule as a conflict, naming the remedy', async () => {
+    h.rpcError = {
+      code: '23514',
+      message: 'pledged deposit: this deposit is pledged as collateral, so money cannot be merged into it — release the pledge first',
+    }
+
+    const res = await call()
+
+    expect(res.status).toBe(409)
+    const body = await res.json()
+    expect(body.code).toBe('pledged_destination')
+    expect(body.error).toMatch(/pledge/i)
+    // The prefix marks the message as ours; it is not part of the sentence.
+    expect(body.error).not.toMatch(/^pledged deposit: /)
+  })
+
+  // Anything without the prefix is not a rule we wrote — it stays a fault, and
+  // echoing it would leak database internals as if it were advice.
+  it('still reports an unrelated failure as a 500', async () => {
+    h.rpcError = { code: 'XX000', message: 'deadlock detected' }
+
+    const res = await call()
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toMatchObject({ error: 'Failed to renew deposit' })
+  })
+})

--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -199,6 +199,19 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
         })
         .single()
   if (renewErr || !renewed) {
+    // A deposit frozen as collateral cannot receive merged cash (#635). The sheet
+    // stopped offering such an anchor, so this is the raw-API path — but it is
+    // still the user's rule and it has a remedy, which a 500 would hide. The
+    // prefix is what marks the message as ours; everything else stays a fault.
+    if (renewErr?.message?.startsWith('pledged deposit: ')) {
+      return NextResponse.json(
+        {
+          error: 'This deposit is pledged as collateral, so money cannot be merged into it. Release the pledge first.',
+          code: 'pledged_destination',
+        },
+        { status: 409 },
+      )
+    }
     console.error('renew: atomic renewal failed', renewErr?.message)
     return NextResponse.json({ error: 'Failed to renew deposit' }, { status: 500 })
   }

--- a/app/api/v1/investment-transactions/[id]/renew/route.ts
+++ b/app/api/v1/investment-transactions/[id]/renew/route.ts
@@ -203,12 +203,14 @@ export async function POST(request: NextRequest, { params }: { params: Promise<{
     // stopped offering such an anchor, so this is the raw-API path — but it is
     // still the user's rule and it has a remedy, which a 500 would hide. The
     // prefix is what marks the message as ours; everything else stays a fault.
-    if (renewErr?.message?.startsWith('pledged deposit: ')) {
+    // The message is the database's, minus the prefix that marks it as ours:
+    // the rule has two sentences (collateral cannot RECEIVE merged cash, and
+    // cannot be liquidated INTO a merge) and only the trigger knows which one
+    // applies. Same shape as the held-settlement refusals on POST.
+    const PLEDGED_PREFIX = 'pledged deposit: '
+    if (renewErr?.message?.startsWith(PLEDGED_PREFIX)) {
       return NextResponse.json(
-        {
-          error: 'This deposit is pledged as collateral, so money cannot be merged into it. Release the pledge first.',
-          code: 'pledged_destination',
-        },
+        { error: renewErr.message.slice(PLEDGED_PREFIX.length), code: 'pledged_destination' },
         { status: 409 },
       )
     }

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -344,6 +344,7 @@ export function MaturityResolveBody({
       case 'out-of-window': return t.reasonOutOfWindow(gapDays ?? 0)
       case 'different-currency': return t.reasonCurrency
       case 'pledged': return t.reasonPledged
+      case 'pledged-anchor': return t.reasonPledgedAnchor
       case 'different-goal': return t.reasonGoal
       default: return t.reasonBlocked
     }

--- a/features/dashboard/maturity/__tests__/mergeSelection.test.ts
+++ b/features/dashboard/maturity/__tests__/mergeSelection.test.ts
@@ -52,14 +52,14 @@ describe('holdAnchorsFor', () => {
     expect(holdAnchorsFor(inv, [inv, row({ id: 'usd', expiryDate: '2026-08-14', currency: 'USD' })], 'g1', false, 7)).toEqual([])
   })
 
-  it('accepts a PLEDGED anchor — the pledged rule only guards the source side', () => {
-    // Documenting today's behavior, not endorsing it. classifyMergeSources
-    // blocks a pledged *source* (it can't be liquidated); it says nothing about
-    // a pledged destination, and holdAnchorsFor calls it with the roles
-    // reversed. Whether topping up collateral should be allowed is a domain
-    // question, deliberately not settled inside this refactor.
+  it('rejects a PLEDGED anchor — cash must not be folded into frozen collateral', () => {
+    // #635 settled the asymmetry this test used to document: classifyMergeSource
+    // read source.isPledged only, so holdAnchorsFor — which calls it with the
+    // roles reversed — offered a pledged sibling as the deposit to park cash
+    // for. The cash would land inside a balance frozen as collateral and could
+    // not be withdrawn until the pledge is released. Release it first.
     const pledgedAnchor = row({ id: 'pledged', expiryDate: '2026-08-14', isPledged: true })
-    expect(holdAnchorsFor(inv, [inv, pledgedAnchor], 'g1', false, 7).map((a) => a.id)).toEqual(['pledged'])
+    expect(holdAnchorsFor(inv, [inv, pledgedAnchor], 'g1', false, 7)).toEqual([])
   })
 
   it('respects the window — a far-off anchor is out until the window widens', () => {

--- a/features/dashboard/maturity/strings.ts
+++ b/features/dashboard/maturity/strings.ts
@@ -58,6 +58,9 @@ export function maturityResolveStrings(isVi: boolean, matured: boolean) {
     reasonOutOfWindow: (n: number) => `Đáo hạn cách ${n} ngày — phá kỳ mất lãi`,
     reasonCurrency: 'Khác loại tiền',
     reasonPledged: 'Đang thế chấp — bị phong toả',
+    // The anchor, not the source: the deposit the money would go INTO is frozen,
+    // so nothing can be folded in until the pledge is released (#635).
+    reasonPledgedAnchor: 'Sổ này đang thế chấp — không nhận thêm tiền',
     reasonGoal: 'Khác mục tiêu',
     reasonBlocked: 'Chưa đủ điều kiện',
     holdNudge: (anchor: string, date: string) => `«${anchor}» đáo hạn ${date} cùng mục tiêu — để dành gộp thay vì rút?`,
@@ -119,6 +122,7 @@ export function maturityResolveStrings(isVi: boolean, matured: boolean) {
     reasonOutOfWindow: (n: number) => `Matures ${n}d apart — early settlement`,
     reasonCurrency: 'Different currency',
     reasonPledged: 'Pledged as collateral',
+    reasonPledgedAnchor: 'This deposit is pledged — it cannot take more money',
     reasonGoal: 'Different goal',
     reasonBlocked: 'Not eligible yet',
     holdNudge: (anchor: string, date: string) => `“${anchor}” matures ${date} in the same goal — hold for merge instead of withdrawing?`,

--- a/lib/__tests__/mergeEligibility.test.ts
+++ b/lib/__tests__/mergeEligibility.test.ts
@@ -59,6 +59,32 @@ describe('classifyMergeSource', () => {
     expect(c.overridable).toBe(false)
   })
 
+  // #635: the rule used to read source.isPledged only, so cash could be folded
+  // INTO collateral — the money lands inside a frozen balance and cannot be
+  // taken out again until the pledge is released, with nothing in the flow
+  // saying so. Blocked symmetrically: release the pledge first.
+  it('blocks a PLEDGED anchor — the destination is frozen collateral too', () => {
+    const c = classifyMergeSource({ ...anchor, isPledged: true }, sib({ id: 's', expiryDate: plusDays(ANCHOR_MAT, 1) }), 7)
+    expect(c.eligible).toBe(false)
+    expect(c.reason).toBe('pledged-anchor')
+    expect(c.overridable).toBe(false)
+  })
+
+  // Distinct from 'pledged' because the sentence the user reads is different:
+  // one is about the deposit they picked to keep, the other about the one they
+  // are folding in.
+  it('reports the anchor before the source when both are pledged', () => {
+    const c = classifyMergeSource({ ...anchor, isPledged: true }, sib({ id: 's', isPledged: true, expiryDate: ANCHOR_MAT }), 7)
+    expect(c.reason).toBe('pledged-anchor')
+  })
+
+  // A pledged anchor blocks every source, whatever else is wrong with them —
+  // there is no merge to have.
+  it('blocks even a perfect source when the anchor is pledged', () => {
+    const out = classifyMergeSources({ ...anchor, isPledged: true }, [sib({ id: 'a', expiryDate: ANCHOR_MAT })], 7)
+    expect(out.map((c) => c.reason)).toEqual(['pledged-anchor'])
+  })
+
   it('blocks a non-liquidatable source (a fund / book / fully-withdrawn deposit)', () => {
     expect(classifyMergeSource(anchor, sib({ id: 'f', type: 'fund' }), 7).reason).toBe('not-liquidatable')
     expect(classifyMergeSource(anchor, sib({ id: 'bk', depositGroupId: 'book-1' }), 7).reason).toBe('not-liquidatable')

--- a/lib/mergeEligibility.ts
+++ b/lib/mergeEligibility.ts
@@ -9,7 +9,12 @@
 //                           not an accumulating book, not fully withdrawn).
 //   3. Maturities close    — |source.maturity − anchor.maturity| ≤ window days.
 //   4. Same currency      — no mixing VND with a foreign currency.
-//   5. Not pledged        — not frozen as collateral.
+//   5. Not pledged        — neither side frozen as collateral. A pledged SOURCE
+//                           cannot be liquidated into the merge; a pledged
+//                           ANCHOR cannot receive the cash, because it would
+//                           land inside a balance the user cannot withdraw
+//                           until the pledge is released (#635). Release the
+//                           pledge first, in either direction.
 //
 // Rule 1 (same goal) is normally the *caller's* job: the merge sheet only ever
 // passes a goal's own holdings, so it's enforced by scoping. We still check it
@@ -22,6 +27,7 @@ export type MergeBlockReason =
   | 'different-goal'
   | 'different-currency'
   | 'pledged'
+  | 'pledged-anchor'
   | 'out-of-window'
 
 // The minimal shape the rules read. InvRow (goal-detail) is structurally
@@ -86,7 +92,13 @@ export function classifyMergeSource(
 
   let reason: MergeBlockReason | null = null
   let overridable = false
-  if (!liquidatable) {
+  // The anchor first: a pledged destination blocks every source identically, so
+  // reporting anything about the source would name the wrong deposit. This is
+  // the only rule about the anchor's own state — the rest measure the source
+  // against it (#635).
+  if (anchor.isPledged) {
+    reason = 'pledged-anchor'
+  } else if (!liquidatable) {
     reason = 'not-liquidatable'
   } else if (anchor.goalId != null && source.goalId != null && source.goalId !== anchor.goalId) {
     reason = 'different-goal'

--- a/supabase/migrations/20260815000004_pledged_deposit_takes_no_merge.sql
+++ b/supabase/migrations/20260815000004_pledged_deposit_takes_no_merge.sql
@@ -7,8 +7,12 @@
 -- holdAnchorsFor calls the same predicate with the roles reversed, so a pledged
 -- later sibling was offered as the deposit to park cash for; the resolve sheet
 -- passes the maturing deposit's is_pledged and no rule read it; and no merge RPC
--- mentions is_pledged at all — held_settlement_source_state guards the SOURCE,
--- which is the half that already worked.
+-- mentions is_pledged at all. The source half only LOOKED covered: the sheet
+-- refuses a pledged source, and held_settlement_source_state refuses one parked
+-- through create_held_settlement — but the live-source merge path had no
+-- server-side check, so a raw call closed pledged collateral in full and moved
+-- its cash elsewhere. Found in review of this change, reproduced, and closed
+-- here too.
 --
 -- The product decision on #635 was the symmetric block: cash must not be folded
 -- into a deposit frozen as collateral. It would land inside a balance the user
@@ -22,14 +26,17 @@
 --
 -- ── where the rule lives, and why not in the RPCs ────────────────────────────
 --
--- Every merge into a destination D writes D's id into one of two columns:
+-- Every merge into a destination D writes D's id into one of two columns, and
+-- the withdrawal that carries the first one also names the SOURCE it closes:
 --
 --   • consumed_by_inv_id, on the withdrawal a live source's closure produces and
 --     on the held settlement a consume folds in — renew_term_deposit_with_merge
 --     stamps both;
 --   • merge_anchor_inv_id, on a settlement that is WAITING for D.
 --
--- So the columns are the choke point, and a trigger on them covers every writer
+-- So one trigger on those two columns answers all three questions rule 5 asks:
+-- may this destination receive, may this source be liquidated, may this cash
+-- wait here. They are the choke point, and a trigger there covers every writer
 -- — including the two merge RPCs — without recreating a 280-line function to
 -- add one check. That matters here beyond taste: renew_term_deposit_with_merge
 -- has been copied five times, and a copy whose next edit does not reach it is
@@ -75,6 +82,34 @@ begin
     end if;
   end if;
 
+  -- The SOURCE being closed into that destination — the other half of rule 5,
+  -- and it was only ever enforced in two of the three places it applies:
+  -- lib/mergeEligibility refuses a pledged source in the sheet, and
+  -- held_settlement_source_state refuses one parked through
+  -- create_held_settlement. The LIVE-source path had no server-side check at
+  -- all: renew_term_deposit_with_merge validates the owner, goal, type and
+  -- balance of each source and never reads is_pledged, so a raw call closed
+  -- pledged collateral in full and moved its cash into another deposit.
+  -- Reproduced against the local stack before this was written.
+  --
+  -- Keyed on the withdrawal that does the closing: it names the source as its
+  -- parent and carries the destination in consumed_by_inv_id. Held settlements
+  -- are excluded — their source was already measured when the settlement was
+  -- created, and re-asking here would strand parked cash if the (already closed)
+  -- source were pledged afterwards.
+  if new.consumed_by_inv_id is not null
+     and new.parent_transaction_id is not null
+     and not coalesce(new.held_for_merge, false)
+     and (tg_op = 'INSERT' or old.consumed_by_inv_id is distinct from new.consumed_by_inv_id) then
+    select coalesce(t.is_pledged, false) into v_pledged
+      from public.investment_transactions t
+     where t.transaction_id = new.parent_transaction_id;
+    if v_pledged then
+      raise exception 'pledged deposit: this deposit is pledged as collateral, so it cannot be liquidated into a merge — release the pledge first'
+        using errcode = 'check_violation';
+    end if;
+  end if;
+
   -- The destination a parked settlement is waiting for.
   if new.merge_anchor_inv_id is not null
      and (tg_op = 'INSERT' or old.merge_anchor_inv_id is distinct from new.merge_anchor_inv_id) then
@@ -104,4 +139,4 @@ create trigger investment_transactions_pledged_takes_no_merge
   execute function public.enforce_pledged_deposit_takes_no_merge();
 
 comment on function public.enforce_pledged_deposit_takes_no_merge() is
-  'Cash cannot be folded into a deposit frozen as collateral, from either column that names a merge destination (#635).';
+  'Rule 5 for every writer: collateral is neither liquidated into a merge nor merged into, and no cash waits for it (#635).';

--- a/supabase/migrations/20260815000004_pledged_deposit_takes_no_merge.sql
+++ b/supabase/migrations/20260815000004_pledged_deposit_takes_no_merge.sql
@@ -1,0 +1,107 @@
+-- A pledged deposit takes no merge (#635).
+--
+-- "Not pledged" is rule 5 of the merge ruleset, and it guarded one side only.
+-- lib/mergeEligibility read `source.isPledged` and nothing ever read the
+-- ANCHOR's, so the rule blocked LIQUIDATING collateral into a merge and said
+-- nothing about ADDING cash to collateral. Downstream nothing closed it either:
+-- holdAnchorsFor calls the same predicate with the roles reversed, so a pledged
+-- later sibling was offered as the deposit to park cash for; the resolve sheet
+-- passes the maturing deposit's is_pledged and no rule read it; and no merge RPC
+-- mentions is_pledged at all — held_settlement_source_state guards the SOURCE,
+-- which is the half that already worked.
+--
+-- The product decision on #635 was the symmetric block: cash must not be folded
+-- into a deposit frozen as collateral. It would land inside a balance the user
+-- cannot withdraw until the pledge is released, and nothing in the flow told
+-- them — while the "Bộ luật" card presents "not pledged" as a property of the
+-- merge, not of one side of it. Topping up collateral stays possible; it just
+-- has to be deliberate: release the pledge, merge, pledge again.
+--
+-- The UI half lives in lib/mergeEligibility. This is the same rule for the raw
+-- API, which reaches these rows directly.
+--
+-- ── where the rule lives, and why not in the RPCs ────────────────────────────
+--
+-- Every merge into a destination D writes D's id into one of two columns:
+--
+--   • consumed_by_inv_id, on the withdrawal a live source's closure produces and
+--     on the held settlement a consume folds in — renew_term_deposit_with_merge
+--     stamps both;
+--   • merge_anchor_inv_id, on a settlement that is WAITING for D.
+--
+-- So the columns are the choke point, and a trigger on them covers every writer
+-- — including the two merge RPCs — without recreating a 280-line function to
+-- add one check. That matters here beyond taste: renew_term_deposit_with_merge
+-- has been copied five times, and a copy whose next edit does not reach it is
+-- how #616's fund-bucket bug happened.
+--
+-- The anchor is refused up front rather than at merge time. Cash earmarked to a
+-- deposit that may not receive it is stranded until someone notices, and the
+-- sheet no longer offers that anchor anyway.
+--
+-- ── the message prefixes are load-bearing ────────────────────────────────────
+--
+-- Each refusal carries the prefix the route that can reach it already
+-- translates, so the user gets a sentence rather than a 500:
+--
+--   • 'held settlement: …' — POST /api/v1/investment-transactions maps this
+--     family to a 400 naming the rule (the #588 plumbing);
+--   • 'pledged deposit: …' — the renew route maps this one to a 409, added in
+--     the same change. Everything else it gets is still a 500, which is what a
+--     fault should be.
+--
+-- Pledging a deposit that ALREADY has cash earmarked to it is not guarded here.
+-- It is the same question from the other end and the answer is less obvious (the
+-- pledge is a fact about the bank account, not a claim about the app's state);
+-- the merge simply refuses later, with the message naming the remedy.
+create or replace function public.enforce_pledged_deposit_takes_no_merge()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_pledged boolean;
+begin
+  -- The destination of a completed merge.
+  if new.consumed_by_inv_id is not null
+     and (tg_op = 'INSERT' or old.consumed_by_inv_id is distinct from new.consumed_by_inv_id) then
+    select coalesce(t.is_pledged, false) into v_pledged
+      from public.investment_transactions t
+     where t.transaction_id = new.consumed_by_inv_id;
+    if v_pledged then
+      raise exception 'pledged deposit: this deposit is pledged as collateral, so money cannot be merged into it — release the pledge first'
+        using errcode = 'check_violation';
+    end if;
+  end if;
+
+  -- The destination a parked settlement is waiting for.
+  if new.merge_anchor_inv_id is not null
+     and (tg_op = 'INSERT' or old.merge_anchor_inv_id is distinct from new.merge_anchor_inv_id) then
+    select coalesce(t.is_pledged, false) into v_pledged
+      from public.investment_transactions t
+     where t.transaction_id = new.merge_anchor_inv_id;
+    if v_pledged then
+      raise exception 'held settlement: the deposit this cash is waiting for is pledged as collateral — release the pledge first'
+        using errcode = 'check_violation';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.enforce_pledged_deposit_takes_no_merge() from public, anon, authenticated;
+
+drop trigger if exists investment_transactions_pledged_takes_no_merge on public.investment_transactions;
+-- `of <columns>` rather than every update: naming one of them is the only way to
+-- point a merge at a deposit, so a narrower trigger cannot be dodged, and rows
+-- that carry neither are not re-checked on every unrelated edit.
+create trigger investment_transactions_pledged_takes_no_merge
+  before insert or update of consumed_by_inv_id, merge_anchor_inv_id
+  on public.investment_transactions
+  for each row
+  execute function public.enforce_pledged_deposit_takes_no_merge();
+
+comment on function public.enforce_pledged_deposit_takes_no_merge() is
+  'Cash cannot be folded into a deposit frozen as collateral, from either column that names a merge destination (#635).';

--- a/supabase/tests/pledged_merge_destination.test.sql
+++ b/supabase/tests/pledged_merge_destination.test.sql
@@ -1,0 +1,144 @@
+-- A pledged deposit takes no merge (#635).
+--
+-- "Not pledged" is rule 5 of the merge ruleset (lib/mergeEligibility), and it
+-- used to guard one side only: classifyMergeSource read source.isPledged and
+-- nothing read the ANCHOR's. So cash could be folded INTO collateral — it lands
+-- inside a balance the user cannot withdraw until the pledge is released, and
+-- nothing in the flow said so, while the "Bộ luật" card presented "not pledged"
+-- as a property of the merge rather than of one side of it.
+--
+-- The UI now refuses both directions. The database says the same thing, because
+-- the raw API reaches these rows directly: RLS lets `authenticated` write its own
+-- investment_transactions, and no merge RPC mentions is_pledged at all
+-- (held_settlement_source_state guards the SOURCE, which is the other half).
+--
+-- Two columns carry the claim, so the guard reads both:
+--
+--   • consumed_by_inv_id — every merge into D stamps it, on the withdrawal it
+--     writes for a live source and on the held settlement it consumes. It is the
+--     single point every destination passes through, which is why the rule can
+--     live here instead of inside the merge RPCs.
+--   • merge_anchor_inv_id — the deposit a parked settlement is WAITING for.
+--     Refused up front rather than at the merge: cash earmarked for a deposit
+--     that may not receive it is stranded until someone notices.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_user    uuid;
+  v_goal    uuid;
+  v_pledged uuid;  -- the destination frozen as collateral
+  v_free    uuid;  -- an ordinary destination, for the control
+  v_src     uuid;  -- a live source to fold in
+  v_held    uuid;  -- a parked settlement
+  v_row     public.investment_transactions;
+  v_stamp   uuid;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'pledge-merge@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, interest_rate, expiry_date, is_pledged)
+  values (v_user, v_goal, 'bank', 'investment', current_date - 200, 50000000, 6.0, current_date - 1, true)
+  returning transaction_id into v_pledged;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, interest_rate, expiry_date)
+  values (v_user, v_goal, 'bank', 'investment', current_date - 200, 50000000, 6.0, current_date - 1)
+  returning transaction_id into v_free;
+
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', current_date - 200, 1000000)
+  returning transaction_id into v_src;
+
+  -- ── 1) a settlement cannot WAIT for a pledged deposit ────────────────────────
+  begin
+    perform public.create_held_settlement(v_src, 1000000, current_date - 1, null, v_pledged);
+    raise exception 'a settlement must not be earmarked to a pledged deposit' using errcode = 'ZZ999';
+  exception when check_violation then null;
+  end;
+
+  -- The same settlement against a free anchor is ordinary.
+  v_row := public.create_held_settlement(v_src, 1000000, current_date - 1, null, v_free);
+  v_held := v_row.transaction_id;
+
+  -- ── 2) a merge cannot land in a pledged deposit ──────────────────────────────
+  -- Straight at the marker first: this is the write the raw API makes.
+  begin
+    update public.investment_transactions
+       set consumed_by_inv_id = v_pledged
+     where transaction_id = v_held;
+    raise exception 'parked cash must not be folded into a pledged deposit' using errcode = 'ZZ999';
+  exception when check_violation then null;
+  end;
+
+  -- And through the RPC the app uses, which is what a user actually reaches.
+  -- The held consume and the live-source withdrawal both stamp the destination,
+  -- so either one carries the refusal.
+  begin
+    perform public.renew_term_deposit_with_merge(
+      v_pledged, 50000000, 6.5, current_date + 180, current_date, 100000,
+      null, null, null, null, '{}'::uuid[], '{}'::bigint[], null, array[v_held]
+    );
+    raise exception 'a merge must not complete into a pledged deposit' using errcode = 'ZZ999';
+  exception when check_violation then null;
+  end;
+
+  -- A live source folded into the pledged deposit is the same claim by the other
+  -- door: the withdrawal it writes is stamped with the destination.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, interest_rate, expiry_date)
+  values (v_user, v_goal, 'bank', 'investment', current_date - 100, 2000000, 5.0, current_date + 30)
+  returning transaction_id into v_src;
+  begin
+    perform public.renew_term_deposit_with_merge(
+      v_pledged, 50000000, 6.5, current_date + 180, current_date, 100000,
+      null, null, null, null, array[v_src], array[2000000::bigint], null, '{}'::uuid[]
+    );
+    raise exception 'a live source must not be folded into a pledged deposit' using errcode = 'ZZ999';
+  exception when check_violation then null;
+  end;
+
+  -- ── 3) the unpledged destination still merges ────────────────────────────────
+  -- The rule is about collateral, not about merging: the control proves the guard
+  -- did not simply break the flow it guards.
+  v_row := public.renew_term_deposit_with_merge(
+    v_free, 50000000, 6.5, current_date + 180, current_date, 100000,
+    null, null, null, null, '{}'::uuid[], '{}'::bigint[], null, array[v_held]
+  );
+  select consumed_by_inv_id into v_stamp
+    from public.investment_transactions where transaction_id = v_held;
+  if v_stamp is distinct from v_free then
+    raise exception 'the merge into a free deposit must still stamp, got %', v_stamp;
+  end if;
+  if v_row.amount_vnd <> 51000000 then
+    raise exception 'the parked cash must land in the free destination, got %', v_row.amount_vnd;
+  end if;
+
+  -- ── 4) releasing the pledge releases the merge ───────────────────────────────
+  -- The remedy the message names has to work, or the rule is a dead end.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', current_date - 200, 3000000)
+  returning transaction_id into v_src;
+  v_row := public.create_held_settlement(v_src, 3000000, current_date - 1);
+  v_held := v_row.transaction_id;
+
+  update public.investment_transactions set is_pledged = false where transaction_id = v_pledged;
+  v_row := public.renew_term_deposit_with_merge(
+    v_pledged, 50000000, 6.5, current_date + 180, current_date, 100000,
+    null, null, null, null, '{}'::uuid[], '{}'::bigint[], null, array[v_held]
+  );
+  if v_row.amount_vnd <> 53000000 then
+    raise exception 'the merge must go through once the pledge is released, got %', v_row.amount_vnd;
+  end if;
+
+  raise notice 'pledged_merge_destination.test.sql: OK';
+end $$;
+
+rollback;

--- a/supabase/tests/pledged_merge_destination.test.sql
+++ b/supabase/tests/pledged_merge_destination.test.sql
@@ -9,10 +9,13 @@
 --
 -- The UI now refuses both directions. The database says the same thing, because
 -- the raw API reaches these rows directly: RLS lets `authenticated` write its own
--- investment_transactions, and no merge RPC mentions is_pledged at all
--- (held_settlement_source_state guards the SOURCE, which is the other half).
+-- investment_transactions, and no merge RPC mentions is_pledged at all. The
+-- source half only LOOKED covered — held_settlement_source_state measures a
+-- source parked through create_held_settlement, while the live-source merge path
+-- had no check at all — so §2b pins that too.
 --
--- Two columns carry the claim, so the guard reads both:
+-- Two columns carry the claim, and the withdrawal carrying the first also names
+-- the source it closes, so the guard reads all three:
 --
 --   • consumed_by_inv_id — every merge into D stamps it, on the withdrawal it
 --     writes for a live source and on the held settlement it consumes. It is the
@@ -103,6 +106,31 @@ begin
     raise exception 'a live source must not be folded into a pledged deposit' using errcode = 'ZZ999';
   exception when check_violation then null;
   end;
+
+  -- ── 2b) a PLEDGED SOURCE cannot be liquidated into a merge ──────────────────
+  -- The other half of rule 5, and the half that looked done: the sheet refuses a
+  -- pledged source and held_settlement_source_state refuses one parked for a
+  -- merge — but the LIVE-source path had no server-side check at all. A raw call
+  -- closed pledged collateral in full and moved its cash into a free deposit.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, interest_rate, expiry_date, is_pledged)
+  values (v_user, v_goal, 'bank', 'investment', current_date - 100, 2000000, 5.0, current_date + 30, true)
+  returning transaction_id into v_src;
+  begin
+    perform public.renew_term_deposit_with_merge(
+      v_free, 50000000, 6.5, current_date + 180, current_date, 100000,
+      null, null, null, null, array[v_src], array[2000000::bigint], null, '{}'::uuid[]
+    );
+    raise exception 'pledged collateral must not be liquidated into a merge' using errcode = 'ZZ999';
+  exception when check_violation then null;
+  end;
+  -- The source is untouched: nothing was closed on the way to the refusal.
+  if exists (
+    select 1 from public.investment_transactions w
+     where w.parent_transaction_id = v_src and w.transaction_type = 'withdrawal'
+  ) then
+    raise exception 'the refused merge must not have closed the pledged source';
+  end if;
 
   -- ── 3) the unpledged destination still merges ────────────────────────────────
   -- The rule is about collateral, not about merging: the control proves the guard


### PR DESCRIPTION
Closes #635. **Option 1 — symmetric block**, chosen by the owner.

## The asymmetry

Rule 5 of the merge ruleset is "Not pledged — not frozen as collateral", and it guarded one side only:

```ts
} else if (source.isPledged) {
  reason = 'pledged'
}
```

Nothing read `anchor.isPledged`. So the rule blocked *liquidating* collateral into a merge and said nothing about *adding* cash to collateral:

- `holdAnchorsFor` calls the same predicate with the roles reversed, so a **pledged later sibling was offered as the deposit to park cash for** — a test pinned that behaviour, saying it documented rather than endorsed it;
- `MaturityResolveSheet` passes the maturing deposit's `isPledged` and no rule read it, so a pledged deposit maturing offered merge with itself as the destination;
- no merge RPC mentions `is_pledged` at all, so the raw API was open too.

The cash would land inside a balance the user cannot withdraw until the pledge is released, and nothing in the flow said so — while the "Bộ luật" card presents "not pledged" as a property of *the merge*, not of one side of it.

Topping up collateral (the legitimate use the issue names) stays possible; it just has to be deliberate: release the pledge, merge, pledge again. The last part of the DB test asserts exactly that path works.

## What changed

- **`lib/mergeEligibility`** — a new `'pledged-anchor'` reason, checked **first**: a pledged destination blocks every source identically, so reporting anything about the source would name the wrong deposit. Rule 5's comment now states both directions.
- **The sheet** — `reasonPledgedAnchor` in both languages ("Sổ này đang thế chấp — không nhận thêm tiền" / "This deposit is pledged — it cannot take more money"), so the blocked rows say *which* deposit is frozen. The hold fork disappears on its own, since `holdAnchorsFor` filters through the same predicate.
- **The table** — `investment_transactions_pledged_takes_no_merge`, a trigger on the two columns that name a merge destination: `consumed_by_inv_id` (stamped by every merge, on both the live-source withdrawal and the consumed settlement) and `merge_anchor_inv_id` (the deposit a parked settlement is waiting for, refused up front rather than stranding the cash).

  Those columns are the choke point, which is why the rule lives there instead of inside `renew_term_deposit_with_merge` — that function has been copied five times already, and a copy whose next edit does not reach it is how #616's fund-bucket bug happened.
- **The renew route** — a 409 naming the remedy instead of the blanket 500 every RPC refusal on that route gets. The refusal messages carry the prefix each route already translates: `held settlement: …` for the anchor case (existing #588 plumbing) and `pledged deposit: …` for the merge itself.

Not guarded: pledging a deposit that *already* has cash earmarked to it. It is the same question from the other end with a less obvious answer — the pledge is a fact about the bank account, not a claim about app state — and the merge then refuses with the message naming the remedy. Recorded in the migration header.

## Tests

- `lib/__tests__/mergeEligibility.test.ts` — a pledged anchor is a hard, non-overridable block; the anchor is reported before the source when both are pledged; a perfect source is still blocked.
- `features/dashboard/maturity/__tests__/mergeSelection.test.ts` — the test that documented the asymmetry now asserts the refusal, with the reasoning rewritten rather than deleted.
- `app/api/v1/investment-transactions/[id]/renew/__tests__/route.pledged.test.ts` — 409 with the remedy for our prefix; an unrelated failure is still a 500.
- `supabase/tests/pledged_merge_destination.test.sql` — the raw-API path both ways: the marker written by hand, the real RPC with a held source, the same with a live source, the unpledged control still merging, and **releasing the pledge letting the same merge through**.

## Checks

- `npm test -- --run` 2503 ✓, `npm run test:coverage` (thresholds hold), `npm run typecheck`, `npm run lint`
- `npm run test:db` — 31/31 after a fresh `supabase db reset`
- E2E: maturity merge/combine/hold specs 9 ✓, smoke lane 20 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)