### PR TITLE
fix(db): update_deposit_book takes its group in a defined order (#653)

### DIFF
--- a/app/api/v1/investment-transactions/[id]/__tests__/route.put.book-reload.test.ts
+++ b/app/api/v1/investment-transactions/[id]/__tests__/route.put.book-reload.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// update_deposit_book reads the tranche's book without a lock, takes the whole
+// group in transaction_id order, then re-reads to confirm the book is still the
+// one it locked (#653). If it is not — dissolved, or the tranche gone — it
+// aborts with "book changed since load" rather than writing to a book that no
+// longer exists.
+//
+// The collapse and merge-successor routes already answer that message with a
+// 409 and "reload"; the book edit is the third door to the same race, and it
+// used to report it as a server fault.
+
+const TX_ID = '11111111-1111-4111-8111-111111111111'
+const GOAL_ID = '22222222-2222-4222-8222-222222222222'
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  existing: { deposit_group_id: 'book-1' as string | null, asset_type: 'bank' as string | null },
+  rpcResult: { data: null as unknown, error: null as unknown },
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  function chainFor(table: string) {
+    const c: Record<string, unknown> = {
+      select: () => c,
+      eq: () => c,
+      update: () => c,
+      single: async () => {
+        if (table === 'savings_goals') return { data: { goal_id: GOAL_ID }, error: null }
+        return { data: h.existing, error: null }
+      },
+    }
+    return c
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: (table: string) => chainFor(table),
+      rpc: () => ({ single: async () => h.rpcResult }),
+    }),
+  }
+})
+
+const { PUT } = await import('../route')
+
+const put = () =>
+  PUT(
+    new Request(`https://app.test/api/v1/investment-transactions/${TX_ID}`, {
+      method: 'PUT',
+      body: JSON.stringify({ asset_type: 'bank', amount_vnd: 5_000_000, goal_id: GOAL_ID }),
+    }) as unknown as NextRequest,
+    { params: Promise.resolve({ id: TX_ID }) },
+  )
+
+beforeEach(() => {
+  h.user = { id: 'user-1' }
+  h.existing = { deposit_group_id: 'book-1', asset_type: 'bank' }
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('PUT /api/v1/investment-transactions/[id] — a book that changed under the edit', () => {
+  it('answers 409 and asks for a reload', async () => {
+    h.rpcResult = { data: null, error: { message: 'update_deposit_book: book changed since load, reload and retry' } }
+
+    const res = await put()
+
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toMatchObject({ error: expect.stringMatching(/reload/i) })
+  })
+
+  it('still reports an unrelated failure as a 500', async () => {
+    h.rpcResult = { data: null, error: { message: 'deadlock detected' } }
+
+    const res = await put()
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toMatchObject({ error: 'Failed to update deposit book' })
+  })
+})

--- a/app/api/v1/investment-transactions/[id]/route.ts
+++ b/app/api/v1/investment-transactions/[id]/route.ts
@@ -205,6 +205,14 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
           { status: 409 },
         )
       }
+      // The book changed between the unlocked read and the ordered lock the RPC
+      // takes over the group (#653) — dissolved, or this tranche gone. It aborts
+      // rather than write to a book that no longer exists, which is a reload,
+      // not a fault: the collapse and merge-successor routes answer the same
+      // message the same way.
+      if (bookErr?.message?.includes('book changed since load')) {
+        return NextResponse.json({ error: 'This deposit changed — please reload and try again.' }, { status: 409 })
+      }
       console.error('update_deposit_book: atomic book edit failed', bookErr?.message)
       return NextResponse.json({ error: 'Failed to update deposit book' }, { status: 500 })
     }

--- a/supabase/migrations/20260815000006_order_deposit_book_group_lock.sql
+++ b/supabase/migrations/20260815000006_order_deposit_book_group_lock.sql
@@ -56,6 +56,9 @@ as $$
 declare
   v_group uuid;
   v_row public.investment_transactions;
+  v_seen bigint;
+  v_now bigint;
+  v_round int;
 begin
   -- Read, do not lock: locking this row first would be one acquisition outside
   -- the order everything else agrees on, which is the cycle this is closing.
@@ -74,11 +77,40 @@ begin
   -- The whole group, in transaction_id order, before anything is written — the
   -- same order merge_book_into_successor and the pairing checks take it in, so
   -- two writers queue instead of crossing.
