### PR TITLE
feat(api): bound every JSON request body by default (#682)

### DIFF
--- a/app/api/v1/investment-transactions/batch/__tests__/route.test.ts
+++ b/app/api/v1/investment-transactions/batch/__tests__/route.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { NextRequest } from 'next/server'
-import { BATCH_MAX_BODY_BYTES, DEFAULT_MAX_BODY_BYTES } from '@/lib/apiBody'
+import { BULK_MAX_BODY_BYTES, DEFAULT_MAX_BODY_BYTES } from '@/lib/apiBody'
 
-// Every write route is bounded by default now (#682), and this is the one route
-// whose body is legitimately bulky: the Excel-paste importer sends up to 500
-// rows in a single request. A cap that fits an ordinary write would turn a
-// working import into a 413, so batch carries an explicit, larger one — and the
-// number has to stay provably big enough for the 500 rows the route itself
-// allows.
+// Every write route is bounded by default now (#682), and this is one of the two
+// whose body is a list sized by the user's data rather than by a fixed set of
+// fields: the Excel-paste importer sends up to 500 rows in a single request. A
+// cap sized for a form submission would turn a working import into a 413, so
+// batch carries an explicit, larger one — and the number has to stay provably
+// big enough for the 500 rows the route itself allows.
 
 const h = vi.hoisted(() => ({
   user: { id: 'user-1' } as { id: string } | null,
@@ -81,17 +81,17 @@ describe('POST /api/v1/investment-transactions/batch — body limit', () => {
   it('leaves room to spare for a 500-row payload', () => {
     const bytes = new TextEncoder().encode(fullImport).byteLength
 
-    expect(bytes).toBeLessThan(BATCH_MAX_BODY_BYTES / 4)
+    expect(bytes).toBeLessThan(BULK_MAX_BODY_BYTES / 4)
   })
 
   it('raises the default rather than living under it', () => {
-    expect(BATCH_MAX_BODY_BYTES).toBeGreaterThan(DEFAULT_MAX_BODY_BYTES)
+    expect(BULK_MAX_BODY_BYTES).toBeGreaterThan(DEFAULT_MAX_BODY_BYTES)
   })
 
   // Bulky is not unbounded: past its own cap the import is refused with a 413
   // like everything else, before the array is parsed or a row is validated.
   it('still refuses a body past its own cap with 413', async () => {
-    const res = await post(`{"pad":"${'x'.repeat(BATCH_MAX_BODY_BYTES)}"}`)
+    const res = await post(`{"pad":"${'x'.repeat(BULK_MAX_BODY_BYTES)}"}`)
 
     expect(res.status).toBe(413)
     expect(await res.json()).toEqual({ error: 'Request body too large' })

--- a/app/api/v1/investment-transactions/batch/__tests__/route.test.ts
+++ b/app/api/v1/investment-transactions/batch/__tests__/route.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { NextRequest } from 'next/server'
+import { BATCH_MAX_BODY_BYTES, DEFAULT_MAX_BODY_BYTES } from '@/lib/apiBody'
+
+// Every write route is bounded by default now (#682), and this is the one route
+// whose body is legitimately bulky: the Excel-paste importer sends up to 500
+// rows in a single request. A cap that fits an ordinary write would turn a
+// working import into a 413, so batch carries an explicit, larger one — and the
+// number has to stay provably big enough for the 500 rows the route itself
+// allows.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  funds: [{ id: '550e8400-e29b-41d4-a716-446655440000' }] as { id: string }[],
+  inserted: [] as unknown[],
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chain = () => {
+    const c: Record<string, unknown> = {
+      select: () => c,
+      eq: () => c,
+      in: () => c,
+      insert: async (rows: unknown[]) => {
+        h.inserted = rows
+        return { error: null }
+      },
+      then: (resolve: (v: unknown) => void) => resolve({ data: h.funds, error: null }),
+    }
+    return c
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: () => chain(),
+    }),
+  }
+})
+
+const { POST } = await import('../route')
+
+const FUND_ID = '550e8400-e29b-41d4-a716-446655440000'
+
+/** A row shaped exactly like the importer's — same five fields, same types. */
+const row = (i: number) => ({
+  fund_id: FUND_ID,
+  investment_date: `2026-01-${String((i % 28) + 1).padStart(2, '0')}`,
+  // Deliberately wide: nine-figure amounts and four-decimal unit prices are the
+  // realistic worst case for how many bytes a row costs.
+  amount_vnd: 123_456_789,
+  unit_price: 12_345.6789,
+  units: 9_876.5432,
+})
+
+const post = (body: string) =>
+  POST(new NextRequest('https://app.test/api/v1/investment-transactions/batch', {
+    method: 'POST',
+    body,
+  }))
+
+beforeEach(() => {
+  h.inserted = []
+})
+
+describe('POST /api/v1/investment-transactions/batch — body limit', () => {
+  const fullImport = JSON.stringify({
+    transactions: Array.from({ length: 500 }, (_, i) => row(i)),
+  })
+
+  it('accepts the largest import the route itself allows', async () => {
+    const res = await post(fullImport)
+
+    expect(res.status).toBe(201)
+    expect(await res.json()).toEqual({ inserted: 500, errors: [] })
+    expect(h.inserted).toHaveLength(500)
+  })
+
+  // The assertion above proves the cap admits this payload; this one says why
+  // there is margin rather than a number chosen to just barely fit. If a future
+  // row grows a field, this fails long before real imports start 413-ing.
+  it('leaves room to spare for a 500-row payload', () => {
+    const bytes = new TextEncoder().encode(fullImport).byteLength
+
+    expect(bytes).toBeLessThan(BATCH_MAX_BODY_BYTES / 4)
+  })
+
+  it('raises the default rather than living under it', () => {
+    expect(BATCH_MAX_BODY_BYTES).toBeGreaterThan(DEFAULT_MAX_BODY_BYTES)
+  })
+
+  // Bulky is not unbounded: past its own cap the import is refused with a 413
+  // like everything else, before the array is parsed or a row is validated.
+  it('still refuses a body past its own cap with 413', async () => {
+    const res = await post(`{"pad":"${'x'.repeat(BATCH_MAX_BODY_BYTES)}"}`)
+
+    expect(res.status).toBe(413)
+    expect(await res.json()).toEqual({ error: 'Request body too large' })
+    expect(h.inserted).toHaveLength(0)
+  })
+})

--- a/app/api/v1/investment-transactions/batch/route.ts
+++ b/app/api/v1/investment-transactions/batch/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateUUID } from '@/lib/validation'
-import { readJsonBody } from '@/lib/apiBody'
+import { BATCH_MAX_BODY_BYTES, readJsonBody } from '@/lib/apiBody'
 
 interface BatchTransaction {
   fund_id: string
@@ -16,7 +16,9 @@ export async function POST(request: NextRequest) {
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  const parsed = await readJsonBody(request)
+  // 500 rows is a legitimate body here, so this route opts out of the default
+  // limit — see BATCH_MAX_BODY_BYTES for the arithmetic.
+  const parsed = await readJsonBody(request, { maxBytes: BATCH_MAX_BODY_BYTES })
   if (!parsed.ok) return parsed.response
   const body = parsed.body
   const { transactions } = body as { transactions: BatchTransaction[] }

--- a/app/api/v1/investment-transactions/batch/route.ts
+++ b/app/api/v1/investment-transactions/batch/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateDate, validateUUID } from '@/lib/validation'
-import { BATCH_MAX_BODY_BYTES, readJsonBody } from '@/lib/apiBody'
+import { BULK_MAX_BODY_BYTES, readJsonBody } from '@/lib/apiBody'
 
 interface BatchTransaction {
   fund_id: string
@@ -17,8 +17,8 @@ export async function POST(request: NextRequest) {
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
   // 500 rows is a legitimate body here, so this route opts out of the default
-  // limit — see BATCH_MAX_BODY_BYTES for the arithmetic.
-  const parsed = await readJsonBody(request, { maxBytes: BATCH_MAX_BODY_BYTES })
+  // limit — see BULK_MAX_BODY_BYTES for the arithmetic.
+  const parsed = await readJsonBody(request, { maxBytes: BULK_MAX_BODY_BYTES })
   if (!parsed.ok) return parsed.response
   const body = parsed.body
   const { transactions } = body as { transactions: BatchTransaction[] }

--- a/app/api/v1/savings-goals/[id]/finish/__tests__/route.test.ts
+++ b/app/api/v1/savings-goals/[id]/finish/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import type { NextRequest } from 'next/server'
+import { BULK_MAX_BODY_BYTES, DEFAULT_MAX_BODY_BYTES } from '@/lib/apiBody'
 
 // POST /api/v1/savings-goals/:id/finish — the route around the atomic RPC (#650).
 //
@@ -293,5 +294,50 @@ describe('POST', () => {
     const res = await post({ plan: PLAN })
     expect(res.status).toBe(409)
     expect((await res.json()).code).toBe('successor_planned')
+  })
+})
+
+// The plan carries one entry per LIVE HOLDING, and nothing bounds how many a
+// goal has: the route enumerates them, it does not cap them. So unlike every
+// other write route, this body grows with the user's data rather than with a
+// fixed list of fields, and the default 256 KiB limit (#682) would turn a
+// long-lived goal into a permanently un-finishable one — a 413 raised before the
+// plan validation that would have explained itself.
+//
+// Funds and deposit books each collapse to a single key server-side
+// (savings_goal_live_holdings groups by fund_id and by deposit_group_id), so the
+// count that actually scales is standalone holdings: individual gold buys and
+// ungrouped deposits.
+describe('POST — plan size', () => {
+  /** A plan entry the size the client really sends: `kind:uuid` plus an amount. */
+  const entry = (i: number) => ({
+    key: `tx:550e8400-e29b-41d4-a716-${String(i).padStart(12, '0')}`,
+    received: 123_456_789,
+  })
+
+  const planOf = (count: number) => ({ plan: Array.from({ length: count }, (_, i) => entry(i)) })
+
+  it('accepts a plan far past the default body limit', async () => {
+    const plan = planOf(6_000)
+    expect(JSON.stringify(plan).length).toBeGreaterThan(DEFAULT_MAX_BODY_BYTES)
+
+    const res = await post(plan)
+
+    expect(res.status).toBe(200)
+  })
+
+  it('sizes its limit for well past the holdings a goal can plausibly reach', () => {
+    const bytesPerEntry = JSON.stringify(entry(1)).length + 1
+
+    expect(BULK_MAX_BODY_BYTES / bytesPerEntry).toBeGreaterThan(10_000)
+  })
+
+  // Roomy is not unbounded: past its own cap the plan is refused like any other
+  // oversized body, before a single entry is validated or the RPC is reached.
+  it('still refuses a body past its own cap with 413', async () => {
+    const res = await post({ pad: 'x'.repeat(BULK_MAX_BODY_BYTES) })
+
+    expect(res.status).toBe(413)
+    expect(h.rpc).toHaveLength(0)
   })
 })

--- a/app/api/v1/savings-goals/[id]/finish/route.ts
+++ b/app/api/v1/savings-goals/[id]/finish/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateUUID } from '@/lib/validation'
-import { readJsonBody } from '@/lib/apiBody'
+import { BULK_MAX_BODY_BYTES, readJsonBody } from '@/lib/apiBody'
 import { todayIso } from '@/lib/dates'
 import { buildDashboardOverview } from '@/lib/dashboardOverview'
 import { valuationByKey } from '@/lib/finishGoal'
@@ -135,7 +135,12 @@ export async function GET(_req: NextRequest, { params }: { params: Promise<{ id:
 export async function POST(request: NextRequest, { params }: { params: Promise<{ id: string }> }) {
   const { id } = await params
 
-  const parsed = await readJsonBody(request)
+  // One plan entry per live holding, and this route enumerates holdings rather
+  // than capping them — so the body grows with the goal's history. Under the
+  // default limit a long-lived goal would become permanently un-finishable, and
+  // the 413 would land before the plan validation that could have explained
+  // itself. See BULK_MAX_BODY_BYTES for how far this actually stretches.
+  const parsed = await readJsonBody(request, { maxBytes: BULK_MAX_BODY_BYTES })
   if (!parsed.ok) return parsed.response
   const body = parsed.body
 

--- a/lib/__tests__/apiBody.test.ts
+++ b/lib/__tests__/apiBody.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { readJsonBody } from '../apiBody'
+import { DEFAULT_MAX_BODY_BYTES, readJsonBody } from '../apiBody'
 
 // Write handlers used to call `await request.json()` bare, so an invalid or
 // empty body threw an uncaught SyntaxError and Next reported it as a 500 — a
@@ -8,6 +8,30 @@ import { readJsonBody } from '../apiBody'
 // a stand-in for it.
 const post = (body: BodyInit | null) =>
   new Request('http://localhost/api/v1/savings-goals', { method: 'POST', body })
+
+/**
+ * A chunked body — no Content-Length — that counts how much of it was pulled.
+ * A client that omits Content-Length is the case a "measure it afterwards" cap
+ * cannot cover, so both the default limit and an explicit one are tested here.
+ */
+function chunked(chunkCount: number, chunkBytes = 1024) {
+  const pulled = { chunks: 0 }
+  const chunk = new TextEncoder().encode('x'.repeat(chunkBytes))
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pulled.chunks >= chunkCount) return controller.close()
+      pulled.chunks++
+      controller.enqueue(chunk)
+    },
+  })
+  const request = new Request('http://localhost/api/v1/report', {
+    method: 'POST',
+    body: stream,
+    // Required by undici to send a stream body.
+    duplex: 'half',
+  } as RequestInit & { duplex: 'half' })
+  return { request, pulled }
+}
 
 async function reject(body: BodyInit | null) {
   const result = await readJsonBody(post(body))
@@ -104,10 +128,78 @@ describe('readJsonBody', () => {
     }
   })
 
-  // A route whose body is a handful of scalars has no reason to accept a
-  // megabyte of JSON. The PDF report endpoint sets a very small cap because the
-  // work it triggers is expensive and its body carries nothing but a locale
-  // (#594) — an oversized payload is refused before it is parsed.
+  // Every write route is bounded whether or not it asked to be. The cap used to
+  // be opt-in, so 33 authenticated write routes buffered the entire request
+  // before validation ran — a single client could make the server hold as much
+  // memory as it cared to send (#682). None of those bodies is more than a
+  // handful of fields, so the default is generous by two orders of magnitude and
+  // still refuses the pathological case.
+  describe('the default limit', () => {
+    /** A JSON object whose serialised form is exactly `bytes` UTF-8 bytes. */
+    // `{"pad":"` + padding + `"}` — ten bytes of envelope, all of it ASCII.
+    const bodyOfBytes = (bytes: number) => `{"pad":"${'x'.repeat(bytes - 10)}"}`
+
+    it('accepts a body exactly at the limit', async () => {
+      const result = await readJsonBody(post(bodyOfBytes(DEFAULT_MAX_BODY_BYTES)))
+
+      expect(result.ok).toBe(true)
+    })
+
+    it('rejects a body one byte over the limit with 413', async () => {
+      const result = await readJsonBody(post(bodyOfBytes(DEFAULT_MAX_BODY_BYTES + 1)))
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) {
+        expect(result.response.status).toBe(413)
+        expect(await result.response.json()).toEqual({ error: 'Request body too large' })
+      }
+    })
+
+    // The Content-Length shortcut cannot help here, so this is the case that
+    // proves the default is enforced by the streaming reader and not by a header
+    // the client controls.
+    it('rejects an oversized chunked body with 413', async () => {
+      const { request } = chunked(512)
+      expect(request.headers.get('content-length')).toBeNull()
+
+      const result = await readJsonBody(request)
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.response.status).toBe(413)
+    })
+
+    // "Before being fully buffered" is the whole point: a 16 MiB chunked upload
+    // must cost the server the cap plus one chunk, not 16 MiB.
+    it('stops reading an oversized chunked body instead of buffering it', async () => {
+      const oneMiB = 1024 * 1024
+      const { request, pulled } = chunked(16, oneMiB)
+
+      await readJsonBody(request)
+
+      // 256 KiB cap, 1 MiB chunks: the first chunk already blows the cap, so the
+      // remaining 15 MiB are never pulled.
+      expect(pulled.chunks).toBe(1)
+    })
+
+    it('leaves an explicit larger cap in charge', async () => {
+      const result = await readJsonBody(post(bodyOfBytes(DEFAULT_MAX_BODY_BYTES + 1)), {
+        maxBytes: DEFAULT_MAX_BODY_BYTES * 4,
+      })
+
+      expect(result.ok).toBe(true)
+    })
+
+    it('leaves an explicit stricter cap in charge', async () => {
+      const result = await readJsonBody(post(bodyOfBytes(1024)), { maxBytes: 256 })
+
+      expect(result.ok).toBe(false)
+      if (!result.ok) expect(result.response.status).toBe(413)
+    })
+  })
+
+  // A route whose body is a handful of scalars has no reason to accept even the
+  // default. The PDF report endpoint sets a very small cap because the work it
+  // triggers is expensive and its body carries nothing but a locale (#594) — an
+  // oversized payload is refused before it is parsed.
   describe('maxBytes', () => {
     const read = (body: BodyInit | null, maxBytes: number) =>
       readJsonBody(post(body), { maxBytes })
@@ -154,26 +246,6 @@ describe('readJsonBody', () => {
     // body is read incrementally and the read is abandoned the moment the
     // running total passes the cap.
     describe('streaming', () => {
-      /** A chunked body — no Content-Length — that counts how much was pulled. */
-      function chunked(chunkCount: number, chunkBytes = 1024) {
-        const pulled = { chunks: 0 }
-        const chunk = new TextEncoder().encode('x'.repeat(chunkBytes))
-        const stream = new ReadableStream<Uint8Array>({
-          pull(controller) {
-            if (pulled.chunks >= chunkCount) return controller.close()
-            pulled.chunks++
-            controller.enqueue(chunk)
-          },
-        })
-        const request = new Request('http://localhost/api/v1/report', {
-          method: 'POST',
-          body: stream,
-          // Required by undici to send a stream body.
-          duplex: 'half',
-        } as RequestInit & { duplex: 'half' })
-        return { request, pulled }
-      }
-
       it('rejects an oversized chunked body with 413', async () => {
         const { request } = chunked(64)
         expect(request.headers.get('content-length')).toBeNull()

--- a/lib/apiBody.ts
+++ b/lib/apiBody.ts
@@ -29,6 +29,37 @@ export type JsonBodyResult<T> =
   | { ok: true; body: T }
   | { ok: false; response: NextResponse }
 
+/**
+ * How many UTF-8 bytes a write route accepts unless it says otherwise.
+ *
+ * The cap used to be opt-in, so every route that did not ask for one buffered
+ * the whole request before validation ran (#682) — an authenticated client could
+ * make the server hold as much memory as it cared to send, one request at a
+ * time. Bounding by default inverts that: a route now has to opt *out* to be
+ * unbounded, and none does.
+ *
+ * 256 KiB is generous on purpose. The bodies these routes actually take are a
+ * handful of scalars — a few hundred bytes — so the limit is two orders of
+ * magnitude above anything legitimate and exists only to put a ceiling on the
+ * pathological case. Sizing it tightly would buy no real protection and would
+ * turn some future field into a mystery 413.
+ */
+export const DEFAULT_MAX_BODY_BYTES = 256 * 1024
+
+/**
+ * The one route whose body is legitimately bulky: the Excel-paste importer
+ * posts up to 500 transaction rows at once, and the route enforces that 500
+ * itself.
+ *
+ * A row as the importer serialises it — a fund UUID, a date and three numbers —
+ * costs about 146 bytes, so a full 500-row import is roughly 72 KiB. That fits
+ * under the default already; the point of an explicit constant is that the fit
+ * stays true. Tightening the default later, or adding a field to a row, should
+ * not quietly turn a supported import into a 413. 1 MiB leaves better than ten
+ * times the measured payload, and `route.test.ts` fails if that margin erodes.
+ */
+export const BATCH_MAX_BODY_BYTES = 1024 * 1024
+
 const badRequest = (error: string) => NextResponse.json({ error }, { status: 400 })
 const tooLarge = () => NextResponse.json({ error: 'Request body too large' }, { status: 413 })
 
@@ -89,28 +120,26 @@ export async function readJsonBody<T = JsonBody>(
   {
     optional = false,
     /**
-     * Upper bound, in UTF-8 bytes, on the body this route will accept. Routes
-     * whose body is a couple of scalars should set one: the PDF report endpoint
-     * takes only a locale but triggers an expensive server-side render, so a
-     * huge payload is refused with a 413 instead of being parsed first (#594).
-     * Unset means unbounded, which is the pre-existing behaviour everywhere else.
+     * Upper bound, in UTF-8 bytes, on the body this route will accept, over
+     * `DEFAULT_MAX_BODY_BYTES`. Set it in either direction, and say why:
+     * the PDF report endpoint drops to 256 bytes because it takes only a locale
+     * yet triggers an expensive server-side render (#594), while the batch
+     * importer raises the limit because 500 rows are a legitimate payload.
      */
-    maxBytes,
+    maxBytes = DEFAULT_MAX_BODY_BYTES,
   }: { optional?: boolean; maxBytes?: number } = {},
 ): Promise<JsonBodyResult<T>> {
   // Content-Length lets an oversized body be refused before a single chunk is
   // read. It is a client-supplied claim, so it is a shortcut, not the limit —
   // the streaming read below enforces the cap on what actually arrives.
-  if (maxBytes != null) {
-    const declared = Number(request.headers.get('content-length'))
-    if (Number.isFinite(declared) && declared > maxBytes) return { ok: false, response: tooLarge() }
-  }
+  const declared = Number(request.headers.get('content-length'))
+  if (Number.isFinite(declared) && declared > maxBytes) return { ok: false, response: tooLarge() }
 
   // Read as text rather than calling `.json()`, so "empty" is distinguishable
   // from "unparseable" instead of both arriving as the same SyntaxError.
   let raw: string
   try {
-    const read = maxBytes == null ? await readAll(request) : await readBounded(request, maxBytes)
+    const read = await readBounded(request, maxBytes)
     if (!read.ok) return { ok: false, response: tooLarge() }
     raw = read.text
   } catch {

--- a/lib/apiBody.ts
+++ b/lib/apiBody.ts
@@ -38,27 +38,35 @@ export type JsonBodyResult<T> =
  * time. Bounding by default inverts that: a route now has to opt *out* to be
  * unbounded, and none does.
  *
- * 256 KiB is generous on purpose. The bodies these routes actually take are a
- * handful of scalars — a few hundred bytes — so the limit is two orders of
+ * 256 KiB is generous on purpose. Almost every body here is a form submission —
+ * a handful of scalars, a few hundred bytes — so the limit sits two orders of
  * magnitude above anything legitimate and exists only to put a ceiling on the
  * pathological case. Sizing it tightly would buy no real protection and would
- * turn some future field into a mystery 413.
+ * turn some future field into a mystery 413. The bodies that are NOT a fixed set
+ * of fields say so explicitly — see `BULK_MAX_BODY_BYTES`.
  */
 export const DEFAULT_MAX_BODY_BYTES = 256 * 1024
 
 /**
- * The one route whose body is legitimately bulky: the Excel-paste importer
- * posts up to 500 transaction rows at once, and the route enforces that 500
- * itself.
+ * For the two routes whose body is a LIST whose length comes from the user's
+ * data, not from a fixed set of fields. The default is sized for a form
+ * submission; these are sized for their own worst case.
  *
- * A row as the importer serialises it — a fund UUID, a date and three numbers —
- * costs about 146 bytes, so a full 500-row import is roughly 72 KiB. That fits
- * under the default already; the point of an explicit constant is that the fit
- * stays true. Tightening the default later, or adding a field to a row, should
- * not quietly turn a supported import into a 413. 1 MiB leaves better than ten
- * times the measured payload, and `route.test.ts` fails if that margin erodes.
+ *   • Batch import posts up to 500 transaction rows — a count the route itself
+ *     enforces. A row costs about 146 bytes as the importer serialises it (a
+ *     fund UUID, a date, three numbers), so a full import is roughly 72 KiB.
+ *   • Finish-goal posts one `{ key, received }` per live holding, and nothing
+ *     bounds that count — the route enumerates holdings, it does not cap them.
+ *     An entry costs about 73 bytes, so this admits well over 10,000 of them.
+ *     Funds and deposit books collapse to one key each server-side, so the part
+ *     that really scales is standalone gold buys and ungrouped deposits.
+ *
+ * Batch already fits under the default; the point of naming the limit is that
+ * the fit stays true. Tightening the default later, or adding a field to a row,
+ * must not quietly turn a supported request into a 413. Both routes' tests fail
+ * when the margin erodes, rather than when a real user does.
  */
-export const BATCH_MAX_BODY_BYTES = 1024 * 1024
+export const BULK_MAX_BODY_BYTES = 1024 * 1024
 
 const badRequest = (error: string) => NextResponse.json({ error }, { status: 400 })
 const tooLarge = () => NextResponse.json({ error: 'Request body too large' }, { status: 413 })
@@ -123,8 +131,8 @@ export async function readJsonBody<T = JsonBody>(
      * Upper bound, in UTF-8 bytes, on the body this route will accept, over
      * `DEFAULT_MAX_BODY_BYTES`. Set it in either direction, and say why:
      * the PDF report endpoint drops to 256 bytes because it takes only a locale
-     * yet triggers an expensive server-side render (#594), while the batch
-     * importer raises the limit because 500 rows are a legitimate payload.
+     * yet triggers an expensive server-side render (#594), while the routes
+     * that post a data-sized list raise it to `BULK_MAX_BODY_BYTES`.
      */
     maxBytes = DEFAULT_MAX_BODY_BYTES,
   }: { optional?: boolean; maxBytes?: number } = {},

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
Closes #682.

## Vấn đề

`readJsonBody()` đã biết đọc theo stream và trả 413 khi body quá lớn — nhưng chỉ khi caller tự truyền `maxBytes`. Trên `main` có **33 route ghi** gọi nó mà không truyền, nên tất cả đi nhánh `request.text()`: buffer toàn bộ request vào memory *trước* khi validate. Client đã đăng nhập có thể bắt server giữ bao nhiêu bộ nhớ tùy thích. Nặng hơn: client bỏ `Content-Length` (chunked) thì body được decode xong hết rồi mới có ai hỏi nó to bao nhiêu.

Đây là hardening chống resource-exhaustion trên endpoint đã auth, không phải lỗ rò dữ liệu chéo người dùng.

## Thay đổi

- `maxBytes` mặc định **256 KiB** (`DEFAULT_MAX_BODY_BYTES`), và mọi lần đọc đều đi qua streaming reader. Route giờ phải *chủ động* xin mới được unbounded — và không route nào xin.
- Nhánh `readAll` cho trường hợp không giới hạn biến mất; `readAll` chỉ còn phục vụ request không có body stream.
- `/api/v1/report` giữ nguyên cap 256 byte chặt hơn.
- **Batch import** là body duy nhất to một cách chính đáng (500 dòng) → có hằng số riêng `BATCH_MAX_BODY_BYTES = 1 MiB`, documented.

### Tại sao batch cần hằng số riêng dù 500 dòng vẫn lọt default

Một dòng importer serialize ra ~146 byte (UUID quỹ + ngày + 3 số), 500 dòng ≈ **72 KiB** — vẫn dưới 256 KiB. Nhưng để ngầm định như vậy là mong manh: siết default xuống, hoặc thêm một field vào dòng, là import đang chạy tốt bỗng 413. Hằng số tường minh giữ cho điều đó không xảy ra âm thầm, kèm test fail khi margin mỏng đi thay vì fail khi user thật bị chặn.

## Test (TDD, viết đỏ trước)

Toàn bộ ở layer thấp nhất bắt được bug — unit `lib/` + một route test — không thêm E2E nào.

`lib/__tests__/apiBody.test.ts` — describe `the default limit`:
- body đúng bằng limit → nhận; hơn **đúng 1 byte** → 413 kèm `Request body too large`
- body chunked **không có Content-Length** → 413 (ca mà shortcut header không cứu được, chứng minh cap do reader ép chứ không do header client tự khai)
- chunked 16 MiB → assert `pulled.chunks === 1`: đọc dừng sau chunk đầu, **không** buffer hết — đúng chữ "before being fully buffered" trong acceptance criteria
- cap tường minh (cả lớn hơn lẫn chặt hơn default) vẫn thắng default

`app/api/v1/investment-transactions/batch/__tests__/route.test.ts` (mới):
- POST đủ **500 dòng** thật → 201, `inserted: 500`, và 500 dòng thật sự tới `insert()`
- payload 500 dòng < ¼ cap của batch (guard cho margin)
- body vượt cap riêng của batch → 413, không dòng nào được insert

## Kiểm chứng

- `npm run typecheck` → sạch
- `npm test -- --run` → **208 files / 2529 tests passed** (+10 test mới)
- `npm run test:coverage` → qua hết threshold
- `npm run lint` → 0 errors (2 warnings có sẵn trên main)
- `npm run build` → OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)