### PR TITLE
fix(e2e): assert the renewal, not the 800ms flash it shows (#701)

### DIFF
--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -73,6 +73,28 @@ statement timeout, or the status phrase itself.
 A run whose failures are *all* infra prints an explicit note. Re-run it against
 a healthy stack before chasing the app.
 
+## Never assert on a transient element
+
+A locator assertion is a *poll*, not a subscription. Playwright widens the gap
+between attempts as it waits — 100 ms, 250 ms, 500 ms, then 1 s from there on —
+so an element that lives for less than a second can appear and disappear
+entirely between two samples, and the assertion then burns its whole timeout on
+something that did happen.
+
+That is #701: the maturity sheet's `maturity-renewed` checkmark renders for
+`SUCCESS_FLASH_MS` (800 ms) and then the sheet closes itself. Whenever the
+renew POST took ~1 s or more — the assertion starts polling when the *request*
+goes out, not when the response lands — the flash fell in a 1 s gap and the test
+failed at 20 s on an element that had been in the DOM from 1074 ms to 1895 ms.
+Roughly 1 run in 4, on `main` as much as on any branch, and in the smoke lane
+that gates the production migration push.
+
+So assert the **durable** outcome — the state the page settles into and stays
+in: the sheet closed, the row gone from the list, the value the API now returns.
+For the maturity sheet that is `expectRenewalCommitted(page)` in
+`e2e/helpers/maturity.ts`. What the transient thing *said* belongs in a
+component test, which renders the state directly and never has to race it.
+
 ## Running locally
 
 Both lanes need a Supabase stack and the app. Keep a local stack running for the

--- a/e2e/accumulating-collapse.spec.ts
+++ b/e2e/accumulating-collapse.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test'
 import * as api from './helpers/api'
+import { expectRenewalCommitted } from './helpers/maturity'
 
 // Book-level renewal for accumulating ("Loại 2") deposits: at maturity the whole
 // book COLLAPSES into one fresh plain term deposit. This closes the loop on the
@@ -82,7 +83,7 @@ test.describe('Accumulating book collapse (Loại 2 book-level renewal)', () => 
         page.getByRole('button', { name: /Confirm renewal|Xác nhận tái tục/i }).click(),
       ])
       expect(resp.status()).toBe(200)
-      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+      await expectRenewalCommitted(page)
 
       // ── Assert the persisted outcome ──────────────────────────────────────────
       const all = await (await page.request.get('/api/v1/investment-transactions?include_history=true&limit=1000')).json()
@@ -143,7 +144,7 @@ test.describe('Accumulating book collapse (Loại 2 book-level renewal)', () => 
         page.getByRole('button', { name: /Confirm renewal|Xác nhận tái tục/i }).click(),
       ])
       expect(resp.status()).toBe(200)
-      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+      await expectRenewalCommitted(page)
 
       // Collapsed → a plain term deposit with a future maturity, so it drops off
       // the card. (No deposit_group_id; sibling tranche folded in.)

--- a/e2e/dashboard-desktop.spec.ts
+++ b/e2e/dashboard-desktop.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test'
 import * as api from './helpers/api'
+import { expectRenewalCommitted } from './helpers/maturity'
 
 // All tests run on Desktop Chrome (1280×800) by default from playwright config.
 // These verify the two-column desktop layout for the Overview page.