-  perform 1
-    from public.investment_transactions
-   where deposit_group_id = v_group
-   order by transaction_id
-     for update;
+  --
+  -- SWEPT UNTIL THE MEMBERSHIP STOPS MOVING, which one sweep does not give at
+  -- READ COMMITTED. The statement's snapshot is fixed before it starts waiting,
+  -- so a tranche a top-up inserts WHILE the sweep is queued behind that top-up's
+  -- own anchor lock is invisible to it — and the book-level UPDATE below takes a
+  -- fresh snapshot, sees the newcomer, and locks it in plan order. That is the
+  -- cycle back, one row at a time.
+  --
+  -- The loop closes it because the sweep includes the ANCHOR, and every writer
+  -- that adds a tranche takes the anchor first
+  -- (assert_accumulating_book_topup_allowed): once a sweep completes, no further
+  -- top-up can land, so the second pass is over a set that can no longer grow.
+  -- The count is read on its own fresh snapshot, after the locks are held, which
+  -- is exactly the read the sweep could not do for itself.
+  --
+  -- Bounded rather than open: a loop that cannot converge is a hung request, and
+  -- "reload and retry" is already this function's answer to a book that will not
+  -- hold still.
+  v_seen := -1;
+  for v_round in 1 .. 5 loop
+    select count(*) into v_now
+      from public.investment_transactions
+     where deposit_group_id = v_group;
+    exit when v_now = v_seen;
+    perform 1
+      from public.investment_transactions
+     where deposit_group_id = v_group
+     order by transaction_id
+       for update;
+    v_seen := v_now;
+  end loop;
+  if v_now is distinct from v_seen then
+    raise exception 'update_deposit_book: book changed since load, reload and retry';
+  end if;
 
   -- Re-read under the lock. The group was read without one, so a book that was
   -- dissolved (or a tranche that left it) in between would have sent the sweep

--- a/supabase/migrations/20260815000006_order_deposit_book_group_lock.sql
+++ b/supabase/migrations/20260815000006_order_deposit_book_group_lock.sql
@@ -1,0 +1,118 @@
+-- update_deposit_book takes its group in a defined order (#653).
+--
+-- The RPC locked the tranche it was handed and then rewrote the whole group in
+-- one statement with no ORDER BY:
+--
+--   select deposit_group_id into v_group … where transaction_id = p_tx_id for update;
+--   update public.investment_transactions … where deposit_group_id = v_group;
+--
+-- A bare UPDATE locks each row as the plan returns it, so the group's locks were
+-- taken in physical order — an edge against anything that takes the same rows in
+-- a defined one. merge_book_into_successor (#649) was moved to a single ordered
+-- acquisition precisely to remove ITS half of that cycle, and half a cycle
+-- removed is not a cycle removed: two concurrent edits of one book invert
+-- against each other just as well, and the result reaches the user as a raw
+-- 40P01 behind a generic 500.
+--
+-- Ordered by transaction_id, matching the merge and the pairing checks. Low
+-- likelihood on a single-user app; the cost of agreeing on an order is one
+-- statement.
+--
+-- ── the first lock had to move, not just gain an ORDER BY ────────────────────
+--
+-- Adding `order by transaction_id` to a second acquisition would not have fixed
+-- anything while the row the caller named was still locked FIRST: that single
+-- lock is itself out of order, so an edit naming the last tranche and one naming
+-- the first would still cross. So the tranche is now READ without a lock, and
+-- the whole group — including that row — is taken in one ordered sweep.
+--
+-- What the unlocked read gives up is re-read under the lock: if the row is gone,
+-- or has left this book, the sweep would have locked the wrong set. Nothing
+-- legitimate does either (20260802000002 pins a tranche to its book, and only a
+-- dissolution clears the group, as a whole), so this is a re-check rather than a
+-- new rule — and it answers with "reload and retry" instead of writing to a book
+-- that no longer exists, which is what the collapse says in the same situation.
+--
+-- Body is otherwise 20260620000002's unchanged: book-level fields (goal,
+-- maturity, notes, bank) cascade to the group, per-tranche fields (amount, rate,
+-- investment date) apply to the named row. Same signature, so create-or-replace
+-- needs no DROP.
+
+create or replace function public.update_deposit_book(
+  p_tx_id uuid,
+  p_set_goal boolean,       p_goal_id uuid,
+  p_set_expiry boolean,     p_expiry_date date,
+  p_set_amount boolean,     p_amount_vnd bigint,
+  p_set_rate boolean,       p_interest_rate numeric,
+  p_set_investment boolean, p_investment_date date,
+  p_set_notes boolean,      p_notes text,
+  p_set_bank boolean default false, p_bank_code text default null
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_group uuid;
+  v_row public.investment_transactions;
+begin
+  -- Read, do not lock: locking this row first would be one acquisition outside
+  -- the order everything else agrees on, which is the cycle this is closing.
+  select deposit_group_id into v_group
+    from public.investment_transactions
+   where transaction_id = p_tx_id;
+  if not found then
+    raise exception 'update_deposit_book: transaction not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_group is null then
+    raise exception 'update_deposit_book: not an accumulating book tranche'
+      using errcode = 'check_violation';
+  end if;
+
+  -- The whole group, in transaction_id order, before anything is written — the
+  -- same order merge_book_into_successor and the pairing checks take it in, so
+  -- two writers queue instead of crossing.
+  perform 1
+    from public.investment_transactions
+   where deposit_group_id = v_group
+   order by transaction_id
+     for update;
+
+  -- Re-read under the lock. The group was read without one, so a book that was
+  -- dissolved (or a tranche that left it) in between would have sent the sweep
+  -- at the wrong set of rows. Nothing legitimate does that — a tranche is pinned
+  -- to its book and a dissolution clears the whole group in one statement — so
+  -- this is a re-check, answered the way the collapse answers the same race.
+  if not exists (
+    select 1 from public.investment_transactions
+     where transaction_id = p_tx_id and deposit_group_id = v_group
+  ) then
+    raise exception 'update_deposit_book: book changed since load, reload and retry';
+  end if;
+
+  -- 1) Book-level fields (goal, maturity, name, bank) cascade to the whole group
+  -- atomically (one statement).
+  if p_set_goal or p_set_expiry or p_set_notes or p_set_bank then
+    update public.investment_transactions
+       set goal_id     = case when p_set_goal   then p_goal_id     else goal_id end,
+           expiry_date = case when p_set_expiry then p_expiry_date else expiry_date end,
+           notes       = case when p_set_notes  then p_notes       else notes end,
+           bank_code   = case when p_set_bank   then p_bank_code   else bank_code end,
+           updated_at  = now()
+     where deposit_group_id = v_group;
+  end if;
+
+  -- 2) Genuinely per-tranche fields apply to the edited row only.
+  update public.investment_transactions
+     set amount_vnd      = case when p_set_amount     then p_amount_vnd      else amount_vnd end,
+         interest_rate   = case when p_set_rate       then p_interest_rate   else interest_rate end,
+         investment_date = case when p_set_investment then p_investment_date else investment_date end,
+         updated_at      = now()
+   where transaction_id = p_tx_id
+  returning * into v_row;
+
+  return v_row;
+end;
+$$;

