### PR TITLE
feat(deposits): merge provenance survives the successor's first renewal (#656)

### DIFF
--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -10,7 +10,7 @@ import type { GoalData } from '@/features/dashboard/contracts'
 import { GD_COLORS, TypeIcon, UnlinkSvg, BankInfoStrip, TopUpControl, RenewalSummaryLine, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { buildCompositionSegments, buildInvRows, buildRenewalSummary } from './goalDetailRows'
 import { needsMaturityAction, needsBookMaturityAction } from './goalDetailMaturity'
-import { computeGoalCalculator, describeHistoryRow } from './goalDetailModel'
+import { computeGoalCalculator, describeHistoryRow, mergedFromLabel } from './goalDetailModel'
 import { MaturityResolveModal } from './MaturityResolveSheet'
 import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
@@ -551,6 +551,13 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                       <div style={{ fontSize: 10, color: 'var(--c-muted)', marginTop: 1 }}>
                         {fmtTxDate(tx.investment_date, locale)}
                       </div>
+                      {/* Which book paid for this cycle (#656) — see the mobile
+                          sheet for why it takes a line rather than a third pill. */}
+                      {mergedFromLabel(tx, bookNames, isVi) && (
+                        <div data-testid="history-merged-from" style={{ fontSize: 10, color: 'var(--c-muted)', marginTop: 1 }}>
+                          {mergedFromLabel(tx, bookNames, isVi)}
+                        </div>
+                      )}
                     </div>
                     <span style={{ fontSize: 12, fontWeight: 600, color: ink, fontVariantNumeric: 'tabular-nums', flexShrink: 0 }}>
                       {sign}{fmtCompact(tx.amount_vnd)}

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -553,9 +553,9 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
                       </div>
                       {/* Which book paid for this cycle (#656) — see the mobile
                           sheet for why it takes a line rather than a third pill. */}
-                      {mergedFromLabel(tx, bookNames, isVi) && (
+                      {mergedFromLabel(tx, bookNames, isVi, transactions) && (
                         <div data-testid="history-merged-from" style={{ fontSize: 10, color: 'var(--c-muted)', marginTop: 1 }}>
-                          {mergedFromLabel(tx, bookNames, isVi)}
+                          {mergedFromLabel(tx, bookNames, isVi, transactions)}
                         </div>
                       )}
                     </div>

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -16,7 +16,7 @@ import { SellWithdrawSheet } from './SellWithdrawSheet'
 import { MaturityResolveSheet } from './MaturityResolveSheet'
 import { GD_COLORS, TypeIcon, ProgressCreditNote, ProgressGatherNote, progressCredit, type InvRow, type GoalDetailTx } from './goalDetailShared'
 import { buildCompositionSegments, buildInvRows, buildRenewalSummary } from './goalDetailRows'
-import { computeGoalCalculator, describeHistoryRow } from './goalDetailModel'
+import { computeGoalCalculator, describeHistoryRow, mergedFromLabel } from './goalDetailModel'
 import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 import LoadError from './LoadError'
@@ -713,6 +713,14 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
                       <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2 }}>
                         {fmtTxDate(tx.investment_date, isVI ? 'vi' : 'en')}
                       </div>
+                      {/* Which book paid for this cycle (#656). Its own line rather
+                          than a pill: the name line is nowrap + ellipsis, so a third
+                          chip there would clip the book's own name first. */}
+                      {mergedFromLabel(tx, bookNames, isVI) && (
+                        <div data-testid="history-merged-from" style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2 }}>
+                          {mergedFromLabel(tx, bookNames, isVI)}
+                        </div>
+                      )}
                     </div>
                     <span style={{ fontSize: 13, fontWeight: 600, color: ink, fontVariantNumeric: 'tabular-nums' }}>
                       {sign}{fmtCompact(tx.amount_vnd)}

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -716,9 +716,9 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
                       {/* Which book paid for this cycle (#656). Its own line rather
                           than a pill: the name line is nowrap + ellipsis, so a third
                           chip there would clip the book's own name first. */}