@@ -203,7 +204,7 @@ test.describe('Desktop overview layout', () => {
       // Renew via the card → desktop resolve modal → confirm the default renewal.
       await card.getByRole('button', { name: /Handle|Xử lý/i }).first().click()
       await page.getByRole('button', { name: /Confirm renewal|Xác nhận tái tục/i }).click()
-      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+      await expectRenewalCommitted(page)
 
       // After it rolls forward (future maturity), the deposit leaves the card.
       await expect(card.getByText('E2E Maturing Deposit')).toHaveCount(0, { timeout: 30_000 })

--- a/e2e/goal-detail-desktop.spec.ts
+++ b/e2e/goal-detail-desktop.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test'
 import * as api from './helpers/api'
+import { expectRenewalCommitted } from './helpers/maturity'
 
 // Desktop viewport (Desktop Chrome default) — all tests run in 1280×800+
 
@@ -247,8 +248,8 @@ test.describe('Desktop goal detail panel', () => {
       await page.getByText(/^(Handle maturity|Xử lý đáo hạn)$/).click()
       await page.getByRole('button', { name: /Confirm renewal|Xác nhận tái tục/i }).click()
 
-      // Success confirmation proves the PUT landed.
-      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+      // The sheet closing proves the PUT landed.
+      await expectRenewalCommitted(page)
 
       // Close the loop: the stored deposit must now have a future maturity, a
       // larger principal (interest rolled in) and an accrual date anchored to the
@@ -355,7 +356,7 @@ test.describe('Desktop goal detail panel', () => {
       await panel.getByRole('button', { name: 'Options', exact: true }).first().click()
       await page.getByText(/^(Handle maturity|Xử lý đáo hạn)$/).click()
       await page.getByRole('button', { name: /Confirm renewal|Xác nhận tái tục/i }).click()
-      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+      await expectRenewalCommitted(page)
 
       // The active row rolled forward to a fresh principal (net + interest).
       await expect.poll(async () => {

--- a/e2e/helpers/maturity.ts
+++ b/e2e/helpers/maturity.ts
@@ -1,0 +1,27 @@
+import { expect, type Page } from '@playwright/test'
+
+// Both confirm buttons the maturity sheet offers: "Save new deposit" for a
+// combine/merge, "Confirm renewal" for a plain roll-forward or a collapse.
+const CONFIRM_RENEWAL = /Save new deposit|Lưu sổ mới|Confirm renewal|Xác nhận tái tục/i
+
+/**
+ * Wait for a renewal driven from the maturity sheet to have landed.
+ *
+ * Do NOT assert on the `maturity-renewed` flash instead: it renders for
+ * SUCCESS_FLASH_MS (800 ms) and then the sheet closes itself, so an assertion
+ * that starts polling *before* the response arrives can step straight over it.
+ * Playwright's expect backs its poll interval off to a 1 s cap — wider than the
+ * flash's own lifetime — and the 20 s budget then expires on an element that
+ * came and went while nothing was looking. Measured on a failing run of #701:
+ * the flash was in the DOM from 1074 ms to 1895 ms and was never sampled, even
+ * though the renew had returned 200 and the money had moved.
+ *
+ * The durable outcome is the confirm button leaving the DOM. The sheet swaps
+ * its whole form for the flash only after a 2xx, and a failed renewal keeps the
+ * form — and its error — on screen, so this fails loudly on a real regression
+ * rather than on a timer. The flash's own content is covered by the
+ * MaturityResolveSheet component tests, which don't have to race it.
+ */
+export async function expectRenewalCommitted(page: Page) {
+  await expect(page.getByRole('button', { name: CONFIRM_RENEWAL })).toBeHidden({ timeout: 20_000 })
+}

--- a/e2e/maturity-combine-cluster.spec.ts
+++ b/e2e/maturity-combine-cluster.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test'
 import * as api from './helpers/api'
+import { expectRenewalCommitted } from './helpers/maturity'
 
 // PR3 — cluster auto-detection on the dashboard "Cần xử lý" card. When a goal has
 // two (or more) bank deposits maturing close together, the card surfaces a one-tap
@@ -73,11 +74,10 @@ test.describe('Maturity card — merge-cluster auto-detection', () => {
         page.getByRole('button', { name: /Save new deposit|Lưu sổ mới/i }).click(),
       ])
       expect(res.ok()).toBeTruthy()
-      // NOT the `maturity-renewed` flash: it shows for SUCCESS_FLASH_MS and then the
-      // sheet closes itself, so racing it made this test fail ~1 run in 3 (on main
-      // too). The durable outcomes — the sheet closing, and the sibling leaving the
-      // goal's holdings — are what the merge actually promises.
-      await expect(page.getByRole('button', { name: /Save new deposit|Lưu sổ mới/i })).toBeHidden({ timeout: 20_000 })
+      // The durable outcomes — the sheet closing, and the sibling leaving the
+      // goal's holdings — are what the merge actually promises; the success flash
+      // is a timer, not an outcome (see the helper).
+      await expectRenewalCommitted(page)
 
       await gotoFreshDashboard(page)
       const after = await goalHoldingIds(page, goal.goal_id)

--- a/e2e/maturity-combine-explicit-link.spec.ts
+++ b/e2e/maturity-combine-explicit-link.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test'
 import * as api from './helpers/api'
+import { expectRenewalCommitted } from './helpers/maturity'
 
 // Explicit deposit↔recurring link. When a goal funds several recurring bank
 // savings, name/sole matching can't tell which one belongs to a maturing
@@ -65,7 +66,7 @@ test.describe('Term-deposit maturity — explicit deposit↔recurring link', () 
       // Combine is offered and (via the explicit link) pre-selected.
       await expect(page.getByTestId('maturity-combine')).toBeVisible({ timeout: 10_000 })
       await page.getByRole('button', { name: /Save new deposit|Lưu sổ mới/i }).click()
-      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+      await expectRenewalCommitted(page)
 
       // The LINKED recurring is fulfilled; the sibling is untouched.
       const fulfilled = await fulfilledMap(page)

--- a/e2e/maturity-combine-holding.spec.ts
+++ b/e2e/maturity-combine-holding.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test'
 import * as api from './helpers/api'
+import { expectRenewalCommitted } from './helpers/maturity'
 
 // "Ví chờ gộp" (merge holding pool) — PR4 of "Gộp nhiều nguồn". An earlier-
 // maturing deposit can be settled with "Để dành gộp": it is closed by a held
@@ -122,7 +123,7 @@ test.describe('Term-deposit maturity — "Ví chờ gộp" holding pool', () => 
         page.getByRole('button', { name: /Save new deposit|Lưu sổ mới/i }).click(),
       ])
       expect(renewReq.postDataJSON().held_sources).toEqual([heldId])
-      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+      await expectRenewalCommitted(page)
 
       // Consumed: the pool is empty and the goal value STILL matches the start —
       // the held cash moved into A's principal, never counted twice.

--- a/e2e/maturity-combine-merge.spec.ts
+++ b/e2e/maturity-combine-merge.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test'
 import * as api from './helpers/api'
+import { expectRenewalCommitted } from './helpers/maturity'
 
 // Term-deposit maturity "combine" — folding a SIBLING bank deposit into the
 // re-deposit (merge-on-renew). The bug this guards: a user settles a sibling S
@@ -90,7 +91,7 @@ test.describe('Term-deposit maturity — merge a sibling deposit into the re-dep
         page.waitForRequest((r) => r.url().endsWith(`/${D.transaction_id}/renew`) && r.method() === 'POST'),
         page.getByRole('button', { name: /Save new deposit|Lưu sổ mới/i }).click(),
       ])
-      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+      await expectRenewalCommitted(page)
 
       const body = renewReq.postDataJSON()
       const base: number = body.amount_vnd
@@ -240,7 +241,7 @@ test.describe('Term-deposit maturity — merge a sibling deposit into the re-dep
         page.getByRole('button', { name: /Save new deposit|Lưu sổ mới/i }).click(),
       ])
       expect(renewReq.postDataJSON().bank_code).toBe('TCB')
-      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+      await expectRenewalCommitted(page)
 
       const { createClient } = await import('@supabase/supabase-js')
       const supabase = createClient(process.env.E2E_SUPABASE_URL!, process.env.E2E_SUPABASE_SERVICE_ROLE_KEY!)

--- a/e2e/maturity-combine.spec.ts
+++ b/e2e/maturity-combine.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, type Page } from '@playwright/test'
 import * as api from './helpers/api'
+import { expectRenewalCommitted } from './helpers/maturity'
 
 // Term-deposit maturity "combine" flow (Tất toán & gửi lại / settle & re-deposit,
 // merging this month's recurring saving). The correctness risk is a DOUBLE-COUNT:
@@ -71,7 +72,7 @@ test.describe('Term-deposit maturity — combine (merge recurring into re-deposi
       // Confirm with defaults: interest pre-filled, re-deposit = principal +
       // interest + recurring, recurring marked deposited.
       await page.getByRole('button', { name: /Save new deposit|Lưu sổ mới/i }).click()
-      await expect(page.getByTestId('maturity-renewed')).toBeVisible({ timeout: 20_000 })
+      await expectRenewalCommitted(page)
 
       // After: the recurring now lives inside the deposit principal and is
       // suppressed as a standalone contribution — progress must NOT have jumped by


### PR DESCRIPTION
Closes #701.

## Root cause — measured, not inferred

Not the server, and not the merge path. The assertion was sampling something that had already been and gone.

A Playwright locator assertion is a **poll**, not a subscription: the gap between attempts widens 100 ms → 250 ms → 500 ms → 1 s and stays at 1 s. The `maturity-renewed` checkmark renders for `SUCCESS_FLASH_MS` (**800 ms**) and then the sheet closes itself. The wait starts when the *request* goes out (`waitForRequest` resolves at send), not when the response lands — so once the renew took ~1 s, the flash's whole lifetime could fall inside a single 1 s gap.

I reproduced a failure with a `MutationObserver` recording every appearance/disappearance of the element:

```
PROBE assert=flash        passed=false waitedMs=20009 flash=[[1074,true],[1895,false]]
PROBE assert=sheet-closed passed=true  waitedMs=365   flash=[[183,true]]
```

The renew returned **200**, the flash **was** in the DOM (1074 ms → 1895 ms, 821 ms), and `expect()` never sampled it — polls landed at ~850 ms and ~1850 ms, straddling it. That is the whole bug, and it explains both observations in the issue: the failures cluster on slow runs, and the request is always seen.

So: the first branch in the issue's "suggested next step" — a timing problem, not a real bug in the merge/renew path.

## Fix

Assert the **durable** outcome instead of the timer: the confirm button leaving the DOM. The sheet swaps its whole form for the flash only after a 2xx and never brings it back, while a failed renewal keeps the form *and its error* on screen — so this still fails loudly on a real regression.

New `e2e/helpers/maturity.ts` → `expectRenewalCommitted(page)`, applied at all 9 call sites across 8 specs (`maturity-combine-merge`, `maturity-combine`, `maturity-combine-holding`, `maturity-combine-explicit-link`, `accumulating-collapse`, `dashboard-desktop`, `goal-detail-desktop`). `maturity-combine-cluster` had already worked this out locally for the same reason ("racing it made this test fail ~1 run in 3") — it now shares the helper instead of carrying its own copy.

Nothing is lost: every one of those tests already asserts the persisted/rendered outcome afterwards (DB row, overview API, holdings list), and the flash's own content is covered by the `MaturityResolveSheet` component tests, which render the state directly and never have to race it.

`docs/e2e.md` gains a short "never assert on a transient element" section so the next spec doesn't re-learn this.

## Verification

- Reproduced the failure and its cause as above (probe spec, not committed).
- `npx playwright test e2e/maturity-combine-merge.spec.ts --project=chromium --repeat-each=4` → **17/17 passed**. The smoke test now finishes in ~5 s instead of 17–21 s.
- **Full E2E suite: 239 passed, 8.0 m, no failures.**
- `npm run typecheck` ✅ · `npm run lint` ✅ · `npm run knip` ✅ · `npm test -- --run` → 2747 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)