### PR TITLE
fix(maturity): the payout at a maturity close is the user's to type (#705)

### DIFF
--- a/app/assets/DashboardClient.tsx
+++ b/app/assets/DashboardClient.tsx
@@ -97,8 +97,10 @@ export default function DashboardClient({ userId }: { userId: string }) {
   // SellWithdrawSheet so a goal-assigned deposit withdraws in one tap (linked to
   // its goal, issue #261) instead of bouncing through the goal detail panel.
   const [maturityWithdraw, setMaturityWithdraw] = useState<
-    { item: SellItem; goalId: string; goalCurrentValue: number; goalTargetAmount: number | null } | null
+    { item: SellItem; goalId: string; goalCurrentValue: number; goalTargetAmount: number | null; received: number | null } | null
   >(null)
+  // Same figure for the unallocated fork, which reuses the plain sell sheet (#705).
+  const [sellPayout, setSellPayout] = useState<number | null>(null)
   const [showReportSheet, setShowReportSheet] = useState(false)
   const [selectedInsuranceId, setSelectedInsuranceId] = useState<string | null>(null)
   const [desktopAddTxOpen, setDesktopAddTxOpen] = useState(false)
@@ -247,7 +249,9 @@ export default function DashboardClient({ userId }: { userId: string }) {
   // the withdrawal links to the goal (issue #261); an unassigned one uses the
   // unallocated sell flow. Takes the dep explicitly because the resolve sheet
   // clears `resolveDep` before invoking onWithdraw.
-  function withdrawMaturingDeposit(dep: MaturingDep | null) {
+  // `received` is the payout the user stated at the maturity sheet (#705); it
+  // opens the withdraw sheet on their figure instead of a fresh estimate.
+  function withdrawMaturingDeposit(dep: MaturingDep | null, received?: number) {
     if (!dep) return
     const item = sellItemForMaturingDeposit(dep, isVi)
     if (dep.goalId) {
@@ -257,9 +261,11 @@ export default function DashboardClient({ userId }: { userId: string }) {
         goalId: dep.goalId,
         goalCurrentValue: goal?.currentValue ?? dep.raw.currentValue,
         goalTargetAmount: goal?.targetAmount ?? null,
+        received: received ?? null,
       })
     } else {
       setSellItem(item)
+      setSellPayout(received ?? null)
       setSellSheetOpen(true)
     }
   }
@@ -752,8 +758,9 @@ export default function DashboardClient({ userId }: { userId: string }) {
         item={sellItem}
         open={sellSheetOpen}
         context="unallocated"
+        receivedPrefill={sellPayout}
         desktop={isDesktop}
-        onClose={() => setSellSheetOpen(false)}
+        onClose={() => { setSellSheetOpen(false); setSellPayout(null) }}
         onSuccess={() => fetchData({ force: true })}
       />
 
@@ -766,6 +773,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
           goalId={maturityWithdraw.goalId}
           goalCurrentValue={maturityWithdraw.goalCurrentValue}
           goalTargetAmount={maturityWithdraw.goalTargetAmount}
+          receivedPrefill={maturityWithdraw.received}
           desktop={isDesktop}
           onClose={() => setMaturityWithdraw(null)}
           onSuccess={() => { setMaturityWithdraw(null); fetchData({ force: true }) }}
@@ -783,7 +791,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
           isVi={isVi}
           onClose={() => setResolveDep(null)}
           onRenewed={() => { setResolveDep(null); fetchData({ force: true }) }}
-          onWithdraw={() => withdrawMaturingDeposit(resolveDep)}
+          onWithdraw={(received) => withdrawMaturingDeposit(resolveDep, received)}
         />
       )}
       {isDesktop && resolveDep && (
@@ -795,7 +803,7 @@ export default function DashboardClient({ userId }: { userId: string }) {
           isVi={isVi}
           onClose={() => setResolveDep(null)}
           onRenewed={() => { setResolveDep(null); fetchData({ force: true }) }}
-          onWithdraw={() => withdrawMaturingDeposit(resolveDep)}
+          onWithdraw={(received) => withdrawMaturingDeposit(resolveDep, received)}
         />
       )}
 

--- a/app/assets/components/DesktopGoalDetail.tsx
+++ b/app/assets/components/DesktopGoalDetail.tsx
@@ -68,6 +68,8 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
   const [showInvOptions, setShowInvOptions] = useState(false)
   const [showResolve, setShowResolve] = useState(false)
   const [showSell, setShowSell] = useState(false)
+  // The payout stated at the maturity sheet, carried into the withdraw sheet (#705).
+  const [sellPayout, setSellPayout] = useState<number | null>(null)
   const [showUnassignConfirm, setShowUnassignConfirm] = useState(false)
   const [unassigning, setUnassigning] = useState(false)
   const [unassignedIds, setUnassignedIds] = useState<string[]>([])
@@ -643,7 +645,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
           isVi={isVi}
           onClose={() => setShowResolve(false)}
           onRenewed={() => { setShowResolve(false); (onRenewed ?? onDataChanged)() }}
-          onWithdraw={() => { setShowResolve(false); setTimeout(() => setShowSell(true), 80) }}
+          onWithdraw={(received) => { setShowResolve(false); setSellPayout(received ?? null); setTimeout(() => setShowSell(true), 80) }}
         />
       )}
 