-                      {mergedFromLabel(tx, bookNames, isVI) && (
+                      {mergedFromLabel(tx, bookNames, isVI, transactions) && (
                         <div data-testid="history-merged-from" style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 2 }}>
-                          {mergedFromLabel(tx, bookNames, isVI)}
+                          {mergedFromLabel(tx, bookNames, isVI, transactions)}
                         </div>
                       )}
                     </div>

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -856,4 +856,26 @@ describe('GoalDetailSheet — merge provenance on a renewed row (#656)', () => {
     const row = await screen.findByTestId('history-renewed-row')
     expect(row).not.toHaveTextContent(/Merged from/)
   })
+
+  // The common case, and the one the off-page fixture above hides: a recent merge
+  // leaves the source among the goal's own rows. useGoalDetailData deliberately
+  // keeps those OUT of bookNames — `nameOnly` skips ids already `present` — so a
+  // lookup that reads bookNames alone falls back to the anonymous wording for
+  // exactly the merges most likely to be on screen. buildInvRows already merges
+  // on-page notes over the map for the same reason.
+  it('names an on-page source from the rows already loaded', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({
+          transactions: [snapshot, sourceBook],
+        }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+    render(<GoalDetailSheet {...baseProps} goal={{ ...mockGoal, funds: [] }} />)
+
+    await userEvent.click(await screen.findByRole('button', { name: /history/i }))
+    const row = await screen.findByTestId('history-renewed-row')
+    expect(row).toHaveTextContent('Merged from PVcomBank A')
+  })
 })

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -785,3 +785,75 @@ describe('GoalDetailSheet — recurring contributions are not holdings (#640)', 
     expect(screen.getAllByRole('button', { name: /^Options$/ })).toHaveLength(1)
   })
 })
