### PR TITLE
chore(deps): bump transitive nanoid to 3.3.18 (#681)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8716,9 +8716,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Closes #681.

## Vấn đề

`npm audit --omit=dev` báo đúng một advisory ở production: `nanoid@3.3.16` dính GHSA-2v37-7h3g-55p8 — custom generator có thể lặp vô hạn khi size bằng 0. App không import `nanoid` trực tiếp, nó đi kèm theo PostCSS, nên rủi ro thực tế thấp.

## Thay đổi

Chỉ refresh lockfile: `npm update nanoid --package-lock-only`. `3.3.18` đã nằm trong range `^3.3.16` sẵn có nên `package.json` không đổi, không mở rộng dependency surface. Diff đúng 3 dòng (version / resolved / integrity).

## Kiểm chứng

- `npm audit --omit=dev` → **found 0 vulnerabilities**
- `npm ci` → cài đúng `nanoid@3.3.18`
- `npm run typecheck` → sạch
- `npm run lint` → 0 errors (2 warnings có sẵn từ trước)
- `npm test -- --run` → 207 files, 2519 tests passed

Không thêm test: đây là bump dependency thuần, không có hành vi nào của app thay đổi để mà assert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)