### PR TITLE
fix(a11y): make the dialog contract something a sheet cannot forget (#688)

### DIFF
--- a/app/(app)/planning/components/FixedExpenseManager.tsx
+++ b/app/(app)/planning/components/FixedExpenseManager.tsx
@@ -6,6 +6,10 @@ import { toast } from 'sonner'
 import { Plus, ChevronLeft } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import { formatIntVN, parseIntVN } from '@/lib/numberFormat'
+import DialogShell from '@/components/ui/DialogShell'
+
+// The confirmation's visible title is its accessible name (#688).
+const DELETE_TITLE_ID = 'fixed-expense-delete-title'
 
 // Master fixed-expense definitions. Categories mirror the Settings tab and the
 // API's accepted values; labels are localised for display only.
@@ -360,36 +364,37 @@ export default function FixedExpenseManager({ onChange, onToast, variant = 'moda
           // Bottom-anchored sheet so it sits on the phone frame (mirrors the
           // mobile plan's bottom sheets) instead of floating mid-screen.
           return (
-            <div
-              data-testid="fe-delete-overlay"
-              style={{ position: 'fixed', inset: 0, zIndex: 300, background: 'rgba(15,23,42,0.4)', display: 'flex', alignItems: 'flex-end' }}
-              onClick={() => !deleting && setConfirmDelete(null)}
+            <DialogShell
+              onClose={() => setConfirmDelete(null)}
+              // A delete in flight owns the sheet: clicking away mid-request
+              // would hide the confirmation while the row is still going.
+              dismissOnClickAway={!deleting}
+              labelledBy={DELETE_TITLE_ID}
+              overlayStyle={{ zIndex: 300, alignItems: 'flex-end' }}
+              overlayProps={{ 'data-testid': 'fe-delete-overlay' }}
+              panelStyle={{ width: '100%', background: 'var(--c-card)', borderRadius: '16px 16px 0 0', paddingBottom: 'env(safe-area-inset-bottom,0)', animation: 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' }}
             >
-              <div
-                onClick={(e) => e.stopPropagation()}
-                style={{ width: '100%', background: 'var(--c-card)', borderRadius: '16px 16px 0 0', paddingBottom: 'env(safe-area-inset-bottom,0)', animation: 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' }}
-              >
                 <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '8px auto 0' }} />
                 <div style={{ padding: '14px 16px 0' }}>
-                  <p style={{ fontWeight: 700, fontSize: 16, color: 'var(--c-ink)', margin: '0 0 16px' }}>{t('deleteModal')}</p>
+                  <p id={DELETE_TITLE_ID} style={{ fontWeight: 700, fontSize: 16, color: 'var(--c-ink)', margin: '0 0 16px' }}>{t('deleteModal')}</p>
                 </div>
                 <div style={{ padding: '0 16px 24px', display: 'grid', gap: 16 }}>{body}</div>
-              </div>
-            </div>
+            </DialogShell>
           )
         }
 
         return (
-          <div
-            data-testid="fe-delete-overlay"
-            style={{ position: 'fixed', inset: 0, zIndex: 300, background: 'rgba(15,23,42,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}
-            onClick={() => !deleting && setConfirmDelete(null)}
+          <DialogShell
+            onClose={() => setConfirmDelete(null)}
+            dismissOnClickAway={!deleting}
+            labelledBy={DELETE_TITLE_ID}
+            overlayStyle={{ zIndex: 300, padding: 24 }}
+            overlayProps={{ 'data-testid': 'fe-delete-overlay' }}
+            panelStyle={{ width: 360, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, boxShadow: '0 20px 50px rgba(15,23,42,0.25)', display: 'grid', gap: 16 }}
           >
-            <div onClick={(e) => e.stopPropagation()} style={{ width: 360, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, boxShadow: '0 20px 50px rgba(15,23,42,0.25)', display: 'grid', gap: 16 }}>
-              <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--c-ink)' }}>{t('deleteModal')}</div>
+              <div id={DELETE_TITLE_ID} style={{ fontSize: 15, fontWeight: 700, color: 'var(--c-ink)' }}>{t('deleteModal')}</div>
               {body}
-            </div>
-          </div>
+          </DialogShell>
         )
       })()}
     </div>

--- a/app/(app)/planning/components/RecurringSavingManager.tsx
+++ b/app/(app)/planning/components/RecurringSavingManager.tsx
@@ -6,6 +6,10 @@ import { toast } from 'sonner'
 import { Plus, ChevronLeft } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import { formatIntVN, parseIntVN } from '@/lib/numberFormat'
+import DialogShell from '@/components/ui/DialogShell'
+
+// The confirmation's visible title is its accessible name (#688).
+const DELETE_TITLE_ID = 'recurring-saving-delete-title'
 import type { Goal } from '@/features/planning/contracts'
 
 interface Saving {
@@ -448,36 +452,37 @@ export default function RecurringSavingManager({ goals, onChange, onToast, varia
 
         if (variant === 'sheet') {
           return (
-            <div
-              data-testid="rs-delete-overlay"
-              style={{ position: 'fixed', inset: 0, zIndex: 300, background: 'rgba(15,23,42,0.4)', display: 'flex', alignItems: 'flex-end' }}
-              onClick={() => !deleting && setConfirmDelete(null)}
+            <DialogShell
+              onClose={() => setConfirmDelete(null)}
+              // A delete in flight owns the sheet: clicking away mid-request
+              // would hide the confirmation while the row is still going.
+              dismissOnClickAway={!deleting}
+              labelledBy={DELETE_TITLE_ID}
+              overlayStyle={{ zIndex: 300, alignItems: 'flex-end' }}
+              overlayProps={{ 'data-testid': 'rs-delete-overlay' }}
+              panelStyle={{ width: '100%', background: 'var(--c-card)', borderRadius: '16px 16px 0 0', paddingBottom: 'env(safe-area-inset-bottom,0)', animation: 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' }}
             >
-              <div
-                onClick={(e) => e.stopPropagation()}
-                style={{ width: '100%', background: 'var(--c-card)', borderRadius: '16px 16px 0 0', paddingBottom: 'env(safe-area-inset-bottom,0)', animation: 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' }}
-              >
                 <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '8px auto 0' }} />
                 <div style={{ padding: '14px 16px 0' }}>
-                  <p style={{ fontWeight: 700, fontSize: 16, color: 'var(--c-ink)', margin: '0 0 16px' }}>{title}</p>
+                  <p id={DELETE_TITLE_ID} style={{ fontWeight: 700, fontSize: 16, color: 'var(--c-ink)', margin: '0 0 16px' }}>{title}</p>
                 </div>
                 <div style={{ padding: '0 16px 24px', display: 'grid', gap: 16 }}>{body}</div>
-              </div>
-            </div>
+            </DialogShell>
           )
         }
 
         return (
-          <div
-            data-testid="rs-delete-overlay"
-            style={{ position: 'fixed', inset: 0, zIndex: 300, background: 'rgba(15,23,42,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}
-            onClick={() => !deleting && setConfirmDelete(null)}
+          <DialogShell
+            onClose={() => setConfirmDelete(null)}
+            dismissOnClickAway={!deleting}
+            labelledBy={DELETE_TITLE_ID}
+            overlayStyle={{ zIndex: 300, padding: 24 }}
+            overlayProps={{ 'data-testid': 'rs-delete-overlay' }}
+            panelStyle={{ width: 360, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, boxShadow: '0 20px 50px rgba(15,23,42,0.25)', display: 'grid', gap: 16 }}
           >
-            <div onClick={(e) => e.stopPropagation()} style={{ width: 360, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, boxShadow: '0 20px 50px rgba(15,23,42,0.25)', display: 'grid', gap: 16 }}>
-              <div style={{ fontSize: 15, fontWeight: 700, color: 'var(--c-ink)' }}>{title}</div>
+              <div id={DELETE_TITLE_ID} style={{ fontSize: 15, fontWeight: 700, color: 'var(--c-ink)' }}>{title}</div>
               {body}
-            </div>
-          </div>
+          </DialogShell>
         )
       })()}
     </div>

--- a/app/(app)/planning/components/__tests__/FixedExpenseManager.test.tsx
+++ b/app/(app)/planning/components/__tests__/FixedExpenseManager.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor, within } from '@testing-library/react'
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import FixedExpenseManager from '../FixedExpenseManager'
 
@@ -215,4 +215,50 @@ describe('FixedExpenseManager — delete', () => {
       ).toBeTruthy()
     })
   })
+})
+
+// Guard for #688. The delete confirmation — the one overlay in Planning where a
+// misfire destroys data — had no dialog semantics, no Escape, and left focus on
+// the row behind it, so the very next Tab or Enter landed somewhere the user
+// could not see.
+describe('FixedExpenseManager — delete confirmation dialog contract (#688)', () => {
+  for (const variant of ['modal', 'sheet'] as const) {
+    describe(variant, () => {
+      async function openConfirm() {
+        mockFetch()
+        render(<FixedExpenseManager onChange={vi.fn()} variant={variant} />)
+        const row = await screen.findByTestId('fe-row-fe1')
+        await userEvent.click(within(row).getByTestId('fe-delete'))
+        return screen.getByTestId('fe-delete-overlay')
+      }
+
+      it('is a modal dialog with an accessible name', async () => {
+        await openConfirm()
+
+        const dialog = screen.getByRole('dialog', { name: 'deleteModal' })
+        expect(dialog).toHaveAttribute('aria-modal', 'true')
+      })
+
+      it('closes on Escape without deleting anything', async () => {
+        await openConfirm()
+
+        fireEvent.keyDown(document, { key: 'Escape' })
+
+        await waitFor(() => expect(screen.queryByTestId('fe-delete-overlay')).not.toBeInTheDocument())
+        expect(fetchMock.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'DELETE')).toBe(false)
+      })
+
+      it('moves focus into the confirmation and keeps Tab inside it', async () => {
+        await openConfirm()
+        const dialog = screen.getByRole('dialog')
+        expect(dialog).toContainElement(document.activeElement as HTMLElement)
+
+        const buttons = dialog.querySelectorAll<HTMLElement>('button:not([disabled])')
+        buttons[buttons.length - 1].focus()
+        await userEvent.tab()
+
+        expect(dialog).toContainElement(document.activeElement as HTMLElement)
+      })
+    })
+  }
 })

