### PR TITLE
fix(api): validate an effective-date range against the row it will land on (#686)

### DIFF
--- a/app/api/v1/fixed-expenses/[id]/__tests__/route.test.ts
+++ b/app/api/v1/fixed-expenses/[id]/__tests__/route.test.ts
@@ -1,0 +1,187 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// Guard for #686. The PUT validated the effective range using only the fields
+// the body carried, so `PUT { effective_from: '2026-07' }` on a row that ends
+// 2026-06 compared the new endpoint against null, passed, and was refused by
+// `effective_dates_order` — which the catch-all reported as 404 "Expense not
+// found" about a row that is right there.
+//
+// The merge rule itself is unit-tested in lib/__tests__/effectiveRange.test.ts.
+// What these tests pin is the wiring: that the route reads the stored row when
+// (and only when) it has to, answers 400 rather than reaching the table, and
+// still answers 404 for a row that isn't the caller's.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  stored: null as Record<string, unknown> | null,
+  updated: null as Record<string, unknown> | null,
+  updateError: null as { code?: string; message?: string } | null,
+  reads: 0,
+  updates: [] as Record<string, unknown>[],
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chainFor = () => {
+    let payload: Record<string, unknown> | null = null
+    const chain: Record<string, unknown> = {
+      select: () => chain,
+      eq: () => chain,
+      update: (values: Record<string, unknown>) => {
+        payload = values
+        return chain
+      },
+      single: async () => {
+        if (payload) {
+          h.updates.push(payload)
+          return { data: h.updated, error: h.updateError }
+        }
+        h.reads++
+        return { data: h.stored, error: h.stored ? null : { message: 'no rows' } }
+      },
+    }
+    return chain
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: () => chainFor(),
+    }),
+  }
+})
+
+const { PUT } = await import('../route')
+
+const ID = '11111111-1111-4111-8111-111111111111'
+
+const put = (body: unknown, id: string = ID) =>
+  PUT(
+    new Request(`https://app.test/api/v1/fixed-expenses/${id}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest,
+    { params: Promise.resolve({ id }) },
+  )
+
+describe('PUT /api/v1/fixed-expenses/[id] — effective range (#686)', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    // A row that runs March → June 2026.
+    h.stored = { effective_from: '2026-03-01', effective_to: '2026-06-01' }
+    h.updated = { expense_id: ID, expense_name: 'Rent' }
+    h.updateError = null
+    h.reads = 0
+    h.updates = []
+  })
+
+  it('rejects a from moved past the stored to', async () => {
+    const res = await put({ effective_from: '2026-07' })
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({
+      error: '"Active from" must be before "Active until".',
+    })
+    // The refusal has to happen before the write, or the table answers instead
+    // and the caller gets a 404 about an existing row.
+    expect(h.updates).toEqual([])
+  })
+
+  it('rejects a to moved before the stored from', async () => {
+    const res = await put({ effective_to: '2026-02' })
+
+    expect(res.status).toBe(400)
+    expect(h.updates).toEqual([])
+  })
+
+  it('accepts a from that still lands on or before the stored to', async () => {
+    const res = await put({ effective_from: '2026-06' })
+
+    expect(res.status).toBe(200)
+    expect(h.updates).toHaveLength(1)
+    expect(h.updates[0]).toMatchObject({ effective_from: '2026-06-01' })
+  })
+
+  it('accepts a to that still lands on or after the stored from', async () => {
+    const res = await put({ effective_to: '2026-03' })
+
+    expect(res.status).toBe(200)
+    expect(h.updates[0]).toMatchObject({ effective_to: '2026-03-01' })
+  })
+
+  it('lets an endpoint be cleared without reading the row', async () => {
+    // NULL disables the CHECK on that side, so clearing can never invert the
+    // range — no round trip earns its keep here.
+    const cleared = await put({ effective_from: null })
+
+    expect(cleared.status).toBe(200)
+    expect(h.updates[0]).toMatchObject({ effective_from: null })
+    expect(h.reads).toBe(0)
+
+    const clearedTo = await put({ effective_to: null })
+    expect(clearedTo.status).toBe(200)
+    expect(h.reads).toBe(0)
+  })
+
+  it('judges a body carrying both endpoints without reading the row', async () => {
+    const res = await put({ effective_from: '2026-08', effective_to: '2026-07' })
+
+    expect(res.status).toBe(400)
+    expect(h.reads).toBe(0)
+    expect(h.updates).toEqual([])
+  })
+
+  it('reads nothing when the update leaves the range alone', async () => {
+    const res = await put({ expense_name: 'Rent' })
+
+    expect(res.status).toBe(200)
+    expect(h.reads).toBe(0)
+  })
+
+  it('still answers 404 for a row that is missing or not the caller\'s', async () => {
+    // The pre-read finds nothing; the update then matches nothing either. A
+    // foreign id behaves the same way — .eq(user_id) scopes both statements.
+    h.stored = null
+    h.updated = null
+
+    const res = await put({ effective_from: '2026-07' })
+
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'Expense not found' })
+  })
+
+  it('answers 400, not 404, when the table refuses the range under a race', async () => {
+    // A concurrent update can move the other endpoint between the read and the
+    // write. Then the table is the one that says no — and that is still a
+    // validation failure, not a missing row (#532/#533).
+    h.updated = null
+    h.updateError = {
+      code: '23514',
+      message: 'new row for relation "fixed_expenses" violates check constraint "effective_dates_order"',
+    }
+
+    const res = await put({ effective_from: '2026-05' })
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({
+      error: '"Active from" must be before "Active until".',
+    })
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    h.user = null
+
+    const res = await put({ effective_from: '2026-07' })
+
+    expect(res.status).toBe(401)
+    expect(h.reads).toBe(0)
+  })
+
+  it('rejects a malformed month before any database work', async () => {
+    const res = await put({ effective_from: '2026-13' })
+
+    expect(res.status).toBe(400)
+    expect(h.reads).toBe(0)
+    expect(h.updates).toEqual([])
+  })
+})

--- a/app/api/v1/fixed-expenses/[id]/route.ts
+++ b/app/api/v1/fixed-expenses/[id]/route.ts
@@ -2,6 +2,14 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validateText, validateUUID, validateYearMonth } from '@/lib/validation'
 import { readJsonBody } from '@/lib/apiBody'
+import {
+  INVERTED_RANGE_MESSAGE,
+  isRangeCheckViolation,
+  mergedRangeIsInverted,
+  needsStoredRange,
+  type RangePatch,
+  type StoredRange,
+} from '@/lib/effectiveRange'
 
 function toDateCol(ym: string | undefined | null): string | null {
   if (!ym) return null
@@ -47,10 +55,25 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     throw e
   }
 
-  const fromDate = (updates.effective_from ?? null) as string | null
-  const toDate = (updates.effective_to ?? null) as string | null
-  if (fromDate && toDate && fromDate > toDate) {
-    return NextResponse.json({ error: '"Active from" must be before "Active until".' }, { status: 400 })
+  // Judge the range the table will see, not just the half the body carried: a
+  // partial update has to be compared with the endpoint already stored, or it
+  // sails past this check and is refused below as a 404 (#686).
+  const patch: RangePatch = {}
+  if ('effective_from' in body) patch.from = updates.effective_from as string | null
+  if ('effective_to' in body) patch.to = updates.effective_to as string | null
+
+  let stored: StoredRange = null
+  if (needsStoredRange(patch)) {
+    const { data } = await supabase
+      .from('fixed_expenses')
+      .select('effective_from, effective_to')
+      .eq('expense_id', expenseId)
+      .eq('user_id', user.id)
+      .single()
+    stored = data
+  }
+  if (mergedRangeIsInverted(patch, stored)) {
+    return NextResponse.json({ error: INVERTED_RANGE_MESSAGE }, { status: 400 })
   }
 
   const { data: expense, error } = await supabase
@@ -61,6 +84,12 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     .select()
     .single()
 
+  // A concurrent update can move the other endpoint between the read above and
+  // this write, and then the table refuses the range. That is still a validation
+  // failure — reported as 404 it reads as a missing row (#532/#533, #686).
+  if (isRangeCheckViolation(error)) {
+    return NextResponse.json({ error: INVERTED_RANGE_MESSAGE }, { status: 400 })
+  }
   if (error || !expense) return NextResponse.json({ error: 'Expense not found' }, { status: 404 })
   return NextResponse.json(expense)
 }

--- a/app/api/v1/fixed-expenses/route.ts
+++ b/app/api/v1/fixed-expenses/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServerClient } from '@/lib/supabase-server'
 import { ValidationError, validateAmount, validatePlanMonthFilter, validateText, validateYearMonth, type PlanMonthFilter } from '@/lib/validation'
 import { readJsonBody } from '@/lib/apiBody'
+import { INVERTED_RANGE_MESSAGE } from '@/lib/effectiveRange'
 
 function toDateCol(ym: string | undefined | null): string | null {
   if (!ym) return null
@@ -75,7 +76,7 @@ export async function POST(request: NextRequest) {
   const fromDate = toDateCol(cleanFromYm)
   const toDate = toDateCol(cleanToYm)
   if (fromDate && toDate && fromDate > toDate) {
-    return NextResponse.json({ error: '"Active from" must be before "Active until".' }, { status: 400 })
+    return NextResponse.json({ error: INVERTED_RANGE_MESSAGE }, { status: 400 })
   }
 
   const { data: expense, error } = await supabase

--- a/app/api/v1/recurring-savings/[id]/__tests__/route.test.ts
+++ b/app/api/v1/recurring-savings/[id]/__tests__/route.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// Guard for #686 — the recurring-saving half of the same bug. `PUT
+// { effective_from }` alone compared the new endpoint against null instead of
+// the stored `effective_to`, passed the route, and was refused by
+// `recurring_savings_check`; the catch-all called that "Recurring saving not
+// found" about a row that is right there.
+//
+// The merge rule is unit-tested in lib/__tests__/effectiveRange.test.ts. These
+// tests pin the wiring, and that the range read does not disturb the goal /
+// linked-deposit checks that already live in this route.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  stored: null as Record<string, unknown> | null,
+  updated: null as Record<string, unknown> | null,
+  updateError: null as { code?: string; message?: string } | null,
+  selects: [] as string[],
+  updates: [] as Record<string, unknown>[],
+}))
+
+vi.mock('@/lib/supabase-server', () => {
+  const chainFor = () => {
+    let payload: Record<string, unknown> | null = null
+    const chain: Record<string, unknown> = {
+      select: (columns?: string) => {
+        if (!payload) h.selects.push(columns ?? '')
+        return chain
+      },
+      eq: () => chain,
+      update: (values: Record<string, unknown>) => {
+        payload = values
+        return chain
+      },
+      single: async () => {
+        if (payload) {
+          h.updates.push(payload)
+          return { data: h.updated, error: h.updateError }
+        }
+        return { data: h.stored, error: h.stored ? null : { message: 'no rows' } }
+      },
+    }
+    return chain
+  }
+  return {
+    createSupabaseServerClient: async () => ({
+      auth: { getUser: async () => ({ data: { user: h.user } }) },
+      from: () => chainFor(),
+    }),
+  }
+})
+
+const { PUT } = await import('../route')
+
+const ID = '22222222-2222-4222-8222-222222222222'
+
+/** Reads issued before the write — the range pre-read is the one naming dates. */
+const rangeReads = () => h.selects.filter((columns) => columns.includes('effective_from'))
+
+const put = (body: unknown, id: string = ID) =>
+  PUT(
+    new Request(`https://app.test/api/v1/recurring-savings/${id}`, {
+      method: 'PUT',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    }) as unknown as NextRequest,
+    { params: Promise.resolve({ id }) },
+  )
+
+describe('PUT /api/v1/recurring-savings/[id] — effective range (#686)', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.stored = { effective_from: '2026-03-01', effective_to: '2026-06-01' }
+    h.updated = { saving_id: ID, name: 'Monthly deposit' }
+    h.updateError = null
+    h.selects = []
+    h.updates = []
+  })
+
+  it('rejects a from moved past the stored to', async () => {
+    const res = await put({ effective_from: '2026-07' })
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({
+      error: '"Active from" must be before "Active until".',
+    })
+    expect(h.updates).toEqual([])
+  })
+
+  it('rejects a to moved before the stored from', async () => {
+    const res = await put({ effective_to: '2026-02' })
+
+    expect(res.status).toBe(400)
+    expect(h.updates).toEqual([])
+  })
+
+  it('accepts a from that still lands on or before the stored to', async () => {
+    const res = await put({ effective_from: '2026-06' })
+
+    expect(res.status).toBe(200)
+    expect(h.updates[0]).toMatchObject({ effective_from: '2026-06-01' })
+  })
+
+  it('accepts a to that still lands on or after the stored from', async () => {
+    const res = await put({ effective_to: '2026-03' })
+
+    expect(res.status).toBe(200)
+    expect(h.updates[0]).toMatchObject({ effective_to: '2026-03-01' })
+  })
+
+  it('lets an endpoint be cleared without reading the row', async () => {
+    const res = await put({ effective_from: null })
+
+    expect(res.status).toBe(200)
+    expect(h.updates[0]).toMatchObject({ effective_from: null })
+    expect(rangeReads()).toEqual([])
+  })
+
+  it('judges a body carrying both endpoints without reading the row', async () => {
+    const res = await put({ effective_from: '2026-08', effective_to: '2026-07' })
+
+    expect(res.status).toBe(400)
+    expect(rangeReads()).toEqual([])
+    expect(h.updates).toEqual([])
+  })
+
+  it('reads nothing when the update leaves the range alone', async () => {
+    const res = await put({ name: 'Monthly deposit' })
+
+    expect(res.status).toBe(200)
+    expect(rangeReads()).toEqual([])
+  })
+
+  it('still answers 404 for a row that is missing or not the caller\'s', async () => {
+    h.stored = null
+    h.updated = null
+
+    const res = await put({ effective_from: '2026-07' })
+
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'Recurring saving not found' })
+  })
+
+  it('answers 400, not 404, when the table refuses the range under a race', async () => {
+    h.updated = null
+    h.updateError = {
+      code: '23514',
+      message: 'new row for relation "recurring_savings" violates check constraint "recurring_savings_check"',
+    }
+
+    const res = await put({ effective_from: '2026-05' })
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({
+      error: '"Active from" must be before "Active until".',
+    })
+  })
+
+  it('leaves the linked-deposit refusal path intact', async () => {
+    // A different write refusal on the same route still has to keep its own
+    // message — the range mapping must not swallow it.
+    h.updated = null
+    h.updateError = { message: 'closed deposit: cannot link' }
+
+    const res = await put({ effective_from: '2026-05' })
+
+    expect(res.status).toBe(400)
+    await expect(res.json()).resolves.toEqual({
+      error: 'That deposit has been closed — link a live deposit instead.',
+    })
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    h.user = null
+
+    const res = await put({ effective_from: '2026-07' })
+
+    expect(res.status).toBe(401)
+    expect(rangeReads()).toEqual([])
+  })
+
+  it('rejects a malformed month before any database work', async () => {
+    const res = await put({ effective_to: '2026-00' })
+
+    expect(res.status).toBe(400)
+    expect(rangeReads()).toEqual([])
+    expect(h.updates).toEqual([])
+  })
+})

