### PR TITLE
refactor(planning): represent the shared manager shell once (#689)

### DIFF
--- a/app/(app)/planning/components/EffectiveMonthFields.tsx
+++ b/app/(app)/planning/components/EffectiveMonthFields.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+import { inputStyle, labelStyle } from './planningManagerShell'
+
+// The "effective from / effective to" pair both planning managers ask for
+// (#689). Identical in both but for the ids and the label copy — which is
+// exactly what a prop is for.
+export default function EffectiveMonthFields({
+  idPrefix,
+  fromLabel,
+  toLabel,
+  from,
+  to,
+  onFromChange,
+  onToChange,
+}: {
+  /** 'fe' or 'rs' — keeps each feature's existing ids and test ids. */
+  idPrefix: string
+  fromLabel: string
+  toLabel: string
+  from: string
+  to: string
+  onFromChange: (value: string) => void
+  onToChange: (value: string) => void
+}) {
+  return (
+    // minmax(0,1fr), not 1fr: a month input has a wide intrinsic minimum and
+    // would otherwise push the grid past its container on a narrow phone.
+    <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1fr) minmax(0,1fr)', gap: 10 }}>
+      <div>
+        <label htmlFor={`${idPrefix}-from`} style={labelStyle}>{fromLabel}</label>
+        <input
+          id={`${idPrefix}-from`}
+          data-testid={`${idPrefix}-from`}
+          type="month"
+          value={from}
+          onChange={(e) => onFromChange(e.target.value)}
+          style={{ ...inputStyle, fontVariantNumeric: 'tabular-nums', minWidth: 0 }}
+        />
+      </div>
+      <div>
+        <label htmlFor={`${idPrefix}-to`} style={labelStyle}>{toLabel}</label>
+        <input
+          id={`${idPrefix}-to`}
+          data-testid={`${idPrefix}-to`}
+          type="month"
+          value={to}
+          onChange={(e) => onToChange(e.target.value)}
+          style={{ ...inputStyle, fontVariantNumeric: 'tabular-nums', minWidth: 0 }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/app/(app)/planning/components/FixedExpenseManager.tsx
+++ b/app/(app)/planning/components/FixedExpenseManager.tsx
@@ -6,10 +6,9 @@ import { toast } from 'sonner'
 import { Plus, ChevronLeft } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import { formatIntVN, parseIntVN } from '@/lib/numberFormat'
-import DialogShell from '@/components/ui/DialogShell'
-
-// The confirmation's visible title is its accessible name (#688).
-const DELETE_TITLE_ID = 'fixed-expense-delete-title'
+import EffectiveMonthFields from './EffectiveMonthFields'
+import PlanningDeleteConfirm from './PlanningDeleteConfirm'
+import { ghostBtn, inputStyle, labelStyle, monthRangeLabel, primaryBtn, toMonthInput } from './planningManagerShell'
 
 // Master fixed-expense definitions. Categories mirror the Settings tab and the
 // API's accepted values; labels are localised for display only.
@@ -33,44 +32,10 @@ interface Expense {
 }
 
 // "2026-04-01" → "2026-04" for <input type="month">
-function toMonthInput(date: string | null): string {
-  return date ? date.slice(0, 7) : ''
-}
 
-const SHORT_MONTHS_EN = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-const SHORT_MONTHS_VI = ['Th1', 'Th2', 'Th3', 'Th4', 'Th5', 'Th6', 'Th7', 'Th8', 'Th9', 'Th10', 'Th11', 'Th12']
-
-function periodLabel(e: Expense, isVI: boolean): string {
-  if (!e.effective_from && !e.effective_to) return isVI ? 'Luôn áp dụng' : 'Always'
-  const months = isVI ? SHORT_MONTHS_VI : SHORT_MONTHS_EN
-  const fmtMonth = (d: string | null) => {
-    if (!d) return null
-    const [y, m] = d.split('-').map(Number)
-    return `${months[m - 1]} ${y}`
-  }
-  return `${fmtMonth(e.effective_from) || '…'} → ${fmtMonth(e.effective_to) || '∞'}`
-}
 
 const emptyForm = { expense_name: '', amount_vnd: '', category: '', effective_from: '', effective_to: '' }
 
-// ─── Inline style tokens (work in both the desktop modal and mobile sheet) ──────
-
-const inputStyle: React.CSSProperties = {
-  width: '100%', padding: '10px 12px', fontSize: 16,
-  border: '1px solid var(--c-line)', borderRadius: 10,
-  background: 'var(--c-card-2)', color: 'var(--c-ink)', boxSizing: 'border-box',
-}
-const labelStyle: React.CSSProperties = { fontSize: 13, color: 'var(--c-muted)', display: 'block', marginBottom: 4 }
-const ghostBtn: React.CSSProperties = {
-  flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)',
-  background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500,
-  cursor: 'pointer', fontFamily: 'inherit',
-}
-const primaryBtn: React.CSSProperties = {
-  flex: 2, padding: '10px 0', borderRadius: 10, border: 'none',
-  background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600,
-  cursor: 'pointer', fontFamily: 'inherit',
-}
 
 interface Props {
   onChange: () => void
@@ -235,30 +200,15 @@ export default function FixedExpenseManager({ onChange, onToast, variant = 'moda
           />
         </div>
 
-        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1fr) minmax(0,1fr)', gap: 10 }}>
-          <div>
-            <label htmlFor="fe-from" style={labelStyle}>{t('effectiveFromLabel')}</label>
-            <input
-              id="fe-from"
-              data-testid="fe-from"
-              type="month"
-              value={form.effective_from}
-              onChange={(e) => setForm({ ...form, effective_from: e.target.value })}
-              style={{ ...inputStyle, fontVariantNumeric: 'tabular-nums', minWidth: 0 }}
-            />
-          </div>
-          <div>
-            <label htmlFor="fe-to" style={labelStyle}>{t('effectiveToLabel')}</label>
-            <input
-              id="fe-to"
-              data-testid="fe-to"
-              type="month"
-              value={form.effective_to}
-              onChange={(e) => setForm({ ...form, effective_to: e.target.value })}
-              style={{ ...inputStyle, fontVariantNumeric: 'tabular-nums', minWidth: 0 }}
-            />
-          </div>
-        </div>
+        <EffectiveMonthFields
+          idPrefix="fe"
+          fromLabel={t('effectiveFromLabel')}
+          toLabel={t('effectiveToLabel')}
+          from={form.effective_from}
+          to={form.effective_to}
+          onFromChange={(v) => setForm({ ...form, effective_from: v })}
+          onToChange={(v) => setForm({ ...form, effective_to: v })}
+        />
 
         <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
           <button type="button" onClick={() => setMode('list')} style={ghostBtn}>{tc('cancel')}</button>
@@ -304,7 +254,7 @@ export default function FixedExpenseManager({ onChange, onToast, variant = 'moda
                   </span>
                 </div>
                 <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 3, fontVariantNumeric: 'tabular-nums' }}>
-                  {fmt(e.amount_vnd)} · {periodLabel(e, isVI)}
+                  {fmt(e.amount_vnd)} · {monthRangeLabel(e.effective_from, e.effective_to, isVI, isVI ? 'Luôn áp dụng' : 'Always')}
                 </div>
               </div>
               <button
@@ -339,64 +289,19 @@ export default function FixedExpenseManager({ onChange, onToast, variant = 'moda
         <Plus size={15} strokeWidth={2.4} />{t('create')}
       </button>
 
-      {confirmDelete && (() => {
-        const body = (
-          <>
-            <div style={{ fontSize: 13, color: 'var(--c-muted)' }}>
-              {confirmDelete.expense_name} — {fmtCompact(confirmDelete.amount_vnd)}
-            </div>
-            <div style={{ display: 'flex', gap: 8 }}>
-              <button type="button" onClick={() => setConfirmDelete(null)} style={ghostBtn}>{tc('cancel')}</button>
-              <button
-                type="button"
-                data-testid="fe-delete-confirm"
-                onClick={() => handleDelete(confirmDelete)}
-                disabled={deleting}
-                style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-neg)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', opacity: deleting ? 0.7 : 1 }}
-              >
-                {isVI ? 'Xoá' : 'Delete'}
-              </button>
-            </div>
-          </>
-        )
-
-        if (variant === 'sheet') {
-          // Bottom-anchored sheet so it sits on the phone frame (mirrors the
-          // mobile plan's bottom sheets) instead of floating mid-screen.
-          return (
-            <DialogShell
-              onClose={() => setConfirmDelete(null)}
-              // A delete in flight owns the sheet: clicking away mid-request
-              // would hide the confirmation while the row is still going.
-              dismissOnClickAway={!deleting}
-              labelledBy={DELETE_TITLE_ID}
-              overlayStyle={{ zIndex: 300, alignItems: 'flex-end' }}
-              overlayProps={{ 'data-testid': 'fe-delete-overlay' }}
-              panelStyle={{ width: '100%', background: 'var(--c-card)', borderRadius: '16px 16px 0 0', paddingBottom: 'env(safe-area-inset-bottom,0)', animation: 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' }}
-            >
-                <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '8px auto 0' }} />
-                <div style={{ padding: '14px 16px 0' }}>
-                  <p id={DELETE_TITLE_ID} style={{ fontWeight: 700, fontSize: 16, color: 'var(--c-ink)', margin: '0 0 16px' }}>{t('deleteModal')}</p>
-                </div>
-                <div style={{ padding: '0 16px 24px', display: 'grid', gap: 16 }}>{body}</div>
-            </DialogShell>
-          )
-        }
-
-        return (
-          <DialogShell
-            onClose={() => setConfirmDelete(null)}
-            dismissOnClickAway={!deleting}
-            labelledBy={DELETE_TITLE_ID}
-            overlayStyle={{ zIndex: 300, padding: 24 }}
-            overlayProps={{ 'data-testid': 'fe-delete-overlay' }}
-            panelStyle={{ width: 360, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, boxShadow: '0 20px 50px rgba(15,23,42,0.25)', display: 'grid', gap: 16 }}
-          >
-              <div id={DELETE_TITLE_ID} style={{ fontSize: 15, fontWeight: 700, color: 'var(--c-ink)' }}>{t('deleteModal')}</div>
-              {body}
-          </DialogShell>
-        )
-      })()}
+      {confirmDelete && (
+        <PlanningDeleteConfirm
+          variant={variant}
+          testIdPrefix="fe"
+          title={t('deleteModal')}
+          description={`${confirmDelete.expense_name} — ${fmtCompact(confirmDelete.amount_vnd)}`}
+          cancelLabel={tc('cancel')}
+          confirmLabel={isVI ? 'Xoá' : 'Delete'}
+          deleting={deleting}
+          onCancel={() => setConfirmDelete(null)}
+          onConfirm={() => handleDelete(confirmDelete)}
+        />
+      )}
     </div>
   )
 }

--- a/app/(app)/planning/components/PlanningDeleteConfirm.tsx
+++ b/app/(app)/planning/components/PlanningDeleteConfirm.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { useId } from 'react'
+import DialogShell from '@/components/ui/DialogShell'
+import { ghostBtn, type PlanningVariant } from './planningManagerShell'
+
+// The delete confirmation both planning managers show (#689) — the one overlay
+// on this screen where a misfire destroys data.
+//
+// It was ~62 duplicated lines per manager, differing only in the title, the
+// description and the test-id prefix. Keeping one copy is also what makes the
+// #688 dialog contract hold for both: focus, Escape, the trap and the semantics
+// are inherited from DialogShell here, once, instead of being wired twice and
+// remembered twice.
+export default function PlanningDeleteConfirm({
+  variant,
+  testIdPrefix,
+  title,
+  description,
+  extra,
+  cancelLabel,
+  confirmLabel,
+  deleting,
+  onCancel,
+  onConfirm,
+}: {
+  variant: PlanningVariant
+  /** 'fe' or 'rs' — keeps each feature's existing test ids. */
+  testIdPrefix: string
+  title: string
+  description: ReactNode
+  /** Anything a feature must say before destroying the row. Unused today — the
+   *  seam exists so sharing the shell never becomes the reason a manager cannot
+   *  warn about something specific to it. */
+  extra?: ReactNode
+  cancelLabel: string
+  confirmLabel: string
+  deleting: boolean
+  onCancel: () => void
+  onConfirm: () => void
+}) {
+  const titleId = useId()
+
+  const body = (
+    <>
+      <div style={{ fontSize: 13, color: 'var(--c-muted)' }}>{description}</div>
+      {extra}
+      <div style={{ display: 'flex', gap: 8 }}>
+        <button type="button" onClick={onCancel} style={ghostBtn}>{cancelLabel}</button>
+        <button
+          type="button"
+          data-testid={`${testIdPrefix}-delete-confirm`}
+          onClick={onConfirm}
+          disabled={deleting}
+          style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-neg)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', opacity: deleting ? 0.7 : 1 }}
+        >
+          {confirmLabel}
+        </button>
+      </div>
+    </>
+  )
+
+  // A delete in flight owns the overlay: a stray click outside must not hide the
+  // confirmation while the request is still going.
+  const shared = {
+    onClose: onCancel,
+    dismissOnClickAway: !deleting,
+    labelledBy: titleId,
+    overlayProps: { 'data-testid': `${testIdPrefix}-delete-overlay` },
+  }
+
+  if (variant === 'sheet') {
+    // Bottom-anchored so it sits on the phone frame (mirroring the mobile plan's
+    // other bottom sheets) instead of floating mid-screen.
+    return (
+      <DialogShell
+        {...shared}
+        overlayStyle={{ zIndex: 300, alignItems: 'flex-end' }}
+        panelStyle={{ width: '100%', background: 'var(--c-card)', borderRadius: '16px 16px 0 0', paddingBottom: 'env(safe-area-inset-bottom,0)', animation: 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' }}
+      >
+        <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '8px auto 0' }} />
+        <div style={{ padding: '14px 16px 0' }}>
+          <p id={titleId} style={{ fontWeight: 700, fontSize: 16, color: 'var(--c-ink)', margin: '0 0 16px' }}>{title}</p>
+        </div>
+        <div style={{ padding: '0 16px 24px', display: 'grid', gap: 16 }}>{body}</div>
+      </DialogShell>
+    )
+  }
+
+  return (
+    <DialogShell
+      {...shared}
+      overlayStyle={{ zIndex: 300, padding: 24 }}
+      panelStyle={{ width: 360, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, boxShadow: '0 20px 50px rgba(15,23,42,0.25)', display: 'grid', gap: 16 }}
+    >
+      <div id={titleId} style={{ fontSize: 15, fontWeight: 700, color: 'var(--c-ink)' }}>{title}</div>
+      {body}
+    </DialogShell>
+  )
+}

--- a/app/(app)/planning/components/RecurringSavingManager.tsx
+++ b/app/(app)/planning/components/RecurringSavingManager.tsx
@@ -6,10 +6,9 @@ import { toast } from 'sonner'
 import { Plus, ChevronLeft } from 'lucide-react'
 import { fmt, fmtCompact } from '@/lib/formatters'
 import { formatIntVN, parseIntVN } from '@/lib/numberFormat'
-import DialogShell from '@/components/ui/DialogShell'
-
-// The confirmation's visible title is its accessible name (#688).
-const DELETE_TITLE_ID = 'recurring-saving-delete-title'
+import EffectiveMonthFields from './EffectiveMonthFields'
+import PlanningDeleteConfirm from './PlanningDeleteConfirm'
+import { ghostBtn, inputStyle, labelStyle, monthRangeLabel, primaryBtn, toMonthInput } from './planningManagerShell'
 import type { Goal } from '@/features/planning/contracts'
 
 interface Saving {
@@ -36,42 +35,10 @@ interface LinkTarget {
 }
 
 // "2026-04-01" → "2026-04" for <input type="month">
-function toMonthInput(date: string | null): string {
-  return date ? date.slice(0, 7) : ''
-}
 
-const SHORT_MONTHS_EN = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-const SHORT_MONTHS_VI = ['Th1', 'Th2', 'Th3', 'Th4', 'Th5', 'Th6', 'Th7', 'Th8', 'Th9', 'Th10', 'Th11', 'Th12']
-
-function periodLabel(s: Saving, isVI: boolean): string {
-  if (!s.effective_from && !s.effective_to) return isVI ? 'Hàng tháng' : 'Every month'
-  const months = isVI ? SHORT_MONTHS_VI : SHORT_MONTHS_EN
-  const fmtMonth = (d: string | null) => {
-    if (!d) return null
-    const [y, m] = d.split('-').map(Number)
-    return `${months[m - 1]} ${y}`
-  }
-  return `${fmtMonth(s.effective_from) || '…'} → ${fmtMonth(s.effective_to) || '∞'}`
-}
 
 const emptyForm = { name: '', goal_id: '', amount_vnd: '', effective_from: '', effective_to: '', linked_deposit_tx_id: '' }
 
-const inputStyle: React.CSSProperties = {
-  width: '100%', padding: '10px 12px', fontSize: 16,
-  border: '1px solid var(--c-line)', borderRadius: 10,
-  background: 'var(--c-card-2)', color: 'var(--c-ink)', boxSizing: 'border-box',
-}
-const labelStyle: React.CSSProperties = { fontSize: 13, color: 'var(--c-muted)', display: 'block', marginBottom: 4 }
-const ghostBtn: React.CSSProperties = {
-  flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)',
-  background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500,
-  cursor: 'pointer', fontFamily: 'inherit',
-}
-const primaryBtn: React.CSSProperties = {
-  flex: 2, padding: '10px 0', borderRadius: 10, border: 'none',
-  background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600,
-  cursor: 'pointer', fontFamily: 'inherit',
-}
 
 interface Props {
   goals: Goal[]
@@ -320,30 +287,15 @@ export default function RecurringSavingManager({ goals, onChange, onToast, varia
           />
         </div>
 
-        <div style={{ display: 'grid', gridTemplateColumns: 'minmax(0,1fr) minmax(0,1fr)', gap: 10 }}>
-          <div>
-            <label htmlFor="rs-from" style={labelStyle}>{isVI ? 'Bắt đầu từ' : 'Effective from'}</label>
-            <input
-              id="rs-from"
-              data-testid="rs-from"
-              type="month"
-              value={form.effective_from}
-              onChange={(e) => setForm({ ...form, effective_from: e.target.value })}
-              style={{ ...inputStyle, fontVariantNumeric: 'tabular-nums', minWidth: 0 }}
-            />
-          </div>
-          <div>
-            <label htmlFor="rs-to" style={labelStyle}>{isVI ? 'Kết thúc' : 'Effective to'}</label>
-            <input
-              id="rs-to"
-              data-testid="rs-to"
-              type="month"
-              value={form.effective_to}
-              onChange={(e) => setForm({ ...form, effective_to: e.target.value })}
-              style={{ ...inputStyle, fontVariantNumeric: 'tabular-nums', minWidth: 0 }}
-            />
-          </div>
-        </div>
+        <EffectiveMonthFields
+          idPrefix="rs"
+          fromLabel={isVI ? 'Bắt đầu từ' : 'Effective from'}
+          toLabel={isVI ? 'Kết thúc' : 'Effective to'}
+          from={form.effective_from}
+          to={form.effective_to}
+          onFromChange={(v) => setForm({ ...form, effective_from: v })}
+          onToChange={(v) => setForm({ ...form, effective_to: v })}
+        />
 
         <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: -4 }}>
           {isVI ? 'Tự động lặp lại mỗi tháng. Bỏ trống ngày kết thúc để áp dụng vô thời hạn.' : 'Auto-repeats every month. Leave end blank to apply indefinitely.'}
@@ -393,7 +345,7 @@ export default function RecurringSavingManager({ goals, onChange, onToast, varia
                   </span>
                 </div>
                 <div style={{ fontSize: 11, color: 'var(--c-muted)', marginTop: 3, fontVariantNumeric: 'tabular-nums' }}>
-                  {fmt(s.amount_vnd)} · {periodLabel(s, isVI)}
+                  {fmt(s.amount_vnd)} · {monthRangeLabel(s.effective_from, s.effective_to, isVI, isVI ? 'Hàng tháng' : 'Every month')}
                 </div>
               </div>
               <button
@@ -428,63 +380,19 @@ export default function RecurringSavingManager({ goals, onChange, onToast, varia
         <Plus size={15} strokeWidth={2.4} />{isVI ? 'Thêm khoản định kỳ' : 'Add recurring saving'}
       </button>
 
-      {confirmDelete && (() => {
-        const title = isVI ? 'Xoá khoản định kỳ?' : 'Delete recurring saving?'
-        const body = (
-          <>
-            <div style={{ fontSize: 13, color: 'var(--c-muted)' }}>
-              {confirmDelete.name} — {fmtCompact(confirmDelete.amount_vnd)}
-            </div>
-            <div style={{ display: 'flex', gap: 8 }}>
-              <button type="button" onClick={() => setConfirmDelete(null)} style={ghostBtn}>{tc('cancel')}</button>
-              <button
-                type="button"
-                data-testid="rs-delete-confirm"
-                onClick={() => handleDelete(confirmDelete)}
-                disabled={deleting}
-                style={{ flex: 2, padding: '10px 0', borderRadius: 10, border: 'none', background: 'var(--c-neg)', color: '#fff', fontSize: 14, fontWeight: 600, cursor: 'pointer', fontFamily: 'inherit', opacity: deleting ? 0.7 : 1 }}
-              >
-                {isVI ? 'Xoá' : 'Delete'}
-              </button>
-            </div>
-          </>
-        )
-
-        if (variant === 'sheet') {
-          return (
-            <DialogShell
-              onClose={() => setConfirmDelete(null)}
-              // A delete in flight owns the sheet: clicking away mid-request
-              // would hide the confirmation while the row is still going.
-              dismissOnClickAway={!deleting}
-              labelledBy={DELETE_TITLE_ID}
-              overlayStyle={{ zIndex: 300, alignItems: 'flex-end' }}
-              overlayProps={{ 'data-testid': 'rs-delete-overlay' }}
-              panelStyle={{ width: '100%', background: 'var(--c-card)', borderRadius: '16px 16px 0 0', paddingBottom: 'env(safe-area-inset-bottom,0)', animation: 'slide-up 220ms cubic-bezier(0.2,0.8,0.2,1)' }}
-            >
-                <div style={{ width: 36, height: 4, background: 'var(--c-line-strong)', borderRadius: 999, margin: '8px auto 0' }} />
-                <div style={{ padding: '14px 16px 0' }}>
-                  <p id={DELETE_TITLE_ID} style={{ fontWeight: 700, fontSize: 16, color: 'var(--c-ink)', margin: '0 0 16px' }}>{title}</p>
-                </div>
-                <div style={{ padding: '0 16px 24px', display: 'grid', gap: 16 }}>{body}</div>
-            </DialogShell>
-          )
-        }
-
-        return (
-          <DialogShell
-            onClose={() => setConfirmDelete(null)}
-            dismissOnClickAway={!deleting}
-            labelledBy={DELETE_TITLE_ID}
-            overlayStyle={{ zIndex: 300, padding: 24 }}
-            overlayProps={{ 'data-testid': 'rs-delete-overlay' }}
-            panelStyle={{ width: 360, maxWidth: '100%', background: 'var(--c-card)', borderRadius: 14, padding: 20, boxShadow: '0 20px 50px rgba(15,23,42,0.25)', display: 'grid', gap: 16 }}
-          >
-              <div id={DELETE_TITLE_ID} style={{ fontSize: 15, fontWeight: 700, color: 'var(--c-ink)' }}>{title}</div>
-              {body}
-          </DialogShell>
-        )
-      })()}
+      {confirmDelete && (
+        <PlanningDeleteConfirm
+          variant={variant}
+          testIdPrefix="rs"
+          title={isVI ? 'Xoá khoản định kỳ?' : 'Delete recurring saving?'}
+          description={`${confirmDelete.name} — ${fmtCompact(confirmDelete.amount_vnd)}`}
+          cancelLabel={tc('cancel')}
+          confirmLabel={isVI ? 'Xoá' : 'Delete'}
+          deleting={deleting}
+          onCancel={() => setConfirmDelete(null)}
+          onConfirm={() => handleDelete(confirmDelete)}
+        />
+      )}
     </div>
   )
 }

--- a/app/(app)/planning/components/__tests__/planningManagerShell.test.tsx
+++ b/app/(app)/planning/components/__tests__/planningManagerShell.test.tsx
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { monthRangeLabel, toMonthInput } from '../planningManagerShell'
+import EffectiveMonthFields from '../EffectiveMonthFields'
+import PlanningDeleteConfirm from '../PlanningDeleteConfirm'
+
+// Guard for #689. FixedExpenseManager and RecurringSavingManager each carried
+// their own copy of the same shell — the month range fields, the delete
+// confirmation in two variants, the period label, the style tokens. The copies
+// had already drifted (one said "Always", the other "Every month") and the a11y
+// work in #688 had to be done twice, in two places, from the same review.
+//
+// These are small typed primitives, not one configurable mega-component: what
+// differs between the two features stays a prop.
+
+describe('monthRangeLabel (#689)', () => {
+  it('uses the caller\'s own wording when a rule has no bounds', () => {
+    // The one place the two managers legitimately differ: a fixed expense is
+    // "Always", a recurring saving is "Every month".
+    expect(monthRangeLabel(null, null, false, 'Always')).toBe('Always')
+    expect(monthRangeLabel(null, null, true, 'Luôn áp dụng')).toBe('Luôn áp dụng')
+  })
+
+  it('reads an open-ended start as "from <month>"', () => {
+    expect(monthRangeLabel('2026-03-01', null, false, 'Always')).toBe('Mar 2026 → ∞')
+  })
+
+  it('marks a missing start with an ellipsis rather than inventing one', () => {
+    expect(monthRangeLabel(null, '2026-06-01', false, 'Always')).toBe('… → Jun 2026')
+  })
+
+  it('renders both ends when the rule is bounded', () => {
+    expect(monthRangeLabel('2026-03-01', '2026-06-01', false, 'Always')).toBe('Mar 2026 → Jun 2026')
+  })
+
+  it('uses Vietnamese short months', () => {
+    expect(monthRangeLabel('2026-03-01', '2026-06-01', true, 'Luôn')).toBe('Th3 2026 → Th6 2026')
+  })
+})
+
+describe('toMonthInput (#689)', () => {
+  it('trims a stored date down to what <input type="month"> wants', () => {
+    expect(toMonthInput('2026-06-01')).toBe('2026-06')
+  })
+
+  it('answers empty for a rule with no bound', () => {
+    expect(toMonthInput(null)).toBe('')
+  })
+})
+
+describe('EffectiveMonthFields (#689)', () => {
+  const props = {
+    idPrefix: 'fe',
+    fromLabel: 'Effective from',
+    toLabel: 'Effective to',
+    from: '',
+    to: '',
+    onFromChange: () => {},
+    onToChange: () => {},
+  }
+
+  it('labels each field and ties the label to its input', () => {
+    render(<EffectiveMonthFields {...props} />)
+
+    // getByLabelText only resolves through a real htmlFor/id pair.
+    expect(screen.getByLabelText('Effective from')).toHaveAttribute('id', 'fe-from')
+    expect(screen.getByLabelText('Effective to')).toHaveAttribute('id', 'fe-to')
+  })
+
+  it('keeps the per-feature test ids the specs already use', () => {
+    render(<EffectiveMonthFields {...props} idPrefix="rs" />)
+
+    expect(screen.getByTestId('rs-from')).toBeInTheDocument()
+    expect(screen.getByTestId('rs-to')).toBeInTheDocument()
+  })
+
+  it('reports edits back with the month the user picked', () => {
+    const onFromChange = vi.fn()
+    render(<EffectiveMonthFields {...props} onFromChange={onFromChange} />)
+
+    fireEvent.change(screen.getByTestId('fe-from'), { target: { value: '2026-04' } })
+
+    expect(onFromChange).toHaveBeenCalledWith('2026-04')
+  })
+})
+
+describe('PlanningDeleteConfirm (#689)', () => {
+  const props = {
+    variant: 'modal' as const,
+    testIdPrefix: 'fe',
+    title: 'Delete this expense?',
+    description: 'Rent — ₫ 8500000',
+    cancelLabel: 'Cancel',
+    confirmLabel: 'Delete',
+    deleting: false,
+    onCancel: () => {},
+    onConfirm: () => {},
+  }
+
+  for (const variant of ['modal', 'sheet'] as const) {
+    it(`is a named modal dialog in the ${variant} variant`, () => {
+      render(<PlanningDeleteConfirm {...props} variant={variant} />)
+
+      const dialog = screen.getByRole('dialog', { name: 'Delete this expense?' })
+      expect(dialog).toHaveAttribute('aria-modal', 'true')
+    })
+
+    it(`keeps the feature's overlay and confirm test ids in the ${variant} variant`, () => {
+      render(<PlanningDeleteConfirm {...props} variant={variant} testIdPrefix="rs" />)
+
+      expect(screen.getByTestId('rs-delete-overlay')).toBeInTheDocument()
+      expect(screen.getByTestId('rs-delete-confirm')).toBeInTheDocument()
+    })
+  }
+
+  it('names what is about to be destroyed', () => {
+    render(<PlanningDeleteConfirm {...props} />)
+
+    expect(screen.getByText('Rent — ₫ 8500000')).toBeInTheDocument()
+  })
+
+  it('confirms and cancels through the callbacks it was given', async () => {
+    const onConfirm = vi.fn()
+    const onCancel = vi.fn()
+    render(<PlanningDeleteConfirm {...props} onConfirm={onConfirm} onCancel={onCancel} />)
+
+    await userEvent.click(screen.getByTestId('fe-delete-confirm'))
+    expect(onConfirm).toHaveBeenCalledTimes(1)
+
+    await userEvent.click(screen.getByText('Cancel'))
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('holds itself open while the delete is in flight', async () => {
+    // Clicking away mid-request would hide the confirmation while the row is
+    // still going.
+    const onCancel = vi.fn()
+    render(<PlanningDeleteConfirm {...props} deleting onCancel={onCancel} />)
+
+    await userEvent.click(screen.getByTestId('fe-delete-overlay'))
+
+    expect(onCancel).not.toHaveBeenCalled()
+    expect(screen.getByTestId('fe-delete-confirm')).toBeDisabled()
+  })
+
+  it('closes on Escape and traps focus — the contract, inherited once', async () => {
+    const onCancel = vi.fn()
+    render(<PlanningDeleteConfirm {...props} onCancel={onCancel} />)
+    const dialog = screen.getByRole('dialog')
+    expect(dialog).toContainElement(document.activeElement as HTMLElement)
+
+    fireEvent.keyDown(document, { key: 'Escape' })
+
+    expect(onCancel).toHaveBeenCalledTimes(1)
+  })
+
+  it('lets a feature add its own warning below the description', () => {
+    // Neither manager needs this today; it is the seam that keeps the shared
+    // shell from becoming the reason a feature cannot say something extra
+    // before destroying a row.
+    render(<PlanningDeleteConfirm {...props} extra={<p>this unlinks 2 plan months</p>} />)
+
+    expect(screen.getByText('this unlinks 2 plan months')).toBeInTheDocument()
+  })
+})

--- a/app/(app)/planning/components/planningManagerShell.tsx
+++ b/app/(app)/planning/components/planningManagerShell.tsx
@@ -1,0 +1,71 @@
+import type { CSSProperties, ReactNode } from 'react'
+
+// The shell the two planning managers share (#689).
+//
+// FixedExpenseManager and RecurringSavingManager are the same screen with
+// different fields: a list, a create/edit form, an effective-month range, a
+// delete confirmation in two variants, and the same four style tokens. Each had
+// its own copy, and the copies had already drifted — one said "Always" where the
+// other said "Every month" — while the dialog work in #688 had to be done twice
+// from one review.
+//
+// Small typed primitives, deliberately, not one configurable mega-component:
+// what actually differs between an expense and a saving stays a prop, so the
+// difference is visible at the call site rather than buried in a `variant`.
+
+// ─── style tokens (work in both the desktop modal and the mobile sheet) ───────
+
+export const inputStyle: CSSProperties = {
+  width: '100%', padding: '10px 12px', fontSize: 16,
+  border: '1px solid var(--c-line)', borderRadius: 10,
+  background: 'var(--c-card-2)', color: 'var(--c-ink)', boxSizing: 'border-box',
+}
+export const labelStyle: CSSProperties = { fontSize: 13, color: 'var(--c-muted)', display: 'block', marginBottom: 4 }
+export const ghostBtn: CSSProperties = {
+  flex: 1, padding: '10px 0', borderRadius: 10, border: '1px solid var(--c-line)',
+  background: 'var(--c-card)', color: 'var(--c-ink)', fontSize: 14, fontWeight: 500,
+  cursor: 'pointer', fontFamily: 'inherit',
+}
+export const primaryBtn: CSSProperties = {
+  flex: 2, padding: '10px 0', borderRadius: 10, border: 'none',
+  background: 'var(--c-btn-primary)', color: '#fff', fontSize: 14, fontWeight: 600,
+  cursor: 'pointer', fontFamily: 'inherit',
+}
+
+// ─── the effective-month range ───────────────────────────────────────────────
+
+const SHORT_MONTHS_EN = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+const SHORT_MONTHS_VI = ['Th1', 'Th2', 'Th3', 'Th4', 'Th5', 'Th6', 'Th7', 'Th8', 'Th9', 'Th10', 'Th11', 'Th12']
+
+/** A stored date, trimmed to what `<input type="month">` reads and writes. */
+export function toMonthInput(date: string | null): string {
+  return date ? date.slice(0, 7) : ''
+}
+
+/**
+ * How a rule's period reads on its row: "Mar 2026 → Jun 2026", with an ellipsis
+ * for an open start and ∞ for an open end.
+ *
+ * `unbounded` is the caller's, because this is the one place the two managers
+ * genuinely differ: an expense with no bounds is "Always", a recurring saving is
+ * "Every month". Sharing the formatting without sharing the wording is the point.
+ */
+export function monthRangeLabel(
+  from: string | null,
+  to: string | null,
+  isVI: boolean,
+  unbounded: string,
+): string {
+  if (!from && !to) return unbounded
+  const months = isVI ? SHORT_MONTHS_VI : SHORT_MONTHS_EN
+  const fmtMonth = (d: string | null) => {
+    if (!d) return null
+    const [y, m] = d.split('-').map(Number)
+    return `${months[m - 1]} ${y}`
+  }
+  return `${fmtMonth(from) || '…'} → ${fmtMonth(to) || '∞'}`
+}
+
+export type PlanningVariant = 'modal' | 'sheet'
+
+export type { ReactNode }


### PR DESCRIPTION
Closes #689.

## What was duplicated

`FixedExpenseManager` and `RecurringSavingManager` are the same screen with different fields. Each carried its own copy of the parts that are *not* different:

| Duplicated | Size |
| :--- | :--- |
| delete confirmation, both variants | ~62 lines each, differing only in title, description and test-id prefix |
| effective-month from/to fields | identical but for ids and label copy |
| `toMonthInput`, `SHORT_MONTHS_EN/VI`, the period formatter | byte-identical |
| `inputStyle`, `labelStyle`, `ghostBtn`, `primaryBtn` | byte-identical |

The copies had already drifted, and the dialog work in #688 had to be done **twice, in two files, off one review**. That is the cost the duplication was charging.

## Three small typed primitives, not one configurable component

The issue asked for primitives over a mega-component, and that is the right call here: what actually differs between an expense and a saving stays a prop, visible at the call site, instead of disappearing into a `variant` flag.

- **`planningManagerShell`** — the four style tokens, `toMonthInput`, `monthRangeLabel`. The "no bounds" wording is a **parameter**, because it is the one thing the two managers legitimately disagree on: an unbounded expense is "Always", an unbounded saving is "Every month". Sharing the formatting without flattening the copy is the point.
- **`EffectiveMonthFields`** — the from/to pair. `idPrefix` keeps `fe-from` / `rs-to` exactly as the existing specs use them.
- **`PlanningDeleteConfirm`** — both variants, built on `DialogShell`. The #688 dialog contract is now **inherited once** rather than remembered twice — the acceptance criterion about making accessibility fixes in one place, made structural.

**Net −187 lines** across the two managers (239 removed, 52 added), traded for ~200 lines of primitives that serve both.

## Tests

19 focused tests for the primitives, red first (the modules did not exist). They pin the things a shared shell can quietly break: that `monthRangeLabel` takes its unbounded wording from the caller rather than picking one; that `EffectiveMonthFields` ties each label to its input via a real `htmlFor`/`id` pair (`getByLabelText` only resolves through one); that both features keep their own test ids; and that the delete confirmation still holds itself open mid-request and still answers Escape.

Every existing manager suite passes **untouched** — a refactor is only worth something if it did not move behaviour. Every `data-testid` is unchanged.

Gates: `npm run typecheck` ✅ · `npm run lint` — 0 errors ✅ · `npm run test:coverage` — 220 files, 2702 tests, thresholds pass ✅ · `npx playwright test e2e/planning.spec.ts` — 3/3 ✅ · `npm run test:e2e:smoke` — 20/20 ✅

E2E earns its place: this changes the DOM tree of both managers (one wrapper element fewer around the month fields, the delete block moved into another component), which is exactly the shape of change that breaks selectors.

## Two things I corrected in my own work

While writing the primitives I put two claims in comments that turned out to be false, and false comments are worse than none:

1. That the recurring-saving copy lacked the `minmax(0,1fr)` grid fix. It did not — I had compared misaligned line ranges. Both copies were identical; the comment now just explains why `minmax` is there.
2. That the `extra` slot carries the #655 unlink warning. That warning lives in `LinkLostBadge`, not in the delete confirmation. `extra` is unused today, and now says so — it exists so sharing the shell never becomes the reason a manager cannot warn about something specific to it.

## Reviewer note

Worth confirming on the preview that both delete confirmations still look right in both variants — desktop centred card and mobile bottom sheet — since that markup now comes from one component instead of four copies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)