--- a/app/(app)/planning/components/__tests__/RecurringSavingManager.a11y.test.tsx
+++ b/app/(app)/planning/components/__tests__/RecurringSavingManager.a11y.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import RecurringSavingManager from '../RecurringSavingManager'
+
+// Guard for #688. The other half of Planning's delete confirmations. Like the
+// fixed-expense one it had no dialog semantics, no Escape and no focus handling
+// — and this is the overlay whose confirm button destroys a saving rule.
+vi.mock('sonner', () => ({ toast: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }) }))
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string, params?: Record<string, unknown>) =>
+    params ? `${key}:${JSON.stringify(params)}` : key,
+  useLocale: () => 'en',
+}))
+vi.mock('@/lib/formatters', () => ({ fmt: (n: number) => `₫ ${n}`, fmtCompact: (n: number) => `₫ ${n}` }))
+
+const savings = [
+  {
+    saving_id: 'rs1', name: 'Monthly transfer', goal_id: null, amount_vnd: 5_000_000,
+    effective_from: null, effective_to: null, linked_deposit_tx_id: null,
+    savings_goals: null,
+  },
+]
+
+let fetchMock: ReturnType<typeof vi.fn>
+beforeEach(() => {
+  fetchMock = vi.fn(async (url: string) => {
+    if (String(url).includes('recurring-savings')) return { ok: true, json: async () => ({ savings }) }
+    return { ok: true, json: async () => ({}) }
+  })
+  vi.stubGlobal('fetch', fetchMock)
+})
+
+for (const variant of ['modal', 'sheet'] as const) {
+  describe(`RecurringSavingManager (${variant}) — delete confirmation contract (#688)`, () => {
+    async function openConfirm() {
+      render(<RecurringSavingManager goals={[]} onChange={vi.fn()} variant={variant} />)
+      const del = await screen.findByTestId('rs-delete')
+      await userEvent.click(del)
+      return screen.getByTestId('rs-delete-overlay')
+    }
+
+    it('is a modal dialog with an accessible name', async () => {
+      await openConfirm()
+
+      const dialog = screen.getByRole('dialog', { name: 'Delete recurring saving?' })
+      expect(dialog).toHaveAttribute('aria-modal', 'true')
+    })
+
+    it('closes on Escape without deleting anything', async () => {
+      await openConfirm()
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      await waitFor(() => expect(screen.queryByTestId('rs-delete-overlay')).not.toBeInTheDocument())
+      expect(fetchMock.mock.calls.some(([, init]) => (init as RequestInit | undefined)?.method === 'DELETE')).toBe(false)
+    })
+
+    it('moves focus into the confirmation and keeps Tab inside it', async () => {
+      await openConfirm()
+      const dialog = screen.getByRole('dialog')
+      expect(dialog).toContainElement(document.activeElement as HTMLElement)
+
+      const buttons = dialog.querySelectorAll<HTMLElement>('button:not([disabled])')
+      buttons[buttons.length - 1].focus()
+      await userEvent.tab()
+
+      expect(dialog).toContainElement(document.activeElement as HTMLElement)
+    })
+
+    it('restores focus to the delete button that opened it', async () => {
+      await openConfirm()
+      const trigger = screen.getByTestId('rs-delete')
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      await waitFor(() => expect(trigger).toHaveFocus())
+    })
+  })
+}

--- a/app/assets/components/AddTransactionSheet.tsx
+++ b/app/assets/components/AddTransactionSheet.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useMemo } from 'react'
 import { X, TrendingUp, Building2, Coins, ArrowUpRight, ArrowDownRight } from 'lucide-react'
 import { iconHit } from './iconHit'
 import { useLocale, useTranslations } from 'next-intl'
+import DialogShell from '@/components/ui/DialogShell'
 import { CairnLoader } from '@/components/ui/CairnLoader'
 import { todayIso } from '@/lib/dates'
 import { computeFundPricing, computeSellPreview, buildBuyPayload, buildEditPayload, buildSellPayload, type TxForm } from './addTransactionModel'
@@ -141,6 +142,10 @@ const ASSET_TYPES = [
 ] as const
 
 type AssetType = typeof ASSET_TYPES[number]['v']