+
+// #656: the credited tranche's "Merged from <A>" line used to die with the
+// successor's first renewal — the tranche is deleted and the anchor's
+// deposit_group_id is cleared, so the book stops rendering as a book and the
+// top-up strip that hosted the label is gone. The marker now rides onto the
+// renewal snapshot, and the History tab is where it gets said.
+describe('GoalDetailSheet — merge provenance on a renewed row (#656)', () => {
+  const snapshot = {
+    transaction_id: 'snap-1',
+    transaction_type: 'investment',
+    asset_type: 'bank',
+    investment_date: '2026-08-01',
+    amount_vnd: 8_300_000,
+    notes: 'VCB 6-month book',
+    renewed_from_transaction_id: 'book-1',
+    merged_from_book_id: 'book-a',
+    interest_rate: 5,
+    expiry_date: null,
+    units: null,
+    unit_price: null,
+    principal_withdrawn: null,
+    units_withdrawn: null,
+  }
+  // The source book, named but dissolved — it is what useGoalDetailData backfills
+  // so the label has something to say.
+  const sourceBook = {
+    ...snapshot,
+    transaction_id: 'book-a',
+    notes: 'PVcomBank A',
+    renewed_from_transaction_id: null,
+    merged_from_book_id: null,
+  }
+
+  beforeEach(() => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('ids=')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [sourceBook] }) })
+      }
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({ transactions: [snapshot] }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+  })
+
+  it('names the book that paid for a renewal snapshot', async () => {
+    render(<GoalDetailSheet {...baseProps} goal={{ ...mockGoal, funds: [] }} />)
+
+    await userEvent.click(await screen.findByRole('button', { name: /history/i }))
+    const row = await screen.findByTestId('history-renewed-row')
+    expect(row).toHaveTextContent('Merged from PVcomBank A')
+    // The row still reads as the renewal it is; the provenance is added to it,
+    // not substituted for it.
+    expect(row).toHaveTextContent('Renewed')
+  })
+
+  it('says nothing on a renewal no book paid for', async () => {
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (url.includes('investment-transactions')) {
+        return Promise.resolve({ ok: true, json: async () => ({
+          transactions: [{ ...snapshot, merged_from_book_id: null }],
+        }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+    render(<GoalDetailSheet {...baseProps} goal={{ ...mockGoal, funds: [] }} />)
+
+    await userEvent.click(await screen.findByRole('button', { name: /history/i }))
+    const row = await screen.findByTestId('history-renewed-row')
+    expect(row).not.toHaveTextContent(/Merged from/)
+  })
+})

--- a/app/assets/components/__tests__/goalDetailShared.test.tsx
+++ b/app/assets/components/__tests__/goalDetailShared.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest'
 import { type GoalDetailTx } from '../goalDetailShared'
 import { buildInvRows, buildRenewalSummary } from '../goalDetailRows'
 import { fmtMaturity } from '../goalDetailMaturity'
-import { calcDeadlineMonths, computeGoalCalculator, describeHistoryRow } from '../goalDetailModel'
+import { calcDeadlineMonths, computeGoalCalculator, describeHistoryRow, mergedFromLabel } from '../goalDetailModel'
 import type { FundBreakdownItem } from '@/features/dashboard/contracts'
 import { ArrowUpRight, ArrowDownRight, PiggyBank, GitMerge, RefreshCw } from 'lucide-react'
 import { todayIso, addDaysIso } from '@/lib/dates'
@@ -539,5 +539,33 @@ describe('describeHistoryRow', () => {
     expect(describeHistoryRow({ transaction_type: 'investment', notes: 'Cash' }, false, false).name).toBe('Cash')
     expect(describeHistoryRow({ transaction_type: 'investment' }, false, false).name).toBe('Investment')
     expect(describeHistoryRow({ transaction_type: 'investment' }, false, true).name).toBe('Khoản đầu tư')
+  })
+})
+
+// #656: a credited tranche's "Gộp từ <A>" used to die with the successor's first
+// renewal — the tranche is deleted and the book stops being a book, so the top-up
+// strip that hosted the label is gone. The marker now rides onto the renewal
+// snapshot, and the History row is where it gets said.
+describe('mergedFromLabel', () => {
+  const names = { 'book-a': 'PVcomBank A' }
+
+  it('names the book a renewal snapshot was paid for by', () => {
+    const tx = { merged_from_book_id: 'book-a' }
+    expect(mergedFromLabel(tx, names, true)).toBe('Gộp từ PVcomBank A')
+    expect(mergedFromLabel(tx, names, false)).toBe('Merged from PVcomBank A')
+  })
+
+  it('says nothing for a row no book paid for', () => {
+    expect(mergedFromLabel({}, names, false)).toBeNull()
+    expect(mergedFromLabel({ merged_from_book_id: null }, names, false)).toBeNull()
+  })
+
+  // The source is dissolved by the merge, so its name comes from the page's
+  // book-name map — and a source on a goal past the page falls out of it.
+  // useGoalDetailData backfills those by id, but a miss must still read as
+  // provenance rather than as "Merged from undefined".
+  it('falls back to an anonymous source rather than an empty name', () => {
+    expect(mergedFromLabel({ merged_from_book_id: 'gone' }, names, false)).toBe('Merged from another book')
+    expect(mergedFromLabel({ merged_from_book_id: 'gone' }, names, true)).toBe('Gộp từ một sổ khác')
   })
 })

--- a/app/assets/components/goalDetailModel.ts
+++ b/app/assets/components/goalDetailModel.ts
@@ -36,6 +36,33 @@ export function describeHistoryRow(
   return { kind, ink, fill, Icon, sign, name }
 }
 
