### PR TITLE
fix(goals): delete a goal in one transaction, not four round trips (#687)

### DIFF
--- a/app/api/v1/savings-goals/[id]/__tests__/route.delete.test.ts
+++ b/app/api/v1/savings-goals/[id]/__tests__/route.delete.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// Guard for #687. The DELETE used to be four separate requests — count, check for
+// parked cash, clear dead merge targets, delete — with the errors of the first
+// and third dropped. Between the third and the fourth the cleanup could commit
+// while the delete failed, leaving consumed merge history stripped of the target
+// it recorded and the goal still there.
+//
+// The whole transition now happens inside delete_savings_goal, so what is left
+// to test here is the mapping: the route authenticates, validates, calls the RPC
+// once, and turns each refusal into the answer the user gets.
+
+const h = vi.hoisted(() => ({
+  user: { id: 'user-1' } as { id: string } | null,
+  rpcCalls: [] as { fn: string; args: unknown }[],
+  result: { data: null as unknown, error: null as { message?: string } | null },
+  tables: [] as string[],
+}))
+
+vi.mock('@/lib/supabase-server', () => ({
+  createSupabaseServerClient: async () => ({
+    auth: { getUser: async () => ({ data: { user: h.user } }) },
+    rpc: async (fn: string, args: unknown) => {
+      h.rpcCalls.push({ fn, args })
+      return h.result
+    },
+    // Any direct table work would be a step back outside the transaction.
+    from: (table: string) => {
+      h.tables.push(table)
+      throw new Error(`unexpected table access: ${table}`)
+    },
+  }),
+}))
+
+const { DELETE } = await import('../route')
+
+const ID = '33333333-3333-4333-8333-333333333333'
+
+const del = (id: string = ID) =>
+  DELETE(new Request(`https://app.test/api/v1/savings-goals/${id}`, { method: 'DELETE' }) as unknown as NextRequest, {
+    params: Promise.resolve({ id }),
+  })
+
+describe('DELETE /api/v1/savings-goals/[id] (#687)', () => {
+  beforeEach(() => {
+    h.user = { id: 'user-1' }
+    h.rpcCalls = []
+    h.tables = []
+    h.result = { data: { moved: 2 }, error: null }
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('does the whole delete in one RPC call, touching no table directly', () => {
+    return del().then(async (res) => {
+      expect(res.status).toBe(200)
+      expect(h.rpcCalls).toEqual([{ fn: 'delete_savings_goal', args: { p_goal_id: ID } }])
+      expect(h.tables).toEqual([])
+    })
+  })
+
+  it('reports the count the transaction itself produced', async () => {
+    const res = await del()
+
+    await expect(res.json()).resolves.toEqual({
+      message: 'Goal deleted. 2 transactions moved to Unassigned Investments.',
+    })
+  })
+
+  it('says "transaction" in the singular for exactly one', async () => {
+    h.result = { data: { moved: 1 }, error: null }
+
+    const res = await del()
+
+    await expect(res.json()).resolves.toEqual({
+      message: 'Goal deleted. 1 transaction moved to Unassigned Investments.',
+    })
+  })
+
+  it('handles a goal with nothing linked to it', async () => {
+    h.result = { data: { moved: 0 }, error: null }
+
+    const res = await del()
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({
+      message: 'Goal deleted. 0 transactions moved to Unassigned Investments.',
+    })
+  })
+
+  it('maps parked cash to 409 with the code the sheet acts on', async () => {
+    h.result = {
+      data: null,
+      error: { message: 'delete goal: this goal has cash parked in it for a merge (abc)' },
+    }
+
+    const res = await del()
+
+    expect(res.status).toBe(409)
+    await expect(res.json()).resolves.toEqual({
+      error: 'This goal has cash parked in it for a merge. Release that settlement before deleting the goal.',
+      code: 'held_settlement_parked',
+    })
+  })
+
+  it('maps a goal that is not there — or not the caller\'s — to 404', async () => {
+    // RLS scopes the RPC, so a foreign goal is invisible and answers exactly as a
+    // goal that never existed does. Nothing leaks.
+    h.result = { data: null, error: { message: 'delete goal: goal not found' } }
+
+    const res = await del()
+
+    expect(res.status).toBe(404)
+    await expect(res.json()).resolves.toEqual({ error: 'Goal not found' })
+  })
+
+  it('does not report an unexpected database failure as a missing goal', async () => {
+    // The old route answered 404 for every error, so a deadlock or a permission
+    // fault read as "that goal does not exist" — the error-vs-not-found
+    // conflation of #532/#533.
+    h.result = { data: null, error: { message: 'deadlock detected' } }
+
+    const res = await del()
+
+    expect(res.status).toBe(500)
+    await expect(res.json()).resolves.toEqual({ error: 'Failed to delete the goal' })
+  })
+
+  it('returns 401 without calling the RPC', async () => {
+    h.user = null
+
+    const res = await del()
+
+    expect(res.status).toBe(401)
+    expect(h.rpcCalls).toEqual([])
+  })
+
+  it('rejects a malformed id before any database work', async () => {
+    const res = await del('not-a-uuid')
+
+    expect(res.status).toBe(400)
+    expect(h.rpcCalls).toEqual([])
+  })
+})

--- a/app/api/v1/savings-goals/[id]/route.ts
+++ b/app/api/v1/savings-goals/[id]/route.ts
@@ -172,64 +172,40 @@ export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ 
   const { data: { user } } = await supabase.auth.getUser()
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
 
-  // Count linked transactions before delete (ON DELETE SET NULL handles the nulling)
-  const { count } = await supabase
-    .from('investment_transactions')
-    .select('*', { count: 'exact', head: true })
-    .eq('goal_id', goalId)
-    .eq('user_id', user.id)
+  // One statement, one transaction (#687). Counting the linked transactions,
+  // refusing parked cash, clearing the dead merge targets and removing the goal
+  // used to be four separate requests with nothing holding them together: the
+  // cleanup could commit while the delete failed, and consumed merge history
+  // would lose the target it recorded while the goal was still there. The
+  // function does all of it under the goal's lock; the route authenticates,
+  // validates, and maps the answer.
+  const { data, error } = await supabase.rpc('delete_savings_goal', { p_goal_id: goalId })
 
-  // Cash parked in this goal for a merge (#588). The database refuses the delete
-  // either way — merge_target_goal_id has no foreign key, so it would be left
-  // pointing at a goal that no longer exists — but it refuses through the #525
-  // ownership trigger, whose message is about a goal reference, not about a
-  // settlement. Asking first is what turns that into an answer the user can act
-  // on: 404 "Goal not found" describes the wrong thing entirely, since the goal is
-  // very much there.
-  const { data: parked } = await supabase
-    .from('investment_transactions')
-    .select('transaction_id')
-    .eq('user_id', user.id)
-    .eq('held_for_merge', true)
-    .is('consumed_by_inv_id', null)
-    .or(`merge_target_goal_id.eq.${goalId},goal_id.eq.${goalId}`)
-    .limit(1)
-    .maybeSingle()
-
-  if (parked) {
-    return NextResponse.json(
-      {
-        error: 'This goal has cash parked in it for a merge. Release that settlement before deleting the goal.',
-        code: 'held_settlement_parked',
-      },
-      { status: 409 },
-    )
+  if (error) {
+    const message = error.message ?? ''
+    // Cash earmarked to this goal for a merge. The remedy is in the message
+    // because the database's own refusal talks about a goal reference, not about
+    // a settlement — "Bỏ chờ gộp" releases it, then the goal deletes (#588).
+    if (message.startsWith('delete goal: this goal has cash parked')) {
+      return NextResponse.json(
+        {
+          error: 'This goal has cash parked in it for a merge. Release that settlement before deleting the goal.',
+          code: 'held_settlement_parked',
+        },
+        { status: 409 },
+      )
+    }
+    if (message.startsWith('delete goal: goal not found')) {
+      return NextResponse.json({ error: 'Goal not found' }, { status: 404 })
+    }
+    // Anything else is a fault, not a missing goal. Answering 404 for it is the
+    // error-vs-not-found conflation of #532/#533 — it sends the user looking for
+    // a goal that is sitting right there.
+    console.error('delete_savings_goal failed', message)
+    return NextResponse.json({ error: 'Failed to delete the goal' }, { status: 500 })
   }
 
-  // Settlements whose merge is already DONE are history, and the goal should not
-  // be stuck behind them — but merge_target_goal_id has no foreign key, so the
-  // deletion leaves it pointing at nothing and the #525 ownership trigger then
-  // refuses the very update the deletion depends on. Adding the missing FK does
-  // not help: goal_id and merge_target_goal_id are separate referential actions on
-  // the same row, and whichever runs first leaves the other dangling. Clearing it
-  // here is deterministic. Safe because the pool skips consumed rows entirely —
-  // for them the target is dead metadata.
-  await supabase
-    .from('investment_transactions')
-    .update({ merge_target_goal_id: null })
-    .eq('user_id', user.id)
-    .eq('held_for_merge', true)
-    .not('consumed_by_inv_id', 'is', null)
-    .eq('merge_target_goal_id', goalId)
-
-  const { error } = await supabase
-    .from('savings_goals')
-    .delete()
-    .eq('goal_id', goalId)
-    .eq('user_id', user.id)
-
-  if (error) return NextResponse.json({ error: 'Goal not found' }, { status: 404 })
-  const n = count ?? 0
+  const n = (data as { moved?: number } | null)?.moved ?? 0
   const txWord = n === 1 ? 'transaction' : 'transactions'
   return NextResponse.json({ message: `Goal deleted. ${n} ${txWord} moved to Unassigned Investments.` })
 }

--- a/supabase/migrations/20260819000001_delete_savings_goal.sql
+++ b/supabase/migrations/20260819000001_delete_savings_goal.sql
@@ -122,7 +122,6 @@ declare
   v_new uuid;
   v_old uuid;
   v_completed timestamptz;
-  v_found boolean;
 begin
   execute format('select ($1).%I', v_col) into v_new using new;
   if v_new is null then return new; end if;
@@ -139,11 +138,14 @@ begin
   -- goal for the whole liquidation, and delete_savings_goal holds it for the
   -- whole deletion; a plain EXISTS does not participate in either lock. The row
   -- read once the lock is granted is the post-finish, post-delete version.
-  select true, g.completed_at into v_found, v_completed
+  select g.completed_at into v_completed
     from public.savings_goals g
    where g.goal_id = v_new
      for share;
-  if not v_found then
+  -- FOUND, not a flag selected into a variable. `select true into v_found` leaves
+  -- v_found NULL when there is no row, and `if not null` takes the ELSE branch —
+  -- so the guard below would never fire in the one case it exists for.
+  if not found then
     raise exception 'deleted goal: this goal no longer exists'
       using errcode = 'foreign_key_violation';
   end if;

--- a/supabase/migrations/20260819000001_delete_savings_goal.sql
+++ b/supabase/migrations/20260819000001_delete_savings_goal.sql
@@ -1,0 +1,159 @@
+-- Deleting a goal, as one transaction instead of four round trips (#687).
+--
+-- The DELETE route used to do this transition a statement at a time: count the
+-- linked transactions, look for cash parked for a merge, clear the dead
+-- merge_target_goal_id on settlements already consumed, then delete the goal —
+-- with the errors of the first and third dropped. supabase-js has no
+-- transaction, so between the third and the fourth there is a window nothing
+-- closes: the cleanup commits, the delete fails, and consumed merge history has
+-- lost the target it recorded while the goal it pointed at is still there. The
+-- count could also describe a ledger the delete never saw.
+--
+-- ─── why a function and not a trigger ────────────────────────────────────────
+--
+-- 20260731000001 records why there is deliberately no trigger on savings_goals:
+-- BEFORE DELETE also aborts `delete from auth.users`, where the settlement is
+-- going away too and there is nothing left to protect, and an AFTER DELETE
+-- deferred trigger never runs because the immediate one has already refused the
+-- statement. That reasoning still holds — this function does not add one. It
+-- moves the steps the ROUTE was already doing into the transaction they always
+-- belonged in, and leaves every table trigger exactly where it is:
+-- ON DELETE SET NULL still moves the transactions to Unassigned, and the #525
+-- ownership trigger still has the last word on any reference left dangling.
+create or replace function public.delete_savings_goal(p_goal_id uuid)
+returns jsonb
+language plpgsql
+security invoker
+set search_path = ''
+as $$
+declare
+  v_goal public.savings_goals;
+  v_moved int;
+  v_parked uuid;
+begin
+  -- Security invoker, so RLS decides what this can see: another user's goal is
+  -- simply not there, and answers exactly as a goal that never existed does.
+  --
+  -- FOR UPDATE is also the serialization point. enforce_goal_not_completed takes
+  -- FOR SHARE on the goal before any row may point at it (20260813000002), so a
+  -- settlement being parked against this goal right now either lands first — and
+  -- the blocker check below sees it — or waits here and then finds the goal gone.
+  select * into v_goal from public.savings_goals
+   where goal_id = p_goal_id
+   for update;
+  if not found then
+    raise exception 'delete goal: goal not found' using errcode = 'no_data_found';
+  end if;
+
+  -- Cash parked in this goal for a merge (#588). The database refuses the delete
+  -- either way — merge_target_goal_id has no foreign key, so it would be left
+  -- pointing at a goal that no longer exists, and the #525 ownership trigger
+  -- refuses that — but it refuses with a message about a goal reference, not
+  -- about a settlement. Asking here is what turns that into something the user
+  -- can act on: release the settlement, then the goal deletes.
+  select t.transaction_id into v_parked
+    from public.investment_transactions t
+   where t.user_id = v_goal.user_id
+     and t.held_for_merge
+     and t.consumed_by_inv_id is null
+     and (t.merge_target_goal_id = p_goal_id or t.goal_id = p_goal_id)
+   limit 1;
+  if v_parked is not null then
+    raise exception 'delete goal: this goal has cash parked in it for a merge (%)', v_parked
+      using errcode = 'check_violation';
+  end if;
+
+  -- Counted here, under the same lock that performs the delete, so the number the
+  -- user is told is the number that moved.
+  select count(*) into v_moved
+    from public.investment_transactions t
+   where t.user_id = v_goal.user_id
+     and t.goal_id = p_goal_id;
+
+  -- Settlements whose merge is already DONE are history, and the goal should not
+  -- be stuck behind them. merge_target_goal_id has no foreign key, so the deletion
+  -- would leave it pointing at nothing and the #525 ownership trigger would then
+  -- refuse the very referential update the deletion depends on — which made a goal
+  -- that had ever completed a held merge permanently undeletable. Adding the
+  -- missing FK does not help: goal_id and merge_target_goal_id are two separate
+  -- referential actions on the same row, and whichever runs first leaves the other
+  -- dangling. Clearing it is deterministic, and safe because the pool skips
+  -- consumed rows entirely — for them the target is dead metadata.
+  update public.investment_transactions
+     set merge_target_goal_id = null
+   where user_id = v_goal.user_id
+     and held_for_merge
+     and consumed_by_inv_id is not null
+     and merge_target_goal_id = p_goal_id;
+
+  delete from public.savings_goals where goal_id = p_goal_id;
+
+  return jsonb_build_object('moved', v_moved);
+end;
+$$;
+
+comment on function public.delete_savings_goal(uuid) is
+  'Deletes a goal and the dead merge targets that would block it, in one transaction, returning how many transactions moved to Unassigned (#687).';
+
+revoke all on function public.delete_savings_goal(uuid) from public;
+grant execute on function public.delete_savings_goal(uuid) to authenticated;
+
+-- ─── a reference to a goal that is GONE is refused here too ──────────────────
+--
+-- enforce_goal_not_completed already reads the goal FOR SHARE so a write cannot
+-- slip under a finish that is holding FOR UPDATE. The same read answered nothing
+-- at all when the goal row was absent: `v_completed` stayed null and the trigger
+-- waved the row through.
+--
+-- For goal_id that is harmless — a real foreign key refuses it a moment later.
+-- merge_target_goal_id has no foreign key, and its only other guard, the #525
+-- ownership trigger, reads without a lock: against a delete committing right
+-- beside it, that read sees the goal as still present, passes, and the row
+-- commits pointing at nothing. Under the delete's FOR UPDATE this read is the one
+-- that waits, so it is the one that can tell — and now does.
+create or replace function public.enforce_goal_not_completed()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_col text := tg_argv[0];
+  v_new uuid;
+  v_old uuid;
+  v_completed timestamptz;
+  v_found boolean;
+begin
+  execute format('select ($1).%I', v_col) into v_new using new;
+  if v_new is null then return new; end if;
+  -- An unchanged reference is nothing new to check — EXCEPT where the trigger is
+  -- armed as 'recheck', which is how a fund asks about a goal it has pointed at
+  -- all along. Switching DCA back on writes is_dca and the amount and leaves
+  -- dca_goal_id exactly as it was, so short-circuiting on it would wave through
+  -- a plan aimed at an archive.
+  if tg_op = 'UPDATE' and coalesce(tg_argv[1], '') <> 'recheck' then
+    execute format('select ($1).%I', v_col) into v_old using old;
+    if v_old is not distinct from v_new then return new; end if;
+  end if;
+  -- FOR SHARE, not a plain read. finish_savings_goal holds FOR UPDATE on the
+  -- goal for the whole liquidation, and delete_savings_goal holds it for the
+  -- whole deletion; a plain EXISTS does not participate in either lock. The row
+  -- read once the lock is granted is the post-finish, post-delete version.
+  select true, g.completed_at into v_found, v_completed
+    from public.savings_goals g
+   where g.goal_id = v_new
+     for share;
+  if not v_found then
+    raise exception 'deleted goal: this goal no longer exists'
+      using errcode = 'foreign_key_violation';
+  end if;
+  if v_completed is not null then
+    raise exception 'completed goal: this goal has been finished, so it takes no new money — reopen it first'
+      using errcode = 'check_violation';
+  end if;
+  return new;
+end;
+$$;
+
+comment on function public.enforce_goal_not_completed() is
+  'Refuses to point a new holding, recurring saving or DCA plan at an archived goal, or at one deleted out from under the write (#650, #687). The reference column is tg_argv[0].';

--- a/supabase/tests/delete_savings_goal.test.sql
+++ b/supabase/tests/delete_savings_goal.test.sql
@@ -1,0 +1,281 @@
+-- Deleting a goal is one transaction, not four round trips (#687).
+--
+-- The route used to count linked transactions, look for parked cash, clear the
+-- dead merge targets and delete the goal as four separate statements, ignoring
+-- the errors of the first and third. Between the third and the fourth there is a
+-- window: the cleanup commits, the delete fails, and consumed merge history has
+-- lost the target it recorded while the goal it pointed at is still there.
+--
+-- delete_savings_goal does the whole transition under the goal's lock, so every
+-- one of those steps either lands together or not at all.
+--
+-- Run via `npm run test:db` after migrations are applied.
+begin;
+
+do $$
+declare
+  v_user uuid := gen_random_uuid();
+  v_other uuid := gen_random_uuid();
+  v_goal uuid;
+  v_goal2 uuid;
+  v_goal3 uuid;
+  v_other_goal uuid;
+  v_src uuid;
+  v_anchor uuid;
+  v_settlement uuid;
+  v_kept uuid;
+  v_result jsonb;
+  v_target uuid;
+  v_left int;
+  v_msg text;
+begin
+  insert into auth.users (id, email) values (v_user, 'delete-goal@test.invalid');
+  insert into auth.users (id, email) values (v_other, 'delete-goal-other@test.invalid');
+
+  -- ── 1) the happy path: the goal goes, its transactions stay ────────────────
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Kitchen')
+    returning goal_id into v_goal;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 10000000);
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'gold', 'investment', '2026-01-02', 8000000);
+  -- Unassigned already, and another user's row: neither may be counted.
+  insert into public.investment_transactions
+    (user_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, 'bank', 'investment', '2026-01-03', 1000000)
+    returning transaction_id into v_kept;
+  insert into public.savings_goals (user_id, goal_name) values (v_other, 'Theirs')
+    returning goal_id into v_other_goal;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_other, v_other_goal, 'bank', 'investment', '2026-01-04', 5000000);
+
+  v_result := public.delete_savings_goal(v_goal);
+
+  -- The count is produced inside the transaction that did the delete, so it
+  -- cannot describe a ledger that has since moved.
+  if (v_result ->> 'moved')::int is distinct from 2 then
+    raise exception 'expected 2 moved transactions, got %', v_result;
+  end if;
+  if exists (select 1 from public.savings_goals where goal_id = v_goal) then
+    raise exception 'the goal must be gone';
+  end if;
+  -- ON DELETE SET NULL moved them to Unassigned; nothing was deleted.
+  select count(*) into v_left from public.investment_transactions
+   where user_id = v_user and goal_id is null;
+  if v_left <> 3 then
+    raise exception 'expected 3 unassigned transactions, got %', v_left;
+  end if;
+  if not exists (select 1 from public.investment_transactions
+                  where user_id = v_other and goal_id = v_other_goal) then
+    raise exception 'another user''s transactions must be untouched';
+  end if;
+
+  -- ── 2) a CONSUMED settlement's dead target is cleared, and the goal goes ───
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Car')
+    returning goal_id into v_goal2;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal2, 'bank', 'investment', '2026-02-01', 50000000)
+    returning transaction_id into v_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal2, 'bank', 'investment', '2026-02-02', 20000000)
+    returning transaction_id into v_anchor;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, held_for_merge, merge_target_goal_id)
+  values (v_user, v_goal2, 'bank', 'withdrawal', '2026-03-01', 50000000,
+          v_src, 50000000, true, v_goal2)
+    returning transaction_id into v_settlement;
+  -- Merged already: the pool skips consumed rows, so its target is dead metadata.
+  update public.investment_transactions
+     set consumed_by_inv_id = v_anchor where transaction_id = v_settlement;
+
+  v_result := public.delete_savings_goal(v_goal2);
+
+  if exists (select 1 from public.savings_goals where goal_id = v_goal2) then
+    raise exception 'a goal whose merges are all consumed must delete';
+  end if;
+  select merge_target_goal_id into v_target from public.investment_transactions
+   where transaction_id = v_settlement;
+  if v_target is not null then
+    raise exception 'a consumed settlement''s dead target must be cleared, got %', v_target;
+  end if;
+  -- History itself survives — only the pointer went.
+  if not exists (select 1 from public.investment_transactions
+                  where transaction_id = v_settlement and held_for_merge) then
+    raise exception 'the settlement row itself must survive';
+  end if;
+
+  -- ── 3) parked cash refuses the delete — and rolls back the cleanup with it ─
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Trip')
+    returning goal_id into v_goal3;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal3, 'bank', 'investment', '2026-04-01', 30000000)
+    returning transaction_id into v_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal3, 'bank', 'investment', '2026-04-02', 10000000)
+    returning transaction_id into v_anchor;
+  -- One already merged (its target would be cleared) …
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, held_for_merge, merge_target_goal_id)
+  values (v_user, v_goal3, 'bank', 'withdrawal', '2026-05-01', 30000000,
+          v_src, 30000000, true, v_goal3)
+    returning transaction_id into v_settlement;
+  update public.investment_transactions
+     set consumed_by_inv_id = v_anchor where transaction_id = v_settlement;
+  -- … and one still parked, which is what refuses the delete.
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal3, 'bank', 'investment', '2026-04-03', 15000000)
+    returning transaction_id into v_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, held_for_merge, merge_target_goal_id)
+  values (v_user, v_goal3, 'bank', 'withdrawal', '2026-05-02', 15000000,
+          v_src, 15000000, true, v_goal3);
+
+  begin
+    v_result := public.delete_savings_goal(v_goal3);
+    raise exception 'parked cash must refuse the delete';
+  exception when check_violation then
+    v_msg := sqlerrm;
+  end;
+  if v_msg not like 'delete goal: %parked%' then
+    raise exception 'the refusal must name the parked settlement, got %', v_msg;
+  end if;
+  if not exists (select 1 from public.savings_goals where goal_id = v_goal3) then
+    raise exception 'a refused delete must leave the goal in place';
+  end if;
+  -- The point of the whole issue: the cleanup must not survive the refusal.
+  select merge_target_goal_id into v_target from public.investment_transactions
+   where transaction_id = v_settlement;
+  if v_target is distinct from v_goal3 then
+    raise exception 'a refused delete must roll its cleanup back, target is %', v_target;
+  end if;
+
+  -- ── 4) a goal that isn't there is distinctly not-found ─────────────────────
+  begin
+    v_result := public.delete_savings_goal(gen_random_uuid());
+    raise exception 'a missing goal must not report success';
+  exception when no_data_found then
+    v_msg := sqlerrm;
+  end;
+  if v_msg not like 'delete goal: goal not found%' then
+    raise exception 'expected a not-found refusal, got %', v_msg;
+  end if;
+
+  raise notice 'delete_savings_goal: single-session cases pass';
+end;
+$$;
+
+-- ── 5) ownership: another signed-in user cannot delete this goal ─────────────
+--
+-- The function is security invoker, so RLS is what scopes it. As `authenticated`
+-- with someone else's sub, the goal is simply not visible — the same answer a
+-- goal that never existed gets, which is the answer that leaks nothing.
+do $$
+declare
+  v_owner uuid := gen_random_uuid();
+  v_intruder uuid := gen_random_uuid();
+  v_goal uuid;
+  v_msg text;
+begin
+  insert into auth.users (id, email) values (v_owner, 'delete-goal-owner@test.invalid');
+  insert into auth.users (id, email) values (v_intruder, 'delete-goal-intruder@test.invalid');
+  insert into public.savings_goals (user_id, goal_name) values (v_owner, 'Mine')
+    returning goal_id into v_goal;
+
+  perform set_config('request.jwt.claims', json_build_object('sub', v_intruder::text)::text, true);
+  begin
+    set local role authenticated;
+    begin
+      perform public.delete_savings_goal(v_goal);
+      raise exception 'a foreign goal must not be deletable';
+    exception when no_data_found then
+      v_msg := sqlerrm;
+    end;
+  end;
+  reset role;
+  perform set_config('request.jwt.claims', '', true);
+
+  if v_msg not like 'delete goal: goal not found%' then
+    raise exception 'expected not-found for a foreign goal, got %', v_msg;
+  end if;
+  if not exists (select 1 from public.savings_goals where goal_id = v_goal) then
+    raise exception 'the owner''s goal must survive';
+  end if;
+
+  raise notice 'delete_savings_goal: ownership pass';
+end;
+$$;
+
+-- ── 6) the real path: the OWNER deletes, as `authenticated`, under RLS ───────
+--
+-- Every case above ran as postgres, where RLS is off. That proves the logic and
+-- not the grants, and the route runs as `authenticated`: the function has to be
+-- able to read the count, clear the consumed settlement's dead target and delete
+-- the goal through the policies, or this works everywhere except production.
+do $$
+declare
+  v_user uuid := gen_random_uuid();
+  v_goal uuid;
+  v_src uuid;
+  v_anchor uuid;
+  v_settlement uuid;
+  v_result jsonb;
+  v_target uuid;
+begin
+  insert into auth.users (id, email) values (v_user, 'delete-goal-rls@test.invalid');
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'Boat')
+    returning goal_id into v_goal;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 40000000)
+    returning transaction_id into v_src;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-02', 10000000)
+    returning transaction_id into v_anchor;
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+     parent_transaction_id, principal_withdrawn, held_for_merge, merge_target_goal_id)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-03-01', 40000000,
+          v_src, 40000000, true, v_goal)
+    returning transaction_id into v_settlement;
+  update public.investment_transactions
+     set consumed_by_inv_id = v_anchor where transaction_id = v_settlement;
+
+  perform set_config('request.jwt.claims', json_build_object('sub', v_user::text)::text, true);
+  begin
+    set local role authenticated;
+    v_result := public.delete_savings_goal(v_goal);
+  end;
+  reset role;
+  perform set_config('request.jwt.claims', '', true);
+
+  -- Three transactions carried this goal: the deposit, the anchor and the
+  -- settlement. All three move to Unassigned.
+  if (v_result ->> 'moved')::int is distinct from 3 then
+    raise exception 'expected 3 moved transactions under RLS, got %', v_result;
+  end if;
+  if exists (select 1 from public.savings_goals where goal_id = v_goal) then
+    raise exception 'the owner''s delete must remove the goal';
+  end if;
+  select merge_target_goal_id into v_target from public.investment_transactions
+   where transaction_id = v_settlement;
+  if v_target is not null then
+    raise exception 'the cleanup must reach the settlement under RLS too, got %', v_target;
+  end if;
+
+  raise notice 'delete_savings_goal: authenticated owner pass';
+end;
+$$;
+
+rollback;

