### PR TITLE
chore: drop the orphaned .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,0 @@
-{
-  "semi": false,
-  "singleQuote": true,
-  "tabWidth": 2,
-  "trailingComma": "es5"
-}


### PR DESCRIPTION
Follow-up to #691 / #702.

That PR removed the `prettier` devDependency — there was no format script, no CI step and nothing referencing it — but left `.prettierrc` behind. Knip won't catch this: it flags unused *dependencies*, not a config file whose tool is already gone.

A formatter config that no installed formatter reads is a lie about how the repo is formatted, so it goes. `grep` confirms nothing in the repo (outside `package-lock.json`) mentions prettier any more.

One deleted file, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)