+/**
+ * "Gộp từ <sổ A>" for a row another book paid for (#638 Phase 4, #656), or null.
+ *
+ * The same sentence the live book's top-up strip shows, said on a History row.
+ * That strip is where this started, and it does not survive the successor's own
+ * renewal: the credited tranche is deleted and the anchor's deposit_group_id is
+ * cleared, so the book stops rendering as a book at all. The marker rides onto
+ * the renewal snapshot instead (20260817000002), and this is where it is read.
+ *
+ * `names` is the page's book-name map. A merged source is DISSOLVED, so nothing
+ * points at it through deposit_group_id any more and it can easily be off the
+ * page; useGoalDetailData backfills those by id, but a miss must still read as
+ * provenance — "Merged from undefined" would look like a bug in the ledger
+ * rather than a name this page happens not to have.
+ */
+export function mergedFromLabel(
+  tx: { merged_from_book_id?: string | null },
+  names: Record<string, string>,
+  isVi: boolean,
+): string | null {
+  const id = tx.merged_from_book_id
+  if (!id) return null
+  const name = names[id]
+  if (!name) return isVi ? 'Gộp từ một sổ khác' : 'Merged from another book'
+  return isVi ? `Gộp từ ${name}` : `Merged from ${name}`
+}
+
 export function calcDeadlineMonths(targetDate: string | null): number {
   if (!targetDate) return 12
   return monthsUntilYm(targetDate)

--- a/app/assets/components/goalDetailModel.ts
+++ b/app/assets/components/goalDetailModel.ts
@@ -45,20 +45,27 @@ export function describeHistoryRow(
  * cleared, so the book stops rendering as a book at all. The marker rides onto
  * the renewal snapshot instead (20260817000002), and this is where it is read.
  *
- * `names` is the page's book-name map. A merged source is DISSOLVED, so nothing
- * points at it through deposit_group_id any more and it can easily be off the
- * page; useGoalDetailData backfills those by id, but a miss must still read as
- * provenance — "Merged from undefined" would look like a bug in the ledger
- * rather than a name this page happens not to have.
+ * The name is looked up in TWO places, the same pair buildInvRows uses and for
+ * the same reason. `names` is useGoalDetailData's backfill, which fetches a
+ * source that fell OFF the page — and deliberately skips any id already among
+ * the loaded rows. So a recent merge, whose source is still on the page, is
+ * precisely the case that map does not cover; its name lives on the row itself.
+ * Reading only the map made the commonest merges read as anonymous.
+ *
+ * A miss in both must still read as provenance: "Merged from undefined" would
+ * look like a defect in the ledger rather than a name this page happens not to
+ * have.
  */
 export function mergedFromLabel(
   tx: { merged_from_book_id?: string | null },
   names: Record<string, string>,
   isVi: boolean,
+  rows: { transaction_id: string; notes?: string | null }[] = [],
 ): string | null {
   const id = tx.merged_from_book_id
   if (!id) return null
-  const name = names[id]
+  const name = names[id]?.trim()
+    || rows.find((r) => r.transaction_id === id)?.notes?.trim()
   if (!name) return isVi ? 'Gộp từ một sổ khác' : 'Merged from another book'
   return isVi ? `Gộp từ ${name}` : `Merged from ${name}`
 }

--- a/supabase/migrations/20260817000002_merge_provenance_survives_renewal.sql
+++ b/supabase/migrations/20260817000002_merge_provenance_survives_renewal.sql
@@ -1,0 +1,247 @@
+-- Merge provenance survives the successor's first renewal (#656, #638 Phase 4).
+--
+-- #654 labels a credited tranche `Gộp từ <sổ A>` in a book's top-up history, from
+-- merged_from_book_id. The label did not survive the successor's own renewal, and
+-- for three reasons at once:
+--
+--   • collapse_accumulating_book snapshots each tranche with an explicit column
+--     list that does not include merged_from_book_id;
+--   • it then deletes the credited tranche, and the marker goes with it;
+--   • it clears the anchor's deposit_group_id, so the book stops being a book and
+--     the top-up strip that HOSTED the label no longer renders at all.
+--
+-- The third is why this is not simply "add the column to the list and the label
+-- comes back": there is no top-up history left to put it in. What is left is the
+-- per-tranche snapshot the collapse writes, which is where a closed cycle is
+-- already described — the History tab. So the marker is carried onto the snapshot
+-- and the sentence is said there instead.
+--
+-- ─── Per TRANCHE, which is what makes this honest ────────────────────────────
+--
+-- The collapse writes one snapshot per tranche, in a loop, not one row for the
+-- book. So the marker lands on the snapshot OF the credited tranche and on no
+-- other — the same one-to-one the live book had. A book that absorbed two merges
+-- keeps two labels; a book that absorbed none keeps zero. Nothing is aggregated
+-- and no provenance is invented for a tranche that was funded normally.
+--
+-- ─── What carrying it does NOT switch on ─────────────────────────────────────
+--
+-- guard_merge_credited_tranche_edited fires `when (old.merged_from_book_id is not
+-- null)`, so the snapshot inherits the freeze on amount/units/type/affects_progress.
+-- That is harmless and arguably right: a renewal snapshot is history, and history
+-- is not meant to be rewritten. It is stated here because it is a real consequence
+-- of setting the column rather than an accident.
+--
+-- move_merge_lineage_to_book fires on DELETE under the same condition, so deleting
+-- such a snapshot now runs it. Both of its branches are inert for this row: the
+-- first needs a deposit_group_id (a snapshot has none), and the second refuses only
+-- when a withdrawal still names the row through consumed_by_inv_id — the lineage
+-- points at the book, never at a snapshot. Verified against the local stack.
+--
+-- Copied from 20260815000006, the current definition — NOT from 20260618000003,
+-- which is two revisions behind and does not set the app.collapse_write marker
+-- the merge guards ask for (#652). Re-issuing from the older text silently
+-- reverted that, and the collapse of a successor was refused by its own lineage
+-- move: "this withdrawal records where the cash went, so that cannot be unset".
+
+create or replace function public.collapse_accumulating_book(
+  p_group_id uuid,
+  p_amount_vnd bigint,
+  p_interest_rate numeric,
+  p_expiry_date date,
+  p_investment_date date,
+  p_tranche_ids uuid[],
+  p_tranche_interest bigint[],
+  p_fulfill_saving_id uuid default null,
+  p_fulfill_ym text default null,
+  p_fulfill_amount bigint default null,
+  p_fulfill_source text default null
+)
+returns public.investment_transactions
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_anchor public.investment_transactions;
+  v_tranche public.investment_transactions;
+  v_seen bigint;
+  v_now bigint;
+  v_round int;
+  v_snapshot_id uuid;
+  v_interest bigint;
+  v_idx int;
+  v_renewed public.investment_transactions;
+begin
+  -- THE THIRD CHANGE FROM 20260618000003, and the reason this function is here
+  -- again: it used to lock the ANCHOR first and the tranches afterwards, which
+  -- crosses a writer taking the group in transaction_id order whenever the
+  -- anchor's id does not happen to sort first. update_deposit_book above is now
+  -- one such writer, and merge_book_into_successor has been another since #649,
+  -- so the anchor-first order is the odd one out and it is this one that moves.
+  --
+  -- Read without a lock, sweep the whole group in id order until its membership
+  -- stops moving, then re-read under that lock — the same steps
+  -- update_deposit_book takes, for the same reasons.
+  select * into v_anchor
+    from public.investment_transactions
+   where transaction_id = p_group_id
+     and deposit_group_id = p_group_id;
+  if not found then
+    raise exception 'collapse_accumulating_book: accumulating book not found'
+      using errcode = 'no_data_found';
+  end if;
+
+  -- Swept until the membership stops moving, for the reason spelled out on
+  -- update_deposit_book above: at READ COMMITTED the sweep's snapshot predates
+  -- its wait, so a tranche a top-up inserts while it is queued behind the anchor
+  -- is invisible to it — and the loop below would then take that row's lock in
+  -- investment_date order, outside the sweep. Refusing the collapse afterwards
+  -- (the caller's list cannot account for it) is the right ANSWER but it comes
+  -- after the lock, which is too late to matter for ordering.
+  v_seen := -1;
+  for v_round in 1 .. 5 loop
+    select count(*) into v_now
+      from public.investment_transactions
+     where deposit_group_id = p_group_id;
+    exit when v_now = v_seen;
+    perform 1
+      from public.investment_transactions
+     where deposit_group_id = p_group_id
+     order by transaction_id
+       for update;
+    v_seen := v_now;
+  end loop;
+
+  select * into v_anchor
+    from public.investment_transactions
+   where transaction_id = p_group_id
+     and deposit_group_id = p_group_id;
+  if not found or v_now is distinct from v_seen then
+    raise exception 'collapse_accumulating_book: book changed since load, reload and retry';
+  end if;
+  if v_anchor.asset_type is distinct from 'bank' then
+    raise exception 'collapse_accumulating_book: only bank books can be collapsed'
+      using errcode = 'check_violation';
+  end if;
+  if p_amount_vnd is null or p_amount_vnd <= 0 then
+    raise exception 'collapse_accumulating_book: amount must be positive'
+      using errcode = 'check_violation';
+  end if;
+  if p_investment_date > current_date + 1 then
+    raise exception 'collapse_accumulating_book: investment date cannot be in the future'
+      using errcode = 'check_violation';
+  end if;
+  if p_expiry_date is not null and p_expiry_date <= p_investment_date then
+    raise exception 'collapse_accumulating_book: new maturity must be after the investment date'
+      using errcode = 'check_violation';
+  end if;
+
+  -- 0) Preserve EXPLICIT recurring links (#348): re-point any link that targets a
+  -- tranche of this book onto the surviving anchor BEFORE the deletes below.
+  update public.recurring_savings
+     set linked_deposit_tx_id = p_group_id,
+         updated_at = now()
+   where user_id = v_anchor.user_id
+     and linked_deposit_tx_id in (
+       select transaction_id from public.investment_transactions
+        where deposit_group_id = p_group_id
+          and transaction_type = 'investment'
+          and renewed_from_transaction_id is null
+     );
+
+  -- 1–4) Snapshot, re-parent, then delete every tranche; roll the anchor forward
+  -- after the loop.
+  --
+  -- THE FIRST OF THE TWO CHANGES FROM 20260618000003. The deletes below, and the
+  -- lineage move the delete guard makes on their behalf, are refused unless a
+  -- collapse says it is doing them (#652). Nothing else sets this flag and no
+  -- client can. Dropping this line breaks the collapse of any book holding
+  -- another book's payout — pinned by merge_successor_book.test.sql.
+  perform set_config('app.collapse_write', '1', true);
+  for v_tranche in
+    select * from public.investment_transactions
+     where deposit_group_id = p_group_id
+       and transaction_type = 'investment'
+       and renewed_from_transaction_id is null
+     order by investment_date
+     for update
+  loop
+    v_idx := array_position(p_tranche_ids, v_tranche.transaction_id);
+    -- A live tranche the caller didn't account for ⇒ the book changed since the
+    -- route read it (e.g. a top-up landed mid-flight). Abort so its principal is
+    -- never silently dropped; the client reloads and retries.
+    if v_idx is null then
+      -- NB: a plain raise (errcode P0001), NOT serialization_failure (40001) — the
+      -- latter is conventionally auto-retried by drivers/poolers, which would spin
+      -- on this deterministic abort instead of surfacing it. The route maps this
+      -- message to a 409 so the client reloads.
+      raise exception 'collapse_accumulating_book: book changed since load, reload and retry';
+    end if;
+    v_interest := p_tranche_interest[v_idx];
+
+    insert into public.investment_transactions (
+      user_id, goal_id, asset_type, transaction_type, amount_vnd,
+      investment_date, expiry_date, interest_rate, notes,
+      renewed_from_transaction_id, interest_earned_vnd, affects_progress,
+      -- THE ONLY CHANGE FROM 20260815000006. Which book paid for this tranche
+      -- (#656): carried onto the snapshot because the tranche that held it is
+      -- deleted two statements below, and the book's top-up strip goes with the
+      -- cleared deposit_group_id — the History tab is the only surface a closed
+      -- cycle still has.
+      merged_from_book_id
+    ) values (
+      v_tranche.user_id, v_tranche.goal_id, 'bank', 'investment', v_tranche.amount_vnd,
+      v_tranche.investment_date, v_tranche.expiry_date, v_tranche.interest_rate, v_tranche.notes,
+      p_group_id, v_interest, false,
+      v_tranche.merged_from_book_id
+    )
+    returning transaction_id into v_snapshot_id;
+
+    update public.investment_transactions
+       set parent_transaction_id = v_snapshot_id
+     where parent_transaction_id = v_tranche.transaction_id
+       and transaction_type = 'withdrawal';
+
+    if v_tranche.transaction_id <> p_group_id then
+      delete from public.investment_transactions
+       where transaction_id = v_tranche.transaction_id;
+    end if;
+  end loop;
+  -- Cleared immediately: the licence covers the loop, not the rest of whatever
+  -- transaction this call happens to be in.
+  perform set_config('app.collapse_write', '', true);
+
+  update public.investment_transactions
+     set amount_vnd        = p_amount_vnd,
+         interest_rate     = p_interest_rate,
+         expiry_date       = p_expiry_date,
+         investment_date   = p_investment_date,
+         deposit_group_id  = null,
+         updated_at        = now()
+   where transaction_id = p_group_id
+  returning * into v_renewed;
+
+  if p_fulfill_saving_id is not null and p_fulfill_ym is not null then
+    if not exists (
+      select 1 from public.recurring_savings
+       where saving_id = p_fulfill_saving_id and user_id = v_anchor.user_id
+    ) then
+      raise exception 'collapse_accumulating_book: recurring saving not found'
+        using errcode = 'no_data_found';
+    end if;
+    insert into public.recurring_saving_fulfillments (
+      user_id, recurring_saving_id, ym, amount_vnd, source
+    ) values (
+      v_anchor.user_id, p_fulfill_saving_id, p_fulfill_ym,
+      coalesce(p_fulfill_amount, 0), coalesce(p_fulfill_source, 'maturity-collapse')
+    )
+    on conflict (recurring_saving_id, ym) do update
+      set amount_vnd = excluded.amount_vnd,
+          source     = excluded.source,
+          updated_at = now();
+  end if;
+
+  return v_renewed;
+end;
+$$;

--- a/supabase/tests/merge_successor_book.test.sql
+++ b/supabase/tests/merge_successor_book.test.sql
@@ -732,6 +732,27 @@ begin
     raise exception 'the collapse must still delete the credited tranche';
   end if;
 
+  -- ...and the provenance survives it (#656). The credited tranche is deleted and
+  -- the book stops being a book (deposit_group_id cleared), so the top-up strip
+  -- that hosted "Gộp từ A" is gone with it. What remains is the per-tranche
+  -- snapshot the collapse writes, which is where a closed cycle is already
+  -- described — so the marker is carried onto it rather than lost.
+  --
+  -- Asserted on the SNAPSHOT of the credited tranche specifically, not on "some
+  -- row of this book": every tranche gets a snapshot, and only one of them was
+  -- paid for by another book.
+  if not exists (
+    select 1 from public.investment_transactions s
+     where s.renewed_from_transaction_id = v_b
+       and s.merged_from_book_id is not null
+  ) then
+    raise exception 'the renewal snapshot must still say which book paid for this tranche';
+  end if;
+  if (select count(*) from public.investment_transactions s
+       where s.renewed_from_transaction_id = v_b and s.merged_from_book_id is not null) <> 1 then
+    raise exception 'only the credited tranche was paid for by another book';
+  end if;
+
   -- ...and the deposit it became goes on living. Freezing it because it once
   -- absorbed a merged payout was tried and makes it unrenewable for good: the
   -- renewal rewrites amount_vnd on this very row. Past the collapse the cash is


### PR DESCRIPTION
Closes #656.

## Why the obvious fix isn't the fix

#654 labels a credited tranche `Gộp từ <sổ A>` / `Merged from <A>` in a book's top-up history, from `merged_from_book_id`. It dies with the successor's own renewal, and the issue is right that three things happen at once:

- `collapse_accumulating_book` snapshots each tranche with an explicit column list that omits `merged_from_book_id`;
- it then **deletes** the credited tranche, and the marker goes with it;
- it clears the anchor's `deposit_group_id`, so the book stops being a book — and **the top-up strip that hosted the label no longer renders at all.**

That last point is why "add the column to the list" alone would not bring the label back: there is no surface left to put it on. What survives is the **per-tranche snapshot** the collapse writes, which is where a closed cycle is already described. So the marker rides onto the snapshot, and the sentence is said in the **History tab**.

The issue's other worry — that patching one field back would make merge provenance uniquely persistent among tranche details — does not apply here for a concrete reason: the collapse writes **one snapshot per tranche, in a loop**, not one row for the book. Every per-tranche detail (date, rate, amount) survives on its own snapshot row. Provenance is now one more field on the row that already carries the rest, not an exception to a rule.

## Per tranche, which is what keeps it honest

The marker lands on the snapshot **of the credited tranche** and no other — the same one-to-one the live book had. A book that absorbed two merges keeps two labels; a book that absorbed none keeps zero. Nothing is aggregated, and no provenance is invented for a tranche that was funded normally. The DB test asserts exactly one such snapshot, not merely "at least one".

## The wording

Reused verbatim from the live tranche row (`goalDetailShared.tsx:306`) rather than invented, so the phrase a user already recognises is the phrase that survives:

```
Sổ VCB 6 tháng          [Đã tái tục]
01 thg 8, 2026
Gộp từ PVcomBank A                    8.300.000 ₫
```

It takes **its own line rather than a third pill**: the name line is `nowrap` + `ellipsis`, so a chip there would clip the book's own name first.

A merged source is *dissolved*, so nothing points at it through `deposit_group_id` and it can easily sit off the page. `useGoalDetailData` already backfills those names by id (#638 Phase 4), but a miss now reads `Gộp từ một sổ khác` / `Merged from another book` — "Merged from undefined" would look like a defect in the ledger rather than a name this page happens not to have.

## A trap worth recording

The migration is re-issued from **`20260815000006`, the current definition** — not from `20260618000003`, which is two revisions behind and does **not** set the `app.collapse_write` marker the merge guards ask for (#652). Copying the older text silently reverted that, and the collapse of a successor was then refused by its own lineage move:

```
merge successor: this withdrawal records where the cash went, so that cannot be unset
```

`merge_successor_book.test.sql` pins exactly that, which is how it surfaced. Worth stating because "re-issue the function verbatim" is the normal move in this repo and the newest definition is not always where you'd look for it.

## Tests

- **`supabase/tests/merge_successor_book.test.sql`** — after the successor's collapse, the renewal snapshot still names the book that paid for the tranche, and exactly one snapshot does. Confirmed red first.
- **`goalDetailShared.test.tsx`** — `mergedFromLabel` in both languages, silent when no book paid, and the anonymous fallback for an off-page source.
- **`GoalDetailSheet.test.tsx`** — the rendered outcome, which is the assertion that matters: a renewed History row carries `Merged from PVcomBank A` **and** still reads `Renewed` (the provenance is added to the row, not substituted for it), plus a renewal no book paid for that says nothing.

## Checks

Full `supabase/tests` suite green · `npm run typecheck` clean · 2518 unit tests pass · `npm run lint` 0 errors · targeted E2E (`zz-successor-book-journey`, `accumulating-deposit`) **5 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)