### PR TITLE
fix(dashboard): a promised book opened from the needs-attention card offers the merge (#659)

### DIFF
--- a/app/api/v1/dashboard/overview/__tests__/route.test.ts
+++ b/app/api/v1/dashboard/overview/__tests__/route.test.ts
@@ -15,6 +15,7 @@ import { SNAPSHOT_WRITE_TIMEOUT_MS } from '@/lib/snapshots'
 const h = vi.hoisted(() => ({
   user: { id: 'user-1' } as { id: string } | null,
   tables: {} as Record<string, { data: unknown; error: unknown }>,
+  selects: {} as Record<string, string>,
   upsertCalls: [] as unknown[],
   // How the snapshot upsert behaves, and whether it had actually settled by the
   // time GET() resolved — the fire-and-forget bug (#592) is precisely a response
@@ -43,7 +44,12 @@ vi.mock('@/lib/supabase-server', () => {
   function chainFor(name: string) {
     const result = () => h.tables[name] ?? { data: [], error: null }
     const chain: Record<string, unknown> = {
-      select: () => chain,
+      // The column list is recorded, not just accepted. This mock returns
+      // whatever row the test hands it regardless of what was selected, so a
+      // column MISSING from the real query is invisible to any assertion about
+      // the payload — the shape of #659, where the successor promise was mapped
+      // correctly but never fetched.
+      select: (cols?: string) => { if (cols) h.selects[name] = cols; return chain },
       eq: () => chain,
       in: () => chain,
       single: async () => result(),
@@ -101,6 +107,7 @@ beforeEach(() => {
   h.upsertCalls = []
   h.upsertOutcome = 'ok'
   h.upsertSettled = false
+  h.selects = {}
   baseHappy()
 })
 
@@ -148,6 +155,47 @@ describe('GET /api/v1/dashboard/overview — partial reads never corrupt snapsho
       expect(h.upsertCalls).toHaveLength(0)
     })
   }
+})
+
+// #659 — the dashboard's needs-attention card is where a matured deposit asks to
+// be dealt with, and the sheet it opens gates its whole merge panel on the book's
+// successor promise. The overview never fetched the column, so the card's sheet
+// decided "no handover" for every book and offered the renewal fork instead —
+// every option of which the database refuses while the promise stands.
+describe('GET /api/v1/dashboard/overview — a book carries its successor promise (#659)', () => {
+  it('asks for the successor column', async () => {
+    // Asserted on the QUERY, because the payload assertion below cannot see this:
+    // the mock returns the row it is handed whatever was selected, while the real
+    // client returns a row with the field simply absent.
+    await GET()
+    expect(h.selects.active_investment_transactions).toContain('successor_deposit_tx_id')
+  })
+
+  it('carries the promise into the goal bucket the book sits in', async () => {
+    h.tables.savings_goals = { data: [{ goal_id: 'g1', goal_name: 'Goal', target_amount: 10_000_000, target_date: null }], error: null }
+    h.tables.active_investment_transactions = {
+      data: [
+        {
+          transaction_id: 'book-1', goal_id: 'g1', asset_type: 'bank', transaction_type: 'investment',
+          amount_vnd: 20_000_000, investment_date: '2025-01-01', expiry_date: '2026-01-01',
+          deposit_group_id: 'book-1', successor_deposit_tx_id: 'book-2', affects_progress: true,
+        },
+        {
+          transaction_id: 'tr-2', goal_id: 'g1', asset_type: 'bank', transaction_type: 'investment',
+          amount_vnd: 15_000_000, investment_date: '2025-06-01', expiry_date: '2026-01-01',
+          deposit_group_id: 'book-1', affects_progress: true,
+        },
+      ],
+      error: null,
+    }
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const d = await res.json() as { goals: { nonFunds: { transactionId: string; successorDepositTxId?: string | null }[] }[] }
+    const byId = new Map(d.goals[0].nonFunds.map((n) => [n.transactionId, n]))
+    expect(byId.get('book-1')?.successorDepositTxId).toBe('book-2')
+    // A tranche is not the promise — only the anchor may carry one.
+    expect(byId.get('tr-2')?.successorDepositTxId ?? null).toBeNull()
+  })
 })
 
 // #606 — a withdrawal parented to a FUND PURCHASE (not itself fund-keyed: no

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -7,6 +7,8 @@ import { fmt } from '@/lib/formatters'
 import { formatIntVN } from '@/lib/numberFormat'
 import { SUCCESS_FLASH_MS } from '../../successFlash'
 import type { InvRow } from '../goalDetailShared'
+import type { DashboardData, NonFundUnallocatedItem } from '@/features/dashboard/contracts'
+import { maturingDeposits, tagNonFunds } from '@/features/dashboard/dashboardModel'
 import { todayIso, addDaysIso } from '@/lib/dates'
 
 // A YYYY-MM-DD string `n` days from today (deterministic regardless of run date).
@@ -879,6 +881,55 @@ describe('MaturityResolveBody', () => {
     expect(screen.queryByTestId('maturity-term-input')).not.toBeInTheDocument()
     // ...and the way out is offered without having to trip over a refusal first.
     expect(screen.getByTestId('cancel-handover-btn')).toBeInTheDocument()
+  })
+
+  // ...and the same book opened from the DASHBOARD's needs-attention card gets
+  // the same sheet (#659). Every fixture above hands the sheet an InvRow built by
+  // hand; the card builds its own from the overview payload, and that path used to
+  // drop the promise — so the card, which is where a matured deposit ASKS to be
+  // dealt with, offered the renewal fork for a book the database refuses to renew.
+  // The row here is built by the real pipeline for that reason: asserting on a
+  // hand-made row would pass while the bug was live.
+  it('offers the merge when the book is opened from the dashboard card', async () => {
+    global.fetch = vi.fn(async (url: string | URL | Request, init?: RequestInit) => {
+      if (String(url).includes('/merge-successor') && init?.method !== 'POST') {
+        return { ok: true, json: async () => ({
+          tranches: [{ transaction_id: 'tr-1', effective_principal: 35_000_000 }],
+          successor_id: 'book-2', projected_value: 37_000_000,
+        }) } as Response
+      }
+      return { ok: true, json: async () => ({ banks: [] }) } as Response
+    }) as unknown as typeof fetch
+
+    // Two tranches of one matured book, as the overview returns them, with the
+    // promise on the anchor where the database keeps it.
+    const tranche = (over: Partial<NonFundUnallocatedItem>): NonFundUnallocatedItem => ({
+      transactionId: 'tr-2', type: 'bank', amount: 15_000_000, currentValue: 15_400_000,
+      interestRate: 5.8, expiryDate: daysFromNow(-12), investmentDate: '2025-06-01',
+      notes: null, units: null, depositGroupId: 'book-1', ...over,
+    })
+    const data = {
+      goals: [{ goalId: 'g1', nonFunds: [
+        tranche({ transactionId: 'book-1', amount: 20_000_000, currentValue: 21_000_000, notes: 'Sổ tích luỹ', successorDepositTxId: 'book-2' }),
+        tranche({}),
+      ] }],
+      unallocated: { nonFunds: [] },
+    } as unknown as DashboardData
+
+    const rows = maturingDeposits(tagNonFunds(data), false)
+    expect(rows).toHaveLength(1)   // one book, not two tranches
+
+    render(
+      <MaturityResolveBody inv={rows[0].inv} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={() => {}} />,
+    )
+
+    expect(screen.getByTestId('merge-successor-panel')).toBeInTheDocument()
+    // The dead ends the card used to offer: each one is refused by the database
+    // while the promise stands.
+    expect(screen.queryByRole('button', { name: /Confirm renewal/i })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: /Don.t renew/i })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('maturity-term-input')).not.toBeInTheDocument()
+    await waitFor(() => expect(screen.getByTestId('cancel-handover-btn')).toBeInTheDocument())
   })
 
   it('cancels the handover from the promised book’s own sheet', async () => {

--- a/features/dashboard/__tests__/dashboardModel.test.ts
+++ b/features/dashboard/__tests__/dashboardModel.test.ts
@@ -280,6 +280,13 @@ describe('nonFundToInvRow', () => {
     expect(nonFundToInvRow(nonFund({ type: 'gold', bankCode: 'VCB' }), false).bankCode).toBeNull()
   })
 
+  // #659: MaturityResolveSheet gates its merge panel on this field, so a mapper
+  // that silently drops it decides "no handover" for every row it produces.
+  it('carries the successor promise through', () => {
+    expect(nonFundToInvRow(nonFund({ successorDepositTxId: 'book-2' }), false).successorDepositTxId).toBe('book-2')
+    expect(nonFundToInvRow(nonFund(), false).successorDepositTxId).toBeNull()
+  })
+
   it('computes gain against the principal, and reports null when there is none', () => {
     expect(nonFundToInvRow(nonFund({ amount: 1_000_000, currentValue: 1_100_000 }), false).gainPct).toBeCloseTo(10)
     expect(nonFundToInvRow(nonFund({ amount: 0 }), false).gainPct).toBeNull()

--- a/features/dashboard/__tests__/maturityCardItems.test.ts
+++ b/features/dashboard/__tests__/maturityCardItems.test.ts
@@ -35,6 +35,31 @@ describe('actionableBooks — group accumulating tranches into one card row', ()
     expect(goalId).toBe('g1')
   })
 
+  // #659: the promise lives on the anchor, and MaturityResolveSheet gates its
+  // whole merge panel on `inv.successorDepositTxId`. Dropping it here left the
+  // dashboard card's sheet offering the ordinary renewal fork for a book the
+  // database refuses to renew — the user picks an action, confirms, and is
+  // refused for a rule the screen never mentioned.
+  it('carries the anchor\'s successor promise onto the row', () => {
+    const [{ inv }] = actionableBooks([
+      tag(tranche({ transactionId: 'grp', successorDepositTxId: 'book-2' })),
+      tag(tranche({ transactionId: 't2' })),
+    ], false)
+    expect(inv.successorDepositTxId).toBe('book-2')
+  })
+
+  // A tranche is not the promise. Only the anchor may carry one (the DB's
+  // `investment_transactions_successor_shape` says so), so reading it off the
+  // first member would invent a handover on a book that has none whenever the
+  // anchor sorts late.
+  it('reads the promise from the anchor, not from whichever tranche comes first', () => {
+    const [{ inv }] = actionableBooks([
+      tag(tranche({ transactionId: 't2', successorDepositTxId: 'not-the-anchor' })),
+      tag(tranche({ transactionId: 'grp' })),
+    ], false)
+    expect(inv.successorDepositTxId).toBeNull()
+  })
+
   it('groups a book to ONE row even if its tranches are split across goal buckets, using the anchor\'s goal', () => {
     // Mid-way through #349's non-atomic goal cascade a book can momentarily span
     // goals. Global grouping must still yield one row with the FULL principal and

--- a/features/dashboard/contracts.ts
+++ b/features/dashboard/contracts.ts
@@ -86,6 +86,10 @@ export interface NonFundUnallocatedItem {
   bankCode?: string | null
   currency?: string | null
   isPledged?: boolean | null
+  // The book this one was promised to at maturity (#638), carried so the sheet
+  // opened from the dashboard's needs-attention card makes the same decision as
+  // the one opened from goal detail (#659). Set on a book anchor only.
+  successorDepositTxId?: string | null
 }
 
 export interface DashboardData {

--- a/features/dashboard/dashboardModel.ts
+++ b/features/dashboard/dashboardModel.ts
@@ -214,6 +214,7 @@ export function nonFundToInvRow(it: NonFundUnallocatedItem, isVi: boolean): InvR
     bankCode: it.type === 'bank' ? (it.bankCode ?? null) : null,
     currency: it.currency ?? null,
     isPledged: it.isPledged ?? false,
+    successorDepositTxId: it.successorDepositTxId ?? null,
   }
 }
 

--- a/features/dashboard/maturityCardItems.ts
+++ b/features/dashboard/maturityCardItems.ts
@@ -29,6 +29,7 @@ export interface MaturityNonFund {
   notes: string | null
   units: number | null
   depositGroupId?: string | null
+  successorDepositTxId?: string | null
 }
 
 // A tranche tagged with the goal bucket it came from (null = unallocated). The
@@ -87,6 +88,12 @@ export function actionableBooks<T extends MaturityNonFund>(
       investmentDate: earliest,
       fund: null,
       depositGroupId: groupId,
+      // From the ANCHOR, which is where the database keeps a promise — only a
+      // book anchor may name a successor. MaturityResolveSheet gates its whole
+      // merge panel on this, and every renewal option it offers instead is one a
+      // promised book is refused (#638, #659). Reading it off `members[0]` would
+      // invent a handover whenever the anchor sorts late.
+      successorDepositTxId: anchorTag.it.successorDepositTxId ?? null,
     }
     if (isActionableAccumulatingBook({ type: inv.type, expiryDate: inv.expiryDate, depositGroupId: inv.depositGroupId })) {
       out.push({ inv, anchor: anchorTag.it, goalId: anchorTag.goalId })

--- a/lib/dashboardOverview.ts
+++ b/lib/dashboardOverview.ts
@@ -51,10 +51,16 @@ type NonFundEntry = {
   bankCode: string | null
   currency: string | null
   isPledged: boolean
+  // The book this one was promised to at maturity (#638). Only a book anchor may
+  // carry it — `investment_transactions_successor_shape` says so — and the
+  // maturity sheet gates its whole merge panel on it, so a book that reaches the
+  // dashboard's needs-attention card without it is offered a renewal fork the
+  // database refuses every option of (#659).
+  successorDepositTxId: string | null
 }
 
 function buildNonFund(
-  tx: { transaction_id: string; asset_type: string; interest_rate: number | null; expiry_date: string | null; investment_date: string; notes: string | null; deposit_group_id?: string | null; bank_code?: string | null; currency?: string | null; is_pledged?: boolean | null },
+  tx: { transaction_id: string; asset_type: string; interest_rate: number | null; expiry_date: string | null; investment_date: string; notes: string | null; deposit_group_id?: string | null; bank_code?: string | null; currency?: string | null; is_pledged?: boolean | null; successor_deposit_tx_id?: string | null },
   amount: number,
   currentValue: number,
   units: number | null,
@@ -73,6 +79,7 @@ function buildNonFund(
     bankCode: tx.bank_code ?? null,
     currency: tx.currency ?? null,
     isPledged: tx.is_pledged ?? false,
+    successorDepositTxId: tx.successor_deposit_tx_id ?? null,
   }
 }
 
@@ -111,7 +118,7 @@ export async function buildDashboardOverview(
       // Snapshot-free view — renewal history rows can't reach the net-worth /
       // goal / allocation totals (defence on top of the app-side filter below).
       .from('active_investment_transactions')
-      .select('transaction_id, goal_id, amount_vnd, interest_rate, investment_date, asset_type, transaction_type, units, unit_price, units_withdrawn, principal_withdrawn, fund_id, parent_transaction_id, renewed_from_transaction_id, deposit_group_id, expiry_date, notes, affects_progress, bank_code, currency, is_pledged, held_for_merge, merge_target_goal_id, consumed_by_inv_id, funds(id, name, nav, updated_at, fund_type)')
+      .select('transaction_id, goal_id, amount_vnd, interest_rate, investment_date, asset_type, transaction_type, units, unit_price, units_withdrawn, principal_withdrawn, fund_id, parent_transaction_id, renewed_from_transaction_id, deposit_group_id, expiry_date, notes, affects_progress, bank_code, currency, is_pledged, held_for_merge, merge_target_goal_id, consumed_by_inv_id, successor_deposit_tx_id, funds(id, name, nav, updated_at, fund_type)')
       .eq('user_id', userId),
     supabase
       .from('insurance_members')

--- a/supabase/migrations/20260816000002_active_view_carries_the_successor.sql
+++ b/supabase/migrations/20260816000002_active_view_carries_the_successor.sql
@@ -1,0 +1,29 @@
+-- Re-expand active_investment_transactions so it carries every column the table
+-- has — including successor_deposit_tx_id (#638, #659).
+--
+-- The view is `select * from investment_transactions`, and Postgres expands that
+-- star ONCE, at creation. A column added later is simply not in the view, with no
+-- error anywhere: 20260811000001 added successor_deposit_tx_id to the table and
+-- nothing re-stated the view, so the column has been invisible to every reader
+-- that goes through it ever since.
+--
+-- Which is the whole dashboard. lib/dashboardOverview reads the ledger from this
+-- view, and PostgREST answers a select naming a column the view lacks with a 400 —
+-- so the moment the overview asked for the promise, every screen fed by it went
+-- blank at once. Found exactly that way: the targeted E2E lane failed 13 product
+-- tests across dashboard.spec, accumulating-deposit.spec and the successor journey,
+-- not one of them about successors.
+--
+-- 20260620000004 left the warning in its own header ("The dashboard overview reads
+-- the held-pool columns FROM THIS VIEW ... so it must be re-expanded or the select
+-- errors and the overview 500s"), and the same trap caught the next column added.
+-- supabase/tests/successor_book.test.sql now asserts the view carries it, so a
+-- third one is caught by the suite rather than by a blank dashboard.
+--
+-- security_invoker stays on — required, see 20260613000003.
+create or replace view public.active_investment_transactions
+  with (security_invoker = true) as
+  select * from public.investment_transactions
+  where renewed_from_transaction_id is null;
+
+grant select on public.active_investment_transactions to authenticated;

--- a/supabase/tests/successor_book.test.sql
+++ b/supabase/tests/successor_book.test.sql
@@ -621,4 +621,45 @@ begin
 end;
 $$;
 
+-- The readers go through active_investment_transactions, and that view is
+-- `select *` — expanded ONCE, at creation. A column added to the table afterwards
+-- is silently absent from it, and PostgREST answers a select naming an absent
+-- column with a 400, so the first reader to ask for it takes the whole dashboard
+-- down. That is what happened here: 20260811000001 added the column and left the
+-- view alone, and asking the overview for the promise blanked every screen fed by
+-- it (#659). 20260620000004's header warned about exactly this and the next column
+-- fell into it anyway, so the guard is a test rather than another comment.
+do $$
+begin
+  if not exists (
+    select 1 from information_schema.columns
+     where table_schema = 'public'
+       and table_name = 'active_investment_transactions'
+       and column_name = 'successor_deposit_tx_id'
+  ) then
+    raise exception 'active_investment_transactions must expose successor_deposit_tx_id — re-issue the view (create or replace) after adding a column to investment_transactions';
+  end if;
+
+  -- Stated as the general rule too, so the NEXT column added is caught here
+  -- instead of by a blank dashboard.
+  if exists (
+    select c.column_name from information_schema.columns c
+     where c.table_schema = 'public' and c.table_name = 'investment_transactions'
+       and not exists (
+         select 1 from information_schema.columns v
+          where v.table_schema = 'public' and v.table_name = 'active_investment_transactions'
+            and v.column_name = c.column_name)
+  ) then
+    raise exception 'active_investment_transactions is missing column(s) the table has: % — re-issue the view',
+      (select string_agg(c.column_name, ', ') from information_schema.columns c
+        where c.table_schema = 'public' and c.table_name = 'investment_transactions'
+          and not exists (
+            select 1 from information_schema.columns v
+             where v.table_schema = 'public' and v.table_name = 'active_investment_transactions'
+               and v.column_name = c.column_name));
+  end if;
+
+  raise notice 'successor book: the active view carries every column the table has';
+end $$;
+
 rollback;


### PR DESCRIPTION
Closes #659.

## The bug as filed

`MaturityResolveSheet` gates its whole merge panel on one field:

```ts
const hasSuccessor = !!inv.successorDepositTxId && !handoverCancelled
```

Goal detail sets it — `buildInvRows` reads it off the book's anchor. The dashboard's needs-attention card builds its rows from the overview payload instead, which never carried the field, so the **same book** opened from the card rendered the ordinary renewal fork: roll principal + interest, roll principal only, change amount, withdraw.

Every one of those is a dead end. A promised book is not collapsed behind the promise's back (`successor_book.test.sql` pins it), so the user picks an action, confirms, and gets a refusal for a rule the screen never mentioned — and the one action that would work is not on it. The card is where a matured deposit *asks* to be dealt with, so it is the likelier entry point of the two.

Carried through the whole path: the overview select, `NonFundEntry` / `buildNonFund`, `NonFundUnallocatedItem`, `nonFundToInvRow`, and the `actionableBooks` row. That last one reads it from the **anchor**, which is where the database keeps a promise (`investment_transactions_successor_shape` — only a book anchor may name a successor); reading it off `members[0]` would invent a handover whenever the anchor sorts late, and there's a test for that.

## The bigger half, found by the E2E lane

`active_investment_transactions` is `select * from investment_transactions`, and Postgres expands that star **once, at creation**. `20260811000001` added `successor_deposit_tx_id` to the table and left the view alone, so the column has been invisible to every reader that goes through it ever since — silently, with no error anywhere.

Which is the whole dashboard. PostgREST answers a select naming a column the view lacks with a 400, so the moment the overview asked for the promise, every screen fed by it went blank at once:

```
13 product failure(s), 0 infra failure(s)
  ✗ dashboard.spec.ts › dashboard shows net worth card when data exists
  ✗ dashboard.spec.ts › clicking a goal card opens goal detail panel
  ✗ accumulating-deposit.spec.ts › a live book rolls up its tranches …
  ✗ zz-successor-book-journey.spec.ts › a locked book hands over to a successor …
  … 9 more
```

Not one of them about successors. `20260620000004` left the warning in its own header — *"The dashboard overview reads the held-pool columns FROM THIS VIEW … so it must be re-expanded or the select errors and the overview 500s"* — and the next column added fell into it anyway.

So the view is re-issued (`20260816000002`), and the guard is a **test** rather than another comment: `successor_book.test.sql` now asserts the view exposes this column, and, more usefully, that the view carries *every* column the table has. The next column added is caught by `npm run test:db` instead of by a blank dashboard.

## Tests

Written first, all six assertions red before the fix.

- **`app/api/v1/dashboard/overview/__tests__/route.test.ts`** — one test asserts the **query**, because the payload assertion cannot see this: the mock returns whatever row it is handed regardless of what was selected, while the real client returns a row with the field simply absent. That is the exact shape of this bug, so the harness now records select strings. A second test drives the real handler and asserts the anchor carries the promise and a plain tranche does not.
- **`features/dashboard/__tests__/maturityCardItems.test.ts`** — the promise comes from the anchor; a promise on a non-anchor tranche is *not* read.
- **`features/dashboard/__tests__/dashboardModel.test.ts`** — `nonFundToInvRow` does not swallow the field.
- **`app/assets/components/__tests__/MaturityResolveSheet.test.tsx`** — the closed loop for the reported symptom: overview-shaped data → the real `tagNonFunds` + `maturingDeposits` → render the sheet with the row **the pipeline produced**, assert the merge panel is there and the three renewal dead ends are gone. Every other successor fixture in that file hands the sheet a hand-made row, which would have passed the whole time the bug was live.
- **`supabase/tests/successor_book.test.sql`** — the view-column guard above.

## Checks

`npm run typecheck` clean · 2512 unit tests pass · `npm run lint` 0 errors · `npm run test:coverage` over thresholds · full `supabase/tests` suite green · targeted E2E (`dashboard`, `accumulating-deposit`, `zz-successor-book-journey`) **16 passed**, from 13 product failures before the view fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)