### PR TITLE
fix(ledger): a recorded withdrawal can have its received amount corrected (#705)

### DIFF
--- a/app/assets/components/TransactionLedgerSheet.tsx
+++ b/app/assets/components/TransactionLedgerSheet.tsx
@@ -170,6 +170,15 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
   const [formMode, setFormMode] = useState<'edit' | null>(null)
   const [formError, setFormError] = useState('')
   const [saving, setSaving] = useState(false)
+  // Correcting a recorded withdrawal (#705). Its own dialog rather than the
+  // generic form above: a withdrawal owns only the cash it paid out, the date and
+  // the notes. The principal it withdrew, its parent holding and the asset type
+  // are the claim the DB invariants measure against that holding, so editing them
+  // here would offer a change the table refuses.
+  const [wdTx, setWdTx] = useState<LedgerTransaction | null>(null)
+  const [wdForm, setWdForm] = useState({ amount_vnd: '', investment_date: '', notes: '' })
+  const [wdError, setWdError] = useState('')
+  const [wdSaving, setWdSaving] = useState(false)
   // Where a transaction can be MOVED to, which is not the same list as the one
   // you can filter history by: a completed goal is an archive (#650). The one
   // exception is the goal this very transaction is already filed under — a
@@ -298,7 +307,7 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
     if (!open) return
     document.body.style.overflow = 'hidden'
     return () => { document.body.style.overflow = '' }
-  }, [open, showAdd, editExisting, showImport, formMode])
+  }, [open, showAdd, editExisting, showImport, formMode, wdTx])
 
   function setSelectFilter(key: 'asset_type' | 'goal_id', value: string) {
     setFilters((prev) => ({ ...prev, [key]: value }))
@@ -338,6 +347,46 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
     setEditTx(tx)
     setFormError('')
     setFormMode('edit')
+  }
+
+  function openWithdrawEdit(tx: LedgerTransaction) {
+    setWdForm({
+      amount_vnd: String(tx.amount_vnd),
+      investment_date: tx.investment_date,
+      notes: tx.notes ?? '',
+    })
+    setWdError('')
+    setWdTx(tx)
+  }
+
+  async function handleWithdrawSave() {
+    if (!wdTx) return
+    setWdError('')
+    if (!wdForm.amount_vnd || Number(wdForm.amount_vnd) <= 0) { setWdError(t('amountRequired')); return }
+    if (!wdForm.investment_date) { setWdError(t('dateRequired')); return }
+
+    setWdSaving(true)
+    // Only the three fields the dialog shows. The PUT applies exactly what the
+    // body names, so omitting the rest leaves the claim columns
+    // (principal_withdrawn, units_withdrawn, parent_transaction_id) untouched.
+    const res = await fetch(`/api/v1/investment-transactions/${wdTx.transaction_id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        amount_vnd: Number(wdForm.amount_vnd),
+        investment_date: wdForm.investment_date,
+        notes: wdForm.notes || null,
+      }),
+    })
+    if (!res.ok) {
+      const { error } = await res.json()
+      setWdError(error ?? tc('error'))
+    } else {
+      setWdTx(null)
+      await fetchTransactions()
+      notifyChanged()
+    }
+    setWdSaving(false)
   }
 
   function notifyChanged() {
@@ -492,6 +541,12 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
     <span style={{ display: 'inline-flex', gap: 2, whiteSpace: 'nowrap' }}>
       {!isWithdrawal(tx) && (
         <button onClick={() => (tx.asset_type === 'stock' ? openEdit(tx) : setEditExisting(tx))} className="cn-btn ghost" style={{ ...iconHit }} aria-label={tc('edit')}><Edit2 size={14} color="var(--c-muted)" /></button>
+      )}
+      {/* A plain withdrawal gets the narrow received-amount form (#705). A held
+          settlement and a consumed one do not: their cash is a claim on a merge
+          pool that other rows are already measured against. */}
+      {txKind(tx) === 'withdrawal' && (
+        <button data-testid="tx-ledger-withdraw-edit" onClick={() => openWithdrawEdit(tx)} className="cn-btn ghost" style={{ ...iconHit }} aria-label={tc('edit')}><Edit2 size={14} color="var(--c-muted)" /></button>
       )}
       <button data-testid="tx-ledger-delete" onClick={() => askDelete(tx)} className="cn-btn ghost" style={{ ...iconHit }} aria-label={tc('delete')}><Trash size={14} color="var(--c-neg)" /></button>
     </span>
@@ -761,6 +816,29 @@ export default function TransactionLedgerSheet({ open, desktop, locale, onClose,
           <div style={{ display: 'flex', gap: 8, marginTop: 2 }}>
             <button type="button" onClick={() => setFormMode(null)} className="cn-btn" style={{ flex: 1, justifyContent: 'center' }}>{tc('cancel')}</button>
             <button type="submit" className="cn-btn primary" style={{ flex: 2, justifyContent: 'center' }} disabled={saving}>{saving ? tc('saving') : tc('save')}</button>
+          </div>
+        </form>
+      </Shell>
+
+      {/* Correct a recorded withdrawal (#705) */}
+      <Shell open={!!wdTx} onClose={() => setWdTx(null)} title={t('editWithdrawTitle')} desktop={desktop} width={420} testId="tx-ledger-withdraw-edit-form">
+        <form onSubmit={(e) => { e.preventDefault(); handleWithdrawSave() }} style={{ display: 'grid', gap: 14 }}>
+          <Field label={t('receivedAmount')}>
+            <AmountInput data-testid="withdraw-received-input" value={wdForm.amount_vnd} onChange={(raw) => setWdForm((f) => ({ ...f, amount_vnd: raw }))} placeholder="10,000,000" className="cn-input tabular" />
+          </Field>
+          <p style={{ margin: 0, fontSize: 11, color: 'var(--c-muted)', lineHeight: 1.5 }}>{t('editWithdrawHint')}</p>
+          <Field label={t('colDate')}>
+            <input type="date" value={wdForm.investment_date} onChange={(e) => setWdForm((f) => ({ ...f, investment_date: e.target.value }))} className="cn-input tabular" />
+          </Field>
+          <Field label={tc('notes')}>
+            <textarea value={wdForm.notes} onChange={(e) => setWdForm((f) => ({ ...f, notes: e.target.value }))} rows={2} className="cn-input" style={{ resize: 'none' }} />
+          </Field>
+
+          {wdError && <p style={{ margin: 0, fontSize: 13, color: 'var(--c-neg)' }}>{wdError}</p>}
+
+          <div style={{ display: 'flex', gap: 8, marginTop: 2 }}>
+            <button type="button" onClick={() => setWdTx(null)} className="cn-btn" style={{ flex: 1, justifyContent: 'center' }}>{tc('cancel')}</button>
+            <button data-testid="withdraw-edit-save" type="submit" className="cn-btn primary" style={{ flex: 2, justifyContent: 'center' }} disabled={wdSaving}>{wdSaving ? tc('saving') : tc('save')}</button>
           </div>
         </form>
       </Shell>

--- a/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
+++ b/app/assets/components/__tests__/TransactionLedgerSheet.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen, within } from '@testing-library/react'
+import { render, screen, within, fireEvent } from '@testing-library/react'
 import TransactionLedgerSheet from '../TransactionLedgerSheet'
 
 // Keys pass through, but interpolated values come with them — a message whose
@@ -399,3 +399,67 @@ describe('TransactionLedgerSheet — editing a transaction under a finished goal
   })
 })
 
+
+// #705: a recorded withdrawal had NO edit affordance at all — the row offered
+// only delete — so a mistyped "số tiền nhận được" (the cash the bank actually
+// paid, stored as the withdrawal's amount_vnd) could only be fixed by deleting
+// the withdrawal and recording it again. The edit is deliberately narrow: the
+// cash received, the date and the notes. Principal withdrawn, the parent holding
+// and the asset type are what the withdrawal *claims* against its source — the
+// DB invariants measure those — so they stay out of this form.
+describe('TransactionLedgerSheet — a recorded withdrawal can have its received amount corrected (#705)', () => {
+  const base = {
+    asset_type: 'bank', investment_date: '2026-06-01', amount_vnd: 10_000_000,
+    savings_goals: { goal_name: 'House' },
+  }
+  const withdrawTx = { ...base, transaction_id: 'w1', transaction_type: 'withdrawal', notes: 'early close' }
+  const heldTx = { ...base, transaction_id: 'h1', transaction_type: 'withdrawal', held_for_merge: true }
+
+  let putCalls: { url: string; body: Record<string, unknown> }[]
+
+  function mockTxs(list: unknown[]) {
+    putCalls = []
+    global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') {
+        putCalls.push({ url, body: JSON.parse(String(init.body)) })
+        return Promise.resolve({ ok: true, json: async () => ({}) })
+      }
+      if (url.includes('savings-goals')) return Promise.resolve({ ok: true, json: async () => ({ goals: [] }) })
+      if (url.includes('/api/funds')) return Promise.resolve({ ok: true, json: async () => ({ funds: [] }) })
+      if (url.includes('investment-transactions')) return Promise.resolve({ ok: true, json: async () => ({ transactions: list, total: list.length }) })
+      return Promise.resolve({ ok: true, json: async () => ({}) })
+    })
+  }
+
+  const props = { open: true, desktop: true, locale: 'en', onClose: vi.fn() }
+
+  it('opens a received-amount form prefilled from the row and PUTs only the fields it owns', async () => {
+    mockTxs([withdrawTx])
+    render(<TransactionLedgerSheet {...props} />)
+
+    const edit = await screen.findByTestId('tx-ledger-withdraw-edit')
+    edit.click()
+
+    const received = await screen.findByTestId('withdraw-received-input') as HTMLInputElement
+    expect(received.value).toBe('10.000.000')
+
+    fireEvent.change(received, { target: { value: '9.750.000' } })
+    screen.getByTestId('withdraw-edit-save').click()
+
+    await vi.waitFor(() => expect(putCalls).toHaveLength(1))
+    expect(putCalls[0].url).toBe('/api/v1/investment-transactions/w1')
+    expect(putCalls[0].body).toEqual({
+      amount_vnd: 9_750_000,
+      investment_date: '2026-06-01',
+      notes: 'early close',
+    })
+  })
+
+  it('leaves a held-for-merge settlement uneditable — its cash is a claim on the merge pool', async () => {
+    mockTxs([heldTx])
+    render(<TransactionLedgerSheet {...props} />)
+
+    await screen.findByTestId('tx-ledger-row')
+    expect(screen.queryByTestId('tx-ledger-withdraw-edit')).toBeNull()
+  })
+})

--- a/messages/en.json
+++ b/messages/en.json
@@ -326,6 +326,9 @@
   },
   "transactions": {
     "title": "Investment Transactions",
+    "editWithdrawTitle": "Edit Withdrawal",
+    "receivedAmount": "Amount received (VND)",
+    "editWithdrawHint": "Corrects the cash actually paid out. The principal this withdrawal took out of the holding is unchanged.",
     "ledgerTitle": "Transactions",
     "addTitle": "Add transaction",
     "editTitle": "Edit transaction",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -326,6 +326,9 @@
   },
   "transactions": {
     "title": "Giao dịch Đầu tư",
+    "editWithdrawTitle": "Sửa Giao dịch Rút",
+    "receivedAmount": "Số tiền thực nhận (VND)",
+    "editWithdrawHint": "Chỉ sửa số tiền ngân hàng thực trả. Tiền gốc đã rút khỏi khoản này giữ nguyên.",
     "ledgerTitle": "Giao dịch",
     "addTitle": "Thêm giao dịch",
     "editTitle": "Sửa giao dịch",

--- a/supabase/tests/withdrawal_received_editable.test.sql
+++ b/supabase/tests/withdrawal_received_editable.test.sql
@@ -1,0 +1,78 @@
+-- Correcting the cash a withdrawal paid out is allowed; its CLAIM on the source
+-- is what the invariants measure (#705).
+--
+-- A recorded withdrawal had no edit affordance at all, so a mistyped "số tiền
+-- thực nhận" could only be fixed by deleting the withdrawal and recording it
+-- again. The ledger now offers a narrow form for it — amount received, date,
+-- notes — which is only honest if the table actually accepts that update.
+--
+-- The two columns are different statements. principal_withdrawn is the claim
+-- against the holding, which 20260730000002 measures on every write; amount_vnd
+-- on a WITHDRAWAL row is the cash the bank handed over, and it is routinely
+-- LARGER than the principal (the interest) or smaller (an early-withdrawal
+-- penalty). This pins that the trigger reads the claim and not the cash — if a
+-- later guard starts measuring amount_vnd, the narrow edit form silently becomes
+-- a form that can be refused, and this test says so first.
+--
+-- Runs against the local stack in a rolled-back transaction. Run via
+-- `npm run test:db`.
+
+begin;
+
+do $$
+declare
+  v_user uuid;
+  v_goal uuid;
+  v_bank uuid;
+  v_wd   uuid;
+  v_amt  bigint;
+  v_prin bigint;
+begin
+  insert into auth.users (id, email) values (gen_random_uuid(), 'wd-received-edit@test.invalid') returning id into v_user;
+  insert into public.savings_goals (user_id, goal_name) values (v_user, 'House') returning goal_id into v_goal;
+
+  insert into public.investment_transactions (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd)
+  values (v_user, v_goal, 'bank', 'investment', '2026-01-01', 100000000) returning transaction_id into v_bank;
+
+  -- 60M of principal out, 61M in cash (a month of interest on top).
+  insert into public.investment_transactions
+    (user_id, goal_id, asset_type, transaction_type, investment_date, amount_vnd, parent_transaction_id, principal_withdrawn)
+  values (v_user, v_goal, 'bank', 'withdrawal', '2026-02-01', 61000000, v_bank, 60000000)
+  returning transaction_id into v_wd;
+
+  -- The bank slip said 59.5M — an early withdrawal cost the interest and then
+  -- some. Correcting the cash alone must be accepted.
+  update public.investment_transactions
+     set amount_vnd = 59500000, updated_at = now()
+   where transaction_id = v_wd;
+
+  -- And the other way: cash well above the principal is normal, not a claim.
+  update public.investment_transactions
+     set amount_vnd = 63000000, updated_at = now()
+   where transaction_id = v_wd;
+
+  select amount_vnd, principal_withdrawn into v_amt, v_prin
+    from public.investment_transactions where transaction_id = v_wd;
+
+  if v_amt <> 63000000 then
+    raise exception 'the corrected cash must stick, got: %', v_amt;
+  end if;
+  -- The claim the holding is measured against was never part of the edit.
+  if v_prin <> 60000000 then
+    raise exception 'the withdrawn principal must be untouched, got: %', v_prin;
+  end if;
+
+  -- The guard is still there: raising the CLAIM above what the book holds is
+  -- refused, so the acceptance above is about the cash, not a hole in the check.
+  begin
+    update public.investment_transactions
+       set principal_withdrawn = 120000000
+     where transaction_id = v_wd;
+    raise exception 'raising the claim above the remaining principal must be refused';
+  exception when sqlstate '23514' then null;
+  end;
+
+  raise notice 'withdrawal_received_editable: OK';
+end $$;
+
+rollback;


### PR DESCRIPTION
Closes #705.

## Vấn đề

Một giao dịch **rút** đã ghi nhận chỉ có nút **Xóa** — không có nút sửa. Nhưng "số tiền thực nhận" (tiền ngân hàng thực trả, lưu ở `amount_vnd` của dòng rút) chính là con số dễ nhập sai nhất: nó đọc từ giấy của ngân hàng *sau khi* rút, và rút trước hạn thường trả khác con số ước tính mà form điền sẵn. Muốn sửa một số, phải xóa cả giao dịch rút rồi ghi lại.

## Cách sửa

Ledger ("Xem tất cả") giờ có form hẹp cho dòng rút: **số tiền thực nhận, ngày, ghi chú**. Chỉ ba trường đó được PUT lên `/api/v1/investment-transactions/:id`.

Cố ý **không** cho sửa trong form này:
- `principal_withdrawn`, `parent_transaction_id`, `asset_type` — đây là *claim* của khoản rút lên khoản gốc, và các trigger của DB đo đúng những cột này ở mọi lần ghi.
- Dòng **chờ gộp** (held) và **đã gộp** (consumed) vẫn không sửa được: tiền của chúng là một claim lên merge pool mà các dòng khác đã được đo theo.

## Test

- Component test (Vitest + RTL) trên `TransactionLedgerSheet`: dòng rút có nút sửa, form điền sẵn `10.000.000`, sửa thành `9.750.000` → PUT đúng URL và body **chỉ** gồm `amount_vnd` / `investment_date` / `notes`; dòng held vẫn không có nút sửa.
- SQL test `withdrawal_received_editable.test.sql`: trigger đo *claim* chứ không đo *tiền mặt* — sửa `amount_vnd` của dòng rút theo cả hai chiều đều được chấp nhận (cao hơn tiền gốc là bình thường — đó là lãi), trong khi nâng `principal_withdrawn` vượt số dư còn lại vẫn bị từ chối.

## Đã chạy

`npm run typecheck` ✅ · `npm run lint` ✅ · `npm test -- --run` (221 files, 2749 tests) ✅ · `npm run build` ✅

Chưa chạy được ở máy local: `npm run test:db` và E2E — Docker/Supabase stack không bật. Gate DB Tests và smoke lane của CI sẽ chạy chúng trên PR này.

🤖 Generated with [Claude Code](https://claude.com/claude-code)