@@ -663,6 +665,7 @@ export default function DesktopGoalDetail({ goal, locale, onClose, onDataChanged
         <SellWithdrawSheet
           desktop
           open
+          receivedPrefill={sellPayout}
           item={invToSellItem(actionInv)}
           context="goal"
           goalId={goal.goalId}

--- a/app/assets/components/GoalDetailSheet.tsx
+++ b/app/assets/components/GoalDetailSheet.tsx
@@ -66,6 +66,9 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
   const [investActionOpen, setInvestActionOpen] = useState(false)
   const [resolveOpen, setResolveOpen] = useState(false)
   const [sellOpen, setSellOpen] = useState(false)
+  // The payout stated at the maturity sheet, carried into the withdraw sheet
+  // (#705). Null for every other way of opening it.
+  const [sellPayout, setSellPayout] = useState<number | null>(null)
   const [unassignConfirmOpen, setUnassignConfirmOpen] = useState(false)
   const [unassigning, setUnassigning] = useState(false)
   const [unassignedIds, setUnassignedIds] = useState<string[]>([])
@@ -812,11 +815,12 @@ export default function GoalDetailSheet({ goal, open, onClose, onDataChanged, re
         isVi={isVI}
         onClose={() => setResolveOpen(false)}
         onRenewed={() => { setResolveOpen(false); onDataChanged() }}
-        onWithdraw={() => { setResolveOpen(false); setSellOpen(true) }}
+        onWithdraw={(received) => { setResolveOpen(false); setSellPayout(received ?? null); setSellOpen(true) }}
       />
 
       <SellWithdrawSheet
         open={sellOpen}
+        receivedPrefill={sellPayout}
         item={actionInv ? invToSellItem(actionInv) : null}
         context="goal"
         goalId={goal.goalId}

--- a/app/assets/components/MaturityResolveSheet.tsx
+++ b/app/assets/components/MaturityResolveSheet.tsx
@@ -82,7 +82,8 @@ export function MaturityResolveBody({
   isVi: boolean
   onClose: () => void
   onRenewed: () => void
-  onWithdraw: () => void
+  // Receives the payout the user stated here, so the withdraw sheet opens on it.
+  onWithdraw: (received?: number) => void
 }) {
   // An accumulating ("Loại 2") book: `inv` is the rolled-up book row (principal =
   // Σ tranche principals, value = Σ tranche valuations). It renews by COLLAPSING
@@ -193,6 +194,10 @@ export function MaturityResolveBody({
   // user edits it down if early settlement is penalised).
   const [holdChoice, setHoldChoice] = useState<'hold' | 'cash'>('hold')
   const [holdReceived, setHoldReceived] = useState(String(Math.round(inv.value ?? principal)))
+  // The payout the user states for a straight withdrawal (#705). null until they
+  // touch it, so the field keeps tracking the computed estimate while the rate or
+  // the interest below it still moves; once typed, their figure stands.
+  const [payoutOverride, setPayoutOverride] = useState<string | null>(null)
   // ── Held-pool consume (when THIS deposit is the anchor) ───────────────────────
   // The goal's pooled holdings, all preselected to fold in. heldSel records only
   // explicit deselects (a deselected holding is unheld → restored to a deposit).
@@ -317,6 +322,8 @@ export function MaturityResolveBody({
   const newMaturity = dateTouched ? maturityOverride : derivedMaturity
   const newMaturityFmt = fmtMaturity(newMaturity, isVi)?.formatted ?? newMaturity
   const payout = principal + iNum
+  const payoutValue = payoutOverride ?? String(Math.round(payout))
+  const payoutNum = payoutValue.trim() === '' ? 0 : Number(payoutValue)
 
   const t = maturityResolveStrings(isVi, matured)
 
@@ -479,7 +486,9 @@ export function MaturityResolveBody({
     if (mode === 'withdraw') {
       // The hold fork only exists when there's an eligible anchor; default is hold.
       if (canHold && holdChoice === 'hold') { await handleHold(); return }
-      onClose(); setTimeout(onWithdraw, 60); return
+      // The payout goes with it: the withdraw sheet would otherwise re-estimate
+      // the cash and quietly discard what the user just typed here (#705).
+      onClose(); setTimeout(() => onWithdraw(payoutNum), 60); return
     }
     if (!canRenew) return
     setSaving(true); setError('')
@@ -844,7 +853,7 @@ export function MaturityResolveBody({
           canHold={canHold} holdAnchor={holdAnchor}
           holdChoice={holdChoice} setHoldChoice={setHoldChoice}
           holdReceived={holdReceived} setHoldReceived={setHoldReceived}
-          payout={payout}
+          payout={payoutValue} setPayout={setPayoutOverride}
         />
       )}
 
@@ -895,7 +904,7 @@ export function MaturityResolveBody({
           // Holding posts instead of withdrawing — navy CTA + piggy icon, never the
           // red withdraw button (the money is staying in the goal).
           const holding = mode === 'withdraw' && canHold && holdChoice === 'hold'
-          const disabled = saving || (mode !== 'withdraw' && !canRenew) || (holding && !(holdReceivedNum > 0))
+          const disabled = saving || (mode !== 'withdraw' && !canRenew) || (holding && !(holdReceivedNum > 0)) || (mode === 'withdraw' && !holding && !(payoutNum > 0))
           return (
             <button type="button" onClick={handleConfirm} disabled={disabled} style={{
               flex: 2, justifyContent: 'center', gap: 7, padding: '10px 14px', borderRadius: 10, border: 'none',
@@ -926,7 +935,7 @@ export function MaturityResolveSheet({
   isVi: boolean
   onClose: () => void
   onRenewed: () => void
-  onWithdraw: () => void
+  onWithdraw: (received?: number) => void
 }) {
   useEffect(() => {
     if (!open) return
@@ -973,7 +982,7 @@ export function MaturityResolveModal({
   isVi: boolean
   onClose: () => void
   onRenewed: () => void
-  onWithdraw: () => void
+  onWithdraw: (received?: number) => void
 }) {
   return (
     <div

--- a/app/assets/components/SellWithdrawSheet.tsx
+++ b/app/assets/components/SellWithdrawSheet.tsx
@@ -31,6 +31,12 @@ interface Props {
   goalTargetAmount?: number | null
   onClose: () => void
   onSuccess: () => void
+  // Cash the user already stated at the maturity sheet ("Tổng nhận về", #705).
+  // Present only when this sheet was opened by closing a matured deposit, and it
+  // means the whole book goes: the amount opens at the full principal and the
+  // received field at their figure, instead of the estimate this sheet computes.
+  // They can still change both here — it is a starting point, not a lock.
+  receivedPrefill?: number | null
   // Desktop renders a centered modal dialog; mobile keeps the bottom sheet.
   desktop?: boolean
 }
@@ -49,7 +55,15 @@ const TYPE_COLOR = {
   stock: '#7c3aed',
 } as const
 
-export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValue, goalTargetAmount, onClose, onSuccess, desktop }: Props) {
+// A maturity close is a FULL close, so the amount it opens with is the whole
+// remaining principal — the payout the user carried over says what the bank paid
+// for it, not how much of the book is leaving.
+function maturityCloseAmount(item: SellItem | null, receivedPrefill?: number | null): string {
+  if (item?.type !== 'bank' || receivedPrefill == null) return ''
+  return String(Math.round(item.purchasePrice ?? item.currentValue ?? 0))
+}
+
+export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValue, goalTargetAmount, onClose, onSuccess, receivedPrefill, desktop }: Props) {
   const locale = useLocale()
   // Generic fallback shown when the API fails without a message. Inline-localized
   // to match the rest of this file (no next-intl t() here).
@@ -57,9 +71,14 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
     ? 'Đã xảy ra lỗi. Vui lòng thử lại.'
     : 'An error occurred. Please try again.'
 
-  const [amount, setAmount] = useState('')
+  // Seeded lazily for the same reason the gold price below is: this sheet is
+  // often rendered by a parent that mounts it ALREADY open (the maturity
+  // hand-off does exactly that), and useResetOnOpen only fires on a transition.
+  const [amount, setAmount] = useState(() => maturityCloseAmount(item, receivedPrefill))
   const [units, setUnits] = useState('')
-  const [received, setReceived] = useState('') // bank: cash actually received
+  const [received, setReceived] = useState(
+    () => (item?.type === 'bank' && receivedPrefill != null ? String(Math.round(receivedPrefill)) : ''),
+  ) // bank: cash actually received
   // Seeded lazily as well as synced below: useResetOnOpen fires on a *transition*
   // into open, so a sheet that mounts already open — which is how it renders when
   // the parent shows it in the same commit — would otherwise never get its gold
@@ -172,6 +191,17 @@ export function SellWithdrawSheet({ item, open, context, goalId, goalCurrentValu
   useResetOnOpen(open, () => {
     if (isGold && navPerUnit) setSalePrice(String(Math.round(navPerUnit)))
   }, navPerUnit)
+
+  // A maturity close arrives with its payout already stated (#705). Seeded the
+  // same way as the gold price and for the same reason: the reset above runs on
+  // the way in, so this has to land after it. The amount is the full principal
+  // because "Không tái tục — rút" is a full close, and the received field takes
+  // the user's figure rather than estimateReceivedForPrincipal's.
+  useResetOnOpen(open, () => {
+    if (item?.type !== 'bank' || receivedPrefill == null) return
+    setAmount(maturityCloseAmount(item, receivedPrefill))
+    setReceived(String(Math.round(receivedPrefill)))
+  }, receivedPrefill)
 
   function handleAmountChange(val: string) {
     const raw = parseIntVN(val)

--- a/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
+++ b/app/assets/components/__tests__/MaturityResolveSheet.test.tsx
@@ -1152,3 +1152,32 @@ describe('MaturityResolveBody', () => {
     await waitFor(() => expect(previews).toBe(2))
   })
 })
+
+// #705: on "Xử lý đáo hạn" → "Không tái tục — rút", the payout was a read-only
+// row. It is an ESTIMATE (principal + accrued interest); the bank's slip says
+// something else whenever the close is early or a fee lands, and the user was
+// reading the real figure off that slip with nowhere to type it. The row is now
+// the field, and the number it holds is what the withdraw sheet opens with —
+// otherwise editing it here would be theatre.
+describe('MaturityResolveBody — the maturity payout is the user’s to correct (#705)', () => {
+  it('hands the edited payout to the withdraw flow', async () => {
+    const user = userEvent.setup()
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) }))
+    const onWithdraw = vi.fn()
+
+    render(
+      <MaturityResolveBody inv={maturedDeposit} isVi={false} onClose={() => {}} onRenewed={() => {}} onWithdraw={onWithdraw} />,
+    )
+    await user.click(screen.getByText(/Don.t renew — withdraw/i))
+
+    // Prefilled with the estimate the sheet computes: 35,000,000 + 2,030,000.
+    const payout = await screen.findByTestId('maturity-payout-input') as HTMLInputElement
+    expect(payout.value).toBe(formatIntVN('37030000'))
+
+    // The bank actually paid 36,800,000 (early-close penalty).
+    fireEvent.change(payout, { target: { value: formatIntVN('36800000') } })
+    await user.click(screen.getByRole('button', { name: /Mark for withdrawal/i }))
+
+    await waitFor(() => expect(onWithdraw).toHaveBeenCalledWith(36_800_000))
+  })
+})

--- a/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
+++ b/app/assets/components/__tests__/SellWithdrawSheet.test.tsx
@@ -393,3 +393,30 @@ describe('SellWithdrawSheet — responsive presentation (#248)', () => {
     expect(screen.getByTestId('sell-body').style.paddingTop).toBe('16px')
   })
 })
+
+// #705: the maturity sheet's "Tổng nhận về" is now editable, and this is where
+// that number has to land. Opening the withdraw sheet from a maturity close means
+// the whole book goes: the amount is the full principal, and the cash is whatever
+// the user already told the maturity sheet the bank paid — not the estimate this
+// sheet would compute for itself.
+describe('SellWithdrawSheet — a payout carried over from the maturity sheet (#705)', () => {
+  const book = {
+    type: 'bank' as const, name: 'Vikki',
+    currentValue: 54_890_294, interestRate: 4.7,
+    transactionId: 't9', purchasePrice: 52_400_000,
+  }
+
+  it('opens on the full principal with the carried payout as the cash received', () => {
+    render(
+      <SellWithdrawSheet item={book} open context="unallocated" receivedPrefill={54_500_000} onClose={vi.fn()} onSuccess={vi.fn()} />,
+    )
+    expect((screen.getByTestId('sell-amount-input') as HTMLInputElement).value).toBe('52.400.000')
+    expect((screen.getByTestId('sell-received-input') as HTMLInputElement).value).toBe('54.500.000')
+  })
+
+  it('leaves the sheet blank when no payout was carried over', () => {
+    render(<SellWithdrawSheet item={book} open context="unallocated" onClose={vi.fn()} onSuccess={vi.fn()} />)
+    expect((screen.getByTestId('sell-amount-input') as HTMLInputElement).value).toBe('')
+    expect((screen.getByTestId('sell-received-input') as HTMLInputElement).value).toBe('')
+  })
+})

--- a/app/assets/components/maturityResolveFields.tsx
+++ b/app/assets/components/maturityResolveFields.tsx
@@ -6,7 +6,7 @@
 // state and passes it in. The renew/combine sections still live in the sheet and
 // import the field primitives from here.
 import { PiggyBank, ArrowDownToLine, Check, GitMerge } from 'lucide-react'
-import { fmt, fmtCompact } from '@/lib/formatters'
+import { fmtCompact } from '@/lib/formatters'
 import AmountInput from '@/components/ui/AmountInput'
 
 export const fieldLabel: React.CSSProperties = {
@@ -88,7 +88,7 @@ export function MoneyField({ label, value, onChange, testId }: { label: string; 
 // eligible anchor exists) plus the total payout. The sheet routes hold → the
 // held-settlement write and cash → its existing Sell/Withdraw flow.
 export function WithdrawSection({
-  t, canHold, holdAnchor, holdChoice, setHoldChoice, holdReceived, setHoldReceived, payout,
+  t, canHold, holdAnchor, holdChoice, setHoldChoice, holdReceived, setHoldReceived, payout, setPayout,
 }: {
   t: {
     holdForkPrompt: string
@@ -105,7 +105,8 @@ export function WithdrawSection({
   setHoldChoice: (v: 'hold' | 'cash') => void
   holdReceived: string
   setHoldReceived: (v: string) => void
-  payout: number
+  payout: string
+  setPayout: (v: string) => void
 }) {
   return (
         <div style={{ display: 'grid', gap: 12 }}>
@@ -148,10 +149,15 @@ export function WithdrawSection({
             </div>
           )}
 
-          <div style={{ border: '1px solid var(--c-line)', borderRadius: 12, padding: '12px 14px', display: 'flex', alignItems: 'center', justifyContent: 'space-between', background: 'var(--c-card-2)' }}>
-            <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--c-muted)' }}>{t.totalPayout}</span>
-            <span style={{ fontSize: 16, fontWeight: 700, fontVariantNumeric: 'tabular-nums' }}>{fmt(payout)}</span>
-          </div>
+          {/* The payout is an ESTIMATE — principal plus the interest accrued to
+              today. Closing early, a fee, or a bank that rounds its own way all
+              make the slip say something else, and this used to be a read-only
+              row with nowhere to put the real figure (#705). It is the field the
+              withdraw sheet then opens with. Hidden while holding: that fork has
+              its own received field just above. */}
+          {!(canHold && holdChoice === 'hold') && (
+            <MoneyField label={t.totalPayout} value={payout} onChange={setPayout} testId="maturity-payout-input" />
+          )}
         </div>
   )
 }


### PR DESCRIPTION
Cùng issue #705 với PR #706, nhưng đúng màn hình bạn chỉ trong ảnh chụp.

## Vấn đề

**Xử lý đáo hạn → "Không tái tục — rút"**: dòng **"Tổng nhận về"** chỉ là ô hiển thị (gốc + lãi tính tới hôm nay). Đó là con số **ước tính** — ngân hàng trả khác khi tất toán sớm, có phí, hoặc làm tròn kiểu khác — và người dùng đang cầm giấy của ngân hàng mà không có chỗ nào để gõ số thật. Ô nhập duy nhất trên màn đó thuộc nhánh "Để dành gộp", chỉ xuất hiện khi có sổ khác đáo hạn sau đủ điều kiện gộp.

## Cách sửa

Dòng đó giờ là **ô nhập**, và số trong đó chính là số mà sheet **Rút** mở lên:
- `Số tiền gốc muốn rút` = toàn bộ gốc còn lại (tất toán đáo hạn là rút cả sổ)
- `Số tiền thực nhận` = số bạn vừa gõ, thay vì ước tính mà sheet Rút tự tính

Cả hai ô ở sheet Rút vẫn sửa được — đây là giá trị điền sẵn, không phải khoá. Nút xác nhận bị chặn khi ô payout trống, giống hệt nhánh hold đã chặn khi "Số tiền thực nhận" trống.

Về kỹ thuật: giá trị được truyền qua `onWithdraw(received)` tới ba nơi wire nó (`DashboardClient`, `GoalDetailSheet`, `DesktopGoalDetail`) rồi vào `SellWithdrawSheet` qua prop `receivedPrefill`. Sheet đó seed cả lúc mount lẫn lúc `open` chuyển trạng thái, vì luồng từ dashboard mount sheet khi nó **đã** open.

## Test

- `MaturityResolveSheet`: chế độ rút hiện ô payout điền sẵn 37.030.000 (35tr gốc + 2,03tr lãi); sửa thành 36.800.000 → `onWithdraw` được gọi với đúng `36800000`.
- `SellWithdrawSheet`: có `receivedPrefill` → ô gốc = toàn bộ gốc, ô thực nhận = số mang sang; không có prefill → cả hai vẫn trống (khỏi vacuous).

## Đã chạy

`npm run typecheck` ✅ · `npm run lint` ✅ · `npm test -- --run` (221 files, 2750 tests) ✅ · `npm run build` ✅ · không spec E2E nào tham chiếu dòng payout cũ.

Docker không bật ở máy local nên `test:db` / E2E để CI chạy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)