--- a/supabase/tests/delete_savings_goal_race.test.sql
+++ b/supabase/tests/delete_savings_goal_race.test.sql
@@ -123,13 +123,23 @@ begin
   raise notice 'delete_savings_goal race: pass';
 
 exception when others then
-  -- Clean up through a connection of this block's own: a delete issued here would
-  -- roll back with the block that failed.
-  perform dblink_connect('goal687_cleanup', v_conn);
-  perform dblink_exec('goal687_cleanup', format('delete from auth.users where id = %L', c_user));
-  perform dblink_disconnect('goal687_cleanup');
+  -- Drop the worker sessions FIRST. An assertion that fails between the
+  -- deleter's `begin` and its `commit` leaves that session holding the goal, the
+  -- user row and the transactions it has already deleted — and the cleanup below
+  -- would queue behind those locks forever, hanging the DB suite instead of
+  -- reporting the failure that got us here. Disconnecting rolls their open
+  -- transactions back and releases everything (measured: the same delete goes
+  -- from a lock timeout to succeeding).
   begin perform dblink_disconnect('goal687_deleter'); exception when others then null; end;
   begin perform dblink_disconnect('goal687_parker'); exception when others then null; end;
+  -- Then clean up through a connection of this block's own: a delete issued here
+  -- would roll back with the block that failed.
+  perform dblink_connect('goal687_cleanup', v_conn);
+  -- Belt and braces. If anything still holds a lock on the fixture, say so
+  -- instead of hanging — a stuck DB job reads as infrastructure, not as this bug.
+  perform dblink_exec('goal687_cleanup', 'set lock_timeout = ''10s''');
+  perform dblink_exec('goal687_cleanup', format('delete from auth.users where id = %L', c_user));
+  perform dblink_disconnect('goal687_cleanup');
   raise;
 end;
 $$;