+
+// The visible heading is the dialog's accessible name. One id for both
+// wrappers: only ever one of them is on screen.
+const TITLE_ID = 'add-transaction-title'
 
 export default function AddTransactionSheet({ open, onClose, onSaved, desktop, existing, prefill }: Props) {
   const t = useTranslations('addTx')
@@ -648,51 +653,44 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
 
   if (desktop) {
     return (
-      <div
-        onClick={onClose}
-        style={{
-          position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)', zIndex: 200,
-          display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24,
+      <DialogShell
+        onClose={onClose}
+        labelledBy={TITLE_ID}
+        overlayStyle={{
+          zIndex: 200, padding: 24,
           animation: 'fade-in 150ms ease', backdropFilter: 'blur(2px)',
         }}
+        panelStyle={{
+          width: '100%', maxWidth: 520, maxHeight: 'calc(100vh - 48px)',
+          background: 'var(--c-card)', borderRadius: 16,
+          boxShadow: '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)',
+          display: 'flex', flexDirection: 'column',
+          animation: 'modal-in 200ms cubic-bezier(0.2,0.8,0.2,1)', overflow: 'hidden',
+        }}
       >
-        <div
-          onClick={(e) => e.stopPropagation()}
-          style={{
-            width: '100%', maxWidth: 520, maxHeight: 'calc(100vh - 48px)',
-            background: 'var(--c-card)', borderRadius: 16,
-            boxShadow: '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)',
-            display: 'flex', flexDirection: 'column',
-            animation: 'modal-in 200ms cubic-bezier(0.2,0.8,0.2,1)', overflow: 'hidden',
-          }}
-        >
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '18px 20px 14px', borderBottom: '1px solid var(--c-line)', flexShrink: 0 }}>
-            <h3 style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{existing ? t('editTitle') : t('title')}</h3>
+            <h3 id={TITLE_ID} style={{ margin: 0, fontSize: 16, fontWeight: 700, letterSpacing: '-0.01em' }}>{existing ? t('editTitle') : t('title')}</h3>
             <button onClick={onClose} style={{ ...iconHit, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)' }} aria-label="Close"><X size={18} /></button>
           </div>
           <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto', overflowX: 'hidden', overscrollBehavior: 'contain' }}>
             {formBody}
           </div>
-        </div>
-      </div>
+      </DialogShell>
     )
   }
 
   return (
-    <div
-      onClick={onClose}
-      style={{
-        position: 'fixed', inset: 0,
+    <DialogShell
+      onClose={onClose}
+      labelledBy={TITLE_ID}
+      overlayStyle={{
         background: 'rgba(15, 23, 42, 0.45)',
         zIndex: 100,
-        display: 'flex', alignItems: 'flex-end', justifyContent: 'center',
+        alignItems: 'flex-end',
         animation: open ? 'fade-in 180ms ease' : 'fade-out 180ms ease forwards',
         pointerEvents: open ? 'auto' : 'none',
       }}
-    >
-      <div
-        onClick={(e) => e.stopPropagation()}
-        style={{
+      panelStyle={{
           width: '100%', maxWidth: 480, maxHeight: '90dvh',
           background: 'var(--c-card)',
           borderTopLeftRadius: 20, borderTopRightRadius: 20,
@@ -706,7 +704,7 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
 
         {/* Header — pinned, sits outside the scrollable body so the title stays put */}
         <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '0 16px 20px', flexShrink: 0 }}>
-          <h3 style={{ margin: 0, fontSize: 17, fontWeight: 600, color: 'var(--c-ink)' }}>
+          <h3 id={TITLE_ID} style={{ margin: 0, fontSize: 17, fontWeight: 600, color: 'var(--c-ink)' }}>
             {existing ? t('editTitle') : t('title')}
           </h3>
           <button
@@ -722,7 +720,6 @@ export default function AddTransactionSheet({ open, onClose, onSaved, desktop, e
         <div style={{ flex: 1, overflowY: 'auto', overflowX: 'hidden', overscrollBehavior: 'contain', touchAction: 'pan-y', padding: '0 16px 32px' }}>
           {formBody}
         </div>
-      </div>
-    </div>
+    </DialogShell>
   )
 }

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -1,12 +1,15 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import {
   ChevronLeft, MoreHorizontal,
   Target, PiggyBank, Plus,
 } from 'lucide-react'
 import { iconHit } from './iconHit'
 import { useLocale, useTranslations } from 'next-intl'
+
+// The goal name already on screen is the dialog's accessible name (#688).
+const TITLE_ID = 'goal-detail-title'
 import { toast } from 'sonner'
 import { fmt, fmtCompact, fmtPct } from '@/lib/formatters'
 import { formatIntVN, parseIntVN } from '@/lib/numberFormat'
@@ -21,6 +24,7 @@ import { fmtTxDate } from './transactionUtils'
 import { TxRowsSkeleton } from './Skeletons'
 import LoadError from './LoadError'
 import { useGoalDetailData } from './useGoalDetailData'
+import { useDialogA11y } from '@/components/ui/useDialogA11y'
 import { deleteGoal, reopenGoal, unholdTransaction, unassignInvestment } from './goalActions'
 import { FinishGoalSheet } from './FinishGoalSheet'
 import { goalCompletion } from '@/lib/finishGoal'
@@ -45,6 +49,7 @@ interface Props {
 }
 
 export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, refreshKey, onAddToGoal }: Props) {
+  const panelRef = useRef<HTMLDivElement>(null)
   const isVI = useLocale() === 'vi'
   const td = useTranslations('deleteTransaction')
   const [mounted, setMounted] = useState(false)
@@ -175,6 +180,11 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
     setHistoryLoading(false)
   }
 
+  // Applied directly rather than through DialogShell: this sheet IS the fixed
+  // element — full-screen, its own scroll container, no scrim and so no
+  // click-away. The contract it owes a keyboard user is the same (#688).
+  useDialogA11y(panelRef, open && mounted, onClose)
+
   if (!mounted || !goal) return null
 
   // A finished goal reads off its snapshot, not off holdings that are now zero
@@ -212,6 +222,10 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   return (
     <>
       <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={TITLE_ID}
         style={{
           position: 'fixed', inset: 0, zIndex: 40,
           background: 'var(--c-canvas,#faf9f7)',
@@ -240,7 +254,7 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
               <div style={{ fontSize: 11, color: 'var(--c-muted)', letterSpacing: '0.06em', textTransform: 'uppercase', fontWeight: 600 }}>
                 {isVI ? 'Mục tiêu' : 'Goal'}
               </div>
-              <h1 style={{ margin: 0, fontSize: 22, fontWeight: 600, letterSpacing: '-0.015em', color: 'var(--c-ink)' }}>
+              <h1 id={TITLE_ID} style={{ margin: 0, fontSize: 22, fontWeight: 600, letterSpacing: '-0.015em', color: 'var(--c-ink)' }}>
                 {goal.goalName}
               </h1>
             </div>

--- a/app/assets/components/InsuranceDetailSheet.tsx
+++ b/app/assets/components/InsuranceDetailSheet.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import type { InsuranceData } from '@/features/dashboard/contracts'
 import DesktopInsuranceDetail from './DesktopInsuranceDetail'
 import { useDialogMount } from '@/components/ui/useDialogMount'
+import { useDialogA11y } from '@/components/ui/useDialogA11y'
 
 interface Props {
   ins: InsuranceData | null
@@ -23,6 +24,14 @@ export default function InsuranceDetailSheet({ ins, open, locale, onClose, onCha
   // 200ms here, not the 220 default — this sheet's exit animation is shorter.
   const mounted = useDialogMount(open, 200)
 
+  // The dialog contract, applied directly rather than through DialogShell: this
+  // sheet IS the fixed element — full-screen, its own scroll container, no scrim
+  // and so no click-away — and wrapping it in the shell's overlay would put a
+  // second scrolling box around the one the animation and overscroll rules are
+  // written for. What it owes a keyboard user is the same either way (#688).
+  const panelRef = useRef<HTMLDivElement>(null)
+  useDialogA11y(panelRef, open && mounted, onClose)
+
   useEffect(() => {
     if (!open) return
     document.body.style.overflow = 'hidden'
@@ -33,7 +42,13 @@ export default function InsuranceDetailSheet({ ins, open, locale, onClose, onCha
 
   return (
     <div
+      ref={panelRef}
       data-testid="insurance-detail-sheet"
+      role="dialog"
+      aria-modal="true"
+      // Named by the policy it is showing: "dialog" alone tells a screen-reader
+      // user nothing about which member they just opened.
+      aria-label={ins.insuranceName}
       style={{
         position: 'fixed', inset: 0, zIndex: 120,
         background: 'var(--c-canvas, #faf9f7)',

--- a/app/assets/components/RecurringBookTopUpSheet.tsx
+++ b/app/assets/components/RecurringBookTopUpSheet.tsx
@@ -10,6 +10,7 @@
 
 import { useEffect, useState, type CSSProperties } from 'react'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
+import DialogShell from '@/components/ui/DialogShell'
 import { fmtCompact } from '@/lib/formatters'
 import { todayIso } from '@/lib/dates'
 
@@ -24,10 +25,12 @@ export interface BookTopUpTarget {
 }
 
 const field: CSSProperties = {
-  width: '100%', boxSizing: 'border-box', padding: '10px 12px', fontSize: 15, fontWeight: 600,
+  width: '100%', boxSizing: 'border-box', padding: '10px 12px', fontSize: 16, fontWeight: 600,
   background: 'var(--c-canvas,#faf9f7)', border: '1.5px solid var(--c-line)', borderRadius: 10,
   color: 'var(--c-ink)', outline: 'none', fontVariantNumeric: 'tabular-nums',
 }
+// The visible title is the dialog's accessible name, so the two cannot drift.
+const TITLE_ID = 'recurring-topup-title'
 const lbl: CSSProperties = { fontSize: 11, fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--c-muted)', marginBottom: 6, display: 'block' }
 
 export default function RecurringBookTopUpSheet({
@@ -79,10 +82,18 @@ export default function RecurringBookTopUpSheet({
   }
 
   return (
-    <div onClick={() => !saving && onClose()} style={{ position: 'fixed', inset: 0, zIndex: 340, background: 'rgba(15,23,42,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
-      <div onClick={(e) => e.stopPropagation()} data-testid="recurring-topup-modal" style={{ width: 380, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, display: 'grid', gap: 12, boxShadow: '0 20px 50px rgba(15,23,42,0.25)' }}>
+    <DialogShell
+      onClose={onClose}
+      // A save in flight owns the sheet: a stray click outside must not discard
+      // a form that is already writing.
+      dismissOnClickAway={!saving}
+      labelledBy={TITLE_ID}
+      overlayStyle={{ zIndex: 340, padding: 24 }}
+      panelStyle={{ width: 380, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, display: 'grid', gap: 12, boxShadow: '0 20px 50px rgba(15,23,42,0.25)' }}
+      panelProps={{ 'data-testid': 'recurring-topup-modal' }}
+    >
         <div>
-          <div style={{ fontSize: 15, fontWeight: 700 }}>{isVi ? 'Nạp vào sổ tích luỹ' : 'Top up accumulating book'}</div>
+          <div id={TITLE_ID} style={{ fontSize: 15, fontWeight: 700 }}>{isVi ? 'Nạp vào sổ tích luỹ' : 'Top up accumulating book'}</div>
           <div style={{ fontSize: 12, color: 'var(--c-muted)', marginTop: 2, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
             {target.bookName} · {isVi ? 'định kỳ tháng này' : "this month's recurring"}
           </div>
@@ -112,7 +123,6 @@ export default function RecurringBookTopUpSheet({
           <button type="button" onClick={onClose} style={{ flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)', background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500, cursor: 'pointer', fontFamily: 'inherit' }}>{isVi ? 'Huỷ' : 'Cancel'}</button>
           <button type="button" data-testid="recurring-topup-submit" onClick={submit} disabled={saving || !(amt > 0)} style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit', opacity: saving || !(amt > 0) ? 0.6 : 1 }}>{isVi ? 'Nạp & ghi nhận' : 'Top up & record'}</button>
         </div>
-      </div>
-    </div>
+    </DialogShell>
   )
 }

--- a/app/assets/components/SuccessorBookSheet.tsx
+++ b/app/assets/components/SuccessorBookSheet.tsx
@@ -13,6 +13,7 @@
 import { useEffect, useState, type CSSProperties } from 'react'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 import { fmtCompact } from '@/lib/formatters'
+import DialogShell from '@/components/ui/DialogShell'
 import { classifyAccumulatingTopUp } from '@/lib/accumulatingTopUp'
 
 export interface SuccessorTarget {
@@ -32,10 +33,12 @@ export interface SuccessorTarget {
 }
 
 const field: CSSProperties = {
-  width: '100%', boxSizing: 'border-box', padding: '10px 12px', fontSize: 15, fontWeight: 600,
+  width: '100%', boxSizing: 'border-box', padding: '10px 12px', fontSize: 16, fontWeight: 600,
   background: 'var(--c-canvas,#faf9f7)', border: '1.5px solid var(--c-line)', borderRadius: 10,
   color: 'var(--c-ink)', outline: 'none', fontVariantNumeric: 'tabular-nums',
 }
+// The visible title is the dialog's accessible name, so the two cannot drift.
+const TITLE_ID = 'successor-book-title'
 const lbl: CSSProperties = { fontSize: 11, fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--c-muted)', marginBottom: 6, display: 'block' }
 
 export default function SuccessorBookSheet({
@@ -127,10 +130,18 @@ export default function SuccessorBookSheet({
   }
 
   return (
-    <div onClick={() => !saving && onClose()} style={{ position: 'fixed', inset: 0, zIndex: 330, background: 'rgba(15,23,42,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
-      <div onClick={(e) => e.stopPropagation()} data-testid="successor-modal" style={{ width: 400, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, display: 'grid', gap: 12, boxShadow: '0 20px 50px rgba(15,23,42,0.25)' }}>
+    <DialogShell
+      onClose={onClose}
+      // A save in flight owns the sheet: a stray click outside must not discard
+      // a form that is already writing.
+      dismissOnClickAway={!saving}
+      labelledBy={TITLE_ID}
+      overlayStyle={{ zIndex: 330, padding: 24 }}
+      panelStyle={{ width: 400, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, display: 'grid', gap: 12, boxShadow: '0 20px 50px rgba(15,23,42,0.25)' }}
+      panelProps={{ 'data-testid': 'successor-modal' }}
+    >
         <div>
-          <div style={{ fontSize: 15, fontWeight: 700 }}>{isVi ? 'Mở sổ kế nhiệm' : 'Open successor book'}</div>
+          <div id={TITLE_ID} style={{ fontSize: 15, fontWeight: 700 }}>{isVi ? 'Mở sổ kế nhiệm' : 'Open successor book'}</div>
           <p style={{ margin: '6px 0 0', fontSize: 12, lineHeight: 1.5, color: 'var(--c-muted)' }}>
             {isVi
               ? `${target.bookName} không nhận nạp thêm nữa. Khoản ${fmtCompact(target.amount)} này sẽ vào sổ mới, và sổ cũ được ghi nhận sẽ gộp vào đây khi đáo hạn.`
@@ -180,7 +191,6 @@ export default function SuccessorBookSheet({
             {isVi ? 'Mở sổ mới' : 'Open the new book'}
           </button>
         </div>
-      </div>
-    </div>
+    </DialogShell>
   )
 }

--- a/app/assets/components/TransactionHistorySheet.tsx
+++ b/app/assets/components/TransactionHistorySheet.tsx
@@ -1,17 +1,21 @@
 'use client'
 
+import { useRef } from 'react'
 import { ChevronLeft, ArrowUpRight, ArrowDownRight, Plus } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import { fmtCompact, fmtNav, fmtPct, fmtUnits } from '@/lib/formatters'
 import { TxRowsSkeleton } from './Skeletons'
 import LoadError from './LoadError'
 import { useDialogMount } from '@/components/ui/useDialogMount'
+import { useDialogA11y } from '@/components/ui/useDialogA11y'
 
 export interface PurchaseHistoryRow {
   purchase_date: string
   units: number | null
   nav_at_purchase: number | null
 }
+
+const TITLE_ID = 'transaction-history-title'
 
 interface Props {
   open: boolean
@@ -39,6 +43,12 @@ export default function TransactionHistorySheet({
   const isVI = useLocale() === 'vi'
   const mounted = useDialogMount(open)
 
+  // Applied directly rather than through DialogShell: this sheet IS the fixed
+  // element — full-screen, its own scroll container, no scrim and so no
+  // click-away. What it owes a keyboard user is the same either way (#688).
+  const panelRef = useRef<HTMLDivElement>(null)
+  useDialogA11y(panelRef, open && mounted, onClose)
+
   if (!mounted) return null
 
   const isPositive = profitLoss >= 0
@@ -46,6 +56,12 @@ export default function TransactionHistorySheet({
 
   return (
     <div
+      ref={panelRef}
+      role="dialog"
+      aria-modal="true"
+      // The fund heading below is the name; pointing at it keeps one name rather
+      // than a second copy that can drift.
+      aria-labelledby={TITLE_ID}
       style={{
         position: 'fixed', inset: 0, zIndex: 200,
         background: 'var(--c-canvas,#faf9f7)',
@@ -82,7 +98,7 @@ export default function TransactionHistorySheet({
             }}>
               {isVI ? 'Khoản nắm giữ' : 'Holding'}
             </div>
-            <h1 style={{
+            <h1 id={TITLE_ID} style={{
               margin: 0, fontSize: 22, fontWeight: 600,
               letterSpacing: '-0.015em', color: 'var(--c-ink)',
               overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',

--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef, useId } from 'react'
 import { useTranslations } from 'next-intl'
 import { Plus, Download, Edit2, Trash, ChevronLeft, ChevronRight, X, Calendar, ArrowUpRight, ArrowDownRight, PiggyBank, GitMerge } from 'lucide-react'
 import { iconHit } from './iconHit'
@@ -14,6 +14,7 @@ import { ASSET_TYPES, type AssetType, type LedgerTransaction, isWithdrawal, mayC
 import { toast } from 'sonner'
 import { deleteTransaction } from './deleteTransaction'
 import { useDialogMount } from '@/components/ui/useDialogMount'
+import DialogShell from '@/components/ui/DialogShell'
 
 interface Goal { goal_id: string; goal_name: string; completed_at?: string | null }
 interface Fund { id: string; name: string; code: string; nav: number }
@@ -91,34 +92,45 @@ function Shell({ open, onClose, title, desktop, width = 520, testId, children }:
   children: React.ReactNode
 }) {
   const mounted = useDialogMount(open)
+  // Every dialog in this file goes through here, so the accessible name is
+  // derived from the title each one already passes — four overlays, one rule.
+  const titleId = useId()
   if (desktop ? !open : !mounted) return null
 
   const header = (
     <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: desktop ? '18px 20px 14px' : '0 16px 16px', borderBottom: desktop ? '1px solid var(--c-line)' : 'none', flexShrink: 0 }}>
-      <h3 style={{ margin: 0, fontSize: desktop ? 16 : 17, fontWeight: desktop ? 700 : 600, letterSpacing: '-0.01em', color: 'var(--c-ink)' }}>{title}</h3>
+      <h3 id={titleId} style={{ margin: 0, fontSize: desktop ? 16 : 17, fontWeight: desktop ? 700 : 600, letterSpacing: '-0.01em', color: 'var(--c-ink)' }}>{title}</h3>
       <button onClick={onClose} style={{ ...iconHit, border: 'none', background: 'transparent', borderRadius: 8, cursor: 'pointer', color: 'var(--c-muted)' }} aria-label="Close"><X size={18} /></button>
     </div>
   )
 
   if (desktop) {
     return (
-      <div onClick={onClose} style={{ position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.4)', zIndex: 200, display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24, animation: 'fade-in 150ms ease', backdropFilter: 'blur(2px)' }}>
-        <div data-testid={testId} onClick={(e) => e.stopPropagation()} style={{ width: '100%', maxWidth: width, maxHeight: 'calc(100vh - 48px)', background: 'var(--c-card)', borderRadius: 16, boxShadow: '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)', display: 'flex', flexDirection: 'column', animation: 'modal-in 200ms cubic-bezier(0.2,0.8,0.2,1)', overflow: 'hidden' }}>
+      <DialogShell
+        onClose={onClose}
+        labelledBy={titleId}
+        overlayStyle={{ zIndex: 200, padding: 24, animation: 'fade-in 150ms ease', backdropFilter: 'blur(2px)' }}
+        panelStyle={{ width: '100%', maxWidth: width, maxHeight: 'calc(100vh - 48px)', background: 'var(--c-card)', borderRadius: 16, boxShadow: '0 24px 48px rgba(15,23,42,0.18), 0 8px 16px rgba(15,23,42,0.08)', display: 'flex', flexDirection: 'column', animation: 'modal-in 200ms cubic-bezier(0.2,0.8,0.2,1)', overflow: 'hidden' }}
+        panelProps={{ 'data-testid': testId }}
+      >
           {header}
           <div style={{ flex: 1, padding: '18px 20px', overflowY: 'auto', overflowX: 'hidden', overscrollBehavior: 'contain' }}>{children}</div>
-        </div>
-      </div>
+      </DialogShell>
     )
   }
 
   return (
-    <div onClick={onClose} style={{ position: 'fixed', inset: 0, background: 'rgba(15,23,42,0.45)', zIndex: 100, display: 'flex', alignItems: 'flex-end', justifyContent: 'center', animation: open ? 'fade-in 180ms ease' : 'fade-out 180ms ease forwards', pointerEvents: open ? 'auto' : 'none' }}>
-      <div data-testid={testId} onClick={(e) => e.stopPropagation()} style={{ width: '100%', maxWidth: 520, maxHeight: '90dvh', background: 'var(--c-card)', borderTopLeftRadius: 20, borderTopRightRadius: 20, display: 'flex', flexDirection: 'column', overflow: 'hidden', animation: open ? 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' : 'slide-down 180ms ease forwards', boxShadow: '0 -8px 24px rgba(0,0,0,0.12)' }}>
+    <DialogShell
+      onClose={onClose}
+      labelledBy={titleId}
+      overlayStyle={{ background: 'rgba(15,23,42,0.45)', zIndex: 100, alignItems: 'flex-end', animation: open ? 'fade-in 180ms ease' : 'fade-out 180ms ease forwards', pointerEvents: open ? 'auto' : 'none' }}
+      panelStyle={{ width: '100%', maxWidth: 520, maxHeight: '90dvh', background: 'var(--c-card)', borderTopLeftRadius: 20, borderTopRightRadius: 20, display: 'flex', flexDirection: 'column', overflow: 'hidden', animation: open ? 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' : 'slide-down 180ms ease forwards', boxShadow: '0 -8px 24px rgba(0,0,0,0.12)' }}
+      panelProps={{ 'data-testid': testId }}
+    >
         <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '6px auto 14px', flexShrink: 0 }} />
         {header}
         <div style={{ flex: 1, overflowY: 'auto', overflowX: 'hidden', overscrollBehavior: 'contain', touchAction: 'pan-y', padding: '0 16px 24px' }}>{children}</div>
-      </div>
-    </div>
+    </DialogShell>
   )
 }
 

--- a/app/assets/components/__tests__/AddTransactionSheet.a11y.test.tsx
+++ b/app/assets/components/__tests__/AddTransactionSheet.a11y.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { useState } from 'react'
+import AddTransactionSheet from '../AddTransactionSheet'
+
+// Guard for #688. Both wrappers — the desktop centred modal and the mobile
+// bottom sheet — were bare fixed <div>s. The form inside is the app's longest,
+// so Tab escaping it dropped a keyboard user into the page behind a scrim they
+// could not see past.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => 'en',
+}))
+
+beforeEach(() => {
+  document.body.style.overflow = ''
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ json: () => Promise.resolve([]) })))
+})
+
+for (const [name, desktop] of [['desktop', true], ['mobile', false]] as const) {
+  describe(`AddTransactionSheet (${name}) — dialog contract (#688)`, () => {
+    it('is a modal dialog named by its own heading', () => {
+      render(<AddTransactionSheet open onClose={vi.fn()} desktop={desktop} />)
+
+      const dialog = screen.getByRole('dialog', { name: 'title' })
+      expect(dialog).toHaveAttribute('aria-modal', 'true')
+    })
+
+    it('takes the edit title when editing an existing transaction', () => {
+      render(<AddTransactionSheet open onClose={vi.fn()} desktop={desktop} existing={{ id: 't1' } as never} />)
+
+      expect(screen.getByRole('dialog', { name: 'editTitle' })).toBeInTheDocument()
+    })
+
+    it('closes on Escape', () => {
+      const onClose = vi.fn()
+      render(<AddTransactionSheet open onClose={onClose} desktop={desktop} />)
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('moves focus into the dialog on open', () => {
+      render(<AddTransactionSheet open onClose={vi.fn()} desktop={desktop} />)
+
+      expect(screen.getByRole('dialog')).toContainElement(document.activeElement as HTMLElement)
+    })
+
+    it('keeps Tab inside the dialog', async () => {
+      render(<AddTransactionSheet open onClose={vi.fn()} desktop={desktop} />)
+      const dialog = screen.getByRole('dialog')
+      const focusables = dialog.querySelectorAll<HTMLElement>('button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled])')
+      focusables[focusables.length - 1].focus()
+
+      await userEvent.tab()
+
+      expect(dialog).toContainElement(document.activeElement as HTMLElement)
+    })
+
+    it('restores focus to the control that opened it', async () => {
+      function Harness() {
+        const [open, setOpen] = useState(false)
+        return (
+          <>
+            <button type="button" onClick={() => setOpen(true)}>add</button>
+            {open && <AddTransactionSheet open onClose={() => setOpen(false)} desktop={desktop} />}
+          </>
+        )
+      }
+      render(<Harness />)
+      const trigger = screen.getByText('add')
+      await userEvent.click(trigger)
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      await waitFor(() => expect(trigger).toHaveFocus())
+    })
+
+    it('still closes on a click outside the panel', async () => {
+      const onClose = vi.fn()
+      render(<AddTransactionSheet open onClose={onClose} desktop={desktop} />)
+
+      await userEvent.click(screen.getByTestId('dialog-overlay'))
+
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+}

--- a/app/assets/components/__tests__/GoalDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/GoalDetailSheet.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen, waitFor, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import GoalDetailSheet from '../GoalDetailSheet'
 import type { GoalData } from '@/features/dashboard/contracts'
@@ -877,5 +877,39 @@ describe('GoalDetailSheet — merge provenance on a renewed row (#656)', () => {
     await userEvent.click(await screen.findByRole('button', { name: /history/i }))
     const row = await screen.findByTestId('history-renewed-row')
     expect(row).toHaveTextContent('Merged from PVcomBank A')
+  })
+})
+
+// Guard for #688. A full-screen sheet with no dialog semantics at all: nothing
+// announced it as a modal, Escape did nothing, and focus stayed on the goal card
+// behind it, so Tab walked the dashboard underneath.
+describe('GoalDetailSheet — dialog contract (#688)', () => {
+  it('is a modal dialog named by the goal heading it already shows', async () => {
+    render(<GoalDetailSheet {...baseProps} />)
+
+    const dialog = await screen.findByRole('dialog', { name: mockGoal.goalName })
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+  })
+
+  it('closes on Escape', async () => {
+    const onClose = vi.fn()
+    render(<GoalDetailSheet {...baseProps} onClose={onClose} />)
+    await screen.findByRole('dialog')
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('moves focus into the sheet and keeps Tab inside it', async () => {
+    render(<GoalDetailSheet {...baseProps} />)
+    const dialog = await screen.findByRole('dialog')
+    expect(dialog).toContainElement(document.activeElement as HTMLElement)
+
+    const focusables = dialog.querySelectorAll<HTMLElement>('button:not([disabled]), input:not([disabled])')
+    focusables[focusables.length - 1].focus()
+    await userEvent.tab()
+
+    expect(dialog).toContainElement(document.activeElement as HTMLElement)
   })
 })

--- a/app/assets/components/__tests__/InsuranceDetailSheet.test.tsx
+++ b/app/assets/components/__tests__/InsuranceDetailSheet.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import InsuranceDetailSheet from '../InsuranceDetailSheet'
 import type { InsuranceData } from '@/features/dashboard/contracts'
 
@@ -34,5 +34,39 @@ describe('InsuranceDetailSheet (issue #222)', () => {
     // KPI details from DesktopInsuranceDetail
     expect(screen.getByText('Annual premium')).toBeInTheDocument()
     expect(screen.getByText('Saved')).toBeInTheDocument()
+  })
+})
+
+// Guard for #688. The sheet covers the whole screen, so a keyboard user who
+// could still Tab into the page underneath had no way of knowing they had left
+// it — and nothing announced the overlay as a modal at all.
+describe('InsuranceDetailSheet — dialog contract (#688)', () => {
+  const ins = {
+    insuranceId: 'i1', insuranceName: 'Manulife', coverageType: 'life',
+    annualPremium: 12_000_000, amountSaved: 3_000_000, savingsProgressPercentage: 25,
+    status: 'on_track' as const, nextPaymentDate: '2026-09-01', lastPaymentDate: null,
+  }
+
+  it('is a modal dialog named by the policy it shows', () => {
+    render(<InsuranceDetailSheet ins={ins} open locale="en" onClose={() => {}} />)
+
+    const dialog = screen.getByRole('dialog', { name: 'Manulife' })
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toBe(screen.getByTestId('insurance-detail-sheet'))
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    render(<InsuranceDetailSheet ins={ins} open locale="en" onClose={onClose} />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('moves focus into the sheet on open', () => {
+    render(<InsuranceDetailSheet ins={ins} open locale="en" onClose={() => {}} />)
+
+    expect(screen.getByTestId('insurance-detail-sheet')).toContainElement(document.activeElement as HTMLElement)
   })
 })

--- a/app/assets/components/__tests__/RecurringBookTopUpSheet.a11y.test.tsx
+++ b/app/assets/components/__tests__/RecurringBookTopUpSheet.a11y.test.tsx
@@ -1,0 +1,22 @@
+import { vi, beforeEach, afterEach } from 'vitest'
+import RecurringBookTopUpSheet from '../RecurringBookTopUpSheet'
+import { dialogContract } from './helpers/dialogContract'
+
+vi.mock('@/lib/formatters', () => ({ fmtCompact: (n: number) => String(n) }))
+
+const target = {
+  savingId: 's1', bookId: 'b1', bookName: 'Tích luỹ VCB',
+  amount: 3_000_000, rate: 3.5, date: '2026-06-01', ym: '2026-06', planId: 'p1',
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })))
+})
+afterEach(() => vi.unstubAllGlobals())
+
+dialogContract({
+  name: 'RecurringBookTopUpSheet',
+  accessibleName: 'Top up accumulating book',
+  insideTestId: 'recurring-topup-amount',
+  open: (onClose) => <RecurringBookTopUpSheet target={target} isVi={false} onClose={onClose} onDone={() => {}} />,
+})

--- a/app/assets/components/__tests__/SuccessorBookSheet.a11y.test.tsx
+++ b/app/assets/components/__tests__/SuccessorBookSheet.a11y.test.tsx
@@ -1,0 +1,26 @@
+import { vi, beforeEach, afterEach } from 'vitest'
+import SuccessorBookSheet from '../SuccessorBookSheet'
+import { dialogContract } from './helpers/dialogContract'
+
+// Guard for #688. This sheet was a bare fixed <div>: no role, no accessible
+// name, no Escape, focus left on the page behind it and Tab walking straight out
+// of the modal into the ledger underneath.
+vi.mock('@/lib/formatters', () => ({ fmtCompact: (n: number) => String(n) }))
+
+const target = {
+  bookId: 'b1', bookName: 'Tích luỹ VCB', amount: 5_000_000, rate: 4.2,
+  date: '2026-06-01', sourceExpiry: '2026-05-01', lockDays: 30,
+  savingId: null, ym: null, planId: null,
+}
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })))
+})
+afterEach(() => vi.unstubAllGlobals())
+
+dialogContract({
+  name: 'SuccessorBookSheet',
+  accessibleName: 'Open successor book',
+  insideTestId: 'successor-amount',
+  open: (onClose) => <SuccessorBookSheet target={target} isVi={false} onClose={onClose} onDone={() => {}} />,
+})

--- a/app/assets/components/__tests__/TopUpControl.a11y.test.tsx
+++ b/app/assets/components/__tests__/TopUpControl.a11y.test.tsx
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TopUpControl, type InvRow } from '../goalDetailShared'
+import { addDaysIso, todayIso } from '@/lib/dates'
+
+// Guard for #688. The top-up dialog was a bare fixed <div>, and it is also the
+// one that opens ANOTHER dialog: the successor sheet launches from inside it, so
+// this file is where the nested rules get pinned.
+
+const openBook: InvRow = {
+  id: 'book-1', name: 'PVcomBank', type: 'bank', value: 10_000_000,
+  gainPct: null, units: null, principal: 10_000_000, interestRate: 4,
+  investmentDate: addDaysIso(todayIso(), -330), expiryDate: addDaysIso(todayIso(), 200),
+  fund: null, depositGroupId: 'book-1', topUpLockDays: null,
+}
+const lockedBook: InvRow = { ...openBook, expiryDate: addDaysIso(todayIso(), 10), topUpLockDays: 30 }
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })))
+})
+afterEach(() => vi.unstubAllGlobals())
+
+/** The dialog only exists once its trigger is pressed. */
+function OpenedTopUp({ onClose }: { onClose: () => void }) {
+  return <TopUpControl inv={openBook} isVi={false} onDone={onClose} />
+}
+
+describe('TopUpControl — the dialog opens from its trigger (#688)', () => {
+  it('is a modal dialog named by its title', async () => {
+    render(<OpenedTopUp onClose={() => {}} />)
+
+    await userEvent.click(screen.getByTestId('top-up-btn'))
+
+    const dialog = screen.getByRole('dialog', { name: 'Top up deposit' })
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+  })
+
+  it('moves focus in, and back to the trigger on Escape', async () => {
+    render(<OpenedTopUp onClose={() => {}} />)
+    const trigger = screen.getByTestId('top-up-btn')
+
+    await userEvent.click(trigger)
+    expect(screen.getByRole('dialog')).toContainElement(document.activeElement as HTMLElement)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument())
+    expect(trigger).toHaveFocus()
+  })
+
+  it('keeps Tab inside the dialog', async () => {
+    render(<OpenedTopUp onClose={() => {}} />)
+    await userEvent.click(screen.getByTestId('top-up-btn'))
+    const dialog = screen.getByRole('dialog')
+    const focusables = dialog.querySelectorAll<HTMLElement>('button, input')
+    focusables[focusables.length - 1].focus()
+
+    await userEvent.tab()
+
+    expect(dialog).toContainElement(document.activeElement as HTMLElement)
+  })
+
+  it('types at 16px so iOS Safari does not zoom (#265)', async () => {
+    render(<OpenedTopUp onClose={() => {}} />)
+    await userEvent.click(screen.getByTestId('top-up-btn'))
+
+    for (const input of screen.getByRole('dialog').querySelectorAll<HTMLInputElement>('input')) {
+      if (!input.style.fontSize) continue
+      expect(Number.parseFloat(input.style.fontSize)).toBeGreaterThanOrEqual(16)
+    }
+  })
+})
+
+// The nested flow named in the acceptance criteria: top-up → successor.
+describe('TopUpControl — nested successor dialog (#688)', () => {
+  async function openBoth() {
+    render(<TopUpControl inv={lockedBook} isVi={false} onDone={() => {}} />)
+    await userEvent.click(screen.getByTestId('top-up-btn'))
+    fireEvent.change(screen.getByTestId('top-up-amount'), { target: { value: '2000000' } })
+    fireEvent.click(screen.getByTestId('open-successor-btn'))
+    return screen.getByTestId('successor-modal')
+  }
+
+  it('Escape closes only the successor sheet, leaving the top-up dialog open', async () => {
+    // Both dialogs listen on document. Without a stack this Escape collapsed the
+    // pile and the user lost the sheet they were not even in.
+    await openBoth()
+    expect(screen.getByTestId('top-up-modal')).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    await waitFor(() => expect(screen.queryByTestId('successor-modal')).not.toBeInTheDocument())
+    expect(screen.getByTestId('top-up-modal')).toBeInTheDocument()
+  })
+
+  it('a second Escape then closes the top-up dialog', async () => {
+    await openBoth()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    await waitFor(() => expect(screen.queryByTestId('successor-modal')).not.toBeInTheDocument())
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    await waitFor(() => expect(screen.queryByTestId('top-up-modal')).not.toBeInTheDocument())
+  })
+
+  it('traps Tab in the successor sheet, not the dialog underneath', async () => {
+    const sheet = await openBoth()
+    const focusables = sheet.querySelectorAll<HTMLElement>('button, input')
+    focusables[focusables.length - 1].focus()
+
+    await userEvent.tab()
+
+    expect(sheet).toContainElement(document.activeElement as HTMLElement)
+  })
+
+  it('returns focus to the top-up dialog when the successor sheet closes', async () => {
+    await openBoth()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    await waitFor(() => expect(screen.queryByTestId('successor-modal')).not.toBeInTheDocument())
+    // Back inside the parent dialog, not stranded on the page behind it.
+    expect(screen.getByTestId('top-up-modal')).toContainElement(document.activeElement as HTMLElement)
+  })
+})

--- a/app/assets/components/__tests__/TransactionHistorySheet.test.tsx
+++ b/app/assets/components/__tests__/TransactionHistorySheet.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import TransactionHistorySheet from '../TransactionHistorySheet'
 
@@ -126,5 +126,45 @@ describe('TransactionHistorySheet', () => {
     render(<TransactionHistorySheet {...baseProps} onAddTransaction={onAddTransaction} />)
     await userEvent.click(screen.getByRole('button', { name: /add transaction/i }))
     expect(onAddTransaction).toHaveBeenCalledOnce()
+  })
+})
+
+// Guard for #688. A full-screen sheet with no dialog semantics: nothing told a
+// screen reader it was a modal, Escape did nothing, and focus stayed on the row
+// behind it so Tab walked the page underneath.
+describe('TransactionHistorySheet — dialog contract (#688)', () => {
+  it('is a modal dialog named by the fund heading it already shows', () => {
+    render(<TransactionHistorySheet {...baseProps} />)
+
+    // aria-labelledby, not a duplicated aria-label: one name, and it is the one
+    // on screen.
+    const dialog = screen.getByRole('dialog', { name: 'VNINDEX ETF' })
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    render(<TransactionHistorySheet {...baseProps} onClose={onClose} />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('moves focus into the sheet on open', () => {
+    render(<TransactionHistorySheet {...baseProps} />)
+
+    expect(screen.getByRole('dialog')).toContainElement(document.activeElement as HTMLElement)
+  })
+
+  it('keeps Tab inside the sheet', async () => {
+    render(<TransactionHistorySheet {...baseProps} />)
+    const dialog = screen.getByRole('dialog')
+    const focusables = dialog.querySelectorAll<HTMLElement>('button, a[href], input')
+    focusables[focusables.length - 1].focus()
+
+    await userEvent.tab()
+
+    expect(dialog).toContainElement(document.activeElement as HTMLElement)
   })
 })

--- a/app/assets/components/__tests__/TransactionLedgerSheet.a11y.test.tsx
+++ b/app/assets/components/__tests__/TransactionLedgerSheet.a11y.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import TransactionLedgerSheet from '../TransactionLedgerSheet'
+
+// Guard for #688. Every dialog in this file goes through one internal Shell —
+// the ledger, the edit form, the CSV import and the delete confirmation — so the
+// contract was missing from four overlays at once, and the delete confirmation
+// opens on top of the ledger, which makes it the second nested case.
+vi.mock('next-intl', () => ({
+  useTranslations: () => (k: string, params?: Record<string, unknown>) =>
+    params ? `${k}:${JSON.stringify(params)}` : k,
+}))
+vi.mock('../AddTransactionSheet', () => ({ default: () => null }))
+vi.mock('sonner', () => ({ toast: { error: vi.fn() } }))
+
+const tx = {
+  transaction_id: 't1', asset_type: 'bank', transaction_type: 'investment',
+  investment_date: '2026-06-01', amount_vnd: 10_000_000,
+  savings_goals: { goal_name: 'House' },
+}
+
+beforeEach(() => {
+  global.fetch = vi.fn().mockImplementation((url: string) => {
+    if (url.includes('savings-goals')) return Promise.resolve({ ok: true, json: async () => ({ goals: [] }) })
+    if (url.includes('/api/funds')) return Promise.resolve({ ok: true, json: async () => ({ funds: [] }) })
+    if (url.includes('investment-transactions')) return Promise.resolve({ ok: true, json: async () => ({ transactions: [tx], total: 1 }) })
+    return Promise.resolve({ ok: true, json: async () => ({}) })
+  }) as never
+})
+
+for (const [name, desktop] of [['desktop', true], ['mobile', false]] as const) {
+  describe(`TransactionLedgerSheet (${name}) — dialog contract (#688)`, () => {
+    const props = { open: true, desktop, locale: 'en', onClose: vi.fn() }
+
+    it('is a modal dialog named by its heading', async () => {
+      render(<TransactionLedgerSheet {...props} />)
+
+      const dialog = await screen.findByRole('dialog', { name: 'ledgerTitle' })
+      expect(dialog).toHaveAttribute('aria-modal', 'true')
+      expect(dialog).toBe(screen.getByTestId('tx-ledger'))
+    })
+
+    it('closes on Escape', async () => {
+      const onClose = vi.fn()
+      render(<TransactionLedgerSheet {...props} onClose={onClose} />)
+      await screen.findByTestId('tx-ledger')
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('moves focus into the dialog and keeps Tab inside it', async () => {
+      render(<TransactionLedgerSheet {...props} />)
+      const dialog = await screen.findByTestId('tx-ledger')
+      expect(dialog).toContainElement(document.activeElement as HTMLElement)
+
+      const focusables = dialog.querySelectorAll<HTMLElement>('button:not([disabled]), input:not([disabled]), select:not([disabled])')
+      focusables[focusables.length - 1].focus()
+      await userEvent.tab()
+
+      expect(dialog).toContainElement(document.activeElement as HTMLElement)
+    })
+  })
+}
+
+describe('TransactionLedgerSheet — the delete confirmation on top of the ledger (#688)', () => {
+  const props = { open: true, desktop: true, locale: 'en', onClose: vi.fn() }
+
+  async function openConfirm() {
+    render(<TransactionLedgerSheet {...props} />)
+    await screen.findByTestId('tx-ledger')
+    const del = screen.getAllByTestId('tx-ledger-delete')[0]
+    fireEvent.click(del)
+    return screen.getByRole('dialog', { name: 'deleteTitle' })
+  }
+
+  it('is its own named modal dialog', async () => {
+    const confirm = await openConfirm()
+
+    expect(confirm).toHaveAttribute('aria-modal', 'true')
+  })
+
+  it('Escape closes only the confirmation, leaving the ledger open', async () => {
+    await openConfirm()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'deleteTitle' })).not.toBeInTheDocument())
+    expect(screen.getByTestId('tx-ledger')).toBeInTheDocument()
+  })
+
+  it('traps Tab in the confirmation, not the ledger underneath', async () => {
+    const confirm = await openConfirm()
+    const focusables = confirm.querySelectorAll<HTMLElement>('button:not([disabled])')
+    focusables[focusables.length - 1].focus()
+
+    await userEvent.tab()
+
+    expect(confirm).toContainElement(document.activeElement as HTMLElement)
+  })
+})

--- a/app/assets/components/__tests__/helpers/dialogContract.tsx
+++ b/app/assets/components/__tests__/helpers/dialogContract.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useState, type ReactNode } from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+// The dialog contract of #688, as one reusable suite.
+//
+// Every overlay owes a keyboard user the same six things, and writing them out
+// per sheet is what let them drift apart in the first place — some had Escape,
+// some had a trap, almost none had a name. Stating the contract once means a new
+// sheet inherits the assertions by naming itself, and a sheet cannot quietly
+// meet four of six.
+
+export function dialogContract({
+  name,
+  open,
+  accessibleName,
+  /** A control inside the panel, for the click-inside case. */
+  insideTestId,
+  /** False for sheets whose inputs are not user-typed (nothing to zoom). */
+  checksInputZoom = true,
+}: {
+  name: string
+  open: (onClose: () => void) => ReactNode
+  accessibleName: string | RegExp
+  insideTestId?: string
+  checksInputZoom?: boolean
+}) {
+  describe(`${name} — dialog contract (#688)`, () => {
+    it('is a modal dialog with an accessible name', () => {
+      render(<>{open(() => {})}</>)
+
+      const dialog = screen.getByRole('dialog', { name: accessibleName })
+      expect(dialog).toHaveAttribute('aria-modal', 'true')
+    })
+
+    it('closes on Escape', () => {
+      const onClose = vi.fn()
+      render(<>{open(onClose)}</>)
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+
+    it('moves focus into the dialog on open', () => {
+      render(<>{open(() => {})}</>)
+
+      // Not left on the page behind it, where Tab would walk the content
+      // underneath the overlay.
+      expect(screen.getByRole('dialog')).toContainElement(document.activeElement as HTMLElement)
+    })
+
+    it('keeps Tab inside the dialog', async () => {
+      render(<>{open(() => {})}</>)
+      const dialog = screen.getByRole('dialog')
+      const focusables = dialog.querySelectorAll<HTMLElement>('a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])')
+      focusables[focusables.length - 1]?.focus()
+
+      await userEvent.tab()
+
+      expect(dialog).toContainElement(document.activeElement as HTMLElement)
+    })
+
+    it('keeps Shift+Tab inside the dialog', async () => {
+      render(<>{open(() => {})}</>)
+      const dialog = screen.getByRole('dialog')
+      const focusables = dialog.querySelectorAll<HTMLElement>('a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])')
+      focusables[0]?.focus()
+
+      await userEvent.tab({ shift: true })
+
+      expect(dialog).toContainElement(document.activeElement as HTMLElement)
+    })
+
+    it('restores focus to the control that opened it', async () => {
+      function Harness() {
+        const [shown, setShown] = useState(false)
+        return (
+          <>
+            <button type="button" onClick={() => setShown(true)}>launch</button>
+            {shown && open(() => setShown(false))}
+          </>
+        )
+      }
+      render(<Harness />)
+      const trigger = screen.getByText('launch')
+      await userEvent.click(trigger)
+      expect(screen.getByRole('dialog')).toBeInTheDocument()
+
+      fireEvent.keyDown(document, { key: 'Escape' })
+
+      await waitFor(() => expect(trigger).toHaveFocus())
+    })
+
+    it('closes on a click outside the panel', async () => {
+      const onClose = vi.fn()
+      render(<>{open(onClose)}</>)
+
+      await userEvent.click(screen.getAllByTestId('dialog-overlay')[0])
+
+      expect(onClose).toHaveBeenCalled()
+    })
+
+    if (insideTestId) {
+      it('does not close on a click inside the panel', async () => {
+        const onClose = vi.fn()
+        render(<>{open(onClose)}</>)
+
+        await userEvent.click(screen.getByTestId(insideTestId))
+
+        expect(onClose).not.toHaveBeenCalled()
+      })
+    }
+
+    if (checksInputZoom) {
+      it('sets typed inputs at 16px so iOS Safari does not zoom on focus (#265)', () => {
+        render(<>{open(() => {})}</>)
+
+        const inputs = screen.getByRole('dialog').querySelectorAll<HTMLInputElement>('input')
+        expect(inputs.length, 'no inputs to check — pass checksInputZoom: false').toBeGreaterThan(0)
+        for (const input of inputs) {
+          if (!input.style.fontSize) continue
+          expect(Number.parseFloat(input.style.fontSize)).toBeGreaterThanOrEqual(16)
+        }
+      })
+    }
+  })
+}

--- a/app/assets/components/goalDetailShared.tsx
+++ b/app/assets/components/goalDetailShared.tsx
@@ -8,6 +8,7 @@ import { TrendingUp, Building, Coins, BarChart2, Target, RefreshCw, Plus } from 
 import { fmtCompact } from '@/lib/formatters'
 import { todayIso } from '@/lib/dates'
 import { classifyAccumulatingTopUp } from '@/lib/accumulatingTopUp'
+import DialogShell from '@/components/ui/DialogShell'
 import SuccessorBookSheet, { type SuccessorTarget } from './SuccessorBookSheet'
 import { formatIntVN, parseIntVN, formatDecimalVN, parseDecimalVN } from '@/lib/numberFormat'
 import { fmtTxDate } from './transactionUtils'
@@ -324,6 +325,9 @@ export function BankInfoStrip({ inv, isVi }: { inv: InvRow; isVi: boolean }) {
 // a small modal to add a tranche (amount + this slice's rate + date). Posts a new
 // investment_transactions row linked to the book via tops_up_deposit_id; the
 // route inherits the book's goal + maturity. Renders nothing for non-books.
+// The visible title is the dialog's accessible name, so the two cannot drift.
+const TOP_UP_TITLE_ID = 'top-up-title'
+
 export function TopUpControl({ inv, isVi, onDone }: { inv: InvRow; isVi: boolean; onDone: () => void }) {
   const [open, setOpen] = useState(false)
   const [amount, setAmount] = useState('')
@@ -383,7 +387,7 @@ export function TopUpControl({ inv, isVi, onDone }: { inv: InvRow; isVi: boolean
     } catch { setError(isVi ? 'Lỗi kết nối' : 'Connection error') } finally { setSaving(false) }
   }
 
-  const field: CSSProperties = { width: '100%', boxSizing: 'border-box', padding: '10px 12px', fontSize: 15, fontWeight: 600, background: 'var(--c-canvas,#faf9f7)', border: '1.5px solid var(--c-line)', borderRadius: 10, color: 'var(--c-ink)', outline: 'none', fontVariantNumeric: 'tabular-nums' }
+  const field: CSSProperties = { width: '100%', boxSizing: 'border-box', padding: '10px 12px', fontSize: 16, fontWeight: 600, background: 'var(--c-canvas,#faf9f7)', border: '1.5px solid var(--c-line)', borderRadius: 10, color: 'var(--c-ink)', outline: 'none', fontVariantNumeric: 'tabular-nums' }
   const lbl: CSSProperties = { fontSize: 11, fontWeight: 600, letterSpacing: '0.05em', textTransform: 'uppercase', color: 'var(--c-muted)', marginBottom: 6, display: 'block' }
 
   return (
@@ -393,9 +397,15 @@ export function TopUpControl({ inv, isVi, onDone }: { inv: InvRow; isVi: boolean
         <Plus size={14} strokeWidth={2.4} />{isVi ? 'Nạp thêm' : 'Top up'}
       </button>
       {open && (
-        <div onClick={() => !saving && setOpen(false)} style={{ position: 'fixed', inset: 0, zIndex: 320, background: 'rgba(15,23,42,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 24 }}>
-          <div onClick={(e) => e.stopPropagation()} data-testid="top-up-modal" style={{ width: 380, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, display: 'grid', gap: 12, boxShadow: '0 20px 50px rgba(15,23,42,0.25)' }}>
-            <div style={{ fontSize: 15, fontWeight: 700 }}>{isVi ? 'Nạp thêm vào sổ' : 'Top up deposit'}</div>
+        <DialogShell
+          onClose={() => setOpen(false)}
+          dismissOnClickAway={!saving}
+          labelledBy={TOP_UP_TITLE_ID}
+          overlayStyle={{ zIndex: 320, padding: 24 }}
+          panelStyle={{ width: 380, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, display: 'grid', gap: 12, boxShadow: '0 20px 50px rgba(15,23,42,0.25)' }}
+          panelProps={{ 'data-testid': 'top-up-modal' }}
+        >
+            <div id={TOP_UP_TITLE_ID} style={{ fontSize: 15, fontWeight: 700 }}>{isVi ? 'Nạp thêm vào sổ' : 'Top up deposit'}</div>
             <div>
               <label style={lbl}>{isVi ? 'Số tiền nạp (₫)' : 'Top-up amount (₫)'}</label>
               <input data-testid="top-up-amount" type="text" inputMode="numeric" value={formatIntVN(amount)} onChange={(e) => setAmount(parseIntVN(e.target.value))} placeholder="2.000.000" style={field} />
@@ -427,8 +437,7 @@ export function TopUpControl({ inv, isVi, onDone }: { inv: InvRow; isVi: boolean
               <button type="button" data-testid="top-up-submit" onClick={submit} disabled={saving || !(amt > 0) || eligibility.status !== 'allowed'} style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: saving ? 'default' : 'pointer', fontFamily: 'inherit', opacity: saving || !(amt > 0) || eligibility.status !== 'allowed' ? 0.6 : 1 }}>{isVi ? 'Nạp thêm' : 'Top up'}</button>
               )}
             </div>
-          </div>
-        </div>
+        </DialogShell>
       )}
       <SuccessorBookSheet target={successor} isVi={isVi} onClose={() => setSuccessor(null)} onDone={() => { setOpen(false); setAmount(''); onDone() }} />
     </>

--- a/components/ui/DialogShell.tsx
+++ b/components/ui/DialogShell.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useRef, type CSSProperties, type ReactNode, type RefObject } from 'react'
+import { useDialogA11y } from './useDialogA11y'
+
+// The dialog contract as a component, not as a checklist (#688).
+//
+// useDialogA11y has been shared since #600, but every asset and planning overlay
+// still hand-rolled its own fixed <div>: a few called the hook, most did not, and
+// almost none set role/aria-modal/an accessible name. The behaviour a keyboard or
+// screen-reader user gets was decided per file, by whoever wrote it — which is
+// how a contract quietly stops being one.
+//
+// So the overlay itself is the contract now. A sheet supplies content and its own
+// styling; it cannot opt out of Escape, focus entry, focus restore, the Tab trap
+// or the semantics by forgetting a line.
+
+const OVERLAY: CSSProperties = {
+  position: 'fixed',
+  inset: 0,
+  background: 'rgba(15,23,42,0.4)',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}
+
+export default function DialogShell({
+  onClose,
+  label,
+  labelledBy,
+  dismissOnClickAway = true,
+  overlayStyle,
+  panelStyle,
+  panelProps,
+  panelRef,
+  overlayProps,
+  children,
+}: {
+  onClose: () => void
+  /** An accessible name, when no visible element carries it. */
+  label?: string
+  /** id of the visible title naming this dialog. Preferred over `label`. */
+  labelledBy?: string
+  /** False while a save is in flight, so a stray click cannot discard the form. */
+  dismissOnClickAway?: boolean
+  overlayStyle?: CSSProperties
+  panelStyle?: CSSProperties
+  panelProps?: Record<string, unknown>
+  /** For a sheet that measures or scrolls its own panel. */
+  panelRef?: RefObject<HTMLDivElement | null>
+  overlayProps?: Record<string, unknown>
+  children: ReactNode
+}) {
+  const ownRef = useRef<HTMLDivElement>(null)
+  const ref = panelRef ?? ownRef
+
+  // Always active: the wrapper only renders while its sheet is open, so mounting
+  // IS opening. A sheet that keeps itself mounted while closed renders nothing.
+  useDialogA11y(ref, true, onClose)
+
+  return (
+    <div
+      data-testid="dialog-overlay"
+      onClick={() => dismissOnClickAway && onClose()}
+      style={{ ...OVERLAY, ...overlayStyle }}
+      {...overlayProps}
+    >
+      <div
+        ref={ref}
+        role="dialog"
+        aria-modal="true"
+        aria-label={labelledBy ? undefined : label}
+        aria-labelledby={labelledBy}
+        // The panel swallows its own clicks so the overlay's dismissal only ever
+        // means "outside".
+        onClick={(e) => e.stopPropagation()}
+        style={panelStyle}
+        {...panelProps}
+      >
+        {children}
+      </div>
+    </div>
+  )
+}

--- a/components/ui/__tests__/DialogShell.test.tsx
+++ b/components/ui/__tests__/DialogShell.test.tsx
@@ -1,0 +1,217 @@
+import { describe, it, expect, vi } from 'vitest'
+import { useRef, useState } from 'react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import DialogShell from '../DialogShell'
+
+// Guard for #688. The app has a shared dialog contract (useDialogA11y), but the
+// asset and planning overlays each hand-rolled their own fixed <div> and skipped
+// it — no role, no accessible name, focus left behind the overlay, Tab escaping,
+// Escape doing nothing. Wiring each of them individually is how the contract got
+// lost in the first place, so the contract now lives in a wrapper: what a sheet
+// supplies is its own content and styling, and it cannot opt out of the
+// behaviour by forgetting a hook.
+
+function Harness({ onClose = () => {}, dismissOnClickAway = true }: { onClose?: () => void; dismissOnClickAway?: boolean }) {
+  return (
+    <DialogShell onClose={onClose} label="Test dialog" dismissOnClickAway={dismissOnClickAway} panelProps={{ 'data-testid': 'panel' }}>
+      <button type="button">first</button>
+      <button type="button">second</button>
+    </DialogShell>
+  )
+}
+
+describe('DialogShell — dialog semantics (#688)', () => {
+  it('is a role=dialog, modal, with an accessible name', () => {
+    render(<Harness />)
+
+    const dialog = screen.getByRole('dialog', { name: 'Test dialog' })
+    expect(dialog).toHaveAttribute('aria-modal', 'true')
+    expect(dialog).toBe(screen.getByTestId('panel'))
+  })
+
+  it('takes its name from a heading when given one', () => {
+    render(
+      <DialogShell onClose={() => {}} labelledBy="t">
+        <h2 id="t">Open successor book</h2>
+      </DialogShell>,
+    )
+
+    expect(screen.getByRole('dialog', { name: 'Open successor book' })).toBeInTheDocument()
+  })
+})
+
+describe('DialogShell — keyboard contract (#688)', () => {
+  it('moves focus into the dialog on open', () => {
+    render(<Harness />)
+
+    // Focus lands on the first focusable, not left behind on the trigger where a
+    // keyboard user would be tabbing through the page underneath.
+    expect(screen.getByText('first')).toHaveFocus()
+  })
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn()
+    render(<Harness onClose={onClose} />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+
+  it('wraps Tab from the last control back to the first', async () => {
+    render(<Harness />)
+
+    screen.getByText('second').focus()
+    await userEvent.tab()
+
+    expect(screen.getByText('first')).toHaveFocus()
+  })
+
+  it('wraps Shift+Tab from the first control to the last', async () => {
+    render(<Harness />)
+
+    screen.getByText('first').focus()
+    await userEvent.tab({ shift: true })
+
+    expect(screen.getByText('second')).toHaveFocus()
+  })
+
+  it('restores focus to the control that opened it', async () => {
+    function Openable() {
+      const [open, setOpen] = useState(false)
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>open</button>
+          {open && (
+            <DialogShell onClose={() => setOpen(false)} label="d">
+              <button type="button">inside</button>
+            </DialogShell>
+          )}
+        </>
+      )
+    }
+    render(<Openable />)
+    const trigger = screen.getByText('open')
+    await userEvent.click(trigger)
+    expect(screen.getByText('inside')).toHaveFocus()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    await waitFor(() => expect(trigger).toHaveFocus())
+  })
+})
+
+describe('DialogShell — dismissal (#688)', () => {
+  it('closes on a click outside the panel', async () => {
+    const onClose = vi.fn()
+    render(<Harness onClose={onClose} />)
+
+    await userEvent.click(screen.getByTestId('dialog-overlay'))
+
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('does not close on a click inside the panel', async () => {
+    const onClose = vi.fn()
+    render(<Harness onClose={onClose} />)
+
+    await userEvent.click(screen.getByText('first'))
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+
+  it('holds the overlay shut while a save is in flight', async () => {
+    // Clicking away mid-save used to discard a form that was already writing.
+    const onClose = vi.fn()
+    render(<Harness onClose={onClose} dismissOnClickAway={false} />)
+
+    await userEvent.click(screen.getByTestId('dialog-overlay'))
+
+    expect(onClose).not.toHaveBeenCalled()
+  })
+})
+
+describe('DialogShell — nesting (#688)', () => {
+  it('lets only the topmost dialog answer Escape', () => {
+    // The successor flow opens a dialog from inside a dialog. Both listen on
+    // document, so without a stack one Escape collapsed the whole pile and the
+    // user lost the sheet they were actually in.
+    const outer = vi.fn()
+    const inner = vi.fn()
+    render(
+      <>
+        <DialogShell onClose={outer} label="outer"><button type="button">o</button></DialogShell>
+        <DialogShell onClose={inner} label="inner"><button type="button">i</button></DialogShell>
+      </>,
+    )
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(inner).toHaveBeenCalledTimes(1)
+    expect(outer).not.toHaveBeenCalled()
+  })
+
+  it('hands Escape back to the parent once the child closes', () => {
+    const outer = vi.fn()
+    const inner = vi.fn()
+    function Nested() {
+      const [childOpen, setChildOpen] = useState(true)
+      return (
+        <>
+          <DialogShell onClose={outer} label="outer"><button type="button">o</button></DialogShell>
+          {childOpen && (
+            <DialogShell onClose={() => { inner(); setChildOpen(false) }} label="inner">
+              <button type="button">i</button>
+            </DialogShell>
+          )}
+        </>
+      )
+    }
+    render(<Nested />)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(inner).toHaveBeenCalledTimes(1)
+    expect(outer).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(outer).toHaveBeenCalledTimes(1)
+  })
+
+  it('traps Tab inside the topmost dialog, not the one underneath', async () => {
+    render(
+      <>
+        <DialogShell onClose={() => {}} label="outer"><button type="button">outer-btn</button></DialogShell>
+        <DialogShell onClose={() => {}} label="inner">
+          <button type="button">inner-a</button>
+          <button type="button">inner-b</button>
+        </DialogShell>
+      </>,
+    )
+
+    screen.getByText('inner-b').focus()
+    await userEvent.tab()
+
+    expect(screen.getByText('inner-a')).toHaveFocus()
+  })
+})
+
+// A ref is how the useDialogA11y hook was used directly; the wrapper must not
+// take that away from a sheet that needs to measure or scroll its own panel.
+describe('DialogShell — panel ref (#688)', () => {
+  it('forwards a ref to the panel', () => {
+    function WithRef() {
+      const ref = useRef<HTMLDivElement>(null)
+      return (
+        <DialogShell onClose={() => {}} label="d" panelRef={ref}>
+          <button type="button" onClick={() => ref.current?.setAttribute('data-measured', '1')}>measure</button>
+        </DialogShell>
+      )
+    }
+    render(<WithRef />)
+
+    fireEvent.click(screen.getByText('measure'))
+
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-measured', '1')
+  })
+})

--- a/components/ui/useDialogA11y.ts
+++ b/components/ui/useDialogA11y.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type RefObject } from 'react'
+import { useEffect, useMemo, useRef, type RefObject } from 'react'
 
 // Shared dialog accessibility for every modal/sheet wrapper in the app — the
 // Plan page's DModal/Sheet, the settings views, the fund library, the dashboard
@@ -33,6 +33,14 @@ const FOCUSABLE = [
   'input:not([disabled])', 'select:not([disabled])', '[tabindex]:not([tabindex="-1"])',
 ].join(',')
 
+// Which dialogs are open, innermost last. Every dialog listens on document, so
+// without this an Escape in a dialog opened FROM a dialog — the successor flow —
+// ran both handlers and collapsed the whole pile: the user asked to leave one
+// sheet and lost the one underneath too. stopPropagation cannot help, because
+// the listeners share a target. Nor can the Tab trap be left ungated: the dialog
+// underneath would answer as well, pulling focus out of the one on top (#688).
+const openDialogs: object[] = []
+
 export function useDialogA11y(
   ref: RefObject<HTMLElement | null>,
   active: boolean,
@@ -40,6 +48,19 @@ export function useDialogA11y(
 ) {
   const onCloseRef = useRef(onClose)
   useEffect(() => { onCloseRef.current = onClose })
+
+  // Identity for this dialog's place in the stack — stable across renders, and
+  // useMemo rather than a ref because the value is read while rendering the
+  // effect's dependencies, which reading a ref there is not allowed to do.
+  const token = useMemo(() => ({}), [])
+  useEffect(() => {
+    if (!active) return
+    openDialogs.push(token)
+    return () => {
+      const at = openDialogs.indexOf(token)
+      if (at !== -1) openDialogs.splice(at, 1)
+    }
+  }, [active, token])
 
   // Focus in on open; restore on close.
   useEffect(() => {
@@ -57,6 +78,9 @@ export function useDialogA11y(
   useEffect(() => {
     if (!active) return
     function onKey(e: KeyboardEvent) {
+      // Only the dialog on top answers. A dialog that is open but covered is not
+      // the one the user is interacting with.
+      if (openDialogs[openDialogs.length - 1] !== token) return
       if (e.key === 'Escape') { e.stopPropagation(); onCloseRef.current(); return }
       if (e.key !== 'Tab') return
       const node = ref.current
@@ -74,5 +98,5 @@ export function useDialogA11y(
     }
     document.addEventListener('keydown', onKey, true)
     return () => document.removeEventListener('keydown', onKey, true)
-  }, [active, ref])
+  }, [active, ref, token])
 }


### PR DESCRIPTION
Closes #688.

## What was broken

`useDialogA11y` has been shared since #600 — but the asset and planning overlays each hand-rolled their own fixed `<div>`. Measured across the files the issue names: **0 of 8 called the hook, 0 of 8 set `role="dialog"` or `aria-modal`.** What a keyboard or screen-reader user got was decided per file, by whoever wrote it. Focus stayed behind the overlay, Tab walked the page underneath, Escape did nothing, and nothing announced any of it as a modal.

Wiring each of them individually is exactly how the contract was lost the first time. So the overlay itself is the contract now.

## `components/ui/DialogShell.tsx`

Owns the scrim, the panel, the semantics and the hook. A sheet supplies content and its own styling; it **cannot opt out by forgetting a line**. This is the issue's "prefer shared modal/sheet wrappers so new features inherit this behaviour", made structural.

| Overlay | How |
| :--- | :--- |
| SuccessorBookSheet | DialogShell |
| RecurringBookTopUpSheet | DialogShell |
| goal-detail top-up dialog | DialogShell |
| AddTransactionSheet — desktop + mobile wrappers | DialogShell |
| TransactionLedgerSheet's internal `Shell` | DialogShell — **four dialogs at once**: ledger, edit, CSV import, delete |
| Planning delete confirmations ×2, both variants | DialogShell |
| InsuranceDetailSheet, TransactionHistorySheet, GoalDetailSheet | hook directly — see below |

**Why three sheets keep the hook rather than the shell.** They *are* the fixed element: full-screen, their own scroll container, no scrim and therefore no click-away. Wrapping them in the shell's overlay would put a second scrolling box around the one their `animation` and `overscrollBehavior` rules are written for. Same contract, different shape — and the reason is in the code, so the next person doesn't "fix" it.

## The nested case needed the hook itself fixed

Every dialog listens on `document`. So Escape in the successor sheet — which opens from *inside* the top-up dialog — ran both handlers and collapsed the pile: the user asked to leave one sheet and lost the one underneath too. `stopPropagation` cannot help, because the listeners share a target.

`useDialogA11y` now keeps a stack of open dialogs and gates **both Escape and the Tab trap** on being topmost. The Tab half matters as much: without it the dialog underneath answers too and pulls focus out of the one on top.

## Also: the 16px rule from #265

The three newer forms set `fontSize: 15` — inline, which is why the issue's `text-[15px]` grep finds nothing. Below 16px iOS Safari zooms on focus. Now 16.

## Tests

Every conversion was red first. A reusable `dialogContract()` suite states the six obligations once, so a new sheet inherits the assertions by naming itself instead of re-deriving them (and cannot quietly satisfy four of six).

| Suite | Red before |
| :--- | :--- |
| DialogShell (14) | module did not exist |
| SuccessorBookSheet (9) | 8 |
| RecurringBookTopUpSheet (9) | 8 |
| TopUpControl incl. nested successor (8) | — see below |
| AddTransactionSheet desktop+mobile (14) | 12 |
| TransactionLedgerSheet incl. delete-on-ledger (9) | 9 |
| FixedExpenseManager delete, both variants (6) | 6 |
| RecurringSavingManager delete, both variants (8) | 6 |
| InsuranceDetail / TransactionHistory / GoalDetail (10) | 3 / 4 / 3 |

**The stack has its own proof.** Removing the topmost gate turns exactly the four nested assertions red — the two in DialogShell and the two in the top-up → successor flow — and restoring it returns 22/22. A guard that cannot fail is not a guard; this one fails.

Gates: `npm run typecheck` ✅ · `npm run lint` — 0 errors (2 pre-existing unrelated warnings) ✅ · `npm run test:coverage` — 219 files, 2683 tests, thresholds pass ✅ · `npm run test:e2e:smoke` — 20/20 in 1m2s ✅

The smoke lane earns its place here: this change alters the DOM of nine overlays, adding an overlay element in some and moving `data-testid="fe-delete-overlay"` / `rs-delete-overlay` onto the shell's overlay (kept there deliberately — the id says "overlay").

## Reviewer note

Worth a keyboard pass on the preview: open a goal → top up → "Open successor book", then press Escape twice. First press should close only the successor sheet and leave the top-up dialog focused; second should close the top-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)