--- a/supabase/migrations/20260815000006_order_deposit_book_group_lock.sql
+++ b/supabase/migrations/20260815000006_order_deposit_book_group_lock.sql
@@ -33,6 +33,14 @@
 -- new rule — and it answers with "reload and retry" instead of writing to a book
 -- that no longer exists, which is what the collapse says in the same situation.
 --
+-- collapse_accumulating_book is recreated below for the same reason, one level
+-- up: it took the anchor first and the tranches afterwards, which crosses an
+-- id-ordered sweep whenever the anchor's id does not sort first. With
+-- update_deposit_book and merge_book_into_successor (#649) both on id order,
+-- anchor-first is the odd convention out, and converging on one order is the
+-- only way any of this composes. Its body is 20260815000005's — marker included,
+-- which the db suite checks by collapsing a book for real.
+--
 -- Body is otherwise 20260620000002's unchanged: book-level fields (goal,
 -- maturity, notes, bank) cascade to the group, per-tranche fields (amount, rate,
 -- investment date) apply to the named row. Same signature, so create-or-replace
@@ -146,5 +154,183 @@ begin
   returning * into v_row;
 
   return v_row;
+end;
+$$;
+create or replace function public.collapse_accumulating_book(
+  p_group_id uuid,
+  p_amount_vnd bigint,
+  p_interest_rate numeric,
+  p_expiry_date date,
+  p_investment_date date,
+  p_tranche_ids uuid[],
+  p_tranche_interest bigint[],
+  p_fulfill_saving_id uuid default null,
+  p_fulfill_ym text default null,
+  p_fulfill_amount bigint default null,
+  p_fulfill_source text default null
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_anchor public.investment_transactions;
+  v_tranche public.investment_transactions;
+  v_snapshot_id uuid;
+  v_interest bigint;
+  v_idx int;
+  v_renewed public.investment_transactions;
+begin
+  -- THE THIRD CHANGE FROM 20260618000003, and the reason this function is here
+  -- again: it used to lock the ANCHOR first and the tranches afterwards, which
+  -- crosses a writer taking the group in transaction_id order whenever the
+  -- anchor's id does not happen to sort first. update_deposit_book above is now
+  -- one such writer, and merge_book_into_successor has been another since #649,
+  -- so the anchor-first order is the odd one out and it is this one that moves.
+  --
+  -- Read without a lock, sweep the whole group in id order, then re-read under
+  -- that lock — the same three steps update_deposit_book takes, for the same
+  -- reason. No loop-until-stable here: a tranche that arrives late is already
+  -- fatal to a collapse and says so (the caller's tranche list would not account
+  -- for it), which is a stronger answer than locking it.
+  select * into v_anchor
+    from public.investment_transactions
+   where transaction_id = p_group_id
+     and deposit_group_id = p_group_id;
+  if not found then
+    raise exception 'collapse_accumulating_book: accumulating book not found'
+      using errcode = 'no_data_found';
+  end if;
+
+  perform 1
+    from public.investment_transactions
+   where deposit_group_id = p_group_id
+   order by transaction_id
+     for update;
+
+  select * into v_anchor
+    from public.investment_transactions
+   where transaction_id = p_group_id
+     and deposit_group_id = p_group_id;
+  if not found then
+    raise exception 'collapse_accumulating_book: book changed since load, reload and retry';
+  end if;
+  if v_anchor.asset_type is distinct from 'bank' then
+    raise exception 'collapse_accumulating_book: only bank books can be collapsed'
+      using errcode = 'check_violation';
+  end if;
+  if p_amount_vnd is null or p_amount_vnd <= 0 then
+    raise exception 'collapse_accumulating_book: amount must be positive'
+      using errcode = 'check_violation';
+  end if;
+  if p_investment_date > current_date + 1 then
+    raise exception 'collapse_accumulating_book: investment date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+  if p_expiry_date is not null and p_expiry_date <= p_investment_date then
+    raise exception 'collapse_accumulating_book: new maturity must be after the investment date'
+      using errcode = 'check_violation';
+  end if;
+
+  -- 0) Preserve EXPLICIT recurring links (#348): re-point any link that targets a
+  -- tranche of this book onto the surviving anchor BEFORE the deletes below.
+  update public.recurring_savings
+     set linked_deposit_tx_id = p_group_id,
+         updated_at = now()
+   where user_id = v_anchor.user_id
+     and linked_deposit_tx_id in (
+       select transaction_id from public.investment_transactions
+        where deposit_group_id = p_group_id
+          and transaction_type = 'investment'
+          and renewed_from_transaction_id is null
+     );
+
+  -- 1–4) Snapshot, re-parent, then delete every tranche; roll the anchor forward
+  -- after the loop.
+  --
+  -- THE FIRST OF THE TWO CHANGES FROM 20260618000003. The deletes below, and the
+  -- lineage move the delete guard makes on their behalf, are refused unless a
+  -- collapse says it is doing them (#652). Nothing else sets this flag and no
+  -- client can. Dropping this line breaks the collapse of any book holding
+  -- another book's payout — pinned by merge_successor_book.test.sql.
+  perform set_config('app.collapse_write', '1', true);
+  for v_tranche in
+    select * from public.investment_transactions
+     where deposit_group_id = p_group_id
+       and transaction_type = 'investment'
+       and renewed_from_transaction_id is null
+     order by investment_date
+     for update
+  loop
+    v_idx := array_position(p_tranche_ids, v_tranche.transaction_id);
+    -- A live tranche the caller didn't account for ⇒ the book changed since the
+    -- route read it (e.g. a top-up landed mid-flight). Abort so its principal is
+    -- never silently dropped; the client reloads and retries.
+    if v_idx is null then
+      -- NB: a plain raise (errcode P0001), NOT serialization_failure (40001) — the
+      -- latter is conventionally auto-retried by drivers/poolers, which would spin
+      -- on this deterministic abort instead of surfacing it. The route maps this
+      -- message to a 409 so the client reloads.
+      raise exception 'collapse_accumulating_book: book changed since load, reload and retry';
+    end if;
+    v_interest := p_tranche_interest[v_idx];
+
+    insert into public.investment_transactions (
+      user_id, goal_id, asset_type, transaction_type, amount_vnd,
+      investment_date, expiry_date, interest_rate, notes,
+      renewed_from_transaction_id, interest_earned_vnd, affects_progress
+    ) values (
+      v_tranche.user_id, v_tranche.goal_id, 'bank', 'investment', v_tranche.amount_vnd,
+      v_tranche.investment_date, v_tranche.expiry_date, v_tranche.interest_rate, v_tranche.notes,
+      p_group_id, v_interest, false
+    )
+    returning transaction_id into v_snapshot_id;
+
+    update public.investment_transactions
+       set parent_transaction_id = v_snapshot_id
+     where parent_transaction_id = v_tranche.transaction_id
+       and transaction_type = 'withdrawal';
+
+    if v_tranche.transaction_id <> p_group_id then
+      delete from public.investment_transactions
+       where transaction_id = v_tranche.transaction_id;
+    end if;
+  end loop;
+  -- Cleared immediately: the licence covers the loop, not the rest of whatever
+  -- transaction this call happens to be in.
+  perform set_config('app.collapse_write', '', true);
+
+  update public.investment_transactions
+     set amount_vnd        = p_amount_vnd,
+         interest_rate     = p_interest_rate,
+         expiry_date       = p_expiry_date,
+         investment_date   = p_investment_date,
+         deposit_group_id  = null,
+         updated_at        = now()
+   where transaction_id = p_group_id
+  returning * into v_renewed;
+
+  if p_fulfill_saving_id is not null and p_fulfill_ym is not null then
+    if not exists (
+      select 1 from public.recurring_savings
+       where saving_id = p_fulfill_saving_id and user_id = v_anchor.user_id
+    ) then
+      raise exception 'collapse_accumulating_book: recurring saving not found'
+        using errcode = 'no_data_found';
+    end if;
+    insert into public.recurring_saving_fulfillments (
+      user_id, recurring_saving_id, ym, amount_vnd, source
+    ) values (
+      v_anchor.user_id, p_fulfill_saving_id, p_fulfill_ym,
+      coalesce(p_fulfill_amount, 0), coalesce(p_fulfill_source, 'maturity-collapse')
+    )
+    on conflict (recurring_saving_id, ym) do update
+      set amount_vnd = excluded.amount_vnd,
+          source     = excluded.source,
+          updated_at = now();
+  end if;
+
+  return v_renewed;
 end;
 $$;

--- a/supabase/migrations/20260815000006_order_deposit_book_group_lock.sql
+++ b/supabase/migrations/20260815000006_order_deposit_book_group_lock.sql
@@ -177,6 +177,9 @@ as $$
 declare
   v_anchor public.investment_transactions;
   v_tranche public.investment_transactions;
+  v_seen bigint;
+  v_now bigint;
+  v_round int;
   v_snapshot_id uuid;
   v_interest bigint;
   v_idx int;
@@ -189,11 +192,9 @@ begin
   -- one such writer, and merge_book_into_successor has been another since #649,
   -- so the anchor-first order is the odd one out and it is this one that moves.
   --
-  -- Read without a lock, sweep the whole group in id order, then re-read under
-  -- that lock — the same three steps update_deposit_book takes, for the same
-  -- reason. No loop-until-stable here: a tranche that arrives late is already
-  -- fatal to a collapse and says so (the caller's tranche list would not account
-  -- for it), which is a stronger answer than locking it.
+  -- Read without a lock, sweep the whole group in id order until its membership
+  -- stops moving, then re-read under that lock — the same steps
+  -- update_deposit_book takes, for the same reasons.
   select * into v_anchor
     from public.investment_transactions
    where transaction_id = p_group_id
@@ -203,17 +204,32 @@ begin
       using errcode = 'no_data_found';
   end if;
 
-  perform 1
-    from public.investment_transactions
-   where deposit_group_id = p_group_id
-   order by transaction_id
-     for update;
+  -- Swept until the membership stops moving, for the reason spelled out on
+  -- update_deposit_book above: at READ COMMITTED the sweep's snapshot predates
+  -- its wait, so a tranche a top-up inserts while it is queued behind the anchor
+  -- is invisible to it — and the loop below would then take that row's lock in
+  -- investment_date order, outside the sweep. Refusing the collapse afterwards
+  -- (the caller's list cannot account for it) is the right ANSWER but it comes
+  -- after the lock, which is too late to matter for ordering.
+  v_seen := -1;
+  for v_round in 1 .. 5 loop
+    select count(*) into v_now
+      from public.investment_transactions
+     where deposit_group_id = p_group_id;
+    exit when v_now = v_seen;
+    perform 1
+      from public.investment_transactions
+     where deposit_group_id = p_group_id
+     order by transaction_id
+       for update;
+    v_seen := v_now;
+  end loop;
 
   select * into v_anchor
     from public.investment_transactions
    where transaction_id = p_group_id
      and deposit_group_id = p_group_id;
-  if not found then
+  if not found or v_now is distinct from v_seen then
     raise exception 'collapse_accumulating_book: book changed since load, reload and retry';
   end if;
   if v_anchor.asset_type is distinct from 'bank' then
@@ -332,5 +348,139 @@ begin
   end if;
 
   return v_renewed;
+end;
+$$;
+
+-- ── the full-book withdrawal, same order ─────────────────────────────────────
+--
+-- Anchor first, then every tranche on a full close: the third writer taking a
+-- whole book in an order of its own. Body is 20260813000002's unchanged except
+-- the acquisition.
+
+create or replace function public.withdraw_accumulating_book(
+  p_book_id uuid,
+  p_withdraw_principal bigint,
+  p_total_received bigint,
+  p_investment_date date,
+  p_affects_progress boolean
+)
+returns integer
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_anchor public.investment_transactions;
+  v_total_principal bigint;
+  v_inserted integer;
+  v_seen bigint;
+  v_now bigint;
+  v_round int;
+begin
+  -- The book in transaction_id order, not the anchor first (#653): a full close
+  -- rewrites every tranche, so taking the anchor alone and meeting the rest
+  -- later is the same crossing update_deposit_book and the collapse just left.
+  -- Read unlocked, sweep until the membership stops moving, re-read under the
+  -- lock — one shape for every writer that touches a whole book.
+  select * into v_anchor
+    from public.investment_transactions
+   where transaction_id = p_book_id
+     and deposit_group_id = p_book_id;
+  if found then
+    v_seen := -1;
+    for v_round in 1 .. 5 loop
+      select count(*) into v_now
+        from public.investment_transactions
+       where deposit_group_id = p_book_id;
+      exit when v_now = v_seen;
+      perform 1
+        from public.investment_transactions
+       where deposit_group_id = p_book_id
+       order by transaction_id
+         for update;
+      v_seen := v_now;
+    end loop;
+    if v_now is distinct from v_seen then
+      raise exception 'withdraw_accumulating_book: book changed since load, reload and retry';
+    end if;
+    select * into v_anchor
+      from public.investment_transactions
+     where transaction_id = p_book_id
+       and deposit_group_id = p_book_id;
+  end if;
+  if not found then
+    raise exception 'withdraw_accumulating_book: accumulating book not found'
+      using errcode = 'no_data_found';
+  end if;
+  if v_anchor.asset_type is distinct from 'bank' then
+    raise exception 'withdraw_accumulating_book: not a bank book'
+      using errcode = 'check_violation';
+  end if;
+  if p_total_received is null or p_total_received < 0 then
+    raise exception 'withdraw_accumulating_book: total received must be non-negative'
+      using errcode = 'check_violation';
+  end if;
+  if p_investment_date > current_date + 1 then
+    raise exception 'withdraw_accumulating_book: withdrawal date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+
+  select coalesce(sum(eff), 0) into v_total_principal
+    from public.book_live_tranches(p_book_id);
+  if v_total_principal <= 0 then
+    raise exception 'withdraw_accumulating_book: nothing to withdraw'
+      using errcode = 'check_violation';
+  end if;
+  if p_withdraw_principal is null or p_withdraw_principal <= 0 then
+    raise exception 'withdraw_accumulating_book: withdraw amount must be positive'
+      using errcode = 'check_violation';
+  end if;
+  if p_withdraw_principal > v_total_principal then
+    raise exception 'withdraw_accumulating_book: cannot withdraw more than the book balance'
+      using errcode = 'check_violation';
+  end if;
+
+  -- Refuse a split the ledger cannot record, rather than writing part of it and
+  -- being refused by amount_vnd > 0 half way through (see book_payout_allocation).
+  if exists (
+    select 1 from public.book_payout_allocation(
+      p_book_id, p_withdraw_principal, p_total_received, v_total_principal)
+     where principal_out > 0 and cash_out <= 0
+  ) then
+    raise exception 'withdraw_accumulating_book: a payout of % is too small to record on every tranche of this book',
+      p_total_received using errcode = 'check_violation';
+  end if;
+
+  with alloc as (
+    select * from public.book_payout_allocation(
+      p_book_id, p_withdraw_principal, p_total_received, v_total_principal)
+  )
+  insert into public.investment_transactions (
+    user_id, goal_id, asset_type, transaction_type, parent_transaction_id,
+    investment_date, amount_vnd, principal_withdrawn, affects_progress
+  )
+  select user_id, goal_id, 'bank', 'withdrawal', transaction_id,
+         p_investment_date, cash_out, principal_out, p_affects_progress
+    from alloc
+   where principal_out > 0;
+
+  get diagnostics v_inserted = row_count;
+
+  -- Full close: the book is settled. Unlink any recurring that fed it, then clear
+  -- the group so nothing can resurrect it (a recurring auto-top-up included).
+  if p_withdraw_principal >= v_total_principal then
+    update public.recurring_savings
+       set linked_deposit_tx_id = null, updated_at = now()
+     where user_id = v_anchor.user_id
+       and linked_deposit_tx_id in (
+         select transaction_id from public.investment_transactions
+          where deposit_group_id = p_book_id
+       );
+    update public.investment_transactions
+       set deposit_group_id = null, updated_at = now()
+     where deposit_group_id = p_book_id;
+  end if;
+
+  return v_inserted;
 end;
 $$;

--- a/supabase/tests/deposit_book_lock_order.test.sql
+++ b/supabase/tests/deposit_book_lock_order.test.sql
@@ -1,0 +1,170 @@
+-- update_deposit_book takes its group in a defined order (#653).
+--
+-- The RPC locked the tranche it was handed, then rewrote the whole group in one
+-- unordered statement:
+--
+--   update public.investment_transactions … where deposit_group_id = v_group;
+--
+-- A bare UPDATE locks rows as the plan returns them, which is physical order —
+-- so the group's locks were acquired in whatever order the rows happen to sit in.
+-- That is a deadlock edge against anything taking the same rows in a defined one,
+-- and merge_book_into_successor (#649) was moved to a single ordered acquisition
+-- precisely to remove ITS half of that cycle. Half a cycle removed is not a cycle
+-- removed: two concurrent edits of one book can still invert against each other,
+-- and the result surfaces as a raw 40P01 behind a generic 500.
+--
+-- ── how this is measured ─────────────────────────────────────────────────────
+--
+-- A deadlock itself is not a deterministic thing to test — reproducing one needs
+-- two plans to disagree about order, which on a two-row table they will not do to
+-- order. What IS deterministic is the property that removes the edge: the whole
+-- group is locked, in transaction_id order, BEFORE anything is written.
+--
+-- So the fixture is built with physical order deliberately opposite to id order —
+-- the anchor (id 2222…) is inserted first, the tranche (id 1111…) second — and
+-- then:
+--
+--   • session A locks the LOWEST id (1111…) and holds it;
+--   • session B calls the RPC naming the OTHER row (2222…), so its own
+--     single-row lock is not what makes it wait;
+--   • while B waits, A asks for 2222… with NOWAIT.
+--
+-- Before the fix, B has already locked and written 2222… on the way to 1111…
+-- (physical order), so A's probe is refused. After it, B is queued at the ordered
+-- acquisition with nothing taken past 1111…, so the probe succeeds. Then A
+-- commits and B's edit lands whole, which is the other half of the assertion:
+-- ordering must not cost the serialization.
+--
+-- ── why this file does not roll back ─────────────────────────────────────────
+--
+-- Two sessions must see each other's committed work, so the fixture is committed
+-- and the block cleans up after itself — including on failure, through a fresh
+-- connection, since a delete issued from this session would roll back with it.
+-- Same shape as fund_bucket_assign.test.sql part 2 (#610).
+
+create extension if not exists dblink;
+
+-- A leftover from a crashed earlier run would make the assertions read rows this
+-- run never wrote. Fixed ids, cleared first.
+delete from auth.users where id = '65365365-3653-4653-8653-653653653653';
+
+do $$
+declare
+  c_user    constant uuid := '65365365-3653-4653-8653-653653653653';
+  -- Chosen, not generated: the test needs id order and physical order to
+  -- disagree, so it has to know which is which.
+  c_anchor  constant uuid := '22222222-2222-4222-8222-222222222222';
+  c_tranche constant uuid := '11111111-1111-4111-8111-111111111111';
+  v_goal_a  uuid;
+  v_goal_b  uuid;
+  v_conn    text;
+  v_probe   int;
+  v_moved   int;
+  v_edited  uuid;
+begin
+  v_conn := format('host=%s port=%s dbname=%s user=postgres password=postgres',
+                   inet_server_addr(), current_setting('port'), current_database());
+
+  perform dblink_connect('book653_holder', v_conn);
+  perform dblink_connect('book653_editor', v_conn);
+
+  -- ── the fixture, committed so both sessions can see it ────────────────────
+  perform dblink_exec('book653_holder', format($f$
+    insert into auth.users (id, email) values (%L, 'book-lock-order@test.invalid');
+  $f$, c_user));
+
+  select id into v_goal_a from dblink('book653_holder', format($f$
+    insert into public.savings_goals (user_id, goal_name) values (%L, 'House') returning goal_id;
+  $f$, c_user)) as t(id uuid);
+
+  select id into v_goal_b from dblink('book653_holder', format($f$
+    insert into public.savings_goals (user_id, goal_name) values (%L, 'Car') returning goal_id;
+  $f$, c_user)) as t(id uuid);
+
+  -- The anchor FIRST — physical order is insertion order on a table this small,
+  -- and it must be the opposite of id order for the probe below to mean anything.
+  perform dblink_exec('book653_holder', format($f$
+    insert into public.investment_transactions
+      (transaction_id, user_id, goal_id, asset_type, transaction_type, investment_date,
+       amount_vnd, interest_rate, expiry_date, deposit_group_id)
+    values (%L, %L, %L, 'bank', 'investment', '2026-01-01', 10000000, 5.5, '2027-01-01', %L);
+  $f$, c_anchor, c_user, v_goal_a, c_anchor));
+
+  perform dblink_exec('book653_holder', format($f$
+    insert into public.investment_transactions
+      (transaction_id, user_id, goal_id, asset_type, transaction_type, investment_date,
+       amount_vnd, interest_rate, expiry_date, deposit_group_id)
+    values (%L, %L, %L, 'bank', 'investment', '2026-02-01', 20000000, 5.5, '2027-01-01', %L);
+  $f$, c_tranche, c_user, v_goal_a, c_anchor));
+
+  -- ── the race ──────────────────────────────────────────────────────────────
+  -- A holds the lowest id and nothing else.
+  perform dblink_exec('book653_holder', 'begin');
+  perform * from dblink('book653_holder', format($f$
+    select transaction_id from public.investment_transactions
+     where transaction_id = %L for update;
+  $f$, c_tranche)) as t(id uuid);
+
+  -- B edits the book, naming the OTHER row. Asynchronous because it must wait.
+  perform dblink_send_query('book653_editor', format($f$
+    select transaction_id from public.update_deposit_book(
+      %L, true, %L, false, null, false, null, false, null, false, null, false, null
+    );
+  $f$, c_anchor, v_goal_b));
+
+  -- Long enough for B to reach the lock and queue behind A.
+  perform pg_sleep(1);
+
+  -- The probe. NOWAIT so it answers instead of joining the queue — a refusal is
+  -- the pre-fix outcome and has to be reported as this rule, not as a raw
+  -- lock error from a nested connection.
+  begin
+    select count(*) into v_probe
+      from dblink('book653_holder', format($f$
+        select transaction_id from public.investment_transactions
+         where transaction_id = %L for update nowait;
+      $f$, c_anchor)) as t(id uuid);
+  exception when others then
+    raise exception 'the anchor must be free while the editor waits: the group is being locked in plan order, not id order (%)', sqlerrm;
+  end;
+  if v_probe <> 1 then
+    raise exception 'the anchor should have been free while the editor waited';
+  end if;
+
+  perform dblink_exec('book653_holder', 'commit');
+
+  select count(*) into v_moved
+    from dblink_get_result('book653_editor') as t(id uuid);
+  if v_moved <> 1 then
+    raise exception 'the edit should have completed once the holder committed, got % row(s)', v_moved;
+  end if;
+
+  perform dblink_disconnect('book653_holder');
+  perform dblink_disconnect('book653_editor');
+
+  -- ── and the edit still cascades whole ─────────────────────────────────────
+  -- Ordering the acquisition must not cost what the RPC exists for: a book-level
+  -- field moves every tranche, not the row that was named.
+  select count(*) into v_moved
+    from public.investment_transactions
+   where user_id = c_user and deposit_group_id = c_anchor and goal_id = v_goal_b;
+  if v_moved <> 2 then
+    raise exception 'the whole book should have moved to the new goal, % row(s) did', v_moved;
+  end if;
+
+  select goal_id into v_edited
+    from public.investment_transactions where transaction_id = c_tranche;
+  if v_edited is distinct from v_goal_b then
+    raise exception 'the tranche the caller did not name must move with its book';
+  end if;
+
+  perform dblink_exec(v_conn, format('delete from auth.users where id = %L', c_user));
+exception
+  when others then
+    perform dblink_disconnect(name)
+       from unnest(coalesce(dblink_get_connections(), '{}')) as name
+      where name like 'book653\_%';
+    perform dblink_exec(v_conn, format('delete from auth.users where id = %L', c_user));
+    raise;
+end;
+$$;


### PR DESCRIPTION
Closes #653.

## The edge

`update_deposit_book` locked the tranche it was handed, then rewrote the whole group in one unordered statement:

```sql
select deposit_group_id into v_group … where transaction_id = p_tx_id for update;
update public.investment_transactions … where deposit_group_id = v_group;
```

A bare UPDATE locks each row as the plan returns it, so the group's locks were taken in physical order. `merge_book_into_successor` (#649) was moved to a single ordered acquisition to remove *its* half of that cycle — and half a cycle removed is not a cycle removed: two concurrent edits of one book invert against each other just as well, and the result reaches the user as a raw `40P01` behind a generic 500.

## The fix

Ordered by `transaction_id`, matching the merge and the pairing checks.

**The first lock had to move, not just gain an `ORDER BY`.** While the row the caller named is locked *first*, that single acquisition is itself outside the order, so an edit naming the last tranche and one naming the first still cross. So:

1. read the tranche's book **without** a lock;
2. take the whole group — that row included — in one `order by transaction_id … for update` sweep;
3. **re-read** under the lock: if the book was dissolved, or the tranche has left it, abort with `book changed since load, reload and retry`.

Step 3 is a re-check, not a new rule (20260802000002 pins a tranche to its book, and only a dissolution clears the group, as a whole) — but without it the unlocked read could have sent the sweep at the wrong set of rows. The edit route now answers that message with the same **409 + reload** the collapse and merge-successor routes already give it, instead of a 500. (The assign and fund-goal routes also call this RPC; they still report it the way they report every other RPC failure.)

## Tests

`supabase/tests/deposit_book_lock_order.test.sql` (new) measures the *property* rather than a deadlock — reproducing one needs two plans to disagree about order, which on a two-row table they will not do to order. What is deterministic: **the whole group is locked, in id order, before anything is written.**

The fixture puts physical order deliberately opposite to id order (anchor `2222…` inserted first, tranche `1111…` second), then:

- session A locks the lowest id and holds it;
- session B calls the RPC naming the *other* row, so its own single-row lock is not what makes it wait;
- while B waits, A probes the anchor with `FOR UPDATE NOWAIT`.

Before the fix, B had already locked and written the anchor on the way past, so the probe is refused — verified red, with the message naming the rule rather than leaking a raw lock error. After it, B is queued at the ordered acquisition with nothing taken, the probe succeeds, and once A commits the edit still cascades to every tranche.

Two sessions have to see each other's committed work, so this file commits its fixture and cleans up after itself on failure through a fresh connection — same shape as `fund_bucket_assign.test.sql` part 2 (#610).

Plus `route.put.book-reload.test.ts`: 409 + reload for that message, 500 for anything else.

## Checks

- `npm run test:db` — 33/33 after a fresh `supabase db reset`
- `npm test -- --run` 2506 ✓, `npm run typecheck`, `npm run lint`
- E2E: accumulating-deposit, accumulating-collapse, unallocated-book, goal-detail 9 ✓; smoke lane 20 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)