--- a/supabase/tests/delete_savings_goal_race.test.sql
+++ b/supabase/tests/delete_savings_goal_race.test.sql
@@ -1,0 +1,138 @@
+-- A settlement cannot be parked into a goal while that goal is being deleted (#687).
+--
+-- The old route asked "is there cash parked here?" in one request and issued the
+-- delete in another, holding nothing in between. Cash parked into the goal in
+-- that window landed against a goal the next statement removed — the preflight
+-- had already said yes.
+--
+-- delete_savings_goal takes the goal FOR UPDATE before it asks, and holds it
+-- through the delete. enforce_goal_not_completed reads the goal FOR SHARE before
+-- any row may point at it, so the parking write has to wait — and what it finds
+-- when the lock is granted is a goal that is gone.
+--
+-- ─── Why this file does not roll back ────────────────────────────────────────
+--
+-- It needs TWO sessions that see each other's committed work, so the fixture has
+-- to be committed. dblink supplies the connections and the block cleans up after
+-- itself. Same shape as deposit_book_lock_order.test.sql.
+--
+-- Run via `npm run test:db` after migrations are applied.
+
+create extension if not exists dblink;
+
+-- A leftover from a crashed earlier run would have this run read rows it never
+-- wrote. Fixed id, cleared first.
+delete from auth.users where id = '68768768-7687-4687-8687-687687687687';
+
+do $$
+declare
+  c_user  constant uuid := '68768768-7687-4687-8687-687687687687';
+  c_src   constant uuid := '68768768-7687-4687-8687-000000000001';
+  v_goal  uuid;
+  v_conn  text;
+  v_busy  int;
+  v_moved int;
+  v_left  int;
+  v_err   text := null;
+begin
+  v_conn := format('host=%s port=%s dbname=%s user=postgres password=postgres',
+                   inet_server_addr(), current_setting('port'), current_database());
+
+  perform dblink_connect('goal687_deleter', v_conn);
+  perform dblink_connect('goal687_parker', v_conn);
+
+  -- ── the fixture, committed so both sessions can see it ────────────────────
+  perform dblink_exec('goal687_deleter', format($f$
+    insert into auth.users (id, email) values (%L, 'delete-goal-race@test.invalid');
+  $f$, c_user));
+
+  select id into v_goal from dblink('goal687_deleter', format($f$
+    insert into public.savings_goals (user_id, goal_name) values (%L, 'Trip') returning goal_id;
+  $f$, c_user)) as t(id uuid);
+
+  -- The deposit a settlement would close. Live and unparked, so the delete's
+  -- blocker check finds nothing and gets all the way to the delete.
+  perform dblink_exec('goal687_deleter', format($f$
+    insert into public.investment_transactions
+      (transaction_id, user_id, goal_id, asset_type, transaction_type,
+       investment_date, amount_vnd, interest_rate, expiry_date)
+    values (%L, %L, %L, 'bank', 'investment', '2026-01-01', 30000000, 5.5, '2027-01-01');
+  $f$, c_src, c_user, v_goal));
+
+  -- ── the race ──────────────────────────────────────────────────────────────
+  -- The delete runs and holds its lock, uncommitted.
+  perform dblink_exec('goal687_deleter', 'begin');
+  perform * from dblink('goal687_deleter', format($f$
+    select public.delete_savings_goal(%L);
+  $f$, v_goal)) as t(result jsonb);
+
+  -- Cash parked into that same goal, from another session. Asynchronous because
+  -- it must wait: this is the write that used to slip through the window.
+  perform dblink_send_query('goal687_parker', format($f$
+    insert into public.investment_transactions
+      (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd,
+       parent_transaction_id, principal_withdrawn, held_for_merge, merge_target_goal_id)
+    values (%L, %L, 'bank', 'withdrawal', '2026-06-01', 30000000, %L, 30000000, true, %L)
+    returning transaction_id;
+  $f$, c_user, v_goal, c_src, v_goal));
+
+  -- Long enough for it to reach the lock and queue behind the delete.
+  perform pg_sleep(1);
+
+  -- The assertion that matters: it is WAITING, not committing. Before the lock
+  -- was held across the check and the delete, this write would already be done.
+  v_busy := dblink_is_busy('goal687_parker');
+  if v_busy <> 1 then
+    raise exception 'parking cash must wait for the delete that is holding the goal';
+  end if;
+
+  perform dblink_exec('goal687_deleter', 'commit');
+
+  -- Released now — and refused, because the goal it named is gone.
+  begin
+    perform * from dblink_get_result('goal687_parker') as t(id uuid);
+  exception when others then
+    v_err := sqlerrm;
+  end;
+  -- Drain the trailing empty result so the connection is reusable.
+  perform * from dblink_get_result('goal687_parker') as t(id uuid);
+
+  if v_err is null then
+    raise exception 'parking cash into a deleted goal must be refused, it succeeded';
+  end if;
+
+  perform dblink_disconnect('goal687_deleter');
+  perform dblink_disconnect('goal687_parker');
+
+  -- ── and the ledger says the same thing ────────────────────────────────────
+  if exists (select 1 from public.savings_goals where goal_id = v_goal) then
+    raise exception 'the goal should have been deleted';
+  end if;
+  select count(*) into v_left from public.investment_transactions
+   where user_id = c_user and held_for_merge;
+  if v_left <> 0 then
+    raise exception 'no settlement may survive against a deleted goal, found %', v_left;
+  end if;
+  -- The deposit itself is still there, moved to Unassigned.
+  select count(*) into v_moved from public.investment_transactions
+   where user_id = c_user and goal_id is null;
+  if v_moved <> 1 then
+    raise exception 'the deposit should have moved to Unassigned, got % row(s)', v_moved;
+  end if;
+
+  raise notice 'delete_savings_goal race: pass';
+
+exception when others then
+  -- Clean up through a connection of this block's own: a delete issued here would
+  -- roll back with the block that failed.
+  perform dblink_connect('goal687_cleanup', v_conn);
+  perform dblink_exec('goal687_cleanup', format('delete from auth.users where id = %L', c_user));
+  perform dblink_disconnect('goal687_cleanup');
+  begin perform dblink_disconnect('goal687_deleter'); exception when others then null; end;
+  begin perform dblink_disconnect('goal687_parker'); exception when others then null; end;
+  raise;
+end;
+$$;
+
+-- The fixture was committed, so it has to be removed explicitly.
+delete from auth.users where id = '68768768-7687-4687-8687-687687687687';

--- a/supabase/tests/delete_savings_goal_race.test.sql
+++ b/supabase/tests/delete_savings_goal_race.test.sql
@@ -146,3 +146,137 @@ $$;
 
 -- The fixture was committed, so it has to be removed explicitly.
 delete from auth.users where id = '68768768-7687-4687-8687-687687687687';
+
+-- ── a reference that no foreign key covers ───────────────────────────────────
+--
+-- The case above is caught twice over: the parked row also carries goal_id, and
+-- that column has a real foreign key. merge_target_goal_id has none, and its only
+-- other guard — the #525 ownership trigger — reads without a lock, so against a
+-- delete committing beside it that read sees the goal as still present and waves
+-- the row through. (Trigger order puts the ownership check first, so in every
+-- non-racing case it is the one that answers.)
+--
+-- A CONSUMED settlement is where this bites: the held-shape constraint only ties
+-- merge_target_goal_id to goal_id while the settlement is unconsumed, so a
+-- consumed row can be re-pointed at any goal on its own. Nothing but
+-- enforce_goal_not_completed holds a lock when that happens.
+delete from auth.users where id = '68768768-7687-4687-8687-687687687688';
+
+do $$
+declare
+  c_user   constant uuid := '68768768-7687-4687-8687-687687687688';
+  c_src    constant uuid := '68768768-7687-4687-8687-000000000011';
+  c_anchor constant uuid := '68768768-7687-4687-8687-000000000012';
+  c_held   constant uuid := '68768768-7687-4687-8687-000000000013';
+  v_doomed uuid;
+  v_keeper uuid;
+  v_conn   text;
+  v_busy   int;
+  v_target uuid;
+  v_err    text := null;
+begin
+  v_conn := format('host=%s port=%s dbname=%s user=postgres password=postgres',
+                   inet_server_addr(), current_setting('port'), current_database());
+
+  perform dblink_connect('goal687b_deleter', v_conn);
+  perform dblink_connect('goal687b_pointer', v_conn);
+
+  perform dblink_exec('goal687b_deleter', format($f$
+    insert into auth.users (id, email) values (%L, 'delete-goal-race-b@test.invalid');
+  $f$, c_user));
+
+  -- The goal about to be deleted, and a second goal that holds the settlement —
+  -- so nothing the pointer writes touches goal_id at all.
+  select id into v_doomed from dblink('goal687b_deleter', format($f$
+    insert into public.savings_goals (user_id, goal_name) values (%L, 'Doomed') returning goal_id;
+  $f$, c_user)) as t(id uuid);
+  select id into v_keeper from dblink('goal687b_deleter', format($f$
+    insert into public.savings_goals (user_id, goal_name) values (%L, 'Keeper') returning goal_id;
+  $f$, c_user)) as t(id uuid);
+
+  perform dblink_exec('goal687b_deleter', format($f$
+    insert into public.investment_transactions
+      (transaction_id, user_id, goal_id, asset_type, transaction_type,
+       investment_date, amount_vnd, interest_rate, expiry_date)
+    values (%L, %L, %L, 'bank', 'investment', '2026-01-01', 20000000, 5.5, '2027-01-01');
+  $f$, c_src, c_user, v_keeper));
+  perform dblink_exec('goal687b_deleter', format($f$
+    insert into public.investment_transactions
+      (transaction_id, user_id, goal_id, asset_type, transaction_type,
+       investment_date, amount_vnd)
+    values (%L, %L, %L, 'bank', 'investment', '2026-01-02', 5000000);
+  $f$, c_anchor, c_user, v_keeper));
+  perform dblink_exec('goal687b_deleter', format($f$
+    insert into public.investment_transactions
+      (transaction_id, user_id, goal_id, asset_type, transaction_type, investment_date,
+       amount_vnd, parent_transaction_id, principal_withdrawn, held_for_merge,
+       merge_target_goal_id)
+    values (%L, %L, %L, 'bank', 'withdrawal', '2026-03-01', 20000000, %L, 20000000, true, %L);
+  $f$, c_held, c_user, v_keeper, c_src, v_keeper));
+  -- Merged already, which is what frees its target from the shape constraint.
+  perform dblink_exec('goal687b_deleter', format($f$
+    update public.investment_transactions set consumed_by_inv_id = %L
+     where transaction_id = %L;
+  $f$, c_anchor, c_held));
+
+  -- ── the race ──────────────────────────────────────────────────────────────
+  perform dblink_exec('goal687b_deleter', 'begin');
+  perform * from dblink('goal687b_deleter', format($f$
+    select public.delete_savings_goal(%L);
+  $f$, v_doomed)) as t(result jsonb);
+
+  -- Re-point the consumed settlement at the goal being deleted. The ownership
+  -- trigger reads it as still there — it does not take the lock — so what has to
+  -- refuse this is the FOR SHARE read that waits.
+  perform dblink_send_query('goal687b_pointer', format($f$
+    update public.investment_transactions set merge_target_goal_id = %L
+     where transaction_id = %L returning transaction_id;
+  $f$, v_doomed, c_held));
+
+  perform pg_sleep(1);
+
+  v_busy := dblink_is_busy('goal687b_pointer');
+  if v_busy <> 1 then
+    raise exception 'pointing at a goal under deletion must wait for the lock';
+  end if;
+
+  perform dblink_exec('goal687b_deleter', 'commit');
+
+  begin
+    perform * from dblink_get_result('goal687b_pointer') as t(id uuid);
+  exception when others then
+    v_err := sqlerrm;
+  end;
+  perform * from dblink_get_result('goal687b_pointer') as t(id uuid);
+
+  perform dblink_disconnect('goal687b_deleter');
+  perform dblink_disconnect('goal687b_pointer');
+
+  if v_err is null then
+    raise exception 'a reference to a deleted goal must be refused, the update succeeded';
+  end if;
+
+  -- Nothing may be left pointing at a goal that is gone.
+  select merge_target_goal_id into v_target from public.investment_transactions
+   where transaction_id = c_held;
+  if v_target is distinct from v_keeper then
+    raise exception 'the settlement must still point at its own goal, got %', v_target;
+  end if;
+  if exists (select 1 from public.savings_goals where goal_id = v_doomed) then
+    raise exception 'the goal should have been deleted';
+  end if;
+
+  raise notice 'delete_savings_goal race (no foreign key): pass';
+
+exception when others then
+  begin perform dblink_disconnect('goal687b_deleter'); exception when others then null; end;
+  begin perform dblink_disconnect('goal687b_pointer'); exception when others then null; end;
+  perform dblink_connect('goal687b_cleanup', v_conn);
+  perform dblink_exec('goal687b_cleanup', 'set lock_timeout = ''10s''');
+  perform dblink_exec('goal687b_cleanup', format('delete from auth.users where id = %L', c_user));
+  perform dblink_disconnect('goal687b_cleanup');
+  raise;
+end;
+$$;
+
+delete from auth.users where id = '68768768-7687-4687-8687-687687687688';


### PR DESCRIPTION
Closes #687.

## What was broken

`DELETE /api/v1/savings-goals/[id]` performed a four-step state transition through separate Supabase requests, with the errors of steps 1 and 3 dropped:

1. count linked transactions — **error ignored**
2. look for cash parked for a merge
3. clear `merge_target_goal_id` on consumed settlements — **error ignored**
4. delete the goal

supabase-js has no transaction, so between 3 and 4 there is a window nothing closes: the cleanup commits, the delete fails, and consumed merge history has lost the target it recorded while the goal it pointed at is still there. A settlement parked between 2 and 4 slipped past a preflight that had already said yes. And every failure — deadlock, permission fault, anything — answered `404 Goal not found` about a goal sitting right there.

## The fix

`delete_savings_goal(uuid)` does the whole transition under the goal's lock and returns the count:

- **`FOR UPDATE` on the goal first**, so the blocker check and the delete cannot be separated. `security invoker`, so RLS scopes it — a foreign goal reads as not-found and leaks nothing.
- The parked-settlement refusal keeps its actionable message and its `held_settlement_parked` code; not-found is raised distinctly (`no_data_found`).
- The count is taken inside the same transaction that deletes.
- Cleanup and delete commit together or roll back together.

The route keeps authentication, validation, one RPC call, and the mapping — now including a **500 for an unexpected fault**, which used to read as a missing goal (#532/#533).

### The other half of the lock

`enforce_goal_not_completed` already read the goal `FOR SHARE` so a write could not slip under a `finish_savings_goal` holding `FOR UPDATE` — but when the goal row was *absent* the read said nothing and the trigger waved the row through. For `goal_id` a real foreign key catches that a moment later; `merge_target_goal_id` has no foreign key, and its only other guard (#525 ownership) reads without a lock, so against a delete committing beside it that read sees the goal as still present and the row commits pointing at nothing. It is refused now.

### What did *not* change

No trigger on `savings_goals`. `20260731000001` records why one cannot work — `BEFORE DELETE` also aborts `delete from auth.users`, and an `AFTER DELETE` deferred trigger never runs because the immediate one already refused the statement. That reasoning is untouched; only the route's statements moved into the transaction they belonged in. `ON DELETE SET NULL` still moves transactions to Unassigned, and the #525 trigger still has the last word on a dangling reference.

## Tests

TDD, red first at each layer.

**`supabase/tests/delete_savings_goal.test.sql`** — success and the exact count (other users' rows excluded); a consumed settlement's dead target cleared while the history row survives; **parked cash refuses the delete *and* rolls the cleanup back with it** (the window this issue is about); not-found raised distinctly; ownership through RLS as another signed-in user.

Sixth case worth calling out: the first five run as `postgres`, where **RLS is off** — that proves the logic and not the grants, while the route runs as `authenticated`. So there is a case where the owner deletes their own goal under RLS, with a consumed settlement to clear. Without it this would work everywhere except production.

**`supabase/tests/delete_savings_goal_race.test.sql`** — two real sessions over dblink. The delete runs and holds its lock uncommitted; another session parks cash into that same goal and **blocks** (asserted via `dblink_is_busy`, which is the actual proof the window is closed); the delete commits; the parking write is refused and no settlement survives.

**`app/api/v1/savings-goals/[id]/__tests__/route.delete.test.ts`** — 9 tests on the mapping: one RPC call and *no direct table access*, the count and its singular/plural, parked → 409 + code, not-found → 404, an unexpected error → 500 (not 404), 401 and a malformed id before any database work.

Verified locally:

- `npm run typecheck` ✅
- `npm run test:db` — the whole SQL suite, including the three new files ✅
- `npm run test:coverage` — 212 files, 2588 tests, thresholds pass ✅
- `npm run lint` — 0 errors (2 pre-existing unrelated warnings) ✅
- `npm run build` ✅

## Reviewer note — please check the migrate job on merge

This PR carries a migration, and the `main` run for #694 ended **cancelled**: the E2E Smoke job hit its 30-minute timeout stalled on *Install Playwright browsers*, which skipped *Apply DB migrations (production)*. That was harmless there (no migration), but if it recurs here Vercel ships code calling `delete_savings_goal` at a database that does not have it yet — every goal delete would 500. If the migrate job is skipped, re-run it before using the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)