--- a/app/api/v1/recurring-savings/[id]/route.ts
+++ b/app/api/v1/recurring-savings/[id]/route.ts
@@ -4,6 +4,14 @@ import { ValidationError, validateAmount, validateText, validateUUID, validateYe
 import { linkRefusalMessage, validateLinkedDeposit } from '../linkValidation'
 import { archivedGoalError, ownershipError } from '@/lib/assertOwned'
 import { readJsonBody } from '@/lib/apiBody'
+import {
+  INVERTED_RANGE_MESSAGE,
+  isRangeCheckViolation,
+  mergedRangeIsInverted,
+  needsStoredRange,
+  type RangePatch,
+  type StoredRange,
+} from '@/lib/effectiveRange'
 
 function toDateCol(ym: string | undefined | null): string | null {
   if (!ym) return null
@@ -52,10 +60,25 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
     throw e
   }
 
-  const fromDate = (updates.effective_from ?? null) as string | null
-  const toDate = (updates.effective_to ?? null) as string | null
-  if (fromDate && toDate && fromDate > toDate) {
-    return NextResponse.json({ error: '"Active from" must be before "Active until".' }, { status: 400 })
+  // Judge the range the table will see, not just the half the body carried: a
+  // partial update has to be compared with the endpoint already stored, or it
+  // sails past this check and is refused below as a 404 (#686).
+  const patch: RangePatch = {}
+  if ('effective_from' in body) patch.from = updates.effective_from as string | null
+  if ('effective_to' in body) patch.to = updates.effective_to as string | null
+
+  let storedRange: StoredRange = null
+  if (needsStoredRange(patch)) {
+    const { data } = await supabase
+      .from('recurring_savings')
+      .select('effective_from, effective_to')
+      .eq('saving_id', savingId)
+      .eq('user_id', user.id)
+      .single()
+    storedRange = data
+  }
+  if (mergedRangeIsInverted(patch, storedRange)) {
+    return NextResponse.json({ error: INVERTED_RANGE_MESSAGE }, { status: 400 })
   }
 
   // Same check the POST does. Without it, moving an existing saving onto a
@@ -115,6 +138,12 @@ export async function PUT(request: NextRequest, { params }: { params: Promise<{ 
   // that is right there.
   const refusal = linkRefusalMessage(error)
   if (refusal) return NextResponse.json({ error: refusal }, { status: 400 })
+  // A concurrent update can move the other endpoint between the read above and
+  // this write, and then the table refuses the range. Still a validation
+  // failure, so it must not fall through to the 404 below (#686).
+  if (isRangeCheckViolation(error)) {
+    return NextResponse.json({ error: INVERTED_RANGE_MESSAGE }, { status: 400 })
+  }
   if (error || !saving) return NextResponse.json({ error: 'Recurring saving not found' }, { status: 404 })
   return NextResponse.json(saving)
 }

--- a/app/api/v1/recurring-savings/route.ts
+++ b/app/api/v1/recurring-savings/route.ts
@@ -4,6 +4,7 @@ import { ValidationError, validateAmount, validatePlanMonthFilter, validateText,
 import { linkRefusalMessage, validateLinkedDeposit } from './linkValidation'
 import { archivedGoalError, ownershipError } from '@/lib/assertOwned'
 import { readJsonBody } from '@/lib/apiBody'
+import { INVERTED_RANGE_MESSAGE } from '@/lib/effectiveRange'
 
 function toDateCol(ym: string | undefined | null): string | null {
   if (!ym) return null
@@ -100,7 +101,7 @@ export async function POST(request: NextRequest) {
   const fromDate = toDateCol(cleanFromYm)
   const toDate = toDateCol(cleanToYm)
   if (fromDate && toDate && fromDate > toDate) {
-    return NextResponse.json({ error: '"Active from" must be before "Active until".' }, { status: 400 })
+    return NextResponse.json({ error: INVERTED_RANGE_MESSAGE }, { status: 400 })
   }
 
   // linked_deposit_tx_id was already ownership-checked by validateLinkedDeposit;

--- a/lib/__tests__/effectiveRange.test.ts
+++ b/lib/__tests__/effectiveRange.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import {
+  INVERTED_RANGE_MESSAGE,
+  isRangeCheckViolation,
+  mergedRangeIsInverted,
+  needsStoredRange,
+} from '../effectiveRange'
+
+// Guard for #686. `fixed_expenses` and `recurring_savings` both carry
+// CHECK (effective_from IS NULL OR effective_to IS NULL OR effective_from <= effective_to),
+// but the PUT routes validated only the fields the request happened to send. A
+// PUT of `{ effective_from }` alone compared the new endpoint against null
+// instead of the stored `effective_to`, sailed past the route check, and hit the
+// constraint — which the catch-all then reported as 404 "not found" about a row
+// that is right there.
+//
+// The merge decision is pure: given what the body supplies and what the row
+// stores, is the resulting range inverted? Testing it here rather than through
+// two near-identical route suites is what keeps both routes honest with one set
+// of cases.
+describe('needsStoredRange (#686)', () => {
+  it('needs no read when the body supplies both endpoints', () => {
+    // Both endpoints known → the resulting range is fully determined.
+    expect(needsStoredRange({ from: '2026-07-01', to: '2026-06-01' })).toBe(false)
+    expect(needsStoredRange({ from: null, to: null })).toBe(false)
+  })
+
+  it('needs no read when the body touches neither endpoint', () => {
+    expect(needsStoredRange({})).toBe(false)
+  })
+
+  it('needs no read when the supplied endpoint is being cleared', () => {
+    // Clearing can never invert a range: NULL disables the CHECK on that side.
+    expect(needsStoredRange({ from: null })).toBe(false)
+    expect(needsStoredRange({ to: null })).toBe(false)
+  })
+
+  it('needs the stored row when only one endpoint is set', () => {
+    expect(needsStoredRange({ from: '2026-07-01' })).toBe(true)
+    expect(needsStoredRange({ to: '2026-06-01' })).toBe(true)
+  })
+})
+
+describe('mergedRangeIsInverted (#686)', () => {
+  const stored = { effective_from: '2026-03-01', effective_to: '2026-06-01' }
+
+  it('rejects a from moved past the stored to', () => {
+    expect(mergedRangeIsInverted({ from: '2026-07-01' }, stored)).toBe(true)
+  })
+
+  it('rejects a to moved before the stored from', () => {
+    expect(mergedRangeIsInverted({ to: '2026-02-01' }, stored)).toBe(true)
+  })
+
+  it('accepts a from that still lands on or before the stored to', () => {
+    expect(mergedRangeIsInverted({ from: '2026-06-01' }, stored)).toBe(false)
+    expect(mergedRangeIsInverted({ from: '2026-05-01' }, stored)).toBe(false)
+  })
+
+  it('accepts a to that still lands on or after the stored from', () => {
+    expect(mergedRangeIsInverted({ to: '2026-03-01' }, stored)).toBe(false)
+    expect(mergedRangeIsInverted({ to: '2026-04-01' }, stored)).toBe(false)
+  })
+
+  it('accepts either endpoint against an open-ended stored row', () => {
+    const open = { effective_from: null, effective_to: null }
+    expect(mergedRangeIsInverted({ from: '2026-07-01' }, open)).toBe(false)
+    expect(mergedRangeIsInverted({ to: '2026-02-01' }, open)).toBe(false)
+  })
+
+  it('accepts clearing an endpoint however the stored row looks', () => {
+    expect(mergedRangeIsInverted({ from: null }, stored)).toBe(false)
+    expect(mergedRangeIsInverted({ to: null }, stored)).toBe(false)
+  })
+
+  it('judges a body that supplies both endpoints on its own, ignoring the row', () => {
+    // The full-update case the routes already handled — same answer, one helper.
+    expect(mergedRangeIsInverted({ from: '2026-08-01', to: '2026-07-01' }, stored)).toBe(true)
+    expect(mergedRangeIsInverted({ from: '2026-01-01', to: '2026-02-01' }, stored)).toBe(false)
+  })
+
+  it('treats an absent stored row as nothing to contradict', () => {
+    // Ownership/existence is the update statement's job; a missing row must not
+    // become a 400 here or a foreign id would answer differently from a
+    // nonexistent one.
+    expect(mergedRangeIsInverted({ from: '2026-07-01' }, null)).toBe(false)
+  })
+})
+
+describe('isRangeCheckViolation (#686)', () => {
+  it('recognises the constraint by name', () => {
+    // fixed_expenses names it; recurring_savings declares it inline, so Postgres
+    // generates recurring_savings_check.
+    expect(isRangeCheckViolation({ code: '23514', message: 'violates check constraint "effective_dates_order"' })).toBe(true)
+    expect(isRangeCheckViolation({ code: '23514', message: 'violates check constraint "recurring_savings_check"' })).toBe(true)
+  })
+
+  it('ignores other check violations', () => {
+    // amount_vnd > 0 is a different refusal with a different message.
+    expect(isRangeCheckViolation({ code: '23514', message: 'violates check constraint "recurring_savings_amount_vnd_check"' })).toBe(false)
+  })
+
+  it('ignores unrelated errors and no error at all', () => {
+    expect(isRangeCheckViolation({ code: '23503', message: 'foreign key' })).toBe(false)
+    expect(isRangeCheckViolation(null)).toBe(false)
+  })
+})
+
+describe('INVERTED_RANGE_MESSAGE (#686)', () => {
+  it('names both fields the way the form labels them', () => {
+    expect(INVERTED_RANGE_MESSAGE).toContain('Active from')
+    expect(INVERTED_RANGE_MESSAGE).toContain('Active until')
+  })
+})

--- a/lib/effectiveRange.ts
+++ b/lib/effectiveRange.ts
@@ -1,0 +1,66 @@
+// Effective-date range rules shared by the fixed-expense and recurring-saving
+// APIs (#686).
+//
+// Both tables carry the same guard —
+//   CHECK (effective_from IS NULL OR effective_to IS NULL OR effective_from <= effective_to)
+// — and both PUT routes used to check only the fields the request supplied. A
+// partial update therefore compared the new endpoint against `null` rather than
+// the endpoint already stored: `PUT { effective_from: '2026-07' }` on a row
+// ending 2026-06 passed the route and was refused by the table, and the
+// catch-all reported that refusal as 404 "not found" about a row that is right
+// there. Deciding this from (what the body supplies + what the row stores) is
+// pure, so it lives here and both routes ask the same questions.
+
+/** The endpoints a request supplies. A key is absent when the body omits it. */
+export type RangePatch = { from?: string | null; to?: string | null }
+
+/** The endpoints already stored, or null when there is no such row. */
+export type StoredRange = { effective_from: string | null; effective_to: string | null } | null
+
+export const INVERTED_RANGE_MESSAGE = '"Active from" must be before "Active until".'
+
+/**
+ * Does judging this patch require reading the row first?
+ *
+ * Only when exactly one endpoint is being *set*. Supplying both determines the
+ * resulting range on its own, and clearing an endpoint can never invert it —
+ * NULL disables the CHECK on that side — so neither case is worth a round trip.
+ */
+export function needsStoredRange(patch: RangePatch): boolean {
+  const setsFrom = 'from' in patch && patch.from != null
+  const setsTo = 'to' in patch && patch.to != null
+  if (setsFrom && setsTo) return false
+  return setsFrom || setsTo
+}
+
+/**
+ * Would applying this patch to that row leave `effective_from` after
+ * `effective_to`? Fields the body omits fall back to the stored value, which is
+ * the whole point: the merged row is what the table will see.
+ *
+ * A missing row is nothing to contradict — existence and ownership are the
+ * update statement's job, so a foreign id keeps answering 404 rather than 400.
+ */
+export function mergedRangeIsInverted(patch: RangePatch, stored: StoredRange): boolean {
+  const from = 'from' in patch ? patch.from ?? null : stored?.effective_from ?? null
+  const to = 'to' in patch ? patch.to ?? null : stored?.effective_to ?? null
+  return Boolean(from && to && from > to)
+}
+
+// `fixed_expenses` names the constraint; `recurring_savings` declares it inline
+// at table level, so Postgres generates `<table>_check`.
+const RANGE_CONSTRAINTS = ['effective_dates_order', 'recurring_savings_check']
+
+/**
+ * Is this write refusal the range CHECK?
+ *
+ * The read-then-write above can still be outrun by a concurrent update moving
+ * the other endpoint, and then the table is the one that says no. That refusal
+ * is a validation failure and must answer 400 — reported as 404 it reads as a
+ * missing row, the error-vs-not-found conflation of #532/#533.
+ */
+export function isRangeCheckViolation(error: { code?: string; message?: string } | null): boolean {
+  if (error?.code !== '23514') return false
+  const message = error.message ?? ''
+  return RANGE_CONSTRAINTS.some((name) => message.includes(`"${name}"`))
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -75,7 +75,7 @@ export default defineConfig({
 
         // The money math. These modules are the ones that have actually shipped
         // bugs, and they are fully covered today — hold them there.
-        'lib/{accumulating,bankWithdrawal,dates,depositValuation,finance,fundWithdrawal,goldWithdrawal,heldForMerge,maturity,mergeCluster,mergeEligibility,planning,recurringLink,snapshots,validation,withdrawalProgress}.ts':
+        'lib/{accumulating,bankWithdrawal,dates,depositValuation,effectiveRange,finance,fundWithdrawal,goldWithdrawal,heldForMerge,maturity,mergeCluster,mergeEligibility,planning,recurringLink,snapshots,validation,withdrawalProgress}.ts':
           { lines: 100, functions: 100, branches: 80 },
 
         // The server routes the audit flagged as thin. Floors sit just under


### PR DESCRIPTION
Closes #686.

## What was broken

Both PUT routes derived the effective range from the request body alone:

```ts
const fromDate = (updates.effective_from ?? null) as string | null
const toDate   = (updates.effective_to   ?? null) as string | null
if (fromDate && toDate && fromDate > toDate) → 400
```

So `PUT { effective_from: '2026-07' }` on a row ending `2026-06-01` compared the new endpoint against `null`, passed, and was refused by the table's CHECK — which the catch-all turned into `404 Expense not found` / `404 Recurring saving not found` about a row that is right there. The inverse partial update failed identically.

Verified against the running database rather than inferred from the migrations:

| Table | Constraint | Real error |
| :--- | :--- | :--- |
| `fixed_expenses` | `effective_dates_order` | `23514 … violates check constraint "effective_dates_order"` |
| `recurring_savings` | `recurring_savings_check` (inline, so Postgres names it) | `23514 … violates check constraint "recurring_savings_check"` |

## The fix

The merge decision is pure logic, so it lives in `lib/effectiveRange.ts` and both routes ask it the same questions:

- **`needsStoredRange(patch)`** — read the row only when exactly one endpoint is being *set*. Supplying both already determines the resulting range, and clearing one can never invert it (NULL disables the CHECK on that side), so neither case spends a round trip.
- **`mergedRangeIsInverted(patch, stored)`** — whatever the body omits falls back to the stored value, so what gets judged is the row the table will actually see. A missing row is nothing to contradict, which keeps existence/ownership the update statement's job.
- **`isRangeCheckViolation(error)`** — a concurrent update can move the other endpoint between the read and the write, and then the table is the one that refuses. That refusal now maps to 400 instead of falling through to 404 (the error-vs-not-found conflation of #532/#533).

Untouched: ownership, the archived-goal check, and the linked-deposit refusals — a foreign row still answers 404, and a closed-deposit link still says so in its own words (there is a test pinning that the range mapping doesn't swallow it).

The message the four call sites duplicated is now one exported constant.

## Tests

TDD, three red-first rounds:

| Suite | Red before the fix |
| :--- | :--- |
| `lib/__tests__/effectiveRange.test.ts` (16 tests) | module did not exist |
| `app/api/v1/fixed-expenses/[id]/__tests__/route.test.ts` (11) | **3 failed** — from-only, to-only, and the race |
| `app/api/v1/recurring-savings/[id]/__tests__/route.test.ts` (12) | **3 failed** — same three |

Route tests cover every partial-update case from the acceptance criteria: from-only, to-only, either endpoint cleared, both supplied, no range fields at all, missing/foreign row, the race, 401, and a malformed month. They also assert *where* the work happens — no write is issued on a 400, and no read is issued when the patch can't invert the range.

`lib/effectiveRange.ts` is added to the 100%-lines coverage ratchet in `vitest.config.ts` (measured 12/12 lines, 4/4 functions).

Verified locally:

- `npm run typecheck` ✅
- `npm test -- --run` — 211 files, 2579 tests ✅
- `npm run lint` — 0 errors (2 pre-existing unrelated warnings) ✅
- `npm run test:coverage` — thresholds pass ✅
- `npm run build` ✅
- `npx playwright test e2e/planning.spec.ts --project=chromium` — 3 passed ✅

No new E2E: this is route-level logic, and the layer that catches it is the unit/route test above.

## Reviewer note

The pre-read costs one extra indexed lookup on a single-endpoint update — skipped entirely when the body clears an endpoint, sends both, or touches neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)