### PR TITLE
fix(db): live holdings measure a fund bucket the way the invariant does (#668)

### DIFF
--- a/supabase/migrations/20260817000001_live_holdings_mirror_the_bucket.sql
+++ b/supabase/migrations/20260817000001_live_holdings_mirror_the_bucket.sql
@@ -1,0 +1,145 @@
+-- savings_goal_live_holdings measures a bucket the way the invariant does (#668).
+--
+-- It carries its own copy of check_withdrawal_balance's parent-backed-claim
+-- derivation, and says why in its own comment: "Derivation copied from
+-- 20260803000005 so the two cannot disagree." #668 put `p.user_id = wd.user_id`
+-- into that function — a fund bucket counts only its own owner's purchases — and
+-- left the copy behind. This is the copy catching up.
+--
+-- The direction of the disagreement is the bad one. This function subtracts MORE
+-- than the invariant now does, so the sale it proposes is smaller than the balance
+-- allows: the invariant accepts it, and the goal is archived without being fully
+-- liquidated. Probed against the local stack, with the ownership trigger disabled
+-- to plant the legacy rows:
+--
+--   A's goal holds one 100-unit purchase. A legacy purchase owned by B carries
+--   that goal and fund; A has a 10-unit claim parented to it.
+--
+--     savings_goal_live_holdings → 90 units / 90,000,000
+--     finish_savings_goal        → {"holdings": 1, "realized": 90000000,
+--                                   "completion_percentage": 100}
+--     units left in the archived goal → 10
+--
+-- A live holding inside a completed goal. The finish is advertised as
+-- all-or-nothing and the plan check compares against this same function, so the
+-- residue is self-consistent and invisible: no screen shows it, and the goal reads
+-- 100%.
+--
+-- Reachable only through legacy data — enforce_fk_ownership (20260722000004)
+-- refuses a cross-owner parent at write time, and withdrawal_ledger_audit names
+-- what is already in the ledger (#667). Everything else below is verbatim from
+-- 20260813000002.
+
+create or replace function public.savings_goal_live_holdings(p_goal_id uuid)
+returns table (
+  key text, kind text, fund_id uuid, tx_id uuid, asset_type text,
+  principal bigint, units numeric, name text
+)
+language sql
+security invoker
+stable
+set search_path = ''
+as $$
+    with parent_wd as (
+      select w.parent_transaction_id as pid,
+             sum(coalesce(w.principal_withdrawn, 0)) as principal,
+             sum(coalesce(w.units_withdrawn, 0)) as units
+        from public.investment_transactions w
+       where w.user_id = (select g.user_id from public.savings_goals g where g.goal_id = p_goal_id)
+         and w.transaction_type = 'withdrawal'
+         and w.parent_transaction_id is not null
+         -- A row keyed by a fund draws on that bucket, not on its parent — the
+         -- same precedence check_withdrawal_balance applies.
+         and not coalesce(w.asset_type = 'fund' and w.fund_id is not null, false)
+       group by 1
+    ),
+    fund_wd as (
+      select w.fund_id,
+             sum(coalesce(w.principal_withdrawn, 0)) as principal,
+             sum(coalesce(w.units_withdrawn, 0)) as units
+        from public.investment_transactions w
+       where w.user_id = (select g.user_id from public.savings_goals g where g.goal_id = p_goal_id)
+         and w.transaction_type = 'withdrawal'
+         and w.asset_type = 'fund'
+         and w.fund_id is not null
+         and w.goal_id is not distinct from p_goal_id
+       group by 1
+    ),
+    -- The bucket's OTHER kind of claim (#606). A withdrawal PARENTED to one of
+    -- its purchases and not itself fund-keyed draws on the bucket too, at its
+    -- recorded units or the capped pro-rata share of the purchase it names.
+    -- Such rows can no longer be written, but the ones already in the ledger are
+    -- still claims and check_withdrawal_balance measures every new sale against
+    -- them — so a goal holding one could not be finished at all: this function
+    -- computed the gross bucket and the table refused the oversized sale.
+    -- Derivation copied from 20260803000005 so the two cannot disagree.
+    fund_parent_wd as (
+      select p.fund_id,
+             sum(case when coalesce(w.units_withdrawn, 0) > 0 then w.units_withdrawn
+                      else least(p.units, p.units * coalesce(w.principal_withdrawn, 0) / p.amount_vnd)
+                 end) as units,
+             sum(coalesce(w.principal_withdrawn, 0)) as principal
+        from public.investment_transactions w
+        join public.investment_transactions p
+          on p.transaction_id = w.parent_transaction_id
+       where w.user_id = (select g.user_id from public.savings_goals g where g.goal_id = p_goal_id)
+         and w.transaction_type = 'withdrawal'
+         and (w.asset_type is distinct from 'fund' or w.fund_id is null)
+         and p.transaction_type = 'investment'
+         and p.asset_type = 'fund'
+         -- The PURCHASE's owner, matching check_withdrawal_balance since #668. Its
+         -- basis sum counts only the goal owner's own purchases, so a claim on
+         -- someone else's is charged against units this bucket was never counted to
+         -- hold — and subtracting it here understates what the finish must sell.
+         and p.user_id = (select g.user_id from public.savings_goals g where g.goal_id = p_goal_id)
+         and p.goal_id is not distinct from p_goal_id
+         -- A purchase with no units is no bucket: its withdrawal sits on the
+         -- parent axis and is measured there instead.
+         and coalesce(p.units, 0) > 0
+         and coalesce(p.amount_vnd, 0) > 0
+       group by p.fund_id
+    ),
+    live as (
+      select t.*,
+             t.amount_vnd - coalesce(pw.principal, 0) as eff_principal,
+             coalesce(t.units, 0) - coalesce(pw.units, 0) as eff_units
+        from public.investment_transactions t
+        left join parent_wd pw on pw.pid = t.transaction_id
+       where t.user_id = (select g.user_id from public.savings_goals g where g.goal_id = p_goal_id)
+         and t.goal_id = p_goal_id
+         and t.transaction_type = 'investment'
+         and t.renewed_from_transaction_id is null
+         and not coalesce(t.held_for_merge, false)
+    )
+    select 'fund:' || l.fund_id as key, 'fund'::text as kind, l.fund_id,
+           null::uuid as tx_id, 'fund'::text as asset_type,
+           (sum(l.amount_vnd) - coalesce(max(fw.principal), 0) - coalesce(max(fpw.principal), 0))::bigint as principal,
+           (sum(l.units) - coalesce(max(fw.units), 0) - coalesce(max(fpw.units), 0))::numeric as units
+           , max(f.name) as name
+      from live l
+      left join public.funds f on f.id = l.fund_id
+      left join fund_wd fw on fw.fund_id = l.fund_id
+      left join fund_parent_wd fpw on fpw.fund_id = l.fund_id
+     where l.fund_id is not null and l.asset_type = 'fund' and l.units is not null
+     group by l.fund_id
+    having sum(l.units) - coalesce(max(fw.units), 0) - coalesce(max(fpw.units), 0) > 0
+    union all
+    select 'book:' || l.deposit_group_id, 'book', null, l.deposit_group_id, 'bank',
+           sum(l.eff_principal)::bigint, null::numeric,
+           max(case when l.transaction_id = l.deposit_group_id then l.notes end)
+      from live l
+     where l.fund_id is null and l.deposit_group_id is not null
+       and l.eff_principal > 0
+     group by l.deposit_group_id
+    union all
+    select 'tx:' || l.transaction_id, 'single', null, l.transaction_id, l.asset_type,
+           l.eff_principal::bigint,
+           case when l.asset_type = 'gold' then l.eff_units::numeric else null end,
+           l.notes
+      from live l
+     where l.fund_id is null and l.deposit_group_id is null
+       and (case when l.asset_type = 'gold' then l.eff_units > 0 else l.eff_principal > 0 end)
+$$;
+
+comment on function public.savings_goal_live_holdings(uuid) is
+  'The holdings a finish would liquidate, by the same balance keys the ledger uses (#650). One enumeration for the sheet and the RPC.';

--- a/supabase/tests/finish_savings_goal.test.sql
+++ b/supabase/tests/finish_savings_goal.test.sql
@@ -900,4 +900,81 @@ begin
   raise notice 'finish_savings_goal disabled DCA: all assertions passed';
 end $$;
 
+-- ═══ live holdings measure the bucket the way the invariant does (#668) ══════
+--
+-- savings_goal_live_holdings carries its own copy of 20260803000005's
+-- parent-backed-claim derivation, and says why in its own comment: "copied from
+-- 20260803000005 so the two cannot disagree". #668 put `p.user_id = wd.user_id`
+-- into that function — a bucket counts only its own owner's purchases — and the
+-- copy has to move with it, or the two disagree in the direction that archives a
+-- goal it did not finish liquidating.
+--
+-- Probed before the fix: a goal holding 100 units, plus a legacy claim of 10 on a
+-- cross-owner purchase carrying this goal, reported 90 live units. The finish
+-- liquidated 90, and left the goal archived at 100% with ten units still in it —
+-- a live holding inside a completed goal, which no screen shows.
+do $$
+declare
+  v_a uuid; v_b uuid; v_g uuid; v_fund uuid; v_buy uuid; v_foreign uuid;
+  v_units numeric; v_principal bigint; v_res jsonb; v_left numeric;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'fin-668a@test.invalid') returning id into v_a;
+  insert into auth.users (id, email) values (gen_random_uuid(), 'fin-668b@test.invalid') returning id into v_b;
+  insert into public.savings_goals (user_id, goal_name, target_amount)
+  values (v_a, 'Cross-owner claim', 100000000) returning goal_id into v_g;
+  insert into public.funds (user_id, name, code, fund_type, nav)
+  values (v_a, 'Finish Fund', 'FINF', 'equity', 1000000) returning id into v_fund;
+
+  -- Every deferred check in this transaction has to settle before the table can be
+  -- altered — including any left pending by the blocks above, which is why this is
+  -- ALL rather than the two this block writes against.
+  set constraints all immediate;
+  alter table public.investment_transactions disable trigger user;
+
+  -- Everything this goal actually holds: A's own 100 units.
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_a, v_g, v_fund, 'fund', 'investment', '2026-01-01', 100000000, 100, 1000000)
+  returning transaction_id into v_buy;
+  -- A legacy purchase owned by B carrying this goal and fund, and A's claim on it.
+  -- enforce_fk_ownership refuses both now (#474 / #525).
+  insert into public.investment_transactions
+    (user_id, goal_id, fund_id, asset_type, transaction_type, investment_date, amount_vnd, units, unit_price)
+  values (v_b, v_g, v_fund, 'fund', 'investment', '2026-01-01', 50000000, 50, 1000000)
+  returning transaction_id into v_foreign;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, units_withdrawn, principal_withdrawn)
+  values (v_a, v_g, null, 'withdrawal', '2026-02-01', 10000000, v_foreign, 10, 10000000);
+
+  alter table public.investment_transactions enable trigger user;
+  set constraints all deferred;
+
+  -- What the goal holds is what the invariant would let it sell: all 100 units.
+  select principal, units into v_principal, v_units
+    from public.savings_goal_live_holdings(v_g) where key = 'fund:' || v_fund;
+  if v_units <> 100 or v_principal <> 100000000 then
+    raise exception 'live holdings must count the bucket as the invariant does, got % units / %', v_units, v_principal;
+  end if;
+
+  select public.finish_savings_goal(v_g,
+    jsonb_build_array(jsonb_build_object('key', 'fund:' || v_fund, 'received', 100000000)),
+    current_date, 100000000, public.savings_goal_ledger_fingerprint(v_g)) into v_res;
+
+  -- And an archived goal holds nothing. This is the assertion that matters: the
+  -- finish is advertised as all-or-nothing, so a residue in a completed goal is a
+  -- lie the UI has no way to show.
+  select coalesce(sum(t.units), 0)
+         - coalesce((select sum(w.units_withdrawn) from public.investment_transactions w
+                      where w.user_id = v_a and w.transaction_type = 'withdrawal'
+                        and w.asset_type = 'fund' and w.fund_id = v_fund), 0)
+    into v_left
+    from public.investment_transactions t
+   where t.user_id = v_a and t.fund_id = v_fund and t.transaction_type = 'investment';
+  if v_left <> 0 then
+    raise exception 'an archived goal must hold nothing, % units left', v_left;
+  end if;
+
+  raise notice 'finish_savings_goal: live holdings mirror the bucket the invariant measures';
+end $$;
+
 rollback;


### PR DESCRIPTION
Follow-up to #678 (issue #668). Found while reading `savings_goal_live_holdings` for #664.

## What broke

That function carries its own copy of `check_withdrawal_balance`'s parent-backed-claim derivation, and states why in the comment beside it:

> Derivation copied from 20260803000005 so the two cannot disagree.

#678 added `p.user_id = wd.user_id` to that function — a fund bucket counts only its own owner's purchases — and left the copy behind.

**The disagreement runs the wrong way.** This function now subtracts *more* than the invariant does, so the sale it proposes is smaller than the balance allows. The invariant accepts it, and the goal is archived without being fully liquidated. Probed against the local stack, ownership trigger disabled to plant the legacy rows:

```
A's goal holds one 100-unit purchase. A legacy purchase owned by B carries
that goal and fund; A has a 10-unit claim parented to it.

  savings_goal_live_holdings → 90 units / 90,000,000
  finish_savings_goal        → {"holdings": 1, "realized": 90000000,
                                "completion_percentage": 100}
  units left in the archived goal → 10
```

A live holding inside a completed goal. The plan-vs-live-holdings check compares against this same function, so the residue is **self-consistent and invisible**: nothing refuses it, no screen shows it, and the goal reads 100%.

Reachable only through legacy data — `enforce_fk_ownership` refuses a cross-owner parent at write time, and `parent_belongs_to_another_user` (#667) names what is already in the ledger.

## The fix

The one predicate, in the one copy, with the reasoning inline.

## Test

`supabase/tests/finish_savings_goal.test.sql` gains the fixture above, asserting both halves:

1. live holdings count all 100 units — the direct symptom;
2. **an archived goal holds nothing** — the assertion that matters, since all-or-nothing is what the finish promises. A test that only checked (1) would pass on a future change that fixed the enumeration and broke the liquidation.

Confirmed red before the fix (`live holdings must count the bucket as the invariant does, got 90 units / 90000000`).

## Checks

Full `supabase/tests` suite green · `npm run typecheck` clean · 2513 unit tests pass · `npm run lint` 0 errors. No TypeScript changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)